### PR TITLE
Revert to use fixed delay before including a deploy in a proposed block

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -39,7 +39,6 @@ All notable changes to this project will be documented in this file.  The format
 * Persist event stream event index across node restarts.
 * Separate transfers from other deploys in the block proposer.
 * Enable getting validators for future eras in `EffectBuilder::get_era_validators()`.
-* Replace config option `[block_propser][deploy_delay]` (which specified a fixed delay before proposing a deploy) with a gossip-finished announcement.
 * Improve logging around stalled consensus detection.
 * Skip storage integrity checks if the node didn't previously crash.
 * Update pinned version of Rust to `nightly-2021-06-17`.

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -3,6 +3,7 @@
 //! The block proposer stores deploy hashes in memory, tracking their suitability for inclusion into
 //! a new block. Upon request, it returns a list of candidates that can be included.
 
+mod config;
 mod deploy_sets;
 mod event;
 mod metrics;
@@ -16,10 +17,10 @@ use std::{
     time::Duration,
 };
 
+pub use config::Config;
 use datasize::DataSize;
 use itertools::Itertools;
 use prometheus::{self, Registry};
-use smallvec::smallvec;
 use tracing::{debug, error, info, trace, warn};
 
 use casper_types::PublicKey;
@@ -36,7 +37,7 @@ use crate::{
     types::{
         appendable_block::{AddError, AppendableBlock},
         chainspec::DeployConfig,
-        BlockPayload, Chainspec, Deploy, DeployHash, DeployHeader, DeployOrTransferHash, Timestamp,
+        BlockPayload, Chainspec, DeployHash, DeployHeader, DeployOrTransferHash, Timestamp,
     },
     NodeRng,
 };
@@ -85,6 +86,8 @@ enum BlockProposerState {
         pending: Vec<Event>,
         /// The deploy config from the current chainspec.
         deploy_config: DeployConfig,
+        /// The configuration, containing local settings for deploy selection.
+        local_config: Config,
     },
     /// Normal operation.
     Ready(BlockProposerReady),
@@ -97,6 +100,7 @@ impl BlockProposer {
         effect_builder: EffectBuilder<REv>,
         next_finalized_block: BlockHeight,
         chainspec: &Chainspec,
+        local_config: Config,
     ) -> Result<(Self, Effects<Event>), prometheus::Error>
     where
         REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
@@ -113,6 +117,7 @@ impl BlockProposer {
             state: BlockProposerState::Initializing {
                 pending: Vec::new(),
                 deploy_config: chainspec.deploy_config,
+                local_config,
             },
             metrics: BlockProposerMetrics::new(registry)?,
         };
@@ -144,6 +149,7 @@ where
                 BlockProposerState::Initializing {
                     ref mut pending,
                     deploy_config,
+                    local_config,
                 },
                 Event::Loaded {
                     finalized_deploys,
@@ -158,6 +164,7 @@ where
                     unhandled_finalized: Default::default(),
                     deploy_config: *deploy_config,
                     request_queue: Default::default(),
+                    local_config: local_config.clone(),
                 };
 
                 // Replay postponed events onto new state.
@@ -213,6 +220,8 @@ struct BlockProposerReady {
     deploy_config: DeployConfig,
     /// The queue of requests awaiting being handled.
     request_queue: RequestQueue,
+    /// The block proposer configuration, containing local settings for selecting deploys.
+    local_config: Config,
 }
 
 impl BlockProposerReady {
@@ -249,21 +258,8 @@ impl BlockProposerReady {
                         .ignore()
                 }
             }
