### PR TITLE
Add SSE server tests and fix issues exposed by these

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
+checksum = "a88b6bd5df287567ffdf4ddf4d33060048e1068308e5f62d81c6f9824a045a48"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -290,7 +290,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -404,9 +404,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
  "cc",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-tools"
@@ -814,7 +814,7 @@ dependencies = [
  "fs2",
  "futures",
  "futures-io",
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "hex",
  "hex-buffer-serde",
  "hex_fmt",
@@ -843,6 +843,7 @@ dependencies = [
  "pem",
  "pin-project 1.0.7",
  "pnet",
+ "pretty_assertions",
  "prometheus",
  "proptest",
  "quanta",
@@ -851,6 +852,7 @@ dependencies = [
  "rand_core 0.6.2",
  "rand_pcg",
  "regex",
+ "reqwest",
  "rmp-serde",
  "schemars",
  "serde",
@@ -858,7 +860,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "signal-hook 0.3.8",
+ "signal-hook 0.3.9",
  "signature",
  "smallvec",
  "static_assertions",
@@ -909,7 +911,7 @@ dependencies = [
  "datasize",
  "displaydoc",
  "ed25519-dalek",
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "hex",
  "hex_fmt",
  "k256",
@@ -941,11 +943,11 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -969,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -1106,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
@@ -1249,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1270,8 +1272,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.4",
- "crossbeam-utils 0.8.4",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1291,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
- "memoffset 0.6.3",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -1326,11 +1328,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -1501,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.13"
+version = "0.99.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1527,6 +1528,12 @@ dependencies = [
  "casper-contract",
  "casper-types",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "difference"
@@ -1655,7 +1662,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_bytes",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "zeroize",
 ]
 
@@ -1923,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
+checksum = "e5b36e6f2295f393f44894c6031f67df4d185b984cd54d08f768ce678007efcd"
 dependencies = [
  "serde",
 ]
@@ -2074,9 +2081,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2089,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2099,15 +2106,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2117,15 +2124,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2138,10 +2145,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -2150,15 +2158,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-timer"
@@ -2168,10 +2176,11 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -2274,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2410,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2523,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -2534,15 +2543,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -2552,9 +2561,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2737,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2764,7 +2773,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.4",
+ "sha2 0.9.5",
 ]
 
 [[package]]
@@ -2814,9 +2823,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libp2p"
@@ -2878,7 +2887,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2946,7 +2955,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -2986,7 +2995,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -3048,7 +3057,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3327,9 +3336,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -3434,16 +3443,16 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -3662,9 +3671,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -3706,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
@@ -3731,6 +3743,15 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3920,9 +3941,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -4101,11 +4122,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
+name = "pretty_assertions"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
 dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -4147,9 +4181,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -4394,7 +4428,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -4444,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque 0.8.0",
@@ -4456,13 +4490,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
 ]
@@ -4497,11 +4531,10 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
@@ -4730,9 +4763,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "b239a3d5db51252f6f48f42172c65317f37202f4a21021bf5f9d40a408f4592c"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -4743,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4792,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
@@ -4830,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4863,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4874,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bb5fef7eaf5a97917567183607ac4224c5b451c15023930f23b937cce879fe"
+checksum = "bd1055d1c20532080b9da5040ec8e27425f4d4573d8e29eb19ba4ff1e4b9da2d"
 dependencies = [
  "serde",
 ]
@@ -4895,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659df5fc3ce22274daac600ffb845300bd2125bcfaec047823075afdab81c00"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -4920,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -4965,9 +4998,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4975,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -5028,7 +5061,7 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version 0.2.3",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "subtle 2.4.0",
  "x25519-dalek",
 ]
@@ -5276,18 +5309,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5340,9 +5373,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5356,9 +5389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5404,9 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5429,9 +5462,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5452,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "pin-project 1.0.7",
@@ -5761,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -5850,24 +5883,25 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "serde",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
 dependencies = [
  "ctor",
+ "version_check",
 ]
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"
@@ -6010,9 +6044,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -6022,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -6037,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -6049,9 +6083,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6059,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6072,9 +6106,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasm-timer"
@@ -6117,9 +6151,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -106,8 +106,10 @@ vergen = "3"
 fake_instant = "0.4.0"
 multihash = "0.13.2"
 pnet = "0.27.2"
+pretty_assertions = "0.7.2"
 rand_core = "0.6.2"
 rand_pcg = "0.3.0"
+reqwest = { version = "0.11.3", features = ["stream"] }
 tokio = { version = "1", features = ["test-util"] }
 
 [features]

--- a/node/src/components/event_stream_server/event_indexer.rs
+++ b/node/src/components/event_stream_server/event_indexer.rs
@@ -54,6 +54,11 @@ impl EventIndexer {
         self.index = index.wrapping_add(1);
         index
     }
