### PR TITLE
HWY-293: Request latest state only if stalled.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -474,7 +474,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
             let mut outcomes = self.latest_panorama_request();
             outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now + self.standstill_timeout * 2,
+                now + self.standstill_timeout,
                 TIMER_ID_STANDSTILL_ALERT,
             ));
             return outcomes;

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -63,8 +63,8 @@ const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
 const TIMER_ID_STANDSTILL_ALERT: TimerId = TimerId(4);
 /// The timer for logging synchronizer queue size.
 const TIMER_ID_SYNCHRONIZER_LOG: TimerId = TimerId(5);
-/// The timer for sending the latest panorama request.
-const TIMER_ID_PANORAMA_REQUEST: TimerId = TimerId(6);
+/// The timer to check for initial progress.
+const TIMER_ID_PROGRESS_ALERT: TimerId = TimerId(6);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -197,7 +197,6 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             round_success_meter,
             synchronizer: Synchronizer::new(
                 config.highway.pending_vertex_timeout,
-                config.highway.request_latest_state_timeout,
                 validators_count,
                 instance_id,
             ),
@@ -228,7 +227,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             ),
             ProtocolOutcome::ScheduleTimer(
                 now.max(era_start_time) + highway_config.standstill_timeout,
-                TIMER_ID_STANDSTILL_ALERT,
+                TIMER_ID_PROGRESS_ALERT,
             ),
             ProtocolOutcome::ScheduleTimer(now + TimeDiff::from(5_000), TIMER_ID_SYNCHRONIZER_LOG),
         ]
@@ -460,6 +459,33 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         self.finality_detector
             .last_finalized()
             .map_or(false, is_switch)
+    }
+
+    // Check if we've made any progress since joining.
+    // If we haven't, we might have been left alone in the era and we should request the state from
+    // peers.
+    fn handle_progress_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+        if self.evidence_only || self.finalized_switch_block() {
+            return vec![]; // Era has ended. No further progress is expected.
+        }
+        if self.last_panorama == *self.highway.state().panorama() {
+            // We haven't made any progress. Request latest panorama from peers and schedule
+            // standstill alert. If we still won't progress by the time
+            // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
+            let mut outcomes = self.latest_panorama_request();
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now + self.standstill_timeout * 2,
+                TIMER_ID_STANDSTILL_ALERT,
+            ));
+            return outcomes;
+        }
+
+        // Record the current panorama and schedule the next standstill check.
+        self.last_panorama = self.highway.state().panorama().clone();
+        vec![ProtocolOutcome::ScheduleTimer(
+            now + self.standstill_timeout,
+            TIMER_ID_STANDSTILL_ALERT,
+        )]
     }
 
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
@@ -729,6 +755,7 @@ where
                     vec![]
                 }
             }
+            TIMER_ID_PROGRESS_ALERT => self.handle_progress_alert_timer(now),
             TIMER_ID_STANDSTILL_ALERT => self.handle_standstill_alert_timer(now),
             TIMER_ID_SYNCHRONIZER_LOG => {
                 self.synchronizer.log_len();
@@ -739,29 +766,13 @@ where
                     vec![]
                 }
             }
