### PR TITLE
Outgoing logs: Levels and blocked failure reporting

### DIFF
--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -492,7 +492,7 @@ where
                         Some(DialRequest::Disconnect { span, handle })
                     }
                     OutgoingState::Waiting { .. } | OutgoingState::Connecting { .. } => {
-                        debug!("address blocked");
+                        info!("address blocked");
                         self.change_outgoing_state(addr, OutgoingState::Blocked { since: now });
                         None
                     }

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -688,7 +688,7 @@ where
             }
 
             DialOutcome::Failed { addr, error, when } => {
-                debug!(err = display_error(&error), "outgoing connection failed");
+                info!(err = display_error(&error), "outgoing connection failed");
 
                 let failures_so_far = if let Some(outgoing) = self.outgoing.get(&addr) {
                     match outgoing.state {

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -691,13 +691,22 @@ where
                 debug!(err = display_error(&error), "outgoing connection failed");
 
                 let failures_so_far = if let Some(outgoing) = self.outgoing.get(&addr) {
-                    if let OutgoingState::Connecting { failures_so_far,.. } = outgoing.state {
-                         failures_so_far + 1
-                    } else {
-                        debug!(
-                            "processing dial outcome on a connection that was not marked as connecting"
-                        );
-                        1
+                    match outgoing.state {
+                        OutgoingState::Connecting { failures_so_far,.. } => {
+                            failures_so_far + 1
+                        }
+                        OutgoingState::Blocked { .. } => {
+                            debug!("failed dial outcome after block ignored");
+                            1
+                        }
+                        OutgoingState::Waiting { .. } |
+                        OutgoingState::Connected { .. } |
+                        OutgoingState::Loopback => {
+                            warn!(
+                                "processing dial outcome on a connection that was not marked as connecting or blocked"
+                            );
+                            1
+                        }
                     }
                 } else {
                     warn!("processing dial outcome non-existent connection");


### PR DESCRIPTION
This changes some of the log levels back to the old levels, and fixes the bug where warnings are emitted upon a connection failure of an already blocked peer.