### PR TITLE
NO-TICKET: Fix `nctl` scripts.

### DIFF
--- a/utils/casper-tool/casper-tool.py
+++ b/utils/casper-tool/casper-tool.py
@@ -301,7 +301,7 @@ def create_accounts_toml(output_file, pubkeys):
         account = {
             'public_key': key_hex,
             'balance': f'{motes}',
-            'staked_amount': f'{weight}'
+            'bonded_amount': f'{weight}'
         }
         accounts += [account]
     

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -95,7 +95,7 @@ function _set_chainspec_account()
 [[accounts]]
 public_key = "${ACCOUNT_KEY}"
 balance = "$INITIAL_BALANCE"
-staked_amount = "$INITIAL_WEIGHT"
+bonded_amount = "$INITIAL_WEIGHT"
 EOM
 }
 

--- a/utils/nctl/sh/assets/setup_node.sh
+++ b/utils/nctl/sh/assets/setup_node.sh
@@ -54,7 +54,7 @@ function setup_node()
 [[accounts]]
 public_key = "$(get_account_key "$NCTL_ACCOUNT_TYPE_NODE" "$NODE_ID")"
 balance = "$NCTL_INITIAL_BALANCE_VALIDATOR"
-staked_amount = "$POS_WEIGHT"
+bonded_amount = "$POS_WEIGHT"
 EOM
 }
 


### PR DESCRIPTION
https://github.com/CasperLabs/casper-node/pull/957 broke `nctl` scripts – it used `staked_amount` where `bonded_amount` was [expected](https://github.com/CasperLabs/casper-node/blob/master/node/src/types/chainspec/accounts_config.rs#L24).