### PR TITLE
Parameterize Sync Timeout

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -23,13 +23,14 @@
 //! execute (as we do in the first, SynchronizeTrustedHash, phase) it would have taken more time and
 //! we might miss more eras.
 
+mod config;
 mod event;
 mod metrics;
 mod peers;
 mod state;
 mod traits;
 
-use std::{convert::Infallible, fmt::Display, mem, str::FromStr};
+use std::{convert::Infallible, fmt::Display, mem};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -52,6 +53,7 @@ use crate::{
     },
     NodeRng,
 };
+pub use config::Config;
 use event::BlockByHeightResult;
 pub use event::Event;
 pub use metrics::LinearChainSyncMetrics;
@@ -94,15 +96,14 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         highest_block: Option<Block>,
         after_upgrade: bool,
         next_upgrade_activation_point: Option<ActivationPoint>,
+        config: Config,
     ) -> Result<(Self, Effects<Event<I>>), Err>
     where
         REv: From<Event<I>> + Send,
         Err: From<prometheus::Error> + From<storage::Error>,
     {
-        // set timeout to 5 minutes after now.
-        let five_minutes = TimeDiff::from_str("5minutes").unwrap();
         let timeout_event = effect_builder
-            .set_timeout(five_minutes.into())
+            .set_timeout(config.get_sync_timeout().into())
             .event(|_| Event::InitializeTimeout);
         let protocol_version = chainspec.protocol_config.version;
         if let Some(state) = read_init_state(storage, chainspec)? {

--- a/node/src/components/linear_chain_sync/config.rs
+++ b/node/src/components/linear_chain_sync/config.rs
@@ -1,0 +1,27 @@
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+use crate::types::TimeDiff;
+
+const DEFAULT_SYNC_TIMEOUT: &str = "5min";
+
+/// Configuration options for fetching.
+#[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
+pub struct Config {
+    sync_timeout: TimeDiff,
+}
+
+impl Config {
+    pub(crate) fn get_sync_timeout(&self) -> TimeDiff {
+        self.sync_timeout
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            sync_timeout: TimeDiff::from_str(DEFAULT_SYNC_TIMEOUT).unwrap(),
+        }
+    }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -59,6 +59,7 @@ pub use components::{
     event_stream_server::Config as EventStreamServerConfig,
     fetcher::Config as FetcherConfig,
     gossiper::{Config as GossipConfig, Error as GossipError},
+    linear_chain_sync::Config as LinearChainSyncConfig,
     rest_server::Config as RestServerConfig,
     rpc_server::{rpcs, Config as RpcServerConfig},
     small_network::{Config as SmallNetworkConfig, Error as SmallNetworkError},

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -494,6 +494,7 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.initial_block().cloned(),
             chainspec_loader.after_upgrade(),
             maybe_next_activation_point,
+            config.linear_chain_sync,
         )?;
 
         effects.extend(reactor::wrap_effects(

--- a/node/src/reactor/participating/config.rs
+++ b/node/src/reactor/participating/config.rs
@@ -3,8 +3,8 @@ use serde::Deserialize;
 
 use crate::{
     logging::LoggingConfig, types::NodeConfig, ConsensusConfig, ContractRuntimeConfig,
-    DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig, GossipConfig, RestServerConfig,
-    RpcServerConfig, SmallNetworkConfig, StorageConfig,
+    DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig, GossipConfig,
+    LinearChainSyncConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig, StorageConfig,
 };
 
 /// Root configuration.
@@ -36,4 +36,6 @@ pub struct Config {
     pub contract_runtime: ContractRuntimeConfig,
     /// Deploy acceptor configuration.
     pub deploy_acceptor: DeployAcceptorConfig,
+    /// Linear chain sync configuration.
+    pub linear_chain_sync: LinearChainSyncConfig,
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -313,3 +313,7 @@ verify_accounts = true
 #
 # If unset, defaults to 5.
 #max_query_depth = 5
+
+[linear_chain_sync]
+# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
+sync_timeout = "1min"

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -316,4 +316,4 @@ verify_accounts = true
 
 [linear_chain_sync]
 # Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
-sync_timeout = "1min"
+sync_timeout = "1hr"

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -312,3 +312,7 @@ verify_accounts = true
 #
 # If unset, defaults to 5.
 #max_query_depth = 5
+
+[linear_chain_sync]
+# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
+sync_timeout = "1min"

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -315,4 +315,4 @@ verify_accounts = true
 
 [linear_chain_sync]
 # Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
-sync_timeout = "1min"
+sync_timeout = "1hr"


### PR DESCRIPTION
This PR introduces `sync_timeout` as a config option that allows an operator to control the duration of time that a node will sync before shutting down.