### PR TITLE
Added: npm reference to the github and docs homepage

### DIFF
--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -2,6 +2,12 @@
   "name": "casper-contract",
   "version": "1.0.0",
   "description": "Library for developing Casper smart contracts.",
+  "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/casper-network/casper-node.git",
+    "directory": "smart_contracts/contract_as"
+  },
   "main": "index.js",
   "ascMain": "assembly/index.ts",
   "dependencies": {},


### PR DESCRIPTION
***What does this change do?***

- Added reference to the github repo
- Added reference to assembly script docs page in casperlabs docs

***Why is this change needed?***

- Improve DevX experience. Difficult to track it back to the code and
docs when found on npm.