### PR TITLE
HWY-288: Avoid redundant requests caused by the Highway synchronizer.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -106,7 +106,7 @@ impl<C: Context> From<PreValidatedVertex<C>> for Vertex<C> {
 /// Note that this must only be added to the `Highway` instance that created it. Can cause a panic
 /// or inconsistent state otherwise.
 #[derive(Clone, DataSize, Debug, Eq, PartialEq, Hash)]
-pub(crate) struct ValidVertex<C>(pub(super) Vertex<C>)
+pub(crate) struct ValidVertex<C>(pub(crate) Vertex<C>)
 where
     C: Context;
 

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -105,7 +105,7 @@ impl<C: Context> From<PreValidatedVertex<C>> for Vertex<C> {
 ///
 /// Note that this must only be added to the `Highway` instance that created it. Can cause a panic
 /// or inconsistent state otherwise.
-#[derive(Clone, DataSize, Debug, Eq, PartialEq)]
+#[derive(Clone, DataSize, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct ValidVertex<C>(pub(super) Vertex<C>)
 where
     C: Context;

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -302,8 +302,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     /// dependencies or validation. Recursively schedules events to add everything that is
     /// unblocked now.
     fn add_vertex(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
-        let (maybe_pending_vertex, mut outcomes) =
-            self.synchronizer.pop_vertex_to_add(&self.highway);
+        let (maybe_pending_vertex, mut outcomes) = self
+            .synchronizer
+            .pop_vertex_to_add(&self.highway, &self.pending_values);
         let pending_vertex = match maybe_pending_vertex {
             None => return outcomes,
             Some(pending_vertex) => pending_vertex,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -76,7 +76,7 @@ where
     C: Context,
 {
     /// Incoming blocks we can't add yet because we are waiting for validation.
-    pending_values: HashMap<ProposedBlock<C>, Vec<ValidVertex<C>>>,
+    pending_values: HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, I)>>,
     finality_detector: FinalityDetector<C>,
     highway: Highway<C>,
     /// A tracker for whether we are keeping up with the current round exponent or not.
@@ -346,14 +346,17 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 let ancestor_values = self.ancestors(fork_choice).cloned().collect();
                 let block_context = BlockContext::new(timestamp, ancestor_values);
                 let proposed_block = ProposedBlock::new(value.clone(), block_context);
-                self.pending_values
+                if self
+                    .pending_values
                     .entry(proposed_block.clone())
                     .or_default()
-                    .push(vv);
-                outcomes.push(ProtocolOutcome::ValidateConsensusValue {
-                    sender,
-                    proposed_block,
-                });
+                    .insert((vv, sender.clone()))
+                {
+                    outcomes.push(ProtocolOutcome::ValidateConsensusValue {
+                        sender,
+                        proposed_block,
+                    });
+                }
                 return outcomes;
             } else {
                 self.log_proposal(vertex, "proposal does not need validation");
@@ -789,7 +792,7 @@ where
                 .remove(&proposed_block)
                 .into_iter()
                 .flatten()
-                .flat_map(|vv| self.add_valid_vertex(vv, now))
+                .flat_map(|(vv, _)| self.add_valid_vertex(vv, now))
                 .collect_vec();
             outcomes.extend(self.synchronizer.remove_satisfied_deps(&self.highway));
             outcomes.extend(self.detect_finality());
@@ -802,7 +805,7 @@ where
             let dropped_vertex_ids = dropped_vertices
                 .into_iter()
                 .flatten()
-                .map(|vv| {
+                .map(|(vv, _)| {
                     self.log_proposal(vv.inner(), "dropping invalid proposal");
                     vv.inner().id()
                 })

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -367,7 +367,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     || pending_values
                         .values()
                         .flatten()
-                        .any(|(vv, s)| vv.inner().id() == dep && s == &sender)
+                        .any(|(vv, s)| vv.inner().id() == transitive_dependency && s == &sender)
                 {
                     // If we've already requested the same dependency from the same peer, ignore.
                     continue;

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -2,11 +2,12 @@ use super::*;
 
 use crate::components::consensus::{
     highway_core::{
-        highway::tests::test_validators,
+        highway::{tests::test_validators, ValidVertex},
         highway_testing::TEST_INSTANCE_ID,
         state::{tests::*, State},
     },
     protocols::highway::tests::NodeId,
+    BlockContext,
 };
 
 use std::collections::BTreeSet;
@@ -229,6 +230,89 @@ fn do_not_download_synchronized_dependencies() {
         }
     }
     assert!(sync.is_empty());
+}
+
+#[test]
+fn transitive_proposal_dependency() {
+    let params = test_params(0);
+    // A Highway and state instances that are used to create PreValidatedVertex instances below.
+
+    let mut state = State::new(WEIGHTS, params.clone(), vec![]);
+    let util_highway =
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
+
+    // We use round exponent 4u8, so a round is 0x10 ms. With seed 0, Carol is the first leader.
+    //
+    // time:  0x00 0x0A 0x1A 0x2A 0x3A
+    //
+    // Carol   c0 — c1
+    //                \
+    // Bob             — b0
+
+    let c0 = add_unit!(state, CAROL, 0x00, 4u8, 0xA; N, N, N).unwrap();
+    let c1 = add_unit!(state, CAROL, 0x0A, 4u8, None; N, N, c0).unwrap();
+    let b0 = add_unit!(state, BOB, 0x2A, 4u8, None; N, N, c1).unwrap();
+
+    // Returns the WireUnit with the specified hash.
+    let unit = |hash: u64| Vertex::Unit(state.wire_unit(&hash, TEST_INSTANCE_ID).unwrap());
+    // Returns the PreValidatedVertex with the specified hash.
+    let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
+
+    let peer0 = NodeId(0);
+
+    // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
+    let mut sync = Synchronizer::<NodeId, TestContext>::new(
+        0x20.into(),
+        0x20.into(),
+        WEIGHTS.len(),
+        TEST_INSTANCE_ID,
+    );
+
+    let highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
+    let now = 0x20.into();
+
+    assert!(matches!(
+        *sync.schedule_add_vertex(peer0, pvv(c1), now),
+        [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
+    ));
+    // `c1` can't be added to the protocol state yet b/c it's missing its `c0` dependency.
+    let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
+    assert!(pv.is_none());
+    assert_targeted_message(
+        &unwrap_single(outcomes),
+        &peer0,
+        HighwayMessage::RequestDependency(Dependency::Unit(c0)),
+    );
+    // "Download" and schedule addition of c0.
+    let c0_outcomes = sync.schedule_add_vertex(peer0, pvv(c0), now);
+    assert!(matches!(
+        *c0_outcomes,
+        [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
+    ));
+    // `c0` has no dependencies so we can try adding it to the protocol state.
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
+    let pv = maybe_pv.expect("expected c0 vertex");
+    assert_eq!(pv.vertex(), &unit(c0));
+    assert!(outcomes.is_empty());
+    // `b0` can't be added either b/c it's relying on `c1` and `c0`.
+    assert!(matches!(
+        *sync.schedule_add_vertex(peer0, pvv(b0), now),
+        [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
+    ));
+    let c0_pending_values = {
+        let mut tmp = HashMap::new();
+        let vv = ValidVertex(unit(c0));
+        let proposed_block = ProposedBlock::new(1u32, BlockContext::new(now, Vec::new()));
+        let mut set = HashSet::new();
+        set.insert((vv, peer0));
+        tmp.insert(proposed_block, set);
+        tmp
+    };
+    let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &c0_pending_values);
+    assert!(pv.is_none());
+    // `b0` depends on `c1` and `c0` transitively but `c0`'s deploys are being downloaded,
+    // so we don't re-request it.
+    assert!(outcomes.is_empty())
 }
 
 fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -65,7 +65,7 @@ fn purge_vertices() {
 
     // No new vertices can be added yet, because all are missing dependencies.
     // The missing dependencies of c1 and c2 are requested.
-    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert!(maybe_pv.is_none());
     assert_targeted_message(
         &unwrap_single(outcomes),
@@ -82,7 +82,7 @@ fn purge_vertices() {
         "unexpected outcomes: {:?}",
         outcomes
     );
-    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert_eq!(Dependency::Unit(c0), maybe_pv.unwrap().vertex().id());
     assert!(outcomes.is_empty());
     let vv_c0 = highway.validate_vertex(pvv(c0)).expect("c0 is valid");
@@ -106,7 +106,7 @@ fn purge_vertices() {
     sync.purge_vertices(0x41.into());
 
     // The main queue should now contain only c1. If we remove it, the synchronizer is empty.
-    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert_eq!(Dependency::Unit(c1), maybe_pv.unwrap().vertex().id());
     assert!(outcomes.is_empty());
     assert!(sync.is_empty());
@@ -160,7 +160,7 @@ fn do_not_download_synchronized_dependencies() {
         [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
     ));
     // `c2` can't be added to the protocol state yet b/c it's missing its `c1` dependency.
-    let (pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert!(pv.is_none());
     assert_targeted_message(
         &unwrap_single(outcomes),
@@ -176,7 +176,7 @@ fn do_not_download_synchronized_dependencies() {
     // `b0` can't be added to the protocol state b/c it's missing its `c1` dependency,
     // but `c1` has already been downloaded so we should not request it again. We will only request
     // `c0` as that's what `c1` depends on.
-    let (pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert!(pv.is_none());
     assert_targeted_message(
         &unwrap_single(outcomes),
@@ -189,7 +189,7 @@ fn do_not_download_synchronized_dependencies() {
         *sync.schedule_add_vertex(peer0, pvv(b0), now),
         [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
     ));
-    let (pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
     assert!(pv.is_none());
     // `b0` depends on `c1`, that is already in the synchronizer's state, but it also depends on
     // `c0` transitively that is not yet known. We should request it, even if we had already
@@ -206,7 +206,7 @@ fn do_not_download_synchronized_dependencies() {
         .into_iter()
         .map(Dependency::Unit)
         .collect();
-    while let (Some(pv), outcomes) = sync.pop_vertex_to_add(&highway) {
+    while let (Some(pv), outcomes) = sync.pop_vertex_to_add(&highway, &Default::default()) {
         // Verify that we don't request any dependency now.
         assert!(
             !outcomes


### PR DESCRIPTION
Once all Highway dependencies are resolved, the synchronizer forgets about a proposed block and gives it to `HighwayProtocol` for inclusion into the protocol state. However, nonempty blocks are not immediately added: They are kept in the `pending_values` map while the block validator is downloading the deploys and checking the block limits. During that period, the synchronizer will request the same block again, if any dependent unit is added.

This PR should fix both the redundant requests for the block itself as well as the redundant requests to the block validator.

https://casperlabs.atlassian.net/browse/HWY-288