### PR TITLE
EE-1222: Express MAX_PAYMENT in Gas

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1173,8 +1173,8 @@ where
             Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
         };
 
-        let max_payment_cost =
-            Motes::from_gas(*MAX_PAYMENT, 1u64).ok_or(Error::GasConversionOverflow)?;
+        let max_payment_cost = Motes::from_gas(*MAX_PAYMENT, deploy_item.gas_price)
+            .ok_or(Error::GasConversionOverflow)?;
 
         // Enforce minimum main purse balance validation
         // validation_spec_5: account main purse minimum balance

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -89,7 +89,7 @@ use crate::{
 };
 
 pub const MAX_PAYMENT_AMOUNT: u64 = 2_500_000_000;
-pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
+pub static MAX_PAYMENT: Lazy<Gas> = Lazy::new(|| Gas::new(U512::from(MAX_PAYMENT_AMOUNT)));
 
 /// Gas/motes conversion rate of wasmless transfer cost is always 1 regardless of what user wants to
 /// pay.
@@ -1168,7 +1168,8 @@ where
             Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
         };
 
-        let max_payment_cost = Motes::new(*MAX_PAYMENT);
+        let max_payment_cost =
+            Motes::from_gas(*MAX_PAYMENT, 1u64).ok_or(Error::GasConversionOverflow)?;
 
         // Enforce minimum main purse balance validation
         // validation_spec_5: account main purse minimum balance

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -132,7 +132,7 @@ fn get_balance_using_public_key_should_work() {
 
     let alice_main_purse = alice_account.main_purse();
 
-    let alice_balance_result = builder.get_public_key_balance_result(*ALICE_KEY);
+    let alice_balance_result = builder.get_public_key_balance_result(ALICE_KEY.clone());
 
     let alice_balance = alice_balance_result
         .motes()

--- a/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
@@ -32,7 +32,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         TRANSFER_PURSE_TO_ACCOUNT_WASM,
-        runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => *MAX_PAYMENT - U512::one() },
+        runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => (*MAX_PAYMENT).value() - U512::one() },
     )
     .build();
 
@@ -107,7 +107,7 @@ fn should_forward_payment_execution_runtime_error() {
 
     let transaction_fee = builder.get_proposer_purse_balance() - proposer_reward_starting_balance;
     let initial_balance: U512 = U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE);
-    let expected_reward_balance = *MAX_PAYMENT;
+    let expected_reward_balance = MAX_PAYMENT.value();
 
     let modified_balance = builder.get_purse_balance(
         builder
@@ -176,7 +176,7 @@ fn should_forward_payment_execution_gas_limit_error() {
 
     let transaction_fee = builder.get_proposer_purse_balance() - proposer_reward_starting_balance;
     let initial_balance: U512 = U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE);
-    let expected_reward_balance = *MAX_PAYMENT;
+    let expected_reward_balance = MAX_PAYMENT.value();
 
     let modified_balance = builder.get_purse_balance(
         builder
@@ -209,11 +209,9 @@ fn should_forward_payment_execution_gas_limit_error() {
     let execution_result = utils::get_success_result(response);
     let error = execution_result.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(execution::Error::GasLimit));
-    let payment_gas_limit = Gas::from_motes(Motes::new(*MAX_PAYMENT), DEFAULT_GAS_PRICE)
-        .expect("should convert to gas");
     assert_eq!(
         execution_result.cost(),
-        payment_gas_limit,
+        *MAX_PAYMENT,
         "cost should equal gas limit"
     );
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1471,7 +1471,7 @@ impl<REv> EffectBuilder<REv> {
                     let balance_request = BalanceRequest::new(state_hash, purse_uref);
                     if let Ok(balance_result) = self.get_balance(balance_request).await {
                         if let Some(motes) = balance_result.motes() {
-                            return Some(motes >= &*MAX_PAYMENT);
+                            return Some(motes >= &MAX_PAYMENT.value());
                         }
                     }
                 }


### PR DESCRIPTION
Changelog:

- Changed MAX_PAYMENT to be represented as `Gas` as opposed to simply `U512`
- Accounted for above change
