### PR TITLE
Update chainspec loader initialization and add tests

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -341,7 +341,7 @@ impl ChainspecLoader {
     }
 
     /// Returns the era ID of where we should reset back to.  This means stored blocks in that and
-    /// subsequent eras are ignored (conceptually deleted from storage).
+    /// subsequent eras are deleted from storage.
     pub(crate) fn hard_reset_to_start_of_era(&self) -> Option<EraId> {
         self.chainspec
             .protocol_config
@@ -405,7 +405,11 @@ impl ChainspecLoader {
                 // TODO - if migrating data yields a new empty block as a means to store the
                 //        post-migration global state hash, we'll come to this code branch, and we
                 //        should not exit the process in that case.
-                warn!("invalid run, expected highest block to be switch block: exit to downgrade");
+                warn!(
+                    %current_chainspec_activation_point,
+                    %highest_block,
+                    "invalid run, expected highest block to be switch block: exit to downgrade"
+                );
                 self.reactor_exit =
                     Some(ReactorExit::ProcessShouldExit(ExitCode::DowngradeVersion));
                 return Effects::new();
@@ -415,43 +419,54 @@ impl ChainspecLoader {
         if highest_block_era_id < current_chainspec_activation_point {
             // This is an invalid run where blocks are missing from storage.  Try exiting the
             // process and downgrading the version to recover the missing blocks.
-            warn!("invalid run, missing blocks from storage: exit to downgrade");
+            warn!(
+                %current_chainspec_activation_point,
+                %highest_block,
+                "invalid run, missing blocks from storage: exit to downgrade"
+            );
             self.reactor_exit = Some(ReactorExit::ProcessShouldExit(ExitCode::DowngradeVersion));
             return Effects::new();
         }
 
-        let debug_assert_version_match = || {
-            debug_assert!(previous_protocol_version == self.chainspec.protocol_config.version);
+        let unplanned_shutdown = match self.next_upgrade {
+            Some(ref next_upgrade) => highest_block_era_id < next_upgrade.activation_point.era_id(),
+            None => true,
         };
 
-        let next_upgrade_activation_point = match self.next_upgrade {
-            Some(ref next_upgrade) => next_upgrade.activation_point.era_id(),
-            None => {
+        if unplanned_shutdown {
+            if previous_protocol_version == self.chainspec.protocol_config.version {
                 // This is a valid run, restarted after an unplanned shutdown.
-                debug_assert_version_match();
                 self.initial_state_root_hash = *highest_block.state_root_hash();
-                info!("valid run after an unplanned shutdown with no scheduled upgrade");
+                info!(
+                    %current_chainspec_activation_point,
+                    %highest_block,
+                    "valid run after an unplanned shutdown before upgrade due"
+                );
                 self.reactor_exit = Some(ReactorExit::ProcessShouldContinue);
-                return Effects::new();
+            } else {
+                // This is an invalid run, where we previously forked and missed an upgrade.
+                warn!(
+                    current_chainspec_protocol_version = %self.chainspec.protocol_config.version,
+                    %current_chainspec_activation_point,
+                    %highest_block,
+                    "invalid run after missing an upgrade and forking"
+                );
+                self.reactor_exit = Some(ReactorExit::ProcessShouldExit(ExitCode::Abort));
             }
-        };
-
-        if highest_block_era_id < next_upgrade_activation_point {
-            // This is a valid run, restarted after an unplanned shutdown.
-            debug_assert_version_match();
-            self.initial_state_root_hash = *highest_block.state_root_hash();
-            info!("valid run after an unplanned shutdown before upgrade due");
-            self.reactor_exit = Some(ReactorExit::ProcessShouldContinue);
             return Effects::new();
         }
 
-        // The is an invalid run as the highest block era ID >= next activation point, so we're
+        // This is an invalid run as the highest block era ID >= next activation point, so we're
         // running an outdated version.  Exit with success to indicate we should upgrade.
-        //
-        // TODO - once the block includes the protocol version, we can deduce here whether we're
-        //        running a version where we missed an upgrade and ran on a fork.  In that case, we
-        //        should set our exit code to `ExitCode::Abort`.
-        warn!("running outdated version: exit to upgrade");
+        warn!(
+            next_upgrade_activation_point = %self
+                .next_upgrade
+                .as_ref()
+                .map(|next_upgrade| next_upgrade.activation_point.era_id())
+                .unwrap_or_default(),
+            %highest_block,
+            "running outdated version: exit to upgrade"
+        );
         self.reactor_exit = Some(ReactorExit::ProcessShouldExit(ExitCode::Success));
         Effects::new()
     }
@@ -790,8 +805,15 @@ fn next_upgrade(dir: PathBuf, current_version: ProtocolVersion) -> Option<NextUp
 
 #[cfg(test)]
 mod tests {
+    use rand::Rng;
+
     use super::*;
-    use crate::{testing::TestRng, types::chainspec::CHAINSPEC_NAME};
+    use crate::{
+        logging,
+        reactor::{validator::Event as ValidatorEvent, EventQueueHandle, QueueKind, Scheduler},
+        testing::TestRng,
+        types::chainspec::CHAINSPEC_NAME,
+    };
 
     #[test]
     fn should_get_next_installed_version() {
@@ -974,5 +996,360 @@ mod tests {
         // Check we return `None` if the next version upgrade_point file is missing.
         fs::remove_file(&path_v1_0_0).unwrap();
         assert!(maybe_next_point(&current).is_none());
+    }
+
+    struct TestFixture {
+        chainspec_loader: ChainspecLoader,
+        effect_builder: EffectBuilder<ValidatorEvent>,
+    }
+
+    impl TestFixture {
+        fn new() -> Self {
+            let _ = logging::init();
+
+            // By default the local chainspec is a genesis one.  We don't want that for most tests,
+            // so set it to V1.5.0 activated at era 300.
+            let mut chainspec = Chainspec::from_resources("local");
+            chainspec.protocol_config.version = ProtocolVersion::from_parts(1, 5, 0);
+            chainspec.protocol_config.activation_point = ActivationPoint::EraId(EraId::new(300));
+
+            let chainspec_loader = ChainspecLoader {
+                chainspec: Arc::new(chainspec),
+                root_dir: PathBuf::from("."),
+                reactor_exit: None,
+                initial_state_root_hash: Digest::default(),
+                next_upgrade: None,
+                initial_block: None,
+            };
+
+            let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));
+            let effect_builder = EffectBuilder::new(EventQueueHandle::new(&scheduler));
+
+            TestFixture {
+                chainspec_loader,
+                effect_builder,
+            }
+        }
+
+        /// Returns the current chainspec's activation point.
+        fn current_activation_point(&self) -> EraId {
+            self.chainspec_loader
+                .chainspec
+                .protocol_config
+                .activation_point
+                .era_id()
+        }
+
+        /// Returns the current chainspec's protocol version.
+        fn current_protocol_version(&self) -> ProtocolVersion {
+            self.chainspec_loader.chainspec.protocol_config.version
+        }
+
+        /// Returns a protocol version earlier than the current chainspec's version.
+        fn earlier_protocol_version(&self) -> ProtocolVersion {
+            ProtocolVersion::from_parts(
+                self.current_protocol_version().value().major,
+                self.current_protocol_version().value().minor - 1,
+                0,
+            )
+        }
+
+        /// Returns a protocol version later than the current chainspec's version.
+        fn later_protocol_version(&self) -> ProtocolVersion {
+            ProtocolVersion::from_parts(
+                self.current_protocol_version().value().major,
+                self.current_protocol_version().value().minor + 1,
+                0,
+            )
+        }
+
+        /// Sets a valid value for the next upgrade in the chainspec loader.
+        fn set_next_upgrade(&mut self, era_diff: u64) {
+            self.chainspec_loader.next_upgrade = Some(NextUpgrade {
+                activation_point: ActivationPoint::EraId(
+                    self.current_activation_point() + era_diff,
+                ),
+                protocol_version: self.later_protocol_version(),
+            });
+        }
+
+        /// Calls `handle_initialize()` on the chainspec loader, asserting the provided block has
+        /// been recorded and that the expected number of effects were returned.
+        fn assert_handle_initialize(
+            &mut self,
+            maybe_highest_block: Option<Block>,
+            expected_effect_count: usize,
+        ) {
+            let effects = self.chainspec_loader.handle_initialize(
+                self.effect_builder,
+                maybe_highest_block.clone().map(Box::new),
+            );
+
+            assert_eq!(self.chainspec_loader.initial_block, maybe_highest_block);
+            assert_eq!(effects.len(), expected_effect_count);
+        }
+
+        /// Asserts that the chainspec loader indicates initialization is ongoing, i.e. that
+        /// `chainspec_loader.reactor_exit` is `None`.
+        fn assert_initialization_incomplete(&self) {
+            assert!(self.chainspec_loader.reactor_exit.is_none())
+        }
+
+        /// Asserts that the chainspec loader indicates initialization is complete and the node
+        /// process should not stop.
+        fn assert_process_should_continue(&self) {
+            assert_eq!(
+                self.chainspec_loader.reactor_exit,
+                Some(ReactorExit::ProcessShouldContinue)
+            )
+        }
+
+        /// Asserts that the chainspec loader indicates the process should stop to downgrade.
+        fn assert_process_should_downgrade(&self) {
+            assert_eq!(
+                self.chainspec_loader.reactor_exit,
+                Some(ReactorExit::ProcessShouldExit(ExitCode::DowngradeVersion))
+            )
+        }
+
+        /// Asserts that the chainspec loader indicates the process should stop to upgrade.
+        fn assert_process_should_upgrade(&self) {
+            assert_eq!(
+                self.chainspec_loader.reactor_exit,
+                Some(ReactorExit::ProcessShouldExit(ExitCode::Success))
+            )
+        }
+
+        /// Asserts that the chainspec loader indicates the process should stop with an error.
+        fn assert_process_should_abort(&self) {
+            assert_eq!(
+                self.chainspec_loader.reactor_exit,
+                Some(ReactorExit::ProcessShouldExit(ExitCode::Abort))
+            )
+        }
+    }
+
+    /// Simulates an initial run of the node where no blocks have been stored previously and the
+    /// chainspec is the genesis one.
+    #[test]
+    fn should_keep_running_if_first_run_at_genesis() {
+        let mut fixture = TestFixture::new();
+        fixture.chainspec_loader.chainspec = Arc::new(Chainspec::from_resources("local"));
+        assert!(fixture.chainspec_loader.chainspec.is_genesis());
+
+        // Should return a single effect (commit genesis).
+        fixture.assert_handle_initialize(None, 1);
+
+        // We're still waiting for the result of the commit genesis event.
+        fixture.assert_initialization_incomplete();
+    }
+
+    /// Simulates an initial run of the node where no blocks have been stored previously but the
+    /// chainspec is not the genesis one.
+    #[test]
+    fn should_downgrade_if_first_run_not_genesis() {
+        let mut fixture = TestFixture::new();
+        assert!(!fixture.chainspec_loader.chainspec.is_genesis());
+
+        fixture.assert_handle_initialize(None, 0);
+        fixture.assert_process_should_downgrade();
+    }
+
+    /// Simulates a valid run immediately after an upgrade.
+    #[test]
+    fn should_keep_running_after_upgrade() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Immediately after an upgrade, the highest block will be the switch block from the era
+        // immediately before the upgrade.
+        let previous_era = fixture.current_activation_point() - 1;
+        let height = rng.gen();
+        let earlier_version = fixture.earlier_protocol_version();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, previous_era, height, earlier_version, true);
+
+        // Should return a single effect (commit upgrade).
+        fixture.assert_handle_initialize(Some(highest_block), 1);
+
+        // We're still waiting for the result of the commit upgrade event.
+        fixture.assert_initialization_incomplete();
+    }
+
+    /// Simulates an invalid run where the highest block is from the previous era, but isn't the
+    /// switch block.
+    ///
+    /// This is unlikely to happen unless a user modifies the launcher's config file to force the
+    /// wrong version of node to be executed, or somehow manually removes the last (switch) block
+    /// from storage as the node upgraded.
+    #[test]
+    fn should_downgrade_if_highest_block_is_from_previous_era_but_is_not_switch() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Make the highest block a non-switch block from the era immediately before the upgrade.
+        let previous_era = fixture.current_activation_point() - 1;
+        let height = rng.gen();
+        let earlier_version = fixture.earlier_protocol_version();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, previous_era, height, earlier_version, false);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_downgrade();
+    }
+
+    /// Simulates an invalid run where the highest block is from an era before the previous era, and
+    /// may or may not be a switch block.
+    ///
+    /// This is unlikely to happen unless a user modifies the launcher's config file to force the
+    /// wrong version of node to be executed, or somehow manually removes later blocks from storage.
+    #[test]
+    fn should_downgrade_if_highest_block_is_from_earlier_era() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Make the highest block from an era before the one immediately before the upgrade.
+        let current_era = fixture.current_activation_point().value();
+        let previous_era = fixture.current_activation_point() - rng.gen_range(2..current_era);
+        let height = rng.gen();
+        let earlier_version = fixture.earlier_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block = Block::random_with_specifics(
+            &mut rng,
+            previous_era,
+            height,
+            earlier_version,
+            is_switch,
+        );
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_downgrade();
+    }
+
+    /// Simulates a valid run where the highest block is from an era the same or newer than the
+    /// current chainspec activation point, and there is no scheduled upcoming upgrade.
+    ///
+    /// This would happen in the case of an unplanned shutdown of the node.
+    #[test]
+    fn should_keep_running_if_unplanned_shutdown_and_no_upgrade_scheduled() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Make the highest block from an era the same or newer than the current chainspec one.
+        let future_era = fixture.current_activation_point() + rng.gen_range(0..3);
+        let height = rng.gen();
+        let current_version = fixture.current_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, future_era, height, current_version, is_switch);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_continue();
+    }
+
+    /// Simulates a valid run where the highest block is from an era the same or newer than the
+    /// current chainspec activation point, but older than a scheduled upgrade's activation point.
+    ///
+    /// This would happen in the case of an unplanned shutdown of the node.
+    #[test]
+    fn should_keep_running_if_unplanned_shutdown_and_future_upgrade_scheduled() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Set an upgrade for 10 eras after the current chainspec activation point.
+        let era_diff = 10;
+        fixture.set_next_upgrade(era_diff);
+
+        // Make the highest block from an era the same or newer than the current chainspec one.
+        let future_era = fixture.current_activation_point() + rng.gen_range(0..era_diff);
+        let height = rng.gen();
+        let current_version = fixture.current_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, future_era, height, current_version, is_switch);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_continue();
+    }
+
+    /// Simulates an invalid run where:
+    /// * the highest block is from an era the same or newer than the current chainspec activation
+    ///   point,
+    /// * there is no scheduled upcoming upgrade,
+    /// * and the protocol version of the highest block doesn't match the current chainspec version.
+    ///
+    /// This would happen in the case of an unplanned shutdown of the node after e.g. forking.
+    #[test]
+    fn should_abort_if_unplanned_shutdown_after_fork_and_no_upgrade_scheduled() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Make the highest block from an era the same or newer than the current chainspec one, but
+        // with an old protocol version.
+        let future_era = fixture.current_activation_point() + rng.gen_range(0..3);
+        let height = rng.gen();
+        let earlier_version = fixture.earlier_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, future_era, height, earlier_version, is_switch);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_abort();
+    }
+
+    /// Simulates an invalid run where:
+    /// * the highest block is from an era the same or newer than the current chainspec activation
+    ///   point,
+    /// * but older than a scheduled upgrade's activation point,
+    /// * and the protocol version of the highest block doesn't match the current chainspec version.
+    ///
+    /// This would happen in the case of an unplanned shutdown of the node after e.g. forking.
+    #[test]
+    fn should_abort_if_unplanned_shutdown_after_fork_and_future_upgrade_scheduled() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Set an upgrade for 10 eras after the current chainspec activation point.
+        let era_diff = 10;
+        fixture.set_next_upgrade(era_diff);
+
+        // Make the highest block from an era the same or newer than the current chainspec one, but
+        // with an old protocol version.
+        let future_era = fixture.current_activation_point() + rng.gen_range(0..era_diff);
+        let height = rng.gen();
+        let earlier_version = fixture.earlier_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, future_era, height, earlier_version, is_switch);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_abort();
+    }
+
+    /// Simulates an invalid run where the highest block is from an era the same or newer than the
+    /// than a scheduled upgrade's activation point.
+    ///
+    /// This is unlikely to happen unless a user modifies the launcher's config file to force the
+    /// wrong version of node to be executed.
+    #[test]
+    fn should_upgrade_if_highest_block_from_after_future_upgrade_activation_point() {
+        let mut fixture = TestFixture::new();
+        let mut rng = TestRng::new();
+
+        // Set an upgrade for 10 eras after the current chainspec activation point.
+        let era_diff = 10;
+        fixture.set_next_upgrade(era_diff);
+
+        // Make the highest block from an era the same or later than the upgrade activation point.
+        let future_era =
+            fixture.current_activation_point() + rng.gen_range(era_diff..(era_diff + 10));
+        let height = rng.gen();
+        let later_version = fixture.later_protocol_version();
+        let is_switch = rng.gen();
+        let highest_block =
+            Block::random_with_specifics(&mut rng, future_era, height, later_version, is_switch);
+
+        fixture.assert_handle_initialize(Some(highest_block), 0);
+        fixture.assert_process_should_upgrade();
     }
 }

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -612,7 +612,13 @@ mod tests {
         let unbonding_delay = 2;
         let mut lc = LinearChain::new(protocol_version, auction_delay, unbonding_delay);
         // Set the latest known block so that we can trigger the following checks.
-        let block = Block::random_with_specifics(&mut rng, EraId::new(3), 10, false);
+        let block = Block::random_with_specifics(
+            &mut rng,
+            EraId::new(3),
+            10,
+            ProtocolVersion::V1_0_0,
+            false,
+        );
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
         let put_block_outcomes = lc.handle_put_block(Box::new(block.clone()));
@@ -649,7 +655,13 @@ mod tests {
         let unbonding_delay = 2;
         let mut lc = LinearChain::new(protocol_version, auction_delay, unbonding_delay);
         // Set the latest known block so that we can trigger the following checks.
-        let block = Block::random_with_specifics(&mut rng, EraId::new(3), 10, false);
+        let block = Block::random_with_specifics(
+            &mut rng,
+            EraId::new(3),
+            10,
+            ProtocolVersion::V1_0_0,
+            false,
+        );
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
         let put_block_outcomes = lc.handle_new_block(Box::new(block.clone()), HashMap::new());

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -455,18 +455,21 @@ fn can_retrieve_block_by_height() {
         &mut harness.rng,
         EraId::new(1),
         33,
+        ProtocolVersion::V1_0_0,
         true,
     ));
     let block_14 = Box::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         14,
+        ProtocolVersion::V1_0_0,
         false,
     ));
     let block_99 = Box::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(2),
         99,
