### PR TITLE
CEP58 / request rate limiting

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -234,11 +234,11 @@ where
             return Err(Error::EmptyKnownHosts);
         }
 
-        let upstream_limiter: Box<dyn Limiter> = if cfg.max_non_validating_peer_bps == 0 {
+        let upstream_limiter: Box<dyn Limiter> = if cfg.max_outgoing_byte_rate_non_validators == 0 {
             Box::new(limiter::Unlimited)
         } else {
             Box::new(limiter::ClassBasedLimiter::new(
-                cfg.max_non_validating_peer_bps,
+                cfg.max_outgoing_byte_rate_non_validators,
             ))
         };
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -242,11 +242,11 @@ where
             ))
         };
 
-        let incoming_limiter: Box<dyn Limiter> = if cfg.max_non_validating_peer_request_rate == 0 {
+        let incoming_limiter: Box<dyn Limiter> = if cfg.max_incoming_message_rate_non_validators == 0 {
             Box::new(limiter::Unlimited)
         } else {
             Box::new(limiter::ClassBasedLimiter::new(
-                cfg.max_non_validating_peer_request_rate,
+                cfg.max_incoming_message_rate_non_validators,
             ))
         };
 

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -32,6 +32,7 @@ impl Default for Config {
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
             max_non_validating_peer_bps: 0,
+            max_non_validating_peer_request_rate: 0,
         }
     }
 }
@@ -60,6 +61,8 @@ pub struct Config {
     pub max_addr_pending_time: TimeDiff,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_non_validating_peer_bps: u32,
+    /// Maximum of requests answered from non-validating peers. Unlimited if 0.
+    pub max_non_validating_peer_request_rate: u32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -31,7 +31,7 @@ impl Default for Config {
             isolation_reconnect_delay: TimeDiff::from_seconds(2),
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
-            max_non_validating_peer_bps: 0,
+            max_outgoing_byte_rate_non_validators: 0,
             max_non_validating_peer_request_rate: 0,
         }
     }
@@ -60,7 +60,7 @@ pub struct Config {
     /// Maximum allowed time for an address to be kept in the pending set.
     pub max_addr_pending_time: TimeDiff,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
-    pub max_non_validating_peer_bps: u32,
+    pub max_outgoing_byte_rate_non_validators: u32,
     /// Maximum of requests answered from non-validating peers. Unlimited if 0.
     pub max_non_validating_peer_request_rate: u32,
 }

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -32,7 +32,7 @@ impl Default for Config {
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
             max_outgoing_byte_rate_non_validators: 0,
-            max_non_validating_peer_request_rate: 0,
+            max_incoming_message_rate_non_validators: 0,
         }
     }
 }
