### PR TITLE
NDRS-1247: start recurring connection housekeeping task

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -304,6 +304,13 @@ where
                 .event(|_| Event::GossipOurAddress),
         );
 
+        // Start regular housekeeping of the outgoing connections.
+        effects.extend(
+            effect_builder
+                .set_timeout(OUTGOING_MANAGER_SWEEP_INTERVAL)
+                .event(|_| Event::SweepOutgoing),
+        );
+
         Ok((component, effects))
     }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1247

This PR fixes an oversight in the recent cleanup of small_network, whereby a recurring housekeeping task was never actually started on initialisation of the component.

I have run the integration test `itst01.sh` successfully three times after making this change.