### PR TITLE
OP-2047: NCTL - Use assert_node_proposed with timeout

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -47,22 +47,6 @@ function assert_new_bonded_validator() {
     fi
 }
 
-function assert_node_proposed() {
-    local NODE_ID=${1}
-    local NODE_PATH=$(get_path_to_node "$NODE_ID")
-    local PUBLIC_KEY_HEX=$(get_node_public_key_hex "$NODE_ID")
-    local TIMEOUT=${2:-300}
-    log_step "Waiting for a node-$NODE_ID to produce a block..."
-    local OUTPUT=$(timeout "$TIMEOUT" tail -n 1 -f "$NODE_PATH/logs/stdout.log" | grep -o -m 1 "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)")
-    if ( echo "$OUTPUT" | grep -q "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)" ); then
-        log "Node-$NODE_ID created a block!"
-        log "$OUTPUT"
-    else
-        log "ERROR: Node-$NODE_ID didn't create a block within timeout=$TIMEOUT"
-        exit 1
-    fi
-}
-
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -289,12 +289,18 @@ function get_running_node_count {
 # Check that a certain node has produced blocks.
 function assert_node_proposed() {
     local NODE_ID=${1}
-    local NODE_PATH=$(get_path_to_node $NODE_ID)
-    local PUBLIC_KEY_HEX=$(get_node_public_key_hex $NODE_ID)
-    log_step "Waiting for node-$NODE_ID to produce a block..."
-    local OUTPUT=$(tail -f "$NODE_PATH/logs/stdout.log" | grep -o -m 1 "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)")
-    log "node-$NODE_ID created a block!"
-    log "$OUTPUT"
+    local NODE_PATH=$(get_path_to_node "$NODE_ID")
+    local PUBLIC_KEY_HEX=$(get_node_public_key_hex "$NODE_ID")
+    local TIMEOUT=${2:-300}
+    log_step "Waiting for a node-$NODE_ID to produce a block..."
+    local OUTPUT=$(timeout "$TIMEOUT" tail -n 1 -f "$NODE_PATH/logs/stdout.log" | grep -o -m 1 "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)")
+    if ( echo "$OUTPUT" | grep -q "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)" ); then
+        log "Node-$NODE_ID created a block!"
+        log "$OUTPUT"
+    else
+        log "ERROR: Node-$NODE_ID didn't create a block within timeout=$TIMEOUT"
+        exit 1
+    fi
 }
 
 # Checks logs for nodes 1-10 for equivocators

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -64,22 +64,6 @@ function assert_same_era() {
     fi
 }
 
-function assert_node_proposed() {
-    local NODE_ID=${1}
-    local NODE_PATH=$(get_path_to_node "$NODE_ID")
-    local PUBLIC_KEY_HEX=$(get_node_public_key_hex "$NODE_ID")
-    local TIMEOUT=${2:-300}
-    log_step "Waiting for a node-$NODE_ID to produce a block..."
-    local OUTPUT=$(timeout "$TIMEOUT" tail -n 1 -f "$NODE_PATH/logs/stdout.log" | grep -o -m 1 "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)")
-    if ( echo "$OUTPUT" | grep -q "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)" ); then
-        log "Node-$NODE_ID created a block!"
-        log "$OUTPUT"
-    else
-        log "ERROR: Node-$NODE_ID didn't create a block within timeout=$TIMEOUT"
-        exit 1
-    fi
-}
-
 function assert_no_equivocation() {
     local NODE_ID=${1}
     local QUERY_NODE_ID=${2}


### PR DESCRIPTION
Syncs `assert_node_proposed` function across the nctl tests.

Ticket: https://casperlabs.atlassian.net/browse/OP-2047