### PR TITLE
RES-419: Add more logging for Highway units and finality.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1060,6 +1060,7 @@ where
                     era.start_height + relative_height,
                     proposer,
                 );
+                info!(?finalized_block, "finalized block");
                 self.era_supervisor
                     .metrics
                     .finalized_block(&finalized_block);

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub standstill_timeout: TimeDiff,
     /// Log inactive or faulty validators periodically, with this interval.
     pub log_participation_interval: TimeDiff,
+    /// Log the size of every incoming and outgoing serialized unit.
+    pub log_unit_sizes: bool,
     /// The maximum number of blocks by which execution is allowed to lag behind finalization.
     /// If it is more than that, consensus will pause, and resume once the executor has caught up.
     pub max_execution_delay: u64,
@@ -36,6 +38,7 @@ impl Default for Config {
             request_latest_state_timeout: "5sec".parse().unwrap(),
             standstill_timeout: "1min".parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
+            log_unit_sizes: false,
             max_execution_delay: 3,
             round_success_meter: RSMConfig::default(),
         }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -73,13 +73,12 @@ where
     let config = Config {
         secret_key_path: Default::default(),
         highway: HighwayConfig {
-            unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "1min".parse().unwrap(),
             standstill_timeout: STANDSTILL_TIMEOUT.parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
-            round_success_meter: Default::default(),
             request_latest_state_timeout: "10sec".parse().unwrap(),
+            ..HighwayConfig::default()
         },
     };
     // Timestamp of the genesis era start and test start.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -52,6 +52,9 @@ standstill_timeout = '5min'
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
 
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
 # The maximum number of blocks by which execution is allowed to lag behind finalization.
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -52,6 +52,9 @@ standstill_timeout = '5min'
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
 
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
 # The maximum number of blocks by which execution is allowed to lag behind finalization.
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3


### PR DESCRIPTION
This adds a config option for logging the size of every incoming and outgoing unit, and an INFO-level log message for when finality is detected.

https://casperlabs.atlassian.net/browse/RES-419