### PR TITLE
HWY-292, HWY-293, NDRS-1237: Reduce redundant data and requests in Highway. (ports to dev)

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -14,6 +14,7 @@ mod tests;
 use std::{
     collections::{HashMap, HashSet},
     convert::Infallible,
+    sync::Arc,
     time::Duration,
 };
 
@@ -406,7 +407,7 @@ impl BlockProposerReady {
         past_deploys: HashSet<DeployHash>,
         accusations: Vec<PublicKey>,
         random_bit: bool,
-    ) -> BlockPayload {
+    ) -> Arc<BlockPayload> {
         let mut appendable_block = AppendableBlock::new(deploy_config, block_timestamp);
 
         // We prioritize transfers over deploys, so we try to include them first.
@@ -470,7 +471,7 @@ impl BlockProposerReady {
             }
         }
 
-        appendable_block.into_block_payload(accusations, random_bit)
+        Arc::new(appendable_block.into_block_payload(accusations, random_bit))
     }
 
     /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned.

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -91,7 +91,7 @@ fn new_proposed_block(
     // These values are not checked by the block validator.
     let block_context = BlockContext::new(timestamp, vec![]);
     let block_payload = BlockPayload::new(deploy_hashes, transfer_hashes, vec![], true);
-    ProposedBlock::new(block_payload, block_context)
+    ProposedBlock::new(Arc::new(block_payload), block_context)
 }
 
 fn new_deploy(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDiff) -> Deploy {

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -18,6 +18,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     convert::Infallible,
     fmt::{self, Debug, Display, Formatter},
+    sync::Arc,
     time::Duration,
 };
 
@@ -78,7 +79,7 @@ pub struct ActionId(pub u8);
 #[derive(DataSize, Debug, From)]
 pub struct NewBlockPayload {
     era_id: EraId,
-    block_payload: BlockPayload,
+    block_payload: Arc<BlockPayload>,
     block_context: BlockContext<ClContext>,
 }
 

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -45,7 +45,7 @@ impl ValidatorSecret for Keypair {
     }
 }
 
