### PR TITLE
NDRS-846: Add unbonding to existing bonding scenario

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -36,11 +36,11 @@ function main() {
     do_await_era_change "4"
     # 9. Assert unbonded
     assert_eviction "6"
-    # Gather Block Hash after evicted  node for walkback later
+    # Gather Block Hash after evicted node for walkback later
     local AFTER_EVICTION_HASH=$(do_read_lfb_hash '1')
     # 10. Wait 3 eras to see if the node ends up proposing
     do_await_era_change "3"
-    # 11. Assert node didn't propose since being shutdown
+    # 11. Assert node didn't propose since being unbonded
     assert_no_proposal_walkback '6' "$AFTER_EVICTION_HASH"
     # 12. Check for equivocators
     assert_no_equivocators_logs

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -44,7 +44,7 @@ unbonding_delay = 14
 # Ticks per year: 31536000000
 #
 # (1+0.02)^((2^12)/31536000000)-1 is expressed as a fractional number below.
-round_seigniorage_rate = [15_959, 6_204_824_582_392]
+round_seigniorage_rate = [0, 1]
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -341,12 +341,16 @@ function assert_no_equivocators_logs() {
     for i in $(seq 1 $(get_count_of_nodes)); do
         # true is because grep exits 1 on no match
         LOGS=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w 'validator equivocated') || true
+        log "... checking node-$i's log"
         if [ ! -z "$LOGS" ]; then
             log "$(echo $LOGS)"
-            log "Fail: Equivocator(s) found!"
+            log "ERROR: Equivocator(s) found!"
             exit 1
+        else
+            log "... No Equivocator(s) found! [expected]"
         fi
     done
+    log "Finished Equivocator(s) search successfully!"
 }
 
 function do_submit_auction_bids()
@@ -381,4 +385,43 @@ function assert_same_era() {
         log "... ERA = $ERA : CURRENT_ERA = $(check_current_era $NODE_ID)"
         exit 1
     fi
+}
+
+# Checks that the current era + 1 contains a nodes
+# public key hex
+function is_trusted_validator() {
+    local NODE_ID=${1}
+    local HEX=$(get_node_public_key_hex_extended "$NODE_ID")
+    local ERA=$(check_current_era)
+    # Plus 1 to avoid query issue if era switches mid run
+    local ERA_PLUS_1=$(expr $ERA + 1)
+    # note: tonumber is a must here to prevent jq from being too smart.
+    # The jq arg 'era' is set to $ERA_PLUS_1. The query looks to find that
+    # the validator is removed from era_validators list. We grep for
+    # the public_key_hex to see if the validator is still listed and return
+    # the exit code to check success.
+    nctl-view-chain-auction-info | jq --arg era "$ERA_PLUS_1" '.auction_state.era_validators[] | select(.era_id == ($era | tonumber))' | grep -q "$HEX"
+    return $?
+}
+
+function assert_eviction() {
+    local NODE_ID=${1}
+    local SYNC_TIMEOUT_SEC=${2:-"300"}
+    local WAIT_TIME_SEC='0'
+
+    log_step "Checking for evicted node-$NODE_ID..."
+    while [ "$WAIT_TIME_SEC" != "$SYNC_TIMEOUT_SEC" ]; do
+        if ( ! is_trusted_validator "$NODE_ID" ); then
+            log "validator node-$NODE_ID was ejected! [expected]"
+            break
+        fi
+
+        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
+
+        if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
+            log "ERROR: Time out. Failed to confirm node-$NODE_ID as evicted validator in $SYNC_TIMEOUT_SEC seconds."
+            exit 1
+        fi
+        sleep 1
+    done
 }

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -99,23 +99,6 @@ function check_inactive() {
     return $?
 }
 
-# Checks that the current era + 1 contains a nodes 
-# public key hex
-function is_trusted_validator() {
-    local NODE_ID=${1}
-    local HEX=$(get_node_public_key_hex_extended "$NODE_ID")
-    local ERA=$(check_current_era)
-    # Plus 1 to avoid query issue if era switches mid run
-    local ERA_PLUS_1=$(expr $ERA + 1)
-    # note: tonumber is a must here to prevent jq from being too smart.
-    # The jq arg 'era' is set to $ERA_PLUS_1. The query looks to find that
-    # the validator is removed from era_validators list. We grep for
-    # the public_key_hex to see if the validator is still listed and return
-    # the exit code to check success.
-    nctl-view-chain-auction-info | jq --arg era "$ERA_PLUS_1" '.auction_state.era_validators[] | select(.era_id == ($era | tonumber))' | grep -q "$HEX"
-    return $?
-}
-
 function assert_inactive() {
     local NODE_ID=${1}
     log_step "Checking for inactive node-$NODE_ID..."
@@ -129,25 +112,6 @@ function assert_inactive() {
 
         if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
             log "ERROR: Time out. Failed to confirm node-$NODE_ID as inactive validator in $SYNC_TIMEOUT_SEC seconds."
-            exit 1
-        fi
-        sleep 1
-    done
-}
-
-function assert_eviction() {
-    local NODE_ID=${1}
-    log_step "Checking for evicted node-$NODE_ID..."
-    while [ "$WAIT_TIME_SEC" != "$SYNC_TIMEOUT_SEC" ]; do
-        if ( ! is_trusted_validator "$NODE_ID" ); then
-            log "validator node-$NODE_ID was ejected! [expected]"
-            break
-        fi
-
-        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
-
-        if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
-            log "ERROR: Time out. Failed to confirm node-$NODE_ID as evicted validator in $SYNC_TIMEOUT_SEC seconds."
             exit 1
         fi
         sleep 1


### PR DESCRIPTION
Changes:
- Adds unbonding testing to `bond_its.sh`
- Turns off seignorage in `bond_its.chainspec.toml.in` for consistent unbonding
- Moved `is_trusted_validator` & `assert_eviction` to common for re-use
- Updated logging messages for `assert_no_equivocators_logs` function

Jira: https://casperlabs.atlassian.net/browse/NDRS-846