### PR TITLE
Introduce Integrity Check For New Block Storage Scheme

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1675,10 +1675,7 @@ fn garbage_collect_block_body_v2_db(
             continue;
         }
         let mut current_digest = *body_hash;
-        loop {
-            if current_digest == hash::SENTINEL1 || live_digests.contains(&current_digest) {
-                break;
-            }
+        while current_digest != hash::SENTINEL1 && !live_digests.contains(&current_digest) {
             live_digests.insert(current_digest);
             let [key_to_part_db, merkle_proof_of_rest]: [Digest; 2] =
                 match txn.get_value(*block_body_v2_db, &current_digest)? {

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -87,10 +87,10 @@ pub enum LmdbExtError {
         merkle_root: Digest,
     },
     #[error(
-        "Could not delete block body part with Merkle linked list node hash: \
+        "Could not find block body part with Merkle linked list node hash: \
          {merkle_linked_list_node_hash:?}"
     )]
-    CouldNotDeleteBlockBodyPart {
+    CouldNotFindBlockBodyPart {
         merkle_linked_list_node_hash: Digest,
     },
 }

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -91,6 +91,7 @@ pub enum LmdbExtError {
          {merkle_linked_list_node_hash:?}"
     )]
     CouldNotFindBlockBodyPart {
+        block_hash: BlockHash,
         merkle_linked_list_node_hash: Digest,
     },
 }


### PR DESCRIPTION
Issue: #1610

(Edit: also closes #1630).

This fixes how block data is being deleted from the databases (some entries can be referred to by multiple blocks), which ensures some aspects of the integrity, and adds checks for other aspects.