### PR TITLE
Schedule timers with past timestamp immediately.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -147,7 +147,7 @@ where
                 .send_message(to, era_id.message(out_msg))
                 .ignore(),
             ConsensusProtocolResult::ScheduleTimer(timestamp) => {
-                let timediff = timestamp - Timestamp::now();
+                let timediff = timestamp.saturating_sub(Timestamp::now());
                 effect_builder
                     .set_timeout(timediff.into())
                     .event(move |_| Event::Timer { era_id, timestamp })

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -33,6 +33,11 @@ impl Timestamp {
     pub fn millis(&self) -> u64 {
         self.0
     }
+
+    /// Returns the difference between `self` and `other`, or `0` if `self` is earlier than `other`.
+    pub fn saturating_sub(self, other: Timestamp) -> TimeDiff {
+        TimeDiff(self.0.saturating_sub(other.0))
+    }
 }
 
 impl Display for Timestamp {


### PR DESCRIPTION
If by the time `ScheduleTimer` is processed the timestamp has already passed, the timer should be scheduled with delay 0.

https://casperlabs.atlassian.net/browse/NDRS-151