### PR TITLE
[NDRS-1574] Add `--force` Boolean flag to commands that may overwrite files.

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Changed
 * Change `account-address` subcommand to output properly formatted string.
 * Change `put-deploy` and `make-deploy` subcommands to support transfers.
+* Change `make-deploy`, `make-transfer` and `sign-deploy` to not overwrite files unless `--force` is passed.
 
 
 

--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
     #[error("Failed to parse as JSON-RPC response: {0}")]
     FailedToParseResponse(reqwest::Error),
 
-    /// Failed to create new key file because it already exists.
+    /// Failed to create new file because it already exists.
     #[error("File at {} already exists", .0.display())]
     FileAlreadyExists(PathBuf),
 

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -295,6 +295,7 @@ pub extern "C" fn casper_make_deploy(
     deploy_params: *const casper_deploy_params_t,
     session_params: *const casper_session_params_t,
     payment_params: *const casper_payment_params_t,
+    force: bool,
 ) -> casper_error_t {
     let maybe_output_path = try_unsafe_arg!(maybe_output_path);
     let deploy_params = try_arg_into!(deploy_params);
@@ -305,6 +306,7 @@ pub extern "C" fn casper_make_deploy(
         deploy_params,
         session_params,
         payment_params,
+        force,
     );
     try_unwrap_result!(result);
     casper_error_t::CASPER_SUCCESS
@@ -319,11 +321,12 @@ pub extern "C" fn casper_sign_deploy_file(
     input_path: *const c_char,
     secret_key: *const c_char,
     maybe_output_path: *const c_char,
+    force: bool,
 ) -> casper_error_t {
     let input_path = try_unsafe_arg!(input_path);
     let secret_key = try_unsafe_arg!(secret_key);
     let maybe_output_path = try_unsafe_arg!(maybe_output_path);
-    let result = super::sign_deploy_file(input_path, secret_key, maybe_output_path);
+    let result = super::sign_deploy_file(input_path, secret_key, maybe_output_path, force);
     try_unwrap_result!(result);
     casper_error_t::CASPER_SUCCESS
 }

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -410,6 +410,7 @@ pub extern "C" fn casper_make_transfer(
     transfer_id: *const c_char,
     deploy_params: *const casper_deploy_params_t,
     payment_params: *const casper_payment_params_t,
+    force: bool,
 ) -> casper_error_t {
     let maybe_output_path = try_unsafe_arg!(maybe_output_path);
     let amount = try_unsafe_arg!(amount);
@@ -424,6 +425,7 @@ pub extern "C" fn casper_make_transfer(
         transfer_id,
         deploy_params,
         payment_params,
+        force,
     );
     try_unwrap_result!(result);
     casper_error_t::CASPER_SUCCESS

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -22,7 +22,7 @@ mod parsing;
 mod rpc;
 mod validation;
 
-use std::{convert::TryInto, fs, io::Cursor};
+use std::{convert::TryInto, fs, io::Cursor, path::PathBuf};
 
 use jsonrpc_lite::JsonRpc;
 use serde::Serialize;
@@ -93,23 +93,35 @@ pub fn make_deploy(
     deploy_params: DeployStrParams<'_>,
     session_params: SessionStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
+    force: bool,
 ) -> Result<()> {
-    let output = deploy::output_or_stdout(none_if_empty(maybe_output_path)).map_err(|error| {
-        Error::IoError {
-            context: format!(
-                "unable to get file or stdout, provided '{:?}'",
-                maybe_output_path
-            ),
-            error,
-        }
+    let maybe_output_path = none_if_empty(maybe_output_path);
+    let path_exists = if let Some(p) = maybe_output_path {
+        PathBuf::from(p).exists()
+    } else {
+        false
+    };
+
+    let output = deploy::output_or_stdout(maybe_output_path).map_err(|error| Error::IoError {
+        context: format!(
+            "unable to get file or stdout, provided '{:?}'",
+            maybe_output_path
+        ),
+        error,
     })?;
 
-    Deploy::with_payment_and_session(
-        deploy_params.try_into()?,
-        payment_params.try_into()?,
-        session_params.try_into()?,
-    )?
-    .write_deploy(output)
+    match (path_exists, force) {
+        (true, false) => {
+            let pb = PathBuf::from(maybe_output_path.unwrap());
+            Err(Error::FileAlreadyExists(pb))
+        }
+        (true, true) | (false, true) | (false, false) => Deploy::with_payment_and_session(
+            deploy_params.try_into()?,
+            payment_params.try_into()?,
+            session_params.try_into()?,
+        )?
+        .write_deploy(output),
+    }
 }
 
 /// Reads a previously-saved `Deploy` from a file, cryptographically signs it, and outputs it to a
@@ -119,9 +131,19 @@ pub fn make_deploy(
 /// * `secret_key` specifies the path to the secret key with which to sign the `Deploy`.
 /// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
 ///   file already exists, it will be overwritten.
-pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &str) -> Result<()> {
+pub fn sign_deploy_file(
+    input_path: &str,
+    secret_key: &str,
+    maybe_output_path: &str,
+    force: bool,
+) -> Result<()> {
     let secret_key = parsing::secret_key(secret_key)?;
     let maybe_output_path = none_if_empty(maybe_output_path);
+    let path_exists = if let Some(p) = maybe_output_path {
+        PathBuf::from(p).exists()
+    } else {
+        false
+    };
 
     let input = fs::read(input_path).map_err(|error| Error::IoError {
         context: format!("unable to read deploy file at '{}'", input_path),
@@ -136,7 +158,15 @@ pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &
         error,
     })?;
 
-    Deploy::sign_and_write_deploy(Cursor::new(input), secret_key, output)
+    match (path_exists, force) {
+        (true, false) => {
+            let pb = PathBuf::from(maybe_output_path.unwrap());
+            Err(Error::FileAlreadyExists(pb))
+        }
+        (true, true) | (false, true) | (false, false) => {
+            Deploy::sign_and_write_deploy(Cursor::new(input), secret_key, output)
+        }
+    }
 }
 
 /// Reads a previously-saved `Deploy` from a file and sends it to the network for execution.

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -86,9 +86,10 @@ pub fn put_deploy(
 ///   [`SessionStrParams`](struct.SessionStrParams.html) for more details.
 /// * `payment_params` contains payment-related options for this `Deploy`. See
 ///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
-/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
-/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
-/// returned and no files are written.
+/// * If `force` is true, and a file exists at `maybe_output_path`, it will be overwritten. If
+///   `force` is false and a file exists at `maybe_output_path`,
+///   [`Error::FileAlreadyExists`](enum.Error.html#variant.FileAlreadyExists) is returned and a file
+///   will not be written.
 pub fn make_deploy(
     maybe_output_path: &str,
     deploy_params: DeployStrParams<'_>,
@@ -116,9 +117,10 @@ pub fn make_deploy(
 /// * `input_path` specifies the path to the previously-saved `Deploy` file.
 /// * `secret_key` specifies the path to the secret key with which to sign the `Deploy`.
 /// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`.
-/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
-/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
-/// returned and no files are written.
+/// * If `force` is true, and a file exists at `maybe_output_path`, it will be overwritten. If
+///   `force` is false and a file exists at `maybe_output_path`,
+///   [`Error::FileAlreadyExists`](enum.Error.html#variant.FileAlreadyExists) is returned and a file
+///   will not be written.
 pub fn sign_deploy_file(
     input_path: &str,
     secret_key: &str,
@@ -227,9 +229,10 @@ pub fn transfer(
 ///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
 /// * `payment_params` contains payment-related options for this `Deploy`. See
 ///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
-/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
-/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
-/// returned and no files are written.
+/// * If `force` is true, and a file exists at `maybe_output_path`, it will be overwritten. If
+///   `force` is false and a file exists at `maybe_output_path`,
+///   [`Error::FileAlreadyExists`](enum.Error.html#variant.FileAlreadyExists) is returned and a file
+///   will not be written.
 pub fn make_transfer(
     maybe_output_path: &str,
     amount: &str,

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -80,14 +80,16 @@ pub fn put_deploy(
 /// [`sign_deploy_file()`](fn.sign_deploy_file.html) and then sent to the network for execution
 /// using [`send_deploy_file()`](fn.send_deploy_file.html).
 ///
-/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
-///   file already exists, it will be overwritten.
+/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`.
 /// * `deploy_params` contains deploy-related options for this `Deploy`. See
 ///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
 /// * `session_params` contains session-related options for this `Deploy`. See
 ///   [`SessionStrParams`](struct.SessionStrParams.html) for more details.
 /// * `payment_params` contains payment-related options for this `Deploy`. See
 ///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
+/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
+/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
+/// returned and no files are written.
 pub fn make_deploy(
     maybe_output_path: &str,
     deploy_params: DeployStrParams<'_>,
@@ -129,8 +131,10 @@ pub fn make_deploy(
 ///
 /// * `input_path` specifies the path to the previously-saved `Deploy` file.
 /// * `secret_key` specifies the path to the secret key with which to sign the `Deploy`.
-/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
-///   file already exists, it will be overwritten.
+/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`.
+/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
+/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
+/// returned and no files are written.
 pub fn sign_deploy_file(
     input_path: &str,
     secret_key: &str,
@@ -245,8 +249,7 @@ pub fn transfer(
 /// [`sign_deploy_file()`](fn.sign_deploy_file.html) and then sent to the network for execution
 /// using [`send_deploy_file()`](fn.send_deploy_file.html).
 ///
-/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
-///   file already exists, it will be overwritten.
+/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`.
 /// * `amount` is a string to be parsed as a `U512` specifying the amount to be transferred.
 /// * `target_account` is the account `PublicKey` into which the funds will be transferred,
 ///   formatted as a hex-encoded string. The account's main purse will receive the funds.
@@ -256,6 +259,9 @@ pub fn transfer(
 ///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
 /// * `payment_params` contains payment-related options for this `Deploy`. See
 ///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
+/// * If `force` is true, existing files will be overwritten. If `force` is false and any of the
+/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
+/// returned and no files are written.
 pub fn make_transfer(
     maybe_output_path: &str,
     amount: &str,

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -46,6 +46,7 @@ pub(super) enum DisplayOrder {
     PaymentPackageName,
     PaymentEntryPoint,
     PaymentVersion,
+    Force,
 }
 
 /// Handles providing the arg for and executing the show-arg-examples option.
@@ -937,5 +938,25 @@ pub(super) mod payment_version {
 
     pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches.value_of(ARG_NAME).unwrap_or_default()
+    }
+}
+
+pub(super) mod force {
+    use super::*;
+
+    pub const ARG_NAME: &str = "force";
+    const ARG_HELP: &str =
+        "Use with commands that accept the 'force' flag to bypass certain restrictions.";
+
+    pub fn arg() -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .help(ARG_HELP)
+            .required(false)
+            .display_order(DisplayOrder::Force as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> bool {
+        matches.is_present(ARG_NAME)
     }
 }

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -940,23 +940,3 @@ pub(super) mod payment_version {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
-
-pub(super) mod force {
-    use super::*;
-
-    pub const ARG_NAME: &str = "force";
-    const ARG_HELP: &str =
-        "Use with commands that accept the 'force' flag to bypass certain restrictions.";
-
-    pub fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
-            .long(ARG_NAME)
-            .help(ARG_HELP)
-            .required(false)
-            .display_order(DisplayOrder::Force as usize)
-    }
-
-    pub fn get(matches: &ArgMatches) -> bool {
-        matches.is_present(ARG_NAME)
-    }
-}

--- a/client/src/deploy/make.rs
+++ b/client/src/deploy/make.rs
@@ -18,6 +18,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
         let subcommand = SubCommand::with_name(Self::NAME)
             .about(Self::ABOUT)
             .arg(creation_common::output::arg())
+            .arg(creation_common::force::arg())
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand);
@@ -38,6 +39,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
+        let force = creation_common::force::get(matches);
 
         casper_client::make_deploy(
             maybe_output_path,
@@ -51,6 +53,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
             },
             session_str_params,
             payment_str_params,
+            force,
         )
         .map(|_| {
             Success::Output(if maybe_output_path.is_empty() {

--- a/client/src/deploy/make.rs
+++ b/client/src/deploy/make.rs
@@ -18,7 +18,10 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
         let subcommand = SubCommand::with_name(Self::NAME)
             .about(Self::ABOUT)
             .arg(creation_common::output::arg())
-            .arg(creation_common::force::arg())
+            .arg(common::force::arg(
+                creation_common::DisplayOrder::Force as usize,
+                true,
+            ))
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand);
@@ -39,7 +42,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        let force = creation_common::force::get(matches);
+        let force = common::force::get(matches);
 
         casper_client::make_deploy(
             maybe_output_path,

--- a/client/src/deploy/make_transfer.rs
+++ b/client/src/deploy/make_transfer.rs
@@ -60,6 +60,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
                 chain_name,
             },
             payment_str_params,
+            force,
         )
         .map(|_| {
             Success::Output(if maybe_output_path.is_empty() {

--- a/client/src/deploy/make_transfer.rs
+++ b/client/src/deploy/make_transfer.rs
@@ -21,7 +21,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
             .arg(creation_common::output::arg())
             .arg(transfer::amount::arg())
             .arg(transfer::target_account::arg())
-            .arg(transfer::transfer_id::arg());
+            .arg(transfer::transfer_id::arg())
+            .arg(creation_common::force::arg());
         let subcommand = creation_common::apply_common_payment_options(subcommand);
         creation_common::apply_common_creation_options(subcommand, false)
     }
@@ -43,6 +44,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
+        let force = creation_common::force::get(matches);
 
         casper_client::make_transfer(
             maybe_output_path,

--- a/client/src/deploy/make_transfer.rs
+++ b/client/src/deploy/make_transfer.rs
@@ -22,7 +22,10 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
             .arg(transfer::amount::arg())
             .arg(transfer::target_account::arg())
             .arg(transfer::transfer_id::arg())
-            .arg(creation_common::force::arg());
+            .arg(common::force::arg(
+                creation_common::DisplayOrder::Force as usize,
+                true,
+            ));
         let subcommand = creation_common::apply_common_payment_options(subcommand);
         creation_common::apply_common_creation_options(subcommand, false)
     }
@@ -44,7 +47,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        let force = creation_common::force::get(matches);
+        let force = common::force::get(matches);
 
         casper_client::make_transfer(
             maybe_output_path,

--- a/client/src/deploy/sign.rs
+++ b/client/src/deploy/sign.rs
@@ -22,21 +22,25 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
             ))
             .arg(creation_common::input::arg())
             .arg(creation_common::output::arg())
+            .arg(creation_common::force::arg())
     }
 
     fn run(matches: &ArgMatches<'_>) -> Result<Success, Error> {
         let input_path = creation_common::input::get(matches);
         let secret_key = common::secret_key::get(matches);
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        casper_client::sign_deploy_file(&input_path, secret_key, maybe_output_path).map(|_| {
-            Success::Output(if maybe_output_path.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    "Signed the deploy at {} and wrote to {}",
-                    input_path, maybe_output_path
-                )
-            })
-        })
+        let force = creation_common::force::get(matches);
+        casper_client::sign_deploy_file(&input_path, secret_key, maybe_output_path, force).map(
+            |_| {
+                Success::Output(if maybe_output_path.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "Signed the deploy at {} and wrote to {}",
+                        input_path, maybe_output_path
+                    )
+                })
+            },
+        )
     }
 }

--- a/client/src/deploy/sign.rs
+++ b/client/src/deploy/sign.rs
@@ -22,14 +22,17 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
             ))
             .arg(creation_common::input::arg())
             .arg(creation_common::output::arg())
-            .arg(creation_common::force::arg())
+            .arg(common::force::arg(
+                creation_common::DisplayOrder::Force as usize,
+                true,
+            ))
     }
 
     fn run(matches: &ArgMatches<'_>) -> Result<Success, Error> {
         let input_path = creation_common::input::get(matches);
         let secret_key = common::secret_key::get(matches);
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        let force = creation_common::force::get(matches);
+        let force = common::force::get(matches);
         casper_client::sign_deploy_file(&input_path, secret_key, maybe_output_path, force).map(
             |_| {
                 Success::Output(if maybe_output_path.is_empty() {

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -708,7 +708,8 @@ mod make_transfer {
                 TARGET_ACCOUNT,
                 TRANSFER_ID,
                 deploy_params::test_data_valid(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -727,7 +728,8 @@ mod make_transfer {
                 TARGET_ACCOUNT,
                 TRANSFER_ID,
                 deploy_params::test_data_valid(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -541,7 +541,8 @@ mod make_deploy {
                 "",
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -558,7 +559,8 @@ mod make_deploy {
                 file_path.to_str().unwrap(),
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -589,7 +591,8 @@ mod send_deploy {
                 file_path.to_str().unwrap(),
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -616,7 +619,8 @@ mod sign_deploy {
                 unsigned_file_path.to_str().unwrap(),
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -626,6 +630,7 @@ mod sign_deploy {
                 unsigned_file_path.to_str().unwrap(),
                 "../resources/local/secret_keys/node-1.pem",
                 signed_file_path.to_str().unwrap(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -642,7 +647,8 @@ mod sign_deploy {
                 unsigned_file_path.to_str().unwrap(),
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -651,7 +657,8 @@ mod sign_deploy {
             casper_client::sign_deploy_file(
                 unsigned_file_path.to_str().unwrap(),
                 "../resources/local/secret_keys/node-1.pem",
-                ""
+                "",
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -668,7 +675,8 @@ mod sign_deploy {
                 unsigned_file_path.to_str().unwrap(),
                 deploy_params::test_data_valid(),
                 session_params::test_data_with_package_hash(),
-                payment_params::test_data_with_name()
+                payment_params::test_data_with_name(),
+                false
             )
             .map_err(ErrWrapper),
             Ok(())
@@ -676,7 +684,8 @@ mod sign_deploy {
         assert!(casper_client::sign_deploy_file(
             unsigned_file_path.to_str().unwrap(),
             "<this is not a path>",
-            ""
+            "",
+            false
         )
         .is_err());
     }

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -572,7 +572,8 @@ mod make_deploy {
         let temp_dir = TempDir::new()
             .unwrap_or_else(|err| panic!("Failed to create temp dir with error: {}", err));
         let file_path = temp_dir.path().join("test_deploy.json");
-        fs::write(file_path.clone(), "hi")
+        let contents = "contents of test file";
+        fs::write(file_path.clone(), &contents)
             .unwrap_or_else(|err| panic!("Failed to create temp file with error: {}", err));
 
         assert_eq!(
@@ -584,8 +585,14 @@ mod make_deploy {
                 false
             )
             .map_err(ErrWrapper),
-            Err(Error::FileAlreadyExists(file_path).into())
+            Err(Error::FileAlreadyExists(file_path.clone()).into())
         );
+
+        let contents_after_fail = fs::read_to_string(file_path).unwrap_or_else(|err| {
+            panic!("Failed to read contents of test file with error: {}", err)
+        });
+
+        assert_eq!(contents, contents_after_fail);
     }
 
     #[test]
@@ -759,6 +766,10 @@ mod sign_deploy {
             .map_err(ErrWrapper),
             Ok(())
         );
+
+        let contents = fs::read_to_string(signed_file_path.clone())
+            .unwrap_or_else(|err| panic!("Failed to read contents of file with error: {}", err));
+
         assert_eq!(
             casper_client::sign_deploy_file(
                 unsigned_file_path.to_str().unwrap(),
@@ -767,8 +778,13 @@ mod sign_deploy {
                 false
             )
             .map_err(ErrWrapper),
-            Err(Error::FileAlreadyExists(signed_file_path).into())
+            Err(Error::FileAlreadyExists(signed_file_path.clone()).into())
         );
+
+        let contents_after_failure = fs::read_to_string(signed_file_path)
+            .unwrap_or_else(|err| panic!("Failed to read contents of file with error: {}", err));
+
+        assert_eq!(contents, contents_after_failure);
     }
 
     #[test]
@@ -861,7 +877,8 @@ mod make_transfer {
         let temp_dir = TempDir::new()
             .unwrap_or_else(|err| panic!("Failed to create temp dir with error: {}", err));
         let file_path = temp_dir.path().join("test_deploy.json");
-        fs::write(file_path.clone(), "hi")
+        let contents = "contents of test file";
+        fs::write(file_path.clone(), &contents)
             .unwrap_or_else(|err| panic!("Failed to create temp file with error: {}", err));
 
         assert_eq!(
@@ -875,8 +892,13 @@ mod make_transfer {
                 false
             )
             .map_err(ErrWrapper),
-            Err(Error::FileAlreadyExists(file_path).into())
+            Err(Error::FileAlreadyExists(file_path.clone()).into())
         );
+
+        let contents_after_fail = fs::read_to_string(file_path)
+            .unwrap_or_else(|err| panic!("Failed to read from temp file with error: {}", err));
+
+        assert_eq!(contents, contents_after_fail);
     }
 
     #[test]


### PR DESCRIPTION
# About These Changes
* Adds a `--force` Boolean flag that can be passed to `make-deploy`, `sign-deploy` or `make-transfer`.

closes casper-network/casper-node#1574