### PR TITLE
Fix Highway validation bug.

### DIFF
--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -345,10 +345,6 @@ impl<C: Context> State<C> {
         if wvote.panorama.get(creator).is_faulty() {
             return Err(VoteError::FaultyCreator);
         }
-        let is_terminal = |hash: &C::Hash| self.is_terminal_block(hash);
-        if wvote.value.is_some() && self.fork_choice(&wvote.panorama).map_or(false, is_terminal) {
-            return Err(VoteError::ValueAfterTerminalBlock);
-        }
         Ok(())
     }
 
@@ -386,6 +382,10 @@ impl<C: Context> State<C> {
                     }
                 }
             }
+        }
+        let is_terminal = |hash: &C::Hash| self.is_terminal_block(hash);
+        if wvote.value.is_some() && self.fork_choice(&wvote.panorama).map_or(false, is_terminal) {
+            return Err(VoteError::ValueAfterTerminalBlock);
         }
         Ok(())
     }


### PR DESCRIPTION
The `pre_validate_vertex` method is called before we have all dependencies, so it must not run the fork choice.

The validation that needs the fork choice can only happen later, in `validate_vertex`.