+        ProtocolVersion::V1_0_0,
         true,
     ));
 
@@ -580,12 +583,14 @@ fn different_block_at_height_is_fatal() {
         &mut harness.rng,
         EraId::new(1),
         44,
+        ProtocolVersion::V1_0_0,
         false,
     ));
     let block_44_b = Box::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         44,
+        ProtocolVersion::V1_0_0,
         false,
     ));
 
@@ -1045,6 +1050,7 @@ fn should_hard_reset() {
                 &mut harness.rng,
                 EraId::from(height as u64 / 3),
                 height as u64,
+                ProtocolVersion::V1_0_0,
                 is_switch,
             )
         })

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1168,22 +1168,28 @@ impl Block {
         let height = era * 10 + rng.gen_range(0..10);
         let is_switch = rng.gen_bool(0.1);
 
-        Block::random_with_specifics(rng, EraId::from(era), height, is_switch)
+        Block::random_with_specifics(
+            rng,
+            EraId::from(era),
+            height,
+            ProtocolVersion::V1_0_0,
+            is_switch,
+        )
     }
 
-    /// Generates a random instance using a `TestRng`, but using the specified era ID and height.
+    /// Generates a random instance using a `TestRng`, but using the specified values.
     #[cfg(test)]
     pub fn random_with_specifics(
         rng: &mut TestRng,
         era_id: EraId,
         height: u64,
+        protocol_version: ProtocolVersion,
         is_switch: bool,
     ) -> Self {
         let parent_hash = BlockHash::new(Digest::random(rng));
         let state_root_hash = Digest::random(rng);
         let finalized_block = FinalizedBlock::random_with_specifics(rng, era_id, height, is_switch);
         let parent_seed = Digest::random(rng);
-        let protocol_version = ProtocolVersion::V1_0_0;
         let next_era_validator_weights = match finalized_block.era_report {
             Some(_) => Some(BTreeMap::<PublicKey, U512>::default()),
             None => None,
@@ -1211,7 +1217,7 @@ impl Display for Block {
         write!(
             formatter,
             "executed block {}, parent hash {}, post-state hash {}, body hash {}, \
-             random bit {}, timestamp {}, era_id {}, height {}",
+             random bit {}, timestamp {}, era_id {}, height {}, protocol version: {}",
             self.hash.inner(),
             self.header.parent_hash.inner(),
             self.header.state_root_hash,
@@ -1220,6 +1226,7 @@ impl Display for Block {
             self.header.timestamp,
             self.header.era_id.value(),
             self.header.height,
+            self.header.protocol_version
         )?;
         if let Some(ee) = &self.header.era_end {
             write!(formatter, ", era_end: {}", ee)?;


### PR DESCRIPTION
This PR improves the chainspec loader, in particular now properly handling the case of restarting after a chain fork rather than just debug asserting.

It also improves the logging during initialization, and adds unit tests.

Closes #1482.