### PR TITLE
NO-TICK: Use block height when resolving pre-state hash.

### DIFF
--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -12,7 +12,6 @@ use tracing::{debug, error, trace};
 
 use casperlabs_types::ProtocolVersion;
 
-use super::consensus::EraId;
 use crate::{
     components::{
         contract_runtime::{

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -89,6 +89,7 @@ impl ProtoBlock {
         &self.hash
     }
 
+    #[allow(unused)]
     pub(crate) fn parent_hash(&self) -> &ProtoBlockHash {
         &self.parent_hash
     }


### PR DESCRIPTION
This PR changes how the pre-state hash for the finalized block is calculated. Instead of fetching it by protoblock's hash we fetch it based on the finalized block height. 