-impl ConsensusValueT for BlockPayload {
+impl ConsensusValueT for Arc<BlockPayload> {
     fn needs_validation(&self) -> bool {
         !self.transfer_hashes().is_empty() || !self.deploy_hashes().is_empty()
     }
@@ -56,7 +56,7 @@ impl ConsensusValueT for BlockPayload {
 pub struct ClContext;
 
 impl Context for ClContext {
-    type ConsensusValue = BlockPayload;
+    type ConsensusValue = Arc<BlockPayload>;
     type ValidatorId = PublicKey;
     type ValidatorSecret = Keypair;
     type Signature = Signature;

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -39,7 +39,6 @@ impl<C: Context> BlockContext<C> {
     }
 
     /// The block's relative height, i.e. the number of ancestors in the current era.
-    #[cfg(test)]
     pub(crate) fn height(&self) -> u64 {
         self.ancestor_values.len() as u64
     }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -993,12 +993,6 @@ where
                 .immediately()
                 .event(move |()| Event::Action { era_id, action_id }),
             ProtocolOutcome::CreateNewBlock(block_context) => {
-                let past_deploys = block_context
-                    .ancestor_values()
-                    .iter()
-                    .flat_map(|block_payload| block_payload.deploys_and_transfers_iter())
-                    .cloned()
-                    .collect();
                 let accusations = self
                     .era_supervisor
                     .iter_past(era_id, self.era_supervisor.bonded_eras())
@@ -1009,8 +1003,7 @@ where
                     .collect();
                 self.effect_builder
                     .request_block_payload(
-                        block_context.timestamp(),
-                        past_deploys,
+                        block_context.clone(),
                         self.era_supervisor.next_block_height,
                         accusations,
                         self.rng.gen(),

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1053,7 +1053,7 @@ where
                         .collect(),
                 });
                 let finalized_block = FinalizedBlock::new(
-                    value,
+                    Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone()),
                     era_end,
                     timestamp,
                     era_id,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -195,12 +195,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway,
             round_success_meter,
-            synchronizer: Synchronizer::new(
-                config.highway.pending_vertex_timeout,
-                config.highway.request_latest_state_timeout,
-                validators_count,
-                instance_id,
-            ),
+            synchronizer: Synchronizer::new(config.highway.clone(), validators_count, instance_id),
             pvv_cache: Default::default(),
             evidence_only: false,
             last_panorama,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -63,8 +63,8 @@ const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
 const TIMER_ID_STANDSTILL_ALERT: TimerId = TimerId(4);
 /// The timer for logging synchronizer queue size.
 const TIMER_ID_SYNCHRONIZER_LOG: TimerId = TimerId(5);
-/// The timer for sending the latest panorama request.
-const TIMER_ID_PANORAMA_REQUEST: TimerId = TimerId(6);
+/// The timer to check for initial progress.
+const TIMER_ID_PROGRESS_ALERT: TimerId = TimerId(6);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -223,7 +223,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             ),
             ProtocolOutcome::ScheduleTimer(
                 now.max(era_start_time) + highway_config.standstill_timeout,
-                TIMER_ID_STANDSTILL_ALERT,
+                TIMER_ID_PROGRESS_ALERT,
             ),
             ProtocolOutcome::ScheduleTimer(now + TimeDiff::from(5_000), TIMER_ID_SYNCHRONIZER_LOG),
         ]
@@ -455,6 +455,33 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         self.finality_detector
             .last_finalized()
             .map_or(false, is_switch)
+    }
+
+    // Check if we've made any progress since joining.
+    // If we haven't, we might have been left alone in the era and we should request the state from
+    // peers.
+    fn handle_progress_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+        if self.evidence_only || self.finalized_switch_block() {
+            return vec![]; // Era has ended. No further progress is expected.
+        }
+        if self.last_panorama == *self.highway.state().panorama() {
+            // We haven't made any progress. Request latest panorama from peers and schedule
+            // standstill alert. If we still won't progress by the time
+            // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
+            let mut outcomes = self.latest_panorama_request();
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now + self.standstill_timeout,
+                TIMER_ID_STANDSTILL_ALERT,
+            ));
+            return outcomes;
+        }
+
+        // Record the current panorama and schedule the next standstill check.
+        self.last_panorama = self.highway.state().panorama().clone();
+        vec![ProtocolOutcome::ScheduleTimer(
+            now + self.standstill_timeout,
+            TIMER_ID_STANDSTILL_ALERT,
+        )]
     }
 
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
@@ -724,6 +751,7 @@ where
                     vec![]
                 }
             }
+            TIMER_ID_PROGRESS_ALERT => self.handle_progress_alert_timer(now),
             TIMER_ID_STANDSTILL_ALERT => self.handle_standstill_alert_timer(now),
             TIMER_ID_SYNCHRONIZER_LOG => {
                 self.synchronizer.log_len();
@@ -734,29 +762,13 @@ where
                     vec![]
                 }
             }
-            TIMER_ID_PANORAMA_REQUEST => {
-                if !self.finalized_switch_block() {
-                    let mut outcomes = self.latest_panorama_request();
-                    let next_timer =
-                        Timestamp::now() + self.synchronizer.request_latest_state_timeout();
-                    outcomes.push(ProtocolOutcome::ScheduleTimer(next_timer, timer_id));
-                    outcomes
-                } else {
-                    vec![]
-                }
-            }
             _ => unreachable!("unexpected timer ID"),
         }
     }
 
     fn handle_is_current(&self) -> ProtocolOutcomes<I, C> {
         // Request latest protocol state of the current era.
-        let mut outcomes = self.latest_panorama_request();
-        outcomes.push(ProtocolOutcome::ScheduleTimer(
-            Timestamp::now() + self.synchronizer.request_latest_state_timeout(),
-            TIMER_ID_PANORAMA_REQUEST,
-        ));
-        outcomes
+        self.latest_panorama_request()
     }
 
     fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<I, C> {

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     /// The maximum number of blocks by which execution is allowed to lag behind finalization.
     /// If it is more than that, consensus will pause, and resume once the executor has caught up.
     pub max_execution_delay: u64,
+    /// The maximum number of peers we request the same vertex from in parallel.
+    pub max_requests_for_vertex: usize,
     pub round_success_meter: RSMConfig,
 }
 
