### PR TITLE
HWY-289,NDRS-1158: Exclude inactive validators from proposing blocks.

### DIFF
--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -214,7 +214,7 @@ mod tests {
             TEST_ENDORSEMENT_EVIDENCE_LIMIT,
         );
         let weights = &[Weight(ALICE_W), Weight(BOB_W), Weight(CAROL_W)];
-        let mut state = State::new(weights, params, vec![]);
+        let mut state = State::new(weights, params, vec![], vec![]);
         let total_weight = state.total_weight().0;
 
         // Round 0: Alice has round length 16, Bob and Carol 8.

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -174,7 +174,8 @@ impl<C: Context> Highway<C> {
         info!(%validators, instance=%instance_id, "creating Highway instance");
         let weights = validators.iter().map(Validator::weight);
         let banned = validators.iter_banned_idx();
-        let state = State::new(weights, params, banned);
+        let cannot_propose = validators.iter_cannot_propose_idx();
+        let state = State::new(weights, params, banned, cannot_propose);
         Highway {
             instance_id,
             validators,

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -18,7 +18,6 @@ pub(super) use unit::Unit;
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    convert::identity,
     iter,
 };
 
@@ -116,8 +115,8 @@ pub(crate) enum Fault<C>
 where
     C: Context,
 {
-    /// The validator was known to be faulty from the beginning. All their messages are considered
-    /// invalid in this Highway instance.
+    /// The validator was known to be malicious from the beginning. All their messages are
+    /// considered invalid in this Highway instance.
     Banned,
     /// We have direct evidence of the validator's fault.
     Direct(Evidence<C>),
@@ -151,6 +150,8 @@ where
     /// Cumulative validator weights: Entry `i` contains the sum of the weights of validators `0`
     /// through `i`.
     cumulative_w: ValidatorMap<Weight>,
+    /// Cumulative validator weights, but with the weight of banned validators set to `0`.
+    cumulative_w_leaders: ValidatorMap<Weight>,
     /// All units imported so far, by hash.
     /// This is a downward closed set: A unit must only be added here once all of its dependencies
     /// have been added as well, and it has been fully validated.
@@ -164,6 +165,9 @@ where
     /// Every validator that has an equivocation in `units` must have an entry here, but there can
     /// be additional entries for other kinds of faults.
     faults: HashMap<ValidatorIndex, Fault<C>>,
+    /// A map with `true` for all validators that should be assign slots as leaders, and are
+    /// allowed to propose blocks.
+    can_propose: ValidatorMap<bool>,
     /// The full panorama, corresponding to the complete protocol state.
     /// This points to the latest unit of every honest validator.
     panorama: Panorama<C>,
@@ -184,25 +188,42 @@ where
 }
 
 impl<C: Context> State<C> {
-    pub(crate) fn new<I, IB>(weights: I, params: Params, banned: IB) -> State<C>
+    pub(crate) fn new<I, IB, IB2>(
+        weights: I,
+        params: Params,
+        banned: IB,
+        cannot_propose: IB2,
+    ) -> State<C>
     where
         I: IntoIterator,
         I::Item: Borrow<Weight>,
         IB: IntoIterator<Item = ValidatorIndex>,
+        IB2: IntoIterator<Item = ValidatorIndex>,
     {
         let weights = ValidatorMap::from(weights.into_iter().map(|w| *w.borrow()).collect_vec());
         assert!(
             weights.len() > 0,
             "cannot initialize Highway with no validators"
         );
-        let mut sum = Weight(0);
-        let add = |w: &Weight| {
-            sum = sum.checked_add(*w).expect("total weight must be < 2^64");
-            sum
+        let sums = |mut sums: Vec<Weight>, w: Weight| {
+            let sum = sums.last().copied().unwrap_or(Weight(0));
+            sums.push(sum.checked_add(w).expect("total weight must be < 2^64"));
+            sums
         };
-        let cumulative_w = weights.iter().map(add).collect();
-        assert!(sum > Weight(0), "total weight must not be zero");
+        let cumulative_w = ValidatorMap::from(weights.iter().copied().fold(vec![], sums));
+        assert!(
+            *cumulative_w.as_ref().last().unwrap() > Weight(0),
+            "total weight must not be zero"
+        );
         let mut panorama = Panorama::new(weights.len());
+        let mut can_propose: ValidatorMap<bool> = weights.iter().map(|_| true).collect();
+        for idx in cannot_propose {
+            assert!(
+                idx.0 < weights.len() as u32,
+                "invalid validator index for exclusion from leader sequence"
+            );
+            can_propose[idx] = false;
+        }
         let faults: HashMap<_, _> = banned.into_iter().map(|idx| (idx, Fault::Banned)).collect();
         for idx in faults.keys() {
             assert!(
@@ -211,6 +232,11 @@ impl<C: Context> State<C> {
             );
             panorama[*idx] = Observation::Faulty;
         }
+        let cumulative_w_leaders = weights
+            .enumerate()
+            .map(|(idx, weight)| can_propose[idx].then(|| *weight).unwrap_or(Weight(0)))
+            .fold(vec![], sums)
+            .into();
         let pings = iter::repeat(params.start_timestamp())
             .take(weights.len())
             .collect();
@@ -218,9 +244,11 @@ impl<C: Context> State<C> {
             params,
             weights,
             cumulative_w,
+            cumulative_w_leaders,
             units: HashMap::new(),
             blocks: HashMap::new(),
             faults,
+            can_propose,
             panorama,
             endorsements: HashMap::new(),
             incomplete_endorsements: HashMap::new(),
@@ -384,6 +412,12 @@ impl<C: Context> State<C> {
     }
 
     /// Returns the leader in the specified time slot.
+    ///
+    /// First the assignment is computed ignoring the `can_propose` flags. Only if the selected
+    /// leader's entry is `false`, the computation is repeated, this time with the flagged
+    /// validators excluded. This ensures that once the validator set has been decided, correct
+    /// validators' slots never get reassigned to someone else, even if after the fact someone is
+    /// excluded as a leader.
     pub(crate) fn leader(&self, timestamp: Timestamp) -> ValidatorIndex {
         let seed = self.params.seed().wrapping_add(timestamp.millis());
         // We select a random one out of the `total_weight` weight units, starting numbering at 1.
@@ -392,7 +426,23 @@ impl<C: Context> State<C> {
         // `cumulative_w[i]` denotes the last weight unit that belongs to validator `i`.
         // `binary_search` returns the first `i` with `cumulative_w[i] >= r`, i.e. the validator
         // who owns the randomly selected weight unit.
-        self.cumulative_w.binary_search(&r).unwrap_or_else(identity)
+        let leader_index = self.cumulative_w.binary_search(&r).unwrap_or_else(|| {
+            error!("random number out of range");
+            ValidatorIndex(0)
+        });
+        if self.can_propose[leader_index] {
+            return leader_index;
+        }
+        // If the selected leader is excluded, we reassign the slot to someone else. This time we
+        // consider only the non-banned validators.
+        let total_w_leaders = *self.cumulative_w_leaders.as_ref().last().unwrap();
+        let r = Weight(leader_prng(total_w_leaders.0, seed.wrapping_add(1)));
+        self.cumulative_w_leaders
+            .binary_search(&r)
+            .unwrap_or_else(|| {
+                error!("random number out of range");
+                ValidatorIndex(0)
+            })
     }
 
     /// Adds the unit to the protocol state.

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -847,23 +847,25 @@ fn test_log2() {
 
 #[test]
 fn test_leader() {
-    let weights = &[Weight(3), Weight(4), Weight(5)];
+    let weights = &[Weight(3), Weight(4), Weight(5), Weight(4), Weight(5)];
 
-    // All three validators get slots in the leader sequence.
+    // All five validators get slots in the leader sequence. If 1, 2 and 4 are excluded, their slots
+    // get reassigned, but 0 and 3 keep their old slots.
+    let before = vec![0, 2, 4, 3, 3, 1, 2, 1, 0, 0, 0, 2, 0, 2, 3, 2, 3, 3, 1, 2];
+    let after = vec![0, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3];
+    let excluded = vec![ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(4)];
     let state = State::<TestContext>::new(weights, test_params(0), vec![], vec![]);
     assert_eq!(
-        vec![CAROL, CAROL, CAROL, CAROL, CAROL, ALICE, BOB, ALICE, CAROL, ALICE],
-        (0..10u64)
-            .map(|r_id| state.leader(r_id.into()))
+        before,
+        (0..20u64)
+            .map(|r_id| state.leader(r_id.into()).0)
             .collect_vec()
     );
-
-    // If Carol is excluded, her slots get reassigned, but Alice and Bob keep their old slots.
-    let state = State::<TestContext>::new(weights, test_params(0), vec![], vec![CAROL]);
+    let state = State::<TestContext>::new(weights, test_params(0), vec![], excluded);
     assert_eq!(
-        vec![ALICE, BOB, BOB, BOB, ALICE, ALICE, BOB, ALICE, ALICE, ALICE],
-        (0..10u64)
-            .map(|r_id| state.leader(r_id.into()))
+        after,
+        (0..20u64)
+            .map(|r_id| state.leader(r_id.into()).0)
             .collect_vec()
     );
 }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -137,7 +137,7 @@ pub(crate) fn test_params(seed: u64) -> Params {
 impl State<TestContext> {
     /// Returns a new `State` with `TestContext` parameters suitable for tests.
     pub(crate) fn new_test(weights: &[Weight], seed: u64) -> Self {
-        State::new(weights, test_params(seed), vec![])
+        State::new(weights, test_params(seed), vec![], vec![])
     }
 
     /// Adds the unit to the protocol state, or returns an error if it is invalid.
@@ -251,7 +251,7 @@ fn ban_and_mark_faulty() -> Result<(), AddUnitError<TestContext>> {
         TEST_ENDORSEMENT_EVIDENCE_LIMIT,
     );
     // Everyone already knows Alice is faulty, so she is banned.
-    let mut state = State::new(WEIGHTS, params, vec![ALICE]);
+    let mut state = State::new(WEIGHTS, params, vec![ALICE], vec![]);
 
     assert_eq!(panorama![F, N, N], *state.panorama());
     assert_eq!(Some(&Fault::Banned), state.maybe_fault(ALICE));
@@ -843,6 +843,29 @@ fn test_log2() {
     assert_eq!(63, log2(u64::MAX));
     assert_eq!(63, log2(1 << 63));
     assert_eq!(62, log2((1 << 63) - 1));
+}
+
+#[test]
+fn test_leader() {
+    let weights = &[Weight(3), Weight(4), Weight(5)];
+
+    // All three validators get slots in the leader sequence.
+    let state = State::<TestContext>::new(weights, test_params(0), vec![], vec![]);
+    assert_eq!(
+        vec![CAROL, CAROL, CAROL, CAROL, CAROL, ALICE, BOB, ALICE, CAROL, ALICE],
+        (0..10u64)
+            .map(|r_id| state.leader(r_id.into()))
+            .collect_vec()
+    );
+
+    // If Carol is excluded, her slots get reassigned, but Alice and Bob keep their old slots.
+    let state = State::<TestContext>::new(weights, test_params(0), vec![], vec![CAROL]);
+    assert_eq!(
+        vec![ALICE, BOB, BOB, BOB, ALICE, ALICE, BOB, ALICE, ALICE, ALICE],
+        (0..10u64)
+            .map(|r_id| state.leader(r_id.into()))
+            .collect_vec()
+    );
 }
 
 #[test]

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -103,6 +103,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         instance_id: C::InstanceId,
         validator_stakes: BTreeMap<C::ValidatorId, U512>,
         slashed: &HashSet<C::ValidatorId>,
+        inactive: &HashSet<C::ValidatorId>,
         protocol_config: &ProtocolConfig,
         config: &Config,
         prev_cp: Option<&dyn ConsensusProtocol<I, C>>,
@@ -127,6 +128,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
         for vid in slashed {
             validators.ban(vid);
+        }
+        for vid in inactive {
+            validators.set_cannot_propose(vid);
         }
 
         let highway_config = &protocol_config.highway_config;

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -133,6 +133,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             validators.set_cannot_propose(vid);
         }
 
+        assert!(
+            validators.ensure_nonzero_proposing_stake(),
+            "cannot start era with total weight 0"
+        );
+
         let highway_config = &protocol_config.highway_config;
 
         let total_weight = u128::from(validators.total_weight());

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 #[test]
 fn purge_vertices() {
     let params = test_params(0);
-    let mut state = State::new(WEIGHTS, params.clone(), vec![]);
+    let mut state = State::new(WEIGHTS, params.clone(), vec![], vec![]);
 
     // We use round exponent 4u8, so a round is 0x10 ms. With seed 0, Carol is the first leader.
     //
@@ -123,7 +123,7 @@ fn do_not_download_synchronized_dependencies() {
     let params = test_params(0);
     // A Highway and state instances that are used to create PreValidatedVertex instances below.
 
-    let mut state = State::new(WEIGHTS, params.clone(), vec![]);
+    let mut state = State::new(WEIGHTS, params.clone(), vec![], vec![]);
     let util_highway =
         Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
 
@@ -242,7 +242,7 @@ fn transitive_proposal_dependency() {
     let params = test_params(0);
     // A Highway and state instances that are used to create PreValidatedVertex instances below.
 
-    let mut state = State::new(WEIGHTS, params.clone(), vec![]);
+    let mut state = State::new(WEIGHTS, params.clone(), vec![], vec![]);
     let util_highway =
         Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -50,7 +50,7 @@ where
         highway_testing::TEST_ENDORSEMENT_EVIDENCE_LIMIT,
     );
     let weights = weights.into_iter().map(|w| w.into()).collect::<Vec<_>>();
-    state::State::new(weights, params, vec![])
+    state::State::new(weights, params, vec![], vec![])
 }
 
 const INSTANCE_ID_DATA: &[u8; 1] = &[123u8; 1];
@@ -86,6 +86,7 @@ where
         ClContext::hash(INSTANCE_ID_DATA),
         weights.into_iter().collect(),
         &init_slashed.into_iter().collect(),
+        &None.into_iter().collect(),
         &(&chainspec).into(),
         &config,
         None,


### PR DESCRIPTION
This implements [CEP 43](https://github.com/casper-network/ceps/pull/43) and excludes validators who were inactive for the whole duration of the previous era or faulty in a recent era from proposing blocks in the next one. Their slots are assigned to other validators instead. This is expected to improve liveness and make it less likely that proposals are missed.

https://github.com/casper-network/ceps/pull/43
https://casperlabs.atlassian.net/browse/HWY-289
https://casperlabs.atlassian.net/browse/NDRS-1158