### PR TITLE
Flexible protocol serialization scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "casper-types",
  "chrono",
  "datasize",
+ "derivative",
  "derive_more",
  "derp",
  "ed25519-dalek",
@@ -1497,6 +1498,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
 dependencies = [
  "const-oid",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,6 +26,7 @@ casper-node-macros = { version = "1.0.0", path = "../node_macros" }
 casper-types = { version = "1.0.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
+derivative = "2.2.0"
 derive_more = "0.99.7"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false, features = ["rand", "serde", "u64_backend"] }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -521,8 +521,10 @@ where
             ConnectionError::TlsInitialization(_)
             | ConnectionError::TcpConnection(_)
             | ConnectionError::TlsHandshake(_)
+            | ConnectionError::HandshakeSerialization(_)
             | ConnectionError::HandshakeSend(_)
-            | ConnectionError::HandshakeRecv(_) => false,
+            | ConnectionError::HandshakeRecv(_)
+            | ConnectionError::HandshakeDeserialization(_) => false,
 
             // These could be candidates for blocking, but for now we decided not to.
             ConnectionError::NoPeerCertificate

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1113,6 +1113,7 @@ pub type BoxedTransportStream<P> = Box<
 
 impl WireProtocol {
     /// Constructs a wire protocol based on the protocol version.
+    #[allow(clippy::match_single_binding)]
     pub fn from_protocol_versions<P>(
         our_version: ProtocolVersion,
         their_version: ProtocolVersion,

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -47,7 +47,7 @@ pub(crate) trait BandwidthLimiterHandle: Send + Sync {
 
 /// An unlimited bandwidth "limiter".
 ///
-/// Does not restrict outgoing bandwidth in any way (`create_handle` returns immediately).
+/// Does not restrict outgoing bandwidth in any way (`request_allowance` returns immediately).
 #[derive(Debug)]
 pub(super) struct Unlimited;
 

--- a/node/src/components/small_network/bandwidth_limiter.rs
+++ b/node/src/components/small_network/bandwidth_limiter.rs
@@ -402,7 +402,7 @@ mod tests {
         for handle in handles {
             let start = Instant::now();
 
-            // Send 9_0001 bytes, we expect this to take roughly 15 seconds.
+            // Send 9_001 bytes, we expect this to take roughly 15 seconds.
             handle.request_allowance(1000).await;
             handle.request_allowance(1000).await;
             handle.request_allowance(1000).await;

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -160,6 +160,13 @@ pub enum ConnectionError {
     /// TLS validation error.
     #[error("TLS validation error of peer certificate")]
     PeerCertificateInvalid(#[source] ValidationError),
+    /// Failed to serialize handshake.
+    #[error("handshake serialization failed")]
+    HandshakeSerialization(
+        #[serde(skip_serializing)]
+        #[source]
+        rmp_serde::encode::Error,
+    ),
     /// Failed to send handshake.
     #[error("handshake send failed")]
     HandshakeSend(
@@ -173,6 +180,13 @@ pub enum ConnectionError {
         #[serde(skip_serializing)]
         #[source]
         IoError<io::Error>,
+    ),
+    /// Failed to deserialize handshake.
+    #[error("handshake deserialization failed")]
+    HandshakeDeserialization(
+        #[serde(skip_serializing)]
+        #[source]
+        rmp_serde::decode::Error,
     ),
     /// Peer reported a network name that does not match ours.
     #[error("peer is on different network: {0}")]

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -46,6 +46,7 @@ impl<P: Payload> Message<P> {
 }
 
 /// A pair of secret keys used by consensus.
+#[derive(Debug)]
 pub(super) struct ConsensusKeyPair {
     secret_key: Arc<SecretKey>,
     public_key: PublicKey,

--- a/node/src/components/small_network/message_pack_format.rs
+++ b/node/src/components/small_network/message_pack_format.rs
@@ -23,6 +23,8 @@ use super::Message;
 #[derive(Debug)]
 pub struct MessagePackFormat;
 
+// TODO: Fix settings for encoding/decoding.
+
 impl<P> Serializer<Arc<Message<P>>> for MessagePackFormat
 where
     Message<P>: Serialize,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -192,7 +192,7 @@ where
             chain_info: &self.chain_info,
             public_addr: self.public_addr,
             consensus_keys: self.consensus_keys.as_ref(),
-            connection_id: connection_id,
+            connection_id,
         }
     }
 }
@@ -341,8 +341,8 @@ struct HandshakeParameters<'a> {
 }
 
 /// Negotiates a connection handshake over the given transport.
-async fn negotiate_handshake<'a, P>(
-    parameters: HandshakeParameters<'a>,
+async fn negotiate_handshake<P>(
+    parameters: HandshakeParameters<'_>,
     transport: &mut FramedTransport<P>,
 ) -> Result<(SocketAddr, Option<PublicKey>), ConnectionError>
 where

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -39,9 +39,8 @@ use super::{
     counting_format::{ConnectionId, Role},
     error::{display_error, ConnectionError, IoError},
     event::{IncomingConnection, OutgoingConnection},
-    framed,
     message::ConsensusKeyPair,
-    Event, FramedTransport, Message, Payload, Transport,
+    Event, FramedTransport, Message, Payload, Transport, WireProtocol,
 };
 use crate::{
     components::networking_metrics::NetworkingMetrics,
@@ -121,7 +120,7 @@ where
 
     // Setup connection sink and stream.
     let connection_id = ConnectionId::from_connection(transport.ssl(), context.our_id, peer_id);
-    let mut transport = framed::<P>(
+    let mut transport = WireProtocol::V1.framed::<P>(
         context.net_metrics.clone(),
         connection_id,
         transport,
@@ -231,7 +230,7 @@ where
 
     // Setup connection sink and stream.
     let connection_id = ConnectionId::from_connection(transport.ssl(), context.our_id, peer_id);
-    let mut transport = framed::<P>(
+    let mut transport = WireProtocol::V1.framed::<P>(
         context.net_metrics.clone(),
         connection_id,
         transport,
@@ -569,7 +568,7 @@ mod tests {
             small_network::{
                 chain_info::ChainInfo,
                 counting_format::{ConnectionId, Role},
-                framed, SmallNetworkIdentity, Transport,
+                SmallNetworkIdentity, Transport, WireProtocol,
             },
         },
         testing::init_logging,
@@ -703,7 +702,7 @@ mod tests {
         let registry = Registry::new();
         let metrics = Arc::new(NetworkingMetrics::new(&registry).expect("could not setup metrics"));
 
-        let mut server_framed = framed::<crate::protocol::Message>(
+        let mut server_framed = WireProtocol::V1.framed::<crate::protocol::Message>(
             Arc::downgrade(&metrics),
             connection_id,
             server_transport,
@@ -711,7 +710,7 @@ mod tests {
             10_000_000,
         );
 
-        let mut client_framed = framed::<crate::protocol::Message>(
+        let mut client_framed = WireProtocol::V1.framed::<crate::protocol::Message>(
             Arc::downgrade(&metrics),
             connection_id,
             client_transport,


### PR DESCRIPTION
Hardcodes the handshake, allowing a switchover of the serialization scheme based on the protocol scheme.

There's an open question of what `V2` serialization should be, although the rest is in place.