### PR TITLE
NCTL - Asset pathing fix for release vs release-candidate

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -25,7 +25,7 @@ function main() {
 
     # Start
     start_upgrade_scenario_1
-    start_upgrade_scenario_3
+    #start_upgrade_scenario_3
 }
 
 # Pulls down all remotely staged files

--- a/utils/nctl/sh/staging/set_remote.sh
+++ b/utils/nctl/sh/staging/set_remote.sh
@@ -44,7 +44,7 @@ function _main()
     pushd "$PATH_TO_REMOTE" || exit
     for REMOTE_FILE in "${_REMOTE_FILES[@]}"
     do
-        if [ "${#PROTOCOL_VERSION}" = '3' ]; then
+        if ( ! curl -Isf "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1 ); then
             log "... downloading RC $PROTOCOL_VERSION :: $REMOTE_FILE"
             curl -O "$_BASE_URL/release-$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
         else


### PR DESCRIPTION
Changes:
- Switched to check if the `vX.Y.Z` url exists.
    - Uses `release-X.Y.Z` url if not