### PR TITLE
NDRS-1567: Add get-account-info command

### DIFF
--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -484,9 +484,10 @@ pub fn get_account_info(
     node_address: &str,
     verbosity_level: u64,
     public_key: &str,
-    block_id: &str,
+    maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_account_info(public_key, block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level)
+        .get_account_info(public_key, maybe_block_id)
 }
 
 /// Retrieves information and examples for all currently supported RPCs.

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -464,6 +464,31 @@ pub fn get_auction_info(
     RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_auction_info(maybe_block_id)
 }
 
+/// Retrieves an Account from the network.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
+/// * `public_key` the public key associated with the `Account`
+/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
+///   `Block` height or empty. If empty, the latest `Block` will be retrieved.
+pub fn get_account_info(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbosity_level: u64,
+    public_key: &str,
+    block_id: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_account_info(public_key, block_id)
+}
+
 /// Retrieves information and examples for all currently supported RPCs.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -243,13 +243,17 @@ impl RpcCall {
         Ok(response)
     }
 
-    pub(crate) fn get_account_info(self, public_key: &str, block_id: &str) -> Result<JsonRpc> {
+    pub(crate) fn get_account_info(
+        self,
+        public_key: &str,
+        maybe_block_identifier: &str,
+    ) -> Result<JsonRpc> {
         let key = if let Ok(public_key) = PublicKey::from_hex(public_key) {
             public_key
         } else {
             return Err(Error::FailedToParseKey);
         };
-        let block_identifier = Self::block_identifier(block_id)?;
+        let block_identifier = Self::block_identifier(maybe_block_identifier)?;
         let params = GetAccountInfoParams {
             public_key: key,
             block_identifier,

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -19,8 +19,8 @@ use casper_node::{
         docs::ListRpcs,
         info::{GetDeploy, GetDeployParams},
         state::{
-            GetAuctionInfo, GetAuctionInfoParams, GetBalance, GetBalanceParams, GetItem,
-            GetItemParams,
+            GetAccountInfo, GetAccountInfoParams, GetAuctionInfo, GetAuctionInfoParams, GetBalance,
+            GetBalanceParams, GetItem, GetItemParams,
         },
         RpcWithOptionalParams, RpcWithParams, RpcWithoutParams, RPC_API_PATH,
     },
@@ -243,6 +243,20 @@ impl RpcCall {
         Ok(response)
     }
 
+    pub(crate) fn get_account_info(self, public_key: &str, block_id: &str) -> Result<JsonRpc> {
+        let key = if let Ok(public_key) = PublicKey::from_hex(public_key) {
+            public_key
+        } else {
+            return Err(Error::FailedToParseKey);
+        };
+        let block_identifier = Self::block_identifier(block_id)?;
+        let params = GetAccountInfoParams {
+            public_key: key,
+            block_identifier,
+        };
+        GetAccountInfo::request_with_map_params(self, params)
+    }
+
     fn block_identifier(maybe_block_identifier: &str) -> Result<Option<BlockIdentifier>> {
         if maybe_block_identifier.is_empty() {
             return Ok(None);
@@ -367,6 +381,10 @@ impl RpcClient for ListRpcs {
     const RPC_METHOD: &'static str = Self::METHOD;
 }
 
+impl RpcClient for GetAccountInfo {
+    const RPC_METHOD: &'static str = Self::METHOD;
+}
+
 pub(crate) trait IntoJsonMap: Serialize {
     fn into_json_map(self) -> Map<String, Value>
     where
@@ -389,3 +407,4 @@ impl IntoJsonMap for GetItemParams {}
 impl IntoJsonMap for GetEraInfoParams {}
 impl IntoJsonMap for ListRpcs {}
 impl IntoJsonMap for GetAuctionInfoParams {}
+impl IntoJsonMap for GetAccountInfoParams {}

--- a/client/src/account_address.rs
+++ b/client/src/account_address.rs
@@ -1,6 +1,6 @@
-use std::{fs, str};
+use std::str;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, ArgMatches, SubCommand};
 
 use casper_client::Error;
 use casper_types::{AsymmetricType, PublicKey};
@@ -10,59 +10,7 @@ use crate::{command::ClientCommand, common, Success};
 /// This struct defines the order in which the args are shown for this subcommand's help message.
 enum DisplayOrder {
     Verbose,
-    Key,
-}
-
-/// Handles providing the arg for and retrieval of the public key.
-mod public_key {
-    use casper_node::crypto::AsymmetricKeyExt;
-    use casper_types::AsymmetricType;
-
-    use super::*;
-
-    const ARG_NAME: &str = "public-key";
-    const ARG_SHORT: &str = "p";
-    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
-    const ARG_HELP: &str =
-        "This must be a properly formatted public key. The public key may instead be read in from \
-        a file, in which case enter the path to the file as the --public-key argument. The file \
-        should be one of the two public key files generated via the `keygen` subcommand; \
-        \"public_key_hex\" or \"public_key.pem\"";
-
-    pub(super) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
-            .long(ARG_NAME)
-            .short(ARG_SHORT)
-            .required(true)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::Key as usize)
-    }
-
-    pub(super) fn get(matches: &ArgMatches) -> Result<String, Error> {
-        let value = matches
-            .value_of(ARG_NAME)
-            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
-
-        // Try to read as a PublicKey PEM file first.
-        if let Ok(public_key) = PublicKey::from_file(value) {
-            return Ok(public_key.to_hex());
-        }
-
-        // Try to read as a hex-encoded PublicKey file next.
-        if let Ok(hex_public_key) = fs::read_to_string(value) {
-            let _ = PublicKey::from_hex(&hex_public_key).map_err(|error| {
-                eprintln!(
-                    "Can't parse the contents of {} as a public key: {}",
-                    value, error
-                );
-                Error::FailedToParseKey
-            })?;
-            return Ok(hex_public_key);
-        }
-
-        Ok(value.to_string())
-    }
+    PublicKey,
 }
 
 pub struct GenerateAccountHash {}
@@ -76,11 +24,11 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GenerateAccountHash {
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
-            .arg(public_key::arg())
+            .arg(common::public_key::arg(DisplayOrder::PublicKey as usize))
     }
 
     fn run(matches: &ArgMatches<'_>) -> Result<Success, Error> {
-        let hex_public_key = public_key::get(matches)?;
+        let hex_public_key = common::public_key::get(matches)?;
         let public_key = PublicKey::from_hex(&hex_public_key).map_err(|error| {
             eprintln!("Can't parse {} as a public key: {}", hex_public_key, error);
             Error::FailedToParseKey

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -1,4 +1,9 @@
+use std::fs;
+
 use clap::{Arg, ArgMatches};
+
+use casper_client::Error;
+use casper_types::PublicKey;
 
 pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
@@ -187,5 +192,57 @@ pub mod block_identifier {
 
     pub(crate) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches.value_of(ARG_NAME).unwrap_or_default()
+    }
+}
+
+/// Handles providing the arg for and retrieval of the public key.
+pub mod public_key {
+    use casper_node::crypto::AsymmetricKeyExt;
+    use casper_types::AsymmetricType;
+
+    use super::*;
+
+    const ARG_NAME: &str = "public-key";
+    const ARG_SHORT: &str = "p";
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "This must be a properly formatted public key. The public key may instead be read in from \
+        a file, in which case enter the path to the file as the --public-key argument. The file \
+        should be one of the two public key files generated via the `keygen` subcommand; \
+        \"public_key_hex\" or \"public_key.pem\"";
+
+    pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(true)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub(crate) fn get(matches: &ArgMatches) -> Result<String, Error> {
+        let value = matches
+            .value_of(ARG_NAME)
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
+
+        // Try to read as a PublicKey PEM file first.
+        if let Ok(public_key) = PublicKey::from_file(value) {
+            return Ok(public_key.to_hex());
+        }
+
+        // Try to read as a hex-encoded PublicKey file next.
+        if let Ok(hex_public_key) = fs::read_to_string(value) {
+            let _ = PublicKey::from_hex(&hex_public_key).map_err(|error| {
+                eprintln!(
+                    "Can't parse the contents of {} as a public key: {}",
+                    value, error
+                );
+                Error::FailedToParseKey
+            })?;
+            return Ok(hex_public_key);
+        }
+
+        Ok(value.to_string())
     }
 }

--- a/client/src/get_account_info.rs
+++ b/client/src/get_account_info.rs
@@ -1,9 +1,8 @@
-use std::{fs, str};
+use std::str;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, ArgMatches, SubCommand};
 
 use casper_client::Error;
-use casper_types::PublicKey;
 
 use crate::{command::ClientCommand, common, Success};
 use casper_node::rpcs::state::GetAccountInfo;
@@ -13,60 +12,8 @@ enum DisplayOrder {
     Verbose,
     NodeAddress,
     RpcId,
-    Key,
+    PublicKey,
     BlockIdentifier,
-}
-
-/// Handles providing the arg for and retrieval of the public key.
-mod public_key {
-    use casper_node::crypto::AsymmetricKeyExt;
-    use casper_types::AsymmetricType;
-
-    use super::*;
-
-    const ARG_NAME: &str = "public-key";
-    const ARG_SHORT: &str = "p";
-    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
-    const ARG_HELP: &str =
-        "This must be a properly formatted public key. The public key may instead be read in from \
-        a file, in which case enter the path to the file as the --public-key argument. The file \
-        should be one of the two public key files generated via the `keygen` subcommand; \
-        \"public_key_hex\" or \"public_key.pem\"";
-
-    pub(super) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
-            .long(ARG_NAME)
-            .short(ARG_SHORT)
-            .required(true)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::Key as usize)
-    }
-
-    pub(super) fn get(matches: &ArgMatches) -> Result<String, Error> {
-        let value = matches
-            .value_of(ARG_NAME)
-            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
-
-        // Try to read as a PublicKey PEM file first.
-        if let Ok(public_key) = PublicKey::from_file(value) {
-            return Ok(public_key.to_hex());
-        }
-
-        // Try to read as a hex-encoded PublicKey file next.
-        if let Ok(hex_public_key) = fs::read_to_string(value) {
-            let _ = PublicKey::from_hex(&hex_public_key).map_err(|error| {
-                eprintln!(
-                    "Can't parse the contents of {} as a public key: {}",
-                    value, error
-                );
-                Error::FailedToParseKey
-            })?;
-            return Ok(hex_public_key);
-        }
-
-        Ok(value.to_string())
-    }
 }
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
@@ -82,7 +29,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(public_key::arg())
+            .arg(common::public_key::arg(DisplayOrder::PublicKey as usize))
             .arg(common::block_identifier::arg(
                 DisplayOrder::BlockIdentifier as usize,
             ))
@@ -92,7 +39,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
-        let public_key = public_key::get(matches)?;
+        let public_key = common::public_key::get(matches)?;
         let block_identifier = common::block_identifier::get(matches);
 
         casper_client::get_account_info(

--- a/client/src/get_account_info.rs
+++ b/client/src/get_account_info.rs
@@ -1,0 +1,107 @@
+use std::{fs, str};
+
+use clap::{App, Arg, ArgMatches, SubCommand};
+
+use casper_client::Error;
+use casper_types::PublicKey;
+
+use crate::{command::ClientCommand, common, Success};
+use casper_node::rpcs::state::GetAccountInfo;
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+    Key,
+    BlockIdentifier,
+}
+
+/// Handles providing the arg for and retrieval of the public key.
+mod public_key {
+    use casper_node::crypto::AsymmetricKeyExt;
+    use casper_types::AsymmetricType;
+
+    use super::*;
+
+    const ARG_NAME: &str = "public-key";
+    const ARG_SHORT: &str = "p";
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "This must be a properly formatted public key. The public key may instead be read in from \
+        a file, in which case enter the path to the file as the --public-key argument. The file \
+        should be one of the two public key files generated via the `keygen` subcommand; \
+        \"public_key_hex\" or \"public_key.pem\"";
+
+    pub(super) fn arg() -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(true)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::Key as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> Result<String, Error> {
+        let value = matches
+            .value_of(ARG_NAME)
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
+
+        // Try to read as a PublicKey PEM file first.
+        if let Ok(public_key) = PublicKey::from_file(value) {
+            return Ok(public_key.to_hex());
+        }
+
+        // Try to read as a hex-encoded PublicKey file next.
+        if let Ok(hex_public_key) = fs::read_to_string(value) {
+            let _ = PublicKey::from_hex(&hex_public_key).map_err(|error| {
+                eprintln!(
+                    "Can't parse the contents of {} as a public key: {}",
+                    value, error
+                );
+                Error::FailedToParseKey
+            })?;
+            return Ok(hex_public_key);
+        }
+
+        Ok(value.to_string())
+    }
+}
+
+impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
+    const NAME: &'static str = "get-account-info";
+    const ABOUT: &'static str = "Retrieve account information from the network";
+
+    fn build(display_order: usize) -> App<'a, 'b> {
+        SubCommand::with_name(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(public_key::arg())
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockIdentifier as usize,
+            ))
+    }
+
+    fn run(matches: &ArgMatches<'_>) -> Result<Success, Error> {
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        let public_key = public_key::get(matches)?;
+        let block_identifier = common::block_identifier::get(matches);
+
+        casper_client::get_account_info(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            &public_key,
+            block_identifier,
+        )
+        .map(Success::from)
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -49,13 +49,13 @@ enum DisplayOrder {
     GetStateRootHash,
     QueryState,
     GetBalance,
+    GetAccountInfo,
     GetEraInfo,
     GetAuctionInfo,
     Keygen,
     GenerateCompletion,
     GetRpcs,
     AccountAddress,
-    GetAccountInfo,
 }
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
@@ -75,6 +75,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         ))
         .subcommand(ListDeploys::build(DisplayOrder::ListDeploys as usize))
         .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize))
