### PR TITLE
Consensus announcements for deploy buffer

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -161,12 +161,21 @@ where
                     proto_block,
                     block_context,
                 }),
-            ConsensusProtocolResult::FinalizedBlock(block) => effect_builder
-                .execute_block(block)
-                .event(move |executed_block| Event::ExecutedBlock {
-                    era_id,
-                    executed_block,
-                }),
+            ConsensusProtocolResult::FinalizedBlock(block) => {
+                let mut effects =
+                    effect_builder
+                        .execute_block(block.clone())
+                        .event(move |executed_block| Event::ExecutedBlock {
+                            era_id,
+                            executed_block,
+                        });
+                effects.extend(
+                    effect_builder
+                        .announce_finalized_proto_block(block)
+                        .ignore(),
+                );
+                effects
+            }
             ConsensusProtocolResult::ValidateConsensusValue(sender, proto_block) => effect_builder
                 .validate_proto_block(sender.clone(), proto_block)
                 .event(move |(is_valid, proto_block)| {

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -227,8 +227,8 @@ impl<C: Context> ActiveValidator<C> {
         vec![Effect::ScheduleTimer(self.next_timer)]
     }
 
-    /// Returns the earliest timestamp where we can cast our next vote without equivocating, i.e. the
-    /// timestamp of our previous vote, or 0 if there is none.
+    /// Returns the earliest timestamp where we can cast our next vote without equivocating, i.e.
+    /// the timestamp of our previous vote, or 0 if there is none.
     fn earliest_vote_time(&self, state: &State<C>) -> Timestamp {
         let opt_own_vh = state.panorama().get(self.vidx).correct();
         opt_own_vh.map_or(Timestamp::zero(), |own_vh| state.vote(own_vh).timestamp)

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -13,7 +13,7 @@ use derive_more::From;
 use crate::{
     components::Component,
     effect::{requests::DeployQueueRequest, EffectBuilder, EffectExt, Effects},
-    types::{BlockHash, DeployHash, DeployHeader},
+    types::{BlockHash, DeployHash, DeployHeader, ProtoBlock},
 };
 
 /// Deploy buffer.
@@ -117,39 +117,43 @@ impl DeployBuffer {
     }
 
     /// Notifies the deploy buffer of a new block.
-    #[allow(unused)] // TODO
-    pub(crate) fn added_block(&mut self, block: BlockHash, deploys: HashSet<DeployHash>) {
-        let deploy_map = deploys
-            .iter()
+    pub(crate) fn added_block<I>(&mut self, block: BlockHash, deploys: I)
+    where
+        I: IntoIterator<Item = DeployHash>,
+    {
+        // TODO: This will ignore deploys that weren't in `collected_deploys`. They might be added
+        // later, and then would be proposed as duplicates.
+        let deploy_map: HashMap<_, _> = deploys
+            .into_iter()
             .filter_map(|deploy_hash| {
                 self.collected_deploys
-                    .get(deploy_hash)
-                    .map(|deploy| (*deploy_hash, deploy.clone()))
+                    .get(&deploy_hash)
+                    .map(|deploy| (deploy_hash, deploy.clone()))
             })
             .collect();
         self.collected_deploys
-            .retain(|deploy_hash, _| !deploys.contains(deploy_hash));
+            .retain(|deploy_hash, _| !deploy_map.contains_key(deploy_hash));
         self.processed.insert(block, deploy_map);
     }
 
     /// Notifies the deploy buffer that a block has been finalized.
-    #[allow(unused)] // TODO
     pub(crate) fn finalized_block(&mut self, block: BlockHash) {
         if let Some(deploys) = self.processed.remove(&block) {
             self.collected_deploys
                 .retain(|deploy_hash, _| !deploys.contains_key(deploy_hash));
             self.finalized.insert(block, deploys);
         } else {
+            // TODO: Events are not guaranteed to be handled in order, so this could happen!
             panic!("finalized block that hasn't been processed!");
         }
     }
 
     /// Notifies the deploy buffer that a block has been orphaned.
-    #[allow(unused)] // TODO
     pub(crate) fn orphaned_block(&mut self, block: BlockHash) {
         if let Some(deploys) = self.processed.remove(&block) {
             self.collected_deploys.extend(deploys);
         } else {
+            // TODO: Events are not guaranteed to be handled in order, so this could happen!
             panic!("orphaned block that hasn't been processed!");
         }
     }
@@ -160,12 +164,18 @@ impl DeployBuffer {
 pub enum Event {
     #[from]
     QueueRequest(DeployQueueRequest),
+    ProposedProtoBlock(ProtoBlock),
+    FinalizedProtoBlock(ProtoBlock),
+    OrphanedProtoBlock(ProtoBlock),
 }
 
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::QueueRequest(req) => write!(f, "dq request: {}", req),
+            Event::ProposedProtoBlock(block) => write!(f, "dq proposed proto block {}", block),
+            Event::FinalizedProtoBlock(block) => write!(f, "dq finalized proto block {}", block),
+            Event::OrphanedProtoBlock(block) => write!(f, "dq orphaned proto block {}", block),
         }
     }
 }
@@ -184,7 +194,7 @@ impl<REv> Component<REv> for DeployBuffer {
                 hash,
                 header,
                 responder,
-            }) => responder.respond(self.add_deploy(hash, header)).ignore(),
+            }) => return responder.respond(self.add_deploy(hash, header)).ignore(),
             Event::QueueRequest(DeployQueueRequest::RequestForInclusion {
                 current_instant,
                 max_ttl,
@@ -200,14 +210,13 @@ impl<REv> Component<REv> for DeployBuffer {
                     max_dependencies,
                     &past,
                 );
-                // TODO: This is a temporary workaround because we don't call `added_block` yet.
-                // To avoid proposing the same deploys again, we remove them from the buffer.
-                for deploy in &deploys {
-                    self.collected_deploys.remove(deploy);
-                }
-                responder.respond(deploys).ignore()
+                return responder.respond(deploys).ignore();
             }
+            Event::ProposedProtoBlock(block) => self.added_block(block.hash(), block.deploys),
+            Event::FinalizedProtoBlock(block) => self.finalized_block(block.hash()),
+            Event::OrphanedProtoBlock(block) => self.orphaned_block(block.hash()),
         }
