### PR TITLE
NCTL: adjust default gas payment used in NCTL

### DIFF
--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -143,7 +143,7 @@ call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
 call_versioned_contract = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
 create_contract_package_at_hash = { cost = 200, arguments = [0, 0] }
 create_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
-create_purse = { cost = 2_500_000_000, arguments = [0, 0] }
+create_purse = { cost = 170_000, arguments = [0, 0] }
 disable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
 get_balance = { cost = 3_800, arguments = [0, 0, 0] }
 get_blocktime = { cost = 330, arguments = [0] }
@@ -198,9 +198,9 @@ read_era_id = 10_000
 activate_bid = 10_000
 
 [system_costs.mint_costs]
-mint = 2_500_000_000
+mint = 10_000
 reduce_total_supply = 10_000
-create = 2_500_000_000
+create = 10_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -143,7 +143,7 @@ call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
 call_versioned_contract = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
 create_contract_package_at_hash = { cost = 200, arguments = [0, 0] }
 create_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
-create_purse = { cost = 170_000, arguments = [0, 0] }
+create_purse = { cost = 2_500_000_000, arguments = [0, 0] }
 disable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
 get_balance = { cost = 3_800, arguments = [0, 0, 0] }
 get_blocktime = { cost = 330, arguments = [0] }
@@ -198,9 +198,9 @@ read_era_id = 10_000
 activate_bid = 10_000
 
 [system_costs.mint_costs]
-mint = 10_000
+mint = 2_500_000_000
 reduce_total_supply = 10_000
-create = 10_000
+create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000

--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -3,6 +3,7 @@
 source "$NCTL"/sh/utils/main.sh
 source "$NCTL"/sh/views/utils.sh
 source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
+source "$NCTL"/sh/scenarios/common/itst.sh
 
 # Exit if any of the commands fail.
 set -e

--- a/utils/nctl/sh/utils/constants.sh
+++ b/utils/nctl/sh/utils/constants.sh
@@ -47,7 +47,7 @@ export NCTL_DEFAULT_AUCTION_DELEGATE_AMOUNT=1000000000   # (1e9)
 export NCTL_DEFAULT_ERA_ACTIVATION_OFFSET=2
 
 # Default motes to pay for consumed gas.
-export NCTL_DEFAULT_GAS_PAYMENT=10000000000   # (1e10)
+export NCTL_DEFAULT_GAS_PAYMENT=100000000000   # (1e11)
 
 # Default gas price multiplier.
 export NCTL_DEFAULT_GAS_PRICE=10


### PR DESCRIPTION
Changes:
- Adjust default gas payment used by NCTL back to fix hanging bonds test.

Unrelated Change: 
- Source itst.sh to avoid a function failure

Issue: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/54