+
+    #[cfg(test)]
+    pub(super) fn current_index(&self) -> EventIndex {
+        self.index
+    }
 }
 
 impl Drop for EventIndexer {

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -1,11 +1,14 @@
 //! Types and functions used by the http server to manage the event-stream.
 
+use std::{collections::HashMap, time::Duration};
+
 use datasize::DataSize;
 use futures::{future, Stream, StreamExt};
-use http::status::StatusCode;
+use http::StatusCode;
 use hyper::Body;
 #[cfg(test)]
 use rand::Rng;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
     broadcast::{self, error::RecvError},
@@ -40,12 +43,25 @@ pub const SSE_API_ROOT_PATH: &str = "events";
 pub const SSE_API_MAIN_PATH: &str = "main";
 /// The URL path part to subscribe to only `FinalitySignature` events.
 pub const SSE_API_SIGNATURES_PATH: &str = "sigs";
+/// The URL query string field name.
+pub const QUERY_FIELD: &str = "start_from";
+/// The stream keepalive interval.
+///
+/// Some tests use the first keepalive emitted as a signal that the server has sent all available
+/// events, so for test cfg, we set the keepalive duration small.
+pub const KEEPALIVE_INTERVAL: Duration = {
+    if cfg!(test) {
+        Duration::from_millis(100)
+    } else {
+        Duration::from_secs(15)
+    }
+};
 
 /// The "id" field of the events sent on the event stream to clients.
-type Id = u32;
+pub type Id = u32;
 
 /// The "data" field of the events sent on the event stream to clients.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, JsonSchema)]
 pub enum SseData {
     /// The version of this node's API server.  This event will always be the first sent to a new
     /// client, and will have no associated event ID provided.
@@ -85,7 +101,7 @@ pub enum SseData {
 #[cfg(test)]
 impl SseData {
     /// Returns a random `SseData::ApiVersion`.
-    fn random_api_version(rng: &mut TestRng) -> Self {
+    pub(super) fn random_api_version(rng: &mut TestRng) -> Self {
         let protocol_version = ProtocolVersion::from_parts(
             rng.gen_range(0..10),
             rng.gen::<u8>() as u32,
@@ -95,7 +111,7 @@ impl SseData {
     }
 
     /// Returns a random `SseData::BlockAdded`.
-    fn random_block_added(rng: &mut TestRng) -> Self {
+    pub(super) fn random_block_added(rng: &mut TestRng) -> Self {
         let block = Block::random(rng);
         SseData::BlockAdded {
             block_hash: *block.hash(),
@@ -104,7 +120,7 @@ impl SseData {
     }
 
     /// Returns a random `SseData::DeployProcessed`.
-    fn random_deploy_processed(rng: &mut TestRng) -> Self {
+    pub(super) fn random_deploy_processed(rng: &mut TestRng) -> Self {
         let deploy = Deploy::random(rng);
         SseData::DeployProcessed {
             deploy_hash: Box::new(*deploy.id()),
@@ -118,7 +134,7 @@ impl SseData {
     }
 
     /// Returns a random `SseData::Fault`.
-    fn random_fault(rng: &mut TestRng) -> Self {
+    pub(super) fn random_fault(rng: &mut TestRng) -> Self {
         SseData::Fault {
             era_id: EraId::new(rng.gen()),
             public_key: PublicKey::random(rng),
@@ -127,7 +143,7 @@ impl SseData {
     }
 
     /// Returns a random `SseData::FinalitySignature`.
-    fn random_finality_signature(rng: &mut TestRng) -> Self {
+    pub(super) fn random_finality_signature(rng: &mut TestRng) -> Self {
         SseData::FinalitySignature(Box::new(FinalitySignature::random_for_block(
             BlockHash::random(rng),
             rng.gen(),
@@ -135,7 +151,7 @@ impl SseData {
     }
 
     /// Returns a random `SseData::Step`.
-    fn random_step(rng: &mut TestRng) -> Self {
+    pub(super) fn random_step(rng: &mut TestRng) -> Self {
         let execution_effect = match rng.gen::<ExecutionResult>() {
             ExecutionResult::Success { effect, .. } | ExecutionResult::Failure { effect, .. } => {
                 effect
@@ -224,15 +240,9 @@ pub(super) struct NewSubscriberInfo {
     pub(super) initial_events_sender: mpsc::UnboundedSender<ServerSentEvent>,
 }
 
-/// The endpoint's query string, e.g. `http://localhost:22777/events?start_from=999`
-#[derive(Deserialize, Debug)]
-struct Query {
-    start_from: Option<Id>,
-}
-
 /// A filter for event types a client has subscribed to receive.
 #[derive(Clone, Copy, Eq, PartialEq)]
-enum EventFilter {
+pub(super) enum EventFilter {
     /// All events other than `FinalitySignature`s.
     Main,
     /// The initial `ApiVersion` event and then only `FinalitySignature` events.
@@ -270,6 +280,28 @@ fn filter_map_server_sent_event(
     }
 }
 
+/// Extracts the starting event ID from the provided query, or `None` if `query` is empty.
+///
+/// If `query` is not empty, returns a 422 response if `query` doesn't have exactly one entry,
+/// "starts_from" mapped to a value representing an event ID.
+fn parse_query(query: HashMap<String, String>) -> Result<Option<Id>, Response> {
+    if query.is_empty() {
+        return Ok(None);
+    }
+
+    if query.len() > 1 {
+        return Err(create_422());
+    }
+
+    match query
+        .get(QUERY_FIELD)
+        .and_then(|id_str| id_str.parse::<Id>().ok())
+    {
+        Some(id) => Ok(Some(id)),
+        None => Err(create_422()),
+    }
+}
+
 /// Creates a 404 response with a useful error message in the body.
 fn create_404() -> Response {
     let mut response = Response::new(Body::from(format!(
@@ -279,6 +311,17 @@ fn create_404() -> Response {
         sigs = SSE_API_SIGNATURES_PATH
     )));
     *response.status_mut() = StatusCode::NOT_FOUND;
+    response
+}
+
+/// Creates a 422 response with a useful error message in the body for use in case of a bad query
+/// string.
+fn create_422() -> Response {
+    let mut response = Response::new(Body::from(format!(
+        "invalid query: expected single field '{}=<EVENT ID>'\n",
+        QUERY_FIELD
+    )));
+    *response.status_mut() = StatusCode::UNPROCESSABLE_ENTITY;
     response
 }
 
@@ -304,11 +347,16 @@ pub(super) fn create_channels_and_filter(
         .and(path::param::<String>())
         .and(path::end())
         .and(warp::query())
-        .map(move |path_param: String, query: Query| {
+        .map(move |path_param: String, query: HashMap<String, String>| {
             // If `path_param` is not a valid string, return a 404.
             let event_filter = match EventFilter::new(&path_param) {
                 Some(filter) => filter,
                 None => return create_404(),
+            };
+
+            let start_from = match parse_query(query) {
+                Ok(maybe_id) => maybe_id,
+                Err(error_response) => return error_response,
             };
 
             // Create a channel for the client's handler to receive the stream of initial events.
@@ -317,7 +365,7 @@ pub(super) fn create_channels_and_filter(
             // Supply the server with the sender part of the channel along with the client's
             // requested starting point.
             let new_subscriber_info = NewSubscriberInfo {
-                start_from: query.start_from,
+                start_from,
                 initial_events_sender,
             };
             if new_subscriber_info_sender
@@ -330,11 +378,15 @@ pub(super) fn create_channels_and_filter(
             // Create a channel for the client's handler to receive the stream of ongoing events.
             let ongoing_events_receiver = cloned_broadcaster.subscribe();
 
-            sse::reply(sse::keep_alive().stream(stream_to_client(
-                initial_events_receiver,
-                ongoing_events_receiver,
-                event_filter,
-            )))
+            sse::reply(
+                sse::keep_alive()
+                    .interval(KEEPALIVE_INTERVAL)
+                    .stream(stream_to_client(
+                        initial_events_receiver,
+                        ongoing_events_receiver,
+                        event_filter,
+                    )),
+            )
             .into_response()
         })
         .or_else(|_| async move { Ok::<_, Rejection>((create_404(),)) })

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -1,0 +1,899 @@
+use std::{
+    cell::RefCell,
+    error::Error,
+    fs, io, iter, str,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use futures::{join, StreamExt};
+use http::StatusCode;
+use pretty_assertions::assert_eq;
+use rand::Rng;
+use schemars::schema_for;
+use tempfile::TempDir;
+use tokio::{
+    sync::{Barrier, Notify},
+    task::JoinHandle,
+    time,
+};
+use tracing::debug;
+
+use super::*;
+use crate::{logging, testing::TestRng};
+use sse_server::{
+    EventFilter, Id, QUERY_FIELD, SSE_API_MAIN_PATH, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH,
+};
+
+/// The total number of random events each `EventStreamServer` will emit by default, excluding the
+/// initial `ApiVersion` event.
+const EVENT_COUNT: u32 = 100;
+/// The event stream buffer length, set in the server's config.  Set to half of the total event
+/// count to allow for the buffer purging events in the test.
+const BUFFER_LENGTH: u32 = EVENT_COUNT / 2;
+/// The maximum amount of time to wait for a test server to complete.  If this time is exceeded, the
+/// test has probably hung, and should be deemed to have failed.
+const MAX_TEST_TIME: Duration = Duration::from_secs(1);
+/// The duration of the sleep called between each event being sent by the server.
+const DELAY_BETWEEN_EVENTS: Duration = Duration::from_millis(1);
+
+thread_local!(
+    /// A per-test identifier for the clients.
+    static CLIENT_ID: RefCell<usize> = RefCell::new(0)
+);
+
+/// A helper to allow the synchronization of a single client joining the SSE server.
+///
+/// It provides the primitives to allow the client to connect to the server just before a specific
+/// event is emitted by the server.
+#[derive(Clone)]
+struct ClientSyncBehavior {
+    /// The event ID before which the server should wait at the barrier for the client to join.
+    join_before_event: Id,
+    /// The barrier to sync the client joining the server.
+    barrier: Arc<Barrier>,
+}
+
+impl ClientSyncBehavior {
+    fn new(join_before_event: Id) -> (Self, Arc<Barrier>) {
+        let barrier = Arc::new(Barrier::new(2));
+        let behavior = ClientSyncBehavior {
+            join_before_event,
+            barrier: Arc::clone(&barrier),
+        };
+        (behavior, barrier)
+    }
+}
+
+/// A helper to allow the synchronization of all clients joining a single SSE server.
+#[derive(Clone)]
+struct ServerSyncBehavior {
+    /// Whether the server should have a delay between sending events, to allow a client to keep up
+    /// and not be disconnected for lagging.
+    has_delay_between_events: bool,
+    clients: Vec<ClientSyncBehavior>,
+}
+
+impl ServerSyncBehavior {
+    /// Returns a new `ServerSyncBehavior` with a 1 millisecond delay per event, and no clients.
+    fn new() -> Self {
+        ServerSyncBehavior {
+            has_delay_between_events: true,
+            clients: Vec::new(),
+        }
+    }
+
+    /// Removes the delay between events.
+    fn with_no_delay_between_events(mut self) -> Self {
+        self.has_delay_between_events = false;
+        self
+    }
+
+    /// Adds a client sync behavior, specified for the client to connect to the server just before
+    /// `id` is emitted.
+    fn add_client_sync_before_event(&mut self, id: Id) -> Arc<Barrier> {
+        let (client_behavior, barrier) = ClientSyncBehavior::new(id);
+        self.clients.push(client_behavior);
+        barrier
+    }
+
+    /// Waits for all clients which specified they wanted to join just before the given event ID.
+    async fn wait_for_clients(&self, id: Id) {
+        for client_behavior in &self.clients {
+            if client_behavior.join_before_event == id {
+                debug!("server waiting before event {}", id);
+                client_behavior.barrier.wait().await;
+                debug!("server waiting for client to connect before event {}", id);
+                client_behavior.barrier.wait().await;
+                debug!("server finished waiting before event {}", id);
+            }
+        }
+    }
+
+    /// Sleeps if `self` was set to enable delays between events.
+    async fn sleep_if_required(&self) {
+        if self.has_delay_between_events {
+            time::sleep(DELAY_BETWEEN_EVENTS).await;
+        }
+    }
+}
+
+/// A helper to allow the server to be kept alive until a specific call to stop it.
+#[derive(Clone)]
+struct ServerStopper {
+    should_stop: Arc<AtomicBool>,
+    notifier: Arc<Notify>,
+}
+
+impl ServerStopper {
+    fn new() -> Self {
+        ServerStopper {
+            should_stop: Arc::new(AtomicBool::new(false)),
+            notifier: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Returns whether the server should stop now or not.
+    fn should_stop(&self) -> bool {
+        self.should_stop.load(Ordering::SeqCst)
+    }
+
+    /// Waits until the server should stop.
+    async fn wait(&self) {
+        while !self.should_stop() {
+            self.notifier.notified().await;
+        }
+    }
+
+    /// Tells the server to stop.
+    fn stop(&self) {
+        self.should_stop.store(true, Ordering::SeqCst);
+        self.notifier.notify_one();
+    }
+}
+
+impl Drop for ServerStopper {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+struct TestFixture {
+    storage_dir: TempDir,
+    protocol_version: ProtocolVersion,
+    events: Vec<SseData>,
+    first_event_id: Id,
+    server_join_handle: Option<JoinHandle<()>>,
+    server_stopper: ServerStopper,
+}
+
+impl TestFixture {
+    /// Constructs a new `TestFixture` including `EVENT_COUNT` random events ready to be served.
+    fn new(rng: &mut TestRng) -> Self {
+        let _ = logging::init();
+        let storage_dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(&storage_dir).unwrap();
+        let protocol_version = ProtocolVersion::from_parts(1, 2, 3);
+
+        let events = (0..EVENT_COUNT)
+            .map(|_| match rng.gen_range(0..8) {
+                0 => SseData::random_block_added(rng),
+                1 => SseData::random_deploy_processed(rng),
+                2 => SseData::random_fault(rng),
+                3 => SseData::random_step(rng),
+                4..=7 => SseData::random_finality_signature(rng),
+                _ => unreachable!(),
+            })
+            .collect();
+
+        TestFixture {
+            storage_dir,
+            protocol_version,
+            events,
+            first_event_id: 0,
+            server_join_handle: None,
+            server_stopper: ServerStopper::new(),
+        }
+    }
+
+    /// Creates a new `EventStreamServer` and runs it in a tokio task, returning the actual address
+    /// the server is listening on.
+    ///
+    /// Only one server can be run at a time; this panics if there is already a server task running.
+    ///
+    /// The server emits a clone of each of the random events held by the `TestFixture`, in the
+    /// order in which they're held in the `TestFixture`.
+    ///
+    /// The server runs until `TestFixture::stop_server()` is called, or the `TestFixture` is
+    /// dropped.
+    async fn run_server(&mut self, sync_behavior: ServerSyncBehavior) -> SocketAddr {
+        if self.server_join_handle.is_some() {
+            panic!("one `TestFixture` can only run one server at a time");
+        }
+        self.server_stopper = ServerStopper::new();
+
+        // Set the server to use a channel buffer of half the total events it will emit.
+        let config = Config {
+            event_stream_buffer_length: BUFFER_LENGTH,
+            ..Default::default()
+        };
+        let mut server = EventStreamServer::new(
+            config,
+            self.storage_dir.path().to_path_buf(),
+            self.protocol_version,
+        )
+        .unwrap();
+
+        self.first_event_id = server.event_indexer.current_index();
+
+        let first_event_id = server.event_indexer.current_index();
+        let server_address = server.listening_address;
+        let events = self.events.clone();
+        let server_stopper = self.server_stopper.clone();
+
+        let join_handle = tokio::spawn(async move {
+            for (id, event) in events.into_iter().enumerate() {
+                if server_stopper.should_stop() {
+                    debug!("stopping server early");
+                    return;
+                }
+                sync_behavior
+                    .wait_for_clients((id as Id).wrapping_add(first_event_id))
+                    .await;
+                let _ = server.broadcast(event);
+                sync_behavior.sleep_if_required().await;
+            }
+
+            // Keep the server running until told to stop.  Clients connecting from now will only
+            // receive keepalives.
+            debug!("server finished sending all events");
+            server_stopper.wait().await;
+            debug!("server stopped");
+        });
+
+        self.server_join_handle = Some(join_handle);
+
+        server_address
+    }
+
+    /// Stops the currently-running server, if any, panicking if unable to stop the server within
+    /// `MAX_TEST_TIME`.
+    ///
+    /// Must be called and awaited before starting a new server with this particular `TestFixture`.
+    ///
+    /// Should be called in every test where a server has been started, since this will ensure
+    /// failed tests won't hang indefinitely.
+    async fn stop_server(&mut self) {
+        let join_handle = match self.server_join_handle.take() {
+            Some(join_handle) => join_handle,
+            None => return,
+        };
+        self.server_stopper.stop();
+        time::timeout(MAX_TEST_TIME, join_handle)
+            .await
+            .expect("stopping server timed out (test hung)")
+            .expect("server task should not error");
+    }
+
+    /// Returns all the events which would have been received by a client via the `/events/main` URL
+    /// or the `/events/sigs` URL depending on `filter`, where the client connected just before
+    /// `from` was emitted from the server.  This includes the initial `ApiVersion` event.
+    fn filtered_events(&self, filter: EventFilter, from: Id) -> Vec<ReceivedEvent> {
+        // Convert the IDs to `u128`s to cater for wrapping and add `Id::MAX + 1` to `from` if the
+        // buffer wrapped and `from` represents an event from after the wrap.
+        let threshold = Id::MAX - EVENT_COUNT;
+        let from = if self.first_event_id >= threshold && from < threshold {
+            from as u128 + Id::MAX as u128 + 1
+        } else {
+            from as u128
+        };
+
+        let id_filter = |id: u128, event: &SseData| -> Option<ReceivedEvent> {
+            if id < from {
+                return None;
+            }
+            Some(ReceivedEvent {
+                id: Some(id as Id),
+                data: serde_json::to_string(event).unwrap(),
+            })
+        };
+
+        let api_version_event = ReceivedEvent {
+            id: None,
+            data: serde_json::to_string(&SseData::ApiVersion(self.protocol_version)).unwrap(),
+        };
+
+        iter::once(api_version_event)
+            .chain(self.events.iter().enumerate().filter_map(|(id, event)| {
+                let id = id as u128 + self.first_event_id as u128;
+                match event {
+                    SseData::BlockAdded { .. }
+                    | SseData::DeployProcessed { .. }
+                    | SseData::Fault { .. }
+                    | SseData::Step { .. } => match filter {
+                        EventFilter::Main => id_filter(id, event),
+                        EventFilter::Signatures => None,
+                    },
+                    SseData::FinalitySignature(_) => match filter {
+                        EventFilter::Main => None,
+                        EventFilter::Signatures => id_filter(id, event),
+                    },
+                    SseData::ApiVersion(_) => {
+                        panic!("should not hold ApiVersion event in test fixture")
+                    }
+                }
+            }))
+            .collect()
+    }
+
+    /// Returns all the events which would have been received by a client connected from server
+    /// startup via the `/events/main` URL or the `/events/sigs` URL depending on `filter`,
+    /// including the initial `ApiVersion` event.
+    fn all_filtered_events(&self, filter: EventFilter) -> Vec<ReceivedEvent> {
+        self.filtered_events(filter, self.first_event_id)
+    }
+}
+
+/// Returns the URL for a client to use to connect to the server at the given address.
+///
+/// Uses `events/main` or `events/sigs` depending upon the value of `filter`, and appends a
+/// `?start_from=X` query string if `maybe_start_from` is `Some`.
+fn url(server_address: SocketAddr, filter: EventFilter, maybe_start_from: Option<Id>) -> String {
+    format!(
+        "http://{}/{}/{}{}",
+        server_address,
+        SSE_API_ROOT_PATH,
+        match filter {
+            EventFilter::Main => SSE_API_MAIN_PATH,
+            EventFilter::Signatures => SSE_API_SIGNATURES_PATH,
+        },
+        match maybe_start_from {
+            Some(start_from) => format!("?{}={}", QUERY_FIELD, start_from),
+            None => String::new(),
+        }
+    )
+}
+
+/// The representation of an SSE event as received by a subscribed client.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ReceivedEvent {
+    id: Option<Id>,
+    data: String,
+}
+
+/// Runs a client, consuming all SSE events until the server starts emitting keepalive chars `:`.
+///
+/// The client waits at the barrier before connecting to the server, and then again immediately
+/// after connecting to ensure the server doesn't start sending events before the client is
+/// connected.
+async fn subscribe(url: &str, barrier: Arc<Barrier>) -> Result<Vec<ReceivedEvent>, reqwest::Error> {
+    let client_id = CLIENT_ID.with(|client_id| {
+        let mut id = client_id.borrow_mut();
+        let copied_id = *id;
+        *id = copied_id + 1;
+        format!("client {}", copied_id)
+    });
+
+    debug!("{} waiting before connecting via {}", client_id, url);
+    barrier.wait().await;
+    let response = reqwest::get(url).await?;
+    debug!("{} waiting after connecting", client_id);
+    barrier.wait().await;
+    debug!("{} finished waiting", client_id);
+
+    // The stream from the server is not always chunked into events, so gather the stream into a
+    // single `String` until we receive a keepalive.
+    let mut response_text = String::new();
+    let mut stream = response.bytes_stream();
+    while let Some(item) = stream.next().await {
+        // If the server crashes or returns an error in the stream, it is caught here as `item` will
+        // be an `Err`.
+        let bytes = item?;
+        let chunk = str::from_utf8(bytes.as_ref()).unwrap();
+        response_text.push_str(chunk);
+        if response_text.lines().rev().any(|line| line == ":") {
+            debug!("{} received keepalive: exiting", client_id);
+            break;
+        }
+    }
+
+    // Iterate the lines of the response body.  Each line should be one of
+    //   * an SSE event: line starts with "data:" and the remainder of the line is a JSON object
+    //   * an SSE event ID: line starts with "id:" and the remainder is a decimal encoded `u32`
+    //   * empty
+    //   * a keepalive: line contains exactly ":"
+    //
+    // The expected order is:
+    //   * data:<JSON-encoded ApiVersion> (note, no ID line follows this first event)
+    // then the following three repeated for as many events as are applicable to that stream:
+    //   * data:<JSON-encoded event>
+    //   * id:<integer>
+    //   * empty line
+    // then finally, repeated keepalive lines until the server is shut down.
+    let mut received_events = Vec::new();
+    let mut line_itr = response_text.lines();
+    while let Some(data_line) = line_itr.next() {
+        let data = match data_line.strip_prefix("data:") {
+            Some(data_str) => data_str.to_string(),
+            None => {
+                if data_line.trim().is_empty() || data_line.trim() == ":" {
+                    continue;
+                } else {
+                    panic!(
+                        "{}: data line should start with 'data:'\n{}",
+                        client_id, data_line
+                    )
+                }
+            }
+        };
+
+        let id_line = match line_itr.next() {
+            Some(line) => line,
+            None => break,
+        };
+
+        let id = match id_line.strip_prefix("id:") {
+            Some(id_str) => Some(id_str.parse().unwrap_or_else(|_| {
+                panic!("{}: failed to get ID line from:\n{}", client_id, id_line)
+            })),
+            None => {
+                if id_line.trim().is_empty() && received_events.is_empty() {
+                    None
+                } else if id_line.trim() == ":" {
+                    continue;
+                } else {
+                    panic!(
+                        "{}: every event must have an ID except the first one",
+                        client_id
+                    );
+                }
+            }
+        };
+
+        received_events.push(ReceivedEvent { id, data });
+    }
+
+    Ok(received_events)
+}
+
+/// Client setup:
+///   * `<IP:port>/events/main` or `<IP:port>/events/sigs` depending on `filter`
+///   * no `?start_from=` query
+///   * connected before first event
+///
+/// Expected to receive all main or signature events depending on `filter`.
+async fn should_serve_events_with_no_query(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier = sync_behavior.add_client_sync_before_event(0);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url = url(server_address, filter, None);
+    let received_events = subscribe(&url, barrier).await.unwrap();
+    fixture.stop_server().await;
+
+    assert_eq!(received_events, fixture.all_filtered_events(filter));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_main_events_with_no_query() {
+    should_serve_events_with_no_query(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_signature_events_with_no_query() {
+    should_serve_events_with_no_query(EventFilter::Signatures).await;
+}
+
+/// Client setup:
+///   * `<IP:port>/events/main?start_from=25` or `<IP:port>/events/sigs?start_from=25` depending on
+///     `filter`
+///   * connected just before event ID 50
+///
+/// Expected to receive main or signature events (depending on `filter`) from ID 25 onwards, as
+/// events 25 to 49 should still be in the server buffer.
+async fn should_serve_events_with_query(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let connect_at_event_id = BUFFER_LENGTH;
+    let start_from_event_id = BUFFER_LENGTH / 2;
+
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier = sync_behavior.add_client_sync_before_event(connect_at_event_id);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url = url(server_address, filter, Some(start_from_event_id));
+    let received_events = subscribe(&url, barrier).await.unwrap();
+    fixture.stop_server().await;
+
+    let expected_events = fixture.filtered_events(filter, start_from_event_id);
+    assert_eq!(received_events, expected_events);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_main_events_with_query() {
+    should_serve_events_with_query(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_signature_events_with_query() {
+    should_serve_events_with_query(EventFilter::Signatures).await;
+}
+
+/// Client setup:
+///   * `<IP:port>/events/main?start_from=0` or `<IP:port>/events/sigs?start_from=0` depending on
+///     `filter`
+///   * connected just before event ID 75
+///
+/// Expected to receive main or signature events (depending on `filter`) from ID 25 onwards, as
+/// events 0 to 24 should have been purged from the server buffer.
+async fn should_serve_remaining_events_with_query(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let connect_at_event_id = BUFFER_LENGTH * 3 / 2;
+    let start_from_event_id = 0;
+
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier = sync_behavior.add_client_sync_before_event(connect_at_event_id);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url = url(server_address, filter, Some(start_from_event_id));
+    let received_events = subscribe(&url, barrier).await.unwrap();
+    fixture.stop_server().await;
+
+    let expected_first_event = connect_at_event_id - BUFFER_LENGTH;
+    let expected_events = fixture.filtered_events(filter, expected_first_event);
+    assert_eq!(received_events, expected_events);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_remaining_main_events_with_query() {
+    should_serve_remaining_events_with_query(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_remaining_signature_events_with_query() {
+    should_serve_remaining_events_with_query(EventFilter::Signatures).await;
+}
+
+/// Client setup:
+///   * `<IP:port>/events/main?start_from=25` or `<IP:port>/events/sigs?start_from=25` depending on
+///     `filter`
+///   * connected before first event
+///
+/// Expected to receive all main or signature events (depending on `filter`), as event 25 hasn't
+/// been added to the server buffer yet.
+async fn should_serve_events_with_query_for_future_event(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier = sync_behavior.add_client_sync_before_event(0);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url = url(server_address, filter, Some(25));
+    let received_events = subscribe(&url, barrier).await.unwrap();
+    fixture.stop_server().await;
+
+    assert_eq!(received_events, fixture.all_filtered_events(filter));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_main_events_with_query_for_future_event() {
+    should_serve_events_with_query_for_future_event(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_serve_signature_events_with_query_for_future_event() {
+    should_serve_events_with_query_for_future_event(EventFilter::Signatures).await;
+}
+
+/// Checks that when a server is shut down (e.g. for a node upgrade), connected clients don't have
+/// an error while handling the HTTP response.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_exit_should_gracefully_shut_down_stream() {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    // Start the server, waiting for two clients to connect.
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier1 = sync_behavior.add_client_sync_before_event(0);
+    let barrier2 = sync_behavior.add_client_sync_before_event(0);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url1 = url(server_address, EventFilter::Main, None);
+    let url2 = url(server_address, EventFilter::Signatures, None);
+
+    // Run the two clients, and stop the server after a short delay.
+    let (received_events1, received_events2, _) = join!(
+        subscribe(&url1, barrier1),
+        subscribe(&url2, barrier2),
+        async {
+            time::sleep(DELAY_BETWEEN_EVENTS * EVENT_COUNT / 2).await;
+            fixture.stop_server().await
+        }
+    );
+
+    // Ensure both clients' streams terminated without error.
+    let received_events1 = received_events1.unwrap();
+    let received_events2 = received_events2.unwrap();
+
+    // Ensure both clients received some events...
+    assert!(!received_events1.is_empty());
+    assert!(!received_events2.is_empty());
+
+    // ...but not the full set they would have if the server hadn't stopped early.
+    assert!(received_events1.len() < fixture.all_filtered_events(EventFilter::Main).len());
+    assert!(received_events2.len() < fixture.all_filtered_events(EventFilter::Signatures).len());
+}
+
+/// Checks that clients which don't consume the events in a timely manner are forcibly disconnected
+/// by the server.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lagging_clients_should_be_disconnected() {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    // Start the server, waiting for two clients to connect.  Set the server to have no delay
+    // between sending events, meaning the clients will lag.
+    let mut sync_behavior = ServerSyncBehavior::new().with_no_delay_between_events();
+    let barrier1 = sync_behavior.add_client_sync_before_event(0);
+    let barrier2 = sync_behavior.add_client_sync_before_event(0);
+    let server_address = fixture.run_server(sync_behavior).await;
+
+    let url1 = url(server_address, EventFilter::Main, None);
+    let url2 = url(server_address, EventFilter::Signatures, None);
+
+    // Run the two clients, then stop the server.
+    let (result1, result2) = join!(subscribe(&url1, barrier1), subscribe(&url2, barrier2),);
+    fixture.stop_server().await;
+
+    // Ensure both clients' streams terminated with an `UnexpectedEof` error.
+    let check_error = |result: Result<_, reqwest::Error>| {
+        let kind = result
+            .unwrap_err()
+            .source()
+            .expect("reqwest::Error should have source")
+            .downcast_ref::<hyper::Error>()
+            .expect("reqwest::Error's source should be a hyper::Error")
+            .source()
+            .expect("hyper::Error should have source")
+            .downcast_ref::<io::Error>()
+            .expect("hyper::Error's source should be a std::io::Error")
+            .kind();
+        assert!(matches!(kind, io::ErrorKind::UnexpectedEof));
+    };
+    check_error(result1);
+    check_error(result2);
+}
+
+/// Checks that clients using the correct <IP:Port> but wrong path get a helpful error response.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_handle_bad_url_path() {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let server_address = fixture.run_server(ServerSyncBehavior::new()).await;
+
+    #[rustfmt::skip]
+    let urls = [
+        format!("http://{}", server_address),
+        format!("http://{}?{}=0", server_address, QUERY_FIELD),
+        format!("http://{}/bad", server_address),
+        format!("http://{}/bad?{}=0", server_address, QUERY_FIELD),
+        format!("http://{}/{}", server_address, SSE_API_ROOT_PATH),
+        format!("http://{}/{}?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH),
+        format!("http://{}/{}/bad", server_address, SSE_API_ROOT_PATH),
+        format!("http://{}/{}/bad?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH),
+        format!("http://{}/{}/{}bad", server_address, SSE_API_ROOT_PATH, SSE_API_MAIN_PATH),
+        format!("http://{}/{}/{}bad?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH, SSE_API_MAIN_PATH),
+        format!("http://{}/{}/{}bad", server_address, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH),
+        format!("http://{}/{}/{}bad?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH),
+        format!("http://{}/{}/{}/bad", server_address, SSE_API_ROOT_PATH, SSE_API_MAIN_PATH),
+        format!("http://{}/{}/{}/bad?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH, SSE_API_MAIN_PATH),
+        format!("http://{}/{}/{}/bad", server_address, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH),
+        format!("http://{}/{}/{}/bad?{}=0", server_address, QUERY_FIELD, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH),
+    ];
+
+    let expected_body = format!(
+        "invalid path: expected '{0}/{1}' or '{0}/{2}'",
+        SSE_API_ROOT_PATH, SSE_API_MAIN_PATH, SSE_API_SIGNATURES_PATH
+    );
+    for url in &urls {
+        let response = reqwest::get(url).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "URL: {}", url);
+        assert_eq!(
+            response.text().await.unwrap().trim(),
+            &expected_body,
+            "URL: {}",
+            url
+        );
+    }
+
+    fixture.stop_server().await;
+}
+
+/// Checks that clients using the correct <IP:Port/path> but wrong query get a helpful error
+/// response.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_handle_bad_url_query() {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    let server_address = fixture.run_server(ServerSyncBehavior::new()).await;
+
+    let main_url = format!(
+        "http://{}/{}/{}",
+        server_address, SSE_API_ROOT_PATH, SSE_API_MAIN_PATH
+    );
+    let sigs_url = format!(
+        "http://{}/{}/{}",
+        server_address, SSE_API_ROOT_PATH, SSE_API_SIGNATURES_PATH
+    );
+    let urls = [
+        format!("{}?not-a-kv-pair", main_url),
+        format!("{}?not-a-kv-pair", sigs_url),
+        format!("{}?start_fro=0", main_url),
+        format!("{}?start_fro=0", sigs_url),
+        format!("{}?{}=not-integer", main_url, QUERY_FIELD),
+        format!("{}?{}=not-integer", sigs_url, QUERY_FIELD),
+        format!("{}?{}='0'", main_url, QUERY_FIELD),
+        format!("{}?{}='0'", sigs_url, QUERY_FIELD),
+        format!("{}?{}=0&extra=1", main_url, QUERY_FIELD),
+        format!("{}?{}=0&extra=1", sigs_url, QUERY_FIELD),
+    ];
+
+    let expected_body = format!(
+        "invalid query: expected single field '{}=<EVENT ID>'",
+        QUERY_FIELD
+    );
+    for url in &urls {
+        let response = reqwest::get(url).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "URL: {}",
+            url
+        );
+        assert_eq!(
+            response.text().await.unwrap().trim(),
+            &expected_body,
+            "URL: {}",
+            url
+        );
+    }
+
+    fixture.stop_server().await;
+}
+
+/// Check that a server which restarts continues from the previous numbering of event IDs.
+async fn should_persist_event_ids(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    {
+        // Run the first server to emit the 100 events.
+        let mut sync_behavior = ServerSyncBehavior::new();
+        let barrier = sync_behavior.add_client_sync_before_event(0);
+        let server_address = fixture.run_server(sync_behavior).await;
+
+        // Consume these and stop the server.
+        let url = url(server_address, filter, None);
+        let _ = subscribe(&url, barrier).await.unwrap();
+        fixture.stop_server().await;
+    }
+
+    {
+        // Start a new server with a client barrier set for just before event ID 100.
+        let mut sync_behavior = ServerSyncBehavior::new();
+        let barrier = sync_behavior.add_client_sync_before_event(EVENT_COUNT);
+        let server_address = fixture.run_server(sync_behavior).await;
+
+        // Check the test fixture has set the server's first event ID to 100.
+        assert_eq!(fixture.first_event_id, EVENT_COUNT);
+
+        // Consume the events and assert their IDs are all >= 100.
+        let url = url(server_address, filter, None);
+        let received_events = subscribe(&url, barrier).await.unwrap();
+        fixture.stop_server().await;
+
+        assert_eq!(received_events, fixture.all_filtered_events(filter));
+        assert!(received_events
+            .iter()
+            .skip(1)
+            .all(|event| event.id.unwrap() >= EVENT_COUNT));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_persist_main_event_ids() {
+    should_persist_event_ids(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_persist_signature_event_ids() {
+    should_persist_event_ids(EventFilter::Signatures).await;
+}
+
+/// Check that a server handles wrapping round past the maximum value for event IDs.
+async fn should_handle_wrapping_past_max_event_id(filter: EventFilter) {
+    let mut rng = crate::new_rng();
+    let mut fixture = TestFixture::new(&mut rng);
+
+    // Set up an `EventIndexer` cache file as if the server previously stopped at an event with ID
+    // just less than the maximum.
+    let start_index = Id::MAX - (BUFFER_LENGTH / 2);
+    fs::write(
+        fixture.storage_dir.path().join("sse_index"),
+        start_index.to_le_bytes(),
+    )
+    .unwrap();
+
+    // Set up a client which will connect at the start of the stream, and another two for once the
+    // IDs have wrapped past the maximum value.
+    let mut sync_behavior = ServerSyncBehavior::new();
+    let barrier1 = sync_behavior.add_client_sync_before_event(start_index);
+    let barrier2 = sync_behavior.add_client_sync_before_event(BUFFER_LENGTH / 2);
+    let barrier3 = sync_behavior.add_client_sync_before_event(BUFFER_LENGTH / 2);
+    let server_address = fixture.run_server(sync_behavior).await;
+    assert_eq!(fixture.first_event_id, start_index);
+
+    // The first client doesn't need a query string, but the second will request to start from an ID
+    // from before they wrapped past the maximum value, and the third from event 0.
+    let url1 = url(server_address, filter, None);
+    let url2 = url(server_address, filter, Some(start_index + 1));
+    let url3 = url(server_address, filter, Some(0));
+    let (received_events1, received_events2, received_events3) = join!(
+        subscribe(&url1, barrier1),
+        subscribe(&url2, barrier2),
+        subscribe(&url3, barrier3),
+    );
+    fixture.stop_server().await;
+
+    assert_eq!(
+        received_events1.unwrap(),
+        fixture.all_filtered_events(filter)
+    );
+    assert_eq!(
+        received_events2.unwrap(),
+        fixture.filtered_events(filter, start_index + 1)
+    );
+    assert_eq!(
+        received_events3.unwrap(),
+        fixture.filtered_events(filter, 0)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_handle_wrapping_past_max_event_id_for_main() {
+    should_handle_wrapping_past_max_event_id(EventFilter::Main).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_handle_wrapping_past_max_event_id_for_signatures() {
+    should_handle_wrapping_past_max_event_id(EventFilter::Signatures).await;
+}
+
+/// Rather than being a test proper, this is more a means to easily determine differences between
+/// versions of the events emitted by the SSE server by comparing the contents of
+/// `resources/test/sse_data_schema.json` across different versions of the codebase.
+#[test]
+fn schema() {
+    let schema_path = format!(
+        "{}/../resources/test/sse_data_schema.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let expected_schema = fs::read_to_string(schema_path).unwrap();
+    let schema = schema_for!(SseData);
+    assert_eq!(
+        serde_json::to_string_pretty(&schema).unwrap(),
+        expected_schema.trim()
+    );
+}

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1581,7 +1581,7 @@ pub(crate) mod json_compatibility {
 /// A validator's signature of a block, to confirm it is finalized. Clients and joining nodes should
 /// wait until the signers' combined weight exceeds their fault tolerance threshold before accepting
 /// the block as finalized.
-#[derive(Debug, Clone, Serialize, Deserialize, DataSize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, DataSize, PartialEq, Eq, JsonSchema)]
 pub struct FinalitySignature {
     /// Hash of a block this signature is for.
     pub block_hash: BlockHash,

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1,0 +1,1502 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SseData",
+  "description": "The \"data\" field of the events sent on the event stream to clients.",
+  "anyOf": [
+    {
+      "description": "The version of this node's API server.  This event will always be the first sent to a new client, and will have no associated event ID provided.",
+      "type": "object",
+      "required": [
+        "ApiVersion"
+      ],
+      "properties": {
+        "ApiVersion": {
+          "$ref": "#/definitions/ProtocolVersion"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "The given block has been added to the linear chain and stored locally.",
+      "type": "object",
+      "required": [
+        "BlockAdded"
+      ],
+      "properties": {
+        "BlockAdded": {
+          "type": "object",
+          "required": [
+            "block",
+            "block_hash"
+          ],
+          "properties": {
+            "block_hash": {
+              "$ref": "#/definitions/BlockHash"
+            },
+            "block": {
+              "$ref": "#/definitions/JsonBlock"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "The given deploy has been executed, committed and forms part of the given block.",
+      "type": "object",
+      "required": [
+        "DeployProcessed"
+      ],
+      "properties": {
+        "DeployProcessed": {
+          "type": "object",
+          "required": [
+            "account",
+            "block_hash",
+            "dependencies",
+            "deploy_hash",
+            "execution_result",
+            "timestamp",
+            "ttl"
+          ],
+          "properties": {
+            "deploy_hash": {
+              "$ref": "#/definitions/DeployHash"
+            },
+            "account": {
+              "$ref": "#/definitions/PublicKey"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/Timestamp"
+            },
+            "ttl": {
+              "$ref": "#/definitions/TimeDiff"
+            },
+            "dependencies": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DeployHash"
+              }
+            },
+            "block_hash": {
+              "$ref": "#/definitions/BlockHash"
+            },
+            "execution_result": {
+              "$ref": "#/definitions/ExecutionResult"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Generic representation of validator's fault in an era.",
+      "type": "object",
+      "required": [
+        "Fault"
+      ],
+      "properties": {
+        "Fault": {
+          "type": "object",
+          "required": [
+            "era_id",
+            "public_key",
+            "timestamp"
+          ],
+          "properties": {
+            "era_id": {
+              "$ref": "#/definitions/EraId"
+            },
+            "public_key": {
+              "$ref": "#/definitions/PublicKey"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "New finality signature received.",
+      "type": "object",
+      "required": [
+        "FinalitySignature"
+      ],
+      "properties": {
+        "FinalitySignature": {
+          "$ref": "#/definitions/FinalitySignature"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Step"
+      ],
+      "properties": {
+        "Step": {
+          "type": "object",
+          "required": [
+            "era_id",
+            "execution_effect"
+          ],
+          "properties": {
+            "era_id": {
+              "$ref": "#/definitions/EraId"
+            },
+            "execution_effect": {
+              "$ref": "#/definitions/ExecutionEffect"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ProtocolVersion": {
+      "description": "Casper Platform protocol version",
+      "type": "string"
+    },
+    "BlockHash": {
+      "description": "A cryptographic hash identifying a [`Block`](struct.Block.html).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
+    },
+    "Digest": {
+      "description": "Hex-encoded hash digest.",
+      "type": "string"
+    },
+    "JsonBlock": {
+      "description": "A JSON-friendly representation of `Block`.",
+      "type": "object",
+      "required": [
+        "body",
+        "hash",
+        "header",
+        "proofs"
+      ],
+      "properties": {
+        "hash": {
+          "$ref": "#/definitions/BlockHash"
+        },
+        "header": {
+          "$ref": "#/definitions/JsonBlockHeader"
+        },
+        "body": {
+          "$ref": "#/definitions/JsonBlockBody"
+        },
+        "proofs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JsonProof"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonBlockHeader": {
+      "type": "object",
+      "required": [
+        "accumulated_seed",
+        "body_hash",
+        "era_id",
+        "height",
+        "parent_hash",
+        "protocol_version",
+        "random_bit",
+        "state_root_hash",
+        "timestamp"
+      ],
+      "properties": {
+        "parent_hash": {
+          "$ref": "#/definitions/BlockHash"
+        },
+        "state_root_hash": {
+          "$ref": "#/definitions/Digest"
+        },
+        "body_hash": {
+          "$ref": "#/definitions/Digest"
+        },
+        "random_bit": {
+          "type": "boolean"
+        },
+        "accumulated_seed": {
+          "$ref": "#/definitions/Digest"
+        },
+        "era_end": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsonEraEnd"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timestamp": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "era_id": {
+          "$ref": "#/definitions/EraId"
+        },
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "protocol_version": {
+          "$ref": "#/definitions/ProtocolVersion"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonEraEnd": {
+      "type": "object",
+      "required": [
+        "era_report",
+        "next_era_validator_weights"
+      ],
+      "properties": {
+        "era_report": {
+          "$ref": "#/definitions/JsonEraReport"
+        },
+        "next_era_validator_weights": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValidatorWeight"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonEraReport": {
+      "description": "Equivocation and reward information to be included in the terminal block.",
+      "type": "object",
+      "required": [
+        "equivocators",
+        "inactive_validators",
+        "rewards"
+      ],
+      "properties": {
+        "equivocators": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicKey"
+          }
+        },
+        "rewards": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reward"
+          }
+        },
+        "inactive_validators": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicKey"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "PublicKey": {
+      "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+      "type": "string"
+    },
+    "Reward": {
+      "type": "object",
+      "required": [
+        "amount",
+        "validator"
+      ],
+      "properties": {
+        "validator": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidatorWeight": {
+      "type": "object",
+      "required": [
+        "validator",
+        "weight"
+      ],
+      "properties": {
+        "validator": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "weight": {
+          "$ref": "#/definitions/U512"
+        }
+      },
+      "additionalProperties": false
+    },
+    "U512": {
+      "description": "Decimal representation of a 512-bit integer.",
+      "type": "string"
+    },
+    "Timestamp": {
+      "description": "Timestamp formatted as per RFC 3339",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "EraId": {
+      "description": "Era ID newtype.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "JsonBlockBody": {
+      "description": "A JSON-friendly representation of `Body`",
+      "type": "object",
+      "required": [
+        "deploy_hashes",
+        "proposer",
+        "transfer_hashes"
+      ],
+      "properties": {
+        "proposer": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "deploy_hashes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeployHash"
+          }
+        },
+        "transfer_hashes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeployHash"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DeployHash": {
+      "description": "Hex-encoded deploy hash.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
+    },
+    "JsonProof": {
+      "description": "A JSON-friendly representation of a proof, i.e. a block's finality signature.",
+      "type": "object",
+      "required": [
+        "public_key",
+        "signature"
+      ],
+      "properties": {
+        "public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "signature": {
+          "$ref": "#/definitions/Signature"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Signature": {
+      "description": "Hex-encoded cryptographic signature, including the algorithm tag prefix.",
+      "type": "string"
+    },
+    "TimeDiff": {
+      "description": "Human-readable duration.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "ExecutionResult": {
+      "description": "The result of executing a single deploy.",
+      "anyOf": [
+        {
+          "description": "The result of a failed execution.",
+          "type": "object",
+          "required": [
+            "Failure"
+          ],
+          "properties": {
+            "Failure": {
+              "type": "object",
+              "required": [
+                "cost",
+                "effect",
+                "error_message",
+                "transfers"
+              ],
+              "properties": {
+                "effect": {
+                  "description": "The effect of executing the deploy.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/ExecutionEffect"
+                    }
+                  ]
+                },
+                "transfers": {
+                  "description": "A record of Transfers performed while executing the deploy.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/TransferAddr"
+                  }
+                },
+                "cost": {
+                  "description": "The cost of executing the deploy.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/U512"
+                    }
+                  ]
+                },
+                "error_message": {
+                  "description": "The error message associated with executing the deploy.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "The result of a successful execution.",
+          "type": "object",
+          "required": [
+            "Success"
+          ],
+          "properties": {
+            "Success": {
+              "type": "object",
+              "required": [
+                "cost",
+                "effect",
+                "transfers"
+              ],
+              "properties": {
+                "effect": {
+                  "description": "The effect of executing the deploy.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/ExecutionEffect"
+                    }
+                  ]
+                },
+                "transfers": {
+                  "description": "A record of Transfers performed while executing the deploy.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/TransferAddr"
+                  }
+                },
+                "cost": {
+                  "description": "The cost of executing the deploy.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/U512"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ExecutionEffect": {
+      "description": "The effect of executing a single deploy.",
+      "type": "object",
+      "required": [
+        "operations",
+        "transforms"
+      ],
+      "properties": {
+        "operations": {
+          "description": "The resulting operations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "transforms": {
+          "description": "The resulting transformations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TransformEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "description": "An operation performed while executing a deploy.",
+      "type": "object",
+      "required": [
+        "key",
+        "kind"
+      ],
+      "properties": {
+        "key": {
+          "description": "The formatted string of the `Key`.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The type of operation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OpKind"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpKind": {
+      "description": "The type of operation performed while executing a deploy.",
+      "type": "string",
+      "enum": [
+        "Read",
+        "Write",
+        "Add",
+        "NoOp"
+      ]
+    },
+    "TransformEntry": {
+      "description": "A transformation performed while executing a deploy.",
+      "type": "object",
+      "required": [
+        "key",
+        "transform"
+      ],
+      "properties": {
+        "key": {
+          "description": "The formatted string of the `Key`.",
+          "type": "string"
+        },
+        "transform": {
+          "description": "The transformation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Transform"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Transform": {
+      "description": "The actual transformation performed while executing a deploy.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Identity",
+            "WriteContractWasm",
+            "WriteContract",
+            "WriteContractPackage"
+          ]
+        },
+        {
+          "description": "Writes the given CLValue to global state.",
+          "type": "object",
+          "required": [
+            "WriteCLValue"
+          ],
+          "properties": {
+            "WriteCLValue": {
+              "$ref": "#/definitions/CLValue"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given Account to global state.",
+          "type": "object",
+          "required": [
+            "WriteAccount"
+          ],
+          "properties": {
+            "WriteAccount": {
+              "$ref": "#/definitions/AccountHash"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given DeployInfo to global state.",
+          "type": "object",
+          "required": [
+            "WriteDeployInfo"
+          ],
+          "properties": {
+            "WriteDeployInfo": {
+              "$ref": "#/definitions/DeployInfo"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given EraInfo to global state.",
+          "type": "object",
+          "required": [
+            "WriteEraInfo"
+          ],
+          "properties": {
+            "WriteEraInfo": {
+              "$ref": "#/definitions/EraInfo"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given Transfer to global state.",
+          "type": "object",
+          "required": [
+            "WriteTransfer"
+          ],
+          "properties": {
+            "WriteTransfer": {
+              "$ref": "#/definitions/Transfer"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given Bid to global state.",
+          "type": "object",
+          "required": [
+            "WriteBid"
+          ],
+          "properties": {
+            "WriteBid": {
+              "$ref": "#/definitions/Bid"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given Withdraw to global state.",
+          "type": "object",
+          "required": [
+            "WriteWithdraw"
+          ],
+          "properties": {
+            "WriteWithdraw": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnbondingPurse"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given `i32`.",
+          "type": "object",
+          "required": [
+            "AddInt32"
+          ],
+          "properties": {
+            "AddInt32": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given `u64`.",
+          "type": "object",
+          "required": [
+            "AddUInt64"
+          ],
+          "properties": {
+            "AddUInt64": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given `U128`.",
+          "type": "object",
+          "required": [
+            "AddUInt128"
+          ],
+          "properties": {
+            "AddUInt128": {
+              "$ref": "#/definitions/U128"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given `U256`.",
+          "type": "object",
+          "required": [
+            "AddUInt256"
+          ],
+          "properties": {
+            "AddUInt256": {
+              "$ref": "#/definitions/U256"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given `U512`.",
+          "type": "object",
+          "required": [
+            "AddUInt512"
+          ],
+          "properties": {
+            "AddUInt512": {
+              "$ref": "#/definitions/U512"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Adds the given collection of named keys.",
+          "type": "object",
+          "required": [
+            "AddKeys"
+          ],
+          "properties": {
+            "AddKeys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/NamedKey"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A failed transformation, containing an error message.",
+          "type": "object",
+          "required": [
+            "Failure"
+          ],
+          "properties": {
+            "Failure": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CLValue": {
+      "description": "A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
+      "type": "object",
+      "required": [
+        "bytes",
+        "cl_type"
+      ],
+      "properties": {
+        "cl_type": {
+          "$ref": "#/definitions/CLType"
+        },
+        "bytes": {
+          "type": "string"
+        },
+        "parsed": true
+      },
+      "additionalProperties": false
+    },
+    "CLType": {
+      "description": "Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue).",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Bool",
+            "I32",
+            "I64",
+            "U8",
+            "U32",
+            "U64",
+            "U128",
+            "U256",
+            "U512",
+            "Unit",
+            "String",
+            "Key",
+            "URef",
+            "PublicKey",
+            "Any"
+          ]
+        },
+        {
+          "description": "`Option` of a `CLType`.",
+          "type": "object",
+          "required": [
+            "Option"
+          ],
+          "properties": {
+            "Option": {
+              "$ref": "#/definitions/CLType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Variable-length list of a single `CLType` (comparable to a `Vec`).",
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "$ref": "#/definitions/CLType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Fixed-length list of a single `CLType` (comparable to a Rust array).",
+          "type": "object",
+          "required": [
+            "ByteArray"
+          ],
+          "properties": {
+            "ByteArray": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "`Result` with `Ok` and `Err` variants of `CLType`s.",
+          "type": "object",
+          "required": [
+            "Result"
+          ],
+          "properties": {
+            "Result": {
+              "type": "object",
+              "required": [
+                "err",
+                "ok"
+              ],
+              "properties": {
+                "ok": {
+                  "$ref": "#/definitions/CLType"
+                },
+                "err": {
+                  "$ref": "#/definitions/CLType"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Map with keys of a single `CLType` and values of a single `CLType`.",
+          "type": "object",
+          "required": [
+            "Map"
+          ],
+          "properties": {
+            "Map": {
+              "type": "object",
+              "required": [
+                "key",
+                "value"
+              ],
+              "properties": {
+                "key": {
+                  "$ref": "#/definitions/CLType"
+                },
+                "value": {
+                  "$ref": "#/definitions/CLType"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "1-ary tuple of a `CLType`.",
+          "type": "object",
+          "required": [
+            "Tuple1"
+          ],
+          "properties": {
+            "Tuple1": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CLType"
+              },
+              "maxItems": 1,
+              "minItems": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "2-ary tuple of `CLType`s.",
+          "type": "object",
+          "required": [
+            "Tuple2"
+          ],
+          "properties": {
+            "Tuple2": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CLType"
+              },
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "3-ary tuple of `CLType`s.",
+          "type": "object",
+          "required": [
+            "Tuple3"
+          ],
+          "properties": {
+            "Tuple3": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CLType"
+              },
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AccountHash": {
+      "description": "Hex-encoded account hash.",
+      "type": "string"
+    },
+    "DeployInfo": {
+      "description": "Information relating to the given Deploy.",
+      "type": "object",
+      "required": [
+        "deploy_hash",
+        "from",
+        "gas",
+        "source",
+        "transfers"
+      ],
+      "properties": {
+        "deploy_hash": {
+          "description": "The relevant Deploy.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeployHash"
+            }
+          ]
+        },
+        "transfers": {
+          "description": "Transfers performed by the Deploy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TransferAddr"
+          }
+        },
+        "from": {
+          "description": "Account identifier of the creator of the Deploy.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AccountHash"
+            }
+          ]
+        },
+        "source": {
+          "description": "Source purse used for payment of the Deploy.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "gas": {
+          "description": "Gas cost of executing the Deploy.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TransferAddr": {
+      "description": "Hex-encoded transfer address.",
+      "type": "string"
+    },
+    "URef": {
+      "description": "Hex-encoded, formatted URef.",
+      "type": "string"
+    },
+    "EraInfo": {
+      "description": "Auction metadata.  Intended to be recorded at each era.",
+      "type": "object",
+      "required": [
+        "seigniorage_allocations"
+      ],
+      "properties": {
+        "seigniorage_allocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SeigniorageAllocation"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SeigniorageAllocation": {
+      "description": "Information about a seigniorage allocation",
+      "anyOf": [
+        {
+          "description": "Info about a seigniorage allocation for a validator",
+          "type": "object",
+          "required": [
+            "Validator"
+          ],
+          "properties": {
+            "Validator": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator_public_key"
+              ],
+              "properties": {
+                "validator_public_key": {
+                  "description": "Validator's public key",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PublicKey"
+                    }
+                  ]
+                },
+                "amount": {
+                  "description": "Allocated amount",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/U512"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Info about a seigniorage allocation for a delegator",
+          "type": "object",
+          "required": [
+            "Delegator"
+          ],
+          "properties": {
+            "Delegator": {
+              "type": "object",
+              "required": [
+                "amount",
+                "delegator_public_key",
+                "validator_public_key"
+              ],
+              "properties": {
+                "delegator_public_key": {
+                  "description": "Delegator's public key",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PublicKey"
+                    }
+                  ]
+                },
+                "validator_public_key": {
+                  "description": "Validator's public key",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PublicKey"
+                    }
+                  ]
+                },
+                "amount": {
+                  "description": "Allocated amount",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/U512"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Transfer": {
+      "description": "Represents a transfer from one purse to another",
+      "type": "object",
+      "required": [
+        "amount",
+        "deploy_hash",
+        "from",
+        "gas",
+        "source",
+        "target"
+      ],
+      "properties": {
+        "deploy_hash": {
+          "description": "Deploy that created the transfer",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeployHash"
+            }
+          ]
+        },
+        "from": {
+          "description": "Account from which transfer was executed",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AccountHash"
+            }
+          ]
+        },
+        "to": {
+          "description": "Account to which funds are transferred",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AccountHash"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source": {
+          "description": "Source purse",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "target": {
+          "description": "Target purse",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "amount": {
+          "description": "Transfer amount",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        },
+        "gas": {
+          "description": "Gas",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        },
+        "id": {
+          "description": "User-defined id",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Bid": {
+      "description": "An entry in the validator map.",
+      "type": "object",
+      "required": [
+        "bonding_purse",
+        "delegation_rate",
+        "delegators",
+        "inactive",
+        "staked_amount",
+        "validator_public_key"
+      ],
+      "properties": {
+        "validator_public_key": {
+          "description": "Validator public key",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        },
+        "bonding_purse": {
+          "description": "The purse that was used for bonding.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "staked_amount": {
+          "description": "The amount of tokens staked by a validator (not including delegators).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        },
+        "delegation_rate": {
+          "description": "Delegation rate",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "vesting_schedule": {
+          "description": "Vesting schedule for a genesis validator. `None` if non-genesis validator.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VestingSchedule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "delegators": {
+          "description": "This validator's delegators, indexed by their public keys",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Delegator"
+          }
+        },
+        "inactive": {
+          "description": "`true` if validator has been \"evicted\"",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "VestingSchedule": {
+      "type": "object",
+      "required": [
+        "initial_release_timestamp_millis"
+      ],
+      "properties": {
+        "initial_release_timestamp_millis": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "locked_amounts": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/U512"
+          },
+          "maxItems": 14,
+          "minItems": 14
+        }
+      },
+      "additionalProperties": false
+    },
+    "Delegator": {
+      "description": "Represents a party delegating their stake to a validator (or \"delegatee\")",
+      "type": "object",
+      "required": [
+        "bonding_purse",
+        "delegator_public_key",
+        "staked_amount",
+        "validator_public_key"
+      ],
+      "properties": {
+        "delegator_public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "staked_amount": {
+          "$ref": "#/definitions/U512"
+        },
+        "bonding_purse": {
+          "$ref": "#/definitions/URef"
+        },
+        "validator_public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "vesting_schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VestingSchedule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "UnbondingPurse": {
+      "description": "Unbonding purse.",
+      "type": "object",
+      "required": [
+        "amount",
+        "bonding_purse",
+        "era_of_creation",
+        "unbonder_public_key",
+        "validator_public_key"
+      ],
+      "properties": {
+        "bonding_purse": {
+          "description": "Bonding Purse",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "validator_public_key": {
+          "description": "Validators public key.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        },
+        "unbonder_public_key": {
+          "description": "Unbonders public key.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        },
+        "era_of_creation": {
+          "description": "Era in which this unbonding request was created.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EraId"
+            }
+          ]
+        },
+        "amount": {
+          "description": "Unbonding Amount.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "U128": {
+      "description": "Decimal representation of a 128-bit integer.",
+      "type": "string"
+    },
+    "U256": {
+      "description": "Decimal representation of a 256-bit integer.",
+      "type": "string"
+    },
+    "NamedKey": {
+      "description": "A named key.",
+      "type": "object",
+      "required": [
+        "key",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name of the entry.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The value of the entry: a casper `Key` type.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FinalitySignature": {
+      "description": "A validator's signature of a block, to confirm it is finalized. Clients and joining nodes should wait until the signers' combined weight exceeds their fault tolerance threshold before accepting the block as finalized.",
+      "type": "object",
+      "required": [
+        "block_hash",
+        "era_id",
+        "public_key",
+        "signature"
+      ],
+      "properties": {
+        "block_hash": {
+          "description": "Hash of a block this signature is for.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BlockHash"
+            }
+          ]
+        },
+        "era_id": {
+          "description": "Era in which the block was created in.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EraId"
+            }
+          ]
+        },
+        "signature": {
+          "description": "Signature over the block hash.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Signature"
+            }
+          ]
+        },
+        "public_key": {
+          "description": "Public key of the signing validator.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a comprehensive test suite for the SSE server.  In doing so, it revealed two issues in the server, both of which are fixed in this PR:
* The server did not handle malformed queries well.  In some cases it ignored them and in others it treated them as a bad path
* The server did not handle the `start_from` query properly in the case where the buffered events' IDs wrapped past `u32::MAX` back to `0`

The PR also introduces a test which checks the generated JSON schema for the `SseData` enum against a previously-generated, hard-coded schema (added to "resources/test").  Rather than being particularly useful as a unit test, it will instead make it somewhat simple to view differences between discrete versions of the data produced by the SSE server.

Closes #1525.