### PR TITLE
Fix typos in documentation

### DIFF
--- a/utils/nctl/docs/commands-deploy-erc20.md
+++ b/utils/nctl/docs/commands-deploy-erc20.md
@@ -2,7 +2,7 @@
 
 ### nctl-erc20-approve owner={X:-1} spender={Y:-1} amount={Z:-1000000000} 
 
-Allows a user (the spender) to withdraw upto Z tokens from the account of a token holder (the owner).  
+Allows a user (the spender) to withdraw up to Z tokens from the account of a token holder (the owner).  
 
 ```
 nctl-erc20-approve 

--- a/utils/nctl/docs/commands-setup.md
+++ b/utils/nctl/docs/commands-setup.md
@@ -41,7 +41,7 @@ If `chainspec_path` points to a valid custom chainspec.toml, then the template i
 ```
 nctl-assets-setup
 
-nctl-assets-setup net=1 nodes=5 deelay=30  (same as above)
+nctl-assets-setup net=1 nodes=5 delay=30  (same as above)
 
 nctl-assets-setup net=2 nodes=10 delay=60
 ```

--- a/utils/nctl/docs/commands-staging.md
+++ b/utils/nctl/docs/commands-staging.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In order to run upgrade scenarios multiple assets sets are required, typically these are staged prior to scenario execution.  NCTL supports the initialisation of multiple stages - one per scenario.  Within the contect of a stage NCTL supports multiple protocol version upgrades.
+In order to run upgrade scenarios multiple assets sets are required, typically these are staged prior to scenario execution.  NCTL supports the initialisation of multiple stages - one per scenario.  Within the context of a stage NCTL supports multiple protocol version upgrades.
 
 
 ### nctl-stage-init-settings
@@ -13,7 +13,7 @@ Initialise stage settings.  This is done once per stage.
 nctl-stage-init-settings stage=${X:-1}
 ```
 
-NOTE: stage identifer X is assumed to be an unsigned integer.
+NOTE: stage identifier X is assumed to be an unsigned integer.
 
 ### nctl-stage-build-from-settings
 

--- a/utils/nctl/docs/commands-view-node.md
+++ b/utils/nctl/docs/commands-view-node.md
@@ -2,7 +2,7 @@
 
 ### nctl-view-node-config node={X:-1}
 
-Displays configuraiton file node X.
+Displays configuration file node X.
 
 ```
 nctl-view-node-config

--- a/utils/nctl/docs/commands.md
+++ b/utils/nctl/docs/commands.md
@@ -38,4 +38,4 @@ Upon successful setup, NCTL commands are made available via aliases for executio
 
 - NOTE 3: when executing either the `nctl-interactive` or `nctl-start` commands, the node logging level output can be assigned by passing in the `loglevel` parameter.  If you do not pass in this variable then NCTL defaults either to the current value of RUST_LOG or `debug`.
 
-- NOTE 4: many command will accept a `node` parameter to determine to which node a query or deploy will be dispatched.  If node=random then a dispatch node is determined JIT.  If node=0 then a single node is chosen for dispatch.
+- NOTE 4: many commands will accept a `node` parameter to determine to which node a query or deploy will be dispatched.  If node=random then a dispatch node is determined JIT.  If node=0 then a single node is chosen for dispatch.

--- a/utils/nctl/docs/usage.md
+++ b/utils/nctl/docs/usage.md
@@ -1,6 +1,6 @@
 # NCTL Usage
 
-Once activated, NCTL commands can be used to setup & control nodes within a local test network.  Most NCTL users will be testing a single local network, however developers wishing to test multiple networks in parallel may do so.  This usage guide focusses upon the former use case, i.e. testing a single network, and thus all NCTL commands described below are executed with their default values.  Please refer [here](commands.md) for full details of supported NCTL commands.
+Once activated, NCTL commands can be used to setup & control nodes within a local test network.  Most NCTL users will be testing a single local network, however developers wishing to test multiple networks in parallel may do so.  This usage guide focuses upon the former use case, i.e. testing a single network, and thus all NCTL commands described below are executed with their default values.  Please refer [here](commands.md) for full details of supported NCTL commands.
 
 ## Step 0: Compile network binaries.
 
@@ -94,7 +94,7 @@ nctl-stop node=1
 
 ## Step 4: Dump logs & other files.
 
-Upon observation of a network behavioural anomaly you can dump relevant assets such as logs & configuration as follows:
+Upon observation of a network behavioral anomaly you can dump relevant assets such as logs & configuration as follows:
 
 ```
 # Writes dumped files -> $NCTL/dumps/net-1


### PR DESCRIPTION
This PR fixes minor typos in the `nctl` documentation.