@@ -62,7 +62,7 @@ pub struct Config {
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_outgoing_byte_rate_non_validators: u32,
     /// Maximum of requests answered from non-validating peers. Unlimited if 0.
-    pub max_non_validating_peer_request_rate: u32,
+    pub max_incoming_message_rate_non_validators: u32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -292,7 +292,7 @@ async fn worker(
                         while resources_available < 0 {
                             // Determine time delta since last refill.
                             let now = Instant::now();
-                            let elapsed = Instant::now() - last_refill;
+                            let elapsed = now - last_refill;
                             last_refill = now;
 
                             // Add appropriate amount of resources, capped at `max_stored_bytes`.

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -20,9 +20,9 @@ const STORED_BUFFER_SECS: Duration = Duration::from_secs(2);
 
 /// A limiter.
 ///
-/// Any resource consumer of a specific resource is expected to call `create_handle` for every peer
-/// and use the returned handle to request a access to a resource.
-pub(crate) trait Limiter: Send + Sync {
+/// Any consumer of a specific resource is expected to call `create_handle` for every peer and use
+/// the returned handle to request a access to a resource.
+pub(super) trait Limiter: Send + Sync {
     /// Create a handle for a connection using the given peer and optional validator id.
     fn create_handle(
         &self,
@@ -40,7 +40,7 @@ pub(crate) trait Limiter: Send + Sync {
 
 /// A per-peer handle for a limiter.
 #[async_trait]
-pub(crate) trait LimiterHandle: Send + Sync {
+pub(super) trait LimiterHandle: Send + Sync {
     /// Waits until the requestor is allocated `amount` additional resources.
     async fn request_allowance(&self, amount: u32);
 }
@@ -141,7 +141,7 @@ impl ClassBasedLimiter {
     /// Creates a new class based limiter.
     ///
     /// Starts the background worker task as well.
-    pub(crate) fn new(resources_per_second: u32) -> Self {
+    pub(super) fn new(resources_per_second: u32) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
 
         tokio::spawn(worker(

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -189,7 +189,7 @@ impl Limiter for ClassBasedLimiter {
 
 #[async_trait]
 impl LimiterHandle for ClassBasedHandle {
-    async fn request_allowance(&self, num_bytes: u32) {
+    async fn request_allowance(&self, amount: u32) {
         let (responder, waiter) = oneshot::channel();
 
         // Send a request to the limiter and await a response. If we do not receive one due to
@@ -201,7 +201,7 @@ impl LimiterHandle for ClassBasedHandle {
         if self
             .sender
             .send(ClassBasedCommand::RequestResource {
-                amount: num_bytes,
+                amount,
                 id: self.consumer_id.clone(),
                 responder,
             })

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -43,6 +43,15 @@ impl<P: Payload> Message<P> {
             Message::Payload(payload) => payload.classify(),
         }
     }
+
+    /// Returns the incoming resource estimate of the payload.
+    #[inline]
+    pub(super) fn payload_incoming_resource_estimate(&self) -> u32 {
+        match self {
+            Message::Handshake { .. } => 0,
+            Message::Payload(payload) => payload.incoming_resource_estimate(),
+        }
+    }
 }
 
 /// A pair of secret keys used by consensus.
@@ -164,6 +173,11 @@ pub trait Payload:
 {
     /// Classifies the payload based on its contents.
     fn classify(&self) -> MessageKind;
+
+    /// The penalty for resource usage of a message to be applied when processed as incoming.
+    fn incoming_resource_estimate(&self) -> u32 {
+        0
+    }
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -444,6 +444,7 @@ pub(super) async fn server<P, REv>(
 pub(super) async fn message_reader<REv, P>(
     context: Arc<NetworkContext<REv>>,
     mut stream: SplitStream<FramedTransport<P>>,
+    limiter: Box<dyn LimiterHandle>,
     mut shutdown_receiver: watch::Receiver<()>,
     peer_id: NodeId,
     span: Span,
@@ -457,7 +458,12 @@ where
             match msg_result {
                 Ok(msg) => {
                     trace!(%msg, "message received");
-                    // We've received a message, push it to the reactor.
+                    // We've received a message. Ensure we have the proper amount of resources,
+                    // then push it to the reactor.
+
+                    limiter
+                        .request_allowance(msg.payload_incoming_resource_estimate())
+                        .await;
                     context
                         .event_queue
                         .schedule(

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -34,12 +34,12 @@ use tracing::{
 };
 
 use super::{
-    bandwidth_limiter::BandwidthLimiterHandle,
     chain_info::ChainInfo,
     counting_format::{ConnectionId, Role},
     error::{ConnectionError, IoError},
     event::{IncomingConnection, OutgoingConnection},
     framed,
+    limiter::LimiterHandle,
     message::ConsensusKeyPair,
     Event, FramedTransport, Message, Payload, Transport,
 };
@@ -500,7 +500,7 @@ where
 pub(super) async fn message_sender<P>(
     mut queue: UnboundedReceiver<Arc<Message<P>>>,
     mut sink: SplitSink<FramedTransport<P>, Arc<Message<P>>>,
-    limiter: Box<dyn BandwidthLimiterHandle>,
+    limiter: Box<dyn LimiterHandle>,
     counter: IntGauge,
 ) where
     P: Payload,

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -67,6 +67,24 @@ impl Payload for Message {
             Message::FinalitySignature(_) => MessageKind::Consensus,
         }
     }
+
+    #[inline]
+    fn incoming_resource_estimate(&self) -> u32 {
+        match self {
+            Message::Consensus(_) => 0,
+            Message::DeployGossiper(_) => 0,
+            Message::AddressGossiper(_) => 0,
+            Message::GetRequest { tag, .. } | Message::GetResponse { tag, .. } => match tag {
+                Tag::Deploy => 1,
+                Tag::Block => 0,
+                Tag::GossipedAddress => 0,
+                Tag::BlockByHeight => 0,
+                Tag::BlockHeaderByHash => 0,
+                Tag::BlockHeaderAndFinalitySignaturesByHeight => 0,
+            },
+            Message::FinalitySignature(_) => 0,
+        }
+    }
 }
 
 impl Message {

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -123,7 +123,7 @@ max_addr_pending_time = '1min'
 
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
-max_non_validating_peer_bps = 0
+max_outgoing_byte_rate_non_validators = 0
 
 # The maximum amount of requests from validating peers per second answered.
 # A value of `0` means unlimited.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -127,7 +127,7 @@ max_outgoing_byte_rate_non_validators = 0
 
 # The maximum amount of requests from validating peers per second answered.
 # A value of `0` means unlimited.
-max_non_validating_peer_request_rate = 0
+max_incoming_message_rate_non_validators = 0
 
 
 # ==================================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -125,6 +125,11 @@ max_addr_pending_time = '1min'
 # A value of `0` means unlimited.
 max_non_validating_peer_bps = 0
 
+# The maximum amount of requests from validating peers per second answered.
+# A value of `0` means unlimited.
+max_non_validating_peer_request_rate = 0
+
+
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server
 # ==================================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -123,7 +123,7 @@ max_addr_pending_time = '1min'
 
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
-max_non_validating_peer_bps = 0
+max_outgoing_byte_rate_non_validators = 0
 
 # The maximum amount of requests from validating peers per second answered.
 # A value of `0` means unlimited.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -127,7 +127,7 @@ max_outgoing_byte_rate_non_validators = 0
 
 # The maximum amount of requests from validating peers per second answered.
 # A value of `0` means unlimited.
-max_non_validating_peer_request_rate = 0
+max_incoming_message_rate_non_validators = 0
 
 
 # ==================================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -125,6 +125,11 @@ max_addr_pending_time = '1min'
 # A value of `0` means unlimited.
 max_non_validating_peer_bps = 0
 
+# The maximum amount of requests from validating peers per second answered.
+# A value of `0` means unlimited.
+max_non_validating_peer_request_rate = 0
+
+
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server
 # ==================================================

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -123,7 +123,7 @@ max_addr_pending_time = '1min'
 
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
-max_non_validating_peer_bps = 0
+max_outgoing_byte_rate_non_validators = 0
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -125,6 +125,11 @@ max_addr_pending_time = '1min'
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0
 
+# The maximum amount of requests from validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server
 # ==================================================


### PR DESCRIPTION
This introduces request rate limiting as described in CEP58. There are two resource pools, an unlimited one for known current and upcoming validators, and a shared one controlled by `max_non_validating_peer_request_rate`. For example, setting `max_non_validating_peer_request_rate` to `10` limits the amount of allowed `GetRequest`s for `Deploy`s to 10 per second _total_.

A large part of this PR is just the renaming of the `bandwidth_limiter` to `limiter` and resulting changes of types, comments and documentation. It may help to look at the diff that omits this renaming commit (9851442).