### PR TITLE
CI: use cargo directly for audit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ setup-cargo-packagers:
 
 .PHONY: setup-audit
 setup-audit:
-	$(CARGO) install cargo-audit
+	cargo install cargo-audit
 
 .PHONY: setup-rs
 setup-rs: smart_contracts/rust-toolchain


### PR DESCRIPTION
Changes:
- switches `setup-audit` to use `cargo` instead of the variable

Failed Run: https://drone-auto-casper-network.casperlabs.io/casper-network/casper-node/1309/1/5

Issue: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/44