### PR TITLE
NDRS-1604: Fix EraInfo schema representation

### DIFF
--- a/node/src/components/rpc_server/rpcs/chain/era_summary.rs
+++ b/node/src/components/rpc_server/rpcs/chain/era_summary.rs
@@ -2,14 +2,16 @@ use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use casper_types::{system::auction::EraInfo, AsymmetricType, EraId, PublicKey};
+use casper_types::{
+    system::auction::{EraInfo, SeigniorageAllocation},
+    AsymmetricType, EraId, PublicKey, U512,
+};
 
 use crate::{
     crypto::hash::Digest,
     rpcs::{common::MERKLE_PROOF, docs::DocExample},
     types::{json_compatibility::StoredValue, Block, BlockHash, Item},
 };
-use casper_types::{system::auction::SeigniorageAllocation, U512};
 
 pub(super) static ERA_SUMMARY: Lazy<EraSummary> = Lazy::new(|| {
     let delegator_amount = U512::from(1000);

--- a/node/src/components/rpc_server/rpcs/chain/era_summary.rs
+++ b/node/src/components/rpc_server/rpcs/chain/era_summary.rs
@@ -2,20 +2,44 @@ use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use casper_types::{system::auction::EraInfo, EraId};
+use casper_types::{system::auction::EraInfo, AsymmetricType, EraId, PublicKey};
 
 use crate::{
     crypto::hash::Digest,
     rpcs::{common::MERKLE_PROOF, docs::DocExample},
     types::{json_compatibility::StoredValue, Block, BlockHash, Item},
 };
+use casper_types::{system::auction::SeigniorageAllocation, U512};
 
-pub(super) static ERA_SUMMARY: Lazy<EraSummary> = Lazy::new(|| EraSummary {
-    block_hash: Block::doc_example().id(),
-    era_id: EraId::from(42),
-    stored_value: StoredValue::EraInfo(EraInfo::new()),
-    state_root_hash: *Block::doc_example().header().state_root_hash(),
-    merkle_proof: MERKLE_PROOF.clone(),
+pub(super) static ERA_SUMMARY: Lazy<EraSummary> = Lazy::new(|| {
+    let delegator_amount = U512::from(1000);
+    let validator_amount = U512::from(2000);
+    let delegator_public_key =
+        PublicKey::from_hex("01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18")
+            .unwrap();
+    let validator_public_key =
+        PublicKey::from_hex("012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876")
+            .unwrap();
+    let delegator = SeigniorageAllocation::delegator(
+        delegator_public_key,
+        validator_public_key,
+        delegator_amount,
+    );
+    let validator = SeigniorageAllocation::validator(
+        PublicKey::from_hex("012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876")
+            .unwrap(),
+        validator_amount,
+    );
+    let seigniorage_allocations = vec![delegator, validator];
+    let mut era_info = EraInfo::new();
+    *era_info.seigniorage_allocations_mut() = seigniorage_allocations;
+    EraSummary {
+        block_hash: Block::doc_example().id(),
+        era_id: EraId::from(42),
+        stored_value: StoredValue::EraInfo(era_info),
+        state_root_hash: *Block::doc_example().header().state_root_hash(),
+        merkle_proof: MERKLE_PROOF.clone(),
+    }
 });
 
 /// The summary of an era


### PR DESCRIPTION
This relates to [Issue 1604](https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1604)

CHANGELOG:

- Fix the `seigniorage_allocations` which was previously empty by adding a `Delegator` and `Validator` to the era_summary

PS: @mpapierski could you please look at the output (attached to the PR) to see if the example provided is glaringly incorrect
![Screenshot from 2021-06-15 16-27-45](https://user-images.githubusercontent.com/42871449/122125916-a6dbbe80-cdf6-11eb-8a56-2fa330f2a58f.png)
