### PR TITLE
Test that single validator node doesn't shut down in the absence of other validator nodes.

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -80,5 +80,6 @@ start_run_teardown "bond_its.sh"
 start_run_teardown "emergency_upgrade_test.sh"
 start_run_teardown "emergency_upgrade_test_balances.sh"
 start_run_teardown "sync_test.sh node=6 timeout=500"
+start_run_teardown "gov96.sh"
 # Keep this test last
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -1,0 +1,323 @@
+# Configuration file modified for the purpose of gov96 test.
+# It changes the standstill timeout to '30sec' to trigger shutdown problem earlier.
+# It leaves other values as defaults - specifically `shutdown_on_standstill=false`.
+
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The folder in which the files with per-era latest unit hashes will be stored.
+unit_hashes_folder = "../node-storage"
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, request the latest state
+# from peers.
+standstill_timeout = '30sec'
+
+# If after another `standstill_timeout` there still was no progress, shut down.
+shutdown_on_standstill = false
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval (in milliseconds) between each fresh round of gossiping the node's public address.
+gossip_interval = 30000
+
+# Minimum amount of time that has to pass before attempting to reconnect after losing all
+# connections to established nodes.
+isolation_reconnect_delay = '2s'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5s'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum amount of requests from validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = false
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+mem_pool_prune_interval = 1024
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration in seconds for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration_secs = 60
+
+# The timeout duration in seconds for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout_secs = 10
+
+# The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout_secs = 5
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = 3
+
+
+# ===================================================
+# Configuration options for deploy acceptor component
+# ===================================================
+[deploy_acceptor]
+
+# If true, the deploy acceptor will verify the account associated with a received deploy prior to accepting it.
+verify_accounts = true
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional setting to enable bonding or not.  If unset, defaults to false.
+#enable_bonding = false
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+[linear_chain_sync]
+# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
+sync_timeout = "1hr"

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+#######################################
+# Runs an integration tests that tries to simulate
+# stalling consensus by stopping all but one node. It
+# then restarts the nodes and checks for the chain
+# to progress.
+#
+# Test requested by one of the clients who wants to keep network operational
+# (answering queries) but not producing new blocks and resume it weeks later.
+#
+# Arguments:
+#   `timeout=XXX` timeout (in seconds) when syncing.
+#######################################
+function main() {
+    log "------------------------------------------------------------"
+    log "Starting Scenario: gov96"
+    log "------------------------------------------------------------"
+
+    # 0. Wait for network start up
+    do_await_genesis_era_to_complete
+    # 1. Allow chain to progress
+    do_await_era_change
+    # 2. Verify all nodes are in sync
+    check_network_sync
+    # 3-5. Stop three nodes
+    do_stop_node "5"
+    do_stop_node "4"
+    do_stop_node "3"
+    do_stop_node "2"
+    # 6. Ensure chain stalled
+    # Eras are less than a minute long. 
+    # We want to make sure that consensus handles being resumed,
+    # even after being "paused" for multiples of era length.
+    assert_chain_stalled "300"
+    # 7. Verify that the running node can still handle queries.
+    assert_node_operational "1"
+    # 8-10. Restart three nodes
+    do_start_node "5" "$STALLED_LFB"
+    do_start_node "4" "$STALLED_LFB"
+    do_start_node "3" "$STALLED_LFB"
+    do_start_node "2" "$STALLED_LFB"
+    # 11. Verify all nodes are in sync
+    check_network_sync
+    # 12. Ensure era proceeds after restart
+    do_await_era_change "2"
+    # 13. Verify all nodes are in sync
+    check_network_sync
+    # 14-16. Compare stalled lfb hash to currentm
+    assert_chain_progressed "5" "$STALLED_LFB"
+    assert_chain_progressed "4" "$STALLED_LFB"
+    assert_chain_progressed "3" "$STALLED_LFB"
+    assert_chain_progressed "2" "$STALLED_LFB"
+    # 17. Check for Equivocators
+    assert_no_equivocators_logs
+
+    log "------------------------------------------------------------"
+    log "Scenario gov96 complete"
+    log "------------------------------------------------------------"
+}
+
+function assert_chain_progressed() {
+    # Function accepts two hashes as arguments and checks to
+    # see if they match.
+    log_step "node-${1}: checking chain progressed"
+    local LFB1=$(do_read_lfb_hash ${1})
+    local LFB2=${2}
+
+    if [ "$LFB1" = "$LFB2" ]; then
+       log "error: $LFB1 = $LFB2, chain didn't progress."
+       exit 1
+    fi
+}
+
+function assert_node_operational() {
+    log_step "node-${1}: checking if node answers HTTP queries"
+    local LFB1=$(do_read_lfb_hash ${1})
+    if [ "$LFB1" = "-1" ] || [ "$LFB1" = "'N/A'" ]; then
+        log "error: node-${1} did not answer query. Most probably it's shut down."
+        exit 1
+    fi
+    log "node-${1} operational; answered HTTP query"
+}
+
+function assert_chain_stalled() {
+    # Fucntion checks that the remaining node's LFB checked
+    # n-seconds apart doesnt progress
+    log_step "ensuring chain stalled"
+    local SLEEP_TIME=${1}
+    # Sleep 5 seconds to allow for final message propagation.
+    sleep 5
+    local LFB_1_PRE=$(do_read_lfb_hash 1)
+    log "Sleeping ${SLEEP_TIME}s..."
+    sleep $SLEEP_TIME
+    local LFB_1_POST=$(do_read_lfb_hash 1)
+
+    if [ "$LFB_1_PRE" != "$LFB_1_POST" ]; then
+       log "Error: Chain progressed."
+       exit 1
+    else
+        STALLED_LFB=$LFB_1_POST
+        log "node-1 LFB: $LFB_1_PRE = $LFB_1_POST"
+        log "Stall successfully detected, continuing..."
+    fi
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset SYNC_TIMEOUT_SEC
+unset LFB_HASH
+unset STALLED_LFB
+STEP=0
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+SYNC_TIMEOUT_SEC=${SYNC_TIMEOUT_SEC:-"300"}
+
+main "$NODE_ID"

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -6,7 +6,7 @@ source "$NCTL"/sh/scenarios/common/itst.sh
 set -e
 
 #######################################
-# Runs an integration tests that tries to simulate
+# Runs an integration test that tries to simulate
 # stalling consensus by stopping all but one node. It
 # then restarts the nodes and checks for the chain
 # to progress.
@@ -28,35 +28,35 @@ function main() {
     do_await_era_change
     # 2. Verify all nodes are in sync
     check_network_sync
-    # 3-5. Stop three nodes
+    # 3-6. Stop four nodes
     do_stop_node "5"
     do_stop_node "4"
     do_stop_node "3"
     do_stop_node "2"
-    # 6. Ensure chain stalled
+    # 7. Ensure chain stalled
     # Eras are less than a minute long. 
     # We want to make sure that consensus handles being resumed,
     # even after being "paused" for multiples of era length.
     assert_chain_stalled "300"
-    # 7. Verify that the running node can still handle queries.
+    # 8. Verify that the running node can still handle queries.
     assert_node_operational "1"
-    # 8-10. Restart three nodes
+    # 9-12. Restart four nodes
     do_start_node "5" "$STALLED_LFB"
     do_start_node "4" "$STALLED_LFB"
     do_start_node "3" "$STALLED_LFB"
     do_start_node "2" "$STALLED_LFB"
-    # 11. Verify all nodes are in sync
-    check_network_sync
-    # 12. Ensure era proceeds after restart
-    do_await_era_change "2"
     # 13. Verify all nodes are in sync
     check_network_sync
-    # 14-16. Compare stalled lfb hash to currentm
+    # 14. Ensure era proceeds after restart
+    do_await_era_change "2"
+    # 15. Verify all nodes are in sync
+    check_network_sync
+    # 16-17. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"
     assert_chain_progressed "3" "$STALLED_LFB"
     assert_chain_progressed "2" "$STALLED_LFB"
-    # 17. Check for Equivocators
+    # 18. Check for Equivocators
     assert_no_equivocators_logs
 
     log "------------------------------------------------------------"
@@ -88,8 +88,8 @@ function assert_node_operational() {
 }
 
 function assert_chain_stalled() {
-    # Fucntion checks that the remaining node's LFB checked
-    # n-seconds apart doesnt progress
+    # Function checks that the remaining node's LFB checked
+    # n-seconds apart doesn't progress
     log_step "ensuring chain stalled"
     local SLEEP_TIME=${1}
     # Sleep 5 seconds to allow for final message propagation.


### PR DESCRIPTION
Verify that shuting down all nodes but one, allows for resuming it later while maintaining running node available for queries.

Setup:
* Start 5-node validator network.
* Shut down four nodes for period longer than multiple of a single era.
* Query still-running node's HTTP endpoints.
* Verify that it still answers queries.
* Restart previously stopped nodes and wait for them to synchronize.
* Verify that consensus resumes building blocks.

Closes https://github.com/casper-ecosystem/Governance/issues/96