### PR TITLE
NDRS-1114: Step Information should be present on the event stream

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2031,7 +2031,7 @@ where
             .commit(
                 correlation_id,
                 step_request.pre_state_hash,
-                effects.transforms,
+                effects.clone().transforms,
             )
             .map_err(Into::into)?;
 
@@ -2070,6 +2070,7 @@ where
         Ok(StepResult::Success {
             post_state_hash,
             next_era_validators,
+            execution_effect: effects,
         })
     }
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2031,7 +2031,7 @@ where
             .commit(
                 correlation_id,
                 step_request.pre_state_hash,
-                effects.clone().transforms,
+                effects.transforms.clone(),
             )
             .map_err(Into::into)?;
 

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -8,7 +8,7 @@ use casper_types::{
 };
 
 use crate::{
-    core::engine_state::{Error, GetEraValidatorsError},
+    core::engine_state::{execution_effect::ExecutionEffect, Error, GetEraValidatorsError},
     shared::{newtypes::Blake2bHash, TypeMismatch},
 };
 
@@ -124,6 +124,7 @@ pub enum StepResult {
     Success {
         post_state_hash: Blake2bHash,
         next_era_validators: BTreeMap<PublicKey, U512>,
+        execution_effect: ExecutionEffect,
     },
 }
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -337,7 +337,7 @@ where
                                 .commit_upgrade
                                 .observe(start.elapsed().as_secs_f64());
                             info!(?result, "upgrade result");
-                            responder.respond(result.clone()).await
+                            responder.respond(result).await
                         }
                         .ignore()
                     }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -20,7 +20,7 @@ use derive_more::From;
 use lmdb::DatabaseFlags;
 use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
 use thiserror::Error;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -325,7 +325,7 @@ where
                         upgrade_config,
                         responder,
                     } => {
-                        trace!(?upgrade_config, "upgrade");
+                        info!(?upgrade_config, "upgrade");
                         let engine_state = Arc::clone(&self.engine_state);
                         let metrics = Arc::clone(&self.metrics);
                         async move {
@@ -336,8 +336,8 @@ where
                             metrics
                                 .commit_upgrade
                                 .observe(start.elapsed().as_secs_f64());
-                            trace!(?result, "upgrade result");
-                            responder.respond(result).await
+                            info!(?result, "upgrade result");
+                            responder.respond(result.clone()).await
                         }
                         .ignore()
                     }
@@ -605,20 +605,25 @@ where
                         parent_summary,
                     )
                 }
-
                 ContractRuntimeResult::RunStepResult { mut state, result } => {
                     trace!(?result, "run step result");
                     match result {
                         Ok(StepResult::Success {
                             post_state_hash,
                             next_era_validators,
+                            execution_effect,
                         }) => {
                             state.state_root_hash = post_state_hash.into();
-                            self.finalize_block_execution(
+                            let era_id = state.finalized_block.era_id();
+                            let mut effects = effect_builder
+                                .announce_step_result(era_id, execution_effect)
+                                .ignore();
+                            effects.extend(self.finalize_block_execution(
                                 effect_builder,
                                 state,
                                 Some(next_era_validators),
-                            )
+                            ));
+                            effects
                         }
                         _ => {
                             // When step fails, the auction process is broken and we should panic.

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -20,7 +20,7 @@ use derive_more::From;
 use lmdb::DatabaseFlags;
 use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
 use thiserror::Error;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -325,7 +325,7 @@ where
                         upgrade_config,
                         responder,
                     } => {
-                        info!(?upgrade_config, "upgrade");
+                        debug!(?upgrade_config, "upgrade");
                         let engine_state = Arc::clone(&self.engine_state);
                         let metrics = Arc::clone(&self.metrics);
                         async move {
@@ -336,7 +336,7 @@ where
                             metrics
                                 .commit_upgrade
                                 .observe(start.elapsed().as_secs_f64());
-                            info!(?result, "upgrade result");
+                            debug!(?result, "upgrade result");
                             responder.respond(result).await
                         }
                         .ignore()

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -616,7 +616,7 @@ where
                             state.state_root_hash = post_state_hash.into();
                             let era_id = state.finalized_block.era_id();
                             let mut effects = effect_builder
-                                .announce_step_result(era_id, execution_effect)
+                                .announce_step_success(era_id, execution_effect)
                                 .ignore();
                             effects.extend(self.finalize_block_execution(
                                 effect_builder,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -167,6 +167,10 @@ where
                 timestamp,
             }),
             Event::FinalitySignature(fs) => self.broadcast(SseData::FinalitySignature(fs)),
+            Event::Step { era_id, effect } => self.broadcast(SseData::Step {
+                era_id,
+                execution_effect: effect,
+            }),
         }
     }
 }

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -42,7 +42,7 @@ impl Display for Event {
                 public_key, timestamp, era_id,
             ),
             Event::FinalitySignature(fs) => write!(formatter, "finality signature {}", fs),
