### PR TITLE
NDRS-1225: Remove systemd notify support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "reqwest 0.10.10",
  "rmp-serde",
  "schemars",
- "sd-notify",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -4928,12 +4927,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sd-notify"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd08a21f852bd2fe42e3b2a6c76a0db6a95a5b5bd29c0521dd0b30fa1712ec8"
 
 [[package]]
 name = "security-framework"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -68,7 +68,6 @@ rand_chacha = "0.3.0"
 regex = "1"
 rmp-serde = "0.14.4"
 schemars = { version = "0.8.0", features = ["preserve_order"] }
-sd-notify = "0.3.0"
 serde = { version = "1", features = ["derive"] }
 serde-big-array = "0.3.0"
 serde_bytes = "0.11.5"

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -154,9 +154,6 @@ pub struct Network<REv, P> {
 
 impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
     /// Creates a new small network component instance.
-    ///
-    /// If `notify` is set to `false`, no systemd notifications will be sent, regardless of
-    /// configuration.
     #[allow(clippy::type_complexity)]
     pub(crate) fn new(
         event_queue: EventQueueHandle<REv>,
@@ -164,7 +161,6 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         registry: &Registry,
         network_identity: NetworkIdentity,
         chainspec: &Chainspec,
-        notify: bool,
     ) -> Result<(Network<REv, P>, Effects<Event<P>>), Error> {
         let our_peer_id = PeerId::from(&network_identity);
         let our_id = NodeId::from(&network_identity);
@@ -213,10 +209,6 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         }
 
         let net_metrics = NetworkingMetrics::new(registry).map_err(Error::MetricsError)?;
-
-        if notify {
-            debug!("our node id: {}", our_id);
-        }
 
         // Create a keypair for authenticated encryption of the transport.
         let noise_keys = noise::Keypair::<X25519Spec>::new()

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -39,8 +39,6 @@ pub struct Config {
     /// it has no peer connections, and is intended to be amongst the first nodes started on a
     /// network.
     pub is_bootstrap_node: bool,
-    /// Enable systemd startup notification.
-    pub systemd_support: bool,
     /// The timeout for connection setup (including upgrades) for all inbound and outbound
     /// connections.
     pub connection_setup_timeout: TimeDiff,
@@ -64,7 +62,6 @@ impl Default for Config {
             bind_address: DEFAULT_BIND_ADDRESS.to_string(),
             known_addresses: Vec::new(),
             is_bootstrap_node: false,
-            systemd_support: false,
             connection_setup_timeout: TimeDiff::from_str(temp::CONNECTION_SETUP_TIMEOUT).unwrap(),
             max_one_way_message_size: temp::MAX_ONE_WAY_MESSAGE_SIZE,
             request_timeout: TimeDiff::from_str(temp::REQUEST_TIMEOUT).unwrap(),
@@ -127,7 +124,6 @@ impl From<&small_network::Config> for Config {
             bind_address: config.bind_address.clone(),
             known_addresses: config.known_addresses.clone(),
             is_bootstrap_node,
-            systemd_support: config.systemd_support,
             ..Default::default()
         }
     }

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -90,14 +90,8 @@ impl Reactor for TestReactor {
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let chainspec = Chainspec::random(rng);
         let network_identity = NetworkIdentity::new();
-        let (network_component, effects) = NetworkComponent::new(
-            event_queue,
-            config,
-            registry,
-            network_identity,
-            &chainspec,
-            false,
-        )?;
+        let (network_component, effects) =
+            NetworkComponent::new(event_queue, config, registry, network_identity, &chainspec)?;
 
         Ok((
             TestReactor { network_component },

--- a/node/src/components/network/tests_bulk_gossip.rs
+++ b/node/src/components/network/tests_bulk_gossip.rs
@@ -40,7 +40,7 @@ reactor!(LoadTestingReactor {
 
   components: {
       net = has_effects Network::<LoadTestingReactorEvent, DummyPayload>(
-        event_queue, cfg.network_config, registry, NetworkIdentity::new(), &cfg.chainspec, false
+        event_queue, cfg.network_config, registry, NetworkIdentity::new(), &cfg.chainspec
       );
       collector = infallible Collector::<DummyPayload>();
   }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -236,9 +236,6 @@ where
     REv: ReactorEvent + From<Event<P>> + From<NetworkAnnouncement<NodeId, P>>,
 {
     /// Creates a new small network component instance.
-    ///
-    /// If `notify` is set to `false`, no systemd notifications will be sent, regardless of
-    /// configuration.
     #[allow(clippy::type_complexity)]
     pub(crate) fn new<C: Into<ChainInfo>>(
         event_queue: EventQueueHandle<REv>,
@@ -246,7 +243,6 @@ where
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
         chain_info_source: C,
-        notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         let mut known_addresses = HashSet::new();
         for address in &cfg.known_addresses {
@@ -314,20 +310,6 @@ where
             .set_nonblocking(true)
             .map_err(Error::ListenerSetNonBlocking)?;
 
-        // Once the port has been bound, we can notify systemd if instructed to do so.
-        if notify {
-            if cfg.systemd_support {
-                if sd_notify::booted().map_err(Error::SystemD)? {
-                    info!("notifying systemd that the network is ready to receive connections");
-                    sd_notify::notify(true, &[sd_notify::NotifyState::Ready])
-                        .map_err(Error::SystemD)?;
-                } else {
-                    warn!("systemd_support enabled but not booted with systemd, ignoring");
-                }
-            } else {
-                debug!("systemd_support disabled, not notifying");
-            }
-        }
         let local_address = listener.local_addr().map_err(Error::ListenerAddr)?;
 
         // Substitute the actually bound port if set to 0.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -28,7 +28,6 @@ impl Default for Config {
             public_address: DEFAULT_PUBLIC_ADDRESS.to_string(),
             known_addresses: Vec::new(),
             gossip_interval: DEFAULT_GOSSIP_INTERVAL,
-            systemd_support: false,
             isolation_reconnect_delay: TimeDiff::from_seconds(2),
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
@@ -52,8 +51,6 @@ pub struct Config {
     /// Interval in milliseconds used for gossiping.
     #[serde(with = "crate::utils::milliseconds")]
     pub gossip_interval: Duration,
-    /// Enable systemd startup notification.
-    pub systemd_support: bool,
     /// Minimum amount of time that has to pass before attempting to reconnect after isolation.
     pub isolation_reconnect_delay: TimeDiff,
     /// Initial delay before the first round of gossip.
@@ -80,7 +77,6 @@ impl Config {
             public_address: bind_address.to_string(),
             known_addresses: vec![bind_address.to_string()],
             gossip_interval: DEFAULT_TEST_GOSSIP_INTERVAL,
-            systemd_support: false,
             ..Default::default()
         }
     }
@@ -99,7 +95,6 @@ impl Config {
                 SocketAddr::from((TEST_BIND_INTERFACE, known_peer_port)).to_string()
             ],
             gossip_interval: DEFAULT_TEST_GOSSIP_INTERVAL,
-            systemd_support: false,
             ..Default::default()
         }
     }

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -118,9 +118,6 @@ pub enum Error {
         #[from]
         SystemTimeError,
     ),
-    /// Systemd notification error
-    #[error("could not interact with systemd: {0}")]
-    SystemD(#[serde(skip_serializing)] io::Error),
     /// Other error.
     #[error(transparent)]
     Anyhow(

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -152,7 +152,6 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             ChainInfo::create_for_testing(),
-            false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();
         let address_gossiper =

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -387,7 +387,6 @@ impl reactor::Reactor for Reactor {
             registry,
             network_identity,
             chainspec_loader.chainspec(),
-            false,
         )?;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
@@ -395,7 +394,6 @@ impl reactor::Reactor for Reactor {
             registry,
             small_network_identity,
             chainspec_loader.chainspec().as_ref(),
-            false,
         )?;
 
         let linear_chain_fetcher = Fetcher::new("linear_chain", config.fetcher, &registry)?;

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -413,7 +413,6 @@ impl reactor::Reactor for Reactor {
             registry,
             network_identity,
             chainspec_loader.chainspec(),
-            true,
         )?;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
@@ -421,7 +420,6 @@ impl reactor::Reactor for Reactor {
             registry,
             small_network_identity,
             chainspec_loader.chainspec().as_ref(),
-            true,
         )?;
 
         let address_gossiper =

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -110,13 +110,6 @@ known_addresses = ['127.0.0.1:34553']
 # The interval (in milliseconds) between each fresh round of gossiping the node's public address.
 gossip_interval = 30000
 
-# Enable systemd support. If enabled, the node will notify systemd once it has synced and its
-# listening socket for incoming connections is open.
-#
-# It is usually better to leave this option off and enable it explicitly via command-line override
-# only in the unit files themselves via `-C=network.systemd_support=true`.
-systemd_support = false
-
 # Minimum amount of time that has to pass before attempting to reconnect after losing all
 # connections to established nodes.
 isolation_reconnect_delay = '2s'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -110,13 +110,6 @@ known_addresses = ['139.162.132.144:35000','3.225.191.9:35000','31.7.207.16:3500
 # The interval (in milliseconds) between each fresh round of gossiping the node's public address.
 gossip_interval = 120_000
 
-# Enable systemd support. If enabled, the node will notify systemd once it has synced and its
-# listening socket for incoming connections is open.
-#
-# It is usually better to leave this option off and enable it explicitly via command-line override
-# only in the unit files themselves via `-C=network.systemd_support=true`.
-systemd_support = false
-
 # Minimum amount of time that has to pass before attempting to reconnect after losing all
 # connections to established nodes.
 isolation_reconnect_delay = '2s'


### PR DESCRIPTION
Removes the now unused (superseded by `casper-node-launcher`) systemd notification support from all configurations and the functionality from the networking component.

**This does result in a change in configuration files**.