### PR TITLE
Improve bandwidth limiting testing and edge cases

### DIFF
--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -11,7 +11,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::Instant,
 };
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::types::NodeId;
 
@@ -267,7 +267,7 @@ async fn worker(
                     // reserved bandwidth. In this case, do not limit at all.
                     if !logged_uninitialized {
                         logged_uninitialized = true;
-                        warn!("empty set of validators, not limiting bandwidth at all");
+                        info!("empty set of validators, not limiting bandwidth at all");
                         continue;
                     }
                 }

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -248,6 +248,11 @@ async fn worker(
             } => {
                 active_validators = new_active_validators;
                 upcoming_validators = new_upcoming_validators;
+                debug!(
+                    ?active_validators,
+                    ?upcoming_validators,
+                    "bandwidth classes updated"
+                );
             }
             ClassBasedCommand::RequestBandwidth {
                 num_bytes,

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -268,8 +268,8 @@ async fn worker(
                     if !logged_uninitialized {
                         logged_uninitialized = true;
                         info!("empty set of validators, not limiting bandwidth at all");
-                        continue;
                     }
+                    continue;
                 }
 
                 let bandwidth_class = if let Some(ref validator_id) = id.validator_id {

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -165,6 +165,7 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             ChainInfo::create_for_testing(),
+            None,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();
         let address_gossiper =

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -395,6 +395,7 @@ impl reactor::Reactor for Reactor {
             registry,
             small_network_identity,
             chainspec_loader.chainspec().as_ref(),
+            None,
         )?;
 
         let linear_chain_fetcher = Fetcher::new("linear_chain", config.fetcher, &registry)?;

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -414,14 +414,6 @@ impl reactor::Reactor for Reactor {
             network_identity,
             chainspec_loader.chainspec(),
         )?;
-        let (small_network, small_network_effects) = SmallNetwork::new(
-            event_queue,
-            config.network,
-            Some(WithDir::new(&root, &config.consensus)),
-            registry,
-            small_network_identity,
-            chainspec_loader.chainspec().as_ref(),
-        )?;
 
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
@@ -459,6 +451,17 @@ impl reactor::Reactor for Reactor {
             || chainspec_loader.initial_era(),
             |block_header| block_header.next_block_era_id(),
         );
+
+        let (small_network, small_network_effects) = SmallNetwork::new(
+            event_queue,
+            config.network,
+            Some(WithDir::new(&root, &config.consensus)),
+            registry,
+            small_network_identity,
+            chainspec_loader.chainspec().as_ref(),
+            Some(initial_era),
+        )?;
+
         let mut effects = reactor::wrap_effects(Event::BlockProposer, block_proposer_effects);
 
         let maybe_next_activation_point = chainspec_loader


### PR DESCRIPTION
Contains a few minor fixes that are most prominent in testing:

* Disables bandwidth limiting when there is no information about validators at all. This can, for example, be triggered by setting absurdly low bandwidth limits and then starting a new network from genesis, stalling immediately.
* Respect existing known era IDs that are available. This is, due to the fix above, only a minor improvement, causing us to not having to wait until the next switch block.
* Log changes in known validator sets. This makes it possible to inspect traffic shaping behavior at all.

Changes in preparation to #1479.