### PR TITLE
NDRS-1179: Store block headers on retrieval

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,6 @@ steps:
   - make setup
   - make test CARGO_FLAGS=--release
   - make test-contracts CARGO_FLAGS=--release
-  - make test-fast-sync CARGO_FLAGS=--release
 
 - name: client-ffi-tests-and-examples
   image: casperlabs/node-build-u1804

--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -32,7 +32,7 @@ where
 
     #[error(
         "Current version is {current_version}, but retrieved block header with future version: \
-             {block_header_with_future_version:?}"
+         {block_header_with_future_version:?}"
     )]
     RetrievedBlockHeaderFromFutureVersion {
         current_version: ProtocolVersion,
@@ -47,4 +47,7 @@ where
 
     #[error(transparent)]
     TrieFetcherError(#[from] FetcherError<Trie<Key, StoredValue>, I>),
+
+    #[error("Could not store block header: {block_header}")]
+    CouldNotStoreBlockHeader { block_header: Box<BlockHeader> },
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -721,7 +721,6 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the requested block header from the linear block store.
-    #[allow(unused)]
     pub(crate) async fn get_block_header_from_storage(
         self,
         block_hash: BlockHash,
@@ -750,6 +749,21 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| StorageRequest::GetBlockSignatures {
                 block_hash,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Puts a block header to storage.
+    pub(crate) async fn put_block_header_to_storage(self, block_header: Box<BlockHeader>) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::PutBlockHeader {
+                block_header,
                 responder,
             },
             QueueKind::Regular,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -372,6 +372,14 @@ pub enum StorageRequest {
         /// stored.
         responder: Responder<bool>,
     },
+    /// Store a block header.
+    PutBlockHeader {
+        /// Block header that is to be stored.
+        block_header: Box<BlockHeader>,
+        /// Responder to call with the result, if true then the block header was successfully
+        /// stored.
+        responder: Responder<bool>,
+    },
 }
 
 impl Display for StorageRequest {
@@ -455,6 +463,9 @@ impl Display for StorageRequest {
                     "get block and metadata for block by height: {}",
                     block_height
                 )
+            }
+            StorageRequest::PutBlockHeader { block_header, .. } => {
+                write!(formatter, "put block header: {}", block_header)
             }
         }
     }


### PR DESCRIPTION
When retrieving a block header, we need to store them in storage.  This is because the `EraSupervisor` will use them later when determining era validators.