### PR TITLE
NO-TICK: fix accounts_path in chainspec for local

### DIFF
--- a/resources/local/chainspec.toml
+++ b/resources/local/chainspec.toml
@@ -18,7 +18,7 @@ pos_installer_path = '../../target/wasm32-unknown-unknown/release/pos_install.wa
 # Payment system contract.
 standard_payment_installer_path = '../../target/wasm32-unknown-unknown/release/standard_payment_install.wasm'
 # Path (absolute, or relative to this chainspec.toml) to the CSV file containing initial account balances and bonds.
-accounts_path = '../production/accounts.csv'
+accounts_path = 'accounts.csv'
 
 [highway]
 # Tick unit is milliseconds.


### PR DESCRIPTION
`resource/local/chainspec.toml` should point to the `accounts.csv` under same path