-            Event::Step { era_id, .. } => write!(formatter, "step committed for era: {}", era_id),
+            Event::Step { era_id, .. } => write!(formatter, "step committed for {}", era_id),
         }
     }
 }

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -42,11 +42,7 @@ impl Display for Event {
                 public_key, timestamp, era_id,
             ),
             Event::FinalitySignature(fs) => write!(formatter, "finality signature {}", fs),
-            Event::Step { era_id, effect } => write!(
-                formatter,
-                "Execution effect: {:?} committed in era: {}",
-                effect, era_id
-            ),
+            Event::Step { era_id, .. } => write!(formatter, "step committed for era: {}", era_id),
         }
     }
 }

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use casper_types::{EraId, ExecutionResult, PublicKey};
+use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey};
 
 use crate::types::{Block, BlockHash, DeployHash, DeployHeader, FinalitySignature, Timestamp};
 
@@ -19,6 +19,10 @@ pub enum Event {
         timestamp: Timestamp,
     },
     FinalitySignature(Box<FinalitySignature>),
+    Step {
+        era_id: EraId,
+        effect: ExecutionEffect,
+    },
 }
 
 impl Display for Event {
@@ -38,6 +42,11 @@ impl Display for Event {
                 public_key, timestamp, era_id,
             ),
             Event::FinalitySignature(fs) => write!(formatter, "finality signature {}", fs),
+            Event::Step { era_id, effect } => write!(
+                formatter,
+                "Execution effect: {:?} committed in era: {}",
+                effect, era_id
+            ),
         }
     }
 }

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -17,7 +17,7 @@ use warp::{
     Filter, Reply,
 };
 
-use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey};
+use casper_types::{EraId, ExecutionEffect, ExecutionResult, ProtocolVersion, PublicKey};
 
 use crate::types::{BlockHash, DeployHash, FinalitySignature, JsonBlock, TimeDiff, Timestamp};
 
@@ -58,6 +58,11 @@ pub enum SseData {
     },
     /// New finality signature received.
     FinalitySignature(Box<FinalitySignature>),
+    Step {
+        era_id: EraId,
+        #[data_size(skip)]
+        execution_effect: ExecutionEffect,
+    },
 }
 
 /// The components of a single SSE.
