### PR TITLE
CEP 48 part 1: Sequence number-based panoramas.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -433,12 +433,14 @@ impl<C: Context> ActiveValidator<C> {
             );
             return None;
         }
+        let previous = panorama[self.vidx].correct().cloned();
         let seq_number = panorama.next_seq_num(state, self.vidx);
         let endorsed = state.seen_endorsed(&panorama);
         let panorama_hash = panorama.hash();
         let hwunit = WireUnit {
             panorama: panorama.clone(),
             panorama_hash,
+            previous,
             creator: self.vidx,
             instance_id,
             value,

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -435,8 +435,10 @@ impl<C: Context> ActiveValidator<C> {
         }
         let seq_number = panorama.next_seq_num(state, self.vidx);
         let endorsed = state.seen_endorsed(&panorama);
+        let panorama_hash = panorama.hash();
         let hwunit = WireUnit {
             panorama: panorama.clone(),
+            panorama_hash,
             creator: self.vidx,
             instance_id,
             value,

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -857,6 +857,7 @@ pub(crate) mod tests {
         let wunit = WireUnit {
             panorama,
             panorama_hash,
+            previous: None,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(0),
@@ -989,6 +990,7 @@ pub(crate) mod tests {
         let mut wunit0 = WireUnit {
             panorama: panorama.clone(),
             panorama_hash,
+            previous: None,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(0),
@@ -1000,6 +1002,7 @@ pub(crate) mod tests {
         let wunit1 = WireUnit {
             panorama,
             panorama_hash,
+            previous: None,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(1),

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -852,8 +852,11 @@ pub(crate) mod tests {
             state,
             active_validator: None,
         };
+        let panorama = Panorama::new(WEIGHTS.len());
+        let panorama_hash = panorama.hash();
         let wunit = WireUnit {
-            panorama: Panorama::new(WEIGHTS.len()),
+            panorama,
+            panorama_hash,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(0),
@@ -981,8 +984,11 @@ pub(crate) mod tests {
         };
 
         // Two units with different values and the same sequence number. Carol equivocated!
+        let panorama = Panorama::new(WEIGHTS.len());
+        let panorama_hash = panorama.hash();
         let mut wunit0 = WireUnit {
-            panorama: Panorama::new(WEIGHTS.len()),
+            panorama: panorama.clone(),
+            panorama_hash,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(0),
@@ -992,7 +998,8 @@ pub(crate) mod tests {
             endorsed: BTreeSet::new(),
         };
         let wunit1 = WireUnit {
-            panorama: Panorama::new(WEIGHTS.len()),
+            panorama,
+            panorama_hash,
             creator: CAROL,
             instance_id: highway.instance_id,
             value: Some(1),

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -28,6 +28,11 @@ where
     C: Context,
 {
     Unit(C::Hash),
+    /// The unit with its full panorama.
+    UnitWithPanorama(C::Hash),
+    /// A unit specified by sequence number and validator index, as seen by another unit, given by
+    /// hash.
+    UnitBySeqNum(u64, ValidatorIndex, C::Hash),
     Evidence(ValidatorIndex),
     Endorsement(C::Hash),
     Ping(ValidatorIndex, Timestamp),
@@ -37,6 +42,15 @@ impl<C: Context> Dependency<C> {
     /// Returns whether this identifies a unit, as opposed to other types of vertices.
     pub(crate) fn is_unit(&self) -> bool {
         matches!(self, Dependency::Unit(_))
+    }
+    /// Returns `true` if both refer to the same vertex, even if they differ in whether they
+    /// include the panorama.
+    pub(crate) fn matches(&self, other: &Dependency<C>) -> bool {
+        match (self, other) {
+            (Dependency::UnitWithPanorama(hash0), Dependency::Unit(hash1))
+            | (Dependency::Unit(hash0), Dependency::UnitWithPanorama(hash1)) => hash0 == hash1,
+            (dep0, dep1) => dep0 == dep1,
+        }
     }
 }
 

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -91,7 +91,9 @@ mod serde_unit_with_panorama {
         deserializer: D,
     ) -> Result<(SignedWireUnit<C>, Panorama<C>), D::Error> {
         let (swunit, panorama) = <(SignedWireUnit<C>, Panorama<C>)>::deserialize(deserializer)?;
-        // TODO: Validate panorama hash.
+        if panorama.hash() != swunit.wire_unit().panorama_hash {
+            return Err(serde::de::Error::custom("wrong panorama hash"));
+        }
         Ok((swunit, panorama))
     }
 }
@@ -269,6 +271,7 @@ where
     C: Context,
 {
     pub(crate) panorama: Panorama<C>,
+    pub(crate) panorama_hash: C::Hash,
     pub(crate) creator: ValidatorIndex,
     pub(crate) instance_id: C::InstanceId,
     pub(crate) value: Option<C::ConsensusValue>,

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -272,6 +272,7 @@ where
 {
     pub(crate) panorama: Panorama<C>,
     pub(crate) panorama_hash: C::Hash,
+    pub(crate) previous: Option<C::Hash>,
     pub(crate) creator: ValidatorIndex,
     pub(crate) instance_id: C::InstanceId,
     pub(crate) value: Option<C::ConsensusValue>,
@@ -298,7 +299,7 @@ impl<C: Context> Debug for WireUnit<C> {
             .field("instance_id", &self.instance_id)
             .field("seq_number", &self.seq_number)
             .field("timestamp", &self.timestamp.millis())
-            .field("panorama", self.panorama.as_ref())
+            .field("previous", &self.previous)
             .field("round_exp", &self.round_exp)
             .field("endorsed", &self.endorsed)
             .field("round_id()", &self.round_id())
@@ -318,7 +319,7 @@ impl<C: Context> WireUnit<C> {
 
     /// Returns the creator's previous unit.
     pub(crate) fn previous(&self) -> Option<&C::Hash> {
-        self.panorama[self.creator].correct()
+        self.previous.as_ref()
     }
 
     /// Returns the unit's hash, which is used as a unit identifier.

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -632,8 +632,8 @@ where
             .highway()
             .get_dependency(&missing_dependency)
         {
-            GetDepOutcome::Vertex(vv) => {
-                self.add_vertex(rng, recipient, sender, vv.0, delivery_time)
+            GetDepOutcome::Vertex(vertex) => {
+                self.add_vertex(rng, recipient, sender, vertex, delivery_time)
             }
             GetDepOutcome::Evidence(_) | GetDepOutcome::None => Err(
                 TestRunError::SenderMissingDependency(sender, missing_dependency),

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -18,8 +18,8 @@ use super::{
     active_validator::Effect,
     finality_detector::{FinalityDetector, FttExceeded},
     highway::{
-        Dependency, GetDepOutcome, Highway, Params, PreValidatedVertex, SignedWireUnit,
-        ValidVertex, Vertex, VertexError,
+        Dependency, GetDepOutcome, Highway, Params, PreValidatedVertex, SignedWireUnit, Vertex,
+        VertexError,
     },
     state::Fault,
     validators::Validators,
@@ -108,7 +108,8 @@ impl From<Effect<TestContext>> for HighwayMessage {
         match eff {
             // The effect is `ValidVertex` but we want to gossip it to other
             // validators so for them it's just `Vertex` that needs to be validated.
-            Effect::NewVertex(ValidVertex(v)) => HighwayMessage::NewVertex(Box::new(v)),
+            // We omit the panorama to save bandwidth.
+            Effect::NewVertex(vv) => HighwayMessage::NewVertex(Box::new(vv.without_panorama())),
             Effect::ScheduleTimer(t) => HighwayMessage::Timer(t),
             Effect::RequestNewBlock(block_context) => HighwayMessage::RequestBlock(block_context),
             Effect::WeAreFaulty(fault) => HighwayMessage::WeAreFaulty(Box::new(fault)),

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -871,7 +871,11 @@ impl<C: Context> State<C> {
 
     /// Returns the hash of the message with the given sequence number from the creator of `hash`,
     /// or `None` if the sequence number is higher than that of the unit with `hash`.
-    fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {
+    pub(super) fn find_in_swimlane<'a>(
+        &'a self,
+        hash: &'a C::Hash,
+        seq_number: u64,
+    ) -> Option<&'a C::Hash> {
         let unit = self.unit(hash);
         match unit.seq_number.checked_sub(seq_number) {
             None => None,          // There is no unit with seq_number in our swimlane.

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -684,6 +684,7 @@ impl<C: Context> State<C> {
         let wunit = WireUnit {
             panorama: unit.panorama.clone(),
             panorama_hash: unit.panorama_hash,
+            previous: unit.panorama[unit.creator].correct().cloned(),
             creator: unit.creator,
             instance_id,
             value,

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -683,6 +683,7 @@ impl<C: Context> State<C> {
         let endorsed = unit.claims_endorsed().cloned().collect();
         let wunit = WireUnit {
             panorama: unit.panorama.clone(),
+            panorama_hash: unit.panorama_hash,
             creator: unit.creator,
             instance_id,
             value,

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -213,6 +213,11 @@ impl<C: Context> Panorama<C> {
         self.enumerate().filter_map(missing_dep).next()
     }
 
+    /// Returns the checksum of all hashes in this panorama.
+    pub(crate) fn hash(&self) -> C::Hash {
+        <C as Context>::hash(&bincode::serialize(self).expect("serialize Panorama"))
+    }
+
     /// Returns whether `self` can possibly come later in time than `other`, i.e. it can see
     /// every honest message and every fault seen by `other`.
     pub(super) fn geq(&self, state: &State<C>, other: &Panorama<C>) -> bool {

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -179,8 +179,10 @@ fn add_unit() -> Result<(), AddUnitError<TestContext>> {
 
     // Wrong sequence number: Bob hasn't produced b2 yet.
     let panorama = panorama!(N, b1, c0);
+    let panorama_hash = panorama.hash();
     let mut wunit = WireUnit {
         panorama: panorama.clone(),
+        panorama_hash,
         creator: BOB,
         instance_id: TEST_INSTANCE_ID,
         value: None,

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -183,6 +183,7 @@ fn add_unit() -> Result<(), AddUnitError<TestContext>> {
     let mut wunit = WireUnit {
         panorama: panorama.clone(),
         panorama_hash,
+        previous: Some(b1),
         creator: BOB,
         instance_id: TEST_INSTANCE_ID,
         value: None,

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -81,7 +81,7 @@ impl<C: Context> Unit<C> {
                 .expect("nonempty panorama has nonempty fork choice")
         };
         let mut skip_idx = Vec::new();
-        if let Some(hash) = panorama.get(wunit.creator).correct() {
+        if let Some(hash) = wunit.previous() {
             skip_idx.push(*hash);
             for i in 0..wunit.seq_number.trailing_zeros() as usize {
                 let old_unit = state.unit(&skip_idx[i]);

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -59,6 +59,7 @@ impl<C: Context> Unit<C> {
     /// Values must be stored as a block, with the same hash.
     pub(super) fn new(
         swunit: SignedWireUnit<C>,
+        panorama: Panorama<C>,
         fork_choice: Option<&C::Hash>,
         state: &State<C>,
     ) -> (Unit<C>, Option<C::ConsensusValue>) {
@@ -78,7 +79,7 @@ impl<C: Context> Unit<C> {
                 .expect("nonempty panorama has nonempty fork choice")
         };
         let mut skip_idx = Vec::new();
-        if let Some(hash) = wunit.panorama.get(wunit.creator).correct() {
+        if let Some(hash) = panorama.get(wunit.creator).correct() {
             skip_idx.push(*hash);
             for i in 0..wunit.seq_number.trailing_zeros() as usize {
                 let old_unit = state.unit(&skip_idx[i]);
@@ -86,7 +87,7 @@ impl<C: Context> Unit<C> {
             }
         }
         let unit = Unit {
-            panorama: wunit.panorama,
+            panorama,
             seq_number: wunit.seq_number,
             creator: wunit.creator,
             block,

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -25,6 +25,8 @@ where
     /// The list of latest units and faults observed by the creator of this message.
     /// The panorama must be valid, and this unit's creator must not be marked as faulty.
     pub(crate) panorama: Panorama<C>,
+    /// The panorama's hash, so we don't have to recompute it.
+    pub(crate) panorama_hash: C::Hash,
     /// The number of earlier messages by the same creator.
     /// This must be `0` if the creator's entry in the panorama is `None`. Otherwise it must be
     /// the previous unit's sequence number plus one.
@@ -86,8 +88,10 @@ impl<C: Context> Unit<C> {
                 skip_idx.push(old_unit.skip_idx[i]);
             }
         }
+        let panorama_hash = panorama.hash();
         let unit = Unit {
             panorama,
+            panorama_hash,
             seq_number: wunit.seq_number,
             creator: wunit.creator,
             block,

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -316,7 +316,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         let satisfied_deps = self
             .vertices_awaiting_deps
             .keys()
-            .filter(|dep| highway.has_dependency(dep))
+            .filter(|dep| highway.has_dependency(dep) != Some(false))
             .cloned()
             .collect_vec();
         // Safe to unwrap: We know the keys exist. TODO: Replace with BTreeMap::retain once stable.

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -79,8 +79,7 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     /// Returns whether dependency exists in the pending vertices collection.
     fn contains_dependency(&self, d: &Dependency<C>) -> bool {
         self.0.keys().any(|pvv| match (&pvv.inner().id(), d) {
-            (Dependency::Unit(hash0), Dependency::UnitWithPanorama(hash1))
-            | (Dependency::UnitWithPanorama(hash0), Dependency::Unit(hash1)) => hash0 == hash1,
+            (Dependency::UnitWithPanorama(hash0), Dependency::Unit(hash1)) => hash0 == hash1,
             (dep0, dep1) => dep0 == dep1,
         })
     }

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -63,8 +63,9 @@ macro_rules! add_unit {
             }
         }
         let panorama_hash = panorama.hash();
+        let seq_num_panorama = panorama.to_seq_num_panorama(&$state);
         let wunit = WireUnit {
-            panorama: panorama.clone(),
+            seq_num_panorama,
             panorama_hash,
             previous,
             creator,
@@ -95,8 +96,9 @@ macro_rules! add_unit {
         let previous = panorama[creator].correct().cloned();
         let panorama_hash = panorama.hash();
         let seq_number = panorama.next_seq_num(&$state, creator);
+        let seq_num_panorama = panorama.to_seq_num_panorama(&$state);
         let wunit = WireUnit {
-            panorama: panorama.clone(),
+            seq_num_panorama,
             panorama_hash,
             previous,
             creator,

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -61,8 +61,10 @@ macro_rules! add_unit {
                 timestamp += r_len;
             }
         }
+        let panorama_hash = panorama.hash();
         let wunit = WireUnit {
             panorama: panorama.clone(),
+            panorama_hash,
             creator,
             instance_id: TEST_INSTANCE_ID,
             value,
@@ -88,9 +90,11 @@ macro_rules! add_unit {
 
         let creator = $creator;
         let panorama = panorama!($($obs),*);
+        let panorama_hash = panorama.hash();
         let seq_number = panorama.next_seq_num(&$state, creator);
         let wunit = WireUnit {
             panorama: panorama.clone(),
+            panorama_hash,
             creator,
             instance_id: TEST_INSTANCE_ID,
             value: ($val).into(),

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -62,7 +62,7 @@ macro_rules! add_unit {
             }
         }
         let wunit = WireUnit {
-            panorama,
+            panorama: panorama.clone(),
             creator,
             instance_id: TEST_INSTANCE_ID,
             value,
@@ -74,7 +74,7 @@ macro_rules! add_unit {
         let hwunit = wunit.into_hashed();
         let hash = hwunit.hash();
         let swunit = SignedWireUnit::new(hwunit, &TestSecret(($creator).0));
-        $state.add_unit(swunit).map(|()| hash)
+        $state.add_unit(swunit, panorama).map(|()| hash)
     }};
     ($state: ident, $creator: expr, $time: expr, $round_exp: expr, $val: expr; $($obs:expr),*) => {{
         add_unit!($state, $creator, $time, $round_exp, $val; $($obs),*; std::collections::BTreeSet::new())
@@ -90,7 +90,7 @@ macro_rules! add_unit {
         let panorama = panorama!($($obs),*);
         let seq_number = panorama.next_seq_num(&$state, creator);
         let wunit = WireUnit {
-            panorama,
+            panorama: panorama.clone(),
             creator,
             instance_id: TEST_INSTANCE_ID,
             value: ($val).into(),
@@ -102,7 +102,7 @@ macro_rules! add_unit {
         let hwunit = wunit.into_hashed();
         let hash = hwunit.hash();
         let swunit = SignedWireUnit::new(hwunit, &TestSecret(($creator).0));
-        $state.add_unit(swunit).map(|()| hash)
+        $state.add_unit(swunit, panorama).map(|()| hash)
     }};
 }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -624,7 +624,7 @@ where
             Ok(HighwayMessage::NewVertex(v)) => {
                 let v_id = v.id();
                 // If we already have that vertex, do not process it.
-                if self.highway.has_dependency(&v_id) {
+                if self.highway.has_dependency(&v_id) == Some(true) {
                     return vec![];
                 }
                 let pvv = match self.pre_validate_vertex(v) {

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -147,6 +147,7 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         panorama_hash,
+        previous: None,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: None,
@@ -201,6 +202,7 @@ fn send_a_valid_wire_unit() {
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         panorama_hash,
+        previous: None,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: Some(Arc::new(BlockPayload::new(vec![], vec![], vec![], false))),
@@ -268,6 +270,7 @@ fn detect_doppelganger() {
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         panorama_hash,
+        previous: None,
         creator,
         instance_id,
         value: Some(value),

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -144,8 +144,9 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
     let seq_number = panorama.next_seq_num(&state, creator);
     let now = Timestamp::zero();
     let panorama_hash = panorama.hash();
+    let seq_num_panorama = panorama.to_seq_num_panorama(&state);
     let wunit: WireUnit<ClContext> = WireUnit {
-        panorama,
+        seq_num_panorama,
         panorama_hash,
         previous: None,
         creator,
@@ -198,9 +199,10 @@ fn send_a_valid_wire_unit() {
     let panorama: Panorama<ClContext> = Panorama::from(vec![N]);
     let seq_number = panorama.next_seq_num(&state, creator);
     let panorama_hash = panorama.hash();
+    let seq_num_panorama = panorama.to_seq_num_panorama(&state);
     let mut now = Timestamp::zero();
     let wunit: WireUnit<ClContext> = WireUnit {
-        panorama,
+        seq_num_panorama,
         panorama_hash,
         previous: None,
         creator,
@@ -267,8 +269,9 @@ fn detect_doppelganger() {
     let now = Timestamp::zero();
     let value = Arc::new(BlockPayload::new(vec![], vec![], vec![], false));
     let panorama_hash = panorama.hash();
+    let seq_num_panorama = panorama.to_seq_num_panorama(&state);
     let wunit: WireUnit<ClContext> = WireUnit {
-        panorama,
+        seq_num_panorama,
         panorama_hash,
         previous: None,
         creator,

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -143,8 +143,10 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
     let panorama: Panorama<ClContext> = Panorama::from(vec![N]);
     let seq_number = panorama.next_seq_num(&state, creator);
     let now = Timestamp::zero();
+    let panorama_hash = panorama.hash();
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
+        panorama_hash,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: None,
@@ -194,9 +196,11 @@ fn send_a_valid_wire_unit() {
     let state: State<ClContext> = new_test_state(validators.iter().map(|(_pk, w)| *w), 0);
     let panorama: Panorama<ClContext> = Panorama::from(vec![N]);
     let seq_number = panorama.next_seq_num(&state, creator);
+    let panorama_hash = panorama.hash();
     let mut now = Timestamp::zero();
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
+        panorama_hash,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: Some(Arc::new(BlockPayload::new(vec![], vec![], vec![], false))),
@@ -260,8 +264,10 @@ fn detect_doppelganger() {
     let round_exp = 14;
     let now = Timestamp::zero();
     let value = Arc::new(BlockPayload::new(vec![], vec![], vec![], false));
+    let panorama_hash = panorama.hash();
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
+        panorama_hash,
         creator,
         instance_id,
         value: Some(value),


### PR DESCRIPTION
The main component of Highway's protocol state can be viewed as a directed acyclic graph (DAG) of _units_ (the most common kind of Highway message) representing a "happened before" relation. What actually matters to the algorithm is the partial order generated by that graph: Each unit `u` cites other units `v` that `u`'s creator knew about, giving rise to an arrow `u → v` in the DAG. However, `u → v → w` implies that the creator of `u` also knew about `w`. So we write `u > v` in that situation, but also `u > w`, even if `w` is only reachable via multiple arrows. The units form a partial order, and how the generating DAG is represented doesn't matter.

Except for performance: We want to send as little data as necessary over the wire to communicate the [(strict) lower closure](https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure) of `u`, i.e. the set of all `v` with `v < u`.

Currently we send a [panorama](https://github.com/casper-network/casper-node/blob/fa10b20aa8504f60a12e02adde00dee83ee6657b/node/src/components/consensus/highway_core/state/panorama.rs#L102), a list with one entry for each validator, containing the hash of the latest unit `v` by that validator such that `v < u`. A hash is 32 bytes.

This change reduces the size of the panorama in the wire format by replacing the hash of `v` with its sequence number, which is only 8 bytes. So when I receive `u`, and `u → v`, I don't immediately know `v`'s hash, I only know that `v` is e.g. the 42nd unit of that validator.

Since faulty validators can create forks, "the 42nd unit" is not necessarily uniquely defined anymore. A large part of this PR is about double-checking and resolving that ambiguity.

This is part of [CEP 48](https://github.com/casperlabs/ceps/pull/0048), and closes https://github.com/casper-network/casper-node/issues/1481.