### PR TITLE
Add configurable upper limit of concurrent event stream clients

### DIFF
--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -100,7 +100,10 @@ impl EventStreamServer {
             * (100 + ADDITIONAL_PERCENT_FOR_BROADCAST_CHANNEL_SIZE)
             / 100;
         let (broadcaster, new_subscriber_info_receiver, sse_filter) =
-            sse_server::create_channels_and_filter(broadcast_channel_size as usize);
+            sse_server::create_channels_and_filter(
+                broadcast_channel_size as usize,
+                config.max_concurrent_subscribers,
+            );
 
         let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
 

--- a/node/src/components/event_stream_server/config.rs
+++ b/node/src/components/event_stream_server/config.rs
@@ -9,8 +9,8 @@ const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 /// Default number of SSEs to buffer.
 const DEFAULT_EVENT_STREAM_BUFFER_LENGTH: u32 = 5000;
 
-/// Default rate limit in qps.
-const DEFAULT_QPS_LIMIT: u64 = 100;
+/// Default maximum number of subscribers.
+const DEFAULT_MAX_CONCURRENT_SUBSCRIBERS: u32 = 100;
 
 /// SSE HTTP server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -23,8 +23,8 @@ pub struct Config {
     /// Number of SSEs to buffer.
     pub event_stream_buffer_length: u32,
 
-    /// Rate limit for queries per second.
-    pub qps_limit: u64,
+    /// Default maximum number of subscribers across all event streams permitted at any one time.
+    pub max_concurrent_subscribers: u32,
 }
 
 impl Config {
@@ -33,7 +33,7 @@ impl Config {
         Config {
             address: DEFAULT_ADDRESS.to_string(),
             event_stream_buffer_length: DEFAULT_EVENT_STREAM_BUFFER_LENGTH,
-            qps_limit: DEFAULT_QPS_LIMIT,
+            max_concurrent_subscribers: DEFAULT_MAX_CONCURRENT_SUBSCRIBERS,
         }
     }
 }

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -314,14 +314,11 @@ fn create_422() -> Response {
     response
 }
 
-/// Creates a 204 response (No Content) to be returned if the server has too many subscribers.
-///
-/// HTTP 204 is mentioned in
-/// https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events-intro as a
-/// suitable way to tell the client to stop reconnecting.
-fn create_204() -> Response {
-    let mut response = Response::new(Body::empty());
-    *response.status_mut() = StatusCode::NO_CONTENT;
+/// Creates a 503 response (Service Unavailable) to be returned if the server has too many
+/// subscribers.
+fn create_503() -> Response {
+    let mut response = Response::new(Body::from("server has reached limit of subscribers"));
+    *response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
     response
 }
 
@@ -355,7 +352,7 @@ pub(super) fn create_channels_and_filter(
                     %max_concurrent_subscribers,
                     "event stream server has max subscribers: rejecting new one"
                 );
-                return create_204();
+                return create_503();
             }
 
             // If `path_param` is not a valid string, return a 404.

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -463,6 +463,10 @@ async fn handle_response(
 ) -> Result<Vec<ReceivedEvent>, reqwest::Error> {
     if response.status() == StatusCode::SERVICE_UNAVAILABLE {
         debug!("{} rejected by server: too many clients", client_id);
+        assert_eq!(
+            response.text().await.unwrap(),
+            "server has reached limit of subscribers"
+        );
         return Ok(Vec::new());
     }
 

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -461,7 +461,7 @@ async fn handle_response(
     final_event_id: Id,
     client_id: &str,
 ) -> Result<Vec<ReceivedEvent>, reqwest::Error> {
-    if response.status() == StatusCode::NO_CONTENT {
+    if response.status() == StatusCode::SERVICE_UNAVAILABLE {
         debug!("{} rejected by server: too many clients", client_id);
         return Ok(Vec::new());
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -182,9 +182,8 @@ address = '0.0.0.0:9999'
 # The number of event stream events to buffer.
 event_stream_buffer_length = 5000
 
-# The global max rate of requests (per second) before they are limited.
-# Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 100
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
 
 
 # ===============================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -182,9 +182,8 @@ address = '0.0.0.0:9999'
 # The number of event stream events to buffer.
 event_stream_buffer_length = 5000
 
-# The global max rate of requests (per second) before they are limited.
-# Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 10
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
 
 
 # ===============================================


### PR DESCRIPTION
This PR introduces a new config option `[event_stream_server][max_concurrent_subscribers]`, which defines the maximum number of clients allowed to subscribe to a single event stream server at any given time.

The limit is coarse-grained, relating to the total number of clients, regardless of which stream(s) are subscribed to.  It is not a per-stream limit.

Tagging @sacherjj and @momipsl to advise of the change to config file options.

Closes #1633.