### PR TITLE
Persist event stream event index

### DIFF
--- a/node/src/components/event_stream_server/event_indexer.rs
+++ b/node/src/components/event_stream_server/event_indexer.rs
@@ -1,0 +1,163 @@
+use std::{fs, path::PathBuf};
+
+use datasize::DataSize;
+use tracing::{debug, warn};
+
+const CACHE_FILENAME: &str = "sse_index";
+
+pub(super) type EventIndex = u32;
+
+#[derive(Debug, DataSize)]
+pub(super) struct EventIndexer {
+    index: EventIndex,
+    persistent_cache: PathBuf,
+}
+
+impl EventIndexer {
+    pub(super) fn new(storage_path: PathBuf) -> Self {
+        let persistent_cache = storage_path.join(CACHE_FILENAME);
+        let mut bytes = EventIndex::default().to_le_bytes();
+        match fs::read(&persistent_cache) {
+            Err(error) => {
+                if persistent_cache.exists() {
+                    warn!(
+                        file = %persistent_cache.display(),
+                        %error,
+                        "failed to read sse cache file"
+                    );
+                }
+            }
+            Ok(cached_bytes) => {
+                if cached_bytes.len() == bytes.len() {
+                    bytes.copy_from_slice(cached_bytes.as_slice());
+                } else {
+                    warn!(
+                        file = %persistent_cache.display(),
+                        byte_count = %cached_bytes.len(),
+                        "failed to parse sse cache file"
+                    );
+                }
+            }
+        }
+
+        let index = EventIndex::from_le_bytes(bytes);
+        debug!(%index, "initialized sse index");
+
+        EventIndexer {
+            index,
+            persistent_cache,
+        }
+    }
+
+    pub(super) fn next_index(&mut self) -> EventIndex {
+        let index = self.index;
+        self.index = index.wrapping_add(1);
+        index
+    }
+}
+
+impl Drop for EventIndexer {
+    fn drop(&mut self) {
+        if let Err(error) = fs::write(&self.persistent_cache, self.index.to_le_bytes()) {
+            warn!(
+                file = %self.persistent_cache.display(),
+                %error,
+                "failed to write sse cache file"
+            );
+        }
+        debug!(
+            file = %self.persistent_cache.display(),
+            index = %self.index,
+            "cached sse index to file"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use super::*;
+    use crate::logging;
+
+    #[test]
+    fn should_persist_in_cache() {
+        let _ = logging::init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        // This represents a single session where five events are produced before the session ends.
+        let init_and_increment_by_five = |expected_first_index: EventIndex| {
+            let mut event_indexer = EventIndexer::new(tempdir.path().to_path_buf());
+            for i in 0..5 {
+                assert_eq!(event_indexer.next_index(), expected_first_index + i);
+            }
+            // Explicitly drop, just to be clear that the cache write is being triggered.
+            drop(event_indexer);
+        };
+
+        // Should start at 0 when no cache file exists.
+        init_and_increment_by_five(0);
+
+        // Should keep reading and writing to cache over ten subsequent sessions.
+        for session in 1..11 {
+            init_and_increment_by_five(session * 5);
+        }
+    }
+
+    #[test]
+    fn should_wrap() {
+        let _ = logging::init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let mut event_indexer = EventIndexer::new(tempdir.path().to_path_buf());
+        event_indexer.index = EventIndex::MAX;
+
+        assert_eq!(event_indexer.next_index(), EventIndex::MAX);
+        assert_eq!(event_indexer.next_index(), 0);
+    }
+
+    #[test]
+    fn should_reset_index_on_cache_read_failure() {
+        let _ = logging::init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        // Create a folder with the same name as the cache file to cause reading to fail.
+        fs::create_dir(tempdir.path().join(CACHE_FILENAME)).unwrap();
+        let mut event_indexer = EventIndexer::new(tempdir.path().to_path_buf());
+        assert_eq!(event_indexer.next_index(), 0);
+    }
+
+    #[test]
+    fn should_reset_index_on_corrupt_cache() {
+        let _ = logging::init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        {
+            // Create the cache file with too few bytes to be parsed as an `Index`.
+            let index: EventIndex = 1;
+            fs::write(
+                tempdir.path().join(CACHE_FILENAME),
+                &index.to_le_bytes()[1..],
+            )
+            .unwrap();
+
+            let mut event_indexer = EventIndexer::new(tempdir.path().to_path_buf());
+            assert_eq!(event_indexer.next_index(), 0);
+        }
+
+        {
+            // Create the cache file with too many bytes to be parsed as an `Index`.
+            let index: EventIndex = 1;
+            let bytes: Vec<u8> = index
+                .to_le_bytes()
+                .iter()
+                .chain(iter::once(&0))
+                .copied()
+                .collect();
+            fs::write(tempdir.path().join(CACHE_FILENAME), bytes).unwrap();
+
+            let mut event_indexer = EventIndexer::new(tempdir.path().to_path_buf());
+            assert_eq!(event_indexer.next_index(), 0);
+        }
+    }
+}

--- a/node/src/components/event_stream_server/http_server.rs
+++ b/node/src/components/event_stream_server/http_server.rs
@@ -11,7 +11,7 @@ use casper_types::ProtocolVersion;
 
 use super::{
     sse_server::{BroadcastChannelMessage, NewSubscriberInfo, ServerSentEvent},
-    Config, SseData,
+    Config, EventIndex, SseData,
 };
 
 /// Run the HTTP server.
@@ -30,14 +30,13 @@ pub(super) async fn run(
     api_version: ProtocolVersion,
     server_with_shutdown: impl Future<Output = ()> + Send + 'static,
     server_shutdown_sender: oneshot::Sender<()>,
-    mut data_receiver: mpsc::UnboundedReceiver<SseData>,
+    mut data_receiver: mpsc::UnboundedReceiver<(EventIndex, SseData)>,
     broadcaster: broadcast::Sender<BroadcastChannelMessage>,
     mut new_subscriber_info_receiver: mpsc::UnboundedReceiver<NewSubscriberInfo>,
 ) {
     let server_joiner = task::spawn(server_with_shutdown);
 
     // Initialize the index and buffer for the SSEs.
-    let mut event_index = 0_u32;
     let mut buffer = WheelBuf::new(vec![
         ServerSentEvent::initial_event(api_version);
         config.event_stream_buffer_length as usize
@@ -71,7 +70,7 @@ pub(super) async fn run(
 
                 maybe_data = data_receiver.recv() => {
                     match maybe_data {
-                        Some(data) => {
+                        Some((event_index, data)) => {
                             // Buffer the data and broadcast it to subscribed clients.
                             trace!("Event stream server received {:?}", data);
                             let event = ServerSentEvent { id: Some(event_index), data };
@@ -80,7 +79,6 @@ pub(super) async fn run(
                             // This can validly fail if there are no connected clients, so don't log
                             // the error.
                             let _ = broadcaster.send(message);
-                            event_index = event_index.wrapping_add(1);
                         }
                         None => {
                             // The data sender has been dropped - exit the loop.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -46,7 +46,7 @@ use std::{
     collections::{btree_map::Entry, BTreeMap, HashSet},
     fmt::{self, Display, Formatter},
     fs, io, mem,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use datasize::DataSize;
@@ -421,6 +421,11 @@ impl Storage {
         }?;
         txn.commit()?;
         Ok(result)
+    }
+
+    /// Returns the path to the storage folder.
+    pub(crate) fn root_path(&self) -> &Path {
+        &self.root
     }
 
     /// Handles a storage request.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -446,8 +446,11 @@ impl reactor::Reactor for Reactor {
             *protocol_version,
         )?;
 
-        let event_stream_server =
-            EventStreamServer::new(config.event_stream_server.clone(), *protocol_version)?;
+        let event_stream_server = EventStreamServer::new(
+            config.event_stream_server.clone(),
+            storage.root_path().to_path_buf(),
+            *protocol_version,
+        )?;
 
         let block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
 


### PR DESCRIPTION
This PR provides the SSE server with a persistent cache for the last event index.  On dropping the server, the value is written to a file and read on starting.

The same folder used by the storage component is used for holding this file.  This has the advantage of not requiring any change to the config file type, and also restricts the number of locations the app will write to while running.

As well as the provided unit tests, I verified this works as expected by running an nctl upgrade test and asserting that the event indices were persisted across the upgrade by all nodes.

Closes #1417