### PR TITLE
Use ProtoBlock in consensus protocol tests.

### DIFF
--- a/src/components/consensus/consensus_protocol.rs
+++ b/src/components/consensus/consensus_protocol.rs
@@ -247,9 +247,9 @@ mod example {
 
         fn resolve_validity(
             &mut self,
-            _value: &DeployHash,
+            _value: &ProtoBlock,
             _valid: bool,
-        ) -> Result<Vec<ConsensusProtocolResult<DeployHash>>, anyhow::Error> {
+        ) -> Result<Vec<ConsensusProtocolResult<ProtoBlock>>, anyhow::Error> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
This reflects the intended use better than `DeployHash`.

https://casperlabs.atlassian.net/browse/HWY-74
https://casperlabs.atlassian.net/browse/HWY-87

/cc @fizyk20 