### PR TITLE
HWY-57: Check timestamps in State and ActiveValidator.

### DIFF
--- a/src/components/consensus/highway_core/vote.rs
+++ b/src/components/consensus/highway_core/vote.rs
@@ -61,6 +61,11 @@ impl<C: Context> Panorama<C> {
         !self.iter().any(Observation::is_correct)
     }
 
+    /// Returns an iterator over all hashes of the honest validators' latest messages.
+    pub(crate) fn iter_correct(&self) -> impl Iterator<Item = &C::Hash> {
+        self.iter().filter_map(Observation::correct)
+    }
+
     /// Returns an iterator over all observations, by validator index.
     pub(crate) fn enumerate(&self) -> impl Iterator<Item = (ValidatorIndex, &Observation<C>)> {
         self.iter()


### PR DESCRIPTION
This is the first part of HWY-57: It adds timestamp checks to `State` and makes sure `ActiveValidator` produces votes with valid timestamps.

Dealing with incoming votes with future timestamps will be a separate PR, and also part of HWY-57.