### PR TITLE
1691: Mitigate RUSTSEC-2021-0076

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
     commands:
       - cargo install cargo-audit
       - cargo generate-lockfile
-      - cargo audit --ignore RUSTSEC-2021-0073
+      - cargo audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
 
 trigger:
   branch:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2021-0073
+	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)


### PR DESCRIPTION
CHANGELOG:

- Add exception for RUSTSEC-2021-0076 in both `Makefile` and `drone.yml` 

Closes: https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1691