### PR TITLE
Add EffectBuilder::get_consensus_validator_info.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -13,6 +13,7 @@ mod protocols;
 #[cfg(test)]
 mod tests;
 mod traits;
+mod validator_change;
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -53,6 +54,7 @@ pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;
 use traits::NodeIdT;
+pub(crate) use validator_change::ValidatorChange;
 
 #[cfg(test)]
 pub(crate) use era_supervisor::oldest_bonded_era;
@@ -339,6 +341,9 @@ where
             }
             Event::ConsensusRequest(ConsensusRequest::Status(responder)) => {
                 handling_es.status(responder)
+            }
+            Event::ConsensusRequest(ConsensusRequest::ValidatorInfo(responder)) => {
+                responder.respond(self.get_validator_info()).ignore()
             }
         }
     }

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -61,6 +61,8 @@ pub struct Era<I> {
     /// Validators that have been slashed in any of the recent BONDED_ERAS switch blocks. This
     /// includes `newly_slashed`.
     pub(crate) slashed: HashSet<PublicKey>,
+    /// Validators that are excluded from proposing new blocks.
+    pub(crate) cannot_propose: HashSet<PublicKey>,
     /// Accusations collected in this era so far.
     accusations: HashSet<PublicKey>,
     /// The validator weights.
@@ -74,6 +76,7 @@ impl<I> Era<I> {
         start_height: u64,
         newly_slashed: Vec<PublicKey>,
         slashed: HashSet<PublicKey>,
+        cannot_propose: HashSet<PublicKey>,
         validators: BTreeMap<PublicKey, U512>,
     ) -> Self {
         Era {
@@ -83,6 +86,7 @@ impl<I> Era<I> {
             validation_states: HashMap::new(),
             newly_slashed,
             slashed,
+            cannot_propose,
             accusations: HashSet::new(),
             validators,
         }
@@ -181,6 +185,7 @@ where
             validation_states,
             newly_slashed,
             slashed,
+            cannot_propose,
             accusations,
             validators,
         } = self;
@@ -217,6 +222,7 @@ where
             .saturating_add(validation_states.estimate_heap_size())
             .saturating_add(newly_slashed.estimate_heap_size())
             .saturating_add(slashed.estimate_heap_size())
+            .saturating_add(cannot_propose.estimate_heap_size())
             .saturating_add(accusations.estimate_heap_size())
             .saturating_add(validators.estimate_heap_size())
     }

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -1,0 +1,46 @@
+use casper_types::PublicKey;
+
+use super::era_supervisor::Era;
+
+/// A change to a validator's status between two eras.
+pub enum ValidatorChange {
+    /// The validator got newly added to the validator set.
+    Added,
+    /// The validator was removed from the validator set.
+    Removed,
+    /// The validator was banned from this era.
+    Banned,
+    /// The validator was excluded from proposing new blocks in this era.
+    CannotPropose,
+    /// We saw the validator misbehave in this era.
+    SeenAsFaulty,
+}
+
+impl ValidatorChange {
+    pub(super) fn era_changes<I>(
+        era0: &Era<I>,
+        era1: &Era<I>,
+    ) -> Vec<(PublicKey, ValidatorChange)> {
+        let mut changes = Vec::new();
+        for pub_key in era0.validators().keys() {
+            if !era1.validators().contains_key(pub_key) {
+                changes.push((pub_key.clone(), ValidatorChange::Removed));
+            }
+        }
+        for pub_key in era1.consensus.validators_with_evidence() {
+            changes.push((pub_key.clone(), ValidatorChange::SeenAsFaulty));
+        }
+        for pub_key in era1.validators().keys() {
+            if !era0.validators().contains_key(pub_key) {
+                changes.push((pub_key.clone(), ValidatorChange::Added));
+            }
+            if era1.slashed.contains(pub_key) && !era0.slashed.contains(pub_key) {
+                changes.push((pub_key.clone(), ValidatorChange::Banned));
+            }
+            if era1.cannot_propose.contains(pub_key) && !era0.cannot_propose.contains(pub_key) {
+                changes.push((pub_key.clone(), ValidatorChange::CannotPropose));
+            }
+        }
+        changes
+    }
+}

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -104,7 +104,7 @@ use crate::{
     components::{
         block_validator::ValidatingBlock,
         chainspec_loader::{CurrentRunInfo, NextUpgrade},
-        consensus::{BlockContext, ClContext},
+        consensus::{BlockContext, ClContext, ValidatorChange},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor,
         fetcher::FetchResult,
@@ -1715,6 +1715,18 @@ impl<REv> EffectBuilder<REv> {
         REv: From<ConsensusRequest>,
     {
         self.make_request(ConsensusRequest::Status, QueueKind::Regular)
+            .await
+    }
+
+    /// Returns a list of validator status changes, by public key.
+    // TODO: Expose this via RPC.
+    pub(crate) async fn _get_consensus_validator_info(
+        self,
+    ) -> BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>
+    where
+        REv: From<ConsensusRequest>,
+    {
+        self.make_request(ConsensusRequest::ValidatorInfo, QueueKind::Regular)
             .await
     }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -39,7 +39,7 @@ use crate::{
     components::{
         block_validator::ValidatingBlock,
         chainspec_loader::CurrentRunInfo,
-        consensus::{BlockContext, ClContext},
+        consensus::{BlockContext, ClContext, ValidatorChange},
         contract_runtime::{EraValidatorsRequest, ValidatorWeightsByEraIdRequest},
         deploy_acceptor::Error,
         fetcher::FetchResult,
@@ -976,6 +976,8 @@ impl<I: Display> Display for LinearChainRequest<I> {
 pub enum ConsensusRequest {
     /// Request for our public key, and if we're a validator, the next round length.
     Status(Responder<Option<(PublicKey, Option<TimeDiff>)>>),
+    /// Request for a list of validator status changes, by public key.
+    ValidatorInfo(Responder<BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>>),
 }
 
 /// ChainspecLoader component requests.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -886,6 +886,10 @@ impl reactor::Reactor for Reactor {
                 // no consensus, respond with None
                 responder.respond(None).ignore()
             }
+            Event::ConsensusRequest(ConsensusRequest::ValidatorInfo(responder)) => {
+                // no consensus, respond with empty map
+                responder.respond(Default::default()).ignore()
+            }
         }
     }
 


### PR DESCRIPTION
This returns a list of changes to validators' states, i.e. whether they were added, removed, banned, etc.

Merging to a feature branch since it still requires work on the RPC side.

Closes #1526.