### PR TITLE
EE-1221: Follow up

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -18,18 +18,16 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Support building and testing using stable Rust.
-* Changed price of `create_purse` to 2.5CSPR to discourage people from creating purses in the payment code.
+* Increased price of `create_purse` to 2.5CSPR.
 * Improve doc comments to clarify behavior of the bidding functionality.
 
-
+### Fixed
+* Fix a case where user could potentially supply a refund purse as a payment purse.
 
 ## [1.3.0] - 2021-07-19
 
 ### Changed
 * Update pinned version of Rust to `nightly-2021-06-17`.
-
-### Fixed
-* Fix a case where user could potentially supply a refund purse as a payment purse.
 
 
 

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -18,11 +18,13 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Support building and testing using stable Rust.
-* Increased price of `create_purse` to 2.5CSPR.
+* Increase price of `create_purse` to 2.5CSPR.
 * Improve doc comments to clarify behavior of the bidding functionality.
 
 ### Fixed
 * Fix a case where user could potentially supply a refund purse as a payment purse.
+
+
 
 ## [1.3.0] - 2021-07-19
 


### PR DESCRIPTION
Ref: #1326 #1293 

Follow up PR to change a changelog entry from #1326 and move an entry created in #1293 to Unreleased section as it was wrongly changed after resolving merge conflicts.