### PR TITLE
NDRS-1226: BlockWithMetadata fetcher no longer uses storage

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -515,7 +515,7 @@ where
                     self.metrics.found_in_storage.inc();
                     self.got_from_storage(item, peer)
                 }
-                _ => self.failed_to_get_from_storage(effect_builder, id, peer),
+                None => self.failed_to_get_from_storage(effect_builder, id, peer),
             },
             Event::GotRemotely { item, source } => {
                 match source {


### PR DESCRIPTION
Whenever fast-sync fetches a `BlockWithMetadata`, it needs to validate it in order to retrieve its deploys.  Validation requires providing the peer from which the block was fetched.  In the case that the block was retrieved from storage, no such peer is available.  To avoid this, we prevent the `BlockWithMetadata` fetcher from retrieving from storage.