### PR TITLE
NDRS-1454: Account-Address should output formatted string

### DIFF
--- a/client/src/account_address.rs
+++ b/client/src/account_address.rs
@@ -86,6 +86,6 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GenerateAccountHash {
             Error::FailedToParseKey
         })?;
         let account_hash = public_key.to_account_hash();
-        Ok(Success::Output(account_hash.to_string()))
+        Ok(Success::Output(account_hash.to_formatted_string()))
     }
 }


### PR DESCRIPTION
CHANGELOG:

- The command `account-address` now outputs the account hash with the `account-hash-` prefix