### PR TITLE
Make / Put Deploy Should Handle Transfers

### DIFF
--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -785,6 +785,7 @@ pub struct casper_session_params_t {
     session_args_complex: *const c_char,
     session_version: *const c_char,
     session_entry_point: *const c_char,
+    session_transfer: bool,
 }
 
 impl TryInto<super::SessionStrParams<'static>> for casper_session_params_t {
@@ -832,6 +833,7 @@ impl TryInto<super::SessionStrParams<'static>> for casper_session_params_t {
             session_args_complex,
             session_version,
             session_entry_point,
+            session_transfer: self.session_transfer,
         })
     }
 }

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -785,7 +785,7 @@ pub struct casper_session_params_t {
     session_args_complex: *const c_char,
     session_version: *const c_char,
     session_entry_point: *const c_char,
-    session_transfer: bool,
+    is_session_transfer: bool,
 }
 
 impl TryInto<super::SessionStrParams<'static>> for casper_session_params_t {
@@ -833,7 +833,7 @@ impl TryInto<super::SessionStrParams<'static>> for casper_session_params_t {
             session_args_complex,
             session_version,
             session_entry_point,
-            session_transfer: self.session_transfer,
+            is_session_transfer: self.is_session_transfer,
         })
     }
 }

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -786,6 +786,7 @@ impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
             session_args_complex,
             session_version,
             session_entry_point,
+            session_transfer,
         } = self;
 
         parsing::parse_session_info(
@@ -798,6 +799,7 @@ impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
             session_args_complex,
             session_version,
             session_entry_point,
+            session_transfer,
         )
     }
 }
@@ -833,6 +835,7 @@ pub struct SessionStrParams<'a> {
     session_args_complex: &'a str,
     session_version: &'a str,
     session_entry_point: &'a str,
