### PR TITLE
NDRS-1244: add client support for multisig transfers

### DIFF
--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -10,11 +10,11 @@ use casper_node::{
     rpcs::{account::PutDeploy, chain::GetBlockResult, info::GetDeploy, RpcWithParams},
     types::{Deploy, DeployHash, TimeDiff, Timestamp},
 };
-use casper_types::{ProtocolVersion, SecretKey};
+use casper_types::{ProtocolVersion, RuntimeArgs, SecretKey, URef, U512};
 
 use crate::{
     error::{Error, Result},
-    rpc::RpcClient,
+    rpc::{RpcClient, TransferTarget},
 };
 
 /// The maximum permissible size in bytes of a Deploy when serialized via `ToBytes`.
@@ -120,6 +120,16 @@ pub(super) trait DeployExt {
         session: ExecutableDeployItem,
     ) -> Result<Deploy>;
 
+    /// Constructs a transfer `Deploy`.
+    fn new_transfer(
+        amount: U512,
+        source_purse: Option<URef>,
+        target: TransferTarget,
+        id: Option<u64>,
+        params: DeployParams,
+        payment: ExecutableDeployItem,
+    ) -> Result<Deploy>;
+
     /// Writes the `Deploy` to `output`.
     fn write_deploy<W>(&self, output: W) -> Result<()>
     where
@@ -164,6 +174,37 @@ impl DeployExt for Deploy {
         );
         deploy.is_valid_size(MAX_SERIALIZED_SIZE)?;
         Ok(deploy)
+    }
+
+    fn new_transfer(
+        amount: U512,
+        source_purse: Option<URef>,
+        target: TransferTarget,
+        id: Option<u64>,
+        params: DeployParams,
+        payment: ExecutableDeployItem,
+    ) -> Result<Deploy> {
+        const TRANSFER_ARG_AMOUNT: &str = "amount";
+        const TRANSFER_ARG_SOURCE: &str = "source";
+        const TRANSFER_ARG_TARGET: &str = "target";
+        const TRANSFER_ARG_ID: &str = "id";
+
+        let mut transfer_args = RuntimeArgs::new();
+        transfer_args.insert(TRANSFER_ARG_AMOUNT, amount)?;
+        if let Some(source_purse) = source_purse {
+            transfer_args.insert(TRANSFER_ARG_SOURCE, source_purse)?;
+        }
+        match target {
+            TransferTarget::Account(target_account) => {
+                let target_account_hash = target_account.to_account_hash().value();
+                transfer_args.insert(TRANSFER_ARG_TARGET, target_account_hash)?;
+            }
+        }
+        transfer_args.insert(TRANSFER_ARG_ID, id)?;
+        let session = ExecutableDeployItem::Transfer {
+            args: transfer_args,
+        };
+        Deploy::with_payment_and_session(params, payment, session)
     }
 
     fn write_deploy<W>(&self, mut output: W) -> Result<()>

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -252,7 +252,7 @@ pub extern "C" fn casper_get_last_error(buf: *mut c_uchar, len: usize) -> usize 
 
 /// Creates a `Deploy` and sends it to the network for execution.
 ///
