### PR TITLE
NO-TICKET: Set correct name for pos.wasm contract.

### DIFF
--- a/smart_contracts/contracts/system/pos/Cargo.toml
+++ b/smart_contracts/contracts/system/pos/Cargo.toml
@@ -4,6 +4,18 @@ version = "0.1.0"
 authors = ["Andreas Fackler <andreas@casperlabs.io>"]
 edition = "2018"
 
+[lib]
+bench = false
+doctest = false
+test = false
+
+[[bin]]
+name = "pos"
+path = "src/bin/main.rs"
+bench = false
+doctest = false
+test = false
+
 [features]
 std = ["casperlabs-contract/std", "casperlabs-types/std"]
 enable-bonding = []


### PR DESCRIPTION
This contract was built as `main.wasm` which is unexpected name. This regression happened around https://github.com/CasperLabs/CasperLabs/commit/3a9a7bbade6e9cb727c1a5ad600418747941600d#diff-997eca37f0ea61a2216ab90c1eeaf7a6