### PR TITLE
Wrap DeployAccepted event stream event

### DIFF
--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -25,8 +25,9 @@ use tracing::debug;
 use super::*;
 use crate::{logging, testing::TestRng};
 use sse_server::{
-    Id, QUERY_FIELD, SSE_API_DEPLOYS_PATH as DEPLOYS_PATH, SSE_API_MAIN_PATH as MAIN_PATH,
-    SSE_API_ROOT_PATH as ROOT_PATH, SSE_API_SIGNATURES_PATH as SIGS_PATH,
+    DeployAccepted, Id, QUERY_FIELD, SSE_API_DEPLOYS_PATH as DEPLOYS_PATH,
+    SSE_API_MAIN_PATH as MAIN_PATH, SSE_API_ROOT_PATH as ROOT_PATH,
+    SSE_API_SIGNATURES_PATH as SIGS_PATH,
 };
 
 /// The total number of random events each `EventStreamServer` will emit by default, excluding the
@@ -350,8 +351,8 @@ impl TestFixture {
                 SseData::DeployAccepted {
                     deploy: deploy_hash,
                 } => {
-                    let deploy = self.deploy_getter.get_test_deploy(*deploy_hash).unwrap();
-                    serde_json::to_string(&deploy).unwrap()
+                    let deploy_accepted = self.deploy_getter.get_test_deploy(*deploy_hash).unwrap();
+                    serde_json::to_string(&DeployAccepted { deploy_accepted }).unwrap()
                 }
                 _ => serde_json::to_string(event).unwrap(),
             };


### PR DESCRIPTION
This PR changes how an accepted deploy is represented in JSON on the event stream.  Previously, only the contents of the deploy were output.  This now wraps the contents in a `DeployAccepted` type, making it consistent with the style of other SSEs.

Closes #1743.