+        .subcommand(GetAccountInfo::build(DisplayOrder::GetAccountInfo as usize))
         .subcommand(GetStateRootHash::build(
             DisplayOrder::GetStateRootHash as usize,
         ))
@@ -89,7 +90,6 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         ))
         .subcommand(ListRpcs::build(DisplayOrder::GetRpcs as usize))
         .subcommand(AccountAddress::build(DisplayOrder::AccountAddress as usize))
-        .subcommand(GetAccountInfo::build(DisplayOrder::GetAccountInfo as usize))
 }
 
 #[tokio::main]
@@ -107,6 +107,7 @@ async fn main() {
         (GetBlockTransfers::NAME, Some(matches)) => (GetBlockTransfers::run(matches), matches),
         (ListDeploys::NAME, Some(matches)) => (ListDeploys::run(matches), matches),
         (GetBalance::NAME, Some(matches)) => (GetBalance::run(matches), matches),
+        (GetAccountInfo::NAME, Some(matches)) => (GetAccountInfo::run(matches), matches),
         (GetStateRootHash::NAME, Some(matches)) => (GetStateRootHash::run(matches), matches),
         (QueryState::NAME, Some(matches)) => (QueryState::run(matches), matches),
         (GetEraInfoBySwitchBlock::NAME, Some(matches)) => {
@@ -117,7 +118,6 @@ async fn main() {
         (GenerateCompletion::NAME, Some(matches)) => (GenerateCompletion::run(matches), matches),
         (ListRpcs::NAME, Some(matches)) => (ListRpcs::run(matches), matches),
         (AccountAddress::NAME, Some(matches)) => (AccountAddress::run(matches), matches),
-        (GetAccountInfo::NAME, Some(matches)) => (GetAccountInfo::run(matches), matches),
         _ => {
             let _ = cli().print_long_help();
             println!();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,6 +5,7 @@ mod common;
 mod deploy;
 mod docs;
 mod generate_completion;
+mod get_account_info;
 mod get_auction_info;
 mod get_balance;
 mod get_era_info_by_switch_block;
@@ -22,7 +23,7 @@ use casper_node::rpcs::{
     chain::{GetBlock, GetBlockTransfers, GetEraInfoBySwitchBlock, GetStateRootHash},
     docs::ListRpcs,
     info::GetDeploy,
-    state::{GetAuctionInfo, GetBalance, GetItem as QueryState},
+    state::{GetAccountInfo, GetAuctionInfo, GetBalance, GetItem as QueryState},
 };
 
 use account_address::GenerateAccountHash as AccountAddress;
@@ -54,6 +55,7 @@ enum DisplayOrder {
     GenerateCompletion,
     GetRpcs,
     AccountAddress,
+    GetAccountInfo,
 }
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
@@ -87,6 +89,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         ))
         .subcommand(ListRpcs::build(DisplayOrder::GetRpcs as usize))
         .subcommand(AccountAddress::build(DisplayOrder::AccountAddress as usize))
+        .subcommand(GetAccountInfo::build(DisplayOrder::GetAccountInfo as usize))
 }
 
 #[tokio::main]
@@ -114,6 +117,7 @@ async fn main() {
         (GenerateCompletion::NAME, Some(matches)) => (GenerateCompletion::run(matches), matches),
         (ListRpcs::NAME, Some(matches)) => (ListRpcs::run(matches), matches),
         (AccountAddress::NAME, Some(matches)) => (AccountAddress::run(matches), matches),
+        (GetAccountInfo::NAME, Some(matches)) => (GetAccountInfo::run(matches), matches),
         _ => {
             let _ = cli().print_long_help();
             println!();

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -60,6 +60,8 @@ pub(super) async fn run<REv: ReactorEventT>(
         rpcs::chain::GetStateRootHash::create_filter(effect_builder, api_version);
     let rpc_get_item = rpcs::state::GetItem::create_filter(effect_builder, api_version);
     let rpc_get_balance = rpcs::state::GetBalance::create_filter(effect_builder, api_version);
+    let rpc_get_account_info =
+        rpcs::state::GetAccountInfo::create_filter(effect_builder, api_version);
     let rpc_get_deploy = rpcs::info::GetDeploy::create_filter(effect_builder, api_version);
     let rpc_get_peers = rpcs::info::GetPeers::create_filter(effect_builder, api_version);
     let rpc_get_status = rpcs::info::GetStatus::create_filter(effect_builder, api_version);
@@ -99,6 +101,7 @@ pub(super) async fn run<REv: ReactorEventT>(
             .or(rpc_get_status)
             .or(rpc_get_era_info)
             .or(rpc_get_auction_info)
+            .or(rpc_get_account_info)
             .or(rpc_get_rpcs)
             .or(unknown_method)
             .or(parse_failure),

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -46,7 +46,7 @@ enum ErrorCode {
     GetBalanceFailed = -32006,
     GetBalanceFailedToExecute = -32007,
     InvalidDeploy = -32008,
-    GetAccountFailed = -32009,
+    NoSuchAccount = -32009,
 }
 
 #[derive(Debug)]

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -46,6 +46,7 @@ enum ErrorCode {
     GetBalanceFailed = -32006,
     GetBalanceFailedToExecute = -32007,
     InvalidDeploy = -32008,
+    GetAccountFailed = -32009,
 }
 
 #[derive(Debug)]

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -26,7 +26,10 @@ use super::{
     Error, ReactorEventT, RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
     RpcWithoutParamsExt,
 };
-use crate::{effect::EffectBuilder, rpcs::chain::GetEraInfoBySwitchBlock};
+use crate::{
+    effect::EffectBuilder,
+    rpcs::{chain::GetEraInfoBySwitchBlock, state::GetAccountInfo},
+};
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
     ProtocolVersion::from_parts(1, 0, 0);
@@ -69,6 +72,7 @@ pub(crate) static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
 
     schema.push_with_params::<PutDeploy>("receives a Deploy to be executed by the network");
     schema.push_with_params::<GetDeploy>("returns a Deploy from the network");
+    schema.push_with_params::<GetAccountInfo>("returns an Account from the network");
     schema.push_without_params::<GetPeers>("returns a list of peers connected to the node");
     schema.push_without_params::<GetStatus>("returns the current status of the node");
     schema.push_with_optional_params::<GetBlock>("returns a Block from the network");

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -15,7 +15,9 @@ use tracing::info;
 use warp_json_rpc::Builder;
 
 use casper_execution_engine::core::engine_state::{BalanceResult, GetBidsResult};
-use casper_types::{bytesrepr::ToBytes, CLValue, Key, ProtocolVersion, URef, U512};
+use casper_types::{
+    bytesrepr::ToBytes, CLValue, Key, ProtocolVersion, PublicKey, SecretKey, URef, U512,
+};
 
 use super::{
     docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
@@ -32,7 +34,7 @@ use crate::{
         RpcWithOptionalParamsExt,
     },
     types::{
-        json_compatibility::{AuctionState, StoredValue},
+        json_compatibility::{Account, AuctionState, StoredValue},
         Block,
     },
 };
@@ -63,6 +65,19 @@ static GET_AUCTION_INFO_PARAMS: Lazy<GetAuctionInfoParams> = Lazy::new(|| GetAuc
 static GET_AUCTION_INFO_RESULT: Lazy<GetAuctionInfoResult> = Lazy::new(|| GetAuctionInfoResult {
     api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
     auction_state: AuctionState::doc_example().clone(),
+});
+static GET_ACCOUNT_INFO_PARAMS: Lazy<GetAccountInfoParams> = Lazy::new(|| {
+    let secret_key = SecretKey::ed25519_from_bytes([0; 32]).unwrap();
+    let public_key = PublicKey::from(&secret_key);
+    GetAccountInfoParams {
+        public_key,
+        block_identifier: Some(BlockIdentifier::Hash(*Block::doc_example().hash())),
+    }
+});
+static GET_ACCOUNT_INFO_RESULT: Lazy<GetAccountInfoResult> = Lazy::new(|| GetAccountInfoResult {
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
+    account: Account::doc_example().clone(),
+    merkle_proof: MERKLE_PROOF.clone(),
 });
 
 /// Params for "state_get_item" RPC request.
@@ -407,6 +422,135 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
                 api_version,
                 auction_state,
             };
+            Ok(response_builder.success(result)?)
+        }
+        .boxed()
+    }
+}
+
+/// Params for "state_get_account_info" RPC request
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GetAccountInfoParams {
+    /// The public key of the Account.
+    pub public_key: PublicKey,
+    /// The block identifier.
+    pub block_identifier: Option<BlockIdentifier>,
+}
+
+impl DocExample for GetAccountInfoParams {
+    fn doc_example() -> &'static Self {
+        &*GET_ACCOUNT_INFO_PARAMS
+    }
+}
+
+/// Result for "state_get_account_info" RPC response.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GetAccountInfoResult {
+    /// The RPC API version.
+    #[schemars(with = "String")]
+    pub api_version: ProtocolVersion,
+    /// The Account
+    pub account: Account,
+    /// THe merkle proof.
+    pub merkle_proof: String,
+}
+
+impl DocExample for GetAccountInfoResult {
+    fn doc_example() -> &'static Self {
+        &*GET_ACCOUNT_INFO_RESULT
+    }
+}
+
+/// "state_get_account_info" RPC.
+pub struct GetAccountInfo {}
+
+impl RpcWithParams for GetAccountInfo {
+    const METHOD: &'static str = "state_get_account_info";
+    type RequestParams = GetAccountInfoParams;
+    type ResponseResult = GetAccountInfoResult;
+}
+
+impl RpcWithParamsExt for GetAccountInfo {
+    fn handle_request<REv: ReactorEventT>(
+        effect_builder: EffectBuilder<REv>,
+        response_builder: Builder,
+        params: Self::RequestParams,
+        api_version: ProtocolVersion,
+    ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
+        async move {
+            let base_key = {
+                let account_hash = params.public_key.to_account_hash();
+                Key::Account(account_hash)
+            };
+
+            let block: Block = {
+                let maybe_id = params.block_identifier;
+                let maybe_block = effect_builder
+                    .make_request(
+                        |responder| RpcRequest::GetBlock {
+                            maybe_id,
+                            responder,
+                        },
+                        QueueKind::Api,
+                    )
+                    .await;
+
+                match maybe_block {
+                    None => {
+                        let error_msg =
+                            "get-account-info failed to get specified block".to_string();
+                        info!("{}", error_msg);
+                        return Ok(response_builder.error(warp_json_rpc::Error::custom(
+                            ErrorCode::NoSuchBlock as i64,
+                            error_msg,
+                        ))?);
+                    }
+                    Some((block, _)) => block,
+                }
+            };
+
+            // retrieve the global state hash of the block.
+            let state_root_hash = *block.header().state_root_hash();
+
+            let query_result = effect_builder
+                .make_request(
+                    |responder| RpcRequest::QueryGlobalState {
+                        state_root_hash,
+                        base_key,
+                        path: vec![],
+                        responder,
+                    },
+                    QueueKind::Api,
+                )
+                .await;
+
+            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
+                Ok(tuple) => tuple,
+                Err((error_code, error_msg)) => {
+                    info!("{}", error_msg);
+                    return Ok(response_builder
+                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
+                }
+            };
+
+            let account = if let StoredValue::Account(account) = stored_value {
+                account
+            } else {
+                let error_msg = "state_get_account could not retrieve an Account".to_string();
+                return Ok(response_builder.error(warp_json_rpc::Error::custom(
+                    ErrorCode::GetAccountFailed as i64,
+                    error_msg,
+                ))?);
+            };
+
+            let result = Self::ResponseResult {
+                api_version,
+                account,
+                merkle_proof: hex::encode(proof_bytes),
+            };
+
             Ok(response_builder.success(result)?)
         }
         .boxed()

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -451,9 +451,9 @@ pub struct GetAccountInfoResult {
     /// The RPC API version.
     #[schemars(with = "String")]
     pub api_version: ProtocolVersion,
-    /// The Account
+    /// The account.
     pub account: Account,
-    /// THe merkle proof.
+    /// The merkle proof.
     pub merkle_proof: String,
 }
 
@@ -499,8 +499,11 @@ impl RpcWithParamsExt for GetAccountInfo {
 
                 match maybe_block {
                     None => {
-                        let error_msg =
-                            "get-account-info failed to get specified block".to_string();
+                        let error_msg = if maybe_id.is_none() {
+                            "get-account-info failed to get last added block".to_string()
+                        } else {
+                            "get-account-info failed to get specified block".to_string()
+                        };
                         info!("{}", error_msg);
                         return Ok(response_builder.error(warp_json_rpc::Error::custom(
                             ErrorCode::NoSuchBlock as i64,
@@ -511,7 +514,6 @@ impl RpcWithParamsExt for GetAccountInfo {
                 }
             };
 
-            // retrieve the global state hash of the block.
             let state_root_hash = *block.header().state_root_hash();
 
             let query_result = effect_builder
@@ -538,9 +540,9 @@ impl RpcWithParamsExt for GetAccountInfo {
             let account = if let StoredValue::Account(account) = stored_value {
                 account
             } else {
-                let error_msg = "state_get_account could not retrieve an Account".to_string();
+                let error_msg = "get-account-info failed to get specified account".to_string();
                 return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                    ErrorCode::GetAccountFailed as i64,
+                    ErrorCode::NoSuchAccount as i64,
                     error_msg,
                 ))?);
             };

--- a/node/src/types/json_compatibility/account.rs
+++ b/node/src/types/json_compatibility/account.rs
@@ -2,12 +2,37 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use datasize::DataSize;
+use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::types::json_compatibility::vectorize;
+use crate::{rpcs::docs::DocExample, types::json_compatibility::vectorize};
 use casper_execution_engine::shared::account::Account as ExecutionEngineAccount;
-use casper_types::{account::AccountHash, NamedKey, URef};
+use casper_types::{account::AccountHash, NamedKey, PublicKey, SecretKey, URef};
+
+static ACCOUNT: Lazy<Account> = Lazy::new(|| {
+    let main_purse = URef::from_formatted_str(
+        "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+    )
+    .unwrap();
+    let secret_key = SecretKey::ed25519_from_bytes([0; 32]).unwrap();
+    let account_hash = PublicKey::from(&secret_key).to_account_hash();
+    let associated_key = AssociatedKey {
+        account_hash,
+        weight: 1u8,
+    };
+    let action_thresholds = ActionThresholds {
+        deployment: 1u8,
+        key_management: 1u8,
+    };
+    Account {
+        account_hash,
+        named_keys: vec![],
+        main_purse,
+        associated_keys: vec![associated_key],
+        action_thresholds,
+    }
+});
 
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, DataSize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -55,5 +80,11 @@ impl From<&ExecutionEngineAccount> for Account {
                 key_management: ee_account.action_thresholds().key_management().value(),
             },
         }
+    }
+}
+
+impl DocExample for Account {
+    fn doc_example() -> &'static Self {
+        &*ACCOUNT
     }
 }


### PR DESCRIPTION
CHANGELOG:

- Added `get-account-info` command to the client
- Added `state_get_account_info` RPC method to the node which queries `GlobalState` for an `Account`