### PR TITLE
NDRS-1617: Resolve doc warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)
 
 doc-stable/%: CARGO_TOOLCHAIN += +stable
 doc-stable/%:
-	$(CARGO) doc $(CARGO_FLAGS) --manifest-path "$*/Cargo.toml" --no-deps
+	RUSTDOCFLAGS="-D warnings" $(CARGO) doc $(CARGO_FLAGS) --manifest-path "$*/Cargo.toml" --no-deps
 
 .PHONY: check-rs
 check-rs: \

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -717,7 +717,7 @@ extern "C" {
     /// The bytes in wasm memory from offset `key_ptr` to `key_ptr + key_size`
     /// will be used together with the current context’s seed to form a dictionary.
     /// The value at that dictionary is read from the global state, serialized and
-    /// buffered in the runtime. This result can be obtained via the [`read_host_buffer`]
+    /// buffered in the runtime. This result can be obtained via the \[`read_host_buffer`]\
     /// function.
     ///
     /// # Arguments

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -717,7 +717,7 @@ extern "C" {
     /// The bytes in wasm memory from offset `key_ptr` to `key_ptr + key_size`
     /// will be used together with the current context’s seed to form a dictionary.
     /// The value at that dictionary is read from the global state, serialized and
-    /// buffered in the runtime. This result can be obtained via the \[`read_host_buffer`]\
+    /// buffered in the runtime. This result can be obtained via the \[`casper_read_host_buffer`]\
     /// function.
     ///
     /// # Arguments

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -345,7 +345,7 @@ impl Key {
         }
     }
 
-    /// Returns a reference to the inner [`DictionaryAddr`] if `self` is of type
+    /// Returns a reference to the inner `DictionaryAddr` if `self` is of type
     /// [`Key::Dictionary`], otherwise returns `None`.
     pub fn as_dictionary(&self) -> Option<&DictionaryAddr> {
         match self {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -65,7 +65,7 @@ const KEY_DICTIONARY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_D
 /// An alias for [`Key`]s hash variant.
 pub type HashAddr = [u8; KEY_HASH_LENGTH];
 
-/// A newtype for [`Key`]s dictionary variant.
+/// An alias for [`Key`]s dictionary variant.
 pub type DictionaryAddr = [u8; KEY_DICTIONARY_LENGTH];
 
 #[allow(missing_docs)]
@@ -345,7 +345,7 @@ impl Key {
         }
     }
 
-    /// Returns a reference to the inner `DictionaryAddr` if `self` is of type
+    /// Returns a reference to the inner [`DictionaryAddr`] if `self` is of type
     /// [`Key::Dictionary`], otherwise returns `None`.
     pub fn as_dictionary(&self) -> Option<&DictionaryAddr> {
         match self {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -47,7 +47,7 @@ pub const KEY_HASH_LENGTH: usize = 32;
 pub const KEY_TRANSFER_LENGTH: usize = TRANSFER_ADDR_LENGTH;
 /// The number of bytes in a [`Key::DeployInfo`].
 pub const KEY_DEPLOY_INFO_LENGTH: usize = DEPLOY_HASH_LENGTH;
-/// The number of bytes in a [`Key::Local`].
+/// The number of bytes in a [`Key::Dictionary`].
 pub const KEY_DICTIONARY_LENGTH: usize = 32;
 
 const KEY_ID_SERIALIZED_LENGTH: usize = 1;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -71,7 +71,10 @@ pub use execution_result::{
 };
 pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
-pub use key::{HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH};
+pub use key::{
+    DictionaryAddr, HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH, KEY_DICTIONARY_LENGTH,
+    KEY_HASH_LENGTH,
+};
 pub use named_key::NamedKey;
 pub use phase::{Phase, PHASE_SERIALIZED_LENGTH};
 pub use protocol_version::{ProtocolVersion, VersionCheckResult};

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     /// Destination purse not found.
     #[cfg_attr(feature = "std", error("Destination not found"))]
     DestNotFound = 2,
-    /// See `PurseError::InvalidURef`.
+    /// Errors relating to validity of source or destination purses.
     #[cfg_attr(feature = "std", error("Invalid URef"))]
     InvalidURef = 3,
     /// See `PurseError::InvalidAccessRights`.

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -25,10 +25,10 @@ pub enum Error {
     /// Destination purse not found.
     #[cfg_attr(feature = "std", error("Destination not found"))]
     DestNotFound = 2,
-    /// See [`PurseError::InvalidURef`].
+    /// See `PurseError::InvalidURef`.
     #[cfg_attr(feature = "std", error("Invalid URef"))]
     InvalidURef = 3,
-    /// See [`PurseError::InvalidAccessRights`].
+    /// See `PurseError::InvalidAccessRights`.
     #[cfg_attr(feature = "std", error("Invalid AccessRights"))]
     InvalidAccessRights = 4,
     /// Tried to create a new purse with a non-zero initial balance.


### PR DESCRIPTION
CHANGELOG:

- Added `RUSTDOCFLAGS="-D warnings"` to the `Makefile` causing doc warnings to escalated to errors instead
- Resolve resulting errors in both `node` and `types` 