### PR TITLE
NDRS-1156: validate chainspec protocol config

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -214,14 +214,26 @@ impl ChainspecLoader {
         P: AsRef<Path>,
         REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send,
     {
-        chainspec.validate_config();
         let root_dir = chainspec_dir
             .as_ref()
             .parent()
+            .map(|path| path.to_path_buf())
             .unwrap_or_else(|| {
-                panic!("chainspec dir must have a parent");
-            })
-            .to_path_buf();
+                error!("chainspec dir must have a parent");
+                PathBuf::new()
+            });
+
+        if !chainspec.is_valid() || root_dir.as_os_str().is_empty() {
+            let chainspec_loader = ChainspecLoader {
+                chainspec,
+                root_dir,
+                reactor_exit: Some(ReactorExit::ProcessShouldExit(ExitCode::Abort)),
+                initial_state_root_hash: Digest::default(),
+                next_upgrade: None,
+                initial_block: None,
+            };
+            return (chainspec_loader, Effects::new());
+        }
 
         let next_upgrade = next_upgrade(root_dir.clone(), chainspec.protocol_config.version);
 

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -68,9 +68,8 @@ pub struct Chainspec {
 }
 
 impl Chainspec {
-    /// Checks whether the values set in the config make sense and prints warnings or panics if
-    /// they don't.
-    pub(crate) fn validate_config(&self) {
+    /// Returns `false` and logs errors if the values set in the config don't make sense.
+    pub(crate) fn is_valid(&self) -> bool {
         let min_era_ms = 1u64 << self.highway_config.minimum_round_exponent;
         // If the era duration is set to zero, we will treat it as explicitly stating that eras
         // should be defined by height only.
@@ -81,7 +80,7 @@ impl Chainspec {
             warn!("era duration is less than minimum era height * round length!");
         }
 
-        self.highway_config.validate_config();
+        self.protocol_config.is_valid() && self.highway_config.is_valid()
     }
 
     /// Serializes `self` and hashes the resulting bytes.

--- a/node/src/types/chainspec/global_state_update.rs
+++ b/node/src/types/chainspec/global_state_update.rs
@@ -60,7 +60,7 @@ impl ToBytes for GlobalStateUpdate {
 
 #[cfg(test)]
 impl GlobalStateUpdate {
-    fn random(rng: &mut TestRng) -> Self {
+    pub fn random(rng: &mut TestRng) -> Self {
         let entries = rng.gen_range(0..10);
         let mut map = BTreeMap::new();
         for _ in 0..entries {

--- a/node/src/types/chainspec/highway_config.rs
+++ b/node/src/types/chainspec/highway_config.rs
@@ -3,6 +3,7 @@ use num::rational::Ratio;
 #[cfg(test)]
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
@@ -25,33 +26,36 @@ pub(crate) struct HighwayConfig {
 }
 
 impl HighwayConfig {
-    /// Checks whether the values set in the config make sense panics if they don't.
-    pub fn validate_config(&self) {
+    /// Checks whether the values set in the config make sense and returns `false` if they don't.
+    pub(super) fn is_valid(&self) -> bool {
         if self.minimum_round_exponent > self.maximum_round_exponent {
-            panic!(
-                "Minimum round exponent is greater than the maximum round exponent.\n\
-                 Minimum round exponent: {min},\n\
-                 Maximum round exponent: {max}",
-                min = self.minimum_round_exponent,
-                max = self.maximum_round_exponent
+            error!(
+                min = %self.minimum_round_exponent,
+                max = %self.maximum_round_exponent,
+                "minimum round exponent is greater than the maximum round exponent",
             );
+            return false;
         }
 
         if self.finality_threshold_fraction <= Ratio::new(0, 1)
             || self.finality_threshold_fraction >= Ratio::new(1, 1)
         {
-            panic!(
-                "Finality threshold fraction is not in the range (0, 1)! Finality threshold: {ftt}",
-                ftt = self.finality_threshold_fraction
+            error!(
+                ftf = %self.finality_threshold_fraction,
+                "finality threshold fraction is not in the range (0, 1)",
             );
+            return false;
         }
 
         if self.reduced_reward_multiplier > Ratio::new(1, 1) {
-            panic!(
-                "Reduced reward multiplier is not in the range [0, 1]! Multiplier: {rrm}",
-                rrm = self.reduced_reward_multiplier
+            error!(
+                rrm = %self.reduced_reward_multiplier,
+                "reduced reward multiplier is not in the range [0, 1]",
             );
+            return false;
         }
+
+        true
     }
 
     /// Returns the length of the longest allowed round.
@@ -135,5 +139,61 @@ mod tests {
         let encoded = toml::to_string_pretty(&config).unwrap();
         let decoded = toml::from_str(&encoded).unwrap();
         assert_eq!(config, decoded);
+    }
+
+    #[test]
+    fn should_validate_round_exponents() {
+        let mut rng = crate::new_rng();
+        let mut highway_config = HighwayConfig::random(&mut rng);
+
+        // Should be valid for round exponents where min <= max.
+        highway_config.minimum_round_exponent = highway_config.maximum_round_exponent - 1;
+        assert!(highway_config.is_valid());
+        highway_config.minimum_round_exponent = highway_config.maximum_round_exponent;
+        assert!(highway_config.is_valid());
+
+        // Should be invalid for round exponents where min > max.
+        highway_config.minimum_round_exponent = highway_config.maximum_round_exponent + 1;
+        assert!(!highway_config.is_valid());
+    }
+
+    #[test]
+    fn should_validate_for_finality_threshold() {
+        let mut rng = crate::new_rng();
+        let mut highway_config = HighwayConfig::random(&mut rng);
+
+        // Should be valid for FTT > 0 and < 1.
+        highway_config.finality_threshold_fraction = Ratio::new(1, u64::MAX);
+        assert!(highway_config.is_valid());
+        highway_config.finality_threshold_fraction = Ratio::new(u64::MAX - 1, u64::MAX);
+        assert!(highway_config.is_valid());
+
+        // Should be invalid for FTT == 0 or >= 1.
+        highway_config.finality_threshold_fraction = Ratio::new(0, 1);
+        assert!(!highway_config.is_valid());
+        highway_config.finality_threshold_fraction = Ratio::new(1, 1);
+        assert!(!highway_config.is_valid());
+        highway_config.finality_threshold_fraction = Ratio::new(u64::MAX, u64::MAX);
+        assert!(!highway_config.is_valid());
+        highway_config.finality_threshold_fraction = Ratio::new(u64::MAX, u64::MAX - 1);
+        assert!(!highway_config.is_valid());
+    }
+
+    #[test]
+    fn should_validate_for_reduced_reward_multiplier() {
+        let mut rng = crate::new_rng();
+        let mut highway_config = HighwayConfig::random(&mut rng);
+
+        // Should be valid for 0 <= RRM <= 1.
+        highway_config.reduced_reward_multiplier = Ratio::new(0, 1);
+        assert!(highway_config.is_valid());
+        highway_config.reduced_reward_multiplier = Ratio::new(1, 1);
+        assert!(highway_config.is_valid());
+        highway_config.reduced_reward_multiplier = Ratio::new(u64::MAX, u64::MAX);
+        assert!(highway_config.is_valid());
+
+        // Should be invalid for RRM > 1.
+        highway_config.reduced_reward_multiplier = Ratio::new(u64::MAX, u64::MAX - 1);
+        assert!(!highway_config.is_valid());
     }
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1156

This PR adds validation to the `ProtocolConfig` which ensures that the contained values make sense.  It also changes how such a failure is handled, now avoiding direct panics and instead using our own `ExitCode::Abort` to indicate that the process should stop.