### PR TITLE
Limit outgoing traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ version = "1.0.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
+ "async-trait",
  "backtrace",
  "base16",
  "base64",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,6 +14,7 @@ default-run = "casper-node"
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1"
+async-trait = "0.1.50"
 backtrace = "0.3.50"
 base16 = "0.2.1"
 base64 = "0.13.0"

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -753,7 +753,7 @@ where
         // `upcoming`: Era after `next`.
 
         let era_id = block.header().era_id();
-        let mut next: HashSet<PublicKey> = block
+        let next: HashSet<PublicKey> = block
             .header()
             .next_era_validator_weights()
             .map(|validators| validators.keys().map(Clone::clone).collect())
@@ -766,7 +766,7 @@ where
             let current: HashSet<PublicKey> = effect_builder
                 .get_era_validators(era_id)
                 .await
-                .map(|validators| validators.into_iter().map(|(k, v)| k).collect())
+                .map(|validators| validators.into_iter().map(|(k, _)| k).collect())
                 .unwrap_or_else(|| {
                     warn!("could not determine current era validators");
                     Default::default()
@@ -774,7 +774,7 @@ where
             let upcoming_validators: HashSet<PublicKey> = effect_builder
                 .get_era_validators(era_id.successor().successor())
                 .await
-                .map(|validators| validators.into_iter().map(|(k, v)| k).collect())
+                .map(|validators| validators.into_iter().map(|(k, _)| k).collect())
                 .unwrap_or_else(|| {
                     warn!("could not determine upcoming (current+2) era validators");
                     Default::default()

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -23,6 +23,7 @@
 //! Nodes gossip their public listening addresses periodically, and will try to establish and
 //! maintain an outgoing connection to any new address learned.
 
+mod bandwidth_limiter;
 mod chain_info;
 mod config;
 mod counting_format;

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -764,7 +764,7 @@ where
             active_validators.extend(current.into_iter());
             active_validators.extend(next.into_iter());
 
-            (active_validators, upcoming_validators)
+            (Box::new(active_validators), Box::new(upcoming_validators))
         }
         .event(
             |(active_validators, upcoming_validators)| Event::ValidatorsChanged {

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -302,9 +302,10 @@ mod tests {
     use rand::Rng;
     use tokio::time::Instant;
 
-    use crate::ClassBasedLimiter;
-
-    use super::{BandwidthLimiter, BandwidthLimiterHandle, NodeId, PublicKey, Unlimited};
+    use super::{
+        BandwidthLimiter, BandwidthLimiterHandle, ClassBasedLimiter, NodeId, PublicKey, Unlimited,
+    };
+    use crate::crypto::asymmetric_key_ext::AsymmetricKeyExt;
 
     /// Something that happens almost immediately, with some allowance for test jitter.
     const SHORT_TIME: Duration = Duration::from_millis(250);

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -1,0 +1,429 @@
+//! Bandwidth limiters
+//!
+//! Bandwidth limiters restrict the usable amount of bandwidth through slowing down the sending of
+//! message by making each sender request an allowance for sending first.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
+use tracing::{debug, warn};
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct NodeId(u32);
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ValidatorId(u32);
+
+/// Amount of allowed bandwidth to buffer in `ClassBasedLimiter`.
+const STORED_BUFFER_SECS: Duration = Duration::from_secs(2);
+
+/// A bandwidth limiter.
+///
+/// Any sender for a specific connection is expected to call `create_handle` for a connection, and
+/// using that handle to request a bandwidth allowance.
+pub(crate) trait BandwidthLimiter {
+    /// Handle type used by the limiter.
+    type Handle: BandwidthLimiterHandle;
+
+    /// Create a handle for a connection using the given peer and optional validator id.
+    fn create_handle(&self, peer_id: NodeId, validator_id: Option<ValidatorId>) -> Self::Handle;
+}
+
+/// A handle for connections that are bandwidth limited.
+#[async_trait]
+pub(crate) trait BandwidthLimiterHandle {
+    /// Waits until the sender is clear to send `num_bytes` additional bytes.
+    async fn get_allowance(&self, num_bytes: u32);
+}
+
+/// An unlimited bandwidth "limiter".
+///
+/// Does not restrict outgoing bandwidth in any way (`create_handle` returns immediately).
+#[derive(Debug)]
+struct Unlimited;
+
+/// Handle for `Unlimited`.
+struct UnlimitedHandle;
+
+impl BandwidthLimiter for Unlimited {
+    type Handle = UnlimitedHandle;
+
+    fn create_handle(&self, _peer_id: NodeId, _validator_id: Option<ValidatorId>) -> Self::Handle {
+        UnlimitedHandle
+    }
+}
+
+#[async_trait]
+impl BandwidthLimiterHandle for UnlimitedHandle {
+    async fn get_allowance(&self, _num_bytes: u32) {
+        // No limit.
+    }
+}
+
+/// A Bandwidth limiter dividing traffic into multiple classes based on their validator status.
+///
+/// Imposes a limit on non-validator traffic while not limiting active validator traffic at all.
+#[derive(Debug)]
+struct ClassBasedLimiter {
+    /// Sender for commands to the limiter.
+    sender: mpsc::UnboundedSender<ClassBasedCommand>,
+}
+
+/// Bandwidth class for the `ClassBasedLimiter`.
+enum BandwidthClass {
+    /// Preferred traffic serving active validators.
+    ActiveValidator,
+    /// Traffic for upcoming validators that are not active yet.
+    UpcomingValidator,
+    /// Unclassified/low-priority traffic.
+    Bulk,
+}
+
+/// Command sent to the `ClassBasedLimiter`.
+enum ClassBasedCommand {
+    /// Updates the set of active/upcoming validators.
+    UpdateValidators {
+        /// The new set of validators active in the current era.
+        active_validators: HashSet<ValidatorId>,
+        /// The new set of validators in future eras.
+        upcoming_validators: HashSet<ValidatorId>,
+    },
+    /// Requests a certain amount of bandwidth.
+    RequestBandwidth {
+        /// Number of bytes requested.
+        num_bytes: u32,
+        /// Id of the requesting sender.
+        id: Arc<BandwidthConsumerId>,
+        /// Response channel.
+        responder: oneshot::Sender<()>,
+    },
+    /// Shuts down the worker task
+    Shutdown,
+}
+
+/// Handle for `ClassBasedLimiter`.
+#[derive(Debug)]
+struct ClassBasedHandle {
+    /// Sender for commands.
+    sender: mpsc::UnboundedSender<ClassBasedCommand>,
+    /// Consumer ID for the sender holding this handle.
+    consumer_id: Arc<BandwidthConsumerId>,
+}
+
+/// An identity for a bandwidth consumer.
+#[derive(Debug)]
+struct BandwidthConsumerId {
+    /// The node ID data is sent to/from.
+    peer_id: NodeId,
+    /// The remote node's `validator_id`.
+    validator_id: Option<ValidatorId>,
+}
+
+impl ClassBasedLimiter {
+    /// Creates a new class based limiter.
+    ///
+    /// Starts the background worker task as well.
+    pub(crate) fn new(bytes_per_second: u32) -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        tokio::spawn(worker(
+            receiver,
+            bytes_per_second,
+            ((bytes_per_second as f64) * STORED_BUFFER_SECS.as_secs_f64()) as u32,
+        ));
+
+        ClassBasedLimiter { sender }
+    }
+
+    /// Update the validator sets.
+    pub(crate) fn update_validators(
+        &self,
+        active_validators: HashSet<ValidatorId>,
+        upcoming_validators: HashSet<ValidatorId>,
+    ) {
+        if self
+            .sender
+            .send(ClassBasedCommand::UpdateValidators {
+                active_validators,
+                upcoming_validators,
+            })
+            .is_err()
+        {
+            debug!("could not update validator data set of limiter, channel closed");
+        }
+    }
+}
+
+impl BandwidthLimiter for ClassBasedLimiter {
+    type Handle = ClassBasedHandle;
+
+    fn create_handle(&self, peer_id: NodeId, validator_id: Option<ValidatorId>) -> Self::Handle {
+        ClassBasedHandle {
+            sender: self.sender.clone(),
+            consumer_id: Arc::new(BandwidthConsumerId {
+                peer_id,
+                validator_id,
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl BandwidthLimiterHandle for ClassBasedHandle {
+    async fn get_allowance(&self, num_bytes: u32) {
+        let (responder, waiter) = oneshot::channel();
+
+        // Send a request to the limiter and await a response. If we do not receive one due to
+        // errors, simply ignore it and do not restrict bandwidth.
+        //
+        // While ignoring it is suboptimal, it is likely that we can continue operation normally in
+        // many circumstances, thus the message is downgraded from what would be a `warn!` to
+        // `debug!`.
+        if self
+            .sender
+            .send(ClassBasedCommand::RequestBandwidth {
+                num_bytes,
+                id: self.consumer_id.clone(),
+                responder,
+            })
+            .is_err()
+        {
+            debug!("worker was shutdown, sending is unlimited");
+        } else {
+            if waiter.await.is_err() {
+                debug!("failed to await bandwidth allowance, sending unlimited");
+            }
+        }
+    }
+}
+
+impl Drop for ClassBasedLimiter {
+    fn drop(&mut self) {
+        if self.sender.send(ClassBasedCommand::Shutdown).is_err() {
+            warn!("error sending shutdown command to class based limiter");
+        }
+    }
+}
+
+/// Background worker for the limiter.
+///
+/// Will permit any amount of current/future validator traffic, while restricting non-validators to
+/// `bytes_per_second`, although with unlimited single-message burst. The latter guarantees that any
+/// size message can be sent.
+///
+/// Stores up to `max_stored_bytes` during idle times to smooth this process.
+async fn worker(
+    mut receiver: mpsc::UnboundedReceiver<ClassBasedCommand>,
+    bytes_per_second: u32,
+    max_stored_bytes: u32,
+) {
+    let mut active_validators = HashSet::new();
+    let mut upcoming_validators = HashSet::new();
+
+    let mut bytes_available: i64 = 0;
+    let mut last_refill: Instant = Instant::now();
+
+    while let Some(msg) = receiver.recv().await {
+        match msg {
+            ClassBasedCommand::UpdateValidators {
+                active_validators: new_active_validators,
+                upcoming_validators: new_upcoming_validators,
+            } => {
+                active_validators = new_active_validators;
+                upcoming_validators = new_upcoming_validators;
+            }
+            ClassBasedCommand::RequestBandwidth {
+                num_bytes,
+                id,
+                responder,
+            } => {
+                let bandwidth_class = if let Some(validator_id) = id.validator_id {
+                    if active_validators.contains(&validator_id) {
+                        BandwidthClass::ActiveValidator
+                    } else if upcoming_validators.contains(&validator_id) {
+                        BandwidthClass::UpcomingValidator
+                    } else {
+                        BandwidthClass::Bulk
+                    }
+                } else {
+                    BandwidthClass::Bulk
+                };
+
+                match bandwidth_class {
+                    BandwidthClass::ActiveValidator | BandwidthClass::UpcomingValidator => {
+                        // No limit imposed on validators.
+                    }
+                    BandwidthClass::Bulk => {
+                        while bytes_available < 0 {
+                            // Determine time delta since last refill.
+                            let now = Instant::now();
+                            let elapsed = Instant::now() - last_refill;
+                            last_refill = now;
+
+                            // Add the appropriate amount of bytes, capped at `max_stored_bytes`.
+                            bytes_available += ((elapsed.as_nanos() * bytes_per_second as u128)
+                                / 1_000_000_000)
+                                as i64;
+                            bytes_available = bytes_available.min(max_stored_bytes as i64);
+
+                            // If we still do not have enough byte available, sleep until we do.
+                            if bytes_available < 0 {
+                                let estimated_time_remaining = Duration::from_millis(
+                                    (-bytes_available) as u64 * 1000 / bytes_per_second as u64,
+                                );
+
+                                tokio::time::sleep(estimated_time_remaining).await;
+                            }
+                        }
+
+                        // Subtract outgoing message.
+                        bytes_available -= num_bytes as i64;
+                    }
+                }
+
+                if responder.send(()).is_err() {
+                    debug!("Bandwidth requester disappeared before we could answer.")
+                }
+            }
+            ClassBasedCommand::Shutdown => {
+                // Shutdown the channel, processing only the remaining messages.
+                receiver.close();
+            }
+        }
+    }
+    debug!("class based worker exiting");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, time::Duration};
+
+    use rand::Rng;
+    use tokio::time::Instant;
+
+    use crate::ClassBasedLimiter;
+
+    use super::{BandwidthLimiter, BandwidthLimiterHandle, NodeId, Unlimited, ValidatorId};
+
+    /// Something that happens almost immediately, with some allowance for test jitter.
+    const SHORT_TIME: Duration = Duration::from_millis(250);
+
+    impl NodeId {
+        fn random<R: Rng>(rng: &mut R) -> Self {
+            NodeId(rng.gen())
+        }
+    }
+
+    impl ValidatorId {
+        fn random<R: Rng>(rng: &mut R) -> Self {
+            ValidatorId(rng.gen())
+        }
+    }
+
+    #[tokio::test]
+    async fn unlimited_limiter_is_unlimited() {
+        let mut rng = rand::thread_rng();
+
+        let unlimited = Unlimited;
+
+        let handle = unlimited.create_handle(NodeId::random(&mut rng), None);
+
+        let start = Instant::now();
+        handle.get_allowance(0).await;
+        handle.get_allowance(u32::MAX).await;
+        handle.get_allowance(1).await;
+        let end = Instant::now();
+
+        assert!(end - start < SHORT_TIME);
+    }
+
+    #[tokio::test]
+    async fn active_validator_is_unlimited() {
+        let mut rng = rand::thread_rng();
+
+        let validator_id = ValidatorId::random(&mut rng);
+        let limiter = ClassBasedLimiter::new(1_000);
+
+        let mut active_validators = HashSet::new();
+        active_validators.insert(validator_id);
+        limiter.update_validators(active_validators, HashSet::new());
+
+        let handle = limiter.create_handle(NodeId::random(&mut rng), Some(validator_id));
+
+        let start = Instant::now();
+        handle.get_allowance(0).await;
+        handle.get_allowance(u32::MAX).await;
+        handle.get_allowance(1).await;
+        let end = Instant::now();
+
+        assert!(end - start < SHORT_TIME);
+    }
+
+    #[tokio::test]
+    async fn inactive_validator_limited() {
+        let mut rng = rand::thread_rng();
+
+        let validator_id = ValidatorId::random(&mut rng);
+        let limiter = ClassBasedLimiter::new(1_000);
+
+        limiter.update_validators(HashSet::new(), HashSet::new());
+
+        // Try with non-validators or unknown nodes.
+        let handles = vec![
+            limiter.create_handle(NodeId::random(&mut rng), Some(validator_id)),
+            limiter.create_handle(NodeId::random(&mut rng), None),
+        ];
+
+        for handle in handles {
+            let start = Instant::now();
+
+            // Send 9_0001 bytes, we expect this to take roughly 15 seconds.
+            handle.get_allowance(1000).await;
+            handle.get_allowance(1000).await;
+            handle.get_allowance(1000).await;
+            handle.get_allowance(2000).await;
+            handle.get_allowance(4000).await;
+            handle.get_allowance(1).await;
+            let end = Instant::now();
+
+            let diff = end - start;
+            assert!(diff >= Duration::from_secs(9));
+            assert!(diff <= Duration::from_secs(10));
+        }
+    }
+
+    #[tokio::test]
+    async fn nonvalidators_parallel_limited() {
+        let mut rng = rand::thread_rng();
+
+        let validator_id = ValidatorId::random(&mut rng);
+        let limiter = ClassBasedLimiter::new(1_000);
+
+        let start = Instant::now();
+
+        // Parallel test, 5 non-validators sharing 1000 bytes per second. Each sends 1001 bytes, so
+        // total time is expected to be just over 5 seconds.
+        let join_handles = (0..5)
+            .map(|_| limiter.create_handle(NodeId::random(&mut rng), Some(validator_id)))
+            .map(|handle| {
+                tokio::spawn(async move {
+                    handle.get_allowance(500).await;
+                    handle.get_allowance(150).await;
+                    handle.get_allowance(350).await;
+                    handle.get_allowance(1).await;
+                })
+            });
+
+        for join_handle in join_handles {
+            join_handle.await.expect("could not join task");
+        }
+
+        let end = Instant::now();
+        let diff = end - start;
+        assert!(diff >= Duration::from_secs(5));
+        assert!(diff <= Duration::from_secs(6));
+    }
+}

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -35,8 +35,7 @@ pub(crate) trait BandwidthLimiter: Send + Sync {
         &self,
         active_validators: HashSet<PublicKey>,
         upcoming_validators: HashSet<PublicKey>,
-    ) {
-    }
+    );
 }
 
 /// A handle for connections that are bandwidth limited.
@@ -62,6 +61,13 @@ impl BandwidthLimiter for Unlimited {
         _validator_id: Option<PublicKey>,
     ) -> Box<dyn BandwidthLimiterHandle> {
         Box::new(UnlimitedHandle)
+    }
+
+    fn update_validators(
+        &self,
+        _active_validators: HashSet<PublicKey>,
+        _upcoming_validators: HashSet<PublicKey>,
+    ) {
     }
 }
 
@@ -202,10 +208,8 @@ impl BandwidthLimiterHandle for ClassBasedHandle {
             .is_err()
         {
             debug!("worker was shutdown, sending is unlimited");
-        } else {
-            if waiter.await.is_err() {
-                debug!("failed to await bandwidth allowance, sending unlimited");
-            }
+        } else if waiter.await.is_err() {
+            debug!("failed to await bandwidth allowance, sending unlimited");
         }
     }
 }

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -31,6 +31,7 @@ impl Default for Config {
             isolation_reconnect_delay: TimeDiff::from_seconds(2),
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
+            max_non_validating_peer_bps: 0,
         }
     }
 }
@@ -57,6 +58,8 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for an address to be kept in the pending set.
     pub max_addr_pending_time: TimeDiff,
+    /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
+    pub max_non_validating_peer_bps: u32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -88,6 +88,19 @@ pub enum Event<P> {
     /// Blocklist announcement
     #[from]
     BlocklistAnnouncement(BlocklistAnnouncement<NodeId>),
+
+    /// Announcement from the linear chain.
+    ///
+    /// Used to track validator sets.
+    #[from]
+    LinearChainAnnouncement(LinearChainAnnouncement),
+    /// The set of active and upcoming validators changed.
+    ValidatorsChanged {
+        /// Active validators (current and upcoming era).
+        active_validators: HashSet<PublicKey>,
+        /// Upcoming validators (for era + 2).
+        upcoming_validators: HashSet<PublicKey>,
+    },
 }
 
 impl From<NetworkRequest<NodeId, ProtocolMessage>> for Event<ProtocolMessage> {

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 const _SMALL_NETWORK_EVENT_SIZE: usize = mem::size_of::<Event<ProtocolMessage>>();
-const_assert!(_SMALL_NETWORK_EVENT_SIZE < 110);
+const_assert!(_SMALL_NETWORK_EVENT_SIZE < 89);
 
 /// A small network event.
 #[derive(Debug, From, Serialize)]
@@ -98,9 +98,9 @@ pub enum Event<P> {
     /// The set of active and upcoming validators changed.
     ValidatorsChanged {
         /// Active validators (current and upcoming era).
-        active_validators: HashSet<PublicKey>,
+        active_validators: Box<HashSet<PublicKey>>,
         /// Upcoming validators (for era + 2).
-        upcoming_validators: HashSet<PublicKey>,
+        upcoming_validators: Box<HashSet<PublicKey>>,
     },
 }
 

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -28,7 +28,9 @@ use crate::{
     },
     effect::{
         announcements::{ControlAnnouncement, GossiperAnnouncement, NetworkAnnouncement},
-        requests::{NetworkRequest, StorageRequest},
+        requests::{
+            ChainspecLoaderRequest, ContractRuntimeRequest, NetworkRequest, StorageRequest,
+        },
         EffectBuilder, Effects,
     },
     protocol,
@@ -92,6 +94,18 @@ impl From<NetworkRequest<NodeId, protocol::Message>> for Event {
 
 impl From<StorageRequest> for Event {
     fn from(_request: StorageRequest) -> Self {
+        unreachable!()
+    }
+}
+
+impl From<ChainspecLoaderRequest> for Event {
+    fn from(_request: ChainspecLoaderRequest) -> Self {
+        unreachable!()
+    }
+}
+
+impl From<ContractRuntimeRequest> for Event {
+    fn from(_request: ContractRuntimeRequest) -> Self {
         unreachable!()
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -813,6 +813,11 @@ impl reactor::Reactor for Reactor {
                 let reactor_event =
                     Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(block));
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    small_network::Event::from(LinearChainAnnouncement::BlockAdded(block)).into(),
+                ));
                 effects
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::NewFinalitySignature(fs)) => {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -811,7 +811,7 @@ impl reactor::Reactor for Reactor {
                     ),
                 );
                 let reactor_event =
-                    Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(block));
+                    Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(block.clone()));
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 effects.extend(self.dispatch_event(
                     effect_builder,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1041,6 +1041,11 @@ impl reactor::Reactor for Reactor {
                     Event::EventStreamServer(event_stream_server::Event::BlockAdded(block));
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event_es);
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event_consensus));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    small_network::Event::from(LinearChainAnnouncement::BlockAdded(block)).into(),
+                ));
                 effects
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::NewFinalitySignature(fs)) => {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1038,7 +1038,7 @@ impl reactor::Reactor for Reactor {
                     Box::new(block.header().clone()),
                 ));
                 let reactor_event_es =
-                    Event::EventStreamServer(event_stream_server::Event::BlockAdded(block));
+                    Event::EventStreamServer(event_stream_server::Event::BlockAdded(block.clone()));
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event_es);
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event_consensus));
                 effects.extend(self.dispatch_event(

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -121,6 +121,9 @@ initial_gossip_delay = '5s'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_non_validating_peer_bps = 0
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -121,6 +121,9 @@ initial_gossip_delay = '5s'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_non_validating_peer_bps = 0
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server


### PR DESCRIPTION
Adds an optional bandwidth limiter to the networking component that allows limiting the amount of upstream consumed by nodes that are not validators or en route to becoming them in a little over an eras time.

Controlled through the `max_non_validating_peer_bps` setting; if it is set to 0, a no-op limiter is used instead.