### PR TITLE
NO-TICKET: {Storage,System}Provider: remove Error

### DIFF
--- a/node/src/components/contract_runtime/core/runtime/auction_internal.rs
+++ b/node/src/components/contract_runtime/core/runtime/auction_internal.rs
@@ -15,13 +15,11 @@ where
     R: StateReader<Key, StoredValue>,
     R::Error: Into<execution::Error>,
 {
-    type Error = Error;
-
     fn get_key(&mut self, name: &str) -> Option<Key> {
         self.context.named_keys_get(name).cloned()
     }
 
-    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Self::Error> {
+    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Error> {
         match self.context.read_gs(&uref.into()) {
             Ok(Some(StoredValue::CLValue(cl_value))) => {
                 Ok(Some(cl_value.into_t().map_err(|_| Error::Storage)?))
@@ -33,7 +31,7 @@ where
         }
     }
 
-    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Self::Error> {
+    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Error> {
         let cl_value = CLValue::from_t(value).unwrap();
         self.context
             .write_gs(uref.into(), StoredValue::CLValue(cl_value))
@@ -46,13 +44,11 @@ where
     R: StateReader<Key, StoredValue>,
     R::Error: Into<execution::Error>,
 {
-    type Error = Error;
-
     fn create_purse(&mut self) -> URef {
         Runtime::create_purse(self).unwrap()
     }
 
-    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Self::Error> {
+    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
         Runtime::get_balance(self, purse).map_err(|_| Error::GetBalance)
     }
 
@@ -61,7 +57,7 @@ where
         source: URef,
         target: URef,
         amount: U512,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mint_contract_hash = self.get_mint_contract();
         self.mint_transfer(mint_contract_hash, source, target, amount)
             .map_err(|_| Error::Transfer)

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -29,30 +29,26 @@ use casper_types::{
 struct AuctionContract;
 
 impl StorageProvider for AuctionContract {
-    type Error = Error;
-
     fn get_key(&mut self, name: &str) -> Option<Key> {
         runtime::get_key(name)
     }
 
-    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Self::Error> {
+    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Error> {
         Ok(storage::read(uref)?)
     }
 
-    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Self::Error> {
+    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Error> {
         storage::write(uref, value);
         Ok(())
     }
 }
 
 impl SystemProvider for AuctionContract {
-    type Error = Error;
-
     fn create_purse(&mut self) -> URef {
         system::create_purse()
     }
 
-    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Self::Error> {
+    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
         Ok(system::get_balance(purse))
     }
 
@@ -61,7 +57,7 @@ impl SystemProvider for AuctionContract {
         source: URef,
         target: URef,
         amount: U512,
-    ) -> StdResult<(), Self::Error> {
+    ) -> StdResult<(), Error> {
         system::transfer_from_purse_to_purse(source, target, amount).map_err(|_| Error::Transfer)
     }
 }

--- a/types/src/auction/auction_provider.rs
+++ b/types/src/auction/auction_provider.rs
@@ -31,10 +31,7 @@ pub const DEFAULT_UNBONDING_DELAY: u64 = 14;
 const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
 /// Bonding auctions contract implementation.
-pub trait AuctionProvider: StorageProvider + SystemProvider + RuntimeProvider
-where
-    Error: From<<Self as StorageProvider>::Error> + From<<Self as SystemProvider>::Error>,
-{
+pub trait AuctionProvider: StorageProvider + SystemProvider + RuntimeProvider {
     /// Returns era_validators.
     ///
     /// Publicly accessible, but intended for periodic use by the PoS contract to update its own

--- a/types/src/auction/internal.rs
+++ b/types/src/auction/internal.rs
@@ -14,7 +14,6 @@ fn read_from<P, T>(provider: &mut P, name: &str) -> Result<T>
 where
     P: StorageProvider + ?Sized,
     T: FromBytes + CLTyped,
-    Error: From<P::Error>,
 {
     let key = provider.get_key(name).ok_or(Error::MissingKey)?;
     let uref = key.into_uref().ok_or(Error::InvalidKeyVariant)?;
@@ -26,7 +25,6 @@ fn write_to<P, T>(provider: &mut P, name: &str, value: T) -> Result<()>
 where
     P: StorageProvider + ?Sized,
     T: ToBytes + CLTyped,
-    Error: From<P::Error>,
 {
     let key = provider.get_key(name).ok_or(Error::MissingKey)?;
     let uref = key.into_uref().ok_or(Error::InvalidKeyVariant)?;
@@ -34,83 +32,53 @@ where
     Ok(())
 }
 
-pub fn get_bids<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<Bids>
-where
-    Error: From<P::Error>,
-{
+pub fn get_bids<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<Bids> {
     Ok(read_from(provider, BIDS_KEY)?)
 }
 
-pub fn set_bids<P: StorageProvider + ?Sized>(provider: &mut P, validators: Bids) -> Result<()>
-where
-    Error: From<P::Error>,
-{
+pub fn set_bids<P: StorageProvider + ?Sized>(provider: &mut P, validators: Bids) -> Result<()> {
     write_to(provider, BIDS_KEY, validators)
 }
 
-pub fn get_delegators<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<Delegators>
-where
-    Error: From<P::Error>,
-{
+pub fn get_delegators<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<Delegators> {
     read_from(provider, DELEGATORS_KEY)
 }
 
 pub fn set_delegators<P: StorageProvider + ?Sized>(
     provider: &mut P,
     delegators: Delegators,
-) -> Result<()>
-where
-    Error: From<P::Error>,
-{
+) -> Result<()> {
     write_to(provider, DELEGATORS_KEY, delegators)
 }
 
-pub fn get_era_validators<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<EraValidators>
-where
-    Error: From<P::Error>,
-{
+pub fn get_era_validators<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<EraValidators> {
     Ok(read_from(provider, ERA_VALIDATORS_KEY)?)
 }
 
 pub fn set_era_validators<P: StorageProvider + ?Sized>(
     provider: &mut P,
     era_validators: EraValidators,
-) -> Result<()>
-where
-    Error: From<P::Error>,
-{
+) -> Result<()> {
     write_to(provider, ERA_VALIDATORS_KEY, era_validators)
 }
 
-pub fn get_era_id<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<EraId>
-where
-    Error: From<P::Error>,
-{
+pub fn get_era_id<P: StorageProvider + ?Sized>(provider: &mut P) -> Result<EraId> {
     Ok(read_from(provider, ERA_ID_KEY)?)
 }
 
-pub fn set_era_id<P: StorageProvider + ?Sized>(provider: &mut P, era_id: u64) -> Result<()>
-where
-    Error: From<P::Error>,
-{
+pub fn set_era_id<P: StorageProvider + ?Sized>(provider: &mut P, era_id: u64) -> Result<()> {
     write_to(provider, ERA_ID_KEY, era_id)
 }
 
 pub fn get_seigniorage_recipients_snapshot<P: StorageProvider + ?Sized>(
     provider: &mut P,
-) -> Result<SeigniorageRecipientsSnapshot>
-where
-    Error: From<P::Error>,
-{
+) -> Result<SeigniorageRecipientsSnapshot> {
     Ok(read_from(provider, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY)?)
 }
 
 pub fn set_seigniorage_recipients_snapshot<P: StorageProvider + ?Sized>(
     provider: &mut P,
     snapshot: SeigniorageRecipientsSnapshot,
-) -> Result<()>
-where
-    Error: From<P::Error>,
-{
+) -> Result<()> {
     write_to(provider, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, snapshot)
 }

--- a/types/src/auction/providers.rs
+++ b/types/src/auction/providers.rs
@@ -13,29 +13,23 @@ pub trait RuntimeProvider {
 
 /// Provides functionality of a contract storage.
 pub trait StorageProvider {
-    /// Compatible error type.
-    type Error: From<Error>;
-
     /// Obtain named [`Key`].
     fn get_key(&mut self, name: &str) -> Option<Key>;
 
     /// Read data from [`URef`].
-    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Self::Error>;
+    fn read<T: FromBytes + CLTyped>(&mut self, uref: URef) -> Result<Option<T>, Error>;
 
     /// Write data to [`URef].
-    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Self::Error>;
+    fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Error>;
 }
 
 /// Provides functionality of a system module.
 pub trait SystemProvider {
-    /// Error representation for system errors.
-    type Error: From<Error>;
-
     /// Creates new purse.
     fn create_purse(&mut self) -> URef;
 
     /// Gets purse balance.
-    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Self::Error>;
+    fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Error>;
 
     /// Transfers specified `amount` of tokens from `source` purse into a `target` purse.
     fn transfer_from_purse_to_purse(
@@ -43,5 +37,5 @@ pub trait SystemProvider {
         source: URef,
         target: URef,
         amount: U512,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Error>;
 }


### PR DESCRIPTION
The `Error` associated types in the `StorageProvider` and `SystemProvider` traits in the `auction` module are unnecessary and are only adding complexity to type signatures.  The provider traits for the other system modules (formerly "system contracts") do not have any similar constructions - they use the appropriate concrete error type.

This PR removes them.