### PR TITLE
1807: Resolve dictionary query bug

### DIFF
--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -48,7 +48,6 @@ enum ErrorCode {
     InvalidDeploy = -32008,
     NoSuchAccount = -32009,
     FailedToGetDictionaryURef = -32010,
-    NoDictionaryName = -32011,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
CHANGELOG:

- Resolved bug for `state_get_dictionary_item` RPC method that would incorrectly query for the `seed_uref` in the case of a Contract hash
- Fixed bug by retrieving `seed_uref` by looking up the named keys for both `Account` and `Contract` cases


Closes: [1807](https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1807)
