### PR TITLE
HWY-286: Make unchecked timestamp subtraction test-only.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -684,7 +684,7 @@ impl<C: Context> Highway<C> {
             state.params().start_timestamp()
         };
         for skipped_r_id in (1..=MAX_SKIPPED_PROPOSAL_LOGS)
-            .map(|i| r_id - state.params().min_round_length() * i)
+            .map(|i| r_id.saturating_sub(state.params().min_round_length() * i))
             .take_while(|skipped_r_id| *skipped_r_id > parent_timestamp)
         {
             let leader_index = state.leader(skipped_r_id);

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -858,7 +858,7 @@ where
     fn connect_to_peer_if_required(&mut self, peer_address: SocketAddr) -> Effects<Event<P>> {
         let now = Timestamp::now();
         self.blocklist
-            .retain(|_, ts| *ts > now - *BLOCKLIST_RETAIN_DURATION);
+            .retain(|_, ts| *ts > now.saturating_sub(*BLOCKLIST_RETAIN_DURATION));
         if self.pending.contains_key(&peer_address)
             || self.blocklist.contains_key(&peer_address)
             || self

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    ops::{Add, AddAssign, Div, Mul, Rem, Sub},
+    ops::{Add, AddAssign, Div, Mul, Rem},
     str::FromStr,
     time::{Duration, SystemTime},
 };
@@ -123,7 +123,8 @@ impl AddAssign<TimeDiff> for Timestamp {
     }
 }
 
-impl Sub<TimeDiff> for Timestamp {
+#[cfg(test)]
+impl std::ops::Sub<TimeDiff> for Timestamp {
     type Output = Timestamp;
 
     fn sub(self, diff: TimeDiff) -> Timestamp {


### PR DESCRIPTION
That way we can't use the potentially underflowing `timestamp - timediff` in production anymore, and have to use `timestamp.saturating_sub(timediff)`. A panic in production would be unlikely, since the result of the subtraction would have to be before 1970, but it's better to err on the side of caution. The problem did show up in a unit test that used timestamps close to 0 (i.e. beginning of 1970).

https://casperlabs.atlassian.net/browse/HWY-286