### PR TITLE
CI: switch out cargo-audit install method

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
   - name: cargo-audit
     image: casperlabs/node-build-u1804
     commands:
-      - make setup-audit
+      - cargo install cargo-audit
       - cargo generate-lockfile
       - make audit
 


### PR DESCRIPTION
Changes: Switches away from makefile due to `--locked` issue.

Issue: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/44