### PR TITLE
NO-TICKET: Extend with `--all-features` flag.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,7 @@ steps:
     RUSTFLAGS: '-D warnings'
   commands:
   - rustup component add clippy
-  - cargo clippy --all-targets --workspace
+  - cargo clippy --all-targets --all-features --workspace
 
 - name: cargo-audit
   <<: *buildenv

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ format:
 
 .PHONY: lint
 lint:
-	$(CARGO) clippy --all-targets --workspace -- -D warnings -A renamed_and_removed_lints
+	$(CARGO) clippy --all-targets --all-features --workspace -- -D warnings -A renamed_and_removed_lints
 
 .PHONY: audit
 audit:

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -491,6 +491,7 @@ macro_rules! impl_to_from_bytes_for_array {
 
             #[cfg(feature = "no-unstable-features")]
             impl<T: FromBytes> FromBytes for [T; $N] {
+                #[allow(clippy::reversed_empty_ranges)]
                 fn from_bytes(mut bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
                     let mut result: MaybeUninit<[T; $N]> = MaybeUninit::uninit();
                     let result_ptr = result.as_mut_ptr() as *mut T;


### PR DESCRIPTION
Extends linter runs with `--all-features` flag to cargo clippy. 