@@ -184,7 +189,8 @@ fn stream_to_client(
                         (Some(id), &SseData::BlockAdded { .. })
                         | (Some(id), &SseData::DeployProcessed { .. })
                         | (Some(id), &SseData::FinalitySignature(_))
-                        | (Some(id), &SseData::Fault { .. }) => Ok(WarpServerSentEvent::default()
+                        | (Some(id), &SseData::Fault { .. })
+                        | (Some(id), &SseData::Step { .. }) => Ok(WarpServerSentEvent::default()
                             .json_data(event.data)
                             .unwrap_or_default()
                             .id(id.to_string())),

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -696,17 +696,17 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Announce a committed Step result
-    pub(crate) async fn announce_step_result(self, era_id: EraId, execution_effect: ExecutionEffect)
-    where
+    /// Announce a committed Step success.
+    pub(crate) async fn announce_step_success(
+        self,
+        era_id: EraId,
+        execution_effect: ExecutionEffect,
+    ) where
         REv: From<ContractRuntimeAnnouncement>,
     {
         self.0
             .schedule(
-                ContractRuntimeAnnouncement::step_result_success(
-                    era_id,
-                    (&execution_effect).into(),
-                ),
+                ContractRuntimeAnnouncement::step_success(era_id, (&execution_effect).into()),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -130,6 +130,7 @@ use requests::{
 };
 
 use self::announcements::BlocklistAnnouncement;
+use casper_execution_engine::core::engine_state::execution_effect::ExecutionEffect;
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
 static UNOBTAINABLE: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));
@@ -690,6 +691,22 @@ impl<REv> EffectBuilder<REv> {
         self.0
             .schedule(
                 ContractRuntimeAnnouncement::block_already_executed(block),
+                QueueKind::Regular,
+            )
+            .await
+    }
+
+    /// Announce a committed Step result
+    pub(crate) async fn announce_step_result(self, era_id: EraId, execution_effect: ExecutionEffect)
+    where
+        REv: From<ContractRuntimeAnnouncement>,
+    {
+        self.0
+            .schedule(
+                ContractRuntimeAnnouncement::step_result_success(
+                    era_id,
+                    (&execution_effect).into(),
+                ),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -85,6 +85,7 @@ use casper_execution_engine::{
     core::engine_state::{
         self,
         era_validators::GetEraValidatorsError,
+        execution_effect::ExecutionEffect,
         genesis::GenesisResult,
         step::{StepRequest, StepResult},
         upgrade::{UpgradeConfig, UpgradeResult},
@@ -130,7 +131,6 @@ use requests::{
 };
 
 use self::announcements::BlocklistAnnouncement;
-use casper_execution_engine::core::engine_state::execution_effect::ExecutionEffect;
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
 static UNOBTAINABLE: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -10,7 +10,7 @@ use std::{
 
 use serde::Serialize;
 
-use casper_types::{EraId, ExecutionResult, PublicKey};
+use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey};
 
 use crate::{
     components::{
@@ -222,6 +222,8 @@ pub enum ContractRuntimeAnnouncement {
     LinearChainBlock(Box<LinearChainBlock>),
     /// A block was requested to be executed, but it had been executed before.
     BlockAlreadyExecuted(Box<Block>),
+    /// A Step result was committed and has altered global state.
+    StepCommitted(EraId, ExecutionEffect),
 }
 
 impl ContractRuntimeAnnouncement {
@@ -238,6 +240,11 @@ impl ContractRuntimeAnnouncement {
     /// Create a ContractRuntimeAnnouncement::BlockAlreadyExecuted from a Block.
     pub fn block_already_executed(block: Block) -> Self {
         Self::BlockAlreadyExecuted(Box::new(block))
+    }
+
+    /// Create a ContractRuntimeAnnouncement::StepCommitted from an execution effect.
+    pub fn step_result_success(era_id: EraId, execution_effect: ExecutionEffect) -> Self {
+        Self::StepCommitted(era_id, execution_effect)
     }
 }
 
@@ -262,6 +269,13 @@ impl Display for ContractRuntimeAnnouncement {
             }
             ContractRuntimeAnnouncement::BlockAlreadyExecuted(block) => {
                 write!(f, "block had been executed before: {}", block.hash())
+            }
+            ContractRuntimeAnnouncement::StepCommitted(era_id, ..) => {
+                write!(
+                    f,
+                    "execution effect has been successfully committed in era: {}",
+                    era_id
+                )
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -222,8 +222,13 @@ pub enum ContractRuntimeAnnouncement {
     LinearChainBlock(Box<LinearChainBlock>),
     /// A block was requested to be executed, but it had been executed before.
     BlockAlreadyExecuted(Box<Block>),
-    /// A Step result was committed and has altered global state.
-    StepCommitted(EraId, ExecutionEffect),
+    /// A Step succeeded and has altered global state.
+    StepSuccess {
+        /// The era id in which the step was committed to global state.
+        era_id: EraId,
+        /// The operations and transforms committed to global state.
+        execution_effect: ExecutionEffect,
+    },
 }
 
 impl ContractRuntimeAnnouncement {
@@ -242,9 +247,12 @@ impl ContractRuntimeAnnouncement {
         Self::BlockAlreadyExecuted(Box::new(block))
     }
 
-    /// Create a ContractRuntimeAnnouncement::StepCommitted from an execution effect.
-    pub fn step_result_success(era_id: EraId, execution_effect: ExecutionEffect) -> Self {
-        Self::StepCommitted(era_id, execution_effect)
+    /// Create a ContractRuntimeAnnouncement::StepSuccess from an execution effect.
+    pub fn step_success(era_id: EraId, execution_effect: ExecutionEffect) -> Self {
+        Self::StepSuccess {
+            era_id,
+            execution_effect,
+        }
     }
 }
 
@@ -270,12 +278,8 @@ impl Display for ContractRuntimeAnnouncement {
             ContractRuntimeAnnouncement::BlockAlreadyExecuted(block) => {
                 write!(f, "block had been executed before: {}", block.hash())
             }
-            ContractRuntimeAnnouncement::StepCommitted(era_id, ..) => {
-                write!(
-                    f,
-                    "execution effect has been successfully committed in era: {}",
-                    era_id
-                )
+            ContractRuntimeAnnouncement::StepSuccess { era_id, .. } => {
+                write!(f, "step completed for {}", era_id)
             }
         }
     }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -775,10 +775,10 @@ impl reactor::Reactor for Reactor {
                 rng,
                 Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(Box::new(*block))),
             ),
-            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepCommitted(
+            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepSuccess {
                 era_id,
                 execution_effect,
-            )) => self.dispatch_event(
+            }) => self.dispatch_event(
                 effect_builder,
                 rng,
                 Event::EventStreamServer(event_stream_server::Event::Step {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -775,6 +775,17 @@ impl reactor::Reactor for Reactor {
                 rng,
                 Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(Box::new(*block))),
             ),
+            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepCommitted(
+                era_id,
+                execution_effect,
+            )) => self.dispatch_event(
+                effect_builder,
+                rng,
+                Event::EventStreamServer(event_stream_server::Event::Step {
+                    era_id,
+                    effect: execution_effect,
+                }),
+            ),
             Event::LinearChain(event) => reactor::wrap_effects(
                 Event::LinearChain,
                 self.linear_chain.handle_event(effect_builder, rng, event),

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1014,10 +1014,10 @@ impl reactor::Reactor for Reactor {
                 debug!("Ignoring `BlockAlreadyExecuted` announcement in `validator` reactor.");
                 Effects::new()
             }
-            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepCommitted(
+            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepSuccess {
                 era_id,
                 execution_effect,
-            )) => {
+            }) => {
                 let reactor_event = Event::EventStreamServer(event_stream_server::Event::Step {
                     era_id,
                     effect: execution_effect,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1014,6 +1014,16 @@ impl reactor::Reactor for Reactor {
                 debug!("Ignoring `BlockAlreadyExecuted` announcement in `validator` reactor.");
                 Effects::new()
             }
+            Event::ContractRuntimeAnnouncement(ContractRuntimeAnnouncement::StepCommitted(
+                era_id,
+                execution_effect,
+            )) => {
+                let reactor_event = Event::EventStreamServer(event_stream_server::Event::Step {
+                    era_id,
+                    effect: execution_effect,
+                });
+                self.dispatch_event(effect_builder, rng, reactor_event)
+            }
             Event::DeployGossiperAnnouncement(_ann) => {
                 unreachable!("the deploy gossiper should never make an announcement")
             }


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-1114

CHANGELOG:

- Added a new `ContractRuntimeAnnouncement` that raises an event when a step has been committed
- Added a new SSE Event that puts the committed `ExecutionEffect` to the event stream
- Additional wire up to generate this event

Sample output attached

[ndrs1114.txt](https://github.com/casper-network/casper-node/files/6379671/ndrs1114.txt)
