### PR TITLE
Feat fast sync block by height

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -36,7 +36,7 @@ use crate::{
         announcements::{BlocklistAnnouncement, ConsensusAnnouncement},
         requests::{
             BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest, ConsensusRequest,
-            ContractRuntimeRequest, LinearChainRequest, NetworkRequest, StorageRequest,
+            ContractRuntimeRequest, NetworkRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -252,7 +252,6 @@ pub trait ReactorEventT<I>:
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
     + From<ChainspecLoaderRequest>
-    + From<LinearChainRequest<I>>
     + From<BlocklistAnnouncement<I>>
 {
 }
@@ -268,7 +267,6 @@ impl<REv, I> ReactorEventT<I> for REv where
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
         + From<ChainspecLoaderRequest>
-        + From<LinearChainRequest<I>>
         + From<BlocklistAnnouncement<I>>
 {
 }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -638,7 +638,7 @@ impl ContractRuntime {
 
     /// Read a [Trie<Key, StoredValue>] from the trie store.
     pub fn read_trie(
-        &mut self,
+        &self,
         trie_key: Blake2bHash,
     ) -> Result<Option<Trie<Key, StoredValue>>, engine_state::Error> {
         let correlation_id = CorrelationId::new();

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -89,8 +89,6 @@ reactor!(Reactor {
     }
 
     requests: {
-        // This test contains no linear chain requests, so we panic if we receive any.
-        LinearChainRequest<NodeId> -> !;
         NetworkRequest<NodeId, Message> -> network;
         StorageRequest -> storage;
         StateStoreRequest -> storage;

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -30,7 +30,7 @@ use crate::{
             ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
             GossiperAnnouncement, NetworkAnnouncement, RpcServerAnnouncement,
         },
-        requests::{ConsensusRequest, ContractRuntimeRequest, LinearChainRequest},
+        requests::{ConsensusRequest, ContractRuntimeRequest},
         Responder,
     },
     fatal,
@@ -103,12 +103,6 @@ impl From<NetworkRequest<NodeId, Message<Deploy>>> for Event {
 
 impl From<ConsensusRequest> for Event {
     fn from(_request: ConsensusRequest) -> Self {
-        unimplemented!("not implemented for gossiper tests")
-    }
-}
-
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(_request: LinearChainRequest<NodeId>) -> Self {
         unimplemented!("not implemented for gossiper tests")
     }
 }

--- a/node/src/components/linear_chain/event.rs
+++ b/node/src/components/linear_chain/event.rs
@@ -4,18 +4,11 @@ use std::{
 };
 
 use casper_types::ExecutionResult;
-use derive_more::From;
 
-use crate::{
-    effect::requests::LinearChainRequest,
-    types::{Block, BlockSignatures, DeployHash, FinalitySignature},
-};
+use crate::types::{Block, BlockSignatures, DeployHash, FinalitySignature};
 
-#[derive(Debug, From)]
-pub enum Event<I> {
-    /// A linear chain request issued by another node in the network.
-    #[from]
-    Request(LinearChainRequest<I>),
+#[derive(Debug)]
+pub enum Event {
     /// New linear chain block has been produced.
     NewLinearChainBlock {
         /// The block.
@@ -39,10 +32,9 @@ pub enum Event<I> {
     IsBonded(Option<Box<BlockSignatures>>, Box<FinalitySignature>, bool),
 }
 
-impl<I: Display> Display for Event<I> {
+impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Event::Request(req) => write!(f, "linear chain request: {}", req),
             Event::NewLinearChainBlock { block, .. } => {
                 write!(f, "linear chain new block: {}", block.hash())
             }

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -68,9 +68,11 @@ use crate::{
     NodeRng,
 };
 use casper_execution_engine::{shared::stored_value::StoredValue, storage::trie::Trie};
+pub(crate) use error::FinalitySignatureError;
 use event::BlockByHeightResult;
 pub use event::Event;
 pub use metrics::LinearChainSyncMetrics;
+pub(crate) use operations::check_sufficient_finality_signatures;
 pub use peers::PeersState;
 pub use state::State;
 pub use traits::ReactorEventT;

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -124,16 +124,6 @@ where
     Ok(deploy)
 }
 
-/// Returns the genesis validator weights, by public key.
-fn get_genesis_validators(chainspec: &Chainspec) -> BTreeMap<PublicKey, U512> {
-    chainspec
-        .network_config
-        .chainspec_validator_stakes()
-        .into_iter()
-        .map(|(pub_key, motes)| (pub_key, motes.value()))
-        .collect()
-}
-
 /// Get trusted switch block; returns `None` if we are still in the first era.
 async fn maybe_get_trusted_switch_block<REv, I>(
     effect_builder: EffectBuilder<REv>,
@@ -195,6 +185,22 @@ fn validate_finality_signatures(
     // Cryptographically verify block signatures
     block_signatures.verify()?;
 
+    check_sufficient_finality_signatures(
+        trusted_validator_weights,
+        finality_threshold_fraction,
+        block_signatures,
+    )
+}
+
+/// Returns Ok(()) if the finality signatures' total weight exceeds the threshold. Returns an error
+/// if it doesn't, or if one of the signatures does not belong to a validator.
+///
+/// This does _not_ cryptographically verify the signatures.
+pub(crate) fn check_sufficient_finality_signatures(
+    trusted_validator_weights: &BTreeMap<PublicKey, U512>,
+    finality_threshold_fraction: Ratio<u64>,
+    block_signatures: &BlockSignatures,
+) -> Result<(), FinalitySignatureError> {
     // Calculate the weight of the signatures
     let mut signature_weight: U512 = U512::zero();
     for (public_key, _) in block_signatures.proofs.iter() {
@@ -204,11 +210,9 @@ fn validate_finality_signatures(
                     trusted_validator_weights: trusted_validator_weights.clone(),
                     block_signatures: Box::new(block_signatures.clone()),
                     bogus_validator_public_key: Box::new(public_key.clone()),
-                })
+                });
             }
-            Some(validator_weight) => {
-                signature_weight += *validator_weight;
-            }
+            Some(validator_weight) => signature_weight += *validator_weight,
         }
     }
 
@@ -232,7 +236,6 @@ fn validate_finality_signatures(
             finality_threshold_fraction,
         });
     }
-
     Ok(())
 }
 
@@ -448,7 +451,7 @@ where
         maybe_get_trusted_switch_block(effect_builder, &chainspec, &trusted_header).await?;
 
     let mut trusted_validator_weights = maybe_trusted_switch_block.as_ref().map_or_else(
-        || get_genesis_validators(&chainspec),
+        || chainspec.network_config.chainspec_validator_stakes(),
         |switch_block| switch_block.next_era_validator_weights().unwrap().clone(),
     );
 

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    fmt::Debug,
-    ops::{Add, Div},
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt::Debug, ops::Sub, time::Duration};
 
 use num::rational::Ratio;
 use tracing::{error, info, trace, warn};
@@ -222,7 +217,7 @@ pub(crate) fn check_sufficient_finality_signatures(
         .map(|(_, weight)| *weight)
         .sum();
 
-    let lower_bound = finality_threshold_fraction.add(1).div(2);
+    let lower_bound = Ratio::from(1u64).sub(finality_threshold_fraction);
     // Verify: signature_weight / total_weight >= lower_bound
     // Equivalent to the following
     if signature_weight * U512::from(*lower_bound.denom())

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Debug, ops::Sub, time::Duration};
+use std::{collections::BTreeMap, fmt::Debug, time::Duration};
 
 use num::rational::Ratio;
 use tracing::{error, info, trace, warn};
@@ -187,8 +187,8 @@ fn validate_finality_signatures(
     )
 }
 
