### PR TITLE
NDRS-1084: Add databases storing block bodies split into parts

### DIFF
--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -56,6 +56,15 @@ pub enum LmdbExtError {
         queried_block_body_hash: Digest,
         found_block_body_hash: Digest,
     },
+    #[error(
+        "Block body part is missing from storage. \
+        Queried block body hash: {block_body_hash}, \
+        Missing part hash: {part_hash}"
+    )]
+    BlockBodyPartMissing {
+        block_body_hash: Digest,
+        part_hash: Digest,
+    },
 }
 
 // Classifies an `lmdb::Error` according to our scheme. This one of the rare cases where we accept a


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1084 per the comment:

> Create the follow databases:
> - block_body_merkle: BlockBodyHash → vec![hash(deploy_hashes), hash(transfer_hashes), hash(proposer)]
> - deploy_hashes: hash(deploy_hashes) → deploy_hashes
> - transfer_hashes: hash(transfer_hashes) → transfer_hashes
> - proposer: hash(proposer) → proposer

This is to facilitate extensibility of the block body in the future.

Closes #1457 