### PR TITLE
Fix incorrect representation of BlockIdentifier | Backport to 1.3

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -50,7 +50,7 @@ All notable changes to this project will be documented in this file.  The format
 * Shut down SSE event streams gracefully.
 * Limit the maximum number of clients connected to the event stream server via the `[event_stream_server][max_concurrent_subscribers]` config option.
 * Avoid emitting duplicate events in the event stream.
-* Incorrect representation of BlockIdentifier in the Open-RPC schema.
+* Change `BlockIdentifier` params in the Open-RPC schema to be optional.
 
 
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.  The format
 * Shut down SSE event streams gracefully.
 * Limit the maximum number of clients connected to the event stream server via the `[event_stream_server][max_concurrent_subscribers]` config option.
 * Avoid emitting duplicate events in the event stream.
+* Incorrect representation of BlockIdentifier in the Open-RPC schema.
 
 
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -244,7 +244,7 @@ impl OpenRpcSchema {
     /// as false.
     fn make_optional_params(schema: Schema) -> Vec<SchemaParam> {
         let schema_object = schema.into_object().object.expect("should be object");
-        let optional_params = schema_object
+        schema_object
             .properties
             .iter()
             .filter(|(name, _)| schema_object.required.contains(*name))
@@ -253,8 +253,7 @@ impl OpenRpcSchema {
                 schema: schema.clone(),
                 required: false,
             })
-            .collect::<Vec<_>>();
-        optional_params
+            .collect::<Vec<_>>()
     }
 
     /// Insert the new entries into the #/components/schemas/ map.  Panic if we try to overwrite an


### PR DESCRIPTION
Backport of the fix to dev:

CHANGELOG:

  - Fixed incorrect representation of `BlockIdentifier` by adding a new function `make_optional_params` that accounts for incorrectly generated schema for `RpcWithOptionalParams`
  - Added tests to ensure correctness of the fix
  -  Closes ticket [1746](https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1746)