### PR TITLE
Fix dial outcome logic

### DIFF
--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -504,7 +504,7 @@ where
     #[cfg(test)]
     pub(crate) fn is_blocked(&self, addr: SocketAddr) -> bool {
         match self.outgoing.get(&addr) {
-            Some(ref outgoing) => matches!(outgoing.state, OutgoingState::Blocked { .. }),
+            Some(outgoing) => matches!(outgoing.state, OutgoingState::Blocked { .. }),
             None => false,
         }
     }


### PR DESCRIPTION
Adds a unit-level test for the observed issue with reconnections on testnet and fixes it in the code.

Fixes #1831 
