### PR TITLE
GOV-35: Do not synchronize the linear chain immediately after an upgrade.

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -305,7 +305,7 @@ impl ChainspecLoader {
     }
 
     /// Returns whether the current node instance is started immediately after an upgrade –
-    /// i.e. whether the last/highest block stored is a block that trigerred the upgrade.
+    /// i.e. whether the last/highest block stored is a block that triggerred the upgrade.
     pub(crate) fn after_upgrade(&self) -> bool {
         self.after_upgrade
     }

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -51,7 +51,7 @@ use crate::{
     reactor::ReactorExit,
     types::{
         chainspec::{Error, ProtocolConfig, CHAINSPEC_NAME},
-        ActivationPoint, Block, BlockHash, BlockHeader, Chainspec, ChainspecInfo, ExitCode,
+        ActivationPoint, Block, BlockHeader, Chainspec, ChainspecInfo, ExitCode,
     },
     utils::{self, Loadable},
     NodeRng,
@@ -322,10 +322,6 @@ impl ChainspecLoader {
 
     pub(crate) fn initial_block(&self) -> Option<&Block> {
         self.initial_block.as_ref()
-    }
-
-    pub(crate) fn initial_block_hash(&self) -> Option<BlockHash> {
-        self.initial_block_header().map(|hdr| hdr.hash())
     }
 
     /// This returns the era at which we will be starting the operation, assuming the highest known

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -120,12 +120,8 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                     * chainspec.core_config.minimum_era_height,
                 chainspec.core_config.era_duration,
             );
-            let state = match init_hash {
-                Some(init_hash) => State::sync_trusted_hash(
-                    init_hash,
-                    highest_block.map(|block| block.take_header()),
-                ),
-                None => State::Done(highest_block.map(Box::new)),
+
+            let state = match trusted_hash {
             };
             let state_key = create_state_key(chainspec);
             let linear_chain_sync = LinearChainSync {

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -29,14 +29,14 @@ mod peers;
 mod state;
 mod traits;
 
-use std::{collections::BTreeMap, convert::Infallible, fmt::Display, mem, str::FromStr};
+use std::{convert::Infallible, fmt::Display, mem, str::FromStr};
 
 use datasize::DataSize;
 use prometheus::Registry;
 use tracing::{error, info, trace, warn};
 
 use self::event::{BlockByHashResult, DeploysResult};
-use casper_types::{EraId, ProtocolVersion, PublicKey, U512};
+use casper_types::{EraId, ProtocolVersion};
 
 use super::{
     fetcher::FetchResult,
@@ -92,7 +92,6 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         storage: &Storage,
         init_hash: Option<BlockHash>,
         highest_block: Option<Block>,
-        _genesis_validator_weights: BTreeMap<PublicKey, U512>,
         next_upgrade_activation_point: Option<ActivationPoint>,
     ) -> Result<(Self, Effects<Event<I>>), Err>
     where

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -3,7 +3,6 @@
 mod memory_metrics;
 
 use std::{
-    collections::BTreeMap,
     env,
     fmt::{self, Display, Formatter},
     path::PathBuf,
@@ -67,7 +66,6 @@ use crate::{
     utils::{Source, WithDir},
     NodeRng,
 };
-use casper_types::{PublicKey, U512};
 
 /// Top-level event for the reactor.
 #[allow(clippy::large_enum_variant)]
@@ -487,13 +485,6 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec().core_config.unbonding_delay,
         )?;
 
-        let validator_weights: BTreeMap<PublicKey, U512> = chainspec_loader
-            .chainspec()
-            .network_config
-            .chainspec_validator_stakes()
-            .into_iter()
-            .map(|(pk, motes)| (pk, motes.value()))
-            .collect();
         let maybe_next_activation_point = chainspec_loader
             .next_upgrade()
             .map(|next_upgrade| next_upgrade.activation_point());
@@ -504,7 +495,6 @@ impl reactor::Reactor for Reactor {
             &storage,
             init_hash,
             chainspec_loader.initial_block().cloned(),
-            validator_weights,
             maybe_next_activation_point,
         )?;
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -409,12 +409,9 @@ impl reactor::Reactor for Reactor {
 
         let effect_builder = EffectBuilder::new(event_queue);
 
-        let init_hash = config
-            .node
-            .trusted_hash
-            .or_else(|| chainspec_loader.initial_block_hash());
+        let trusted_hash = config.node.trusted_hash;
 
-        match init_hash {
+        match trusted_hash {
             None => {
                 let chainspec = chainspec_loader.chainspec();
                 let era_duration = chainspec.core_config.era_duration;
@@ -436,7 +433,7 @@ impl reactor::Reactor for Reactor {
                 }
                 info!("No synchronization of the linear chain will be done.")
             }
-            Some(hash) => info!("Synchronizing linear chain from: {:?}", hash),
+            Some(hash) => info!(trusted_hash=%hash, "synchronizing linear chain"),
         }
 
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
@@ -493,7 +490,7 @@ impl reactor::Reactor for Reactor {
             effect_builder,
             chainspec_loader.chainspec(),
             &storage,
-            init_hash,
+            trusted_hash,
             chainspec_loader.initial_block().cloned(),
             maybe_next_activation_point,
         )?;

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -492,6 +492,7 @@ impl reactor::Reactor for Reactor {
             &storage,
             trusted_hash,
             chainspec_loader.initial_block().cloned(),
+            chainspec_loader.after_upgrade(),
             maybe_next_activation_point,
         )?;
 

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -3,7 +3,11 @@ use datasize::DataSize;
 use rand::Rng;
 use serde::Serialize;
 
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use casper_execution_engine::shared::motes::Motes;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    PublicKey,
+};
 
 use super::AccountsConfig;
 #[cfg(test)]
@@ -19,6 +23,24 @@ pub struct NetworkConfig {
     // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
     // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
     pub(crate) accounts_config: AccountsConfig,
+}
+
+impl NetworkConfig {
+    #[allow(unused)]
+    /// Returns a vector of chainspec validators' public key and their stake.
+    pub fn chainspec_validator_stakes(&self) -> Vec<(PublicKey, Motes)> {
+        self.accounts_config
+            .accounts()
+            .iter()
+            .filter_map(|account_config| {
+                if account_config.is_genesis_validator() {
+                    Some((account_config.public_key(), account_config.bonded_amount()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -3,11 +3,7 @@ use datasize::DataSize;
 use rand::Rng;
 use serde::Serialize;
 
-use casper_execution_engine::shared::motes::Motes;
-use casper_types::{
-    bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey,
-};
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 use super::AccountsConfig;
 #[cfg(test)]
@@ -23,23 +19,6 @@ pub struct NetworkConfig {
     // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
     // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
     pub(crate) accounts_config: AccountsConfig,
-}
-
-impl NetworkConfig {
-    /// Returns a vector of chainspec validators' public key and their stake.
-    pub fn chainspec_validator_stakes(&self) -> Vec<(PublicKey, Motes)> {
-        self.accounts_config
-            .accounts()
-            .iter()
-            .filter_map(|account_config| {
-                if account_config.is_genesis_validator() {
-                    Some((account_config.public_key(), account_config.bonded_amount()))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a logic that detects whether the current node instance is running immediately after an upgrade and if that's the case – won't perform any linear chain synchronization.