### PR TITLE
NDRS-1193: Introduce task manager

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -26,7 +26,7 @@ pub mod in_memory_network;
 pub(crate) mod metrics;
 pub(crate) mod network;
 pub(crate) mod networking_metrics;
-pub(crate) mod small_network;
+pub mod small_network;
 pub(crate) mod storage;
 
 use crate::{

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -30,6 +30,7 @@ mod error;
 mod event;
 mod gossiped_address;
 mod message;
+mod task_manager;
 #[cfg(test)]
 mod tests;
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1172,10 +1172,13 @@ async fn server_task<P, REv>(
     }
 }
 
+/// Small network identity generation error.
 #[derive(Debug, Error)]
 pub enum SmallNetworkIdentityError {
+    /// Failed to generate a TLS certificate.
     #[error("could not generate TLS certificate: {0}")]
     CouldNotGenerateTlsCertificate(OpenSslErrorStack),
+    /// Invalid small network identity.
     #[error(transparent)]
     ValidationError(#[from] ValidationError),
 }
@@ -1188,6 +1191,7 @@ pub struct SmallNetworkIdentity {
 }
 
 impl SmallNetworkIdentity {
+    /// Creates a new node identity.
     pub fn new() -> result::Result<Self, SmallNetworkIdentityError> {
         let (not_yet_validated_x509_cert, secret_key) = tls::generate_node_cert()
             .map_err(SmallNetworkIdentityError::CouldNotGenerateTlsCertificate)?;

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -638,7 +638,7 @@ where
             effect_builder
                 .immediately()
                 .event(move |_| Event::OutgoingReady {
-                    receiver: receiver,
+                    receiver,
                     sink: Box::new(sink),
                     stream: Box::new(stream),
                     peer_id: Box::new(peer_id),
@@ -1377,6 +1377,7 @@ async fn message_reader<REv, P>(
 ///
 /// Initially sends a handshake including the `chainspec_hash` as a final handshake step.  If the
 /// recipient's `chainspec_hash` doesn't match, the connection will be closed.
+#[allow(clippy::clippy::too_many_arguments)]
 async fn message_sender<P, REv>(
     event_queue: EventQueueHandle<REv>,
     mut queue: UnboundedReceiver<Message<P>>,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -30,7 +30,7 @@ mod error;
 mod event;
 mod gossiped_address;
 mod message;
-mod task_manager;
+pub mod task_manager;
 #[cfg(test)]
 mod tests;
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -106,9 +106,6 @@ pub use error::Error;
 
 const MAX_ASYMMETRIC_CONNECTION_SEEN: u16 = 4;
 
-const MAX_METRICS_DROP_ATTEMPTS: usize = 25;
-const DROP_RETRY_DELAY: Duration = Duration::from_millis(100);
-
 static BLOCKLIST_RETAIN_DURATION: Lazy<TimeDiff> =
     Lazy::new(|| Duration::from_secs(60 * 10).into());
 
@@ -992,9 +989,6 @@ where
             } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
                 warn!(our_id=%self.our_id, "server shutdown while already shut down")
             }
-
-            // Ensure there are no ongoing metrics updates.
-            utils::wait_for_arc_drop(self.net_metrics, MAX_METRICS_DROP_ATTEMPTS, DROP_RETRY_DELAY).await;
         }
         .boxed()
     }

--- a/node/src/components/small_network/counting_format.rs
+++ b/node/src/components/small_network/counting_format.rs
@@ -51,7 +51,7 @@ impl Display for TraceId {
 /// a message is sent or received.
 #[pin_project]
 #[derive(Debug)]
-pub(super) struct CountingFormat<F> {
+pub struct CountingFormat<F> {
     /// The actual serializer performing the work.
     #[pin]
     inner: F,

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -128,9 +128,6 @@ pub enum Error {
         #[from]
         anyhow::Error,
     ),
-    /// Server has stopped.
-    #[error("failed to create outgoing connection as server has stopped")]
-    ServerStopped,
 
     /// Instantiating metrics failed.
     #[error(transparent)]

--- a/node/src/components/small_network/message_pack_format.rs
+++ b/node/src/components/small_network/message_pack_format.rs
@@ -20,7 +20,7 @@ use super::Message;
 
 /// msgpack encoder/decoder for messages.
 #[derive(Debug)]
-pub(super) struct MessagePackFormat;
+pub struct MessagePackFormat;
 
 impl<P> Serializer<Message<P>> for MessagePackFormat
 where

--- a/node/src/components/small_network/task_manager.rs
+++ b/node/src/components/small_network/task_manager.rs
@@ -1,0 +1,191 @@
+//! A manager for background tasks.
+//!
+//! Long-running background tasks that need to be shutdown are captured/managed by the task manager,
+//! which allows for waiting for all of them to complete before continuing.
+//!
+//! ```
+//! let mut task_manager = TaskManager::new();
+//!
+//! task_manager.spawn(|shutdown| {
+//!     for _ in 0..10 {
+//!         tokio::select! {
+//!             _ = &mut shutdown => {
+//!                 // Shutdown received, abort.
+//!                 break;
+//!             }
+//!
+//!             // TODO better example?
+//!         }
+//!     }
+//! });
+//! ```
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use futures::{stream::FuturesUnordered, Future, StreamExt};
+use tokio::{
+    sync::watch,
+    task::{JoinError, JoinHandle},
+    time,
+};
+use tracing::{error, trace, warn};
+
+/// A shutdown receiver.
+///
+/// Can be asked for a shutdown signal via `wait_for_shutdown`.
+#[derive(Debug, Clone)]
+struct ShutdownReceiver(watch::Receiver<()>);
+
+impl ShutdownReceiver {
+    /// Waits for the shutdown signal.
+    ///
+    /// The returned future is safe to cancel.
+    pub(super) async fn wait_for_shutdown(&mut self) {
+        match self.0.changed().await {
+            Ok(()) => {
+                // We are using the dropping of the channel as a signal, not the channel itself!
+                error!("received value on shutdown channel, this should never happen")
+            }
+            Err(_recv_err) => {
+                // All good.
+            }
+        }
+    }
+}
+
+/// The outcome of awaiting a task for shutdown.
+#[derive(Debug)]
+enum ShutdownOutcome {
+    /// The task was shut down completely.
+    Ok,
+    /// Could not join the task, it either panicked or was explicitly cancelled.
+    JoinFailure(JoinError),
+    /// Join timeout.
+    ///
+    /// The task is still running in the background, the join handle has been lost.
+    TimedOut,
+}
+
+/// Manager for tasks.
+///
+/// Can be used to signal a group of tasks to shutdown and wait for their completion, optionally
+/// cancelling execution. All operations are "best effort", won't panic even on poisoned locks.
+///
+/// Dropping a task manager will instruct all tasks to shutdown, but the `drop` will not await their
+/// termination.
+#[derive(Debug)]
+struct TaskManager {
+    /// A counter for joined tasks.
+    ///
+    /// Incremented to provide unique IDs for tasks.
+    task_counter: usize,
+    /// Join handles for all spawned tasks, mapped from task ID to join handle.
+    join_handles: Arc<Mutex<HashMap<usize, JoinHandle<()>>>>,
+    /// Sender for the signal to shutdown.
+    shutdown_sender: watch::Sender<()>,
+    /// Receiver for the signal to shutdown.
+    shutdown_receiver: ShutdownReceiver,
+}
+
+impl TaskManager {
+    /// Creates a new task manager.
+    pub(super) fn new() -> Self {
+        let (shutdown_sender, shutdown_watch_receiver) = watch::channel(());
+
+        Self {
+            task_counter: 0,
+            join_handles: Default::default(),
+            shutdown_sender,
+            shutdown_receiver: ShutdownReceiver(shutdown_watch_receiver),
+        }
+    }
+
+    /// Spawns a new tasks.
+    ///
+    /// Tasks are expected to honor received shutdown signals from the manager, that is they need to
+    /// shutdown once they receive a value on the `Receiver`. No return values are supported for
+    /// spawned tasks.
+    ///
+    /// If the internal log has been poisoned, outputs a warning, but otherwise keeps on going.
+    pub(super) fn spawn<F, G>(&mut self, gen: F)
+    where
+        F: FnOnce(ShutdownReceiver) -> G,
+        G: Future<Output = ()> + Send + 'static,
+    {
+        let task_id = self.task_counter;
+        self.task_counter += 1;
+
+        let join_handles = self.join_handles.clone();
+
+        let fut = gen(self.shutdown_receiver.clone());
+        let join_handle = tokio::spawn(async move {
+            fut.await;
+
+            // To avoid creating an infinite amount of join handles, we remove our entry from the
+            // join handles map, if still in there. If the lock is poisoned we skip this step.
+            if let Ok(mut join_handles) = join_handles.lock() {
+                join_handles.remove(&task_id);
+            }
+        });
+
+        // Now that the task has been spawned, insert into join handle list.
+        if let Ok(mut join_handles) = self.join_handles.lock() {
+            join_handles.insert(task_id, join_handle);
+        } else {
+            // This is problematic, but no reason to crash in some cases.
+            warn!("join handles lock has been poisoned, no freeing entry");
+        }
+    }
+
+    /// Waits for all background tasks to shut down.
+    ///
+    /// Returns the number of tasks that were not joined successfully in time.
+    ///
+    /// If the lock has been poisoned, `Err(())` is returned, as it is impossible to properly join
+    /// the tasks at that point. They will still be asked to shutdown.
+    async fn wait_for_shutdown(self, timeout: Duration) -> Result<usize, ()> {
+        // Dropping the sender will cause all receivers to shutdown.
+        drop(self.shutdown_sender);
+
+        let mut join_handles = self.join_handles.lock().map_err(|_| ())?;
+
+        // We create a stream of join results that we can collect in parallel.
+        let mut joins: FuturesUnordered<_> = join_handles
+            .drain()
+            .map(|(task_id, join_handle)| async move {
+                (
+                    task_id,
+                    match time::timeout(timeout, join_handle).await {
+                        Ok(Ok(())) => ShutdownOutcome::Ok,
+                        Ok(Err(join_err)) => ShutdownOutcome::JoinFailure(join_err),
+                        Err(_) => ShutdownOutcome::TimedOut,
+                    },
+                )
+            })
+            .collect();
+
+        // Collect all the join handles and output appropriate errors.
+        let mut failed = 0;
+        while let Some((task_id, outcome)) = joins.next().await {
+            match outcome {
+                ShutdownOutcome::Ok => {
+                    trace!(task_id, "successfully joined task");
+                }
+                ShutdownOutcome::JoinFailure(err) => {
+                    warn!(task_id, %err, "could not join task");
+                    failed += 1;
+                }
+                ShutdownOutcome::TimedOut => {
+                    error!(task_id, "task joining timed out and handle lost");
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(failed)
+    }
+}

--- a/node/src/components/small_network/task_manager.rs
+++ b/node/src/components/small_network/task_manager.rs
@@ -113,6 +113,12 @@ pub struct TaskManager {
     shutdown_receiver: ShutdownReceiver,
 }
 
+impl Default for TaskManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TaskManager {
     /// Creates a new task manager.
     pub fn new() -> Self {

--- a/node/src/components/small_network/task_manager.rs
+++ b/node/src/components/small_network/task_manager.rs
@@ -53,6 +53,7 @@ use std::{
     time::Duration,
 };
 
+use datasize::DataSize;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use tokio::{
     sync::watch,
@@ -64,8 +65,8 @@ use tracing::{error, trace, warn};
 /// A shutdown receiver.
 ///
 /// Can be asked for a shutdown signal via `wait_for_shutdown`.
-#[derive(Debug, Clone)]
-pub struct ShutdownReceiver(watch::Receiver<()>);
+#[derive(DataSize, Debug, Clone)]
+pub struct ShutdownReceiver(#[data_size(skip)] watch::Receiver<()>);
 
 impl ShutdownReceiver {
     /// Waits for the shutdown signal.
@@ -104,7 +105,7 @@ enum ShutdownOutcome {
 ///
 /// Dropping a task manager will instruct all tasks to shutdown, but the `drop` will not await their
 /// termination.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub struct TaskManager {
     /// A counter for joined tasks.
     ///
@@ -113,6 +114,7 @@ pub struct TaskManager {
     /// Join handles for all spawned tasks, mapped from task ID to join handle.
     join_handles: Arc<Mutex<HashMap<usize, JoinHandle<()>>>>,
     /// Sender for the signal to shutdown.
+    #[data_size(skip)]
     shutdown_sender: watch::Sender<()>,
     /// Receiver for the signal to shutdown.
     shutdown_receiver: ShutdownReceiver,

--- a/node/src/components/small_network/task_manager.rs
+++ b/node/src/components/small_network/task_manager.rs
@@ -41,6 +41,11 @@
 //!
 //! assert_eq!(tasks_leftover, 0);
 //! ```
+//!
+//! # `Drop`
+//!
+//! Dropping the `TaskManager` will cause all tasks to be sent a shutdown notice, but the `Drop`
+//! implementation will **not** wait them to finish.
 
 use std::{
     collections::HashMap,

--- a/node/src/components/small_network/task_manager.rs
+++ b/node/src/components/small_network/task_manager.rs
@@ -207,7 +207,7 @@ impl TaskManager {
                     failed += 1;
                 }
                 ShutdownOutcome::TimedOut => {
-                    error!(task_id, "task joining timed out and handle lost");
+                    error!(task_id, "task joining timed out");
                     failed += 1;
                 }
             }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -12,7 +12,9 @@
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
-    test(attr(forbid(warnings)))
+    // Do NOT set warnings to `forbid`; macros from third-party crates will not be able to suppress
+    // warnings (and thus not compile) in generated code.
+    test(attr(deny(warnings)))
 )]
 #![warn(
     missing_docs,

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -11,7 +11,6 @@ pub(crate) mod rlimit;
 mod round_robin;
 
 use std::{
-    any,
     cell::RefCell,
     fmt::{self, Debug, Display, Formatter},
     fs,
@@ -20,8 +19,6 @@ use std::{
     ops::{Add, BitXorAssign, Div},
     os::unix::fs::OpenOptionsExt,
     path::{Path, PathBuf},
-    sync::Arc,
-    time::Duration,
 };
 #[cfg(test)]
 use std::{env, str::FromStr};
@@ -391,46 +388,9 @@ pub fn xor(lhs: &mut [u8], rhs: &[u8]) {
         .for_each(|(sb, &cb)| sb.bitxor_assign(cb));
 }
 
-/// Wait until all strong references for a particular arc have been dropped.
-///
-/// Downgrades and immediately drops the `Arc`, keeping only a weak reference. The reference will
-/// then be polled `attempts` times, unless it has a strong reference count of 0.
-///
-/// Returns whether or not `arc` has zero strong references left.
-///
-/// # Note
-///
-/// Using this function is usually a potential architectural issue and it should be used very
-/// sparingly. Consider introducing a different access pattern for the value under `Arc`.
-pub async fn wait_for_arc_drop<T>(arc: Arc<T>, attempts: usize, retry_delay: Duration) -> bool {
-    // Ensure that if we do hold the last reference, we are now going to 0.
-    let weak = Arc::downgrade(&arc);
-    drop(arc);
-
-    for _ in 0..attempts {
-        let strong_count = weak.strong_count();
-
-        if strong_count == 0 {
-            // Everything has been dropped, we are done.
-            return true;
-        }
-
-        tokio::time::sleep(retry_delay).await;
-    }
-
-    error!(
-        attempts, ?retry_delay, ty=%any::type_name::<T>(),
-        "failed to clean up shared reference"
-    );
-
-    false
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
-
-    use super::{wait_for_arc_drop, xor};
+    use super::xor;
 
     #[test]
     fn xor_works() {
@@ -450,40 +410,5 @@ mod tests {
         let rhs = [0x04, 0x0b, 0x5c, 0xa1, 0xef, 0x11];
 
         xor(&mut lhs, &rhs);
-    }
-
-    #[tokio::test]
-    async fn arc_drop_waits_for_drop() {
-        let retry_delay = Duration::from_millis(25);
-        let attempts = 15;
-
-        let arc = Arc::new(());
-
-        let arc_in_background = arc.clone();
-        let _weak_in_background = Arc::downgrade(&arc);
-
-        // At this point, the Arc has the following refernces:
-        //
-        // * main test task (`arc`, strong)
-        // * background strong reference (`arc_in_background`)
-        // * background weak reference (`weak_in_background`)
-
-        // Phase 1: waiting for the arc should fail, because there still is the background
-        // reference.
-        assert!(!wait_for_arc_drop(arc, attempts, retry_delay).await);
-
-        // We "restore" the arc from the background arc.
-        let arc = arc_in_background.clone();
-
-        // Add another "foreground" weak reference.
-        let weak = Arc::downgrade(&arc);
-
-        // Phase 2: Our background tasks drops its reference, now we should succeed.
-        drop(arc_in_background);
-        assert!(wait_for_arc_drop(arc, attempts, retry_delay).await);
-
-        // Immedetialy after, we should not be able to obtain a strong reference anymore.
-        // This test fails only if we have a race condition, so false positive tests are possible.
-        assert!(weak.upgrade().is_none());
     }
 }


### PR DESCRIPTION
This introduces a task manager to manage background tasks that need to be shutdown and awaited. This functionality replaces the introduced `Arc` based waiting.

The task manager will wait for task completion when `finalize` is called.