-/// See [super::put_deploy](super::put_deploy) for more details
+/// See [super::put_deploy](super::put_deploy) for more details.
 #[no_mangle]
 pub extern "C" fn casper_put_deploy(
     maybe_rpc_id: *const c_char,
@@ -288,7 +288,7 @@ pub extern "C" fn casper_put_deploy(
 
 /// Creates a `Deploy` and outputs it to a file or stdout.
 ///
-/// See [super::make_deploy](super::make_deploy) for more details
+/// See [super::make_deploy](super::make_deploy) for more details.
 #[no_mangle]
 pub extern "C" fn casper_make_deploy(
     maybe_output_path: *const c_char,
@@ -356,7 +356,7 @@ pub extern "C" fn casper_send_deploy_file(
 
 /// Transfers funds between purses.
 ///
-/// See [super::transfer](super::transfer) for more details
+/// See [super::transfer](super::transfer) for more details.
 #[no_mangle]
 pub extern "C" fn casper_transfer(
     maybe_rpc_id: *const c_char,
@@ -394,6 +394,36 @@ pub extern "C" fn casper_transfer(
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
     })
+}
+
+/// Creates a transfer `Deploy` and outputs it to a file or stdout.
+///
+/// See [super::make_transfer](super::make_transfer) for more details.
+#[no_mangle]
+pub extern "C" fn casper_make_transfer(
+    maybe_output_path: *const c_char,
+    amount: *const c_char,
+    maybe_target_account: *const c_char,
+    maybe_id: *const c_char,
+    deploy_params: *const casper_deploy_params_t,
+    payment_params: *const casper_payment_params_t,
+) -> casper_error_t {
+    let maybe_output_path = try_unsafe_arg!(maybe_output_path);
+    let amount = try_unsafe_arg!(amount);
+    let maybe_target_account = try_unsafe_arg!(maybe_target_account);
+    let maybe_id = try_unsafe_arg!(maybe_id);
+    let deploy_params = try_arg_into!(deploy_params);
+    let payment_params = try_arg_into!(payment_params);
+    let result = super::make_transfer(
+        maybe_output_path,
+        amount,
+        maybe_target_account,
+        maybe_id,
+        deploy_params,
+        payment_params,
+    );
+    try_unwrap_result!(result);
+    casper_error_t::CASPER_SUCCESS
 }
 
 /// Retrieves a `Deploy` from the network.

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -535,22 +535,14 @@ pub(super) fn parse_payment_info(
 }
 
 pub(crate) fn get_transfer_target(target_account: &str) -> Result<TransferTarget> {
-    if !target_account.is_empty() {
-        let account = account(target_account)?;
-        Ok(TransferTarget::Account(account))
-    } else {
-        Err(Error::InvalidArgument(
+    let account = PublicKey::from_hex(target_account).map_err(|error| {
+        Error::InvalidArgument(
             "target_account",
-            format!(
-                "Invalid arguments to get_transfer_target - must provide either a target account. account={}",
-                target_account
-            ),
-        ))
-    }
-}
+            format!("failed to parse as a public key: {}", error),
+        )
+    })?;
 
-pub(crate) fn output(value: &str) -> Option<&str> {
-    none_if_empty(value)
+    Ok(TransferTarget::Account(account))
 }
 
 fn parse_contract_hash(value: &str) -> Result<Option<HashAddr>> {
@@ -578,13 +570,6 @@ fn version(value: &str) -> Result<u32> {
     value
         .parse::<u32>()
         .map_err(|error| Error::FailedToParseInt("version", error))
-}
-
-fn account(value: &str) -> Result<PublicKey> {
-    PublicKey::from_hex(value).map_err(|error| Error::CryptoError {
-        context: "account",
-        error: error.into(),
-    })
 }
 
 pub(crate) fn transfer_id(value: &str) -> Result<Option<u64>> {

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -23,7 +23,7 @@ use casper_node::{
     },
     types::{BlockHash, Deploy, DeployHash},
 };
-use casper_types::{AsymmetricType, Key, PublicKey, RuntimeArgs, URef, U512};
+use casper_types::{AsymmetricType, Key, PublicKey, URef, U512};
 
 use crate::{
     deploy::{DeployExt, DeployParams, SendDeploy, Transfer},
@@ -181,27 +181,8 @@ impl RpcCall {
         deploy_params: DeployParams,
         payment: ExecutableDeployItem,
     ) -> Result<JsonRpc> {
-        const TRANSFER_ARG_AMOUNT: &str = "amount";
-        const TRANSFER_ARG_SOURCE: &str = "source";
-        const TRANSFER_ARG_TARGET: &str = "target";
-        const TRANSFER_ARG_ID: &str = "id";
-
-        let mut transfer_args = RuntimeArgs::new();
-        transfer_args.insert(TRANSFER_ARG_AMOUNT, amount)?;
-        if let Some(source_purse) = source_purse {
-            transfer_args.insert(TRANSFER_ARG_SOURCE, source_purse)?;
-        }
-        match target {
-            TransferTarget::Account(target_account) => {
-                let target_account_hash = target_account.to_account_hash().value();
-                transfer_args.insert(TRANSFER_ARG_TARGET, target_account_hash)?;
-            }
-        }
-        transfer_args.insert(TRANSFER_ARG_ID, id)?;
-        let session = ExecutableDeployItem::Transfer {
-            args: transfer_args,
-        };
-        let deploy = Deploy::with_payment_and_session(deploy_params, payment, session).unwrap();
+        let deploy =
+            Deploy::new_transfer(amount, source_purse, target, id, deploy_params, payment)?;
         let params = PutDeployParams { deploy };
         Transfer::request_with_map_params(self, params)
     }

--- a/client/src/deploy.rs
+++ b/client/src/deploy.rs
@@ -2,14 +2,15 @@ mod creation_common;
 mod get;
 mod list;
 mod make;
+mod make_transfer;
 mod put;
 mod send;
 mod sign;
 mod transfer;
 
-pub use transfer::Transfer;
-
 pub use list::ListDeploys;
 pub use make::MakeDeploy;
+pub use make_transfer::MakeTransfer;
 pub use send::SendDeploy;
 pub use sign::SignDeploy;
+pub use transfer::Transfer;

--- a/client/src/deploy/sign.rs
+++ b/client/src/deploy/sign.rs
@@ -27,8 +27,16 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
     fn run(matches: &ArgMatches<'_>) -> Result<Success, Error> {
         let input_path = creation_common::input::get(matches);
         let secret_key = common::secret_key::get(matches);
-        let maybe_output = creation_common::output::get(matches);
-        casper_client::sign_deploy_file(&input_path, secret_key, maybe_output.unwrap_or_default())
-            .map(|_| Success::Output("Signed the deploy".to_string()))
+        let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
+        casper_client::sign_deploy_file(&input_path, secret_key, maybe_output_path).map(|_| {
+            Success::Output(if maybe_output_path.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "Signed the deploy at {} and wrote to {}",
+                    input_path, maybe_output_path
+                )
+            })
+        })
     }
 }

--- a/client/src/deploy/transfer.rs
+++ b/client/src/deploy/transfer.rs
@@ -35,7 +35,7 @@ pub(super) mod amount {
 pub(super) mod target_account {
     use super::*;
 
-    pub(super) const ARG_NAME: &str = "target-account";
+    pub(in crate::deploy) const ARG_NAME: &str = "target-account";
     const ARG_SHORT: &str = "t";
     const ARG_VALUE_NAME: &str = "HEX STRING";
     const ARG_HELP: &str =
@@ -44,7 +44,7 @@ pub(super) mod target_account {
 
     // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
-    pub(super) fn arg() -> Arg<'static, 'static> {
+    pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -54,7 +54,7 @@ pub(super) mod target_account {
             .display_order(DisplayOrder::TransferTargetAccount as usize)
     }
 
-    pub(super) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(in crate::deploy) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
@@ -63,11 +63,11 @@ pub(super) mod target_account {
 pub(super) mod transfer_id {
     use super::*;
 
-    pub(super) const ARG_NAME: &str = "transfer-id";
+    pub(in crate::deploy) const ARG_NAME: &str = "transfer-id";
     const ARG_VALUE_NAME: &str = "64-BIT INTEGER";
-    const ARG_HELP: &str = "user-defined transfer id";
+    const ARG_HELP: &str = "User-defined identifier, permanently associated with the transfer";
 
-    pub(super) fn arg() -> Arg<'static, 'static> {
+    pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -76,7 +76,7 @@ pub(super) mod transfer_id {
             .display_order(DisplayOrder::TransferId as usize)
     }
 
-    pub(super) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(in crate::deploy) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -25,11 +25,9 @@ use casper_node::rpcs::{
     state::{GetAuctionInfo, GetBalance, GetItem as QueryState},
 };
 
-use deploy::{ListDeploys, MakeDeploy, SendDeploy, SignDeploy};
-
 use account_address::GenerateAccountHash as AccountAddress;
 use command::{ClientCommand, Success};
-use deploy::Transfer;
+use deploy::{ListDeploys, MakeDeploy, MakeTransfer, SendDeploy, SignDeploy, Transfer};
 use generate_completion::GenerateCompletion;
 use keygen::Keygen;
 
@@ -42,6 +40,7 @@ enum DisplayOrder {
     SignDeploy,
     SendDeploy,
     Transfer,
+    MakeTransfer,
     GetDeploy,
     GetBlock,
     GetBlockTransfers,
@@ -66,6 +65,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         .subcommand(SignDeploy::build(DisplayOrder::SignDeploy as usize))
         .subcommand(SendDeploy::build(DisplayOrder::SendDeploy as usize))
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
+        .subcommand(MakeTransfer::build(DisplayOrder::MakeTransfer as usize))
         .subcommand(GetDeploy::build(DisplayOrder::GetDeploy as usize))
         .subcommand(GetBlock::build(DisplayOrder::GetBlock as usize))
         .subcommand(GetBlockTransfers::build(
@@ -98,6 +98,7 @@ async fn main() {
         (SignDeploy::NAME, Some(matches)) => (SignDeploy::run(matches), matches),
         (SendDeploy::NAME, Some(matches)) => (SendDeploy::run(matches), matches),
         (Transfer::NAME, Some(matches)) => (Transfer::run(matches), matches),
+        (MakeTransfer::NAME, Some(matches)) => (MakeTransfer::run(matches), matches),
         (GetDeploy::NAME, Some(matches)) => (GetDeploy::run(matches), matches),
         (GetBlock::NAME, Some(matches)) => (GetBlock::run(matches), matches),
         (GetBlockTransfers::NAME, Some(matches)) => (GetBlockTransfers::run(matches), matches),

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -682,8 +682,51 @@ mod sign_deploy {
     }
 }
 
-mod keygen_generate_files {
+mod make_transfer {
+    use super::*;
 
+    const AMOUNT: &str = "30000000000";
+    const TARGET_ACCOUNT: &str =
+        "01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const TRANSFER_ID: &str = "1314";
+
+    #[test]
+    fn should_succeed_for_stdout() {
+        assert_eq!(
+            casper_client::make_transfer(
+                "",
+                AMOUNT,
+                TARGET_ACCOUNT,
+                TRANSFER_ID,
+                deploy_params::test_data_valid(),
+                payment_params::test_data_with_name()
+            )
+            .map_err(ErrWrapper),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn should_succeed_for_file() {
+        let temp_dir = TempDir::new()
+            .unwrap_or_else(|err| panic!("Failed to create temp dir with error: {}", err));
+        let file_path = temp_dir.path().join("test_deploy.json");
+        assert_eq!(
+            casper_client::make_transfer(
+                file_path.to_str().unwrap(),
+                AMOUNT,
+                TARGET_ACCOUNT,
+                TRANSFER_ID,
+                deploy_params::test_data_valid(),
+                payment_params::test_data_with_name()
+            )
+            .map_err(ErrWrapper),
+            Ok(())
+        );
+    }
+}
+
+mod keygen_generate_files {
     use super::*;
 
     #[test]
@@ -862,22 +905,6 @@ mod transfer {
                 payment_params::test_data_with_name()
             ),
             Ok(())
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn should_fail_if_both_target_purse_and_target_account_are_excluded() {
-        let server_handle = MockServerHandle::spawn::<PutDeployParams>(PutDeploy::METHOD);
-        assert_eq!(
-            server_handle.transfer(
-                "100",
-                "",
-                deploy_params::test_data_valid(),
-                payment_params::test_data_with_name()
-            ),
-            Err(Error::InvalidArgument(
-                "target_account",
-                "Invalid arguments to get_transfer_target - must provide either a target account. account=".to_string()).into())
         );
     }
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1244

This PR is a port of #1406 and introduces a separate subcommand to the Rust client `make-transfer` which is a mixture of the existing two subcommands `make-deploy` and `transfer`.  It allows for the creation of a Deploy for a transfer as a JSON-encoded file.  Using the existing `sign-deploy` and `send-deploy` subcommands on such a file allows us to use the Rust client to create multisig transfers.