### PR TITLE
NDRS-1167: limit deploy size to 1MiB

### DIFF
--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -4,7 +4,7 @@ use humantime::{DurationError, TimestampError};
 use jsonrpc_lite::JsonRpc;
 use thiserror::Error;
 
-use casper_node::crypto::Error as CryptoError;
+use casper_node::{crypto::Error as CryptoError, types::ExcessiveSizeDeployError};
 use casper_types::{
     bytesrepr::Error as ToBytesError, CLValueError, UIntParseError, URefFromStrError,
 };
@@ -42,6 +42,10 @@ pub enum Error {
     /// Failed to parse a `U128`, `U256` or `U512` from a string.
     #[error("Failed to parse '{0}' as U128, U256, or U512: {1:?}")]
     FailedToParseUint(&'static str, UIntParseError),
+
+    /// Deploy size too large.
+    #[error("Deploy size too large: {0}")]
+    DeploySizeTooLarge(#[from] ExcessiveSizeDeployError),
 
     /// Failed to get a response from the node.
     #[error("Failed to get RPC response: {0}")]

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -52,6 +52,7 @@ pub enum casper_error_t {
     CASPER_FFI_SETUP_NOT_CALLED = -21,
     CASPER_FFI_PTR_NULL_BUT_REQUIRED = -22,
     CASPER_CONFLICTING_ARGUMENTS = -23,
+    CASPER_DEPLOY_SIZE_TOO_LARGE = -24,
 }
 
 trait AsFFIError {
@@ -84,6 +85,7 @@ impl AsFFIError for Error {
             Error::FFISetupNotCalled => casper_error_t::CASPER_FFI_SETUP_NOT_CALLED,
             Error::FFIPtrNullButRequired(_) => casper_error_t::CASPER_FFI_PTR_NULL_BUT_REQUIRED,
             Error::ConflictingArguments { .. } => casper_error_t::CASPER_CONFLICTING_ARGUMENTS,
+            Error::DeploySizeTooLarge(_) => casper_error_t::CASPER_DEPLOY_SIZE_TOO_LARGE,
         }
     }
 }

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -70,7 +70,7 @@ pub fn put_deploy(
         deploy.try_into()?,
         payment.try_into()?,
         session.try_into()?,
-    );
+    )?;
     RpcCall::new(maybe_rpc_id, node_address, verbosity_level).put_deploy(deploy)
 }
 
@@ -109,7 +109,7 @@ pub fn make_deploy(
         }
     })?;
 
