### PR TITLE
HWY-65: Enforce at most two votes per round.

### DIFF
--- a/node/src/components/consensus/highway_core/state/vote.rs
+++ b/node/src/components/consensus/highway_core/state/vote.rs
@@ -7,7 +7,7 @@ use crate::{
         },
         traits::Context,
     },
-    types::Timestamp,
+    types::{TimeDiff, Timestamp},
 };
 
 /// A vote sent to or received from the network.
@@ -87,5 +87,10 @@ impl<C: Context> Vote<C> {
     /// Returns the time at which the round containing this vote began.
     pub(crate) fn round_id(&self) -> Timestamp {
         state::round_id(self.timestamp, self.round_exp)
+    }
+
+    /// Returns the length of the round containing this vote.
+    pub(crate) fn round_len(&self) -> TimeDiff {
+        state::round_len(self.round_exp)
     }
 }


### PR DESCRIPTION
The Highway schedule allows two votes per round (proposal _or_ confirmation, and witness). This adds a validity condition: A vote is not allowed to be the third vote in its round.

https://casperlabs.atlassian.net/browse/HWY-65