### PR TITLE
NDRS-1623: Remove purse error

### DIFF
--- a/types/src/system/mint/entry_points.rs
+++ b/types/src/system/mint/entry_points.rs
@@ -10,7 +10,7 @@ use crate::{
     CLType, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Parameter,
 };
 
-/// Returns entry points for a `\[`Mint`\]`
+/// Returns entry points for a [`Mint`](crate::system::mint::Mint)
 pub fn mint_entry_points() -> EntryPoints {
     let mut entry_points = EntryPoints::new();
 

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -1,6 +1,6 @@
 //! Home of the Mint contract's [`Error`] type.
 
-use alloc::{fmt, vec::Vec};
+use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "std")]
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    AccessRights, CLType, CLTyped,
+    CLType, CLTyped,
 };
 
 /// Errors which can occur while executing the Mint contract.
@@ -90,20 +90,6 @@ pub enum Error {
 #[cfg(test)]
 const MAX_ERROR_VALUE: u8 = Error::Sentinel as u8;
 
-impl From<PurseError> for Error {
-    fn from(purse_error: PurseError) -> Error {
-        match purse_error {
-            PurseError::InvalidURef => Error::InvalidURef,
-            PurseError::InvalidAccessRights(_) => {
-                // This one does not carry state from PurseError to the new Error enum. The reason
-                // is that Error is supposed to be simple in serialization and deserialization, so
-                // extra state is currently discarded.
-                Error::InvalidAccessRights
-            }
-        }
-    }
-}
-
 impl CLTyped for Error {
     fn cl_type() -> CLType {
         CLType::U8
@@ -170,29 +156,6 @@ impl FromBytes for Error {
             // Error::Formatting as if its unable to be correctly deserialized.
             .map_err(|_| bytesrepr::Error::Formatting)?;
         Ok((error, rem))
-    }
-}
-
-/// Errors relating to validity of source or destination purses.
-#[derive(Debug, Copy, Clone)]
-pub enum PurseError {
-    /// The given [`URef`](crate::URef) does not reference the account holder's purse, or such a
-    /// [`URef`](crate::URef) does not have the required [`AccessRights`].
-    InvalidURef,
-    /// The source purse is not writeable (see [`URef::is_writeable`](crate::URef::is_writeable)),
-    /// or the destination purse is not addable (see
-    /// [`URef::is_addable`](crate::URef::is_addable)).
-    InvalidAccessRights(Option<AccessRights>),
-}
-
-impl fmt::Display for PurseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            PurseError::InvalidURef => write!(f, "invalid uref"),
-            PurseError::InvalidAccessRights(maybe_access_rights) => {
-                write!(f, "invalid access rights: {:?}", maybe_access_rights)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
CHANGELOG:

- Removed the `PurseError` enum as it was not being used
- Changed inline documentation to account for the removal