### PR TITLE
HWY-85: Add a test seed that is used for generating test case.

### DIFF
--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -719,7 +719,8 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                 let honest_weights = {
                     let faulty_sum = faulty_weights.iter().sum::<u64>();
                     let mut weights_to_distribute: u64 =
-                        faulty_sum * 100 / self.faulty_percent - faulty_sum;
+                        (faulty_sum * 100 + self.faulty_percent - 1) / self.faulty_percent
+                            - faulty_sum;
                     let mut weights = vec![];
                     while weights_to_distribute > 0 {
                         let weight = if weights_to_distribute < upper {
@@ -924,7 +925,7 @@ mod test_harness {
         let mut rng = TestRng::new();
         let mut highway_test_harness: HighwayTestHarness<InstantDeliveryNoDropping> =
             HighwayTestHarnessBuilder::new()
-                .max_faulty_validators(3)
+                .max_faulty_validators(5)
                 .consensus_values_count(5)
                 .weight_limits(5, 10)
                 .faulty_weight_perc(20)


### PR DESCRIPTION
During work on this I had pulled in HWY-117 (generate faulty validators by weight rather than count) which forced me to refactor the `HighwayTestHarness` a bit – I've removed the generic type boundary `C: Context` from it and fixed it for `TestContext`. This unlocked more possibilities like – randomly generating a number of validators inside the builder, generating consensus values vector (rather than accepting it during construction).

https://casperlabs.atlassian.net/browse/HWY-117
https://casperlabs.atlassian.net/browse/HWY-85