### PR TITLE
Add minimum era height to chainspec.

### DIFF
--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -172,10 +172,17 @@ impl DeployConfig {
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub(crate) struct HighwayConfig {
+    // TODO: Most of these are not Highway-specific.
+    // TODO: Some should be defined on-chain in a contract instead, or be part of `UpgradePoint`.
     pub(crate) genesis_era_start_timestamp: Timestamp,
+    // TODO: Use `TimeDiff` instead of `Duration`.
     pub(crate) era_duration: Duration,
+    pub(crate) minimum_era_height: u64,
+    // TODO: This is duplicated (and probably in conflict with) `AUCTION_DELAY`.
     pub(crate) booking_duration: Duration,
     pub(crate) entropy_duration: Duration,
+    // TODO: Do we need this? When we see the switch block finalized it should suffice to keep
+    // gossiping, without producing new votes. Everyone else will eventually see the same finality.
     pub(crate) voting_period_duration: Duration,
     pub(crate) finality_threshold_percent: u8,
     pub(crate) minimum_round_exponent: u8,
@@ -186,8 +193,9 @@ impl Default for HighwayConfig {
         HighwayConfig {
             genesis_era_start_timestamp: Timestamp::zero() + TimeDiff::from(1_583_712_000_000),
             era_duration: Duration::from_millis(604_800_000), // 1 week
+            minimum_era_height: 100,
             booking_duration: Duration::from_millis(864_000_000), // 10 days
-            entropy_duration: Duration::from_millis(10_800_000), // 3 hours
+            entropy_duration: Duration::from_millis(10_800_000),  // 3 hours
             voting_period_duration: Duration::from_millis(172_800_000), // 2 days
             finality_threshold_percent: 10,
             minimum_round_exponent: 14, // 2**14 ms = ~16 seconds
@@ -199,22 +207,15 @@ impl Default for HighwayConfig {
 impl HighwayConfig {
     /// Generates a random instance using a `TestRng`.
     pub fn random(rng: &mut TestRng) -> Self {
-        let genesis_era_start_timestamp = Timestamp::random(rng);
-        let era_duration = Duration::from_millis(rng.gen_range(600_000, 604_800_000));
-        let booking_duration = Duration::from_millis(rng.gen_range(600_000, 864_000_000));
-        let entropy_duration = Duration::from_millis(rng.gen_range(600_000, 10_800_000));
-        let voting_period_duration = Duration::from_millis(rng.gen_range(600_000, 172_800_000));
-        let finality_threshold_percent = rng.gen_range(0, 101);
-        let minimum_round_exponent = rng.gen_range(0, 20);
-
         HighwayConfig {
-            genesis_era_start_timestamp,
-            era_duration,
-            booking_duration,
-            entropy_duration,
-            voting_period_duration,
-            finality_threshold_percent,
-            minimum_round_exponent,
+            genesis_era_start_timestamp: Timestamp::random(rng),
+            era_duration: Duration::from_millis(rng.gen_range(600_000, 604_800_000)),
+            minimum_era_height: 10,
+            booking_duration: Duration::from_millis(rng.gen_range(600_000, 864_000_000)),
+            entropy_duration: Duration::from_millis(rng.gen_range(600_000, 10_800_000)),
+            voting_period_duration: Duration::from_millis(rng.gen_range(600_000, 172_800_000)),
+            finality_threshold_percent: rng.gen_range(0, 101),
+            minimum_round_exponent: rng.gen_range(0, 20),
         }
     }
 }
@@ -426,6 +427,7 @@ mod tests {
             spec.genesis.highway_config.era_duration,
             Duration::from_millis(3)
         );
+        assert_eq!(spec.genesis.highway_config.minimum_era_height, 9);
         assert_eq!(
             spec.genesis.highway_config.booking_duration,
             Duration::from_millis(4)

--- a/node/src/components/chainspec_loader/config.rs
+++ b/node/src/components/chainspec_loader/config.rs
@@ -105,6 +105,7 @@ impl Default for Genesis {
 struct HighwayConfig {
     genesis_era_start_timestamp: Timestamp,
     era_duration_millis: u64,
+    minimum_era_height: u64,
     booking_duration_millis: u64,
     entropy_duration_millis: u64,
     voting_period_duration_millis: u64,
@@ -123,6 +124,7 @@ impl From<chainspec::HighwayConfig> for HighwayConfig {
         HighwayConfig {
             genesis_era_start_timestamp: cfg.genesis_era_start_timestamp,
             era_duration_millis: cfg.era_duration.as_millis() as u64,
+            minimum_era_height: cfg.minimum_era_height,
             booking_duration_millis: cfg.booking_duration.as_millis() as u64,
             entropy_duration_millis: cfg.entropy_duration.as_millis() as u64,
             voting_period_duration_millis: cfg.voting_period_duration.as_millis() as u64,
@@ -213,6 +215,7 @@ impl From<&chainspec::Chainspec> for ChainspecConfig {
                 .highway_config
                 .genesis_era_start_timestamp,
             era_duration_millis: chainspec.genesis.highway_config.era_duration.as_millis() as u64,
+            minimum_era_height: chainspec.genesis.highway_config.minimum_era_height,
             booking_duration_millis: chainspec
                 .genesis
                 .highway_config
@@ -291,6 +294,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<chainspec:
     let highway_config = chainspec::HighwayConfig {
         genesis_era_start_timestamp: chainspec.highway.genesis_era_start_timestamp,
         era_duration: Duration::from_millis(chainspec.highway.era_duration_millis),
+        minimum_era_height: chainspec.highway.minimum_era_height,
         booking_duration: Duration::from_millis(chainspec.highway.booking_duration_millis),
         entropy_duration: Duration::from_millis(chainspec.highway.entropy_duration_millis),
         voting_period_duration: Duration::from_millis(

--- a/resources/local/chainspec.toml
+++ b/resources/local/chainspec.toml
@@ -28,8 +28,10 @@ accounts_path = 'accounts.csv'
 # produce blocks in it, and there won't be a new era build either.  That means when a completely new network is started,
 # the genesis era start time has to be adjusted to be active at the time.
 genesis_era_start_timestamp = 1583712000000
-# Era duration defined as a fixed number of milliseconds.  604800000 ms = 1 week.
-era_duration_millis = 604800000
+# Era duration defined as a fixed number of milliseconds.  30000 ms = 30 seconds.
+era_duration_millis = 30000
+# Minimum number of blocks per era.  An era will take longer than `era_duration_millis` ms if that is necessary to reach the minimum height.
+minimum_era_height = 10
 # Amount of time in milliseconds to go back before the start of the era for picking the booking block.
 # 864000000 ms = 10 days.
 booking_duration_millis = 864000000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -30,6 +30,8 @@ accounts_path = 'accounts.csv'
 genesis_era_start_timestamp = 1583712000000
 # Era duration defined as a fixed number of milliseconds.  604800000 ms = 1 week.
 era_duration_millis = 604800000
+# Minimum number of blocks per era.  An era will take longer than `era_duration_millis` ms if that is necessary to reach the minimum height.
+minimum_era_height = 100
 # Amount of time in milliseconds to go back before the start of the era for picking the booking block.
 # 864000000 ms = 10 days.
 booking_duration_millis = 864000000

--- a/resources/test/valid/chainspec.toml
+++ b/resources/test/valid/chainspec.toml
@@ -10,6 +10,7 @@ accounts_path = 'accounts.csv'
 [highway]
 genesis_era_start_timestamp = 2
 era_duration_millis = 3
+minimum_era_height = 9
 booking_duration_millis = 4
 entropy_duration_millis = 5
 voting_period_duration_millis = 6


### PR DESCRIPTION
This will allow specifying the duration of an era in terms of the number of blocks, instead of wall-clock time.

https://casperlabs.atlassian.net/browse/NDRS-223