### PR TITLE
NDRS-149: address review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is the core application for the CasperLabs blockchain.
 
 ## Running a validator node
 
-To run a validator node with the default configuration using the [local chainspec](resources/local/chainspec.toml):
+To run a validator node with the [local configuration options](resources/local/config.toml):
 
 ```
-cargo run --release -- validator -p=resources/local/chainspec.toml
+cargo run --release -- validator -c=resources/local/config.toml
 ```
 
 It is likely that the configuration requires editing however, so typically one will want to generate a configuration
@@ -16,21 +16,25 @@ file first, edit it and then run:
 ```
 cargo run --release -- generate-config > config.toml
 # ... edit config.toml
-cargo run --release -- validator -p=resources/local/chainspec.toml -c=config.toml
+cargo run --release -- validator -c=config.toml
 ```
 
-If using a config file as described above, it is also possible to override and extend the values in the config file
-from the command line using one or more args in the form of `-C <section>.<key>=<value>`, for instance:
+Note that all paths specified in the config file must be absolute paths or relative to the config file itself.  Paths
+may contain environment variables such as `$HOME`.
+
+It is also possible to specify individual config file options from the command line using one or more args in the form
+of `-C=<SECTION>.<KEY>=<VALUE>`.  These will override values set in a config file if provided, or will override the
+default values otherwise.
 
 ```
-cargo run --release -- validator -c=resources/local/config.toml -C consensus.secret_key_path=secret_keys/node-1.pem
+cargo run --release -- validator -c=resources/local/config.toml -C=consensus.secret_key_path=secret_keys/node-1.pem
 ```
 
 **NOTE:** If you want to run multiple instances on the same machine, ensure you modify the `[storage.path]` field of
 their configuration files to give each a unique path, or else instances will share database files.
 
-As well as the [local chainspec](resources/local/chainspec.toml), there is a commented
-[local config file](resources/local/config.toml) in the same folder.
+As well as the commented [local config file](resources/local/config.toml), there is a commented
+[local chainspec](resources/local/chainspec.toml) in the same folder.
 
 ## Logging
 
@@ -38,7 +42,7 @@ Logging can be enabled by setting the environment variable `RUST_LOG`.  This can
 from lowest priority to highest: `trace`, `debug`, `info`, `warn`, `error`:
 
 ```
-RUST_LOG=info cargo run --release -- validator -p=resources/local/chainspec.toml -c=config.toml
+RUST_LOG=info cargo run --release -- validator -c=resources/local/config.toml
 ```
 
 If the environment variable is unset, it is equivalent to setting `RUST_LOG=error`.

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -3,19 +3,19 @@
 //! Most configuration is done via config files (see [`config`](../config/index.html) for details).
 
 use std::{
-    io,
+    env, io,
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
 };
 
-use anyhow::bail;
+use anyhow::{self, bail, Context};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use regex::Regex;
 use structopt::StructOpt;
-use toml::Value;
-use tracing::info;
+use toml::{value::Table, Value};
+use tracing::{error, info, trace};
 
 use crate::config;
 use casperlabs_node::{
@@ -47,13 +47,14 @@ pub enum Cli {
         config: Option<PathBuf>,
 
         #[structopt(short = "C", long)]
-        /// config entries (section, key, value)
+        /// Overrides and extensions for configuration file entries in the form
+        /// <SECTION>.<KEY>=<VALUE>.  For example, '-C=node.chainspec_config_path=chainspec.toml'
         config_ext: Vec<ConfigExt>,
     },
 }
 
 #[derive(Debug)]
