### PR TITLE
Update peers_to_try with new peers in linear chain sync

### DIFF
--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -64,7 +64,8 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
 
     /// Adds a new peer.
     pub(crate) fn push(&mut self, peer: I) {
-        self.peers.push(peer)
+        self.peers.push(peer.clone());
+        self.peers_to_try.push(peer);
     }
 
     /// Returns the next peer, if any, that we downloaded data the previous time.


### PR DESCRIPTION
This fixes an issue where newly-connected peers are not considered as alternative sources for downloading a block during syncing the linear chain.

The issue meant that a node would stop trying to sync if the first attempt to download a block failed.  This was predominantly an issue in the context of nctl testing, where 5 nodes are started concurrently, attempting to join a network which had already gone through an upgrade.  The new nodes frequently attempted to use each other as the first source for downloading blocks, causing their linear chain sync processes to terminate (with success) early, and leaving them stalled, far behind the current tip of the chain.

Closes #1491.