### PR TITLE
Restore correct address preference in `/status` peer list

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -699,7 +699,6 @@ where
             }
         }
 
-        // Keeping the old interface intact, we simply override earlier with later addresses.
         for (node_id, sym) in &self.connection_symmetries {
             if let Some(addrs) = sym.incoming_addrs() {
                 for addr in addrs {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -703,10 +703,11 @@ where
         for (node_id, sym) in &self.connection_symmetries {
             if let Some(addrs) = sym.incoming_addrs() {
                 for addr in addrs {
-                    ret.insert(*node_id, addr.to_string());
+                    ret.entry(*node_id).or_insert_with(|| addr.to_string());
                 }
             }
         }
+
         ret
     }
 


### PR DESCRIPTION
Simple fix that makes the code ~actually do what the comment says it does~ preserve the behavior before the refactoring.