### PR TITLE
NDRS-79: make EraSupervisor only generic in the consensus value

### DIFF
--- a/src/components/consensus.rs
+++ b/src/components/consensus.rs
@@ -34,12 +34,11 @@ use consensus_service::{
     era_supervisor::EraSupervisor,
     traits::{ConsensusService, EraId, Event as ConsensusEvent, MessageWireFormat},
 };
-use protocols::pothole::PotholeContext;
 
 /// The consensus component.
 #[derive(Debug)]
 pub(crate) struct Consensus {
-    era_supervisor: EraSupervisor<PotholeContext<ConsensusNodeId, Block>>,
+    era_supervisor: EraSupervisor<Block>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,7 +102,7 @@ impl Consensus {
         _effect_builder: EffectBuilder<REv>,
     ) -> (Self, Multiple<Effect<Event>>) {
         let consensus = Consensus {
-            era_supervisor: EraSupervisor::<PotholeContext<ConsensusNodeId, Block>>::new(),
+            era_supervisor: EraSupervisor::<Block>::new(),
         };
 
         (consensus, Default::default())

--- a/src/components/consensus/consensus_service/traits.rs
+++ b/src/components/consensus/consensus_service/traits.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
-use super::super::consensus_protocol::{ConsensusContext, NodeId, TimerId};
+use super::super::consensus_protocol::{NodeId, TimerId};
 
 // Very simple reactor effect.
 #[derive(Debug)]
@@ -27,9 +27,9 @@ pub(crate) struct MessageWireFormat {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct EraId(pub(crate) u64);
 
-pub(crate) enum ConsensusServiceError<Ctx: ConsensusContext> {
+pub(crate) enum ConsensusServiceError {
     InvalidFormat(String),
-    InternalError(Ctx::Error),
+    InternalError(anyhow::Error),
 }
 
 pub(crate) enum Event {
@@ -39,10 +39,5 @@ pub(crate) enum Event {
 
 /// API between the reactor and consensus component.
 pub(crate) trait ConsensusService {
-    type Ctx: ConsensusContext;
-
-    fn handle_event(
-        &mut self,
-        event: Event,
-    ) -> Result<Vec<Effect<Event>>, ConsensusServiceError<Self::Ctx>>;
+    fn handle_event(&mut self, event: Event) -> Result<Vec<Effect<Event>>, ConsensusServiceError>;
 }

--- a/src/components/consensus/protocols/pothole.rs
+++ b/src/components/consensus/protocols/pothole.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::super::{
     consensus_protocol::{
-        ConsensusContext, ConsensusProtocol, ConsensusProtocolResult, NodeId as ConsensusNodeId,
+        ConsensusProtocol, ConsensusProtocolResult, ConsensusValue, NodeId as ConsensusNodeId,
         TimerId,
     },
     consensus_service::traits::{EraId, MessageWireFormat},
@@ -121,24 +121,13 @@ impl<B: Block + Hash + Eq> ProtocolState for PotholeWrapper<B> {
     }
 }
 
-pub(crate) struct PotholeContext<N, B> {
-    _n: PhantomData<N>,
-    _b: PhantomData<B>,
-}
-
-impl<N: NodeId, B: Block + Hash + Eq> ConsensusContext for PotholeContext<N, B> {
-    type ConsensusValue = B;
-    type Error = &'static str;
-    type Message = (N, SynchronizerMessage<PotholeDepSpec<B>>);
-}
-
 #[derive(Debug)]
-pub(crate) struct PotholeWithSynchronizer<N: NodeId, B: Block + Hash + Eq> {
+pub(crate) struct PotholeWithSynchronizer<N: NodeId, B: Block + ConsensusValue> {
     pothole: PotholeWrapper<B>,
     synchronizer: Synchronizer<N, PotholeWrapper<B>>,
 }
 
-impl<N: NodeId, B: Block + Hash + Eq> PotholeWithSynchronizer<N, B> {
+impl<N: NodeId, B: Block + ConsensusValue> PotholeWithSynchronizer<N, B> {
     pub(crate) fn new(pothole: Pothole<B>) -> Self {
         Self {
             pothole: PotholeWrapper::new(pothole),
@@ -147,9 +136,9 @@ impl<N: NodeId, B: Block + Hash + Eq> PotholeWithSynchronizer<N, B> {
     }
 }
 
-fn into_consensus_result<N: NodeId, B: Block + Hash + Eq>(
+fn into_consensus_result<N: NodeId, B: Block + ConsensusValue>(
     pothole_result: PotholeResult<B>,
-) -> Option<ConsensusProtocolResult<PotholeContext<N, B>>> {
+) -> Option<ConsensusProtocolResult<B>> {
     match pothole_result {
         PotholeResult::ScheduleTimer(timer_id, instant) => Some(
             ConsensusProtocolResult::ScheduleTimer(instant, TimerId(timer_id)),
@@ -161,31 +150,35 @@ fn into_consensus_result<N: NodeId, B: Block + Hash + Eq>(
     }
 }
 
-impl<N: NodeId, B: Block + Hash + Eq> ConsensusProtocol<PotholeContext<N, B>>
+impl<N: NodeId + Serialize + DeserializeOwned, B: Block + ConsensusValue> ConsensusProtocol<B>
     for PotholeWithSynchronizer<N, B>
 {
     fn handle_message(
         &mut self,
-        msg: (N, SynchronizerMessage<PotholeDepSpec<B>>),
-    ) -> Result<Vec<ConsensusProtocolResult<PotholeContext<N, B>>>, &'static str> {
-        let (sender, msg) = msg;
+        msg: Vec<u8>,
+    ) -> Result<Vec<ConsensusProtocolResult<B>>, anyhow::Error> {
+        let (sender, msg) = bincode::deserialize(&msg)?;
         Ok(self
             .synchronizer
             .handle_message(&mut self.pothole, sender, msg)
             .into_iter()
-            .map(ConsensusProtocolResult::CreatedNewMessage)
+            .filter_map(|msg| {
+                bincode::serialize(&msg)
+                    .ok()
+                    .map(ConsensusProtocolResult::CreatedNewMessage)
+            })
             .collect())
     }
 
     fn handle_timer(
         &mut self,
         timer_id: TimerId,
-    ) -> Result<Vec<ConsensusProtocolResult<PotholeContext<N, B>>>, &'static str> {
+    ) -> Result<Vec<ConsensusProtocolResult<B>>, anyhow::Error> {
         Ok(self
             .pothole
             .handle_timer(timer_id.0)
             .into_iter()
-            .filter_map(into_consensus_result)
+            .filter_map(into_consensus_result::<N, B>)
             .collect())
     }
 }


### PR DESCRIPTION
This is the initial part of work in this task, the rest has been moved to NDRS-97.

This PR achieves the goal for the price of passing serialized messages everywhere at the EraSupervisor level. This is not really desirable, so NDRS-97 will be dedicated to making this interface more type-safe.