### PR TITLE
Adding emergency upgrades to nctl nightly runs

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -77,6 +77,8 @@ start_run_teardown "itst11.sh"
 start_run_teardown "itst13.sh"
 start_run_teardown "itst14.sh"
 start_run_teardown "bond_its.sh"
+start_run_teardown "emergency_upgrade_test.sh"
+start_run_teardown "emergency_upgrade_test_balances.sh"
 start_run_teardown "sync_test.sh node=6 timeout=500"
 # Keep this test last
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"

--- a/utils/nctl/sh/assets/compile.sh
+++ b/utils/nctl/sh/assets/compile.sh
@@ -9,3 +9,4 @@
 source "$NCTL"/sh/assets/compile_node.sh
 source "$NCTL"/sh/assets/compile_node_launcher.sh
 source "$NCTL"/sh/assets/compile_client.sh
+source "$NCTL"/sh/assets/compile_global_state_update_gen.sh

--- a/utils/nctl/sh/assets/compile_global_state_update_gen.sh
+++ b/utils/nctl/sh/assets/compile_global_state_update_gen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+#######################################
+# Compiles global-state-update-gen for emergency upgrades testing.
+# Globals:
+#   NCTL - path to nctl home directory.
+#   NCTL_CASPER_HOME - path to casper node repo.
+########################################
+
+source "$NCTL"/sh/utils/main.sh
+
+pushd "$NCTL_CASPER_HOME/utils/global-state-update-gen" || exit
+
+cargo build --release
+
+popd || exit

--- a/utils/nctl/sh/assets/upgrade.sh
+++ b/utils/nctl/sh/assets/upgrade.sh
@@ -221,6 +221,7 @@ function _emergency_upgrade_node_balances() {
         "import toml;"
         "cfg=toml.load('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml');"
         "cfg['protocol']['hard_reset']=True;"
+        "cfg['protocol']['last_emergency_restart']=$ACTIVATE_ERA;"
         "toml.dump(cfg, open('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml', 'w'));"
     )
     python3 -c "${SCRIPT[*]}"


### PR DESCRIPTION
- introduces `compile_global_state_update_gen.sh` to `compile.sh`.
- adds `emergency_upgrade_test` & `emergency_upgrade_test_balances` to nightly wrapper.
- small toml update for adding `last_emergency_restart`