### PR TITLE
Reduce chattiness of event dispatching

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Support building and testing using stable Rust.
+* Log chattiness in `debug` or lower levels has been reduced and performance at `info` or higher slightly improved.
 
 ### Removed
 * The unofficial support for nix-related derivations and support tooling has been removed.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -52,7 +52,7 @@ use quanta::{Clock, IntoNanoseconds};
 use serde::Serialize;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
 use tokio::time::{Duration, Instant};
-use tracing::{debug, debug_span, error, info, instrument, trace, warn};
+use tracing::{debug, debug_span, error, info, instrument, warn};
 use tracing_futures::Instrument;
 
 #[cfg(target_os = "linux")]
@@ -552,16 +552,11 @@ where
             QUEUE_DUMP_REQUESTED.store(false, Ordering::SeqCst);
         }
 
-        let (event, q) = self.scheduler.pop().await;
+        let (event, queue) = self.scheduler.pop().await;
 
         // Create another span for tracing the processing of one event.
-        let event_span = debug_span!("dispatch events", ev = self.event_count);
+        let event_span = debug_span!("dispatch", event_count = self.event_count, %event, %queue);
         let (effects, keep_going) = event_span.in_scope(|| {
-            // We log events twice, once in display and once in debug mode.
-            let event_as_string = format!("{}", event);
-            debug!(event=%event_as_string, ?q);
-            trace!(?event, ?q);
-
             // Dispatch the event, then execute the resulting effect.
             let start = self.clock.start();
 
@@ -585,11 +580,9 @@ where
             // Warn if processing took a long time, record to histogram.
             let delta = self.clock.delta(start, end);
             if delta > *DISPATCH_EVENT_THRESHOLD {
-                warn!(
-                    ns = delta.into_nanos(),
-                    event = %event_as_string,
-                    "event took very long to dispatch"
-                );
+                warn!(ev=%self.event_count,
+                      ns = delta.into_nanos(),
+                      "event took very long to dispatch");
             }
             self.metrics
                 .event_dispatch_duration


### PR DESCRIPTION
Moves the event description into the debug level span, omitting debug output at trace level. As a result, we no longer allocate a string each time we process an event, at the cost of getting slightly worse output when an event takes too long to dispatch at info or higher levels.

Note that this changes logging output, causing every event to be fully shown in logs at `debug` level, unless disabled.

Closes #1838 