### PR TITLE
OP-2036, OP-2049 NCTL Fixes

### DIFF
--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -4,6 +4,9 @@ source "$NCTL"/sh/utils/main.sh
 source "$NCTL"/sh/views/utils.sh
 source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
 
+# Trapping exit so we can remove the temp file used in ci run
+trap clean_up EXIT
+
 function clean_up() {
     local EXIT_CODE=$?
     local STDOUT

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -4,6 +4,41 @@ source "$NCTL"/sh/utils/main.sh
 source "$NCTL"/sh/views/utils.sh
 source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
 
+function clean_up() {
+    local EXIT_CODE=$?
+    local STDOUT
+    local STDERR
+
+    # Removes DEPLOY_LOG for ITST06/07
+    if [ -f "$DEPLOY_LOG" ]; then
+        log "Removing transfer tmp file..."
+        rm -f "$DEPLOY_LOG"
+    fi
+
+    # Prints stderr of nodes on failures
+    for i in $(seq 1 $(get_count_of_nodes)); do
+        STDOUT=$(tail "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null) || true
+        STDERR=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stderr.log 2>/dev/null) || true
+        if [ ! -z "$STDERR" ]; then
+            echo ""
+            log "##############################################"
+            log " Node-$i Error Outputs "
+            log "##############################################"
+            # true to ignore "No such file" error from cat
+            echo ""
+            log "STDERR:"
+            echo "$STDERR"
+            echo ""
+            log "Tailed STDOUT:"
+            echo "$STDOUT"
+            echo ""
+        fi
+    done
+
+    log "Test exited with exit code $EXIT_CODE"
+    exit $EXIT_CODE
+}
+
 function log_step() {
     local COMMENT=${1}
     log "------------------------------------------------------------"
@@ -32,7 +67,8 @@ function do_start_node() {
     sleep 1
     if [ "$(do_node_status ${NODE_ID} | awk '{ print $2 }')" != "RUNNING" ]; then
         log "ERROR: node-${NODE_ID} is not running"
-    exit 1
+        nctl-status
+        exit 1
     else
         log "node-${NODE_ID} is running"
     fi

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -5,9 +5,6 @@ source "$NCTL"/sh/scenarios/common/itst.sh
 # Exit if any of the commands fail.
 set -e
 
-# Trapping exit so we can remove the temp file used in ci run
-trap clean_up EXIT 
-
 #######################################
 # Runs an integration tests that tries to simulate
 # transfers being sent to a node that falls over 

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -67,8 +67,13 @@ function check_transfer_inclusion() {
     local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d')
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
+    log_step "Checking transfer inclusion..."
     for (( i='1'; i<="$TRANSFER_COUNT"; i++ )); do
         HASH=$(echo "$TRANSFER_HASHES" | sed -n "$i"p)
+        if [ -z "$HASH" ]; then
+            log "Error: No Hash found!"
+            exit 1
+        fi
         log "Starting walkback for Transfer $i: $HASH"
         verify_transfer_inclusion "$NODE_ID" "$WALKBACK" "$HASH"
         log ""

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -48,19 +48,6 @@ function main() {
     log "------------------------------------------------------------"
 }
 
-# used by trap for clean up of tmp file before exit
-function clean_up() {
-    local EXIT_CODE=$?
-
-    if [ -f "$DEPLOY_LOG" ]; then
-        log "Removing transfer tmp file..."
-        rm -f "$DEPLOY_LOG"
-    fi
-
-    log "Test exited with exit code $EXIT_CODE"
-    exit $EXIT_CODE
-}
-
 # Transfers sent in background so we can mimic a node dying mid-stream.
 function do_background_wasmless_transfers() {
     local NODE_ID=${1}

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -5,9 +5,6 @@ source "$NCTL"/sh/scenarios/common/itst.sh
 # Exit if any of the commands fail.
 set -e
 
-# Trapping exit so we can remove the temp file used in ci run
-trap clean_up EXIT 
-
 #######################################
 # Runs an integration tests that tries to simulate
 # wasm being sent to a node that falls over mid-stream.

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -47,19 +47,6 @@ function main() {
     log "------------------------------------------------------------"
 }
 
-# used by trap for clean up of tmp file before exit
-function clean_up() {
-    local EXIT_CODE=$?
-
-    if [ -f "$DEPLOY_LOG" ]; then
-        log "Removing transfer tmp file..."
-        rm -f "$DEPLOY_LOG"
-    fi
-
-    log "Test exited with exit code $EXIT_CODE"
-    exit $EXIT_CODE
-}
-
 # Transfers sent in background so we can mimic a node dying mid-stream.
 function do_background_wasm_transfers() {
     local NODE_ID=${1}

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -66,8 +66,13 @@ function check_wasm_inclusion() {
     local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d')
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
+    log_step "Checking wasm inclusion..."
     for (( i='1'; i<="$TRANSFER_COUNT"; i++ )); do
         HASH=$(echo "$TRANSFER_HASHES" | sed -n "$i"p)
+        if [ -z "$HASH" ]; then
+            log "Error: No Hash found!"
+            exit 1
+        fi
         log "Starting walkback for Transfer $i: $HASH"
         verify_wasm_inclusion "$NODE_ID" "$WALKBACK" "$HASH"
         log ""


### PR DESCRIPTION
Moves trap cleanup to common.
Extends cleanup to also print stderr/stdout on exit under certain criteria.
Disallows empty hashes for transfer scenarios.
Prints nctl-status if a node fails to start.

https://casperlabs.atlassian.net/browse/OP-2036
https://casperlabs.atlassian.net/browse/OP-2049.