-/// Returns Ok(()) if the finality signatures' total weight exceeds the threshold. Returns an error
-/// if it doesn't, or if one of the signatures does not belong to a validator.
+/// Returns `Ok(())` if the finality signatures' total weight exceeds the threshold. Returns an
+/// error if it doesn't, or if one of the signatures does not belong to a validator.
 ///
 /// This does _not_ cryptographically verify the signatures.
 pub(crate) fn check_sufficient_finality_signatures(
@@ -217,7 +217,7 @@ pub(crate) fn check_sufficient_finality_signatures(
         .map(|(_, weight)| *weight)
         .sum();
 
-    let lower_bound = Ratio::from(1u64).sub(finality_threshold_fraction);
+    let lower_bound = Ratio::from(1u64) - finality_threshold_fraction;
     // Verify: signature_weight / total_weight >= lower_bound
     // Equivalent to the following
     if signature_weight * U512::from(*lower_bound.denom())

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -42,8 +42,8 @@ use crate::{
     effect::{
         announcements::RpcServerAnnouncement,
         requests::{
-            ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, LinearChainRequest,
-            MetricsRequest, NetworkInfoRequest, RpcRequest, StorageRequest,
+            ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, MetricsRequest,
+            NetworkInfoRequest, RpcRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects, Responder,
     },
@@ -63,7 +63,6 @@ pub trait ReactorEventT:
     + From<ChainspecLoaderRequest>
     + From<ContractRuntimeRequest>
     + From<ConsensusRequest>
-    + From<LinearChainRequest<NodeId>>
     + From<MetricsRequest>
     + From<NetworkInfoRequest<NodeId>>
     + From<StorageRequest>
@@ -78,7 +77,6 @@ impl<REv> ReactorEventT for REv where
         + From<ChainspecLoaderRequest>
         + From<ContractRuntimeRequest>
         + From<ConsensusRequest>
-        + From<LinearChainRequest<NodeId>>
         + From<MetricsRequest>
         + From<NetworkInfoRequest<NodeId>>
         + From<StorageRequest>

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1023,7 +1023,7 @@ impl Storage {
     }
 
     /// Retrieves a block by hash.
-    pub fn read_block(&self, block_hash: &BlockHash) -> Result<Option<Block>, LmdbExtError> {
+    pub fn read_block(&self, block_hash: &BlockHash) -> Result<Option<Block>, Error> {
         self.get_single_block(&mut self.env.begin_ro_txn()?, block_hash)
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1351,8 +1351,7 @@ impl Storage {
             Some(block_header) => block_header,
             None => return Ok(None),
         };
-        let maybe_block_body: Option<BlockBody> =
-            self.get_block_body_for_block_header(tx, &block_header)?;
+        let maybe_block_body = self.get_body_for_block_header(tx, &block_header)?;
         let block_body = match maybe_block_body {
             Some(block_body) => block_body,
             None => {
@@ -1367,7 +1366,7 @@ impl Storage {
         Ok(Some(block))
     }
 
-    fn get_block_body_for_block_header<Tx: Transaction>(
+    fn get_body_for_block_header<Tx: Transaction>(
         &self,
         tx: &mut Tx,
         block_header: &BlockHeader,
@@ -1469,7 +1468,7 @@ impl Storage {
             None => return Ok(None),
             Some(block_header_with_metadata) => block_header_with_metadata,
         };
-        if let Some(block_body) = self.get_block_body_for_block_header(tx, &block_header)? {
+        if let Some(block_body) = self.get_body_for_block_header(tx, &block_header)? {
             Ok(Some(BlockWithMetadata {
                 block: Block::new_from_header_and_body(block_header, block_body)?,
                 finality_signatures: block_signatures,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -71,7 +71,6 @@ use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, Transfer,
 use crate::{
     components::{
         linear_chain_sync::{self, FinalitySignatureError},
-        storage::lmdb_ext::LmdbExtError::CouldNotFindBlockBodyPart,
         Component,
     },
     crypto,
@@ -1474,10 +1473,6 @@ impl Storage {
             None => return Ok(None),
             Some(block_signatures) => block_signatures,
         };
-        let switch_block_hash = match self.switch_block_era_id_index.get(&block_header.era_id()) {
-            None => return Ok(None),
-            Some(switch_block_hash) => switch_block_hash,
-        };
         let finality_check_result = if block_header.era_id().is_genesis() {
             linear_chain_sync::check_sufficient_finality_signatures(
                 genesis_validator_weights,
@@ -1485,6 +1480,13 @@ impl Storage {
                 &block_signatures,
             )
         } else {
+            let switch_block_hash = match self
+                .switch_block_era_id_index
+                .get(&(block_header.era_id() - 1))
+            {
+                None => return Ok(None),
+                Some(switch_block_hash) => switch_block_hash,
+            };
             let switch_block_header = match self.get_single_block_header(tx, switch_block_hash)? {
                 None => return Ok(None),
                 Some(switch_block_header) => switch_block_header,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -679,9 +679,7 @@ impl Storage {
             StorageRequest::GetBlock {
                 block_hash,
                 responder,
-            } => responder
-                .respond(self.get_single_block(&mut self.env.begin_ro_txn()?, &block_hash)?)
-                .ignore(),
+            } => responder.respond(self.read_block(&block_hash)?).ignore(),
             StorageRequest::GetBlockHeaderAtHeight { height, responder } => responder
                 .respond(self.get_block_header_by_height(&mut self.env.begin_ro_txn()?, height)?)
                 .ignore(),
@@ -1024,7 +1022,12 @@ impl Storage {
         }))
     }
 
-    /// Retrieves a block header to handle a network request.
+    /// Retrieves a block by hash.
+    pub fn read_block(&self, block_hash: &BlockHash) -> Result<Option<Block>, LmdbExtError> {
+        self.get_single_block(&mut self.env.begin_ro_txn()?, block_hash)
+    }
+
+    /// Retrieves a block header by height.
     /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
     /// before the most recent emergency upgrade.
     pub fn read_block_header_and_sufficient_finality_signatures_by_height(
@@ -1047,7 +1050,7 @@ impl Storage {
         Ok(maybe_block_header_and_finality_signatures)
     }
 
-    /// Retrieves a block to handle a network request.
+    /// Retrieves a block by height.
     /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
     /// before the most recent emergency upgrade.
     pub fn read_block_and_sufficient_finality_signatures_by_height(
@@ -1330,7 +1333,7 @@ impl Storage {
         Ok(true)
     }
 
-    // Retrieves a block header to handle a network request.
+    // Retrieves a block header by hash.
     pub fn get_block_header_by_hash(
         &self,
         block_hash: &BlockHash,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1047,6 +1047,29 @@ impl Storage {
         Ok(maybe_block_header_and_finality_signatures)
     }
 
+    /// Retrieves a block to handle a network request.
+    /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
+    /// before the most recent emergency upgrade.
+    pub fn read_block_and_sufficient_finality_signatures_by_height(
+        &self,
+        height: u64,
+        genesis_validator_weights: &BTreeMap<PublicKey, U512>,
+        finality_threshold_fraction: Ratio<u64>,
+        last_emergency_restart: Option<EraId>,
+    ) -> Result<Option<BlockWithMetadata>, Error> {
+        let mut txn = self.env.begin_ro_txn()?;
+        let maybe_block_and_finality_signatures = self
+            .get_block_and_sufficient_finality_signatures_by_height(
+                &mut txn,
+                height,
+                genesis_validator_weights,
+                finality_threshold_fraction,
+                last_emergency_restart,
+            )?;
+        drop(txn);
+        Ok(maybe_block_and_finality_signatures)
+    }
+
     /// Retrieves single block header by height by looking it up in the index and returning it.
     fn get_block_header_by_height<Tx: Transaction>(
         &self,
@@ -1328,14 +1351,8 @@ impl Storage {
             Some(block_header) => block_header,
             None => return Ok(None),
         };
-        let maybe_block_body: Option<BlockBody> = match block_header.hashing_algorithm_version() {
-            HashingAlgorithmVersion::V1 => {
-                self.get_single_v1_block_body(tx, block_header.body_hash())?
-            }
-            HashingAlgorithmVersion::V2 => {
-                self.get_single_block_body_v2(tx, block_header.body_hash())?
-            }
-        };
+        let maybe_block_body: Option<BlockBody> =
+            self.get_block_body_for_block_header(tx, &block_header)?;
         let block_body = match maybe_block_body {
             Some(block_body) => block_body,
             None => {
@@ -1350,7 +1367,22 @@ impl Storage {
         Ok(Some(block))
     }
 
-    fn get_single_v1_block_body<Tx: Transaction>(
+    fn get_block_body_for_block_header<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        block_header: &BlockHeader,
+    ) -> Result<Option<BlockBody>, LmdbExtError> {
+        match block_header.hashing_algorithm_version() {
+            HashingAlgorithmVersion::V1 => {
+                self.get_single_block_body_v1(tx, block_header.body_hash())
+            }
+            HashingAlgorithmVersion::V2 => {
+                self.get_single_block_body_v2(tx, block_header.body_hash())
+            }
+        }
+    }
+
+    fn get_single_block_body_v1<Tx: Transaction>(
         &self,
         tx: &mut Tx,
         block_body_hash: &Digest,
@@ -1411,6 +1443,41 @@ impl Storage {
         block_hash: &BlockHash,
     ) -> Result<Option<BlockSignatures>, Error> {
         Ok(tx.get_value(self.block_metadata_db, block_hash)?)
+    }
+
+    /// Retrieves single block header by height by looking it up in the index and returning it;
+    /// returns `None` if they are less than the fault tolerance threshold, or if the block is from
+    /// before the most recent emergency upgrade.
+    fn get_block_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        height: u64,
+        genesis_validator_weights: &BTreeMap<PublicKey, U512>,
+        finality_threshold_fraction: Ratio<u64>,
+        last_emergency_restart: Option<EraId>,
+    ) -> Result<Option<BlockWithMetadata>, Error> {
+        let BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        } = match self.get_block_header_and_sufficient_finality_signatures_by_height(
+            tx,
+            height,
+            genesis_validator_weights,
+            finality_threshold_fraction,
+            last_emergency_restart,
+        )? {
+            None => return Ok(None),
+            Some(block_header_with_metadata) => block_header_with_metadata,
+        };
+        if let Some(block_body) = self.get_block_body_for_block_header(tx, &block_header)? {
+            Ok(Some(BlockWithMetadata {
+                block: Block::new_from_header_and_body(block_header, block_body)?,
+                finality_signatures: block_signatures,
+            }))
+        } else {
+            debug!(?block_header, "Missing block body for header");
+            Ok(None)
+        }
     }
 
     /// Retrieves single block header by height by looking it up in the index and returning it;

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -386,7 +386,7 @@ fn can_put_and_get_block() {
 }
 
 #[test]
-fn test_get_block_header_and_finality_signatures_by_height() {
+fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);
 
@@ -458,9 +458,17 @@ fn test_get_block_header_and_finality_signatures_by_height() {
         );
     }
 
+    let genesis_validator_weights = todo!();
+    let finality_threshold_fraction = todo!();
+
     {
         let block_header_with_metadata = storage
-            .read_block_header_and_finality_signatures_by_height(block.header().height())
+            .read_block_header_and_sufficient_finality_signatures_by_height(
+                block.header().height(),
+                genesis_validator_weights,
+                finality_threshold_fraction,
+                None, // last emergency restart
+            )
             .expect("should not throw exception")
             .expect("should not be None");
         assert_eq!(

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -528,6 +528,25 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
             block_header_with_metadata.block_signatures, block_signatures,
             "Should have retrieved expected block signatures"
         );
+
+        let block_with_metadata = storage
+            .read_block_and_sufficient_finality_signatures_by_height(
+                block.header().height(),
+                &genesis_validator_weights,
+                finality_threshold_fraction,
+                None, // last emergency restart
+            )
+            .expect("should not throw exception")
+            .expect("should not be None");
+        assert_eq!(
+            block_with_metadata.block.header(),
+            block.header(),
+            "Should have retrieved expected block header"
+        );
+        assert_eq!(
+            block_with_metadata.finality_signatures, block_signatures,
+            "Should have retrieved expected block signatures"
+        );
     }
 }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -506,7 +506,7 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
     let finality_threshold_fraction = Ratio::new(1, 3);
     let switch_block =
         switch_block_for_block_header(block.header(), genesis_validator_weights.clone());
-    let was_new = put_block(&mut harness, &mut storage, Box::new(switch_block.clone()));
+    let was_new = put_block(&mut harness, &mut storage, Box::new(switch_block));
     assert!(was_new, "putting switch block should have returned `true`");
 
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -989,28 +989,6 @@ impl<I: Display> Display for BlockValidationRequest<I> {
 
 type BlockHeight = u64;
 
-#[derive(Debug, Serialize)]
-/// Requests issued to the Linear Chain component.
-pub enum LinearChainRequest<I> {
-    /// Request whole block from the linear chain, by hash.
-    BlockRequest(BlockHash, I),
-    /// Request for a linear chain block at height.
-    BlockWithMetadataAtHeight(BlockHeight, I),
-}
-
-impl<I: Display> Display for LinearChainRequest<I> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LinearChainRequest::BlockRequest(bh, peer) => {
-                write!(f, "block request for hash {} from {}", bh, peer)
-            }
-            LinearChainRequest::BlockWithMetadataAtHeight(height, sender) => {
-                write!(f, "block request for {} from {}", height, sender)
-            }
-        }
-    }
-}
-
 #[derive(DataSize, Debug)]
 #[must_use]
 /// Consensus component requests.

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -27,8 +27,8 @@ use crate::{
             ChainspecLoaderAnnouncement, ContractRuntimeAnnouncement, ControlAnnouncement,
         },
         requests::{
-            ConsensusRequest, ContractRuntimeRequest, LinearChainRequest, NetworkRequest,
-            RestRequest, StateStoreRequest, StorageRequest,
+            ConsensusRequest, ContractRuntimeRequest, NetworkRequest, RestRequest,
+            StateStoreRequest, StorageRequest,
         },
         EffectBuilder, Effects,
     },
@@ -95,12 +95,6 @@ impl From<NetworkRequest<NodeId, Message>> for Event {
 impl From<ChainspecLoaderAnnouncement> for Event {
     fn from(_announcement: ChainspecLoaderAnnouncement) -> Self {
         unreachable!("no chainspec announcements happen during initialization")
-    }
-}
-
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(_req: LinearChainRequest<NodeId>) -> Self {
-        unreachable!("no linear chain events happen during initialization")
     }
 }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -49,8 +49,8 @@ use crate::{
         },
         requests::{
             BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest, ConsensusRequest,
-            ContractRuntimeRequest, FetcherRequest, LinearChainRequest, MetricsRequest,
-            NetworkInfoRequest, NetworkRequest, RestRequest, StateStoreRequest, StorageRequest,
+            ContractRuntimeRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,
+            NetworkRequest, RestRequest, StateStoreRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -111,7 +111,7 @@ pub enum Event {
     #[from]
     NetworkInfoRequest(#[serde(skip_serializing)] NetworkInfoRequest<NodeId>),
 
-    /// Linear chain fetcher event.
+    /// Block fetcher event.
     #[from]
     BlockFetcher(#[serde(skip_serializing)] fetcher::Event<Block>),
 
@@ -153,7 +153,7 @@ pub enum Event {
 
     /// Linear chain event.
     #[from]
-    LinearChain(#[serde(skip_serializing)] linear_chain::Event<NodeId>),
+    LinearChain(#[serde(skip_serializing)] linear_chain::Event),
 
     /// Address gossiper event.
     #[from]
@@ -241,12 +241,6 @@ impl ReactorEvent for Event {
         } else {
             None
         }
-    }
-}
-
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(req: LinearChainRequest<NodeId>) -> Self {
-        Event::LinearChain(linear_chain::Event::Request(req))
     }
 }
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -54,9 +54,8 @@ use crate::{
         },
         requests::{
             BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest, ConsensusRequest,
-            ContractRuntimeRequest, FetcherRequest, LinearChainRequest, MetricsRequest,
-            NetworkInfoRequest, NetworkRequest, RestRequest, RpcRequest, StateStoreRequest,
-            StorageRequest,
+            ContractRuntimeRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,
+            NetworkRequest, RestRequest, RpcRequest, StateStoreRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -119,7 +118,7 @@ pub enum Event {
     BlockValidator(#[serde(skip_serializing)] block_validator::Event<NodeId>),
     /// Linear chain event.
     #[from]
-    LinearChain(#[serde(skip_serializing)] linear_chain::Event<NodeId>),
+    LinearChain(#[serde(skip_serializing)] linear_chain::Event),
 
     // Requests
     /// Contract runtime request.
@@ -237,12 +236,6 @@ impl From<NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>> for Event 
 impl From<ConsensusRequest> for Event {
     fn from(request: ConsensusRequest) -> Self {
         Event::Consensus(consensus::Event::ConsensusRequest(request))
-    }
-}
-
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(request: LinearChainRequest<NodeId>) -> Self {
-        Event::LinearChain(linear_chain::Event::Request(request))
     }
 }
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -725,7 +725,7 @@ impl reactor::Reactor for Reactor {
                             ))
                         }
                         Tag::BlockAndMetadataByHeight => {
-                            let height = match bincode::deserialize(&serialized_id) {
+                            let block_height = match bincode::deserialize(&serialized_id) {
                                 Ok(block_by_height) => block_by_height,
                                 Err(error) => {
                                     error!(
@@ -737,9 +737,42 @@ impl reactor::Reactor for Reactor {
                                     return Effects::new();
                                 }
                             };
-                            Event::LinearChain(linear_chain::Event::Request(
-                                LinearChainRequest::BlockWithMetadataAtHeight(height, sender),
-                            ))
+
+                            let chainspec = self.chainspec_loader.chainspec();
+                            let genesis_validator_weights =
+                                chainspec.network_config.chainspec_validator_stakes();
+                            let fetched_or_not_found_block_and_finality_signatures = match self
+                                .storage
+                                .read_block_and_sufficient_finality_signatures_by_height(
+                                    block_height,
+                                    &genesis_validator_weights,
+                                    chainspec.highway_config.finality_threshold_fraction,
+                                    chainspec.protocol_config.last_emergency_restart,
+                                ) {
+                                Ok(Some(block)) => FetchedOrNotFound::Fetched(block),
+                                Ok(None) => FetchedOrNotFound::NotFound(block_height),
+                                Err(error) => {
+                                    error!(
+                                        ?block_height,
+                                        ?sender,
+                                        ?error,
+                                        "error getting block at height",
+                                    );
+                                    FetchedOrNotFound::NotFound(block_height)
+                                }
+                            };
+
+                            match Message::new_get_response(
+                                &fetched_or_not_found_block_and_finality_signatures,
+                            ) {
+                                Ok(message) => {
+                                    return effect_builder.send_message(sender, message).ignore();
+                                }
+                                Err(error) => {
+                                    error!("failed to create get-response: {}", error);
+                                    return Effects::new();
+                                }
+                            };
                         }
                         Tag::GossipedAddress => {
                             warn!("received get request for gossiped-address from {}", sender);
@@ -794,7 +827,7 @@ impl reactor::Reactor for Reactor {
                                         ?serialized_id,
                                         ?sender,
                                         ?error,
-                                        "failed to decode block height",
+                                        "failed to decode block header height",
                                     );
                                     return Effects::new();
                                 }
@@ -820,7 +853,7 @@ impl reactor::Reactor for Reactor {
                                             ?block_height,
                                             ?sender,
                                             ?error,
-                                            "error getting block at height",
+                                            "error getting block header at height",
                                         );
                                         FetchedOrNotFound::NotFound(block_height)
                                     }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -367,6 +367,70 @@ impl Reactor {
 }
 
 impl Reactor {
+    /// Handles a request to get an item by id.
+    fn handle_get_request(
+        &self,
+        effect_builder: EffectBuilder<<Self as reactor::Reactor>::Event>,
+        sender: NodeId,
+        tag: Tag,
+        serialized_id: &[u8],
+    ) -> Effects<<Self as reactor::Reactor>::Event> {
+        match tag {
+            Tag::Deploy => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |deploy_hash| {
+                    self.storage.get_deploy(deploy_hash)
+                })
+            }
+            Tag::Block => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_hash| {
+                    self.storage.read_block(&block_hash)
+                })
+            }
+            Tag::BlockAndMetadataByHeight => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_height| {
+                    let chainspec = self.chainspec_loader.chainspec();
+                    let genesis_validator_weights =
+                        chainspec.network_config.chainspec_validator_stakes();
+                    self.storage
+                        .read_block_and_sufficient_finality_signatures_by_height(
+                            block_height,
+                            &genesis_validator_weights,
+                            chainspec.highway_config.finality_threshold_fraction,
+                            chainspec.protocol_config.last_emergency_restart,
+                        )
+                })
+            }
+            Tag::GossipedAddress => {
+                warn!("received get request for gossiped-address from {}", sender);
+                Effects::new()
+            }
+            Tag::BlockHeaderByHash => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_hash| {
+                    self.storage.get_block_header_by_hash(&block_hash)
+                })
+            }
+            Tag::BlockHeaderAndFinalitySignaturesByHeight => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_height| {
+                    let chainspec = self.chainspec_loader.chainspec();
+                    let genesis_validator_weights =
+                        chainspec.network_config.chainspec_validator_stakes();
+                    self.storage
+                        .read_block_header_and_sufficient_finality_signatures_by_height(
+                            block_height,
+                            &genesis_validator_weights,
+                            chainspec.highway_config.finality_threshold_fraction,
+                            chainspec.protocol_config.last_emergency_restart,
+                        )
+                })
+            }
+            Tag::Trie => {
+                Self::respond_to_fetch(effect_builder, serialized_id, sender, |trie_key| {
+                    self.contract_runtime.read_trie(trie_key)
+                })
+            }
+        }
+    }
+
     fn respond_to_fetch<T, F, E>(
         effect_builder: EffectBuilder<<Self as reactor::Reactor>::Event>,
         serialized_id: &[u8],
@@ -710,83 +774,9 @@ impl reactor::Reactor for Reactor {
                     Message::AddressGossiper(message) => {
                         Event::AddressGossiper(gossiper::Event::MessageReceived { sender, message })
                     }
-                    Message::GetRequest { tag, serialized_id } => match tag {
-                        Tag::Deploy => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |deploy_hash| self.storage.get_deploy(deploy_hash),
-                            )
-                        }
-                        Tag::Block => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |block_hash| self.storage.read_block(&block_hash),
-                            )
-                        }
-                        Tag::BlockAndMetadataByHeight => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |block_height| {
-                                    let chainspec = self.chainspec_loader.chainspec();
-                                    let genesis_validator_weights =
-                                        chainspec.network_config.chainspec_validator_stakes();
-                                    self.storage
-                                        .read_block_and_sufficient_finality_signatures_by_height(
-                                            block_height,
-                                            &genesis_validator_weights,
-                                            chainspec.highway_config.finality_threshold_fraction,
-                                            chainspec.protocol_config.last_emergency_restart,
-                                        )
-                                },
-                            )
-                        }
-                        Tag::GossipedAddress => {
-                            warn!("received get request for gossiped-address from {}", sender);
-                            return Effects::new();
-                        }
-                        Tag::BlockHeaderByHash => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |block_hash| self.storage.get_block_header_by_hash(&block_hash),
-                            )
-                        }
-                        Tag::BlockHeaderAndFinalitySignaturesByHeight => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |block_height| {
-                                    let chainspec = self.chainspec_loader.chainspec();
-                                    let genesis_validator_weights =
-                                        chainspec.network_config.chainspec_validator_stakes();
-                                    self
-                                    .storage
-                                    .read_block_header_and_sufficient_finality_signatures_by_height(
-                                        block_height,
-                                        &genesis_validator_weights,
-                                        chainspec.highway_config.finality_threshold_fraction,
-                                        chainspec.protocol_config.last_emergency_restart,
-                                    )
-                                },
-                            )
-                        }
-                        Tag::Trie => {
-                            return Self::respond_to_fetch(
-                                effect_builder,
-                                &serialized_id,
-                                sender,
-                                |trie_key| self.contract_runtime.read_trie(trie_key),
-                            )
-                        }
-                    },
+                    Message::GetRequest { tag, serialized_id } => {
+                        return self.handle_get_request(effect_builder, sender, tag, &serialized_id)
+                    }
                     Message::GetResponse {
                         tag,
                         serialized_item,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -799,11 +799,17 @@ impl reactor::Reactor for Reactor {
                                     return Effects::new();
                                 }
                             };
+                            let chainspec = self.chainspec_loader.chainspec();
+                            let genesis_validator_weights =
+                                chainspec.network_config.chainspec_validator_stakes();
                             let fetched_or_not_found_block_header_and_finality_signatures =
                                 match self
                                     .storage
-                                    .read_block_header_and_finality_signatures_by_height(
+                                    .read_block_header_and_sufficient_finality_signatures_by_height(
                                         block_height,
+                                        &genesis_validator_weights,
+                                        chainspec.highway_config.finality_threshold_fraction,
+                                        chainspec.protocol_config.last_emergency_restart,
                                     ) {
                                     Ok(Some(block_header)) => {
                                         FetchedOrNotFound::Fetched(block_header)

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -727,21 +727,12 @@ impl reactor::Reactor for Reactor {
                             )
                         }
                         Tag::Block => {
-                            let block_hash = match bincode::deserialize(&serialized_id) {
-                                Ok(hash) => hash,
-                                Err(error) => {
-                                    error!(
-                                        ?serialized_id,
-                                        ?sender,
-                                        ?error,
-                                        "failed to decode block hash",
-                                    );
-                                    return Effects::new();
-                                }
-                            };
-                            Event::LinearChain(linear_chain::Event::Request(
-                                LinearChainRequest::BlockRequest(block_hash, sender),
-                            ))
+                            return Self::respond_to_fetch(
+                                effect_builder,
+                                &serialized_id,
+                                sender,
+                                |block_hash| self.storage.read_block(&block_hash),
+                            )
                         }
                         Tag::BlockAndMetadataByHeight => {
                             return Self::respond_to_fetch(

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1429,7 +1429,7 @@ impl Block {
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        let era = rng.gen_range(0..5);
+        let era = rng.gen_range(1..6);
         let height = era * 10 + rng.gen_range(0..10);
         let is_switch = rng.gen_bool(0.1);
 

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -1,12 +1,13 @@
+use std::collections::BTreeMap;
+
 use datasize::DataSize;
 #[cfg(test)]
 use rand::Rng;
 use serde::Serialize;
 
-use casper_execution_engine::shared::motes::Motes;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey,
+    PublicKey, U512,
 };
 
 use super::AccountsConfig;
@@ -27,13 +28,16 @@ pub struct NetworkConfig {
 
 impl NetworkConfig {
     /// Returns a vector of chainspec validators' public key and their stake.
-    pub fn chainspec_validator_stakes(&self) -> Vec<(PublicKey, Motes)> {
+    pub fn chainspec_validator_stakes(&self) -> BTreeMap<PublicKey, U512> {
         self.accounts_config
             .accounts()
             .iter()
             .filter_map(|account_config| {
                 if account_config.is_genesis_validator() {
-                    Some((account_config.public_key(), account_config.bonded_amount()))
+                    Some((
+                        account_config.public_key(),
+                        account_config.bonded_amount().value(),
+                    ))
                 } else {
                     None
                 }

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -73,11 +73,18 @@ impl Timestamp {
     pub fn trailing_zeros(&self) -> u8 {
         self.0.trailing_zeros() as u8
     }
+}
 
+#[cfg(test)]
+impl Timestamp {
     /// Generates a random instance using a `TestRng`.
-    #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
         Timestamp(1_596_763_000_000 + rng.gen_range(200_000..1_000_000))
+    }
+
+    /// Checked subtraction for timestamps
+    pub fn checked_sub(self, other: TimeDiff) -> Option<Timestamp> {
+        self.0.checked_sub(other.0).map(Timestamp)
     }
 }
 


### PR DESCRIPTION
Ensures that we only send 2/3rds finality signatures over the wire when making a fetcher request.

Closes #1655
