### PR TITLE
Seal queues when shutting down reactors

### DIFF
--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -233,6 +233,7 @@ impl Cli {
 
                 // At this point, the joiner is shut down, so we clear the queue to ensure any
                 // connections whose handshake completed but have not been registered are dropped.
+                joiner_queue.seal();
                 for event in joiner_queue.drain_queues().await {
                     debug!(event=%event, "drained event");
                 }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -756,12 +756,14 @@ where
         self.reactor
     }
 
-    /// Deconstruct the runner to return both reactor and scheduler queue.
-    ///
-    /// This is usually used to drain the scheduler after shutting down the reactor.
+    /// Shuts down a reactor, sealing and draining the entire queue before returning it.
     #[inline]
-    pub fn into_inners(self) -> (R, &'static Scheduler<R::Event>) {
-        (self.reactor, self.scheduler)
+    pub async fn drain_into_inner(self) -> R {
+        self.scheduler.seal();
+        for event in self.scheduler.drain_queues().await {
+            debug!(event=%event, "drained event");
+        }
+        self.reactor
     }
 }
 

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -750,12 +750,6 @@ where
         &mut self.reactor
     }
 
-    /// Deconstructs the runner to return the reactor.
-    #[inline]
-    pub fn into_inner(self) -> R {
-        self.reactor
-    }
-
     /// Shuts down a reactor, sealing and draining the entire queue before returning it.
     #[inline]
     pub async fn drain_into_inner(self) -> R {

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -145,13 +145,17 @@ impl TestChain {
             }
 
             // Now we can construct the actual node.
-            let initializer = initializer_runner.into_inner();
+            let initializer = initializer_runner.drain_into_inner().await;
             let mut joiner_runner =
                 Runner::<joiner::Reactor>::new(WithDir::new(root.clone(), initializer), rng)
                     .await?;
             let _ = joiner_runner.run(rng).await;
 
-            let config = joiner_runner.into_inner().into_validator_config().await?;
+            let config = joiner_runner
+                .drain_into_inner()
+                .await
+                .into_validator_config()
+                .await?;
 
             network
                 .add_node_with_config(config, rng)

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -321,7 +321,7 @@ where
 impl<R> Finalize for Network<R>
 where
     R: Finalize + NetworkedReactor + Reactor + Send + 'static,
-    R::Event: Serialize,
+    R::Event: Serialize + Send + Sync,
     R::NodeId: Send,
     R::Error: From<prometheus::Error>,
 {
@@ -331,7 +331,7 @@ where
         async move {
             // Shutdown the sender of every reactor node to ensure the port is open again.
             for (_, node) in self.nodes.into_iter() {
-                node.into_inner().finalize().await;
+                node.drain_into_inner().await.finalize().await;
             }
 
             debug!("network finalized");


### PR DESCRIPTION
This change makes it so that all queues are closed for further events and drained when a reactor is being extracted from a runner, preventing any resource leaks, assuming events are properly dropped.

Logging of the dropped events was not added, as it would add a trait bound for `Display` on everything calling `push`, which has historically not been the case. If necessary, this can be added at a later point in time.