### PR TITLE
Fix intermittent failure in SSE server test

### DIFF
--- a/node/src/components/event_stream_server/event_indexer.rs
+++ b/node/src/components/event_stream_server/event_indexer.rs
@@ -63,18 +63,18 @@ impl EventIndexer {
 
 impl Drop for EventIndexer {
     fn drop(&mut self) {
-        if let Err(error) = fs::write(&self.persistent_cache, self.index.to_le_bytes()) {
-            warn!(
+        match fs::write(&self.persistent_cache, self.index.to_le_bytes()) {
+            Err(error) => warn!(
                 file = %self.persistent_cache.display(),
                 %error,
                 "failed to write sse cache file"
-            );
+            ),
+            Ok(_) => debug!(
+                file = %self.persistent_cache.display(),
+                index = %self.index,
+                "cached sse index to file"
+            ),
         }
-        debug!(
-            file = %self.persistent_cache.display(),
-            index = %self.index,
-            "cached sse index to file"
-        );
     }
 }
 


### PR DESCRIPTION
This makes the lagging client SSE server test more robust by changing it in a couple of ways:
* the test server now emits up to 100,000,000 events rather than the 100 previously
* the lagging clients now run slower by having a small sleep between reading each chunk of received data from the TCP stream
* the clients also pause for 5 seconds after connecting to the server but before starting to read data, to help ensure the server's TCP send buffer and client's TCP receive buffer are filled

Closes #1560.