### PR TITLE
OP-2041: upload genesis s3 files for PR to release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -219,6 +219,24 @@ steps:
     event:
       - push
 
+- name: s3-genesis-rel-pr
+  image: plugins/s3
+  settings:
+    bucket: 'genesis.casperlabs.io'
+    region: 'us-east-2'
+    access_key:
+      from_secret: drone_genesis_key_id
+    secret_key:
+      from_secret: drone_genesis_secret
+    source: "target/upgrade_build/**/*"
+    strip_prefix: 'target/upgrade_build/'
+    target: "/drone/${DRONE_COMMIT}/"
+  when:
+    branch:
+      - "release-*"
+    event:
+      - pull_request
+
 depends_on:
   - pre-checks
 


### PR DESCRIPTION
Enables AJ to pickup the files from `genesis.casperlabs.io` for PRs against release branches.