### PR TITLE
Fast sync: Download all blocks with not-yet-expired deploys.

### DIFF
--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -11,7 +11,8 @@ use crate::{
     components::fetcher::FetcherError,
     crypto,
     types::{
-        BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata, Deploy,
+        Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata,
+        Deploy,
     },
 };
 use num::rational::Ratio;
@@ -89,6 +90,9 @@ where
         current_version: ProtocolVersion,
         block_header_with_future_version: Box<BlockHeader>,
     },
+
+    #[error(transparent)]
+    BlockFetcherError(#[from] FetcherError<Block, I>),
 
     #[error(transparent)]
     BlockHeaderFetcherError(#[from] FetcherError<BlockHeader, I>),


### PR DESCRIPTION
Download all blocks younger than the maximum deploy TTL when joining:
These deploy hashes are necessary for detecting replayed deploys in new blocks.

Closes #1596.

