### PR TITLE
Query State With Optional Block Identifier

### DIFF
--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -381,11 +381,15 @@ pub fn get_item(
     maybe_rpc_id: &str,
     node_address: &str,
     verbosity_level: u64,
-    state_root_hash: &str,
+    maybe_block_identifier: &str,
     key: &str,
     path: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_item(state_root_hash, key, path)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_item(
+        maybe_block_identifier,
+        key,
+        path,
+    )
 }
 
 /// Retrieves a purse's balance from the network.

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -90,12 +90,8 @@ impl RpcCall {
         GetDeploy::request_with_map_params(self, params)
     }
 
-    pub(crate) fn get_item(self, state_root_hash: &str, key: &str, path: &str) -> Result<JsonRpc> {
-        let state_root_hash =
-            Digest::from_hex(state_root_hash).map_err(|error| Error::CryptoError {
-                context: "state_root_hash",
-                error,
-            })?;
+    pub(crate) fn get_item(self, block_identifier: &str, key: &str, path: &str) -> Result<JsonRpc> {
+        let maybe_block_identifier = Self::block_identifier(block_identifier)?;
 
         let key = {
             if let Ok(key) = Key::from_formatted_str(key) {
@@ -114,12 +110,12 @@ impl RpcCall {
         };
 
         let params = GetItemParams {
-            state_root_hash,
+            maybe_block_identifier,
             key: key.to_formatted_string(),
             path: path.clone(),
         };
         let response = GetItem::request_with_map_params(self, params)?;
-        validation::validate_query_response(&response, &state_root_hash, &key, &path)?;
+        validation::validate_query_response(&response, &key, &path)?;
         Ok(response)
     }
 

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -13,7 +13,7 @@ enum DisplayOrder {
     Verbose,
     NodeAddress,
     RpcId,
-    StateRootHash,
+    BlockIdentifier,
     Key,
     Path,
 }
@@ -111,8 +111,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::state_root_hash::arg(
-                DisplayOrder::StateRootHash as usize,
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockIdentifier as usize,
             ))
             .arg(key::arg())
             .arg(path::arg())
@@ -122,7 +122,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
-        let state_root_hash = common::state_root_hash::get(matches);
+        let maybe_block_identifier = common::block_identifier::get(matches);
         let key = key::get(matches)?;
         let path = path::get(matches);
 
@@ -130,7 +130,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
             maybe_rpc_id,
             node_address,
             verbosity_level,
-            state_root_hash,
+            maybe_block_identifier,
             &key,
             path,
         )


### PR DESCRIPTION
About These Changes:
* updated the RPC component to make state root hash an optional block identifier.