### PR TITLE
Shut down sse event streams gracefully

### DIFF
--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -1,7 +1,7 @@
 //! Types and functions used by the http server to manage the event-stream.
 
 use datasize::DataSize;
-use futures::{Stream, StreamExt};
+use futures::{future, Stream, StreamExt};
 use http::status::StatusCode;
 use hyper::Body;
 #[cfg(test)]
@@ -381,6 +381,7 @@ fn stream_to_client(
                 }
             }
         })
+        .take_while(|result| future::ready(!matches!(result, Err(RecvError::Closed))))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR causes SSE event streams to be shut down gracefully rather than returning an error to the client.

For example, if `curl` is used to follow an event stream as a node stops for an upgrade, the stream exits with an error, reported to the user as `curl: (18) transfer closed with outstanding read data remaining` and `curl` exits with code `18`.  With the update in this PR, `curl` now exits with `0` and reports no error.

This also has the effect of avoiding `warp` logging errors on shutdown of the SSE server when client(s) are attached.

Closes #1512.