-            TIMER_ID_PANORAMA_REQUEST => {
-                if !self.finalized_switch_block() {
-                    let mut outcomes = self.latest_panorama_request();
-                    let next_timer =
-                        Timestamp::now() + self.synchronizer.request_latest_state_timeout();
-                    outcomes.push(ProtocolOutcome::ScheduleTimer(next_timer, timer_id));
-                    outcomes
-                } else {
-                    vec![]
-                }
-            }
             _ => unreachable!("unexpected timer ID"),
         }
     }
 
     fn handle_is_current(&self) -> ProtocolOutcomes<I, C> {
         // Request latest protocol state of the current era.
-        let mut outcomes = self.latest_panorama_request();
-        outcomes.push(ProtocolOutcome::ScheduleTimer(
-            Timestamp::now() + self.synchronizer.request_latest_state_timeout(),
-            TIMER_ID_PANORAMA_REQUEST,
-        ));
-        outcomes
+        self.latest_panorama_request()
     }
 
     fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<I, C> {

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -16,8 +16,6 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
-    /// The frequency at which we will ask peers for their latest state.
-    pub request_latest_state_timeout: TimeDiff,
     /// If the current era's protocol state has not progressed for this long, shut down.
     pub standstill_timeout: TimeDiff,
     /// Log inactive or faulty validators periodically, with this interval.
@@ -35,7 +33,6 @@ impl Default for Config {
         Config {
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
-            request_latest_state_timeout: "5sec".parse().unwrap(),
             standstill_timeout: "1min".parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             log_unit_sizes: false,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -165,8 +165,6 @@ where
     vertices_no_deps: PendingVertices<I, C>,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pending_vertex_timeout: TimeDiff,
-    /// The duration between two consecutive requests of the latest state.
-    request_latest_state_timeout: TimeDiff,
     /// Instance ID of an era for which this synchronizer is constructed.
     instance_id: C::InstanceId,
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
@@ -180,7 +178,6 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
     pub(crate) fn new(
         pending_vertex_timeout: TimeDiff,
-        request_latest_state_timeout: TimeDiff,
         validator_len: usize,
         instance_id: C::InstanceId,
     ) -> Self {
@@ -189,7 +186,6 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_no_deps: Default::default(),
             pending_vertex_timeout,
-            request_latest_state_timeout,
             oldest_seen_panorama: iter::repeat(None).take(validator_len).collect(),
             instance_id,
             current_era: true,
@@ -433,11 +429,6 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Returns the timeout for pending vertices: Entries older than this are purged periodically.
     pub(crate) fn pending_vertex_timeout(&self) -> TimeDiff {
         self.pending_vertex_timeout
-    }
-
-    /// Returns the duration between two consecutive requests of the latest state.
-    pub(crate) fn request_latest_state_timeout(&self) -> TimeDiff {
-        self.request_latest_state_timeout
     }
 
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -42,12 +42,8 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
-        WEIGHTS.len(),
-        TEST_INSTANCE_ID,
-    );
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.
@@ -146,12 +142,8 @@ fn do_not_download_synchronized_dependencies() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
-        WEIGHTS.len(),
-        TEST_INSTANCE_ID,
-    );
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
 
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
     let now = 0x20.into();
@@ -261,12 +253,8 @@ fn transitive_proposal_dependency() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
-        WEIGHTS.len(),
-        TEST_INSTANCE_ID,
-    );
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
 
     let highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
     let now = 0x20.into();

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -77,7 +77,6 @@ where
             standstill_timeout: STANDSTILL_TIMEOUT.parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
-            request_latest_state_timeout: "10sec".parse().unwrap(),
             ..HighwayConfig::default()
         },
     };

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -43,9 +43,6 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# The period at which we will ask peers for their latest state.
-request_latest_state_timeout = '30sec'
-
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -43,9 +43,6 @@ unit_hashes_folder = "/var/lib/casper/casper-node"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# The period at which we will ask peers for their latest state.
-request_latest_state_timeout = '30sec'
-
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'
 


### PR DESCRIPTION
With the `TIMER_ID_PANORAMA_REQUEST` firing periodically, a node would send out (to every peer) a request containing its latest panorama. The receiver, would then compare it with its local view of the DAG and either request a dependency from the sender, or send a newer unit (that the sender doesn't have yet). It would do that for every validator. This leads to `m * m * n` requests being made every `request_latest_panorama`, where `m` is the number of nodes in the network and `n` number of validators – everyone (`m`) would send a message to everyone else (`m - 1`) and trigger potentially `n` responses (one for every validator in the panorama), some of which (`RequestDependency`) would trigger a response (yet another message). That amount of additional messages being exchanged turned out to really hurt the performance of the network. We need to remove the periodic message.

Originally, the reason for adding it was to prevent the node from being left alone in an era, while others have already moved on to the next one. The alternative solution proposed here is that rather than sending `LatestStateRequest` periodically, we will do it only when the node detects it's stalled. If, after the timer fires again, the node's protocol state hasn't advanced yet – shut down.

https://casperlabs.atlassian.net/browse/HWY-293