-            Event::BufferDeploy(hash) => effect_builder
-                .get_deploys_from_storage(smallvec![hash])
-                .events(move |maybe_deploys| {
-                    maybe_deploys
-                        .into_iter()
-                        .filter_map(move |maybe_deploy| match maybe_deploy {
-                            None => {
-                                error!(%hash, "failed to retrieve deploy from storage");
-                                None
-                            }
-                            Some(deploy) => Some(Event::GotFromStorage(Box::new(deploy))),
-                        })
-                }),
-            Event::GotFromStorage(deploy) => {
-                self.add_deploy(Timestamp::now(), deploy);
+            Event::BufferDeploy { hash, deploy_info } => {
+                self.add_deploy(Timestamp::now(), hash, *deploy_info);
                 Effects::new()
             }
             Event::Prune => {
@@ -312,39 +308,37 @@ impl BlockProposerReady {
     }
 
     /// Adds a deploy or a transfer to the block proposer.
-    fn add_deploy(&mut self, current_instant: Timestamp, deploy: Box<Deploy>) {
-        let hash = deploy.deploy_or_transfer_hash();
-        if deploy.header().expired(current_instant) {
+    fn add_deploy(
+        &mut self,
+        current_instant: Timestamp,
+        hash: DeployOrTransferHash,
+        deploy_info: DeployInfo,
+    ) {
+        if deploy_info.header.expired(current_instant) {
             trace!(%hash, "expired deploy rejected from the buffer");
             return;
         }
-        if self.unhandled_finalized.remove(deploy.id()) {
+        if self.unhandled_finalized.remove(hash.deploy_hash()) {
             info!(%hash, "deploy was previously marked as finalized, storing header");
             self.sets
                 .finalized_deploys
-                .insert(*deploy.id(), deploy.take_header());
+                .insert(hash.into(), deploy_info.header);
             return;
         }
         // only add the deploy if it isn't contained in a finalized block
-        if self.sets.finalized_deploys.contains_key(deploy.id()) {
+        if self.sets.finalized_deploys.contains_key(hash.deploy_hash()) {
             info!(%hash, "deploy rejected from the buffer");
             return;
         }
 
-        let deploy_info = match deploy.deploy_info() {
-            Ok(deploy_info) => deploy_info,
-            Err(error) => {
-                error!(%error, %deploy, "invalid deploy");
-                return;
-            }
-        };
-
-        if deploy.session().is_transfer() {
+        if hash.is_transfer() {
             self.sets
                 .pending_transfers
-                .insert(*deploy.id(), deploy_info);
+                .insert(*hash.deploy_hash(), (deploy_info, current_instant));
         } else {
-            self.sets.pending_deploys.insert(*deploy.id(), deploy_info);
+            self.sets
+                .pending_deploys
+                .insert(*hash.deploy_hash(), (deploy_info, current_instant));
         }
 
         info!(%hash, "added deploy to the buffer");
@@ -365,7 +359,7 @@ impl BlockProposerReady {
                 }
             };
             match remove_result {
-                Some(deploy_info) => {
+                Some((deploy_info, _)) => {
                     self.sets.finalized_deploys.insert(hash, deploy_info.header);
                 }
                 // If we haven't seen this deploy before, we still need to take note of it.
@@ -437,10 +431,11 @@ impl BlockProposerReady {
         let mut appendable_block = AppendableBlock::new(deploy_config, block_timestamp);
 
         // We prioritize transfers over deploys, so we try to include them first.
-        for (hash, deploy_info) in &self.sets.pending_transfers {
+        for (hash, (deploy_info, received_time)) in &self.sets.pending_transfers {
             if !self.deps_resolved(&deploy_info.header, &past_deploys)
                 || past_deploys.contains(hash)
                 || self.contains_finalized(hash)
+                || block_timestamp.saturating_diff(*received_time) < self.local_config.deploy_delay
             {
                 continue;
             }
@@ -460,10 +455,11 @@ impl BlockProposerReady {
         }
 
         // Now we try to add other deploys to the block.
-        for (hash, deploy_info) in &self.sets.pending_deploys {
+        for (hash, (deploy_info, received_time)) in &self.sets.pending_deploys {
             if !self.deps_resolved(&deploy_info.header, &past_deploys)
                 || past_deploys.contains(hash)
                 || self.contains_finalized(hash)
+                || block_timestamp.saturating_diff(*received_time) < self.local_config.deploy_delay
             {
                 continue;
             }

--- a/node/src/components/block_proposer/config.rs
+++ b/node/src/components/block_proposer/config.rs
@@ -1,0 +1,28 @@
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use crate::types::TimeDiff;
+
+/// Block proposer configuration.
+#[derive(DataSize, Debug, Deserialize, Serialize, Clone)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Deploys are only proposed in a new block if they have been received at least this long ago.
+    /// A longer delay makes it more likely that many proposed deploys are already known by the
+    /// other nodes, and don't have to be requested from the proposer afterwards.
+    #[serde(default = "default_deploy_delay")]
+    pub deploy_delay: TimeDiff,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            deploy_delay: default_deploy_delay(),
+        }
+    }
+}
+
+fn default_deploy_delay() -> TimeDiff {
+    "1min".parse().unwrap()
+}

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -11,12 +11,12 @@ use crate::types::{DeployHash, DeployHeader, Timestamp};
 /// Stores the internal state of the BlockProposer.
 #[derive(Clone, DataSize, Debug, Default)]
 pub(super) struct BlockProposerDeploySets {
-    /// The collection of deploys pending for inclusion in a block, each added when the gossiper
-    /// announces it has finished gossiping it.
-    pub(super) pending_deploys: HashMap<DeployHash, DeployInfo>,
-    /// The collection of transfers pending for inclusion in a block, each added when the gossiper
-    /// announces it has finished gossiping it.
-    pub(super) pending_transfers: HashMap<DeployHash, DeployInfo>,
+    /// The collection of deploys pending for inclusion in a block, with a timestamp of when we
+    /// received them.
+    pub(super) pending_deploys: HashMap<DeployHash, (DeployInfo, Timestamp)>,
+    /// The collection of transfers pending for inclusion in a block, with a timestamp of when we
+    /// received them.
+    pub(super) pending_transfers: HashMap<DeployHash, (DeployInfo, Timestamp)>,
     /// The deploys that have already been included in a finalized block.
     pub(super) finalized_deploys: HashMap<DeployHash, DeployHeader>,
     /// The next block height we expect to be finalized.
@@ -79,10 +79,10 @@ pub(super) fn prune_deploys(
 /// Prunes expired deploy information from an individual pending deploy collection, returns the
 /// total deploys pruned
 pub(super) fn prune_pending_deploys(
-    deploys: &mut HashMap<DeployHash, DeployInfo>,
+    deploys: &mut HashMap<DeployHash, (DeployInfo, Timestamp)>,
     current_instant: Timestamp,
 ) -> usize {
     let initial_len = deploys.len();
-    deploys.retain(|_hash, deploy_info| !deploy_info.header.expired(current_instant));
+    deploys.retain(|_hash, (deploy_info, _)| !deploy_info.header.expired(current_instant));
     initial_len - deploys.len()
 }

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::BlockHeight;
 use crate::{
     effect::requests::BlockProposerRequest,
-    types::{Deploy, DeployHash, DeployHeader, FinalizedBlock},
+    types::{DeployHash, DeployHeader, DeployOrTransferHash, FinalizedBlock},
 };
 use casper_execution_engine::shared::motes::Motes;
 
@@ -33,11 +33,12 @@ pub enum Event {
         /// The height of the next expected finalized block.
         next_finalized_block: BlockHeight,
     },
-    /// A new deploy has been received by this node and gossiped: it should be retrieved from
-    /// storage and buffered here.
-    BufferDeploy(DeployHash),
-    /// The given deploy has been gossiped and can now be included in a block.
-    GotFromStorage(Box<Deploy>),
+    /// A new deploy has been received by this node and stored: it should be retrieved from storage
+    /// and buffered here.
+    BufferDeploy {
+        hash: DeployOrTransferHash,
+        deploy_info: Box<DeployInfo>,
+    },
     /// The block proposer has been asked to prune stale deploys.
     Prune,
     /// A block has been finalized. We should never propose its deploys again.
@@ -56,10 +57,7 @@ impl Display for Event {
                 "loaded block-proposer finalized deploys; expected next finalized block: {}",
                 next_finalized_block
             ),
-            Event::BufferDeploy(hash) => write!(f, "block-proposer add {}", hash),
-            Event::GotFromStorage(deploy) => {
-                write!(f, "block-proposer got from storage {}", deploy.id())
-            }
+            Event::BufferDeploy { hash, .. } => write!(f, "block-proposer add {}", hash),
             Event::Prune => write!(f, "block-proposer prune"),
             Event::FinalizedBlock(block) => {
                 write!(f, "block-proposer finalized block {}", block)

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -88,6 +88,13 @@ fn generate_deploy(
     )
 }
 
+fn create_test_proposer(deploy_delay: TimeDiff) -> BlockProposerReady {
+    BlockProposerReady {
+        local_config: Config { deploy_delay },
+        ..Default::default()
+    }
+}
+
 impl From<StorageRequest> for Event {
     fn from(_: StorageRequest) -> Self {
         // we never send a storage request in our unit tests, but if this does become
@@ -110,7 +117,7 @@ fn should_add_and_take_deploys() {
     let block_time2 = Timestamp::from(120);
     let block_time3 = Timestamp::from(220);
 
-    let mut proposer = BlockProposerReady::default();
+    let mut proposer = create_test_proposer(0.into());
     let mut rng = crate::new_rng();
     let deploy1 = generate_deploy(
         &mut rng,
@@ -155,8 +162,16 @@ fn should_add_and_take_deploys() {
     assert!(block.transfer_hashes().is_empty());
 
     // add two deploys
-    proposer.add_deploy(block_time2, Box::new(deploy1.clone()));
-    proposer.add_deploy(block_time2, Box::new(deploy2.clone()));
+    proposer.add_deploy(
+        block_time2,
+        deploy1.deploy_or_transfer_hash(),
+        deploy1.deploy_info().unwrap(),
+    );
+    proposer.add_deploy(
+        block_time2,
+        deploy2.deploy_or_transfer_hash(),
+        deploy2.deploy_info().unwrap(),
+    );
 
     // if we try to create a block with a timestamp that is too early, we shouldn't get any
     // deploys
@@ -217,8 +232,16 @@ fn should_add_and_take_deploys() {
     proposer.finalized_deploys(deploy_hashes.iter().copied());
 
     // add more deploys
-    proposer.add_deploy(block_time2, Box::new(deploy3.clone()));
-    proposer.add_deploy(block_time2, Box::new(deploy4.clone()));
+    proposer.add_deploy(
+        block_time2,
+        deploy3.deploy_or_transfer_hash(),
+        deploy3.deploy_info().unwrap(),
+    );
+    proposer.add_deploy(
+        block_time2,
+        deploy4.deploy_or_transfer_hash(),
+        deploy4.deploy_info().unwrap(),
+    );
 
     let block = proposer.propose_block_payload(
         DeployConfig::default(),
@@ -274,13 +297,29 @@ fn should_successfully_prune() {
         default_gas_payment(),
         DEFAULT_TEST_GAS_PRICE,
     );
-    let mut proposer = BlockProposerReady::default();
+    let mut proposer = create_test_proposer(0.into());
 
     // pending
-    proposer.add_deploy(creation_time, Box::new(deploy1.clone()));
-    proposer.add_deploy(creation_time, Box::new(deploy2));
-    proposer.add_deploy(creation_time, Box::new(deploy3));
-    proposer.add_deploy(creation_time, Box::new(deploy4));
+    proposer.add_deploy(
+        creation_time,
+        deploy1.deploy_or_transfer_hash(),
+        deploy1.deploy_info().unwrap(),
+    );
+    proposer.add_deploy(
+        creation_time,
+        deploy2.deploy_or_transfer_hash(),
+        deploy2.deploy_info().unwrap(),
+    );
+    proposer.add_deploy(
+        creation_time,
+        deploy3.deploy_or_transfer_hash(),
+        deploy3.deploy_info().unwrap(),
+    );
+    proposer.add_deploy(
+        creation_time,
+        deploy4.deploy_or_transfer_hash(),
+        deploy4.deploy_info().unwrap(),
+    );
 
     // pending => finalized
     proposer.finalized_deploys(vec![deploy1.deploy_or_transfer_hash()]);
@@ -327,10 +366,14 @@ fn should_keep_track_of_unhandled_deploys() {
         default_gas_payment(),
         DEFAULT_TEST_GAS_PRICE,
     );
-    let mut proposer = BlockProposerReady::default();
+    let mut proposer = create_test_proposer(0.into());
 
     // We do NOT add deploy2...
-    proposer.add_deploy(creation_time, Box::new(deploy1.clone()));
+    proposer.add_deploy(
+        creation_time,
+        deploy1.deploy_or_transfer_hash(),
+        deploy1.deploy_info().unwrap(),
+    );
     // But we DO mark it as finalized, by it's hash
     proposer.finalized_deploys(vec![
         deploy1.deploy_or_transfer_hash(),
@@ -362,7 +405,11 @@ fn should_keep_track_of_unhandled_deploys() {
     );
 
     // Now we add Deploy2
-    proposer.add_deploy(creation_time, Box::new(deploy2.clone()));
+    proposer.add_deploy(
+        creation_time,
+        deploy2.deploy_or_transfer_hash(),
+        deploy2.deploy_info().unwrap(),
+    );
     assert!(
         proposer.sets.finalized_deploys.contains_key(deploy2.id()),
         "deploy2 should now be in finalized_deploys"
@@ -538,7 +585,7 @@ fn test_proposer_with(
     let ttl = TimeDiff::from(Duration::from_millis(100));
 
     let mut rng = crate::new_rng();
-    let mut proposer = BlockProposerReady::default();
+    let mut proposer = create_test_proposer(0.into());
     let mut config = proposer.deploy_config;
     // defaults are 10, 1000 respectively
     config.block_max_deploy_count = max_deploy_count;
@@ -557,11 +604,19 @@ fn test_proposer_with(
             payment_amount,
             DEFAULT_TEST_GAS_PRICE,
         );
-        proposer.add_deploy(creation_time, Box::new(deploy));
+        proposer.add_deploy(
+            creation_time,
+            deploy.deploy_or_transfer_hash(),
+            deploy.deploy_info().unwrap(),
+        );
     }
     for _ in 0..transfer_count {
         let transfer = generate_transfer(&mut rng, creation_time, ttl, vec![], payment_amount);
-        proposer.add_deploy(creation_time, Box::new(transfer));
+        proposer.add_deploy(
+            creation_time,
+            transfer.deploy_or_transfer_hash(),
+            transfer.deploy_info().unwrap(),
+        );
     }
 
     let block =
@@ -610,10 +665,14 @@ fn should_return_deploy_dependencies() {
         DEFAULT_TEST_GAS_PRICE,
     );
 
-    let mut proposer = BlockProposerReady::default();
+    let mut proposer = create_test_proposer(0.into());
 
     // add deploy2
-    proposer.add_deploy(creation_time, Box::new(deploy2.clone()));
+    proposer.add_deploy(
+        creation_time,
+        deploy2.deploy_or_transfer_hash(),
+        deploy2.deploy_info().unwrap(),
+    );
 
     // deploy2 has an unsatisfied dependency
     let block = proposer.propose_block_payload(
@@ -626,7 +685,11 @@ fn should_return_deploy_dependencies() {
     assert!(block.transfer_hashes().is_empty());
 
     // add deploy1
-    proposer.add_deploy(creation_time, Box::new(deploy1.clone()));
+    proposer.add_deploy(
+        creation_time,
+        deploy1.deploy_or_transfer_hash(),
+        deploy1.deploy_info().unwrap(),
+    );
 
     let block = proposer.propose_block_payload(
         DeployConfig::default(),
@@ -652,4 +715,42 @@ fn should_return_deploy_dependencies() {
     let deploys2 = block.deploy_hashes();
     assert_eq!(deploys2.len(), 1);
     assert!(deploys2.contains(deploy2.id()));
+}
+
+#[test]
+fn should_respect_deploy_delay() {
+    let mut rng = crate::new_rng();
+    let creation_time = Timestamp::from(0);
+    let ttl = TimeDiff::from(10000);
+    let deploy_config = DeployConfig::default();
+    let deploy = generate_deploy(
+        &mut rng,
+        creation_time,
+        ttl,
+        vec![],
+        default_gas_payment(),
+        DEFAULT_TEST_GAS_PRICE,
+    );
+    let mut proposer = create_test_proposer(10.into()); // Deploy delay: 10 milliseconds
+
+    // Add the deploy at time 100. So at 109 it cannot be proposed yet, but at time 110 it can.
+    proposer.add_deploy(
+        100.into(),
+        deploy.deploy_or_transfer_hash(),
+        deploy.deploy_info().unwrap(),
+    );
+    let block = proposer.propose_block_payload(
+        deploy_config,
+        BlockContext::new(109.into(), vec![]),
+        vec![],
+        true,
+    );
+    assert!(block.deploy_hashes().is_empty());
+    let block = proposer.propose_block_payload(
+        deploy_config,
+        BlockContext::new(110.into(), vec![]),
+        vec![],
+        true,
+    );
+    assert_eq!(&vec![*deploy.id()], block.deploy_hashes());
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -50,6 +50,7 @@ use signal_hook::{
 };
 
 pub use components::{
+    block_proposer::Config as BlockProposerConfig,
     consensus::Config as ConsensusConfig,
     contract_runtime::Config as ContractRuntimeConfig,
     deploy_acceptor::Config as DeployAcceptorConfig,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -444,6 +444,7 @@ impl reactor::Reactor for Reactor {
                 .map(|block_header| block_header.height() + 1)
                 .unwrap_or(0),
             chainspec_loader.chainspec().as_ref(),
+            config.block_proposer,
         )?;
 
         let initial_era = maybe_latest_block_header.as_ref().map_or_else(
@@ -914,12 +915,30 @@ impl reactor::Reactor for Reactor {
                 deploy,
                 source,
             }) => {
+                let deploy_info = match deploy.deploy_info() {
+                    Ok(deploy_info) => deploy_info,
+                    Err(error) => {
+                        error!(%error, "invalid deploy");
+                        return Effects::new();
+                    }
+                };
+
+                let event = block_proposer::Event::BufferDeploy {
+                    hash: deploy.deploy_or_transfer_hash(),
+                    deploy_info: Box::new(deploy_info),
+                };
+                let mut effects =
+                    self.dispatch_event(effect_builder, rng, Event::BlockProposer(event));
+
                 let event = gossiper::Event::ItemReceived {
                     item_id: *deploy.id(),
                     source: source.clone(),
                 };
-                let mut effects =
-                    self.dispatch_event(effect_builder, rng, Event::DeployGossiper(event));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    Event::DeployGossiper(event),
+                ));
 
                 let event = event_stream_server::Event::DeployAccepted(*deploy.id());
                 effects.extend(self.dispatch_event(
@@ -1020,11 +1039,13 @@ impl reactor::Reactor for Reactor {
                 Effects::new()
             }
             Event::DeployGossiperAnnouncement(GossiperAnnouncement::FinishedGossiping(
-                gossiped_deploy_id,
+                _gossiped_deploy_id,
             )) => {
-                let reactor_event =
-                    Event::BlockProposer(block_proposer::Event::BufferDeploy(gossiped_deploy_id));
-                self.dispatch_event(effect_builder, rng, reactor_event)
+                // let reactor_event =
+                //     Event::BlockProposer(block_proposer::Event::
+                // BufferDeploy(gossiped_deploy_id));
+                // self.dispatch_event(effect_builder, rng, reactor_event)
+                Effects::new()
             }
             Event::AddressGossiperAnnouncement(GossiperAnnouncement::NewCompleteItem(
                 gossiped_address,

--- a/node/src/reactor/participating/config.rs
+++ b/node/src/reactor/participating/config.rs
@@ -2,9 +2,10 @@ use datasize::DataSize;
 use serde::Deserialize;
 
 use crate::{
-    logging::LoggingConfig, types::NodeConfig, ConsensusConfig, ContractRuntimeConfig,
-    DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig, GossipConfig,
-    LinearChainSyncConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig, StorageConfig,
+    logging::LoggingConfig, types::NodeConfig, BlockProposerConfig, ConsensusConfig,
+    ContractRuntimeConfig, DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig,
+    GossipConfig, LinearChainSyncConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig,
+    StorageConfig,
 };
 
 /// Root configuration.
@@ -38,4 +39,7 @@ pub struct Config {
     pub deploy_acceptor: DeployAcceptorConfig,
     /// Linear chain sync configuration.
     pub linear_chain_sync: LinearChainSyncConfig,
+    /// Block proposer configuration.
+    #[serde(default)]
+    pub block_proposer: BlockProposerConfig,
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -314,6 +314,22 @@ verify_accounts = true
 # If unset, defaults to 5.
 #max_query_depth = 5
 
+
+# ========================================================
+# Configuration options for synchronizing the linear chain
+# ========================================================
 [linear_chain_sync]
-# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
-sync_timeout = "1hr"
+
+# The amount of time that the node will try to sync without making progress before shutting down.
+sync_timeout = '1hr'
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -313,6 +313,22 @@ verify_accounts = true
 # If unset, defaults to 5.
 #max_query_depth = 5
 
+
+# ========================================================
+# Configuration options for synchronizing the linear chain
+# ========================================================
 [linear_chain_sync]
-# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
-sync_timeout = "1hr"
+
+# The amount of time that the node will try to sync without making progress before shutting down.
+sync_timeout = '1hr'
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'


### PR DESCRIPTION
This PR is a port of #1772 and fixes an edge-case issue where the `BlockProposer` could try to include a deploy in a proposed block before it has stored that deploy locally.  The deploy would not be included in that proposed block, and that node would never try to include that deploy in a proposed block again.

The fix is a temporary change back to the previous approach for this mechanism: the `BlockProposer` only tries to include deploys for which there has been a `DeployAcceptor` announcement (implying the deploy has definitely been stored locally).  Such deploys are only proposed after a configurable fixed period of time has passed.

For reference, this PR reverts most of the changes in #1484.

Closes #1771.
Closes #1778.