### PR TITLE
NCTL: re-sync itst13 config.toml

### DIFF
--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -182,9 +182,8 @@ address = '0.0.0.0:9999'
 # The number of event stream events to buffer.
 event_stream_buffer_length = 5000
 
-# The global max rate of requests (per second) before they are limited.
-# Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 100
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
 
 
 # ===============================================


### PR DESCRIPTION
adds `max_concurrent_subscribers` to `itst13.config.toml`