### PR TITLE
NO-TICKET: Relax constraints on the ValidatorSecret trait

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug};
+
 use tracing::warn;
 
 use super::{
@@ -36,7 +38,6 @@ pub(crate) enum Effect<C: Context> {
 /// If the rounds are long enough (i.e. message delivery is fast enough) and there are enough
 /// honest validators, there will be a lot of confirmations for the proposal, and enough witness
 /// votes citing all those confirmations, to create a summit and finalize the proposal.
-#[derive(Debug)]
 pub(crate) struct ActiveValidator<C: Context> {
     /// Our own validator index.
     vidx: ValidatorIndex,
@@ -46,6 +47,17 @@ pub(crate) struct ActiveValidator<C: Context> {
     round_exp: u8,
     /// The latest timer we scheduled.
     next_timer: u64,
+}
+
+// `#[derive]` doesn't work if `C::ValidatorSecret` is not `Debug`
+impl<C: Context> Debug for ActiveValidator<C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ActiveValidator")
+            .field("vidx", &self.vidx)
+            .field("round_exp", &self.round_exp)
+            .field("next_timer", &self.next_timer)
+            .finish()
+    }
 }
 
 impl<C: Context> ActiveValidator<C> {

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -24,7 +24,7 @@ pub(crate) trait HashT:
 impl<H> HashT for H where H: Eq + Ord + Clone + Debug + Hash + Serialize + DeserializeOwned {}
 
 /// A validator's secret signing key.
-pub(crate) trait ValidatorSecret: Debug + Eq + Clone {
+pub(crate) trait ValidatorSecret {
     type Hash;
 
     type Signature: Eq + PartialEq + Clone + Debug + Hash + Serialize + DeserializeOwned;


### PR DESCRIPTION
This replaces a bunch of `#[derive]`s on Highway structs with manual implementations so that `Context::ValidatorSecret` doesn't have to implement `Clone`, `Debug` and `Eq`. For some reason, even though these structs only contain fields of type `Context::ValidatorSecret::Signature`, the derives require these traits to also be implemented on `ValidatorSecret` itself, and we might deliberately not want to implement them for secret values.