### PR TITLE
Fix new_era() arguments mix-up.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -886,8 +886,8 @@ where
             Timestamp::now(), // TODO: This should be passed in.
             next_era_validators_weights.clone(),
             newly_slashed,
-            era_end.inactive_validators.iter().cloned().collect(),
             slashed,
+            era_end.inactive_validators.iter().cloned().collect(),
             seed,
             switch_block_header.timestamp(),
             switch_block_header.height() + 1,


### PR DESCRIPTION
This fixes the root cause of https://github.com/casper-network/casper-node/issues/1558.

To make the tests work reliably we should also set the standstill alert to a value lower than the minimum era duration and the `auction_delay` to 1, though. (See issue comment.)