+        Effects::new()
     }
 }
 

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::{
     components::storage::{StorageType, Value},
-    types::Deploy,
+    types::{Deploy, ProtoBlock},
 };
 
 /// A networking layer announcement.
@@ -80,6 +80,34 @@ where
         match self {
             StorageAnnouncement::StoredDeploy { deploy_hash, .. } => {
                 write!(formatter, "stored deploy {}", deploy_hash)
+            }
+        }
+    }
+}
+
+/// A consensus announcement.
+#[derive(Debug)]
+pub enum ConsensusAnnouncement {
+    /// A block was proposed and will either be finalized or orphaned soon.
+    Proposed(ProtoBlock),
+    /// A block was finalized.
+    // TODO: Replace with `FinalizedBlock`.
+    Finalized(ProtoBlock),
+    /// A block was orphaned.
+    Orphaned(ProtoBlock),
+}
+
+impl Display for ConsensusAnnouncement {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ConsensusAnnouncement::Proposed(block) => {
+                write!(formatter, "proposed proto block {}", block)
+            }
+            ConsensusAnnouncement::Finalized(block) => {
+                write!(formatter, "finalized proto block {}", block)
+            }
+            ConsensusAnnouncement::Orphaned(block) => {
+                write!(formatter, "orphaned proto block {}", block)
             }
         }
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,12 +22,23 @@ use crate::{
 ///
 /// The word "proto" does _not_ refer to "protocol" or "protobuf"! It is just a prefix to highlight
 /// that this comes before a block in the linear, executed, finalized blockchain is produced.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+#[display(fmt = "proto block")] // TODO: print hash?
 pub struct ProtoBlock {
     /// The list of deploy hashes included in the block
     pub deploys: Vec<DeployHash>,
     /// A random bit needed for initializing a future era
     pub random_bit: bool,
+}
+
+impl ProtoBlock {
+    // TODO: Memoize?
+    // TODO: Should be a separate `ProtoBlockHash` type?
+    pub(crate) fn hash(&self) -> BlockHash {
+        BlockHash::new(hash::hash(
+            &bincode::serialize(self).expect("serialize ProtoBlock"),
+        ))
+    }
 }
 
 /// A proto-block after execution, with the resulting post-state-hash


### PR DESCRIPTION
This adds `ConsensusAnnouncement` to announce proposed, orphaned and finalized proto blocks. The deploy buffer uses these to update its state and keep track of which deploys are eligible for proposal.

https://casperlabs.atlassian.net/browse/NDRS-159