### PR TITLE
OP-2030: NCTL Upgrades remote asset staging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -237,6 +237,33 @@ steps:
     event:
       - pull_request
 
+- name: nctl-upgrade-assets-stage-rc
+  image: casperlabs/node-build-u1804
+  commands:
+    - "./nctl_upgrade_stage.sh"
+  when:
+    branch:
+      - "release-*"
+    event:
+      - push
+
+- name: nctl-bucket-upload-rc
+  image: plugins/s3-sync:latest
+  settings:
+    bucket: 'nctl.casperlabs.io'
+    access_key:
+      from_secret: put-drone-aws-ak
+    secret_key:
+      from_secret: put-drone-aws-sk
+    region: us-east-2
+    source: '/tmp/nctl_upgrade_stage/'
+    target: "/${DRONE_BRANCH}/"
+  when:
+    branch:
+      - "release-*"
+    event:
+      - push
+
 depends_on:
   - pre-checks
 
@@ -493,6 +520,23 @@ steps:
     - true
     access:
     - "public"
+
+- name: nctl-upgrade-assets-stage
+  image: casperlabs/node-build-u1804
+  commands:
+    - "./nctl_upgrade_stage.sh"
+
+- name: nctl-bucket-upload
+  image: plugins/s3-sync:latest
+  settings:
+    bucket: 'nctl.casperlabs.io'
+    access_key:
+      from_secret: put-drone-aws-ak
+    secret_key:
+      from_secret: put-drone-aws-sk
+    region: us-east-2
+    source: '/tmp/nctl_upgrade_stage/'
+    target: "/${DRONE_TAG}/"
 
 trigger:
   ref:

--- a/.drone.yml
+++ b/.drone.yml
@@ -241,6 +241,9 @@ steps:
   image: casperlabs/node-build-u1804
   commands:
     - "./ci/nctl_upgrade_stage.sh"
+  volumes:
+  - name: nctl-temp-dir
+    path: /tmp/nctl_upgrade_stage
   when:
     branch:
       - "release-*"
@@ -256,8 +259,11 @@ steps:
     secret_key:
       from_secret: put-drone-aws-sk
     region: us-east-2
-    source: '/tmp/nctl_upgrade_stage/'
+    source: '../../tmp/nctl_upgrade_stage/'
     target: "/${DRONE_BRANCH}/"
+  volumes:
+  - name: nctl-temp-dir
+    path: /tmp/nctl_upgrade_stage
   when:
     branch:
       - "release-*"
@@ -278,6 +284,10 @@ trigger:
   event:
     exclude:
       - tag
+
+volumes:
+- name: nctl-temp-dir
+  temp: {}
 
 ---
 # Run on success of cargo-test and package pipelines.
@@ -525,6 +535,9 @@ steps:
   image: casperlabs/node-build-u1804
   commands:
     - "./ci/nctl_upgrade_stage.sh"
+  volumes:
+  - name: nctl-temp-dir
+    path: /tmp/nctl_upgrade_stage
 
 - name: nctl-bucket-upload
   image: plugins/s3-sync:latest
@@ -535,12 +548,20 @@ steps:
     secret_key:
       from_secret: put-drone-aws-sk
     region: us-east-2
-    source: '/tmp/nctl_upgrade_stage/'
+    source: '../../tmp/nctl_upgrade_stage/'
     target: "/${DRONE_TAG}/"
+  volumes:
+  - name: nctl-temp-dir
+    path: /tmp/nctl_upgrade_stage
+
+volumes:
+- name: nctl-temp-dir
+  temp: {}
 
 trigger:
   ref:
   - refs/tags/v*
+
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -240,7 +240,7 @@ steps:
 - name: nctl-upgrade-assets-stage-rc
   image: casperlabs/node-build-u1804
   commands:
-    - "./nctl_upgrade_stage.sh"
+    - "./ci/nctl_upgrade_stage.sh"
   when:
     branch:
       - "release-*"
@@ -524,7 +524,7 @@ steps:
 - name: nctl-upgrade-assets-stage
   image: casperlabs/node-build-u1804
   commands:
-    - "./nctl_upgrade_stage.sh"
+    - "./ci/nctl_upgrade_stage.sh"
 
 - name: nctl-bucket-upload
   image: plugins/s3-sync:latest

