### PR TITLE
Add databases storing block bodies split into parts

### DIFF
--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -10,7 +10,7 @@ use casper_execution_engine::{
 use casper_node::{
     crypto::hash::Digest,
     rpcs::chain::{BlockIdentifier, EraSummary, GetEraInfoResult},
-    types::{json_compatibility, Block, BlockValidationError, JsonBlock},
+    types::{error::BlockValidationError, json_compatibility, Block, JsonBlock},
 };
 use casper_types::{bytesrepr, Key, U512};
 
@@ -38,8 +38,8 @@ pub enum ValidateResponseError {
     ValidationError(#[from] ValidationError),
 
     /// Failed to validate a block.
-    #[error("Block validation error {0}")]
-    BlockValidationError(BlockValidationError),
+    #[error(transparent)]
+    BlockValidationError(#[from] BlockValidationError),
 
     /// Serialized value not contained in proof.
     #[error("serialized value not contained in proof")]
@@ -61,12 +61,6 @@ pub enum ValidateResponseError {
 impl From<bytesrepr::Error> for ValidateResponseError {
     fn from(e: bytesrepr::Error) -> Self {
         ValidateResponseError::BytesRepr(e)
-    }
-}
-
-impl From<BlockValidationError> for ValidateResponseError {
-    fn from(e: BlockValidationError) -> Self {
-        ValidateResponseError::BlockValidationError(e)
     }
 }
 

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -11,8 +11,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     components::consensus::{traits::Context, ActionId, TimerId},
+    crypto::hash::{self, Digest},
     types::{TimeDiff, Timestamp},
 };
+use casper_types::bytesrepr::ToBytes;
 
 /// Information about the context in which a new block is created.
 #[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
@@ -107,6 +109,44 @@ pub struct EraReport<VID> {
     pub(crate) rewards: BTreeMap<VID, u64>,
     /// Validators that haven't produced any unit during the era.
     pub(crate) inactive_validators: Vec<VID>,
+}
+
+impl<VID> EraReport<VID> {
+    pub fn hash(&self) -> Digest
+    where
+        VID: ToBytes,
+    {
+        // Helper function to hash slice of validators
+        fn hash_slice_of_validators<VID>(slice_of_validators: &[VID]) -> Digest
+        where
+            VID: ToBytes,
+        {
+            let hashes = slice_of_validators
+                .iter()
+                .map(|validator| {
+                    hash::hash(validator.to_bytes().expect("Could not serialize validator"))
+                })
+                .collect();
+            hash::hash_vec_merkle_tree(hashes)
+        }
+
+        // Pattern match here leverages compiler to ensure every field is accounted for
+        let EraReport {
+            equivocators,
+            inactive_validators,
+            rewards,
+        } = self;
+
+        let hashed_equivocators = hash_slice_of_validators(equivocators);
+        let hashed_inactive_validators = hash_slice_of_validators(inactive_validators);
+        let hashed_rewards = hash::hash_btree_map(rewards).expect("Could not hash rewards");
+
+        hash::hash_slice_rfold(&[
+            hashed_equivocators,
+            hashed_rewards,
+            hashed_inactive_validators,
+        ])
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -346,7 +346,7 @@ where
                 let BlockWithMetadata {
                     block,
                     finality_signatures,
-                } = *item.clone();
+                } = &*item;
 
                 if *block.hash() != block.header().hash() {
                     warn!(

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -359,10 +359,12 @@ where
                     continue;
                 }
 
-                if block.body().hash() != *block.header().body_hash() {
+                if block.body().hash(block.header().protocol_version())
+                    != *block.header().body_hash()
+                {
                     warn!(
                         ?block,
-                        actual_block_body_hash = ?block.body().hash(),
+                        actual_block_body_hash = ?block.body().hash(block.header().protocol_version()),
                         ?peer,
                         "Block from peer did not have correct block body hash.",
                     );

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -348,25 +348,11 @@ where
                     finality_signatures,
                 } = &*item;
 
-                if *block.hash() != block.header().hash() {
+                if let Err(error) = block.verify() {
                     warn!(
-                        ?block,
-                        actual_block_header_hash = ?block.header().hash(),
+                        ?error,
                         ?peer,
-                        "Block from peer did not have correct block header hash.",
-                    );
-                    // TODO: ban peer
-                    continue;
-                }
-
-                if block.body().hash(block.header().protocol_version())
-                    != *block.header().body_hash()
-                {
-                    warn!(
-                        ?block,
-                        actual_block_body_hash = ?block.body().hash(block.header().protocol_version()),
-                        ?peer,
-                        "Block from peer did not have correct block body hash.",
+                        "Error validating finality signatures from peer.",
                     );
                     // TODO: ban peer
                     continue;

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1207,9 +1207,9 @@ impl Storage {
         if !self.put_merkle_block_body_part(tx, self.transfer_hashes_db, transfer_hashes)? {
             return Ok(false);
         };
-        // This might already be present, don't bother checking and early returning.
-        // This behavior might not be correct in the future...
-        self.put_merkle_block_body_part(tx, self.proposer_db, proposer)?;
+        if !self.put_merkle_block_body_part(tx, self.proposer_db, proposer)? {
+            return Ok(false);
+        };
         Ok(true)
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1608,12 +1608,12 @@ fn initialize_block_body_v2_db(
     for (raw_key, raw_val) in cursor.iter() {
         info!(?raw_key, "deleting v2 block");
         if deleted_block_body_hashes.contains(raw_key) {
-            let hashes: Vec<Digest> = lmdb_ext::deserialize(raw_val)?;
-            let _ = deleted_deploy_hashes.insert(hashes[0]);
-            let _ = deleted_transfer_hashes.insert(hashes[1]);
-            let _ = deleted_proposer_hashes.insert(hashes[2]);
+            let [hashed_deploy_hashes, hashed_transfer_hashes, hashed_proposer]: [Digest;
+                BlockBodyHashedParts::NUMBER_OF_HASHES] = lmdb_ext::deserialize(raw_val)?;
+            let _ = deleted_deploy_hashes.insert(hashed_deploy_hashes);
+            let _ = deleted_transfer_hashes.insert(hashed_transfer_hashes);
+            let _ = deleted_proposer_hashes.insert(hashed_proposer);
             cursor.del(WriteFlags::empty())?;
-            continue;
         }
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -68,7 +68,7 @@ use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, Transfer,
 use super::Component;
 use crate::{
     components::storage::lmdb_ext::LmdbExtError::CouldNotDeleteBlockBodyPart,
-    crypto::hash::Digest,
+    crypto::hash::{self, Digest},
     effect::{
         requests::{StateStoreRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
@@ -1131,7 +1131,10 @@ impl Storage {
                 self.proposer_db,
                 transfer_hashes_with_proof.merkle_proof_of_rest(),
             )? {
-            Some(proposer_with_proof) => proposer_with_proof,
+            Some(proposer_with_proof) => {
+                debug_assert_eq!(*proposer_with_proof.merkle_proof_of_rest(), hash::SENTINEL1);
+                proposer_with_proof
+            }
             None => return Ok(None),
         };
         let block_body = BlockBody::new(

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -67,7 +67,7 @@ use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, Transfer,
 
 use super::Component;
 use crate::{
-    crypto::{hash, hash::Digest},
+    crypto::hash::Digest,
     effect::{
         requests::{StateStoreRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
@@ -388,7 +388,6 @@ impl Storage {
             &transfer_hashes_db,
             &proposer_db,
             &deleted_block_body_hashes_raw,
-            should_check_integrity,
         )?;
         initialize_block_metadata_db(
             &env,
@@ -1627,11 +1626,11 @@ fn initialize_block_body_v2_db(
     let deleted_proposer_hashes_raw: HashSet<_> =
         deleted_proposer_hashes.iter().map(Digest::as_ref).collect();
 
-    info!(&deleted_deploy_hashes_raw, "Removing deleted deploy keys");
+    info!(?deleted_deploy_hashes_raw, "Removing deleted deploy keys");
     remove_keys_from_db(&mut txn, deploy_hashes_db, &deleted_deploy_hashes_raw)?;
-    info!(&deleted_deploy_hashes_raw, "Removing deleted transfer keys");
+    info!(?deleted_deploy_hashes_raw, "Removing deleted transfer keys");
     remove_keys_from_db(&mut txn, transfer_hashes_db, &deleted_transfer_hashes_raw)?;
-    info!(&deleted_deploy_hashes_raw, "Removing deleted proposer keys");
+    info!(?deleted_deploy_hashes_raw, "Removing deleted proposer keys");
     remove_keys_from_db(&mut txn, proposer_db, &deleted_proposer_hashes_raw)?;
 
     txn.commit()?;
@@ -1651,7 +1650,7 @@ fn remove_keys_from_db(
 
     for (raw_key, _raw_val) in cursor.iter() {
         if deleted_hashes.contains(raw_key) {
-            info!(&raw_key, "Removing raw key");
+            info!(?raw_key, "Removing raw key");
             cursor.del(WriteFlags::empty())?;
         }
     }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1090,18 +1090,33 @@ impl Storage {
         let deploy_hashes: Vec<DeployHash> =
             match tx.get_value(self.deploy_hashes_db, &hashed_deploy_hashes)? {
                 Some(deploy_hashes) => deploy_hashes,
-                None => return Ok(None),
+                None => {
+                    return Err(LmdbExtError::BlockBodyDidNotHaveDeployHashes {
+                        block_body_hash: *block_body_hash,
+                        hashed_deploy_hashes,
+                    })
+                }
             };
 
         let transfer_hashes: Vec<DeployHash> =
             match tx.get_value(self.transfer_hashes_db, &hashed_transfer_hashes)? {
                 Some(transfer_hashes) => transfer_hashes,
-                None => return Ok(None),
+                None => {
+                    return Err(LmdbExtError::BlockBodyDidNotHaveTransferHashes {
+                        block_body_hash: *block_body_hash,
+                        hashed_transfer_hashes,
+                    })
+                }
             };
 
         let proposer: PublicKey = match tx.get_value(self.proposer_db, &hashed_proposer)? {
             Some(proposer) => proposer,
-            None => return Ok(None),
+            None => {
+                return Err(LmdbExtError::BlockBodyDidNotHaveProposerHash {
+                    block_body_hash: *block_body_hash,
+                    hashed_proposer,
+                })
+            }
         };
 
         let block_body = BlockBody::new(proposer, deploy_hashes, transfer_hashes);

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1606,8 +1606,8 @@ fn initialize_block_body_v2_db(
     let mut deleted_proposer_hashes = HashSet::new();
 
     for (raw_key, raw_val) in cursor.iter() {
-        info!(?raw_key, "deleting v2 block");
         if deleted_block_body_hashes.contains(raw_key) {
+            info!(?raw_key, "deleting v2 block");
             let [hashed_deploy_hashes, hashed_transfer_hashes, hashed_proposer]: [Digest;
                 BlockBodyHashedParts::NUMBER_OF_HASHES] = lmdb_ext::deserialize(raw_val)?;
             let _ = deleted_deploy_hashes.insert(hashed_deploy_hashes);

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1075,7 +1075,7 @@ impl Storage {
     }
 
     /// Retrieves a single Merklized block body in a separate transaction from storage.
-    fn get_single_v2_block_body<Tx: Transaction>(
+    fn get_single_block_body_v2<Tx: Transaction>(
         &self,
         tx: &mut Tx,
         block_body_hash: &Digest,
@@ -1198,7 +1198,7 @@ impl Storage {
                 self.get_single_v1_block_body(tx, block_header.body_hash())?
             }
             HashingAlgorithmVersion::V2 => {
-                self.get_single_v2_block_body(tx, block_header.body_hash())?
+                self.get_single_block_body_v2(tx, block_header.body_hash())?
             }
         };
         let block_body = match maybe_block_body {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -512,7 +512,7 @@ impl Storage {
                         }
                     };
                     if !success {
-                        error!("Could not insert block body for block: {}", block);
+                        error!("Could not insert body for: {}", block);
                         txn.abort();
                         return Ok(responder.respond(false).ignore());
                     }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1554,7 +1554,7 @@ fn initialize_block_body_v1_db(
         let expected_hashing_algorithm_version = HashingAlgorithmVersion::V1;
         let block_body_hash_to_header_map =
             construct_block_body_to_block_header_reverse_lookup(&txn, block_header_db)?;
-        for (raw_key, raw_val) in txn.open_ro_cursor(*block_body_db)?.iter() {
+        for (raw_key, raw_val) in txn.open_ro_cursor(*block_body_v1_db)?.iter() {
             let block_body_hash: Digest = lmdb_ext::deserialize(raw_key)?;
             let block_body: BlockBody = lmdb_ext::deserialize(raw_val)?;
             if let Some(block_header) = block_body_hash_to_header_map.get(&block_body_hash) {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -358,8 +358,7 @@ impl Storage {
                 .expect("non-existent block body referred to by header");
 
             if should_check_integrity {
-                Block::new_from_header_and_body(block_header.clone(), block_body.clone())
-                    .expect("Could not construct valid block.");
+                Block::new_from_header_and_body(block_header.clone(), block_body.clone())?;
             }
 
             insert_to_deploy_index(&mut deploy_hash_index, block_header.hash(), &block_body)?;

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1135,7 +1135,7 @@ impl Storage {
 
         // Insert parts and the vec of hashes to new dbs
         if !tx.put_value(
-            self.deploy_hashes_db,
+            self.proposer_db,
             hashed_proposer,
             block_body.proposer(),
             true,
@@ -1144,15 +1144,16 @@ impl Storage {
         }
 
         if !tx.put_value(
-            self.transfer_hashes_db,
+            self.deploy_hashes_db,
             hashed_deploy_hashes,
             block_body.deploy_hashes(),
             true,
         )? {
             return Ok(false);
         }
+
         if !tx.put_value(
-            self.proposer_db,
+            self.transfer_hashes_db,
             hashed_transfer_hashes,
             block_body.transfer_hashes(),
             true,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1581,7 +1581,7 @@ fn initialize_block_body_v1_db(
     Ok(())
 }
 
-/// Purges stale entries from the (merkelized) block body database, and checks the integrity of the
+/// Purges stale entries from the (Merklized) block body database, and checks the integrity of the
 /// remainder if `should_check_integrity` is true.
 fn initialize_block_body_v2_db(
     env: &Environment,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -523,7 +523,6 @@ impl Storage {
                     txn.abort();
                     return Ok(responder.respond(false).ignore());
                 }
-                txn.commit()?;
                 insert_to_block_header_indices(
                     &mut self.block_height_index,
                     &mut self.switch_block_era_id_index,
@@ -534,6 +533,7 @@ impl Storage {
                     block.header().hash(),
                     block.body(),
                 )?;
+                txn.commit()?;
                 responder.respond(true).ignore()
             }
             StorageRequest::GetBlock {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1554,7 +1554,7 @@ fn initialize_block_body_v1_db(
         let expected_hashing_algorithm_version = HashingAlgorithmVersion::V1;
         let block_body_hash_to_header_map =
             construct_block_body_to_block_header_reverse_lookup(&txn, block_header_db)?;
-        for (raw_key, raw_val) in txn.open_ro_cursor(*block_header_db)?.iter() {
+        for (raw_key, raw_val) in txn.open_ro_cursor(*block_body_db)?.iter() {
             let block_body_hash: Digest = lmdb_ext::deserialize(raw_key)?;
             let block_body: BlockBody = lmdb_ext::deserialize(raw_val)?;
             if let Some(block_header) = block_body_hash_to_header_map.get(&block_body_hash) {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1532,7 +1532,7 @@ fn initialize_block_body_v1_db(
 
     for (raw_key, _raw_val) in cursor.iter() {
         if deleted_block_body_hashes_raw.contains(raw_key) {
-            info!(?raw_key, "deleting block hash");
+            info!(?raw_key, "deleting block body");
             cursor.del(WriteFlags::empty())?;
             continue;
         }

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -78,31 +78,20 @@ pub enum LmdbExtError {
     #[error(transparent)]
     BlockValidationError(#[from] BlockValidationError),
     #[error(
-        "Could not find deploy hashes for block body. \
+        "Block body does not have correct Merkle root for its hash. \
          Block body hash: {block_body_hash}, \
-         Hashed deploy hashes: {hashed_deploy_hashes}"
+         Merkle root: {merkle_root}"
     )]
-    BlockBodyDidNotHaveDeployHashes {
+    IncorrectBlockBodyMerkleRoot {
         block_body_hash: Digest,
-        hashed_deploy_hashes: Digest,
+        merkle_root: Digest,
     },
     #[error(
-        "Could not find deploy hashes for block body. \
-         Block body hash: {block_body_hash}, \
-         Hashed transfer hashes: {hashed_transfer_hashes}"
+        "Could not delete block body part with Merkle linked list node hash: \
+         {merkle_linked_list_node_hash:?}"
     )]
-    BlockBodyDidNotHaveTransferHashes {
-        block_body_hash: Digest,
-        hashed_transfer_hashes: Digest,
-    },
-    #[error(
-        "Could not find a proposer for block body. \
-         Block body hash: {block_body_hash}, \
-         Proposer hash: {hashed_proposer}"
-    )]
-    BlockBodyDidNotHaveProposerHash {
-        block_body_hash: Digest,
-        hashed_proposer: Digest,
+    CouldNotDeleteBlockBodyPart {
+        merkle_linked_list_node_hash: Digest,
     },
 }
 

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -77,6 +77,33 @@ pub enum LmdbExtError {
     },
     #[error(transparent)]
     BlockValidationError(#[from] BlockValidationError),
+    #[error(
+        "Could not find deploy hashes for block body. \
+         Block body hash: {block_body_hash}, \
+         Hashed deploy hashes: {hashed_deploy_hashes}"
+    )]
+    BlockBodyDidNotHaveDeployHashes {
+        block_body_hash: Digest,
+        hashed_deploy_hashes: Digest,
+    },
+    #[error(
+        "Could not find deploy hashes for block body. \
+         Block body hash: {block_body_hash}, \
+         Hashed transfer hashes: {hashed_transfer_hashes}"
+    )]
+    BlockBodyDidNotHaveTransferHashes {
+        block_body_hash: Digest,
+        hashed_transfer_hashes: Digest,
+    },
+    #[error(
+        "Could not find a proposer for block body. \
+         Block body hash: {block_body_hash}, \
+         Proposer hash: {hashed_proposer}"
+    )]
+    BlockBodyDidNotHaveProposerHash {
+        block_body_hash: Digest,
+        hashed_proposer: Digest,
+    },
 }
 
 // Classifies an `lmdb::Error` according to our scheme. This one of the rare cases where we accept a

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -10,10 +10,16 @@
 //! Serialization errors are unified into a generic, type erased `std` error to allow for easy
 //! interchange of the serialization format if desired.
 
-use crate::{crypto::hash::Digest, types::BlockHash};
 use lmdb::{Database, RwTransaction, Transaction, WriteFlags};
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
+
+use crate::{
+    crypto::hash::Digest,
+    types::{
+        error::BlockValidationError, BlockBody, BlockHash, BlockHeader, HashingAlgorithmVersion,
+    },
+};
 
 /// Error wrapper for lower-level storage errors.
 ///
@@ -41,21 +47,36 @@ pub enum LmdbExtError {
     #[error(
         "Block header not stored under its hash. \
          Queried block hash: {queried_block_hash}, \
-         Found block header hash: {found_block_header_hash}"
+         Found block header hash: {found_block_header_hash}, \
+         Block header: {block_header}"
     )]
     BlockHeaderNotStoredUnderItsHash {
         queried_block_hash: BlockHash,
         found_block_header_hash: BlockHash,
+        block_header: Box<BlockHeader>,
     },
     #[error(
-        "Block body not stored under the hash in its header. \
-         Queried block body hash: {queried_block_body_hash}, \
-         Found block body hash: {found_block_body_hash}"
+        "No block header corresponding to block body found in LMDB. \
+         Block body hash: {block_body_hash:?}, \
+         Hashing algorithm version: {hashing_algorithm_version:?}, \
+         Block body: {block_body:?}"
     )]
-    BlockBodyNotStoredUnderItsHash {
-        queried_block_body_hash: Digest,
-        found_block_body_hash: Digest,
+    NoBlockHeaderForBlockBody {
+        block_body_hash: Digest,
+        hashing_algorithm_version: HashingAlgorithmVersion,
+        block_body: Box<BlockBody>,
     },
+    #[error(
+        "Unexpected hashing algorithm version. \
+         Expected: {expected_hashing_algorithm_version:?}, \
+         Actual: {actual_hashing_algorithm_version:?}"
+    )]
+    UnexpectedHashingAlgorithmVersion {
+        expected_hashing_algorithm_version: HashingAlgorithmVersion,
+        actual_hashing_algorithm_version: HashingAlgorithmVersion,
+    },
+    #[error(transparent)]
+    BlockValidationError(#[from] BlockValidationError),
 }
 
 // Classifies an `lmdb::Error` according to our scheme. This one of the rare cases where we accept a

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -178,7 +178,7 @@ impl From<Blake2bHash> for Digest {
 pub const SENTINEL0: Digest = Digest([0u8; 32]);
 /// Sentinel hash to be used by [hash_slice_rfold]. Terminates the fold.
 pub const SENTINEL1: Digest = Digest([1u8; 32]);
-/// Sentinel hash to be used by [hash_vec_merkle_tree] in the case of [
+/// Sentinel hash to be used by [hash_vec_merkle_tree] in the case of an empty list.
 pub const SENTINEL2: Digest = Digest([2u8; 32]);
 
 /// Hashes a pair of [`Digest`]s.

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -181,7 +181,7 @@ pub const SENTINEL1: Digest = Digest([1u8; 32]);
 /// Sentinel hash to be used by [hash_vec_merkle_tree] in the case of [
 pub const SENTINEL2: Digest = Digest([2u8; 32]);
 
-/// Hashes a pair of [Digest]s.
+/// Hashes a pair of [`Digest`]s.
 pub fn hash_pair(hash1: &Digest, hash2: &Digest) -> Digest {
     let mut to_hash = [0; Digest::LENGTH * 2];
     to_hash[..Digest::LENGTH].copy_from_slice(&(hash1.to_array())[..]);
@@ -189,8 +189,8 @@ pub fn hash_pair(hash1: &Digest, hash2: &Digest) -> Digest {
     hash(&to_hash)
 }
 
-/// Hashes a [Vec<Digest>] into a single [Digest] by constructing a [Merkle tree][1].
-/// Reduces pairs of elements in the [Vec<Digest>] by repeatedly calling [hash_pair].
+/// Hashes a [`Vec`] of [`Digest`]s into a single [`Digest`] by constructing a [Merkle tree][1].
+/// Reduces pairs of elements in the [`Vec`] by repeatedly calling [hash_pair].
 /// This hash procedure is suited to hashing [BTree]s.
 ///
 /// The pattern of hashing is as follows.  It is akin to [graph reduction][2]:
@@ -241,7 +241,7 @@ where
 /// Unlike Merkle trees, this is suited to hashing heterogeneous lists we may wish to extend in the
 /// future (ie, hashes of data structures that may undergo revision).
 ///
-/// Returns [SENTINEL1] when given an empty [Vec] as input.
+/// Returns [`SENTINEL1`] when given an empty [`Vec`] as input.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds
 pub fn hash_slice_rfold(slice: &[Digest]) -> Digest {

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -16,6 +16,7 @@ use blake2::{
 use datasize::DataSize;
 use hex_buffer_serde::{Hex, HexForm};
 use hex_fmt::HexFmt;
+use itertools::Itertools;
 #[cfg(test)]
 use rand::Rng;
 use schemars::JsonSchema;
@@ -27,6 +28,7 @@ use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use super::Error;
 #[cfg(test)]
 use crate::testing::TestRng;
+use std::collections::BTreeMap;
 
 /// The hash digest; a wrapped `u8` array.
 #[derive(
@@ -172,6 +174,92 @@ impl From<Blake2bHash> for Digest {
     }
 }
 
+/// Sentinel hash to be used for hashing options in the case of [None].
+pub const SENTINEL0: Digest = Digest([0u8; 32]);
+/// Sentinel hash to be used by [hash_slice_rfold]. Terminates the fold.
+pub const SENTINEL1: Digest = Digest([1u8; 32]);
+/// Sentinel hash to be used by [hash_vec_merkle_tree] in the case of [
+pub const SENTINEL2: Digest = Digest([2u8; 32]);
+
+/// Hashes a pair of [Digest]s.
+pub fn hash_pair(hash1: &Digest, hash2: &Digest) -> Digest {
+    let mut to_hash = [0; Digest::LENGTH * 2];
+    to_hash[..Digest::LENGTH].copy_from_slice(&(hash1.to_array())[..]);
+    to_hash[Digest::LENGTH..].copy_from_slice(&(hash2.to_array())[..]);
+    hash(&to_hash)
+}
+
+/// Hashes a [Vec<Digest>] into a single [Digest] by constructing a [Merkle tree][1].
+/// Reduces pairs of elements in the [Vec<Digest>] by repeatedly calling [hash_pair].
+/// This hash procedure is suited to hashing [BTree]s.
+///
+/// The pattern of hashing is as follows.  It is akin to [graph reduction][2]:
+///
+/// ```text
+/// a b c d e f
+/// |/  |/  |/
+/// g   h   i
+/// | /   /
+/// |/   /
+/// j   k
+/// | /
+/// |/
+/// l
+/// ```
+///
+/// Returns the empty [Digest] when the input is empty.
+///
+/// [1]: https://en.wikipedia.org/wiki/Merkle_tree
+/// [2]: https://en.wikipedia.org/wiki/Graph_reduction
+pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
+    vec.into_iter()
+        .tree_fold1(|x, y| hash_pair(&x, &y))
+        .unwrap_or(SENTINEL2)
+}
+
+/// Hashes a [BTreeMap].
+pub fn hash_btree_map<K, V>(btree_map: &BTreeMap<K, V>) -> Result<Digest, bytesrepr::Error>
+where
+    K: ToBytes,
+    V: ToBytes,
+{
+    let mut kv_hashes: Vec<Digest> = Vec::with_capacity(btree_map.len());
+    for (key, value) in btree_map.iter() {
+        kv_hashes.push(hash_pair(&hash(key.to_bytes()?), &hash(value.to_bytes()?)))
+    }
+    Ok(hash_vec_merkle_tree(kv_hashes))
+}
+
+/// Hashes a `&[Digest]` using a [right fold][1].
+///
+/// This pattern of hashing is as follows:
+///
+/// ```text
+/// hash_pair(a, &hash_pair(b, &hash_pair(c, &SENTINEL)))
+/// ```
+///
+/// Unlike Merkle trees, this is suited to hashing heterogeneous lists we may wish to extend in the
+/// future (ie, hashes of data structures that may undergo revision).
+///
+/// Returns [SENTINEL1] when given an empty [Vec] as input.
+///
+/// [1]: https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds
+pub fn hash_slice_rfold(slice: &[Digest]) -> Digest {
+    slice
+        .iter()
+        .rfold(SENTINEL1, |prev, next| hash_pair(next, &prev))
+}
+
+/// Hashes a `&[Digest]` using a [right fold][1]. Uses `proof` as a Merkle proof for the missing
+/// tail of the slice.
+///
+/// [1]: https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds
+pub fn hash_slice_with_proof(slice: &[Digest], proof: Digest) -> Digest {
+    slice
+        .iter()
+        .rfold(proof, |prev, next| hash_pair(next, &prev))
+}
+
 #[cfg(test)]
 mod test {
     use std::iter::{self, FromIterator};
@@ -247,9 +335,9 @@ mod test {
     #[test]
     fn should_print_digest_upper_hex() {
         let hash = Digest([10u8; 32]);
-        let hash_lower_hex = format!("{:X}", hash);
+        let hash_upper_hex = format!("{:X}", hash);
         assert_eq!(
-            hash_lower_hex,
+            hash_upper_hex,
             "0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A"
         )
     }
@@ -269,5 +357,100 @@ mod test {
         let mut rng = crate::new_rng();
         let hash = Digest::random(&mut rng);
         bytesrepr::test_serialization_roundtrip(&hash);
+    }
+
+    #[test]
+    fn test_hash_pair() {
+        let hash1 = Digest([1u8; 32]);
+        let hash2 = Digest([2u8; 32]);
+
+        let hash = hash_pair(&hash1, &hash2);
+        let hash_lower_hex = format!("{:x}", hash);
+
+        assert_eq!(
+            hash_lower_hex,
+            "30b600fb1f0cc0b3f0fc28cdcb7389405a6659be81c7d5c5905725aa3a5119ce"
+        );
+    }
+
+    #[test]
+    fn test_hash_rfold() {
+        let hashes = vec![
+            Digest([1u8; 32]),
+            Digest([2u8; 32]),
+            Digest([3u8; 32]),
+            Digest([4u8; 32]),
+            Digest([5u8; 32]),
+        ];
+
+        let hash = hash_slice_rfold(&hashes[..]);
+        let hash_lower_hex = format!("{:x}", hash);
+
+        assert_eq!(
+            hash_lower_hex,
+            "e137f4eb94d2387065454eecfe2cdb5584e3dbd5f1ca07fc511fffd13d234e8e"
+        );
+
+        let proof = hash_slice_rfold(&hashes[2..]);
+        let hash_proof = hash_slice_with_proof(&hashes[..2], proof);
+
+        assert_eq!(hash, hash_proof);
+    }
+
+    #[test]
+    fn test_hash_merkle_odd() {
+        let hashes = vec![
+            Digest([1u8; 32]),
+            Digest([2u8; 32]),
+            Digest([3u8; 32]),
+            Digest([4u8; 32]),
+            Digest([5u8; 32]),
+        ];
+
+        let hash = hash_vec_merkle_tree(hashes);
+        let hash_lower_hex = format!("{:x}", hash);
+
+        assert_eq!(
+            hash_lower_hex,
+            "c18aaf359f7b4643991f68fbfa8c503eb460da497399cdff7d8a2b1bc4399589"
+        );
+    }
+
+    #[test]
+    fn test_hash_merkle_even() {
+        let hashes = vec![
+            Digest([1u8; 32]),
+            Digest([2u8; 32]),
+            Digest([3u8; 32]),
+            Digest([4u8; 32]),
+            Digest([5u8; 32]),
+            Digest([6u8; 32]),
+        ];
+
+        let hash = hash_vec_merkle_tree(hashes);
+        let hash_lower_hex = format!("{:x}", hash);
+
+        assert_eq!(
+            hash_lower_hex,
+            "0470ecc8abdcd6ecd3a4c574431b80bb8751c7a43337d5966dadf07899f8804b"
+        );
+    }
+
+    #[test]
+    fn test_hash_btreemap() {
+        let mut map = BTreeMap::new();
+        let _ = map.insert(Digest([1u8; 32]), Digest([2u8; 32]));
+        let _ = map.insert(Digest([3u8; 32]), Digest([4u8; 32]));
+        let _ = map.insert(Digest([5u8; 32]), Digest([6u8; 32]));
+        let _ = map.insert(Digest([7u8; 32]), Digest([8u8; 32]));
+        let _ = map.insert(Digest([9u8; 32]), Digest([10u8; 32]));
+
+        let hash = hash_btree_map(&map).unwrap();
+        let hash_lower_hex = format!("{:x}", hash);
+
+        assert_eq!(
+            hash_lower_hex,
+            "f3bc94beb2470d5c09f575b439d5f238bdc943233774c7aa59e597cc2579e148"
+        );
     }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -5,8 +5,8 @@ use rand::{CryptoRng, RngCore};
 use rand_chacha::ChaCha20Rng;
 
 pub use block::{
-    json_compatibility::JsonBlock, Block, BlockBody, BlockHash, BlockHeader, BlockSignatures,
-    FinalitySignature, HashingAlgorithmVersion,
+    json_compatibility::JsonBlock, Block, BlockBody, BlockBodyHashedParts, BlockHash, BlockHeader,
+    BlockSignatures, FinalitySignature, HashingAlgorithmVersion,
 };
 pub(crate) use block::{BlockHeaderWithMetadata, BlockPayload, BlockWithMetadata, FinalizedBlock};
 pub(crate) use chainspec::ActivationPoint;

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -5,8 +5,9 @@ use rand::{CryptoRng, RngCore};
 use rand_chacha::ChaCha20Rng;
 
 pub use block::{
-    json_compatibility::JsonBlock, Block, BlockBody, BlockBodyHashedParts, BlockHash, BlockHeader,
-    BlockSignatures, FinalitySignature, HashingAlgorithmVersion,
+    json_compatibility::JsonBlock, Block, BlockBody, BlockHash, BlockHeader, BlockSignatures,
+    FinalitySignature, HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart,
+    MerkleLinkedListNode,
 };
 pub(crate) use block::{BlockHeaderWithMetadata, BlockPayload, BlockWithMetadata, FinalizedBlock};
 pub(crate) use chainspec::ActivationPoint;

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,25 +1,12 @@
 //! Common types used across multiple components.
 
-pub(crate) mod appendable_block;
-mod block;
-pub mod chainspec;
-mod deploy;
-mod exit_code;
-mod item;
-pub mod json_compatibility;
-mod node_config;
-mod node_id;
-mod peers_map;
-mod status_feed;
-mod timestamp;
-
 use rand::{CryptoRng, RngCore};
 #[cfg(not(test))]
 use rand_chacha::ChaCha20Rng;
 
 pub use block::{
     json_compatibility::JsonBlock, Block, BlockBody, BlockHash, BlockHeader, BlockSignatures,
-    BlockValidationError, FinalitySignature,
+    FinalitySignature, HashingAlgorithmVersion,
 };
 pub(crate) use block::{BlockHeaderWithMetadata, BlockPayload, BlockWithMetadata, FinalizedBlock};
 pub(crate) use chainspec::ActivationPoint;
@@ -35,6 +22,20 @@ pub(crate) use node_id::NodeId;
 pub use peers_map::PeersMap;
 pub use status_feed::{ChainspecInfo, GetStatusResult, StatusFeed};
 pub use timestamp::{TimeDiff, Timestamp};
+
+pub(crate) mod appendable_block;
+mod block;
+pub mod chainspec;
+mod deploy;
+pub mod error;
+mod exit_code;
+mod item;
+pub mod json_compatibility;
+mod node_config;
+mod node_id;
+mod peers_map;
+mod status_feed;
+mod timestamp;
 
 /// An object-safe RNG trait that requires a cryptographically strong random number generator.
 pub trait CryptoRngCore: CryptoRng + RngCore {}

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -5,6 +5,7 @@
 use std::iter;
 use std::{
     array::TryFromSliceError,
+    cmp::Reverse,
     collections::BTreeMap,
     error::Error as StdError,
     fmt::{self, Debug, Display, Formatter},
@@ -17,6 +18,7 @@ use blake2::{
 use datasize::DataSize;
 use hex::FromHexError;
 use hex_fmt::HexList;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 #[cfg(test)]
 use rand::Rng;
@@ -51,7 +53,6 @@ use crate::{
 };
 
 use super::{Item, Tag, Timestamp};
-use itertools::Itertools;
 
 static ERA_REPORT: Lazy<EraReport> = Lazy::new(|| {
     let secret_key_1 = SecretKey::ed25519_from_bytes([0; 32]).unwrap();
@@ -613,8 +614,7 @@ impl EraEnd {
         // to check finality signatures.
         let descending_validator_weight_hashed_pairs: Vec<Digest> = next_era_validator_weights
             .iter()
-            .sorted_by_key(|(_, weight)| **weight)
-            .rev()
+            .sorted_by_key(|(_, weight)| Reverse(**weight))
             .map(|(validator_id, weight)| {
                 let validator_hash =
                     hash::hash(validator_id.to_bytes().expect("Could not hash validator"));

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -623,7 +623,7 @@ impl EraEnd {
             })
             .collect();
         let hashed_next_era_validator_weights =
-            hash::hash_slice_rfold(&descending_validator_weight_hashed_pairs);
+            hash::hash_vec_merkle_tree(descending_validator_weight_hashed_pairs);
         let hashed_era_report: Digest = era_report.hash();
         hash::hash_slice_rfold(&[hashed_next_era_validator_weights, hashed_era_report])
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1192,7 +1192,7 @@ impl Block {
     /// Version which introduced the first generation hashing function.
     pub const HASH_V1_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 0, 0);
     /// Version that introduced Merkelized hashing functions.
-    pub const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(9999, 0, 0);
+    pub const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 4, 0);
 
     pub(crate) fn new(
         parent_hash: BlockHash,

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1160,7 +1160,7 @@ pub struct Block {
 pub enum HashingAlgorithmVersion {
     /// Version 1
     V1,
-    /// Version 1
+    /// Version 2
     V2,
 }
 

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -261,6 +261,12 @@ impl DeployHash {
     }
 }
 
+impl From<DeployHash> for Digest {
+    fn from(deploy_hash: DeployHash) -> Self {
+        deploy_hash.0
+    }
+}
+
 impl Display for DeployHash {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "deploy-hash({})", self.0,)

--- a/node/src/types/error.rs
+++ b/node/src/types/error.rs
@@ -1,0 +1,68 @@
+//! Errors that may be emitted by methods for common types.
+
+use std::collections::BTreeMap;
+
+use casper_types::{bytesrepr, PublicKey, U512};
+use thiserror::Error;
+
+use crate::{
+    crypto::hash::Digest,
+    types::{block::EraReport, Block, BlockHash},
+};
+
+/// An error that can arise when creating a block from a finalized block and other components
+#[derive(Error, Debug)]
+pub enum BlockCreationError {
+    /// [`EraEnd`]s need both an [`EraReport`] present and a map of the next era validator weights.
+    /// If one of them is not present while trying to construct an [`EraEnd`] we must emit an
+    /// error.
+    #[error(
+        "Cannot create EraEnd unless we have both an EraReport and next era validators. \
+         Era report: {maybe_era_report:?}, \
+         Next era validator weights: {maybe_next_era_validator_weights:?}"
+    )]
+    CouldNotCreateEraEnd {
+        /// An optional [`EraReport`] we tried to use to construct an [`EraEnd`]
+        maybe_era_report: Option<EraReport>,
+        /// An optional map of the next era validator weights used to construct an [`EraEnd`]
+        maybe_next_era_validator_weights: Option<BTreeMap<PublicKey, U512>>,
+    },
+
+    /// Wrapper of [`blake2::digest::InvalidOutputSize`]; occurs when trying to construct a
+    #[error(transparent)]
+    Blake2bDigestInvalidOutputSize(#[from] blake2::digest::InvalidOutputSize),
+}
+
+/// An error that can arise when validating a block's cryptographic integrity using its hashes
+#[derive(Error, Debug)]
+pub enum BlockValidationError {
+    /// Problem serializing some of a block's data into bytes
+    #[error(transparent)]
+    BytesReprError(#[from] bytesrepr::Error),
+
+    /// The body hash in the header is not the same as the hash of the body of the block
+    #[error(
+        "Block header has incorrect body hash. \
+         Actual block body hash: {actual_block_body_hash:?}, \
+         Block: {block:?}"
+    )]
+    UnexpectedBodyHash {
+        /// The [`Block`] with the [`BlockHeader`] with the incorrect block body hash
+        block: Box<Block>,
+        /// The actual hash of the block's [`BlockBody`]
+        actual_block_body_hash: Digest,
+    },
+
+    /// The block's hash is not the same as the header's hash
+    #[error(
+        "Block has incorrect block hash. \
+         Actual block body hash: {actual_block_header_hash:?}, \
+         Block: {block:?}"
+    )]
+    UnexpectedBlockHash {
+        /// The [`Block`] with the incorrect [`BlockHeaderHash`]
+        block: Box<Block>,
+        /// The actual hash of the block's [`BlockHeader`]
+        actual_block_header_hash: BlockHash,
+    },
+}

--- a/node/src/types/error.rs
+++ b/node/src/types/error.rs
@@ -28,7 +28,8 @@ pub enum BlockCreationError {
         maybe_next_era_validator_weights: Option<BTreeMap<PublicKey, U512>>,
     },
 
-    /// Wrapper of [`blake2::digest::InvalidOutputSize`]; occurs when trying to construct a
+    /// Wrapper of [`blake2::digest::InvalidOutputSize`]; occurs when trying to construct
+    /// an [`EraEnd`].
     #[error(transparent)]
     Blake2bDigestInvalidOutputSize(#[from] blake2::digest::InvalidOutputSize),
 }


### PR DESCRIPTION
 - Creates the follow databases:
        1. block_body_merkle: BlockBodyHash → vec![hash(deploy_hashes),
hash(transfer_hashes), hash(proposer)]
        2. deploy_hashes: hash(deploy_hashes) → deploy_hashes
        3. transfer_hashes: hash(transfer_hashes) → transfer_hashes
        4. proposer: hash(proposer) → proposer

 - This is to facilitate extensibility of the block body in the future.

 - Closes #1457 #1547 #1599