### PR TITLE
Return the timestamp together with a finalized value.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -36,7 +36,8 @@ pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT> {
     /// Request deploys for a new block, whose timestamp will be the given `u64`.
     /// TODO: Add more details that are necessary for block creation.
     CreateNewBlock(BlockContext),
-    FinalizedBlock(C),
+    /// A block was finalized. The timestamp is from when the block was proposed.
+    FinalizedBlock(C, Timestamp),
     /// Request validation of the consensus value, contained in a message received from the given
     /// node.
     ///

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -156,7 +156,8 @@ where
                     proto_block,
                     block_context,
                 }),
-            ConsensusProtocolResult::FinalizedBlock(block) => {
+            ConsensusProtocolResult::FinalizedBlock(block, _timestamp) => {
+                // TODO: Create a `FinalizedBlock` with timestamp here.
                 let mut effects =
                     effect_builder
                         .execute_block(block.clone())

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -337,7 +337,11 @@ mod tests {
 
         // Payment finalized! "One Pumpkin Spice Mochaccino for Corbyn!"
         assert_eq!(
-            FinalityOutcome::Finalized(0xC0FFEE, Vec::new()),
+            FinalityOutcome::Finalized {
+                value: 0xC0FFEE,
+                new_equivocators: Vec::new(),
+                timestamp: 416.into(),
+            },
             fd.run(&state)
         );
         Ok(())

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -307,12 +307,16 @@ where
         recipient.push_messages_produced(messages.clone());
 
         let finality_result = match recipient.consensus.run_finality() {
-            FinalityOutcome::Finalized(v, equivocated_ids) => {
-                if !equivocated_ids.is_empty() {
+            FinalityOutcome::Finalized {
+                value,
+                new_equivocators,
+                timestamp,
+            } => {
+                if !new_equivocators.is_empty() {
                     // https://casperlabs.atlassian.net/browse/HWY-120
                     unimplemented!("Equivocations detected but not handled.")
                 }
-                vec![v]
+                vec![value]
             }
             FinalityOutcome::None => vec![],
             // https://casperlabs.atlassian.net/browse/HWY-119

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -124,12 +124,16 @@ impl<I: NodeIdT, C: Context> HighwayProtocol<I, C> {
         match self.finality_detector.run(self.highway.state()) {
             FinalityOutcome::None => (),
             FinalityOutcome::FttExceeded => panic!("Too many faulty validators"),
-            FinalityOutcome::Finalized(block, equivocators) => {
-                if !equivocators.is_empty() {
+            FinalityOutcome::Finalized {
+                value: block,
+                new_equivocators,
+                timestamp,
+            } => {
+                if !new_equivocators.is_empty() {
                     // TODO: Add this information to the proto block for slashing.
-                    info!(?equivocators, "Observed new faulty validators");
+                    info!(?new_equivocators, "Observed new faulty validators");
                 }
-                results.push(ConsensusProtocolResult::FinalizedBlock(block));
+                results.push(ConsensusProtocolResult::FinalizedBlock(block, timestamp));
             }
         }
         results


### PR DESCRIPTION
Highway Core needs to return this together with a finalized consensus value, because the block executor needs to know the timestamp.

https://casperlabs.atlassian.net/browse/NDRS-175