--- a/ci/nctl_upgrade_stage.sh
+++ b/ci/nctl_upgrade_stage.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Script used to group everything needed for nctl upgrade remotes.
+
+set -e
+
+trap clean_up EXIT
+
+function clean_up() {
+    local EXIT_CODE=$?
+
+    if [ "$EXIT_CODE" = '0' ] && [ ! -z ${DRONE} ]; then
+        # Running in CI so don't cleanup stage dir
+        echo "Script completed succesfully!"
+        return
+    fi
+
+    if [ -d "$TEMP_STAGE_DIR" ]; then
+        echo "Script exited $EXIT_CODE"
+        echo "... Removing stage dir: $TEMP_STAGE_DIR"
+        rm -rf "$TEMP_STAGE_DIR"
+        exit "$EXIT_CODE"
+    fi
+}
+
+# DIRECTORIES
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+BIN_BUILD_DIR="$ROOT_DIR/target/release"
+WASM_BUILD_DIR="$ROOT_DIR/target/wasm32-unknown-unknown/release"
+CONFIG_DIR="$ROOT_DIR/resources/local"
+TEMP_STAGE_DIR='/tmp/nctl_upgrade_stage'
+
+# FILES
+BIN_ARRAY=(casper-node casper-client)
+
+WASM_ARRAY=(add_bid.wasm \
+            delegate.wasm \
+            transfer_to_account_u512.wasm \
+            undelegate.wasm \
+            withdraw_bid.wasm)
+
+CONFIG_ARRAY=(chainspec.toml.in config.toml)
+
+# Create temporary staging directory
+if [ ! -d "$TEMP_STAGE_DIR" ]; then
+    mkdir -p '/tmp/nctl_upgrade_stage'
+fi
+
+# Ensure files are built
+cd "$ROOT_DIR"
+cargo build --release --package casper-client
+cargo build --release --package casper-node
+make build-contract-rs/activate-bid
+make build-contract-rs/add-bid
+make build-contract-rs/delegate
+make build-contract-rs/named-purse-payment
+make build-contract-rs/transfer-to-account-u512
+make build-contract-rs/undelegate
+make build-contract-rs/withdraw-bid
+
+# Copy binaries to staging dir
+for i in "${BIN_ARRAY[@]}"; do
+    if [ -f "$BIN_BUILD_DIR/$i" ]; then
+        echo "Copying $BIN_BUILD_DIR/$i to $TEMP_STAGE_DIR"
+        cp "$BIN_BUILD_DIR/$i" "$TEMP_STAGE_DIR"
+    else
+        echo "ERROR: $BIN_BUILD_DIR/$i not found!"
+        exit 1
+    fi
+    echo ""
+done
+
+# Copy wasm to staging dir
+for i in "${WASM_ARRAY[@]}"; do
+    if [ -f "$WASM_BUILD_DIR/$i" ]; then
+        echo "Copying $WASM_BUILD_DIR/$i to $TEMP_STAGE_DIR"
+        cp "$WASM_BUILD_DIR/$i" "$TEMP_STAGE_DIR"
+    else
+        echo "ERROR: $WASM_BUILD_DIR/$i not found!"
+        exit 2
+    fi
+    echo ""
+done
+
+# Copy configs to staging dir
+for i in "${CONFIG_ARRAY[@]}"; do
+    if [ -f "$CONFIG_DIR/$i" ]; then
+        echo "Copying $CONFIG_DIR/$i to $TEMP_STAGE_DIR"
+        cp "$CONFIG_DIR/$i" "$TEMP_STAGE_DIR"
+    else
+        echo "ERROR: $CONFIG_DIR/$i not found!"
+        exit 3
+    fi
+    echo ""
+done


### PR DESCRIPTION
Adds the 9 files used in the upgrade scenario to the nctl bucket

Runs on:
- push to `release-*` branches
    - stored in matching branch name
- tagged releases
    - stored in matching tag name

Ticket: https://casperlabs.atlassian.net/browse/OP-2030

Links for @sacherjj 
- push to release test: https://drone-auto.casperlabs.io/TomVasile/casper-node/117
- tag test: https://drone-auto.casperlabs.io/TomVasile/casper-node/118