### PR TITLE
Port the "No synchronization will be done" message change to the release branch

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -128,6 +128,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                     State::sync_trusted_hash(hash, highest_block.map(|block| block.take_header()))
                 }
                 None if after_upgrade => {
+                    info!("No synchronization of the linear chain will be done.");
                     // Right after upgrade, no linear chain to synchronize.
                     State::Done(highest_block.map(Box::new))
                 }
@@ -139,6 +140,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                         // still be trusted – i.e. it's within the unbonding period.
                         State::sync_descendants(*highest_block.hash(), highest_block, None)
                     } else {
+                        info!("No synchronization of the linear chain will be done.");
                         State::Done(None)
                     }
                 }
@@ -175,6 +177,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             chainspec.highway_config.min_round_length() * chainspec.core_config.minimum_era_height,
             chainspec.core_config.era_duration,
         );
+        if matches!(state, State::None | State::Done(_)) {
+            info!("No synchronization of the linear chain will be done.");
+        }
         Ok(LinearChainSync {
             peers: PeersState::new(),
             state,

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -128,7 +128,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                     State::sync_trusted_hash(hash, highest_block.map(|block| block.take_header()))
                 }
                 None if after_upgrade => {
-                    info!("No synchronization of the linear chain will be done.");
+                    info!(
+                        "No synchronization of the linear chain will be done because the node \
+                        was started right after an upgrade without a trusted hash."
+                    );
                     // Right after upgrade, no linear chain to synchronize.
                     State::Done(highest_block.map(Box::new))
                 }
@@ -140,7 +143,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                         // still be trusted – i.e. it's within the unbonding period.
                         State::sync_descendants(*highest_block.hash(), highest_block, None)
                     } else {
-                        info!("No synchronization of the linear chain will be done.");
+                        info!(
+                            "No synchronization of the linear chain will be done because there \
+                            is neither a trusted hash nor a highest block present."
+                        );
                         State::Done(None)
                     }
                 }
@@ -178,7 +184,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             chainspec.core_config.era_duration,
         );
         if matches!(state, State::None | State::Done(_)) {
-            info!("No synchronization of the linear chain will be done.");
+            info!(
+                "No synchronization of the linear chain will be done because the component is \
+                already in State::Done or in State::None."
+            );
         }
         Ok(LinearChainSync {
             peers: PeersState::new(),

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -431,7 +431,6 @@ impl reactor::Reactor for Reactor {
                         panic!("should have trusted hash after genesis era")
                     }
                 }
-                info!("No synchronization of the linear chain will be done.")
             }
             Some(hash) => info!(trusted_hash=%hash, "synchronizing linear chain"),
         }


### PR DESCRIPTION
The message "No synchronization will be done" used to be misleading, because the linear chain sync component could still load a state that would lead to synchronization being done after that message was printed. This PR makes it so that it's only printed when it's certain that no synchronization will be done.