### PR TITLE
NDRS-1202: Connection negotiation tasks

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -464,6 +464,7 @@ where
     /// Sets up an established outgoing connection.
     ///
     /// Initiates sending of the handshake as soon as the connection is established.
+    #[allow(clippy::redundant_clone)]
     fn handle_outgoing_connection(
         &mut self,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -33,7 +33,7 @@ mod message;
 mod message_pack_format;
 mod outgoing;
 mod symmetry;
-mod tasks;
+pub(crate) mod tasks;
 #[cfg(test)]
 mod tests;
 
@@ -72,10 +72,11 @@ use tracing::{debug, error, info, trace, warn, Instrument, Span};
 use self::{
     counting_format::{ConnectionId, CountingFormat, Role},
     error::Result,
+    event::IncomingConnection,
     message_pack_format::MessagePackFormat,
     outgoing::{DialOutcome, DialRequest, OutgoingConfig, OutgoingManager},
     symmetry::ConnectionSymmetry,
-    tasks::{IncomingConnection, NetworkContext},
+    tasks::NetworkContext,
 };
 pub(crate) use self::{
     error::display_error,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -444,7 +444,7 @@ where
             // Log the outcome.
             match result {
                 Ok(()) => {
-                    info!("regular connection close")
+                    info!("regular connection closing")
                 }
                 Err(ref err) => {
                     warn!(err = display_error(err), "connection dropped")

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -349,6 +349,7 @@ where
         }
     }
 
+    #[allow(clippy::redundant_clone)]
     fn handle_incoming_connection(
         &mut self,
         effect_builder: EffectBuilder<REv>,
@@ -436,7 +437,7 @@ where
         result: io::Result<()>,
         peer_id: Box<NodeId>,
         peer_addr: SocketAddr,
-        span: Box<Span>,
+        span: Span,
     ) -> Effects<Event<P>> {
         span.in_scope(|| {
             // Log the outcome.
@@ -783,7 +784,7 @@ where
                 peer_id,
                 peer_addr,
                 span,
-            } => self.handle_incoming_closed(result, peer_id, peer_addr, span),
+            } => self.handle_incoming_closed(result, peer_id, peer_addr, *span),
 
             Event::OutgoingEstablished {
                 remote_addr,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -515,7 +515,7 @@ where
             }),
         );
         effects.extend(
-            tasks::handshake_reader(self.event_queue, stream, self.our_id, peer_id, peer_address)
+            tasks::read_handshake(self.event_queue, stream, self.our_id, peer_id, peer_address)
                 .ignore::<Event<P>>(),
         );
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -258,7 +258,7 @@ where
         info!(%local_address, %public_address, "{}: starting server background task", our_id);
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
         let shutdown_receiver = server_shutdown_receiver.clone();
-        let server_join_handle = tokio::spawn(tasks::server_task(
+        let server_join_handle = tokio::spawn(tasks::server(
             event_queue,
             tokio::net::TcpListener::from_std(listener).map_err(Error::ListenerConversion)?,
             server_shutdown_receiver,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -383,7 +383,7 @@ where
                 peer_addr: _,
                 ref error,
             } => {
-                // Failed without much info, little we can do about this.
+                // Failed without much info, there is little we can do about this.
                 debug!(err=%display_error(error), "connection failed early");
                 Effects::new()
             }
@@ -421,6 +421,7 @@ where
                         .learn_addr(public_addr, false, Instant::now());
                 let mut effects = self.process_dial_requests(dial_requests);
 
+                // Update connection symmetries.
                 if self
                     .connection_symmetries
                     .entry(peer_id)
@@ -437,7 +438,6 @@ where
                         self.context.clone(),
                         stream,
                         self.shutdown_receiver.clone(),
-                        self.our_id,
                         peer_id,
                     )
                     .instrument(span)

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -238,7 +238,7 @@ where
             our_cert: small_network_identity.tls_certificate,
             secret_key: small_network_identity.secret_key,
             net_metrics: Arc::downgrade(&net_metrics),
-            chain_info: Arc::new(chain_info_source.into()),
+            chain_info: chain_info_source.into(),
             public_addr,
         });
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -417,6 +417,7 @@ where
                         stream,
                         self.shutdown_receiver.clone(),
                         peer_id,
+                        span.clone(),
                     )
                     .instrument(span)
                     .event(move |result| Event::IncomingClosed {
@@ -634,7 +635,7 @@ where
     }
 
     /// Handles a received message.
-    fn handle_message(
+    fn handle_incoming_message(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         peer_id: NodeId,
@@ -743,7 +744,7 @@ where
                 self.handle_incoming_connection(effect_builder, incoming, span)
             }
             Event::IncomingMessage { peer_id, msg, span } => {
-                self.handle_message(effect_builder, *peer_id, *msg, span)
+                self.handle_incoming_message(effect_builder, *peer_id, *msg, span)
             }
             Event::IncomingClosed {
                 result,

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -37,10 +37,10 @@ impl ChainInfo {
     }
 
     /// Create a handshake based on chain identification data.
-    pub(super) fn create_handshake<P>(&self, public_address: SocketAddr) -> Message<P> {
+    pub(super) fn create_handshake<P>(&self, public_addr: SocketAddr) -> Message<P> {
         Message::Handshake {
             network_name: self.network_name.clone(),
-            public_address,
+            public_addr,
             protocol_version: self.protocol_version,
         }
     }

--- a/node/src/components/small_network/counting_format.rs
+++ b/node/src/components/small_network/counting_format.rs
@@ -51,7 +51,7 @@ impl Display for TraceId {
 /// a message is sent or received.
 #[pin_project]
 #[derive(Debug)]
-pub(super) struct CountingFormat<F> {
+pub struct CountingFormat<F> {
     /// The actual serializer performing the work.
     #[pin]
     inner: F,

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -4,7 +4,6 @@ use std::{
     io,
     net::SocketAddr,
     result,
-    time::SystemTimeError,
 };
 
 use datasize::DataSize;
@@ -20,9 +19,6 @@ pub(super) type Result<T> = result::Result<T, Error>;
 /// Error type returned by the `SmallNetwork` component.
 #[derive(Debug, Error, Serialize)]
 pub enum Error {
-    /// Peer ID presented does not match the expected one.
-    #[error("remote node has wrong ID")]
-    WrongId,
     /// The config must have both or neither of certificate and secret key, and must have at least
     /// one known address.
     #[error(
@@ -32,13 +28,6 @@ pub enum Error {
     /// Our own certificate is not valid.
     #[error("own certificate invalid")]
     OwnCertificateInvalid(#[source] ValidationError),
-    /// Error during TLS connection.
-    #[error("failed to connect using TLS")]
-    SslConnectionFailed(
-        #[serde(skip_serializing)]
-        #[source]
-        ssl::Error,
-    ),
     /// Failed to create a TCP listener.
     #[error("failed to create listener on {1}")]
     ListenerCreation(
@@ -75,43 +64,6 @@ pub enum Error {
         #[source]
         ResolveAddressError,
     ),
-    /// Failed to send message.
-    #[error("failed to send message")]
-    MessageNotSent(
-        #[serde(skip_serializing)]
-        #[source]
-        io::Error,
-    ),
-    /// Failed to generate node TLS certificate.
-    #[error("failed to generate cert")]
-    CertificateGeneration(
-        #[serde(skip_serializing)]
-        #[source]
-        ErrorStack,
-    ),
-    /// Received a message that was not a handshake during connection setup.
-    #[error("handshake expected, but not received")]
-    HandshakeExpected,
-    /// TLS validation error.
-    #[error("TLS validation error: {0}")]
-    TlsValidation(#[from] ValidationError),
-    /// System time error.
-    #[error("system time error: {0}")]
-    SystemTime(
-        #[serde(skip_serializing)]
-        #[from]
-        SystemTimeError,
-    ),
-    /// Other error.
-    #[error(transparent)]
-    Anyhow(
-        #[serde(skip_serializing)]
-        #[from]
-        anyhow::Error,
-    ),
-    /// Server has stopped.
-    #[error("failed to create outgoing connection as server has stopped")]
-    ServerStopped,
 
     /// Instantiating metrics failed.
     #[error(transparent)]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -23,9 +23,6 @@ pub enum Error {
     /// Server failed to present certificate.
     #[error("no server certificate presented")]
     NoServerCertificate,
-    /// Client failed to present certificate.
-    #[error("no client certificate presented")]
-    NoClientCertificate,
     /// Peer ID presented does not match the expected one.
     #[error("remote node has wrong ID")]
     WrongId,
@@ -38,6 +35,13 @@ pub enum Error {
     /// Our own certificate is not valid.
     #[error("own certificate invalid")]
     OwnCertificateInvalid(#[source] ValidationError),
+    /// Error during TLS connection.
+    #[error("failed to connect using TLS")]
+    SslConnectionFailed(
+        #[serde(skip_serializing)]
+        #[source]
+        ssl::Error,
+    ),
     /// Failed to create a TCP listener.
     #[error("failed to create listener on {1}")]
     ListenerCreation(
@@ -81,13 +85,6 @@ pub enum Error {
         #[source]
         io::Error,
     ),
-    /// Failed to create TLS acceptor.
-    #[error("failed to create acceptor")]
-    AcceptorCreation(
-        #[serde(skip_serializing)]
-        #[source]
-        ErrorStack,
-    ),
     /// Failed to create configuration for TLS connector.
     #[error("failed to configure connector")]
     ConnectorConfiguration(
@@ -105,13 +102,6 @@ pub enum Error {
     /// Received a message that was not a handshake during connection setup.
     #[error("handshake expected, but not received")]
     HandshakeExpected,
-    /// Handshaking error.
-    #[error("handshake error: {0}")]
-    Handshake(
-        #[serde(skip_serializing)]
-        #[from]
-        ssl::Error,
-    ),
     /// TLS validation error.
     #[error("TLS validation error: {0}")]
     TlsValidation(#[from] ValidationError),

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use static_assertions::const_assert;
 use tracing::Span;
 
-use super::{error::ConnectionError, Error, FramedTransport, GossipedAddress, Message, NodeId};
+use super::{error::ConnectionError, FramedTransport, GossipedAddress, Message, NodeId};
 use crate::{
     effect::{
         announcements::BlocklistAnnouncement,
@@ -57,8 +57,7 @@ pub enum Event<P> {
     /// An established connection was terminated.
     OutgoingDropped {
         peer_id: Box<NodeId>,
-        peer_addr: Box<SocketAddr>,
-        error: Box<Option<Error>>,
+        peer_addr: SocketAddr,
     },
 
     /// Incoming network request.
@@ -119,16 +118,8 @@ impl<P: Display> Display for Event<P> {
             Event::OutgoingConnection { outgoing, span: _ } => {
                 write!(f, "outgoing connection: {}", outgoing)
             }
-            Event::OutgoingDropped {
-                peer_id,
-                peer_addr,
-                error,
-            } => {
-                write!(f, "dropped outgoing {} {}", peer_id, peer_addr)?;
-                if let Some(error) = error.as_ref() {
-                    write!(f, ": {}", error)?;
-                }
-                Ok(())
+            Event::OutgoingDropped { peer_id, peer_addr } => {
+                write!(f, "dropped outgoing {} {}", peer_id, peer_addr)
             }
             Event::NetworkRequest { req } => write!(f, "request: {}", req),
             Event::NetworkInfoRequest { req } => write!(f, "request: {}", req),

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -7,7 +7,6 @@ use std::{
 use derive_more::From;
 use serde::Serialize;
 use static_assertions::const_assert;
-use tokio::net::TcpStream;
 
 use super::{Error, GossipedAddress, Message, NodeId, Transport};
 use crate::{
@@ -23,12 +22,6 @@ const_assert!(_SMALL_NETWORK_EVENT_SIZE < 89);
 
 #[derive(Debug, From, Serialize)]
 pub enum Event<P> {
-    /// A new TCP connection has been established from an incoming connection.
-    IncomingNew {
-        #[serde(skip_serializing)]
-        stream: TcpStream,
-        peer_address: Box<SocketAddr>,
-    },
     /// The TLS handshake completed on the incoming connection.
     IncomingHandshakeCompleted {
         #[serde(skip_serializing)]
@@ -111,9 +104,6 @@ impl From<NetworkInfoRequest<NodeId>> for Event<ProtocolMessage> {
 impl<P: Display> Display for Event<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Event::IncomingNew { peer_address, .. } => {
-                write!(f, "incoming connection from {}", peer_address)
-            }
             Event::IncomingHandshakeCompleted {
                 result,
                 peer_address,

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -37,6 +37,8 @@ pub enum Event<P> {
     IncomingMessage {
         peer_id: Box<NodeId>,
         msg: Box<Message<P>>,
+        #[serde(skip)]
+        span: Span,
     },
     /// Incoming connection closed.
     IncomingClosed {
@@ -117,6 +119,7 @@ impl<P: Display> Display for Event<P> {
             Event::IncomingMessage {
                 peer_id: node_id,
                 msg,
+                span: _,
             } => write!(f, "msg from {}: {}", node_id, msg),
             Event::IncomingClosed { peer_addr, .. } => {
                 write!(f, "closed connection from {}", peer_addr)

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -5,14 +5,12 @@ use std::{
 };
 
 use derive_more::From;
-use futures::stream::SplitStream;
+use futures::stream::{SplitSink, SplitStream};
 use serde::Serialize;
 use static_assertions::const_assert;
 use tracing::Span;
 
-use super::{
-    error::ConnectionError, Error, FramedTransport, GossipedAddress, Message, NodeId, Transport,
-};
+use super::{error::ConnectionError, Error, FramedTransport, GossipedAddress, Message, NodeId};
 use crate::{
     effect::{
         announcements::BlocklistAnnouncement,
@@ -51,16 +49,10 @@ pub enum Event<P> {
     },
 
     /// A new outgoing connection was successfully established.
-    OutgoingEstablished {
-        remote_addr: SocketAddr,
-        peer_id: Box<NodeId>,
+    OutgoingConnection {
+        outgoing: Box<OutgoingConnection<P>>,
         #[serde(skip_serializing)]
-        transport: Transport,
-    },
-    /// An outgoing connection failed to complete dialing.
-    OutgoingDialFailure {
-        peer_addr: Box<SocketAddr>,
-        error: Box<Error>,
+        span: Span,
     },
     /// An established connection was terminated.
     OutgoingDropped {
@@ -124,11 +116,8 @@ impl<P: Display> Display for Event<P> {
             Event::IncomingClosed { peer_addr, .. } => {
                 write!(f, "closed connection from {}", peer_addr)
             }
-            Event::OutgoingEstablished {
-                peer_id: node_id, ..
-            } => write!(f, "established outgoing to {}", node_id),
-            Event::OutgoingDialFailure { peer_addr, error } => {
-                write!(f, "outgoing dial failure {}: {}", peer_addr, error)
+            Event::OutgoingConnection { outgoing, span: _ } => {
+                write!(f, "outgoing connection: {}", outgoing)
             }
             Event::OutgoingDropped {
                 peer_id,
@@ -217,6 +206,60 @@ impl<P> Display for IncomingConnection<P> {
                 "connection established from {}/{}; public: {}",
                 peer_addr, peer_id, public_addr
             ),
+        }
+    }
+}
+
+/// Outcome of an outgoing connection attempt.
+#[derive(Debug, Serialize)]
+pub enum OutgoingConnection<P> {
+    /// The outgoing connection failed early on, before a peer's [`NodeId`] could be determined.
+    FailedEarly {
+        /// Address that was dialed.
+        peer_addr: SocketAddr,
+        /// Error causing the failure.
+        error: ConnectionError,
+    },
+    /// Connection failed after TLS was successfully established; thus we have a valid [`NodeId`].
+    Failed {
+        /// Address that was dialed.
+        peer_addr: SocketAddr,
+        /// Peer's [`NodeId`].
+        peer_id: NodeId,
+        /// Error causing the failure.
+        error: ConnectionError,
+    },
+    /// Connection turned out to be a loopback connection.
+    Loopback { peer_addr: SocketAddr },
+    /// Connection successfully established.
+    Established {
+        /// Address that was dialed.
+        peer_addr: SocketAddr,
+        /// Peer's [`NodeId`].
+        peer_id: NodeId,
+        /// Sink for outgoing messages.
+        #[serde(skip_serializing)]
+        sink: SplitSink<FramedTransport<P>, Message<P>>,
+    },
+}
+
+impl<P> Display for OutgoingConnection<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            OutgoingConnection::FailedEarly { peer_addr, error } => {
+                write!(f, "early failure to {}: {}", peer_addr, error)
+            }
+            OutgoingConnection::Failed {
+                peer_addr,
+                peer_id,
+                error,
+            } => write!(f, "failure to {}/{}: {}", peer_addr, peer_id, error),
+            OutgoingConnection::Loopback { peer_addr } => write!(f, "loopback to {}", peer_addr),
+            OutgoingConnection::Established {
+                peer_addr,
+                peer_id,
+                sink: _,
+            } => write!(f, "connection established to {}/{}", peer_addr, peer_id,),
         }
     }
 }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -18,7 +18,7 @@ pub enum Message<P> {
         /// Network we are connected to.
         network_name: String,
         /// The public address of the node connecting.
-        public_address: SocketAddr,
+        public_addr: SocketAddr,
         /// Protocol version the node is speaking.
         #[serde(default = "default_protocol_version")]
         protocol_version: ProtocolVersion,
@@ -42,12 +42,12 @@ impl<P: Display> Display for Message<P> {
         match self {
             Message::Handshake {
                 network_name,
-                public_address,
+                public_addr,
                 protocol_version,
             } => write!(
                 f,
                 "handshake: {}, public addr: {}, protocol_version: {}",
-                network_name, public_address, protocol_version,
+                network_name, public_addr, protocol_version,
             ),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }
@@ -209,7 +209,7 @@ mod tests {
     fn v1_0_0_can_decode_current_handshake() {
         let modern_handshake = Message::<protocol::Message>::Handshake {
             network_name: "example-handshake".to_string(),
-            public_address: ([12, 34, 56, 78], 12346).into(),
+            public_addr: ([12, 34, 56, 78], 12346).into(),
             protocol_version: ProtocolVersion::from_parts(5, 6, 7),
         };
 
@@ -241,11 +241,11 @@ mod tests {
         match modern_handshake {
             Message::Handshake {
                 network_name,
-                public_address,
+                public_addr,
                 protocol_version,
             } => {
                 assert_eq!(network_name, "example-handshake");
-                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
                 assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
             }
             Message::Payload(_) => {
@@ -261,11 +261,11 @@ mod tests {
         match modern_handshake {
             Message::Handshake {
                 network_name,
-                public_address,
+                public_addr,
                 protocol_version,
             } => {
                 assert_eq!(network_name, "serialization-test");
-                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
                 assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
             }
             Message::Payload(_) => {

--- a/node/src/components/small_network/message_pack_format.rs
+++ b/node/src/components/small_network/message_pack_format.rs
@@ -20,7 +20,7 @@ use super::Message;
 
 /// msgpack encoder/decoder for messages.
 #[derive(Debug)]
-pub(super) struct MessagePackFormat;
+pub struct MessagePackFormat;
 
 impl<P> Serializer<Message<P>> for MessagePackFormat
 where

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -101,7 +101,7 @@ use std::{
 
 use datasize::DataSize;
 
-use tracing::{debug, error_span, info, trace, warn, Span};
+use tracing::{debug, error_span, field::Empty, info, trace, warn, Span};
 
 use super::{display_error, NodeId};
 
@@ -330,7 +330,7 @@ where
             OutgoingState::Connected { peer_id, .. } => {
                 error_span!("outgoing", %addr, state=%outgoing.state, %peer_id)
             }
-            _ => error_span!("outgoing", %addr, state=%outgoing.state),
+            _ => error_span!("outgoing", %addr, state=%outgoing.state, peer_id=Empty),
         }
     } else {
         error_span!("outgoing", %addr, state = "-")

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -128,8 +128,10 @@ where
     // Negotiate the handshake, concluding the incoming connection process.
     match negotiate_handshake(&context, &mut transport).await {
         Ok(public_addr) => {
-            // We don't need the `public_addr`, as we already connected, but check and warn anyway.
-            warn!(%public_addr, %peer_addr, "peer advertises a different public address than what we connected to");
+            if public_addr != peer_addr {
+                // We don't need the `public_addr`, as we already connected, but warn anyway.
+                warn!(%public_addr, %peer_addr, "peer advertises a different public address than what we connected to");
+            }
 
             // Close the receiving end of the transport.
             let (sink, _stream) = transport.split();

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -1,15 +1,6 @@
 //! Tasks run by the component.
 
-use std::{
-    fmt::Display,
-    io,
-    net::SocketAddr,
-    pin::Pin,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{fmt::Display, io, net::SocketAddr, pin::Pin, sync::Arc};
 
 use anyhow::Context;
 
@@ -112,7 +103,6 @@ pub(super) async fn connect_outgoing(
     peer_address: SocketAddr,
     our_certificate: Arc<TlsCert>,
     secret_key: Arc<PKey<Private>>,
-    server_is_stopped: Arc<AtomicBool>,
 ) -> Result<(NodeId, Transport)> {
     let ssl = tls::create_tls_connector(&our_certificate.as_x509(), &secret_key)
         .context("could not create TLS connector")?
@@ -137,16 +127,7 @@ pub(super) async fn connect_outgoing(
 
     let peer_id = tls::validate_cert(peer_cert)?.public_key_fingerprint();
 
-    if server_is_stopped.load(Ordering::SeqCst) {
-        debug!(
-            our_id=%our_certificate.public_key_fingerprint(),
-            %peer_address,
-            "server stopped - aborting outgoing TLS connection"
-        );
-        Err(Error::ServerStopped)
-    } else {
-        Ok((NodeId::from(peer_id), tls_stream))
-    }
+    Ok((NodeId::from(peer_id), tls_stream))
 }
 
 /// Core accept loop for the networking server.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -404,12 +404,12 @@ pub(super) async fn message_reader<REv, P>(
     mut stream: SplitStream<FramedTransport<P>>,
     mut shutdown_receiver: watch::Receiver<()>,
     peer_id: NodeId,
+    span: Span,
 ) -> io::Result<()>
 where
     P: DeserializeOwned + Send + Display + Payload,
     REv: From<Event<P>>,
 {
-    // TODO: Setup span.
     let read_messages = async move {
         while let Some(msg_result) = stream.next().await {
             match msg_result {
@@ -422,7 +422,7 @@ where
                             Event::IncomingMessage {
                                 peer_id: Box::new(peer_id),
                                 msg: Box::new(msg),
-                                span: todo!(),
+                                span: span.clone(),
                             },
                             QueueKind::NetworkIncoming,
                         )

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -63,7 +63,7 @@ pub(super) async fn setup_tls(
 }
 
 /// Network handshake reader for single handshake message received by outgoing connection.
-pub(super) async fn handshake_reader<REv, P>(
+pub(super) async fn read_handshake<REv, P>(
     event_queue: EventQueueHandle<REv>,
     mut stream: SplitStream<FramedTransport<P>>,
     our_id: NodeId,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -1,77 +1,58 @@
 //! Tasks run by the component.
 
-use std::{fmt::Display, io, net::SocketAddr, pin::Pin, sync::Arc};
+use std::{
+    error::Error as StdError,
+    fmt::{self, Debug, Display, Formatter},
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use anyhow::Context;
 
 use futures::{
     future::{self, Either},
     stream::{SplitSink, SplitStream},
-    SinkExt, StreamExt,
+    Future, SinkExt, StreamExt,
 };
 use openssl::{
+    error::ErrorStack,
     pkey::{PKey, Private},
-    ssl::Ssl,
+    ssl::{self, Ssl},
 };
 use prometheus::IntGauge;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use thiserror::Error;
 use tokio::{
     net::TcpStream,
     sync::{mpsc::UnboundedReceiver, watch},
 };
 use tokio_openssl::SslStream;
-use tracing::{debug, info, warn};
-
-use crate::{
-    reactor::{EventQueueHandle, QueueKind},
-    tls::{self, TlsCert},
-    types::NodeId,
+use tracing::{
+    debug, error_span,
+    field::{self, Empty},
+    info, warn, Instrument, Span,
 };
 
 use super::{
+    chain_info::ChainInfo,
+    counting_format::{ConnectionId, Role},
     error::{display_error, Error, Result},
-    Event, FramedTransport, Message, Payload, Transport,
+    framed, Event, FramedTransport, Message, Payload, Transport,
+};
+use crate::{
+    components::networking_metrics::NetworkingMetrics,
+    reactor::{EventQueueHandle, QueueKind},
+    tls::{self, TlsCert, ValidationError},
+    types::NodeId,
 };
 
-/// A `try!`/elvis operator replacement for `Outcome`.
-macro_rules! try_outcome {
-    ($outcome:expr) => {
-        match Outcome::from($outcome) {
-            Outcome::Successful(value) => value,
-            Outcome::Block(err) => return Outcome::Block(err.into()),
-            Outcome::Failed(err) => return Outcome::Failed(err.into()),
-        }
-    };
-}
+// TODO: Constants that need to be made configurable.
 
-/// Server-side TLS handshake.
-///
-/// This function groups the TLS handshake into a convenient function, enabling the `?` operator.
-pub(super) async fn setup_tls(
-    stream: TcpStream,
-    cert: Arc<TlsCert>,
-    secret_key: Arc<PKey<Private>>,
-) -> Result<(NodeId, Transport)> {
-    let mut tls_stream = tls::create_tls_acceptor(&cert.as_x509().as_ref(), &secret_key.as_ref())
-        .and_then(|ssl_acceptor| Ssl::new(ssl_acceptor.context()))
-        .and_then(|ssl| SslStream::new(ssl, stream))
-        .map_err(Error::AcceptorCreation)?;
-
-    SslStream::accept(Pin::new(&mut tls_stream))
-        .await
-        .map_err(Error::Handshake)?;
-
-    // We can now verify the certificate.
-    let peer_cert = tls_stream
-        .ssl()
-        .peer_certificate()
-        .ok_or(Error::NoClientCertificate)?;
-
-    Ok((
-        NodeId::from(tls::validate_cert(peer_cert)?.public_key_fingerprint()),
-        tls_stream,
-    ))
-}
+/// Maximum time allowed to send or receive a handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Network handshake reader for single handshake message received by outgoing connection.
 pub(super) async fn read_handshake<REv, P>(
@@ -79,7 +60,7 @@ pub(super) async fn read_handshake<REv, P>(
     mut stream: SplitStream<FramedTransport<P>>,
     our_id: NodeId,
     peer_id: NodeId,
-    peer_address: SocketAddr,
+    peer_addr: SocketAddr,
 ) where
     P: DeserializeOwned + Send + Display + Payload,
     REv: From<Event<P>>,
@@ -101,7 +82,7 @@ pub(super) async fn read_handshake<REv, P>(
         .schedule(
             Event::OutgoingDropped {
                 peer_id: Box::new(peer_id),
-                peer_address: Box::new(peer_address),
+                peer_addr: Box::new(peer_addr),
                 error: Box::new(None),
             },
             QueueKind::Network,
@@ -111,7 +92,7 @@ pub(super) async fn read_handshake<REv, P>(
 
 /// Initiates a TLS connection to a remote address.
 pub(super) async fn connect_outgoing(
-    peer_address: SocketAddr,
+    peer_addr: SocketAddr,
     our_certificate: Arc<TlsCert>,
     secret_key: Arc<PKey<Private>>,
 ) -> Result<(NodeId, Transport)> {
@@ -124,12 +105,14 @@ pub(super) async fn connect_outgoing(
         })
         .map_err(Error::ConnectorConfiguration)?;
 
-    let stream = TcpStream::connect(peer_address)
+    let stream = TcpStream::connect(peer_addr)
         .await
         .context("TCP connection failed")?;
 
     let mut tls_stream = SslStream::new(ssl, stream).context("tls handshake failed")?;
-    SslStream::connect(Pin::new(&mut tls_stream)).await?;
+    SslStream::connect(Pin::new(&mut tls_stream))
+        .await
+        .map_err(Error::SslConnectionFailed)?;
 
     let peer_cert = tls_stream
         .ssl()
@@ -142,7 +125,7 @@ pub(super) async fn connect_outgoing(
 }
 
 /// A context holding all relevant information for networking communication shared across tasks.
-pub(super) struct NetworkContext<REv>
+pub(crate) struct NetworkContext<REv>
 where
     REv: 'static,
 {
@@ -150,80 +133,307 @@ where
     pub(super) our_id: NodeId,
     pub(super) our_cert: Arc<TlsCert>,
     pub(super) secret_key: Arc<PKey<Private>>,
-
-/// Outcome of an operation that can result in failure, block or success.
-enum Outcome<T, E> {
-    /// Operation completed successfully.
-    Successful(T),
-    /// Operation failed due to a blockable offense.
-    Block(E),
-    /// Operation failed due to regular error.
-    Failed(E),
+    pub(super) net_metrics: Weak<NetworkingMetrics>,
+    pub(super) chain_info: Arc<ChainInfo>,
+    pub(super) public_addr: SocketAddr,
 }
 
-impl<T, E> From<::core::result::Result<T, E>> for Outcome<T, E> {
-    fn from(result: ::core::result::Result<T, E>) -> Self {
-        match result {
-            Ok(value) => Outcome::Successful(value),
-            Err(err) => Outcome::Failed(err),
-        }
-    }
+/// A connection-specific error.
+#[derive(Debug, Error, Serialize)]
+pub enum ConnectionError {
+    /// Failed to create TLS acceptor.
+    #[error("failed to create acceptor")]
+    AcceptorCreation(
+        #[serde(skip_serializing)]
+        #[source]
+        ErrorStack,
+    ),
+    /// Handshaking error.
+    #[error("TLS handshake error")]
+    TlsHandshake(
+        #[serde(skip_serializing)]
+        #[source]
+        ssl::Error,
+    ),
+    /// Client failed to present certificate.
+    #[error("no client certificate presented")]
+    NoClientCertificate,
+    /// TLS validation error.
+    #[error("TLS validation error of peer certificate")]
+    PeerCertificateInvalid(#[source] ValidationError),
+    /// Failed to send handshake.
+    #[error("handshake send failed")]
+    HandshakeSend(
+        #[serde(skip_serializing)]
+        #[source]
+        IoError<io::Error>,
+    ),
+    /// Failed to receive handshake.
+    #[error("handshake receive failed")]
+    HandshakeRecv(
+        #[serde(skip_serializing)]
+        #[source]
+        IoError<io::Error>,
+    ),
+    /// Peer reported a network name that does not match ours.
+    #[error("peer is on different network: {0}")]
+    WrongNetwork(String),
+    /// Peer sent a non-handshake message as its first message.
+    #[error("peer did not send handshake")]
+    DidNotSendHandshake,
 }
 
-impl<T, E> From<Error> for Outcome<T, E> {
-    fn from(_: Error) -> Self {
-        todo!()
-    }
+/// Outcome of an incoming connection negotiation.
+#[derive(Debug, Serialize)]
+pub enum IncomingConnection<P> {
+    /// The connection failed early on, before even a peer's [`NodeId`] could be determined.
+    FailedEarly {
+        /// Remote port the peer dialed us from.
+        peer_addr: SocketAddr,
+        /// Error causing the failure.
+        error: ConnectionError,
+    },
+    /// Connection failed after TLS was successfully established; thus we have a valid [`NodeId`].
+    Failed {
+        /// Remote port the peer dialed us from.
+        peer_addr: SocketAddr,
+        /// Peer's [`NodeId`].
+        peer_id: NodeId,
+        /// Error causing the failure.
+        error: ConnectionError,
+    },
+    /// Connection turned out to be a loopback connection.
+    Loopback,
+    /// Connection successfully established.
+    Established {
+        /// Remote port the peer dialed us from.
+        peer_addr: SocketAddr,
+        /// Public address advertised by the peer.
+        public_addr: SocketAddr,
+        /// Peer's [`NodeId`].
+        peer_id: NodeId,
+        /// Stream of incoming messages. for incoming connections.
+        #[serde(skip_serializing)]
+        stream: SplitStream<FramedTransport<P>>,
+    },
 }
 
-impl<T, E> Outcome<T, E> {
-    fn map_err<F, G>(self, f: F) -> Outcome<T, G>
-    where
-        F: FnOnce(E) -> G,
-    {
+impl<P> Display for IncomingConnection<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Outcome::Successful(value) => Outcome::Successful(value),
-            Outcome::Block(err) => Outcome::Block(f(err)),
-            Outcome::Failed(err) => Outcome::Failed(f(err)),
+            IncomingConnection::FailedEarly { peer_addr, error } => {
+                write!(f, "early failure from {}: {}", peer_addr, error)
+            }
+            IncomingConnection::Failed {
+                peer_addr,
+                peer_id,
+                error,
+            } => write!(f, "failure from {}/{}: {}", peer_addr, peer_id, error),
+            IncomingConnection::Loopback => f.write_str("loopback"),
+            IncomingConnection::Established {
+                peer_addr,
+                public_addr,
+                peer_id,
+                stream: _,
+            } => write!(
+                f,
+                "connection established from {}/{}; public: {}",
+                peer_addr, peer_id, public_addr
+            ),
         }
     }
-}
 }
 
 /// Handles an incoming connection.
 ///
-/// Will setup a TLS connection on the incoming connection.
+/// Sets up a TLS stream and performs the protocol handshake.
 async fn handle_incoming<P, REv>(
     context: Arc<NetworkContext<REv>>,
     stream: TcpStream,
-    peer_address: SocketAddr,
-) where
+    peer_addr: SocketAddr,
+) -> IncomingConnection<P>
+where
     REv: From<Event<P>> + 'static,
+    P: Payload,
+    for<'de> P: Serialize + Deserialize<'de>,
+    for<'de> Message<P>: Serialize + Deserialize<'de>,
 {
-    let tls_setup_result =
-        setup_tls(stream, context.our_cert.clone(), context.secret_key.clone()).await;
+    let (peer_id, transport) =
+        match server_setup_tls(stream, &context.our_cert, &context.secret_key).await {
+            Ok(value) => value,
+            Err(error) => {
+                return IncomingConnection::FailedEarly { peer_addr, error };
+            }
+        };
 
-    let event = Event::IncomingHandshakeCompleted {
-        result: Box::new(tls_setup_result),
-        peer_address: Box::new(peer_address),
-    };
+    // Register the `peer_id` on the [`Span`] for logging the ID from here on out.
+    Span::current().record("peer_id", &field::display(peer_id));
 
-    context
-        .event_queue
-        .schedule(event, QueueKind::NetworkIncoming)
-        .await;
+    if peer_id == context.our_id {
+        info!("incoming loopback connection");
+        return IncomingConnection::Loopback;
+    }
+
+    debug!("TLS connection established");
+
+    // Setup connection sink and stream.
+    let mut transport = framed::<P>(
+        context.net_metrics.clone(),
+        ConnectionId::from_connection(transport.ssl(), context.our_id, peer_id),
+        transport,
+        Role::Listener,
+        context.chain_info.maximum_net_message_size,
+    );
+
+    // Negotiate the handshake, concluding the incoming connection process.
+    match negotiate_handshake(&context, &mut transport).await {
+        Ok(public_addr) => {
+            // Close the receiving end of the transport.
+            let (_sink, stream) = transport.split();
+
+            IncomingConnection::Established {
+                peer_addr,
+                public_addr,
+                peer_id,
+                stream,
+            }
+        }
+        Err(error) => IncomingConnection::Failed {
+            peer_addr,
+            peer_id,
+            error,
+        },
+    }
+}
+
+/// Server-side TLS setup.
+///
+/// This function groups the TLS setup into a convenient function, enabling the `?` operator.
+pub(super) async fn server_setup_tls(
+    stream: TcpStream,
+    cert: &TlsCert,
+    secret_key: &PKey<Private>,
+) -> ::std::result::Result<(NodeId, Transport), ConnectionError> {
+    let mut tls_stream = tls::create_tls_acceptor(&cert.as_x509().as_ref(), &secret_key.as_ref())
+        .and_then(|ssl_acceptor| Ssl::new(ssl_acceptor.context()))
+        .and_then(|ssl| SslStream::new(ssl, stream))
+        .map_err(ConnectionError::AcceptorCreation)?;
+
+    SslStream::accept(Pin::new(&mut tls_stream))
+        .await
+        .map_err(ConnectionError::TlsHandshake)?;
+
+    // We can now verify the certificate.
+    let peer_cert = tls_stream
+        .ssl()
+        .peer_certificate()
+        .ok_or(ConnectionError::NoClientCertificate)?;
+
+    Ok((
+        NodeId::from(
+            tls::validate_cert(peer_cert)
+                .map_err(ConnectionError::PeerCertificateInvalid)?
+                .public_key_fingerprint(),
+        ),
+        tls_stream,
+    ))
+}
+
+/// IO operation that can time out.
+#[derive(Debug, Error)]
+pub enum IoError<E>
+where
+    E: StdError + 'static,
+{
+    /// IO operation timed out.
+    #[error("io timeout")]
+    Timeout,
+    /// Non-timeout IO error.
+    #[error(transparent)]
+    Error(#[from] E),
+    /// Unexpected close/end-of-file.
+    #[error("closed unexpectedly")]
+    UnexpectedEof,
+}
+
+/// Performs an IO-operation that can time out.
+async fn io_timeout<F, T, E>(duration: Duration, future: F) -> ::std::result::Result<T, IoError<E>>
+where
+    F: Future<Output = ::std::result::Result<T, E>>,
+    E: StdError + 'static,
+{
+    tokio::time::timeout(duration, future)
+        .await
+        .map_err(|_elapsed| IoError::Timeout)?
+        .map_err(IoError::Error)
+}
+
+/// Performs an IO-operation that can time out or result in a closed connection.
+async fn io_opt_timeout<F, T, E>(
+    duration: Duration,
+    future: F,
+) -> ::std::result::Result<T, IoError<E>>
+where
+    F: Future<Output = Option<::std::result::Result<T, E>>>,
+    E: StdError + 'static,
+{
+    let item = tokio::time::timeout(duration, future)
+        .await
+        .map_err(|_elapsed| IoError::Timeout)?;
+
+    match item {
+        Some(Ok(value)) => Ok(value),
+        Some(Err(err)) => Err(IoError::Error(err)),
+        None => Err(IoError::UnexpectedEof),
+    }
+}
+
+async fn negotiate_handshake<P, REv>(
+    context: &NetworkContext<REv>,
+    transport: &mut FramedTransport<P>,
+) -> std::result::Result<SocketAddr, ConnectionError>
+where
+    P: Payload,
+{
+    // Send down a handshake and expect one in response.
+    let handshake = context.chain_info.create_handshake(context.public_addr);
+
+    io_timeout(HANDSHAKE_TIMEOUT, transport.send(handshake))
+        .await
+        .map_err(ConnectionError::HandshakeSend)?;
+
+    let remote_handshake = io_opt_timeout(HANDSHAKE_TIMEOUT, transport.next())
+        .await
+        .map_err(ConnectionError::HandshakeRecv)?;
+
+    if let Message::Handshake {
+        network_name,
+        public_addr,
+        protocol_version,
+    } = remote_handshake
+    {
+        debug!(%protocol_version, "handshake received");
+
+        // The handshake was valid, we can check the network name.
+        if network_name != context.chain_info.network_name {
+            Err(ConnectionError::WrongNetwork(network_name))
+        } else {
+            Ok(public_addr)
+        }
+    } else {
+        // Received a non-handshake, this is an error.
+        Err(ConnectionError::DidNotSendHandshake)
+    }
 }
 
 /// Core accept loop for the networking server.
-///
-/// Never terminates.
 pub(super) async fn server<P, REv>(
     context: Arc<NetworkContext<REv>>,
     listener: tokio::net::TcpListener,
     mut shutdown_receiver: watch::Receiver<()>,
 ) where
     REv: From<Event<P>> + Send,
-    P: Send + 'static,
+    P: Payload,
 {
     // The server task is a bit tricky, since it has to wait on incoming connections while at the
     // same time shut down if the networking component is dropped, otherwise the TCP socket will
@@ -236,8 +446,29 @@ pub(super) async fn server<P, REv>(
             // shortage or the remote side closing the connection while it is waiting in
             // the queue.
             match listener.accept().await {
-                Ok((stream, peer_address)) => {
-                    tokio::spawn(handle_incoming(context.clone(), stream, peer_address));
+                Ok((stream, peer_addr)) => {
+                    // The span setup here is used throughout the entire lifetime of the connection.
+                    let span = error_span!("incoming", %peer_addr, peer_id=Empty);
+
+                    let context = context.clone();
+                    let handler_span = span.clone();
+                    tokio::spawn(
+                        async move {
+                            let incoming =
+                                handle_incoming(context.clone(), stream, peer_addr).await;
+                            context
+                                .event_queue
+                                .schedule(
+                                    Event::IncomingConnection {
+                                        incoming: Box::new(incoming),
+                                        span,
+                                    },
+                                    QueueKind::NetworkIncoming,
+                                )
+                                .await;
+                        }
+                        .instrument(handler_span),
+                    );
                 }
 
                 // TODO: Handle resource errors gracefully.
@@ -271,7 +502,7 @@ pub(super) async fn server<P, REv>(
 ///
 /// Schedules all received messages until the stream is closed or an error occurs.
 pub(super) async fn message_reader<REv, P>(
-    event_queue: EventQueueHandle<REv>,
+    context: Arc<NetworkContext<REv>>,
     mut stream: SplitStream<FramedTransport<P>>,
     mut shutdown_receiver: watch::Receiver<()>,
     our_id: NodeId,
@@ -285,9 +516,10 @@ where
         while let Some(msg_result) = stream.next().await {
             match msg_result {
                 Ok(msg) => {
-                    debug!(%our_id, %msg, %peer_id, "message received");
+                    debug!(%msg, "message received");
                     // We've received a message, push it to the reactor.
-                    event_queue
+                    context
+                        .event_queue
                         .schedule(
                             Event::IncomingMessage {
                                 peer_id: Box::new(peer_id),

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -133,7 +133,7 @@ where
     pub(super) our_cert: Arc<TlsCert>,
     pub(super) secret_key: Arc<PKey<Private>>,
     pub(super) net_metrics: Weak<NetworkingMetrics>,
-    pub(super) chain_info: Arc<ChainInfo>,
+    pub(super) chain_info: ChainInfo,
     pub(super) public_addr: SocketAddr,
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -326,7 +326,7 @@ where
     }
 }
 
-/// Core accept loop for the networking server.
+/// Runs the server core acceptor loop.
 pub(super) async fn server<P, REv>(
     context: Arc<NetworkContext<REv>>,
     listener: tokio::net::TcpListener,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -31,7 +31,7 @@ use tokio_openssl::SslStream;
 use tracing::{
     debug, error_span,
     field::{self, Empty},
-    info, warn, Instrument, Span,
+    info, trace, warn, Instrument, Span,
 };
 
 use super::{
@@ -391,7 +391,7 @@ where
         while let Some(msg_result) = stream.next().await {
             match msg_result {
                 Ok(msg) => {
-                    debug!(%msg, "message received");
+                    trace!(%msg, "message received");
                     // We've received a message, push it to the reactor.
                     context
                         .event_queue

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -1,0 +1,289 @@
+//! Tasks run by the component.
+
+use std::{
+    fmt::Display,
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use anyhow::Context;
+
+use futures::{
+    future::{self, Either},
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use openssl::{
+    pkey::{PKey, Private},
+    ssl::Ssl,
+};
+use prometheus::IntGauge;
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::{
+    net::TcpStream,
+    sync::{mpsc::UnboundedReceiver, watch},
+};
+use tokio_openssl::SslStream;
+use tracing::{debug, info, warn};
+
+use crate::{
+    reactor::{EventQueueHandle, QueueKind},
+    tls::{self, TlsCert},
+    types::NodeId,
+};
+
+use super::{
+    error::{display_error, Error, Result},
+    Event, FramedTransport, Message, Payload, Transport,
+};
+
+/// Server-side TLS handshake.
+///
+/// This function groups the TLS handshake into a convenient function, enabling the `?` operator.
+pub(super) async fn setup_tls(
+    stream: TcpStream,
+    cert: Arc<TlsCert>,
+    secret_key: Arc<PKey<Private>>,
+) -> Result<(NodeId, Transport)> {
+    let mut tls_stream = tls::create_tls_acceptor(&cert.as_x509().as_ref(), &secret_key.as_ref())
+        .and_then(|ssl_acceptor| Ssl::new(ssl_acceptor.context()))
+        .and_then(|ssl| SslStream::new(ssl, stream))
+        .map_err(Error::AcceptorCreation)?;
+
+    SslStream::accept(Pin::new(&mut tls_stream))
+        .await
+        .map_err(Error::Handshake)?;
+
+    // We can now verify the certificate.
+    let peer_cert = tls_stream
+        .ssl()
+        .peer_certificate()
+        .ok_or(Error::NoClientCertificate)?;
+
+    Ok((
+        NodeId::from(tls::validate_cert(peer_cert)?.public_key_fingerprint()),
+        tls_stream,
+    ))
+}
+
+/// Network handshake reader for single handshake message received by outgoing connection.
+pub(super) async fn handshake_reader<REv, P>(
+    event_queue: EventQueueHandle<REv>,
+    mut stream: SplitStream<FramedTransport<P>>,
+    our_id: NodeId,
+    peer_id: NodeId,
+    peer_address: SocketAddr,
+) where
+    P: DeserializeOwned + Send + Display + Payload,
+    REv: From<Event<P>>,
+{
+    if let Some(Ok(msg @ Message::Handshake { .. })) = stream.next().await {
+        debug!(%our_id, %msg, %peer_id, "handshake received");
+        return event_queue
+            .schedule(
+                Event::IncomingMessage {
+                    peer_id: Box::new(peer_id),
+                    msg: Box::new(msg),
+                },
+                QueueKind::NetworkIncoming,
+            )
+            .await;
+    }
+    warn!(%our_id, %peer_id, "receiving handshake failed, closing connection");
+    event_queue
+        .schedule(
+            Event::OutgoingDropped {
+                peer_id: Box::new(peer_id),
+                peer_address: Box::new(peer_address),
+                error: Box::new(None),
+            },
+            QueueKind::Network,
+        )
+        .await
+}
+
+/// Initiates a TLS connection to a remote address.
+pub(super) async fn connect_outgoing(
+    peer_address: SocketAddr,
+    our_certificate: Arc<TlsCert>,
+    secret_key: Arc<PKey<Private>>,
+    server_is_stopped: Arc<AtomicBool>,
+) -> Result<(NodeId, Transport)> {
+    let ssl = tls::create_tls_connector(&our_certificate.as_x509(), &secret_key)
+        .context("could not create TLS connector")?
+        .configure()
+        .and_then(|mut config| {
+            config.set_verify_hostname(false);
+            config.into_ssl("this-will-not-be-checked.example.com")
+        })
+        .map_err(Error::ConnectorConfiguration)?;
+
+    let stream = TcpStream::connect(peer_address)
+        .await
+        .context("TCP connection failed")?;
+
+    let mut tls_stream = SslStream::new(ssl, stream).context("tls handshake failed")?;
+    SslStream::connect(Pin::new(&mut tls_stream)).await?;
+
+    let peer_cert = tls_stream
+        .ssl()
+        .peer_certificate()
+        .ok_or(Error::NoServerCertificate)?;
+
+    let peer_id = tls::validate_cert(peer_cert)?.public_key_fingerprint();
+
+    if server_is_stopped.load(Ordering::SeqCst) {
+        debug!(
+            our_id=%our_certificate.public_key_fingerprint(),
+            %peer_address,
+            "server stopped - aborting outgoing TLS connection"
+        );
+        Err(Error::ServerStopped)
+    } else {
+        Ok((NodeId::from(peer_id), tls_stream))
+    }
+}
+
+/// Core accept loop for the networking server.
+///
+/// Never terminates.
+pub(super) async fn server_task<P, REv>(
+    event_queue: EventQueueHandle<REv>,
+    listener: tokio::net::TcpListener,
+    mut shutdown_receiver: watch::Receiver<()>,
+    our_id: NodeId,
+) where
+    REv: From<Event<P>>,
+{
+    // The server task is a bit tricky, since it has to wait on incoming connections while at the
+    // same time shut down if the networking component is dropped, otherwise the TCP socket will
+    // stay open, preventing reuse.
+
+    // We first create a future that never terminates, handling incoming connections:
+    let accept_connections = async move {
+        loop {
+            // We handle accept errors here, since they can be caused by a temporary resource
+            // shortage or the remote side closing the connection while it is waiting in
+            // the queue.
+            match listener.accept().await {
+                Ok((stream, peer_address)) => {
+                    // Move the incoming connection to the event queue for handling.
+                    let event = Event::IncomingNew {
+                        stream,
+                        peer_address: Box::new(peer_address),
+                    };
+                    event_queue
+                        .schedule(event, QueueKind::NetworkIncoming)
+                        .await;
+                }
+                // TODO: Handle resource errors gracefully.
+                //       In general, two kinds of errors occur here: Local resource exhaustion,
+                //       which should be handled by waiting a few milliseconds, or remote connection
+                //       errors, which can be dropped immediately.
+                //
+                //       The code in its current state will consume 100% CPU if local resource
+                //       exhaustion happens, as no distinction is made and no delay introduced.
+                Err(ref err) => {
+                    warn!(%our_id, err=display_error(err), "dropping incoming connection during accept")
+                }
+            }
+        }
+    };
+
+    let shutdown_messages = async move { while shutdown_receiver.changed().await.is_ok() {} };
+
+    // Now we can wait for either the `shutdown` channel's remote end to do be dropped or the
+    // infinite loop to terminate, which never happens.
+    match future::select(Box::pin(shutdown_messages), Box::pin(accept_connections)).await {
+        Either::Left(_) => info!(
+            %our_id,
+            "shutting down socket, no longer accepting incoming connections"
+        ),
+        Either::Right(_) => unreachable!(),
+    }
+}
+
+/// Network message reader.
+///
+/// Schedules all received messages until the stream is closed or an error occurs.
+pub(super) async fn message_reader<REv, P>(
+    event_queue: EventQueueHandle<REv>,
+    mut stream: SplitStream<FramedTransport<P>>,
+    mut shutdown_receiver: watch::Receiver<()>,
+    our_id: NodeId,
+    peer_id: NodeId,
+) -> io::Result<()>
+where
+    P: DeserializeOwned + Send + Display + Payload,
+    REv: From<Event<P>>,
+{
+    let read_messages = async move {
+        while let Some(msg_result) = stream.next().await {
+            match msg_result {
+                Ok(msg) => {
+                    debug!(%our_id, %msg, %peer_id, "message received");
+                    // We've received a message, push it to the reactor.
+                    event_queue
+                        .schedule(
+                            Event::IncomingMessage {
+                                peer_id: Box::new(peer_id),
+                                msg: Box::new(msg),
+                            },
+                            QueueKind::NetworkIncoming,
+                        )
+                        .await;
+                }
+                Err(err) => {
+                    warn!(%our_id, err=display_error(&err), %peer_id, "receiving message failed, closing connection");
+                    return Err(err);
+                }
+            }
+        }
+        Ok(())
+    };
+
+    let shutdown_messages = async move { while shutdown_receiver.changed().await.is_ok() {} };
+
+    // Now we can wait for either the `shutdown` channel's remote end to do be dropped or the
+    // while loop to terminate.
+    match future::select(Box::pin(shutdown_messages), Box::pin(read_messages)).await {
+        Either::Left(_) => info!(
+            %our_id,
+            %peer_id,
+            "shutting down incoming connection message reader"
+        ),
+        Either::Right(_) => (),
+    }
+
+    Ok(())
+}
+
+/// Network message sender.
+///
+/// Reads from a channel and sends all messages, until the stream is closed or an error occurs.
+///
+/// Initially sends a handshake including the `chainspec_hash` as a final handshake step.  If the
+/// recipient's `chainspec_hash` doesn't match, the connection will be closed.
+pub(super) async fn message_sender<P>(
+    mut queue: UnboundedReceiver<Message<P>>,
+    mut sink: SplitSink<FramedTransport<P>, Message<P>>,
+    counter: IntGauge,
+    handshake: Message<P>,
+) -> Result<()>
+where
+    P: Serialize + Send + Payload,
+{
+    sink.send(handshake).await.map_err(Error::MessageNotSent)?;
+    while let Some(payload) = queue.recv().await {
+        counter.dec();
+        // We simply error-out if the sink fails, it means that our connection broke.
+        sink.send(payload).await.map_err(Error::MessageNotSent)?;
+    }
+
+    Ok(())
+}

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -152,7 +152,7 @@ pub(super) async fn connect_outgoing(
 /// Core accept loop for the networking server.
 ///
 /// Never terminates.
-pub(super) async fn server_task<P, REv>(
+pub(super) async fn server<P, REv>(
     event_queue: EventQueueHandle<REv>,
     listener: tokio::net::TcpListener,
     mut shutdown_receiver: watch::Receiver<()>,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -459,8 +459,7 @@ pub(super) async fn message_sender<P>(
     mut queue: UnboundedReceiver<Message<P>>,
     mut sink: SplitSink<FramedTransport<P>, Message<P>>,
     counter: IntGauge,
-) -> ()
-where
+) where
     P: Serialize + Send + Payload,
 {
     while let Some(message) = queue.recv().await {


### PR DESCRIPTION
Note: The size of this PR is in part due to some things being moved from one file to another, or fields being renamed.

This PR extracts tasks (asynchronous functions, most run as effects) from the small networking component into a submodule. In doing so it unifies what used to be broken up steps for establishing a new connection into linear `async` functions.

As a result there is a noticeable complexity reduction in the component itself. Handshake handling benefits immensely from this, as the code can now be properly shared and no longer leaks into the handling of other events.

Tasks become testable as a result.