### PR TITLE
Make shutdown on standstill optional.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -519,7 +519,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
     fn handle_standstill_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
         if self.evidence_only || self.finalized_switch_block() || !self.shutdown_on_standstill {
-            return vec![]; // Era has ended. No further progress is expected.
+            // Era has ended and no further progress is expected, or shutdown on standstill is
+            // turned off.
+            return vec![];
         }
         if self.last_panorama == *self.highway.state().panorama() {
             info!(

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -87,9 +87,12 @@ where
     /// The panorama snapshot. This is updated periodically, and if it does not change for too
     /// long, an alert is raised.
     last_panorama: Panorama<C>,
-    /// If the current era's protocol state has not progressed for this long, return
-    /// `ProtocolOutcome::StandstillAlert`.
+    /// If the current era's protocol state has not progressed for this long, request the latest
+    /// state from peers.
     standstill_timeout: TimeDiff,
+    /// If after another `standstill_timeout` there is no progress, raise
+    /// `ProtocolOutcome::StandstillAlert` and shut down.
+    shutdown_on_standstill: bool,
     /// Log inactive or faulty validators periodically, with this interval.
     log_participation_interval: TimeDiff,
     /// Whether to log the size of every incoming and outgoing serialized unit.
@@ -209,6 +212,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             evidence_only: false,
             last_panorama,
             standstill_timeout: config.highway.standstill_timeout,
+            shutdown_on_standstill: config.highway.shutdown_on_standstill,
             log_participation_interval: config.highway.log_participation_interval,
             log_unit_sizes: config.highway.log_unit_sizes,
         });
@@ -483,13 +487,22 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             // standstill alert. If we still won't progress by the time
             // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
             let mut outcomes = self.latest_panorama_request();
-            outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now + self.standstill_timeout,
-                TIMER_ID_STANDSTILL_ALERT,
-            ));
+            if self.shutdown_on_standstill {
+                outcomes.push(ProtocolOutcome::ScheduleTimer(
+                    now + self.standstill_timeout,
+                    TIMER_ID_STANDSTILL_ALERT,
+                ));
+            }
             return outcomes;
         }
 
+        if !self.shutdown_on_standstill {
+            debug!(
+                instance_id = ?self.highway.instance_id(),
+                "progress detected; not requesting latest state",
+            );
+            return vec![];
+        }
         debug!(
             instance_id = ?self.highway.instance_id(),
             "progress detected; scheduling next standstill check in {}",
@@ -505,7 +518,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
     fn handle_standstill_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
-        if self.evidence_only || self.finalized_switch_block() {
+        if self.evidence_only || self.finalized_switch_block() || !self.shutdown_on_standstill {
             return vec![]; // Era has ended. No further progress is expected.
         }
         if self.last_panorama == *self.highway.state().panorama() {

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -16,8 +16,11 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
-    /// If the current era's protocol state has not progressed for this long, shut down.
+    /// If the current era's protocol state has not progressed for this long, request the latest
+    /// state from peers.
     pub standstill_timeout: TimeDiff,
+    /// If another `standstill_timeout` passes assume we failed to join the network and restart.
+    pub shutdown_on_standstill: bool,
     /// Log inactive or faulty validators periodically, with this interval.
     pub log_participation_interval: TimeDiff,
     /// Log the size of every incoming and outgoing serialized unit.
@@ -36,6 +39,7 @@ impl Default for Config {
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
             standstill_timeout: "1min".parse().unwrap(),
+            shutdown_on_standstill: false,
             log_participation_interval: "10sec".parse().unwrap(),
             log_unit_sizes: false,
             max_execution_delay: 3,

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     /// state from peers.
     pub standstill_timeout: TimeDiff,
     /// If another `standstill_timeout` passes assume we failed to join the network and restart.
+    #[serde(default = "default_shutdown_on_standstill")]
     pub shutdown_on_standstill: bool,
     /// Log inactive or faulty validators periodically, with this interval.
     pub log_participation_interval: TimeDiff,
@@ -31,6 +32,10 @@ pub struct Config {
     /// The maximum number of peers we request the same vertex from in parallel.
     pub max_requests_for_vertex: usize,
     pub round_success_meter: RSMConfig,
+}
+
+fn default_shutdown_on_standstill() -> bool {
+    false
 }
 
 impl Default for Config {

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -75,6 +75,7 @@ where
         highway: HighwayConfig {
             pending_vertex_timeout: "1min".parse().unwrap(),
             standstill_timeout: STANDSTILL_TIMEOUT.parse().unwrap(),
+            shutdown_on_standstill: true,
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
             ..HighwayConfig::default()

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -43,8 +43,12 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# If the current era's protocol state has not progressed for this long, shut down.
+# If the current era's protocol state has not progressed for this long, request the latest state
+# from peers.
 standstill_timeout = '5min'
+
+# If after another `standstill_timeout` there still was no progress, shut down.
+shutdown_on_standstill = false
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -46,6 +46,9 @@ pending_vertex_timeout = '30min'
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'
 
+# If after another `standstill_timeout` there still was no progress, shut down.
+shutdown_on_standstill = false
+
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
 


### PR DESCRIPTION
Add a `shutdown_on_standstill` option: If this is disabled, nodes no longer shut down if no progress is made in consensus.

Closes #1680.