@@ -40,6 +42,7 @@ impl Default for Config {
             log_participation_interval: "10sec".parse().unwrap(),
             log_unit_sizes: false,
             max_execution_delay: 3,
+            max_requests_for_vertex: 5,
             round_success_meter: RSMConfig::default(),
         }
     }

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -16,8 +16,6 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
-    /// The frequency at which we will ask peers for their latest state.
-    pub request_latest_state_timeout: TimeDiff,
     /// If the current era's protocol state has not progressed for this long, shut down.
     pub standstill_timeout: TimeDiff,
     /// Log inactive or faulty validators periodically, with this interval.
@@ -37,7 +35,6 @@ impl Default for Config {
         Config {
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
-            request_latest_state_timeout: "5sec".parse().unwrap(),
             standstill_timeout: "1min".parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             log_unit_sizes: false,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -22,7 +22,7 @@ use crate::{
 
 use super::{HighwayMessage, ProtocolOutcomes, ACTION_ID_VERTEX};
 
-const MAX_REQUESTS_FOR_VERTEX: usize = 10;
+const MAX_REQUESTS_FOR_VERTEX: usize = 2;
 
 #[cfg(test)]
 mod tests;

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -170,6 +170,8 @@ where
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
     /// Used only for logging.
     oldest_seen_panorama: ValidatorMap<Option<u64>>,
+    /// Keeps track of the requests we've sent so far and the recipients.
+    /// Used to decide whether we should ask more nodes for a particular dependency.
     requests_sent: BTreeMap<Dependency<C>, HashSet<I>>,
     /// Boolean flag indicating whether we're synchronizing current era.
     pub(crate) current_era: bool,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -381,15 +381,6 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                 {
                     continue;
                 }
-                // If we have already requested the dependency from this peer, or from the maximum
-                // number of peers, do nothing.
-                let entry = self
-                    .requests_sent
-                    .entry(transitive_dependency.clone())
-                    .or_default();
-                if entry.len() >= MAX_REQUESTS_FOR_VERTEX || !entry.insert(sender.clone()) {
-                    continue;
-                }
                 // If we already have the dependency and it is a proposal that is currently being
                 // handled by the block validator, and this sender is not yet known as a source,
                 // we return the proposal as if this sender had sent it to us, so they get added.
@@ -405,6 +396,15 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                         outcomes.push(ProtocolOutcome::QueueAction(ACTION_ID_VERTEX));
                     }
                     return (Some(dep_pv), outcomes);
+                }
+                // If we have already requested the dependency from this peer, or from the maximum
+                // number of peers, do nothing.
+                let entry = self
+                    .requests_sent
+                    .entry(transitive_dependency.clone())
+                    .or_default();
+                if entry.len() >= MAX_REQUESTS_FOR_VERTEX || !entry.insert(sender.clone()) {
+                    continue;
                 }
                 // Otherwise request the missing dependency from the sender.
                 let ser_msg = HighwayMessage::RequestDependency(transitive_dependency).serialize();

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -6,7 +6,7 @@ use std::{
 
 use datasize::DataSize;
 use itertools::Itertools;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{
     components::consensus::{
@@ -389,6 +389,10 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     .flatten()
                     .find(|(vv, _)| vv.inner().id() == transitive_dependency)
                 {
+                    info!(
+                        dependency = ?transitive_dependency, %sender,
+                        "adding sender as a source for proposal"
+                    );
                     let dep_pv = PendingVertex::new(sender, vv.clone().into(), time_received);
                     // We found the next vertex to add.
                     if !self.vertices_no_deps.is_empty() {
@@ -407,6 +411,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     continue;
                 }
                 // Otherwise request the missing dependency from the sender.
+                info!(dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let ser_msg = HighwayMessage::RequestDependency(transitive_dependency).serialize();
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));
                 continue;

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -22,8 +22,6 @@ use crate::{
 
 use super::{HighwayConfig, HighwayMessage, ProtocolOutcomes, ACTION_ID_VERTEX};
 
-const MAX_REQUESTS_FOR_VERTEX: usize = 2;
-
 #[cfg(test)]
 mod tests;
 
@@ -404,7 +402,9 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     .requests_sent
                     .entry(transitive_dependency.clone())
                     .or_default();
-                if entry.len() >= MAX_REQUESTS_FOR_VERTEX || !entry.insert(sender.clone()) {
+                if entry.len() >= self.config.max_requests_for_vertex
+                    || !entry.insert(sender.clone())
+                {
                     continue;
                 }
                 // Otherwise request the missing dependency from the sender.

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -473,11 +473,6 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         self.config.pending_vertex_timeout
     }
 
-    /// Returns the duration between two consecutive requests of the latest state.
-    pub(crate) fn request_latest_state_timeout(&self) -> TimeDiff {
-        self.config.request_latest_state_timeout
-    }
-
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and
     /// returns the set of their senders. If the specified dependencies are known to be invalid,
     /// those senders must be faulty.

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{TimeDiff, Timestamp},
 };
 
-use super::{HighwayMessage, ProtocolOutcomes, ACTION_ID_VERTEX};
+use super::{HighwayConfig, HighwayMessage, ProtocolOutcomes, ACTION_ID_VERTEX};
 
 const MAX_REQUESTS_FOR_VERTEX: usize = 2;
 
@@ -165,10 +165,8 @@ where
     /// Vertices that might be ready to add to the protocol state: We are not currently waiting for
     /// a requested dependency.
     vertices_no_deps: PendingVertices<I, C>,
-    /// The duration for which incoming vertices with missing dependencies are kept in a queue.
-    pending_vertex_timeout: TimeDiff,
-    /// The duration between two consecutive requests of the latest state.
-    request_latest_state_timeout: TimeDiff,
+    /// This node's local Highway protocol configuration.
+    config: HighwayConfig,
     /// Instance ID of an era for which this synchronizer is constructed.
     instance_id: C::InstanceId,
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
@@ -182,8 +180,7 @@ where
 impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
     pub(crate) fn new(
-        pending_vertex_timeout: TimeDiff,
-        request_latest_state_timeout: TimeDiff,
+        config: HighwayConfig,
         validator_len: usize,
         instance_id: C::InstanceId,
     ) -> Self {
@@ -191,8 +188,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             vertices_awaiting_deps: BTreeMap::new(),
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_no_deps: Default::default(),
-            pending_vertex_timeout,
-            request_latest_state_timeout,
+            config,
             oldest_seen_panorama: iter::repeat(None).take(validator_len).collect(),
             instance_id,
             requests_sent: BTreeMap::new(),
@@ -203,7 +199,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Removes expired pending vertices from the queues, and schedules the next purge.
     pub(crate) fn purge_vertices(&mut self, now: Timestamp) {
         info!("purging synchronizer queues");
-        let oldest = now.saturating_sub(self.pending_vertex_timeout);
+        let oldest = now.saturating_sub(self.config.pending_vertex_timeout);
         self.vertices_no_deps.remove_expired(oldest);
         self.requests_sent.clear();
         Self::remove_expired(&mut self.vertices_to_be_added_later, oldest);
@@ -472,12 +468,12 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     /// Returns the timeout for pending vertices: Entries older than this are purged periodically.
     pub(crate) fn pending_vertex_timeout(&self) -> TimeDiff {
-        self.pending_vertex_timeout
+        self.config.pending_vertex_timeout
     }
 
     /// Returns the duration between two consecutive requests of the latest state.
     pub(crate) fn request_latest_state_timeout(&self) -> TimeDiff {
-        self.request_latest_state_timeout
+        self.config.request_latest_state_timeout
     }
 
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -202,6 +202,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     /// Removes expired pending vertices from the queues, and schedules the next purge.
     pub(crate) fn purge_vertices(&mut self, now: Timestamp) {
+        info!("purging synchronizer queues");
         let oldest = now.saturating_sub(self.pending_vertex_timeout);
         self.vertices_no_deps.remove_expired(oldest);
         self.requests_sent.clear();

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -44,7 +44,6 @@ fn purge_vertices() {
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
         HighwayConfig {
-            request_latest_state_timeout: 0x20.into(),
             pending_vertex_timeout: 0x20.into(),
             ..Default::default()
         },
@@ -152,7 +151,6 @@ fn do_not_download_synchronized_dependencies() {
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
         HighwayConfig {
-            request_latest_state_timeout: 0x20.into(),
             pending_vertex_timeout: 0x20.into(),
             ..Default::default()
         },
@@ -271,7 +269,6 @@ fn transitive_proposal_dependency() {
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
         HighwayConfig {
-            request_latest_state_timeout: 0x20.into(),
             pending_vertex_timeout: 0x20.into(),
             ..Default::default()
         },

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -43,8 +43,11 @@ fn purge_vertices() {
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
+        HighwayConfig {
+            request_latest_state_timeout: 0x20.into(),
+            pending_vertex_timeout: 0x20.into(),
+            ..Default::default()
+        },
         WEIGHTS.len(),
         TEST_INSTANCE_ID,
     );
@@ -148,8 +151,11 @@ fn do_not_download_synchronized_dependencies() {
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
+        HighwayConfig {
+            request_latest_state_timeout: 0x20.into(),
+            pending_vertex_timeout: 0x20.into(),
+            ..Default::default()
+        },
         WEIGHTS.len(),
         TEST_INSTANCE_ID,
     );
@@ -264,8 +270,11 @@ fn transitive_proposal_dependency() {
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
-        0x20.into(),
-        0x20.into(),
+        HighwayConfig {
+            request_latest_state_timeout: 0x20.into(),
+            pending_vertex_timeout: 0x20.into(),
+            ..Default::default()
+        },
         WEIGHTS.len(),
         TEST_INSTANCE_ID,
     );

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -144,6 +144,7 @@ fn do_not_download_synchronized_dependencies() {
     let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
 
     let peer0 = NodeId(0);
+    let peer1 = NodeId(1);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let mut sync = Synchronizer::<NodeId, TestContext>::new(
@@ -187,7 +188,7 @@ fn do_not_download_synchronized_dependencies() {
     // `c1` is now part of the synchronizer's state, we should not try requesting it if other
     // vertices depend on it.
     assert!(matches!(
-        *sync.schedule_add_vertex(peer0, pvv(b0), now),
+        *sync.schedule_add_vertex(peer1, pvv(b0), now),
         [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
     ));
     let (pv, outcomes) = sync.pop_vertex_to_add(&highway, &Default::default());
@@ -197,7 +198,7 @@ fn do_not_download_synchronized_dependencies() {
     // done that for `c1`.
     assert_targeted_message(
         &unwrap_single(outcomes),
-        &peer0,
+        &peer1,
         HighwayMessage::RequestDependency(Dependency::Unit(c0)),
     );
     // "Download" the last dependency.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -77,7 +77,6 @@ where
             standstill_timeout: STANDSTILL_TIMEOUT.parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
-            request_latest_state_timeout: "10sec".parse().unwrap(),
             ..HighwayConfig::default()
         },
     };

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -199,7 +199,7 @@ fn send_a_valid_wire_unit() {
         panorama,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
-        value: Some(BlockPayload::new(vec![], vec![], vec![], false)),
+        value: Some(Arc::new(BlockPayload::new(vec![], vec![], vec![], false))),
         seq_number,
         timestamp: now,
         round_exp: 14,
@@ -259,7 +259,7 @@ fn detect_doppelganger() {
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
     let now = Timestamp::zero();
-    let value = BlockPayload::new(vec![], vec![], vec![], false);
+    let value = Arc::new(BlockPayload::new(vec![], vec![], vec![], false));
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -104,6 +104,7 @@ use crate::{
     components::{
         block_validator::ValidatingBlock,
         chainspec_loader::{CurrentRunInfo, NextUpgrade},
+        consensus::{BlockContext, ClContext},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor,
         fetcher::FetchResult,
@@ -1137,8 +1138,7 @@ impl<REv> EffectBuilder<REv> {
     /// Passes the timestamp of a future block for which deploys are to be proposed.
     pub(crate) async fn request_block_payload(
         self,
-        current_instant: Timestamp,
-        past_deploys: HashSet<DeployHash>,
+        context: BlockContext<ClContext>,
         next_finalized: u64,
         accusations: Vec<PublicKey>,
         random_bit: bool,
@@ -1149,8 +1149,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| {
                 BlockProposerRequest::RequestBlockPayload(BlockPayloadRequest {
-                    current_instant,
-                    past_deploys,
+                    context,
                     next_finalized,
                     responder,
                     accusations,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1142,7 +1142,7 @@ impl<REv> EffectBuilder<REv> {
         next_finalized: u64,
         accusations: Vec<PublicKey>,
         random_bit: bool,
-    ) -> BlockPayload
+    ) -> Arc<BlockPayload>
     where
         REv: From<BlockProposerRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -498,7 +498,7 @@ pub struct BlockPayloadRequest {
     /// Random bit with which to construct the `BlockPayload` requested.
     pub(crate) random_bit: bool,
     /// Responder to call with the result.
-    pub(crate) responder: Responder<BlockPayload>,
+    pub(crate) responder: Responder<Arc<BlockPayload>>,
 }
 
 /// A `BlockProposer` request.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -39,6 +39,7 @@ use crate::{
     components::{
         block_validator::ValidatingBlock,
         chainspec_loader::CurrentRunInfo,
+        consensus::{BlockContext, ClContext},
         contract_runtime::{EraValidatorsRequest, ValidatorWeightsByEraIdRequest},
         deploy_acceptor::Error,
         fetcher::FetchResult,
@@ -48,7 +49,7 @@ use crate::{
     types::{
         Block as LinearBlock, Block, BlockHash, BlockHeader, BlockPayload, BlockSignatures,
         Chainspec, ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock,
-        Item, NodeId, StatusFeed, TimeDiff, Timestamp,
+        Item, NodeId, StatusFeed, TimeDiff,
     },
     utils::DisplayIter,
 };
@@ -484,10 +485,8 @@ impl Display for StateStoreRequest {
 /// Details of a request for a list of deploys to propose in a new block.
 #[derive(DataSize, Debug)]
 pub struct BlockPayloadRequest {
-    /// The instant for which the deploy is requested.
-    pub(crate) current_instant: Timestamp,
-    /// Set of deploy hashes of deploys that should be excluded in addition to the finalized ones.
-    pub(crate) past_deploys: HashSet<DeployHash>,
+    /// The context in which the new block will be proposed.
+    pub(crate) context: BlockContext<ClContext>,
     /// The height of the next block to be finalized at the point the request was made.
     /// This is _only_ a way of expressing how many blocks have been finalized at the moment the
     /// request was made. Block Proposer uses this in order to determine if there might be any
@@ -513,17 +512,16 @@ impl Display for BlockProposerRequest {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             BlockProposerRequest::RequestBlockPayload(BlockPayloadRequest {
-                current_instant,
-                past_deploys,
+                context,
                 next_finalized,
                 responder: _,
                 accusations: _,
                 random_bit: _,
             }) => write!(
                 formatter,
-                "list for inclusion: instant {} past {} next_finalized {}",
-                current_instant,
-                past_deploys.len(),
+                "list for inclusion: instant {} height {} next_finalized {}",
+                context.timestamp(),
+                context.height(),
                 next_finalized
             ),
         }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -59,6 +59,9 @@ log_unit_sizes = false
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3
 
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
 [consensus.highway.round_success_meter]
 # The number of most recent rounds we will be keeping track of.
 num_rounds_to_consider = 40

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -43,9 +43,6 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# The period at which we will ask peers for their latest state.
-request_latest_state_timeout = '30sec'
-
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -43,9 +43,6 @@ unit_hashes_folder = "/var/lib/casper/casper-node"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '30min'
 
-# The period at which we will ask peers for their latest state.
-request_latest_state_timeout = '30sec'
-
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -41,7 +41,7 @@ secret_key_path = '/etc/casper/validator_keys/secret_key.pem'
 unit_hashes_folder = "/var/lib/casper/casper-node"
 
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
-pending_vertex_timeout = '1min'
+pending_vertex_timeout = '30min'
 
 # The period at which we will ask peers for their latest state.
 request_latest_state_timeout = '30sec'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -59,6 +59,9 @@ log_unit_sizes = false
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3
 
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
 [consensus.highway.round_success_meter]
 # The number of most recent rounds we will be keeping track of.
 num_rounds_to_consider = 40


### PR DESCRIPTION
Port https://github.com/casper-network/casper-node/pull/1389 and https://github.com/casper-network/casper-node/pull/1397 to the `dev` branch:
* Avoid requesting the same vertex redundantly from lots of peers.
* Add more logging to the synchronizer.
* Use `Arc` to avoid cloning consensus values (i.e. lists of deploy hashes) in memory.
* Change the default `pending_vertex_timeout` to 30 minutes.
* Only request our peers' latest states if we suspect we might be stuck.

https://casperlabs.atlassian.net/browse/HWY-292
https://casperlabs.atlassian.net/browse/HWY-293
https://casperlabs.atlassian.net/browse/NDRS-1237