-    Deploy::with_payment_and_session(deploy.try_into()?, payment.try_into()?, session.try_into()?)
+    Deploy::with_payment_and_session(deploy.try_into()?, payment.try_into()?, session.try_into()?)?
         .write_deploy(output)
 }
 

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -201,7 +201,7 @@ impl RpcCall {
         let session = ExecutableDeployItem::Transfer {
             args: transfer_args,
         };
-        let deploy = Deploy::with_payment_and_session(deploy_params, payment, session);
+        let deploy = Deploy::with_payment_and_session(deploy_params, payment, session).unwrap();
         let params = PutDeployParams { deploy };
         Transfer::request_with_map_params(self, params)
     }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -26,7 +26,7 @@ pub(crate) use chainspec::ActivationPoint;
 pub use chainspec::Chainspec;
 pub use deploy::{
     Approval, Deploy, DeployHash, DeployHeader, DeployMetadata, DeployValidationFailure,
-    Error as DeployError,
+    Error as DeployError, ExcessiveSizeError as ExcessiveSizeDeployError,
 };
 pub use exit_code::ExitCode;
 pub use item::{Item, Tag};

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -28,6 +28,7 @@ pub struct DeployConfig {
     pub(crate) max_ttl: TimeDiff,
     pub(crate) max_dependencies: u8,
     pub(crate) max_block_size: u32,
+    pub(crate) max_deploy_size: u32,
     pub(crate) block_max_deploy_count: u32,
     pub(crate) block_max_transfer_count: u32,
     pub(crate) block_gas_limit: u64,
@@ -44,6 +45,7 @@ impl DeployConfig {
         let max_ttl = TimeDiff::from(rng.gen_range(60_000..3_600_000));
         let max_dependencies = rng.gen();
         let max_block_size = rng.gen_range(1_000_000..1_000_000_000);
+        let max_deploy_size = rng.gen_range(100_000..1_000_000);
         let block_max_deploy_count = rng.gen();
         let block_max_transfer_count = rng.gen();
         let block_gas_limit = rng.gen_range(100_000_000_000..1_000_000_000_000_000);
@@ -57,6 +59,7 @@ impl DeployConfig {
             max_ttl,
             max_dependencies,
             max_block_size,
+            max_deploy_size,
             block_max_deploy_count,
             block_max_transfer_count,
             block_gas_limit,
@@ -75,6 +78,7 @@ impl Default for DeployConfig {
             max_ttl: TimeDiff::from_str("1day").unwrap(),
             max_dependencies: 10,
             max_block_size: 10_485_760,
+            max_deploy_size: 1_048_576,
             block_max_deploy_count: 10,
             block_max_transfer_count: 1000,
             block_gas_limit: 10_000_000_000_000,
@@ -92,6 +96,7 @@ impl ToBytes for DeployConfig {
         buffer.extend(self.max_ttl.to_bytes()?);
         buffer.extend(self.max_dependencies.to_bytes()?);
         buffer.extend(self.max_block_size.to_bytes()?);
+        buffer.extend(self.max_deploy_size.to_bytes()?);
         buffer.extend(self.block_max_deploy_count.to_bytes()?);
         buffer.extend(self.block_max_transfer_count.to_bytes()?);
         buffer.extend(self.block_gas_limit.to_bytes()?);
@@ -106,6 +111,7 @@ impl ToBytes for DeployConfig {
             + self.max_ttl.serialized_length()
             + self.max_dependencies.serialized_length()
             + self.max_block_size.serialized_length()
+            + self.max_deploy_size.serialized_length()
             + self.block_max_deploy_count.serialized_length()
             + self.block_max_transfer_count.serialized_length()
             + self.block_gas_limit.serialized_length()
@@ -122,6 +128,7 @@ impl FromBytes for DeployConfig {
         let (max_ttl, remainder) = TimeDiff::from_bytes(remainder)?;
         let (max_dependencies, remainder) = u8::from_bytes(remainder)?;
         let (max_block_size, remainder) = u32::from_bytes(remainder)?;
+        let (max_deploy_size, remainder) = u32::from_bytes(remainder)?;
         let (block_max_deploy_count, remainder) = u32::from_bytes(remainder)?;
         let (block_max_transfer_count, remainder) = u32::from_bytes(remainder)?;
         let (block_gas_limit, remainder) = u64::from_bytes(remainder)?;
@@ -133,6 +140,7 @@ impl FromBytes for DeployConfig {
             max_ttl,
             max_dependencies,
             max_block_size,
+            max_deploy_size,
             block_max_deploy_count,
             block_max_transfer_count,
             block_gas_limit,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -118,13 +118,8 @@ pub enum DeployValidationFailure {
     },
 
     /// Deploy is too large.
-    #[error("{deploy_size} deploy size exceeds block size limit of {max_block_size}")]
-    ExcessiveSize {
-        /// The block size limit.
-        max_block_size: u32,
-        /// The size of the deploy provided.
-        deploy_size: usize,
-    },
+    #[error("deploy size too large: {0}")]
+    ExcessiveSize(#[from] ExcessiveSizeError),
 
     /// Excessive time-to-live.
     #[error("time-to-live of {got} exceeds limit of {max_ttl}")]
@@ -186,6 +181,16 @@ pub enum DeployValidationFailure {
         /// The attempted transfer amount.
         attempted: U512,
     },
+}
+
+/// Error returned when a Deploy is too large.
+#[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Error)]
+#[error("deploy size of {actual_deploy_size} bytes exceeds limit of {max_deploy_size}")]
+pub struct ExcessiveSizeError {
+    /// The maximum permitted serialized deploy size, in bytes.
+    pub max_deploy_size: u32,
+    /// The serialized size of the deploy provided, in bytes.
+    pub actual_deploy_size: usize,
 }
 
 /// Errors other than validation failures relating to `Deploy`s.
@@ -609,6 +614,18 @@ impl Deploy {
         }
     }
 
+    /// Returns true if the serialized size of the deploy is not greater than `max_deploy_size`.
+    pub fn is_valid_size(&self, max_deploy_size: u32) -> Result<(), ExcessiveSizeError> {
+        let deploy_size = self.serialized_length();
+        if deploy_size > max_deploy_size as usize {
+            return Err(ExcessiveSizeError {
+                max_deploy_size,
+                actual_deploy_size: deploy_size,
+            });
+        }
+        Ok(())
+    }
+
     /// Returns true if and only if:
     ///   * the deploy hash is correct (should be the hash of the header), and
     ///   * the body hash is correct (should be the hash of the body), and
@@ -635,13 +652,7 @@ impl Deploy {
         chain_name: &str,
         config: &DeployConfig,
     ) -> Result<(), DeployValidationFailure> {
-        let deploy_size = self.serialized_length();
-        if deploy_size > config.max_block_size as usize {
-            return Err(DeployValidationFailure::ExcessiveSize {
-                max_block_size: config.max_block_size,
-                deploy_size,
-            });
-        }
+        self.is_valid_size(config.max_deploy_size)?;
 
         let header = self.header();
         if header.chain_name() != chain_name {

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -74,6 +74,8 @@ max_ttl = '1day'
 max_dependencies = 10
 # Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
 max_block_size = 10_485_760
+# Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
+max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
 block_max_deploy_count = 100
 # The maximum number of wasm-less transfer deploys permitted in a single block.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -77,6 +77,8 @@ max_ttl = '1day'
 max_dependencies = 10
 # Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
 max_block_size = 10_485_760
+# Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
+max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
 block_max_deploy_count = 100
 # The maximum number of wasm-less transfer deploys permitted in a single block.

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -27,6 +27,7 @@ max_payment_cost = '9'
 max_ttl = '10months'
 max_dependencies = 11
 max_block_size = 12
+max_deploy_size = 1_048_576
 block_max_deploy_count = 125
 block_max_transfer_count = 1000
 block_gas_limit = 13

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -26,6 +26,7 @@ reduced_reward_multiplier = [1, 5]
 max_payment_cost = '9'
 max_ttl = '10months'
 max_dependencies = 11
+max_deploy_size = 1_048_576
 max_block_size = 12
 block_max_deploy_count = 125
 block_max_transfer_count = 1000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -28,6 +28,7 @@ max_payment_cost = '9'
 max_ttl = '10months'
 max_dependencies = 11
 max_block_size = 12
+max_deploy_size = 1_048_576
 block_max_deploy_count = 125
 block_max_transfer_count = 1000
 block_gas_limit = 13

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -72,6 +72,8 @@ max_ttl = '1day'
 max_dependencies = 10
 # Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
 max_block_size = 10_485_760
+# Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
+max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
 block_max_deploy_count = 100
 # The maximum number of wasm-less transfer deploys permitted in a single block.


### PR DESCRIPTION
This PR is a port of #1258 which limits the deploy size, both when accepting one in the node, and when creating one in the client.