### PR TITLE
Add an enable-legacy-hashing feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CARGO_OPTS := --locked
 CARGO := $(CARGO) $(CARGO_TOOLCHAIN) $(CARGO_OPTS)
 
 DISABLE_LOGGING = RUST_LOG=MatchesNothing
-LEGACY = RUSTFLAGS='--cfg feature="enable-legacy-hashing"'
+LEGACY = RUSTFLAGS='--cfg feature="casper-mainnet"'
 
 # Rust Contracts
 # Directory names should match crate names

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CARGO_OPTS := --locked
 CARGO := $(CARGO) $(CARGO_TOOLCHAIN) $(CARGO_OPTS)
 
 DISABLE_LOGGING = RUST_LOG=MatchesNothing
+LEGACY = RUSTFLAGS='--cfg feature="enable-legacy-hashing"'
 
 # Rust Contracts
 # Directory names should match crate names
@@ -49,7 +50,7 @@ all: build build-contracts
 
 .PHONY: build
 build:
-	$(CARGO) build $(CARGO_FLAGS)
+	$(LEGACY) $(CARGO) build $(CARGO_FLAGS)
 
 build-contract-rs/%:
 	$(CARGO) build \
@@ -86,7 +87,7 @@ resources/local/chainspec.toml: generate-chainspec.sh resources/local/chainspec.
 
 .PHONY: test-rs
 test-rs: resources/local/chainspec.toml
-	$(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --workspace
+	$(LEGACY) $(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --workspace
 	$(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --features=std --manifest-path=types/Cargo.toml
 	$(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --features=std --manifest-path=smart_contracts/contract/Cargo.toml
 
@@ -160,7 +161,7 @@ clean:
 
 .PHONY: build-for-packaging
 build-for-packaging: build-client-contracts
-	$(CARGO) build --release
+	$(LEGACY) $(CARGO) build --release
 
 .PHONY: deb
 deb: setup build-for-packaging

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -114,7 +114,7 @@ tokio = { version = "1", features = ["test-util"] }
 
 [features]
 vendored-openssl = ['openssl/vendored']
-enable-legacy-hashing = []
+casper-mainnet = []
 
 [[bin]]
 name = "casper-node"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -114,6 +114,7 @@ tokio = { version = "1", features = ["test-util"] }
 
 [features]
 vendored-openssl = ['openssl/vendored']
+enable-legacy-hashing = []
 
 [[bin]]
 name = "casper-node"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -77,8 +77,8 @@ fn version_string(color: bool) -> String {
         "{}-{}{}",
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_SHA_SHORT"),
-        if cfg!(feature = "enable-legacy-hashing") {
-            "-legacy"
+        if cfg!(feature = "casper-mainnet") {
+            "-casper-mainnet"
         } else {
             ""
         }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -73,7 +73,16 @@ pub use utils::OS_PAGE_SIZE;
 pub const MAX_THREAD_COUNT: usize = 512;
 
 fn version_string(color: bool) -> String {
-    let mut version = format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_SHA_SHORT"));
+    let mut version = format!(
+        "{}-{}{}",
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_SHA_SHORT"),
+        if cfg!(feature = "enable-legacy-hashing") {
+            "-legacy"
+        } else {
+            ""
+        }
+    );
 
     // Add a `@DEBUG` (or similar) tag to release string on non-release builds.
     if env!("NODE_BUILD_PROFILE") != "release" {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1253,7 +1253,12 @@ pub enum HashingAlgorithmVersion {
 }
 
 impl HashingAlgorithmVersion {
+    #[cfg(feature = "enable-legacy-hashing")]
     const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 4, 0);
+
+    #[cfg(not(feature = "enable-legacy-hashing"))]
+    const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(0, 0, 0);
+
     fn from_protocol_version(protocol_version: &ProtocolVersion) -> Self {
         if *protocol_version < Self::HASH_V2_PROTOCOL_VERSION {
             HashingAlgorithmVersion::V1

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1253,10 +1253,10 @@ pub enum HashingAlgorithmVersion {
 }
 
 impl HashingAlgorithmVersion {
-    #[cfg(feature = "enable-legacy-hashing")]
+    #[cfg(feature = "casper-mainnet")]
     const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 4, 0);
 
-    #[cfg(not(feature = "enable-legacy-hashing"))]
+    #[cfg(not(feature = "casper-mainnet"))]
     const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(0, 0, 0);
 
     fn from_protocol_version(protocol_version: &ProtocolVersion) -> Self {

--- a/utils/nctl/sh/assets/compile_node.sh
+++ b/utils/nctl/sh/assets/compile_node.sh
@@ -13,9 +13,9 @@ source "$NCTL"/sh/utils/main.sh
 pushd "$NCTL_CASPER_HOME" || exit
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-    cargo build --package casper-node
+    cargo build --package casper-node --features enable-legacy-hashing
 else
-    cargo build --release --package casper-node
+    cargo build --release --package casper-node --features enable-legacy-hashing
 fi
 
 popd || exit

--- a/utils/nctl/sh/assets/compile_node.sh
+++ b/utils/nctl/sh/assets/compile_node.sh
@@ -13,9 +13,9 @@ source "$NCTL"/sh/utils/main.sh
 pushd "$NCTL_CASPER_HOME" || exit
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-    cargo build --package casper-node --features enable-legacy-hashing
+    cargo build --package casper-node --features casper-mainnet
 else
-    cargo build --release --package casper-node --features enable-legacy-hashing
+    cargo build --release --package casper-node --features casper-mainnet
 fi
 
 popd || exit

--- a/utils/nctl/sh/staging/build.sh
+++ b/utils/nctl/sh/staging/build.sh
@@ -50,9 +50,9 @@ function set_stage_binaries()
 
     # Set node binary.
     if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-        cargo build --package casper-node --features enable-legacy-hashing
+        cargo build --package casper-node --features casper-mainnet
     else
-        cargo build --release --package casper-node --features enable-legacy-hashing
+        cargo build --release --package casper-node --features casper-mainnet
     fi
 
     # Set client binary.

--- a/utils/nctl/sh/staging/build.sh
+++ b/utils/nctl/sh/staging/build.sh
@@ -50,9 +50,9 @@ function set_stage_binaries()
 
     # Set node binary.
     if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-        cargo build --package casper-node
+        cargo build --package casper-node --features enable-legacy-hashing
     else
-        cargo build --release --package casper-node
+        cargo build --release --package casper-node --features enable-legacy-hashing
     fi
 
     # Set client binary.


### PR DESCRIPTION
The feature controls whether the new (Merkle) hashing of block bodies is enabled from the start, or only from protocol version 1.4.0. When the flag is enabled, protocol versions up to 1.4.0 use the legacy (non-Merkle) hashing.
It needs to be enabled for mainnet builds.

There were changes to `Makefile` on the `dev` branch that will make this change not merge cleanly, so it will have to be revisited when merging with `dev` (possibly as a part of #1545 ).

Closes #1612 
