### PR TITLE
NDRS-1245: make transfer-id a required arg in the Rust client

### DIFF
--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -125,7 +125,7 @@ pub(super) trait DeployExt {
         amount: U512,
         source_purse: Option<URef>,
         target: TransferTarget,
-        id: Option<u64>,
+        transfer_id: u64,
         params: DeployParams,
         payment: ExecutableDeployItem,
     ) -> Result<Deploy>;
@@ -180,7 +180,7 @@ impl DeployExt for Deploy {
         amount: U512,
         source_purse: Option<URef>,
         target: TransferTarget,
-        id: Option<u64>,
+        transfer_id: u64,
         params: DeployParams,
         payment: ExecutableDeployItem,
     ) -> Result<Deploy> {
@@ -200,7 +200,8 @@ impl DeployExt for Deploy {
                 transfer_args.insert(TRANSFER_ARG_TARGET, target_account_hash)?;
             }
         }
-        transfer_args.insert(TRANSFER_ARG_ID, id)?;
+        let maybe_transfer_id = Some(transfer_id);
+        transfer_args.insert(TRANSFER_ARG_ID, maybe_transfer_id)?;
         let session = ExecutableDeployItem::Transfer {
             args: transfer_args,
         };

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -364,7 +364,7 @@ pub extern "C" fn casper_transfer(
     verbosity_level: u64,
     amount: *const c_char,
     maybe_target_account: *const c_char,
-    maybe_id: *const c_char,
+    transfer_id: *const c_char,
     deploy_params: *const casper_deploy_params_t,
     payment_params: *const casper_payment_params_t,
     response_buf: *mut c_uchar,
@@ -376,7 +376,7 @@ pub extern "C" fn casper_transfer(
     let node_address = try_unsafe_arg!(node_address);
     let amount = try_unsafe_arg!(amount);
     let maybe_target_account = try_unsafe_arg!(maybe_target_account);
-    let maybe_id = try_unsafe_arg!(maybe_id);
+    let transfer_id = try_unsafe_arg!(transfer_id);
     let deploy_params = try_arg_into!(deploy_params);
     let payment_params = try_arg_into!(payment_params);
     runtime.block_on(async move {
@@ -386,7 +386,7 @@ pub extern "C" fn casper_transfer(
             verbosity_level,
             amount,
             maybe_target_account,
-            maybe_id,
+            transfer_id,
             deploy_params,
             payment_params,
         );
@@ -404,21 +404,21 @@ pub extern "C" fn casper_make_transfer(
     maybe_output_path: *const c_char,
     amount: *const c_char,
     maybe_target_account: *const c_char,
-    maybe_id: *const c_char,
+    transfer_id: *const c_char,
     deploy_params: *const casper_deploy_params_t,
     payment_params: *const casper_payment_params_t,
 ) -> casper_error_t {
     let maybe_output_path = try_unsafe_arg!(maybe_output_path);
     let amount = try_unsafe_arg!(amount);
     let maybe_target_account = try_unsafe_arg!(maybe_target_account);
-    let maybe_id = try_unsafe_arg!(maybe_id);
+    let transfer_id = try_unsafe_arg!(transfer_id);
     let deploy_params = try_arg_into!(deploy_params);
     let payment_params = try_arg_into!(payment_params);
     let result = super::make_transfer(
         maybe_output_path,
         amount,
         maybe_target_account,
-        maybe_id,
+        transfer_id,
         deploy_params,
         payment_params,
     );

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -572,14 +572,10 @@ fn version(value: &str) -> Result<u32> {
         .map_err(|error| Error::FailedToParseInt("version", error))
 }
 
-pub(crate) fn transfer_id(value: &str) -> Result<Option<u64>> {
-    if str::is_empty(value) {
-        return Ok(None);
-    }
-    let value = value
-        .parse::<u64>()
-        .map_err(|error| Error::FailedToParseInt("transfer_id", error))?;
-    Ok(Some(value))
+pub(crate) fn transfer_id(value: &str) -> Result<u64> {
+    value
+        .parse()
+        .map_err(|error| Error::FailedToParseInt("transfer-id", error))
 }
 
 #[cfg(test)]
@@ -1064,7 +1060,6 @@ mod tests {
         ///     ]
         /// ];
         /// ```
-        /// 
         /// This generates the following test module (with the fn name passed), with one test per line in `session_str_params[]`:
         /// ```
         /// #[cfg(test)]

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -177,12 +177,18 @@ impl RpcCall {
         amount: U512,
         source_purse: Option<URef>,
         target: TransferTarget,
-        id: Option<u64>,
+        transfer_id: u64,
         deploy_params: DeployParams,
         payment: ExecutableDeployItem,
     ) -> Result<JsonRpc> {
-        let deploy =
-            Deploy::new_transfer(amount, source_purse, target, id, deploy_params, payment)?;
+        let deploy = Deploy::new_transfer(
+            amount,
+            source_purse,
+            target,
+            transfer_id,
+            deploy_params,
+            payment,
+        )?;
         let params = PutDeployParams { deploy };
         Transfer::request_with_map_params(self, params)
     }

--- a/client/src/deploy/make_transfer.rs
+++ b/client/src/deploy/make_transfer.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgGroup, ArgMatches, SubCommand};
+use clap::{App, ArgMatches, SubCommand};
 
 use casper_client::{DeployStrParams, Error};
 
@@ -21,14 +21,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
             .arg(creation_common::output::arg())
             .arg(transfer::amount::arg())
             .arg(transfer::target_account::arg())
-            .arg(transfer::transfer_id::arg())
-            // Group the target args to ensure exactly one is required.
-            .group(
-                ArgGroup::with_name("required-target-args")
-                    .arg(transfer::target_account::ARG_NAME)
-                    .arg(creation_common::show_arg_examples::ARG_NAME)
-                    .required(true),
-            );
+            .arg(transfer::transfer_id::arg());
         let subcommand = creation_common::apply_common_payment_options(subcommand);
         creation_common::apply_common_creation_options(subcommand, false)
     }

--- a/client/src/deploy/transfer.rs
+++ b/client/src/deploy/transfer.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 
 use casper_client::{DeployStrParams, Error};
 
@@ -40,7 +40,7 @@ pub(super) mod target_account {
     const ARG_VALUE_NAME: &str = "HEX STRING";
     const ARG_HELP: &str =
         "Hex-encoded public key of the account from which the main purse will be used as the \
-        target.";
+        target";
 
     // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
@@ -48,7 +48,7 @@ pub(super) mod target_account {
         Arg::with_name(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required(false)
+            .required_unless(creation_common::show_arg_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferTargetAccount as usize)
@@ -64,13 +64,15 @@ pub(super) mod transfer_id {
     use super::*;
 
     pub(in crate::deploy) const ARG_NAME: &str = "transfer-id";
+    const ARG_SHORT: &str = "i";
     const ARG_VALUE_NAME: &str = "64-BIT INTEGER";
     const ARG_HELP: &str = "User-defined identifier, permanently associated with the transfer";
 
     pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
             .long(ARG_NAME)
-            .required(false)
+            .short(ARG_SHORT)
+            .required_unless(creation_common::show_arg_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferId as usize)
@@ -95,14 +97,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(amount::arg())
             .arg(target_account::arg())
-            .arg(transfer_id::arg())
-            // Group the target args to ensure exactly one is required.
-            .group(
-                ArgGroup::with_name("required-target-args")
-                    .arg(target_account::ARG_NAME)
-                    .arg(creation_common::show_arg_examples::ARG_NAME)
-                    .required(true),
-            );
+            .arg(transfer_id::arg());
         let subcommand = creation_common::apply_common_payment_options(subcommand);
         creation_common::apply_common_creation_options(subcommand, true)
     }

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -162,7 +162,7 @@ impl MockServerHandle {
             0,
             amount,
             maybe_target_account,
-            "",
+            "2",
             deploy_params,
             payment_params,
         )


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1245

This PR is a port of #1410 and amends `--transfer-id` to be a non-optional argument of the Rust client's `transfer` and `make-transfer` subcommands.