### PR TITLE
Add slashing instructions to finalized blocks.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -28,7 +28,7 @@ impl BlockContext {
 }
 
 #[derive(Debug)]
-pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT> {
+pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT, VID> {
     CreatedGossipMessage(Vec<u8>),
     CreatedTargetedMessage(Vec<u8>, I),
     InvalidIncomingMessage(Vec<u8>, I, Error),
@@ -37,7 +37,11 @@ pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT> {
     /// TODO: Add more details that are necessary for block creation.
     CreateNewBlock(BlockContext),
     /// A block was finalized. The timestamp is from when the block was proposed.
-    FinalizedBlock(C, Timestamp),
+    FinalizedBlock {
+        value: C,
+        new_equivocators: Vec<VID>,
+        timestamp: Timestamp,
+    },
     /// Request validation of the consensus value, contained in a message received from the given
     /// node.
     ///
@@ -48,26 +52,26 @@ pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT> {
 }
 
 /// An API for a single instance of the consensus.
-pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT> {
+pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT, VID> {
     /// Handles an incoming message (like NewVote, RequestDependency).
     fn handle_message(
         &mut self,
         sender: I,
         msg: Vec<u8>,
-    ) -> Result<Vec<ConsensusProtocolResult<I, C>>, Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<I, C, VID>>, Error>;
 
     /// Triggers consensus' timer.
     fn handle_timer(
         &mut self,
         timerstamp: Timestamp,
-    ) -> Result<Vec<ConsensusProtocolResult<I, C>>, Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<I, C, VID>>, Error>;
 
     /// Proposes a new value for consensus.
     fn propose(
         &mut self,
         value: C,
         block_context: BlockContext,
-    ) -> Result<Vec<ConsensusProtocolResult<I, C>>, Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<I, C, VID>>, Error>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
     /// `ConsensusProtocolResult::ValidateConsensusvalue`.
@@ -75,7 +79,7 @@ pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT> {
         &mut self,
         value: &C,
         valid: bool,
-    ) -> Result<Vec<ConsensusProtocolResult<I, C>>, Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<I, C, VID>>, Error>;
 }
 
 #[cfg(test)]
@@ -116,35 +120,22 @@ mod example {
     #[derive(Debug)]
     struct Error;
 
-    impl<I, P: ProtocolState> ConsensusProtocol<I, ProtoBlock> for DagSynchronizerState<I, P> {
-        fn handle_message(
-            &mut self,
-            _sender: I,
-            _msg: Vec<u8>,
-        ) -> Result<Vec<ConsensusProtocolResult<I, ProtoBlock>>, anyhow::Error> {
+    type CpResult<I> = Result<Vec<ConsensusProtocolResult<I, ProtoBlock, VIdU64>>, anyhow::Error>;
+
+    impl<I, P: ProtocolState> ConsensusProtocol<I, ProtoBlock, VIdU64> for DagSynchronizerState<I, P> {
+        fn handle_message(&mut self, _sender: I, _msg: Vec<u8>) -> CpResult<I> {
             unimplemented!()
         }
 
-        fn handle_timer(
-            &mut self,
-            _timestamp: Timestamp,
-        ) -> Result<Vec<ConsensusProtocolResult<I, ProtoBlock>>, anyhow::Error> {
+        fn handle_timer(&mut self, _timestamp: Timestamp) -> CpResult<I> {
             unimplemented!()
         }
 
-        fn resolve_validity(
-            &mut self,
-            _value: &ProtoBlock,
-            _valid: bool,
-        ) -> Result<Vec<ConsensusProtocolResult<I, ProtoBlock>>, anyhow::Error> {
+        fn resolve_validity(&mut self, _value: &ProtoBlock, _valid: bool) -> CpResult<I> {
             unimplemented!()
         }
 
-        fn propose(
-            &mut self,
-            _value: ProtoBlock,
-            _block_context: BlockContext,
-        ) -> Result<Vec<ConsensusProtocolResult<I, ProtoBlock>>, anyhow::Error> {
+        fn propose(&mut self, _value: ProtoBlock, _block_context: BlockContext) -> CpResult<I> {
             unimplemented!()
         }
     }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -327,7 +327,7 @@ mod tests {
         state.add_vote(effects.next().unwrap().unwrap_vote())?;
         assert_eq!(None, effects.next());
 
-        assert_eq!(FinalityOutcome::None, fd.run(&state)); // Alice has not witnessed Bob's vote yet.
+        assert_eq!(FinalityOutcome::None, fd.run_on_state(&state)); // Alice has not witnessed Bob's vote yet.
 
         // Alice also sends her own witness message, completing the summit for her proposal.
         let mut effects = alice_av.handle_timer(426.into(), &state).into_iter();
@@ -342,7 +342,7 @@ mod tests {
                 new_equivocators: Vec::new(),
                 timestamp: 416.into(),
             },
-            fd.run(&state)
+            fd.run_on_state(&state)
         );
         Ok(())
     }

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -228,7 +228,11 @@ impl<C: Context> Highway<C> {
         }
     }
 
-    pub(crate) fn state(&self) -> &State<C> {
+    pub(crate) fn params(&self) -> &HighwayParams<C> {
+        &self.params
+    }
+
+    pub(super) fn state(&self) -> &State<C> {
         &self.state
     }
 
@@ -282,7 +286,7 @@ impl<C: Context> Highway<C> {
     fn validator_pk(&self, swvote: &SignedWireVote<C>) -> &C::ValidatorId {
         self.params
             .validators
-            .get_by_id(swvote.wire_vote.creator)
+            .get_by_index(swvote.wire_vote.creator)
             .id()
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -28,8 +28,8 @@ struct HighwayConsensus<C: Context> {
 }
 
 impl<C: Context> HighwayConsensus<C> {
-    fn run_finality(&mut self) -> FinalityOutcome<C::ConsensusValue, ValidatorIndex> {
-        self.finality_detector.run(self.highway.state())
+    fn run_finality(&mut self) -> FinalityOutcome<C::ConsensusValue, C::ValidatorId> {
+        self.finality_detector.run(&self.highway)
     }
 
     pub(crate) fn highway(&self) -> &Highway<C> {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -427,7 +427,7 @@ impl<C: Context> State<C> {
 
     /// Returns a vector of validator indexes that equivocated between block
     /// identified by `fhash` and its parent.
-    pub(crate) fn get_new_equivocators(&self, fhash: &C::Hash) -> Vec<ValidatorIndex> {
+    pub(super) fn get_new_equivocators(&self, fhash: &C::Hash) -> Vec<ValidatorIndex> {
         let cvote = self.vote(fhash);
         let mut equivocators: Vec<ValidatorIndex> = Vec::new();
         let fblock = self.block(fhash);

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -62,7 +62,7 @@ impl<VID: Eq + Hash> Validators<VID> {
 
     /// Returns validator at index.
     /// Expects that idx has been validated before calling this function.
-    pub(crate) fn get_by_id(&self, idx: ValidatorIndex) -> &Validator<VID> {
+    pub(crate) fn get_by_index(&self, idx: ValidatorIndex) -> &Validator<VID> {
         &self.validators.get(idx.0 as usize).unwrap()
     }
 

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -6,7 +6,9 @@ mod motes;
 mod node_config;
 mod timestamp;
 
-pub use block::{Block, BlockHash, BlockHeader, ExecutedBlock, FinalizedBlock, ProtoBlock};
+pub use block::{
+    Block, BlockHash, BlockHeader, ExecutedBlock, FinalizedBlock, Instruction, ProtoBlock,
+};
 pub use deploy::{DecodingError, Deploy, DeployHash, DeployHeader, EncodingError};
 pub use motes::Motes;
 pub use node_config::NodeConfig;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -43,30 +43,59 @@ impl ProtoBlock {
     }
 }
 
-/// The piece of information that will become the content of a future block after it was finalized and before execution happened yet.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct FinalizedBlock {
-    pub(crate) proto_block: ProtoBlock,
-    pub(crate) timestamp: Timestamp,
+/// Prints a number of picoseconds, rounding to s, ms, µs or ns if appropriate.
+fn fmt_picoseconds(ps: u64) -> String {
+    if ps < 10_000 {
+        format!("{} ps", ps)
+    } else if ps < 10_000_000 {
+        format!("{} ns", ps / 1_000)
+    } else if ps < 10_000_000_000 {
+        format!("{} µs", ps / 1_000_000)
+    } else if ps < 10_000_000_000_000 {
+        format!("{} ms", ps / 1_000_000_000)
+    } else {
+        format!("{} s", ps / 1_000_000_000_000)
+    }
 }
 
-impl FinalizedBlock {
-    pub(crate) fn new(proto_block: ProtoBlock, timestamp: Timestamp) -> Self {
-        Self {
-            proto_block,
-            timestamp,
-        }
-    }
+/// System transactions like slashing and rewards.
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+pub enum Instruction {
+    /// A validator has equivocated and should be slashed.
+    #[display(fmt = "slash {}", "_0")]
+    Slash(PublicKey),
+    /// Block reward information has been computed for a validator, in picoseconds' worth of total
+    /// seigniorage. This includes the delegator reward.
+    #[display(fmt = "reward {}: {}", "_0, fmt_picoseconds(*_1)")]
+    Reward(PublicKey, u64),
+}
+
+/// The piece of information that will become the content of a future block after it was finalized
+/// and before execution happened yet.
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FinalizedBlock {
+    /// The finalized proto block.
+    pub(crate) proto_block: ProtoBlock,
+    /// The timestamp from when the proto block was proposed.
+    pub(crate) timestamp: Timestamp,
+    /// Instructions for system transactions like slashing and rewards.
+    pub(crate) instructions: Vec<Instruction>,
 }
 
 impl Display for FinalizedBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let instructions: Vec<_> = self
+            .instructions
+            .iter()
+            .map(Instruction::to_string)
+            .collect();
         write!(
             f,
-            "finalized block deploys {:<8x}, random bit {}, timestamp {}",
+            "finalized block deploys {:<8x}, random bit {}, timestamp {}, instructions: [{}]",
             HexList(&self.proto_block.deploys),
             self.proto_block.random_bit,
             self.timestamp,
+            instructions.join(", ")
         )
     }
 }


### PR DESCRIPTION
This adds an `Instruction` type, and a field to `FinalizedBlock`, where the consensus protocol can communicate slashing and reward instructions.

Rewards are not being computed yet, but slashing is.

This PR contains only the consensus component side, i.e. creation of the instructions. Handling them will need to be implemented in the `BlockExecutor`.

https://casperlabs.atlassian.net/browse/NDRS-22