### PR TITLE
Mark known faulty validators when initializing eras.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -371,7 +371,7 @@ where
         for e_id in self.iter_past_other(era_id, self.bonded_eras()) {
             if let Some(old_era) = self.active_eras.get_mut(&e_id) {
                 for pub_key in old_era.consensus.validators_with_evidence() {
-                    let proposed_blocks = era.resolve_evidence(&pub_key);
+                    let proposed_blocks = era.resolve_evidence_and_mark_faulty(&pub_key);
                     if !proposed_blocks.is_empty() {
                         error!(
                             ?proposed_blocks,
@@ -1190,7 +1190,7 @@ where
                 {
                     let proposed_blocks =
                         if let Some(era) = self.era_supervisor.active_eras.get_mut(&e_id) {
-                            era.resolve_evidence(&pub_key)
+                            era.resolve_evidence_and_mark_faulty(&pub_key)
                         } else {
                             continue;
                         };

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -425,12 +425,6 @@ where
         self.active_eras.get(&era_id).map_or(false, has_validator)
     }
 
-    /// Returns the most recent active era.
-    #[cfg(test)]
-    pub(crate) fn current_era(&self) -> EraId {
-        self.current_era
-    }
-
     pub(crate) fn stop_for_upgrade(&self) -> bool {
         self.stop_for_upgrade
     }
@@ -577,6 +571,24 @@ where
             instance_id,
             self.public_signing_key.to_hex()
         ))
+    }
+}
+
+#[cfg(test)]
+impl<I> EraSupervisor<I>
+where
+    I: NodeIdT,
+{
+    /// Returns the most recent active era.
+    pub(crate) fn current_era(&self) -> EraId {
+        self.current_era
+    }
+
+    /// Returns the list of validators who equivocated in this era.
+    pub(crate) fn validators_with_evidence(&self, era_id: EraId) -> Vec<&PublicKey> {
+        self.active_eras[&era_id]
+            .consensus
+            .validators_with_evidence()
     }
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -67,7 +67,7 @@ const FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS: u64 = 60 * 1000;
 type ConsensusConstructor<I> = dyn Fn(
     Digest,                                       // the era's unique instance ID
     BTreeMap<PublicKey, U512>,                    // validator weights
-    &HashSet<PublicKey>,                          // slashed validators that are banned in this era
+    &HashSet<PublicKey>,                          // faulty validators that are banned in this era
     &HashSet<PublicKey>,                          // inactive validators that can't be leaders
     &ProtocolConfig,                              // the network's chainspec
     &Config,                                      // The consensus part of the node config.
@@ -287,8 +287,8 @@ where
         era_id: EraId,
         now: Timestamp,
         validators: BTreeMap<PublicKey, U512>,
-        newly_slashed: Vec<PublicKey>,
-        slashed: HashSet<PublicKey>,
+        new_faulty: Vec<PublicKey>,
+        faulty: HashSet<PublicKey>,
         inactive: HashSet<PublicKey>,
         seed: u64,
         start_time: Timestamp,
@@ -338,7 +338,7 @@ where
         let (mut consensus, mut outcomes) = (self.new_consensus)(
             instance_id,
             validators.clone(),
-            &slashed,
+            &faulty,
             &inactive,
             &self.protocol_config,
             &self.config,
@@ -362,15 +362,15 @@ where
             consensus,
             start_time,
             start_height,
-            newly_slashed,
-            slashed,
+            new_faulty,
+            faulty,
             validators,
         );
         let _ = self.active_eras.insert(era_id, era);
         let oldest_bonded_era_id = oldest_bonded_era(&self.protocol_config, era_id);
         // Clear the obsolete data from the era whose validators are unbonded now. We only retain
         // the information necessary to validate evidence that units in still-bonded eras may refer
-        // to for cross-era slashing.
+        // to for cross-era fault tracking.
         if let Some(evidence_only_era_id) = oldest_bonded_era_id.checked_sub(1) {
             trace!(era = evidence_only_era_id.value(), "clearing unbonded era");
             if let Some(era) = self.active_eras.get_mut(&evidence_only_era_id) {
@@ -451,7 +451,7 @@ where
         let mut result_map = HashMap::new();
 
         for era_id in self.iter_past(self.current_era, self.bonded_eras().saturating_mul(2)) {
-            let newly_slashed;
+            let new_faulty;
             let validators;
             let start_height;
             let era_start_time;
@@ -463,7 +463,7 @@ where
 
             #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
             if era_id.is_genesis() {
-                newly_slashed = vec![];
+                new_faulty = vec![];
                 // The validator set was read from the global state: there's no key block for era 0.
                 validators = activation_era_validators.clone();
                 start_height = 0;
@@ -479,15 +479,15 @@ where
                 era_start_time = key_block.timestamp();
                 seed = Self::era_seed(*booking_block_hash, key_block.accumulated_seed());
                 if era_id == self.protocol_config.last_activation_point {
-                    // After an upgrade or emergency restart, we don't do cross-era slashing.
-                    newly_slashed = vec![];
+                    // After an upgrade or emergency restart, we don't track faults cross-era.
+                    new_faulty = vec![];
                     // And we read the validator sets from the global state, because the key block
                     // might have been overwritten by the upgrade/restart.
                     validators = activation_era_validators.clone();
                 } else {
                     // If it's neither genesis nor upgrade nor restart, we use the validators from
-                    // the key block and ban validators that were slashed in previous eras.
-                    newly_slashed = key_block
+                    // the key block and ban validators that were faulty in previous eras.
+                    new_faulty = key_block
                         .era_end()
                         .expect("key block must be a switch block")
                         .equivocators
@@ -499,7 +499,7 @@ where
                 }
             }
 
-            let slashed = self
+            let faulty = self
                 .iter_past(era_id, self.banning_period())
                 .filter_map(|old_id| key_blocks.get(&old_id).and_then(|bhdr| bhdr.era_end()))
                 .flat_map(|era_end| era_end.equivocators.clone())
@@ -509,8 +509,8 @@ where
                 era_id,
                 Timestamp::now(),
                 validators,
-                newly_slashed,
-                slashed,
+                new_faulty,
+                faulty,
                 key_blocks
                     .get(&era_id)
                     .and_then(|bhdr| bhdr.era_end())
@@ -865,7 +865,7 @@ where
                 .ignore()
             }
         };
-        let newly_slashed = era_end.equivocators.clone();
+        let new_faulty = era_end.equivocators.clone();
         let era_id = switch_block_header.era_id().successor();
         info!(era = era_id.value(), "era created");
         let seed = EraSupervisor::<I>::era_seed(
@@ -873,11 +873,11 @@ where
             switch_block_header.accumulated_seed(),
         );
         trace!(%seed, "the seed for {}: {}", era_id, seed);
-        let slashed = self
+        let faulty = self
             .era_supervisor
             .iter_past_other(era_id, self.era_supervisor.banning_period())
-            .flat_map(|e_id| &self.era_supervisor.active_eras[&e_id].newly_slashed)
-            .chain(&newly_slashed)
+            .flat_map(|e_id| &self.era_supervisor.active_eras[&e_id].new_faulty)
+            .chain(&new_faulty)
             .cloned()
             .collect();
         #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
@@ -885,8 +885,8 @@ where
             era_id,
             Timestamp::now(), // TODO: This should be passed in.
             next_era_validators_weights.clone(),
-            newly_slashed,
-            slashed,
+            new_faulty,
+            faulty,
             era_end.inactive_validators.iter().cloned().collect(),
             seed,
             switch_block_header.timestamp(),
@@ -1016,7 +1016,7 @@ where
                     .iter_past(era_id, self.era_supervisor.bonded_eras())
                     .flat_map(|e_id| self.era(e_id).consensus.validators_with_evidence())
                     .unique()
-                    .filter(|pub_key| !self.era(era_id).slashed.contains(pub_key))
+                    .filter(|pub_key| !self.era(era_id).faulty.contains(pub_key))
                     .cloned()
                     .collect();
                 self.effect_builder
@@ -1050,12 +1050,12 @@ where
                 era.add_accusations(&equivocators);
                 era.add_accusations(value.accusations());
                 // If this is the era's last block, it contains rewards. Everyone who is accused in
-                // the block or seen as equivocating via the consensus protocol gets slashed.
+                // the block or seen as equivocating via the consensus protocol gets faulty.
                 let era_end = terminal_block_data.map(|tbd| EraReport {
                     rewards: tbd.rewards,
-                    // TODO: In the first 90 days we don't slash, and we just report all
-                    // equivocators as "inactive" instead. Change this back 90 days after launch,
-                    // and put era.accusations() into equivocators instead of inactive_validators.
+                    // TODO: This is a temporary change to disable slashing; we just report all
+                    // equivocators as "inactive" instead. Change this back and put
+                    // era.accusations() into equivocators instead of inactive_validators.
                     equivocators: vec![],
                     inactive_validators: tbd
                         .inactive_validators

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -55,12 +55,12 @@ pub struct Era<I> {
     pub(crate) start_height: u64,
     /// Pending blocks, waiting for validation and dependencies.
     validation_states: HashMap<ProposedBlock<ClContext>, ValidationState>,
-    /// Validators banned in this and the next BONDED_ERAS eras, because they were slashed in the
+    /// Validators banned in this and the next BONDED_ERAS eras, because they were faulty in the
     /// previous switch block.
-    pub(crate) newly_slashed: Vec<PublicKey>,
-    /// Validators that have been slashed in any of the recent BONDED_ERAS switch blocks. This
-    /// includes `newly_slashed`.
-    pub(crate) slashed: HashSet<PublicKey>,
+    pub(crate) new_faulty: Vec<PublicKey>,
+    /// Validators that have been faulty in any of the recent BONDED_ERAS switch blocks. This
+    /// includes `new_faulty`.
+    pub(crate) faulty: HashSet<PublicKey>,
     /// Accusations collected in this era so far.
     accusations: HashSet<PublicKey>,
     /// The validator weights.
@@ -72,8 +72,8 @@ impl<I> Era<I> {
         consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
         start_time: Timestamp,
         start_height: u64,
-        newly_slashed: Vec<PublicKey>,
-        slashed: HashSet<PublicKey>,
+        new_faulty: Vec<PublicKey>,
+        faulty: HashSet<PublicKey>,
         validators: BTreeMap<PublicKey, U512>,
     ) -> Self {
         Era {
@@ -81,8 +81,8 @@ impl<I> Era<I> {
             start_time,
             start_height,
             validation_states: HashMap::new(),
-            newly_slashed,
-            slashed,
+            new_faulty,
+            faulty,
             accusations: HashSet::new(),
             validators,
         }
@@ -141,7 +141,7 @@ impl<I> Era<I> {
     /// Adds new accusations from a finalized block.
     pub(crate) fn add_accusations(&mut self, accusations: &[PublicKey]) {
         for pub_key in accusations {
-            if !self.slashed.contains(pub_key) {
+            if !self.faulty.contains(pub_key) {
                 self.accusations.insert(pub_key.clone());
             }
         }
@@ -179,8 +179,8 @@ where
             start_time,
             start_height,
             validation_states,
-            newly_slashed,
-            slashed,
+            new_faulty,
+            faulty,
             accusations,
             validators,
         } = self;
@@ -215,8 +215,8 @@ where
             .saturating_add(start_time.estimate_heap_size())
             .saturating_add(start_height.estimate_heap_size())
             .saturating_add(validation_states.estimate_heap_size())
-            .saturating_add(newly_slashed.estimate_heap_size())
-            .saturating_add(slashed.estimate_heap_size())
+            .saturating_add(new_faulty.estimate_heap_size())
+            .saturating_add(faulty.estimate_heap_size())
             .saturating_add(accusations.estimate_heap_size())
             .saturating_add(validators.estimate_heap_size())
     }

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -100,7 +100,7 @@ impl<I> Era<I> {
 
     /// Marks the dependencies of blocks on evidence against validator `pub_key` as resolved and
     /// returns all valid blocks that have no missing dependencies left.
-    pub(crate) fn resolve_evidence(
+    pub(crate) fn resolve_evidence_and_mark_faulty(
         &mut self,
         pub_key: &PublicKey,
     ) -> Vec<ProposedBlock<ClContext>> {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -46,7 +46,7 @@ use tallies::Tallies;
 
 // TODO: The restart mechanism only persists and loads our own latest unit, so that we don't
 // equivocate after a restart. It doesn't yet persist our latest endorsed units, so we could
-// accidentally endorse conflicting votes. Fix this and enable slashing for conflicting
+// accidentally endorse conflicting votes. Fix this and enable detecting conflicting
 // endorsements again.
 pub(super) const TODO_ENDORSEMENT_EVIDENCE_DISABLED: bool = true;
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -58,7 +58,7 @@ const STANDSTILL_TIMEOUT: &str = "1min";
 
 pub(crate) fn new_test_highway_protocol<I1, I2, T>(
     weights: I1,
-    init_slashed: I2,
+    init_faulty: I2,
 ) -> Box<dyn ConsensusProtocol<NodeId, ClContext>>
 where
     I1: IntoIterator<Item = (PublicKey, T)>,
@@ -85,7 +85,7 @@ where
     let (hw_proto, outcomes) = HighwayProtocol::<NodeId, ClContext>::new_boxed(
         ClContext::hash(INSTANCE_ID_DATA),
         weights.into_iter().collect(),
-        &init_slashed.into_iter().collect(),
+        &init_faulty.into_iter().collect(),
         &None.into_iter().collect(),
         &(&chainspec).into(),
         &config,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -367,6 +367,7 @@ impl Reactor {
     pub(crate) fn consensus(&self) -> &EraSupervisor<NodeId> {
         &self.consensus
     }
+
     /// Inspect storage.
     pub(crate) fn storage(&self) -> &Storage {
         &self.storage

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -207,6 +207,7 @@ async fn run_equivocator_network() {
     let mut rng = crate::new_rng();
 
     let alice_sk = Arc::new(SecretKey::random(&mut rng));
+    let alice_pk = PublicKey::from(&*alice_sk);
     let size: usize = 2;
     let mut keys: Vec<Arc<SecretKey>> = (1..size)
         .map(|_| Arc::new(SecretKey::random(&mut rng)))
@@ -227,27 +228,73 @@ async fn run_equivocator_network() {
         .await
         .expect("network initialization failed");
 
-    info!("Waiting for Era 0 to end");
-    net.settle_on(
-        &mut rng,
-        is_in_era(EraId::from(1)),
-        Duration::from_secs(600),
-    )
-    .await;
-
-    let last_era_number = 5;
     let timeout = Duration::from_secs(90);
 
-    for era_number in 2..last_era_number {
-        info!("Waiting for Era {} to end", era_number);
-        net.settle_on(&mut rng, is_in_era(EraId::from(era_number)), timeout)
-            .await;
+    let mut switch_blocks = Vec::new();
+    for era_number in 1.. {
+        let era_id = EraId::from(era_number);
+        info!("Waiting for Era {} to begin", era_number);
+        net.settle_on(&mut rng, is_in_era(era_id), timeout).await;
+
+        // Collect new switch block headers.
+        for runner in net.nodes().values() {
+            let storage = runner.reactor().inner().storage();
+            let header = storage
+                .transactional_get_switch_block_by_era_id(era_number - 1)
+                .expect("missing switch block")
+                .take_header();
+            assert_eq!(era_number - 1, header.era_id().value());
+            if let Some(other_header) = switch_blocks.get(era_number as usize - 1) {
+                assert_eq!(other_header, &header);
+            } else {
+                switch_blocks.push(header);
+            }
+        }
+
+        // Make sure we waited long enough for this test to include unbonding and dropping eras.
+        let oldest_bonded_era_id = consensus::oldest_bonded_era(&protocol_config, era_id);
+        let oldest_evidence_era_id =
+            consensus::oldest_bonded_era(&protocol_config, oldest_bonded_era_id);
+        if oldest_evidence_era_id.is_genesis() || era_number < 3 {
+            continue;
+        }
+
+        // Wait at least two more eras after the equivocation has been detected.
+        let era_end = switch_blocks[era_number as usize - 3]
+            .era_end()
+            .expect("missing era end");
+        if *era_end.inactive_validators == [alice_pk.clone()] {
+            break;
+        }
     }
 
-    // Make sure we waited long enough for this test to include unbonding and dropping eras.
-    let oldest_bonded_era_id =
-        consensus::oldest_bonded_era(&protocol_config, EraId::from(last_era_number));
-    let oldest_evidence_era_id =
-        consensus::oldest_bonded_era(&protocol_config, oldest_bonded_era_id);
-    assert!(!oldest_evidence_era_id.is_genesis());
+    // The auction delay is 1, so if Alice's equivocation was detected before the switch block in
+    // era N, the switch block of era N should list her as faulty. Starting with the switch block
+    // in era N + 1, she should be removed from the validator set, because she gets evicted in era
+    // N + 2.
+    // No era after N should have direct evidence against her: she got marked as faulty when era
+    // N + 1 was initialized, so no other validator will cite her or process her units.
+    loop {
+        let header = switch_blocks.pop().expect("missing switch block");
+        let validators = header
+            .next_era_validator_weights()
+            .expect("missing validator weights");
+        if validators.contains_key(&alice_pk) {
+            // We've found era N: This is the last switch block that still lists Alice as a
+            // validator.
+            let era_end = header.era_end().expect("missing era end");
+            assert_eq!(*era_end.inactive_validators, [alice_pk.clone()]);
+            return;
+        } else {
+            // We are in era N + 1 or later. There should be no direct evidence; that would mean
+            // Alice equivocated twice.
+            for runner in net.nodes().values() {
+                let consensus = runner.reactor().inner().consensus();
+                assert_eq!(
+                    consensus.validators_with_evidence(header.era_id()),
+                    Vec::<&PublicKey>::new()
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
If someone equivocates in an old era N, we also mark them as faulty in era N + 1, N + 2, etc. (up to `unbonding_delay - auction_delay`). However, if the equivocation was detected _before_ era N + 1 was initialized, we failed to mark them as faulty in era N + 1 on initialization. This PR fixes that:

Now, when initializing a new era, we immediately mark everyone as faulty against whom we have evidence in a recent era. Since the synchronizer ignores faulty validators' units, unless cited by a non-faulty one, this means you can't effectively equivocate two eras in a row.

I also renamed all "slashing" references in consensus, since there are no plans to enable slashing, and that isn't strictly a consensus question anyway.

Closes #1516.