-/// Command line extension to be applied to toml based config file values.
+/// Command line extension to be applied to TOML-based config file values.
 pub struct ConfigExt {
     section: String,
     key: String,
@@ -61,14 +62,11 @@ pub struct ConfigExt {
 }
 
 impl ConfigExt {
-    /// Updates toml table with updated or extended kvp.
-    fn update_toml_table(&self, toml_value: &mut toml::Value) -> Option<()> {
+    /// Updates TOML table with updated or extended key value pairs.
+    fn update_toml_table(&self, toml_value: &mut Value) -> Option<()> {
         let table = toml_value.as_table_mut()?;
         if !table.contains_key(&self.section) {
-            table.insert(
-                self.section.clone(),
-                toml::Value::Table(toml::value::Table::new()),
-            );
+            table.insert(self.section.clone(), Value::Table(Table::new()));
         }
         let val = parse_toml_value(&self.value);
         table[&self.section]
@@ -79,39 +77,49 @@ impl ConfigExt {
 }
 
 impl FromStr for ConfigExt {
-    type Err = &'static str;
+    type Err = anyhow::Error;
 
-    /// Attempts to create a ConfigExt from a str patterned as
-    /// `section.key=value`
+    /// Attempts to create a ConfigExt from a str patterned as `section.key=value`
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let re = Regex::new(r"^([^.]+)\.([^=]+)=(.+)$").unwrap();
-        if let Some(captures) = re.captures(input) {
-            Ok(ConfigExt {
-                section: captures.get(1).expect("section").as_str().to_owned(),
-                key: captures.get(2).expect("section").as_str().to_owned(),
-                value: captures.get(3).expect("section").as_str().to_owned(),
-            })
-        } else {
-            Err("could not parse config_ext (see README.md)")
-        }
+        let captures = re
+            .captures(input)
+            .context("could not parse config_ext (see README.md)")?;
+        Ok(ConfigExt {
+            section: captures
+                .get(1)
+                .context("failed to find section")?
+                .as_str()
+                .to_owned(),
+            key: captures
+                .get(2)
+                .context("failed to find key")?
+                .as_str()
+                .to_owned(),
+            value: captures
+                .get(3)
+                .context("failed to find value")?
+                .as_str()
+                .to_owned(),
+        })
     }
 }
 
-/// Convenience function to parse values passed via command
-/// line into appropriate `toml::Value` representations.
-fn parse_toml_value(raw: &str) -> toml::Value {
+/// Convenience function to parse values passed via command line into appropriate `toml::Value`
+/// representations.
+fn parse_toml_value(raw: &str) -> Value {
     if let Ok(value) = i64::from_str(raw) {
-        return toml::Value::Integer(value);
+        return Value::Integer(value);
     }
     if let Ok(value) = bool::from_str(raw) {
-        return toml::Value::Boolean(value);
+        return Value::Boolean(value);
     }
-    toml::Value::String(raw.to_string())
+    Value::String(raw.to_string())
 }
 
-/// Normalizes any config key ending with `_path` with a value that appears to be
-/// a relative path, relative to the config file path.
-fn normalize_relative_paths(config_path: PathBuf, config: &mut toml::Value) {
+/// Normalizes any config key ending with `path` and a value that appears to be a relative path,
+/// relative to the config file path.
+fn normalize_paths(maybe_config_dir: Option<PathBuf>, config: &mut Value) {
     let table = if let Value::Table(table) = config {
         table
     } else {
@@ -119,25 +127,68 @@ fn normalize_relative_paths(config_path: PathBuf, config: &mut toml::Value) {
     };
 
     for (_section, inner) in table {
-        let table = if let toml::Value::Table(table) = inner {
+        let table = if let Value::Table(table) = inner {
             table
         } else {
             continue;
         };
 
         for (k, v) in table {
-            // skip any key that does not appear to be a file path.
-            if !k.ends_with("_path") {
+            // Skip any key that does not appear to be a file path.
+            if !k.ends_with("path") {
                 continue;
             }
-            if let toml::Value::String(maybe_path) = v {
-                let path = Path::new(maybe_path);
+
+            if let Value::String(path_str) = v {
+                // Replace env vars in the provided path.
+                for (env_var_name, env_var_value) in env::vars() {
+                    *path_str = path_str.replace(&format!("${}", env_var_name), &env_var_value);
+                }
+
+                let path = Path::new(path_str);
                 if path.is_relative() {
-                    *maybe_path = config_path.join(path).display().to_string();
+                    if let Some(root_dir) = maybe_config_dir.as_ref() {
+                        *path_str = root_dir.join(path).display().to_string();
+                    }
                 }
             }
         }
     }
+}
+
+fn config_from_toml_table(toml_table: Value) -> anyhow::Result<validator::Config> {
+    // Parse the TOML table into a validator::Config.  Some values may be discarded if they don't
+    // match fields in the config structs.
+    let validator_config = toml_table.clone().try_into()?;
+
+    // Convert the parsed config back into a TOML table to compare it to the one passed in.
+    let actual_table: Table = toml::from_str(&toml::to_string(&validator_config)?)?;
+    let input_table = toml_table.as_table().unwrap();
+
+    for (section_name, section_values) in
+        input_table.iter().map(|(k, v)| (k, v.as_table().unwrap()))
+    {
+        // Print an error message for any section which has been ignored from the input table.
+        let actual_section_values = match actual_table.get(section_name) {
+            Some(values) => values.as_table().unwrap(),
+            None => {
+                error!(
+                    "ignoring config section {} with values {:?}",
+                    section_name, section_values
+                );
+                continue;
+            }
+        };
+
+        // Print an error message for any other key, value pairs ignored from the input table.
+        for (key, value) in section_values {
+            if !actual_section_values.contains_key(key) {
+                error!("ignoring config entry {}.{}={}", section_name, key, value);
+            }
+        }
+    }
+
+    Ok(validator_config)
 }
 
 impl Cli {
@@ -174,39 +225,33 @@ impl Cli {
                 let mut rng = ChaCha20Rng::from_entropy();
 
                 info!("resolving configuration");
-                // the app supports running without a config file, using default values
+                // The app supports running without a config file, using default values.
                 let maybe_config: Option<validator::Config> =
                     config.as_ref().map(config::load_from_file).transpose()?;
 
-                // get the toml table version of the config indicated from cli args,
-                // or from a new defaulted config instance if one is not provided
-                let mut config_table: toml::Value =
-                    toml::from_str(&toml::to_string(&maybe_config.unwrap_or_default()).unwrap())
-                        .unwrap();
+                // Get the TOML table version of the config indicated from CLI args, or from a new
+                // defaulted config instance if one is not provided.
+                let mut config_table: Value =
+                    toml::from_str(&toml::to_string(&maybe_config.unwrap_or_default())?)?;
 
-                // if any command line overrides to the config values are passed, apply them
+                // If any command line overrides to the config values are passed, apply them.
                 for item in config_ext {
                     item.update_toml_table(&mut config_table);
                 }
 
-                // if a config file path to a toml file was provided, normalize relative paths in
+                // If a config file path to a TOML file was provided, normalize relative paths in
                 // the config to the config file's path.
-                // If a config file path was not passed via cli and a default config instance is
+                // If a config file path was not passed via CLI and a default config instance is
                 // being used instead, do not normalize paths.
                 let maybe_root_path =
-                    config.map(|p| p.parent().unwrap().to_path_buf().canonicalize().unwrap());
+                    config.map(|p| p.canonicalize().unwrap().parent().unwrap().to_path_buf());
 
-                if let Some(root_path) = maybe_root_path {
-                    normalize_relative_paths(root_path, &mut config_table)
-                }
+                normalize_paths(maybe_root_path, &mut config_table);
 
-                // create validator config, including any overridden or normalized values
-                let validator_config = match config_table.try_into() {
-                    Ok(validator_config) => validator_config,
-                    Err(error) => {
-                        bail!(error);
-                    }
-                };
+                // Create validator config, including any overridden or normalized values.
+                let validator_config = config_from_toml_table(config_table)?;
+
+                trace!("{}", config::to_string(&validator_config)?);
 
                 let mut runner =
                     Runner::<initializer::Reactor>::new(validator_config, &mut rng).await?;

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -6,5 +6,5 @@ use std::path::PathBuf;
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// Path to secret key file.
-    pub secret_key_path: Option<PathBuf>,
+    pub secret_key_path: PathBuf,
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -88,13 +88,8 @@ where
         config: Config,
         effect_builder: EffectBuilder<REv>,
     ) -> Result<(Self, Effects<Event<I>>), Error> {
-        let secret_key_path = config.secret_key_path.ok_or_else(|| {
-            anyhow::Error::msg("invalid consensus config; secret_key_path is required")
-        })?;
-
-        let secret_signing_key = SecretKey::from_file(&secret_key_path)
-            .map_err(anyhow::Error::new)?
-            .ok_or_else(|| anyhow::Error::msg("invalid signing key"))?;
+        let secret_signing_key =
+            SecretKey::from_file(&config.secret_key_path).map_err(anyhow::Error::new)?;
 
         let public_key: PublicKey = From::from(&secret_signing_key);
         let params = HighwayParams {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -143,7 +143,7 @@ where
         let server_span = tracing::info_span!("server");
 
         // First, we load or generate the TLS keys.
-        let (cert, secret_key) = match (&cfg.cert, &cfg.secret_key) {
+        let (cert, secret_key) = match (&cfg.cert_path, &cfg.secret_key_path) {
             // We're given a cert_file and a secret_key file. Just load them, additional checking
             // will be performed once we create the acceptor and connector.
             (Some(cert_file), Some(secret_key_file)) => (

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -21,10 +21,10 @@ pub struct Config {
     pub root_addr: SocketAddr,
 
     /// Path to certificate file.
-    pub cert: Option<PathBuf>,
+    pub cert_path: Option<PathBuf>,
 
     /// Path to secret key for certificate.
-    pub secret_key: Option<PathBuf>,
+    pub secret_key_path: Option<PathBuf>,
 
     /// Maximum number of retries before removing an outgoing node. Unlimited if `None`.
     pub max_outgoing_retries: Option<u32>,
@@ -40,8 +40,8 @@ impl Config {
             bind_interface: Ipv4Addr::LOCALHOST.into(),
             bind_port: 0,
             root_addr: (Ipv4Addr::LOCALHOST, port).into(),
-            cert: None,
-            secret_key: None,
+            cert_path: None,
+            secret_key_path: None,
             max_outgoing_retries: Some(360),
             outgoing_retry_delay_millis: 10_000,
         }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -172,8 +172,8 @@ fn gen_config(bind_port: u16) -> small_network::Config {
         max_outgoing_retries: Some(100),
         outgoing_retry_delay_millis: 100,
         // Auto-generate cert and key.
-        cert: None,
-        secret_key: None,
+        cert_path: None,
+        secret_key_path: None,
     }
 }
 
@@ -249,8 +249,8 @@ async fn bind_to_real_network_interface() {
         root_addr: (local_addr, port).into(),
         max_outgoing_retries: Some(360),
         outgoing_retry_delay_millis: 10000,
-        cert: None,
-        secret_key: None,
+        cert_path: None,
+        secret_key_path: None,
     };
 
     let mut net = Network::<TestReactor>::new();

--- a/node/src/components/storage/config.rs
+++ b/node/src/components/storage/config.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
@@ -73,14 +73,7 @@ impl Config {
 
     pub(crate) fn path(&self) -> PathBuf {
         match self.path {
-            Some(ref path) => {
-                // Replace env vars in the provided path.
-                let mut path_str = path.display().to_string();
-                for (env_var_name, env_var_value) in env::vars() {
-                    path_str = path_str.replace(&format!("${}", env_var_name), &env_var_value);
-                }
-                PathBuf::from(path_str)
-            }
+            Some(ref path) => path.clone(),
             None => Self::default_path(),
         }
     }

--- a/node/src/crypto/error.rs
+++ b/node/src/crypto/error.rs
@@ -18,9 +18,14 @@ pub enum Error {
     /// Error resulting when decoding a type from a hex-encoded representation.
     #[error("parsing from hex: {0}")]
     FromHex(#[from] FromHexError),
-    /// Error reading from file.
-    #[error("error reading from file")]
-    FromFile,
+    /// Error while trying to read in a file.
+    #[error("error reading {file}: {error_msg}")]
+    ReadFile {
+        /// The file attempted to be read.
+        file: String,
+        /// The underlying error message.
+        error_msg: String,
+    },
     /// Error resulting when decoding a type from a base64 representation.
     #[error("decoding error: {0}")]
     FromBase64(#[from] DecodeError),

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -1,9 +1,6 @@
 //! Reactor used to initialize a node.
 
-use std::{
-    fmt::{self, Display, Formatter},
-    path::PathBuf,
-};
+use std::fmt::{self, Display, Formatter};
 
 use derive_more::From;
 use prometheus::Registry;
@@ -119,14 +116,8 @@ impl reactor::Reactor for Reactor {
 
         let storage = Storage::new(&config.storage)?;
         let contract_runtime = ContractRuntime::new(&config.storage, config.contract_runtime)?;
-        let chainspec_config_path: PathBuf = {
-            let ret = &config.node.chainspec_config_path;
-            ret.clone().ok_or_else(|| {
-                Error::ConfigError(String::from("missing chainspec_config_path value"))
-            })?
-        };
         let (chainspec_handler, chainspec_effects) =
-            ChainspecHandler::new(chainspec_config_path, effect_builder)?;
+            ChainspecHandler::new(config.node.chainspec_config_path.clone(), effect_builder)?;
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -1,9 +1,19 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+const DEFAULT_CHAINSPEC_CONFIG_PATH: &str = "chainspec.toml";
+
 /// Node configuration.
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct NodeConfig {
-    /// Path to chainspec file.
-    pub chainspec_config_path: Option<PathBuf>,
+    /// Path to chainspec config file.
+    pub chainspec_config_path: PathBuf,
+}
+
+impl Default for NodeConfig {
+    fn default() -> Self {
+        NodeConfig {
+            chainspec_config_path: PathBuf::from(DEFAULT_CHAINSPEC_CONFIG_PATH),
+        }
+    }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -1,16 +1,21 @@
-# ========================================================
-# Configuration options for a node.
-# ========================================================
+# ================================
+# Configuration options for a node
+# ================================
 [node]
+
+# Path (absolute, or relative to this config.toml) to the chainspec configuration file.
 chainspec_config_path = 'chainspec.toml'
+
 
 # ====================================
 # Configuration options for consensus
 # ====================================
 [consensus]
-# relative path to validator's secret key file used to sign consensus messages
-# (can be passed via cli)
-secret_key_path= ''
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
 
 # ====================================
 # Configuration options for networking
@@ -30,10 +35,10 @@ bind_port = 0
 root_addr = '127.0.0.1:34553'
 
 # Optional path to certificate file.
-#cert = 'path/to/certificate'
+#cert_path = 'path/to/certificate'
 
 # Optional path to secret key for certificate.
-#secret_key = 'path/to/secret/key'
+#secret_key_path = 'path/to/secret/key'
 
 # Maximum number of retries before removing an outgoing node.  Unlimited if unset.
 max_outgoing_retries = 360
@@ -59,7 +64,8 @@ bind_port = 0
 # ===============================================
 [storage]
 
-# Optional path to the folder where any files created or read by the storage component will exist.
+# Optional path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist.
 #
 # If the folder doesn't exist, it and any required parents will be created.
 #


### PR DESCRIPTION
This addresses the review comments from #95 which was merged early in order to unblock progress.

Additional changes beyond the review comments include:
* the chainspec path and consensus secret key path are no longer optional in the config, since the node requires these to function
* env vars included in paths in the config file are now handled correctly
* config_ext values which are ignored now generate error messages