### PR TITLE
Deploy buffer: Don't panic on unknown finalized blocks.

### DIFF
--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use derive_more::From;
+use tracing::error;
 
 use crate::{
     components::Component,
@@ -144,7 +145,7 @@ impl DeployBuffer {
             self.finalized.insert(block, deploys);
         } else {
             // TODO: Events are not guaranteed to be handled in order, so this could happen!
-            panic!("finalized block that hasn't been processed!");
+            error!("finalized block that hasn't been processed!");
         }
     }
 
@@ -154,7 +155,7 @@ impl DeployBuffer {
             self.collected_deploys.extend(deploys);
         } else {
             // TODO: Events are not guaranteed to be handled in order, so this could happen!
-            panic!("orphaned block that hasn't been processed!");
+            error!("orphaned block that hasn't been processed!");
         }
     }
 }


### PR DESCRIPTION
Events are not guaranteed to arrive in order, so we shouldn't panic if we are notified about a finalized block we don't know yet.