### PR TITLE
NDRS-1569: Fix peers metric

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -804,6 +804,9 @@ where
         effect_builder: EffectBuilder<REv>,
         peer_id: NodeId,
     ) -> Effects<Event<P>> {
+        self.net_metrics
+            .peers
+            .set(self.connection_symmetries.len() as i64);
         effect_builder.announce_new_peer(peer_id).ignore()
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -804,9 +804,7 @@ where
         effect_builder: EffectBuilder<REv>,
         peer_id: NodeId,
     ) -> Effects<Event<P>> {
-        self.net_metrics
-            .peers
-            .set(self.connection_symmetries.len() as i64);
+        self.net_metrics.peers.set(self.peers().len() as i64);
         effect_builder.announce_new_peer(peer_id).ignore()
     }
 


### PR DESCRIPTION
Cause for the bug:

- Recent changes to the `small_network` component removed the `peers` member from the component which was used to update the corresponding and the function `update_peers_metric` which did the update

Fix:

- The peers metrics now is set based on the current amount of symmetric connections