+    session_transfer: bool,
 }
 
 impl<'a> SessionStrParams<'a> {
@@ -946,6 +949,15 @@ impl<'a> SessionStrParams<'a> {
             session_package_hash,
             session_version,
             session_entry_point,
+            session_args_simple,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_transfer(session_args_simple: Vec<&'a str>, session_args_complex: &'a str) -> Self {
+        Self {
+            session_transfer: true,
             session_args_simple,
             session_args_complex,
             ..Default::default()

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -786,7 +786,7 @@ impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
             session_args_complex,
             session_version,
             session_entry_point,
-            session_transfer,
+            is_session_transfer,
         } = self;
 
         parsing::parse_session_info(
@@ -799,7 +799,7 @@ impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
             session_args_complex,
             session_version,
             session_entry_point,
-            session_transfer,
+            is_session_transfer,
         )
     }
 }
@@ -835,7 +835,7 @@ pub struct SessionStrParams<'a> {
     session_args_complex: &'a str,
     session_version: &'a str,
     session_entry_point: &'a str,
-    session_transfer: bool,
+    is_session_transfer: bool,
 }
 
 impl<'a> SessionStrParams<'a> {
@@ -961,7 +961,7 @@ impl<'a> SessionStrParams<'a> {
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_transfer(session_args_simple: Vec<&'a str>, session_args_complex: &'a str) -> Self {
         Self {
-            session_transfer: true,
+            is_session_transfer: true,
             session_args_simple,
             session_args_complex,
             ..Default::default()

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -955,6 +955,9 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
+    /// Constructs a `SessionStrParams` with its `session_transfer` field set to `true`.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_transfer(session_args_simple: Vec<&'a str>, session_args_complex: &'a str) -> Self {
         Self {
             session_transfer: true,

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -955,7 +955,8 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
-    /// Constructs a `SessionStrParams` with its `session_transfer` field set to `true`.
+    /// Constructs a `SessionStrParams` representing a `Transfer` type of `Deploy`.
+    ///
     /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_transfer(session_args_simple: Vec<&'a str>, session_args_complex: &'a str) -> Self {

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -403,7 +403,7 @@ pub(super) fn parse_session_info(
         if session_args.is_empty() {
             return Err(Error::InvalidArgument(
                 "session_transfer",
-                format!("requires --session-arg to be present"),
+                "requires --session-arg to be present".to_string(),
             ));
         }
         return Ok(ExecutableDeployItem::Transfer { args: session_args });
@@ -1200,6 +1200,7 @@ mod tests {
                 // package_name
                 // package_name + session_version is optional and allowed
                 test[session_package_name => happy::PACKAGE_NAME, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_package_hash]
+                test[session_package_name => happy::VERSION, conflict: session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_transfer]
                 // package_name <-> hash is already checked
                 // package_name <-> name is already checked
                 // package_name <-> path is already checked

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -368,10 +368,10 @@ pub(super) fn parse_session_info(
     session_args_complex: &str,
     session_version: &str,
     session_entry_point: &str,
-    session_transfer: bool,
+    is_session_transfer: bool,
 ) -> Result<ExecutableDeployItem> {
     // This is to make sure that we're using &str consistently in the macro call below.
-    let session_transfer_str = if session_transfer { "true" } else { "" };
+    let session_transfer = if is_session_transfer { "true" } else { "" };
 
     check_exactly_one_not_empty!(
         context: "parse_session_info",
@@ -385,7 +385,7 @@ pub(super) fn parse_session_info(
             requires[session_entry_point] requires_empty[],
         (session_path)
             requires[] requires_empty[session_entry_point, session_version],
-        (session_transfer_str)
+        (session_transfer)
             requires[] requires_empty[session_entry_point, session_version]
     );
     if !session_args.is_empty() && !session_args_complex.is_empty() {
@@ -399,7 +399,7 @@ pub(super) fn parse_session_info(
         arg_simple::session::parse(session_args)?,
         args_complex::session::parse(session_args_complex).ok(),
     );
-    if session_transfer {
+    if is_session_transfer {
         if session_args.is_empty() {
             return Err(Error::InvalidArgument(
                 "session_transfer",

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -368,10 +368,10 @@ pub(super) fn parse_session_info(
     session_args_complex: &str,
     session_version: &str,
     session_entry_point: &str,
-    is_session_transfer: bool,
+    session_transfer: bool,
 ) -> Result<ExecutableDeployItem> {
     // This is to make sure that we're using &str consistently in the macro call below.
-    let session_transfer = if is_session_transfer { "true" } else { "" };
+    let is_session_transfer = if session_transfer { "true" } else { "" };
 
     check_exactly_one_not_empty!(
         context: "parse_session_info",
@@ -385,7 +385,7 @@ pub(super) fn parse_session_info(
             requires[session_entry_point] requires_empty[],
         (session_path)
             requires[] requires_empty[session_entry_point, session_version],
-        (session_transfer)
+        (is_session_transfer)
             requires[] requires_empty[session_entry_point, session_version]
     );
     if !session_args.is_empty() && !session_args_complex.is_empty() {
@@ -399,10 +399,10 @@ pub(super) fn parse_session_info(
         arg_simple::session::parse(session_args)?,
         args_complex::session::parse(session_args_complex).ok(),
     );
-    if is_session_transfer {
+    if session_transfer {
         if session_args.is_empty() {
             return Err(Error::InvalidArgument(
-                "session_transfer",
+                "is_session_transfer",
                 "requires --session-arg to be present".to_string(),
             ));
         }
@@ -1180,33 +1180,34 @@ mod tests {
                 test[session_path => happy::PATH, conflict: session_name =>         happy::HASH,         requires[], path_conflicts_with_name]
                 test[session_path => happy::PATH, conflict: session_version =>      happy::VERSION,      requires[], path_conflicts_with_version]
                 test[session_path => happy::PATH, conflict: session_entry_point =>  happy::ENTRY_POINT,  requires[], path_conflicts_with_entry_point]
-                test[session_path => happy::PATH, conflict: session_transfer =>     happy::TRANSFER,     requires[], path_conflicts_with_transfer]
+                test[session_path => happy::PATH, conflict: is_session_transfer =>     happy::TRANSFER,     requires[], path_conflicts_with_transfer]
 
                 // name
                 test[session_name => happy::NAME, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_hash]
                 test[session_name => happy::NAME, conflict: session_package_name => happy::PACKAGE_NAME, requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_name]
                 test[session_name => happy::NAME, conflict: session_hash =>         happy::HASH,         requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_hash]
                 test[session_name => happy::NAME, conflict: session_version =>      happy::VERSION,      requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_version]
-                test[session_name => happy::NAME, conflict: session_transfer =>     happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_transfer]
+                test[session_name => happy::NAME, conflict: is_session_transfer =>     happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_transfer]
 
                 // hash
                 test[session_hash => happy::HASH, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_hash]
                 test[session_hash => happy::HASH, conflict: session_package_name => happy::PACKAGE_NAME, requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_name]
                 test[session_hash => happy::HASH, conflict: session_version =>      happy::VERSION,      requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_version]
-                test[session_hash => happy::HASH, conflict: session_transfer =>     happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_transfer]
+                test[session_hash => happy::HASH, conflict: is_session_transfer =>     happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_transfer]
                 // name <-> hash is already checked
                 // name <-> path is already checked
 
                 // package_name
                 // package_name + session_version is optional and allowed
                 test[session_package_name => happy::PACKAGE_NAME, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_package_hash]
-                test[session_package_name => happy::VERSION, conflict: session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_transfer]
+                test[session_package_name => happy::VERSION, conflict: is_session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_transfer]
                 // package_name <-> hash is already checked
                 // package_name <-> name is already checked
                 // package_name <-> path is already checked
 
                 // package_hash
                 // package_hash + session_version is optional and allowed
+                test[session_package_hash => happy::PACKAGE_HASH, conflict: is_session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_hash_conflicts_with_transfer]
                 // package_hash <-> package_name is already checked
                 // package_hash <-> hash is already checked
                 // package_hash <-> name is already checked

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -82,7 +82,7 @@ pub(super) mod show_arg_examples {
 pub(super) fn session_str_params<'a>(matches: &'a ArgMatches) -> SessionStrParams<'a> {
     let session_args_simple = arg_simple::session::get(matches);
     let session_args_complex = args_complex::session::get(matches);
-    if session_transfer::get(matches) {
+    if is_session_transfer::get(matches) {
         return SessionStrParams::with_transfer(session_args_simple, session_args_complex);
     }
     if let Some(session_path) = session_path::get(matches) {
@@ -544,7 +544,7 @@ pub(super) fn apply_common_session_options<'a, 'b>(subcommand: App<'a, 'b>) -> A
         .arg(session_path::arg())
         .arg(session_package_hash::arg())
         .arg(session_package_name::arg())
-        .arg(session_transfer::arg())
+        .arg(is_session_transfer::arg())
         .arg(session_hash::arg())
         .arg(session_name::arg())
         .arg(arg_simple::session::arg())
@@ -563,7 +563,7 @@ pub(super) fn apply_common_session_options<'a, 'b>(subcommand: App<'a, 'b>) -> A
                 .arg(session_path::ARG_NAME)
                 .arg(session_package_hash::ARG_NAME)
                 .arg(session_package_name::ARG_NAME)
-                .arg(session_transfer::ARG_NAME)
+                .arg(is_session_transfer::ARG_NAME)
                 .arg(session_hash::ARG_NAME)
                 .arg(session_name::ARG_NAME)
                 .arg(show_arg_examples::ARG_NAME)
@@ -704,10 +704,10 @@ pub(super) mod session_name {
     }
 }
 
-pub(super) mod session_transfer {
+pub(super) mod is_session_transfer {
     use super::*;
 
-    pub const ARG_NAME: &str = "session-transfer";
+    pub const ARG_NAME: &str = "is-session-transfer";
     const ARG_HELP: &str = "Use this flag if you want to make this a transfer.";
 
     pub fn arg() -> Arg<'static, 'static> {

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -718,7 +718,7 @@ pub(super) mod session_transfer {
             .display_order(DisplayOrder::SessionTransfer as usize)
     }
 
-    pub fn get<'a>(matches: &'a ArgMatches) -> bool {
+    pub fn get(matches: &ArgMatches) -> bool {
         matches.is_present(ARG_NAME)
     }
 }

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -35,6 +35,7 @@ pub(super) enum DisplayOrder {
     SessionPackageName,
     SessionEntryPoint,
     SessionVersion,
+    SessionTransfer,
     StandardPayment,
     PaymentCode,
     PaymentArgSimple,
@@ -81,6 +82,9 @@ pub(super) mod show_arg_examples {
 pub(super) fn session_str_params<'a>(matches: &'a ArgMatches) -> SessionStrParams<'a> {
     let session_args_simple = arg_simple::session::get(matches);
     let session_args_complex = args_complex::session::get(matches);
+    if session_transfer::get(matches) {
+        return SessionStrParams::with_transfer(session_args_simple, session_args_complex);
+    }
     if let Some(session_path) = session_path::get(matches) {
         return SessionStrParams::with_path(
             session_path,
@@ -540,6 +544,7 @@ pub(super) fn apply_common_session_options<'a, 'b>(subcommand: App<'a, 'b>) -> A
         .arg(session_path::arg())
         .arg(session_package_hash::arg())
         .arg(session_package_name::arg())
+        .arg(session_transfer::arg())
         .arg(session_hash::arg())
         .arg(session_name::arg())
         .arg(arg_simple::session::arg())
@@ -558,6 +563,7 @@ pub(super) fn apply_common_session_options<'a, 'b>(subcommand: App<'a, 'b>) -> A
                 .arg(session_path::ARG_NAME)
                 .arg(session_package_hash::ARG_NAME)
                 .arg(session_package_name::ARG_NAME)
+                .arg(session_transfer::ARG_NAME)
                 .arg(session_hash::ARG_NAME)
                 .arg(session_name::ARG_NAME)
                 .arg(show_arg_examples::ARG_NAME)
@@ -695,6 +701,25 @@ pub(super) mod session_name {
 
     pub fn get<'a>(matches: &'a ArgMatches) -> Option<&'a str> {
         matches.value_of(ARG_NAME)
+    }
+}
+
+pub(super) mod session_transfer {
+    use super::*;
+
+    pub const ARG_NAME: &str = "session-transfer";
+    const ARG_HELP: &str = "Use this flag if you want to make this a transfer.";
+
+    pub fn arg() -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .help(ARG_HELP)
+            .required(false)
+            .display_order(DisplayOrder::SessionTransfer as usize)
+    }
+
+    pub fn get<'a>(matches: &'a ArgMatches) -> bool {
+        matches.is_present(ARG_NAME)
     }
 }
 


### PR DESCRIPTION
# About These Changes:
* added a new Boolean flag to the `make-deploy` and `put-deploy` subcommands called `--session-transfer` that tells the client that we want to make the deploy a transfer.
* this flag is mutually exclusive with the other `--session-<command>` commands except for `--session-arg`.