### PR TITLE
NDRS-1575 Ensure Client Does Not Damage Files On Failure.

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.  The format
 * Change `account-address` subcommand to output properly formatted string.
 * Change `put-deploy` and `make-deploy` subcommands to support transfers.
 * Change `make-deploy`, `make-transfer` and `sign-deploy` to not overwrite files unless `--force` is passed.
+* Change `make-deploy`, `make-transfer` and `sign-deploy` to use transactional file writing for enhanced safety and reliability.
 
 
 

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -84,7 +84,7 @@ pub(super) enum OutputKind<'a> {
 
 impl<'a> OutputKind<'a> {
     pub(super) fn file(path: &'a str, overwrite_if_exists: bool) -> Self {
-        let tmp_path = [path.clone(), ".tmp"].join("");
+        let tmp_path = Path::new(path).with_extension(".tmp");
         OutputKind::File {
             path,
             tmp_path,

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -94,7 +94,7 @@ impl<'a> OutputKind<'a> {
     pub(super) fn file(path: &'a str, overwrite_if_exists: bool) -> Self {
         let collision_resistant_string = rand::thread_rng()
             .sample_iter(&Alphanumeric)
-            .take(64)
+            .take(5)
             .map(char::from)
             .collect::<String>();
         let extension = format!(".{}.tmp", &collision_resistant_string);

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -120,16 +120,16 @@ impl<'a> OutputKind<'a> {
 
     pub(super) fn commit(self) -> Result<()> {
         match self {
-            OutputKind::File { path, tmp_path, .. } => match fs::rename(tmp_path.clone(), path) {
-                Ok(_) => Ok(()),
-                Err(error) => Err(Error::IoError {
+            OutputKind::File { path, tmp_path, .. } => {
+                fs::rename(&tmp_path, path).map_err(|error| Error::IoError {
                     context: format!(
                         "Could not move tmp file {} to destination {}",
-                        tmp_path, path
+                        tmp_path.display(),
+                        path
                     ),
                     error,
-                }),
-            },
+                })
+            }
             OutputKind::Stdout => Ok(()),
         }
     }

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -98,9 +98,9 @@ pub fn make_deploy(
     force: bool,
 ) -> Result<()> {
     let output = if maybe_output_path.is_empty() {
-        OutputKind::Stdout.get()?
+        OutputKind::Stdout
     } else {
-        OutputKind::file(maybe_output_path, force).get()?
+        OutputKind::file(maybe_output_path, force)
     };
 
     Deploy::with_payment_and_session(
@@ -108,7 +108,9 @@ pub fn make_deploy(
         payment_params.try_into()?,
         session_params.try_into()?,
     )?
-    .write_deploy(output)
+    .write_deploy(output.get()?)?;
+
+    output.commit()
 }
 
 /// Reads a previously-saved `Deploy` from a file, cryptographically signs it, and outputs it to a
@@ -135,12 +137,14 @@ pub fn sign_deploy_file(
     })?;
 
     let output = if maybe_output_path.is_empty() {
-        OutputKind::Stdout.get()?
+        OutputKind::Stdout
     } else {
-        OutputKind::file(maybe_output_path, force).get()?
+        OutputKind::file(maybe_output_path, force)
     };
 
-    Deploy::sign_and_write_deploy(Cursor::new(input), secret_key, output)
+    Deploy::sign_and_write_deploy(Cursor::new(input), secret_key, output.get()?)?;
+
+    output.commit()
 }
 
 /// Reads a previously-saved `Deploy` from a file and sends it to the network for execution.
@@ -249,9 +253,9 @@ pub fn make_transfer(
     let transfer_id = parsing::transfer_id(transfer_id)?;
 
     let output = if maybe_output_path.is_empty() {
-        OutputKind::Stdout.get()?
+        OutputKind::Stdout
     } else {
-        OutputKind::file(maybe_output_path, force).get()?
+        OutputKind::file(maybe_output_path, force)
     };
 
     Deploy::new_transfer(
@@ -262,7 +266,9 @@ pub fn make_transfer(
         deploy_params.try_into()?,
         payment_params.try_into()?,
     )?
-    .write_deploy(output)
+    .write_deploy(output.get()?)?;
+
+    output.commit()
 }
 
 /// Retrieves a `Deploy` from the network.


### PR DESCRIPTION
# About These Changes
* changes `make-deploy`, `make-transfer` and `sign-deploy` to ensure that they do not damage or overwrite existing files if something goes wrong when writing the output file.

closes casper-network/casper-node#1575