### PR TITLE
Event tracing

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add optional incoming message limiter to the networking component, controllable via new `[network][max_incoming_message_rate_non_validators]` config option.
 * Add optional in-memory deduplication of deploys, controllable via new `[storage]` config options `[enable_mem_deduplication]` and `[mem_pool_prune_interval]`.
 * Add a new event stream to SSE server accessed via `<IP:Port>/events/deploys` which emits deploys in full as they are accepted.
+* Events now log their ancestors, so detailed tracing of events is possible.
 
 ### Changed
 * Major rewrite of the network component, covering connection negotiation and management, periodic housekeeping and logging.
@@ -50,6 +51,7 @@ All notable changes to this project will be documented in this file.  The format
 * Don't shut down by default anymore if stalled. To enable set config option `shutdown_on_standstill = true` in `[consensus.highway]`.
 * Major rewrite of the contract runtime component.
 * Ports used for local testing are now determined in a manner that hopefully leads to less accidental conflicts.
+* At log level `DEBUG`, single events are no longer logged (use `TRACE` instead).
 
 ### Removed
 * Remove systemd notify support, including removal of `[network][systemd_support]` config option.

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -49,7 +49,7 @@ impl MockReactor {
     }
 
     async fn expect_block_validator_event(&self) -> Event<NodeId> {
-        let (reactor_event, _) = self.scheduler.pop().await;
+        let ((_ancestor, reactor_event), _) = self.scheduler.pop().await;
         if let ReactorEvent::BlockValidator(event) = reactor_event {
             event
         } else {
@@ -61,7 +61,7 @@ impl MockReactor {
     where
         T: Into<Option<Deploy>>,
     {
-        let (reactor_event, _) = self.scheduler.pop().await;
+        let ((_ancestor, reactor_event), _) = self.scheduler.pop().await;
         if let ReactorEvent::Fetcher(FetcherRequest::Fetch {
             id,
             peer,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -307,11 +307,14 @@ where
 
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
         let shutdown_receiver = server_shutdown_receiver.clone();
-        let server_join_handle = tokio::spawn(tasks::server(
-            context.clone(),
-            tokio::net::TcpListener::from_std(listener).map_err(Error::ListenerConversion)?,
-            server_shutdown_receiver,
-        ));
+        let server_join_handle = tokio::spawn(
+            tasks::server(
+                context.clone(),
+                tokio::net::TcpListener::from_std(listener).map_err(Error::ListenerConversion)?,
+                server_shutdown_receiver,
+            )
+            .in_current_span(),
+        );
 
         let mut component = SmallNetwork {
             cfg,

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -450,7 +450,7 @@ where
 
     /// Creates a new runner from a given configuration, using existing metrics.
     #[inline]
-    #[instrument("runner creation", level = "debug", skip(cfg, rng, registry))]
+    #[instrument("init", level = "debug", skip(cfg, rng, registry))]
     pub async fn with_metrics(
         cfg: R::Config,
         rng: &mut NodeRng,
@@ -485,7 +485,7 @@ where
         Ok(Runner {
             scheduler,
             reactor,
-            current_event_id: 0,
+            current_event_id: 1,
             metrics: RunnerMetrics::new(registry)?,
             last_metrics: Instant::now(),
             event_metrics_min_delay: Duration::from_secs(30),

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -712,7 +712,6 @@ where
 
     /// Runs the reactor until `maybe_exit()` returns `Some` or we get interrupted by a termination
     /// signal.
-    #[inline]
     pub async fn run(&mut self, rng: &mut NodeRng) -> ReactorExit {
         loop {
             match TERMINATION_REQUESTED.load(Ordering::SeqCst) as i32 {

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -269,7 +269,7 @@ impl<REv: 'static> ComponentHarness<REv> {
 
             // Iterate over all events that currently are inside the queue and fish out any fatal.
             for _ in 0..(self.scheduler.item_count()) {
-                let (ev, _queue_kind) = self.runtime.block_on(self.scheduler.pop());
+                let ((_ancestor, ev), _queue_kind) = self.runtime.block_on(self.scheduler.pop());
 
                 if let Some(ctrl_ann) = ev.as_control() {
                     match ctrl_ann {

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -164,7 +164,7 @@ where
 {
     // Note: This will keep waiting forever if the sending end disappears, which is fine for tests.
     loop {
-        let (event, queue_kind) = source.pop().await;
+        let ((_ancestor, event), queue_kind) = source.pop().await;
         target_queue.schedule(event, queue_kind).await;
     }
 }


### PR DESCRIPTION
This PR has two headlining features:

* Event ancestor tracing: Every event is now assigned a non-zero ID (before it used to start at zero) at the time it is dispatched, logged as `ev`. Any event resulting from an effect created by that event will have that event ID stored in the queue as its ancestor. When an event is dispatched, the ancestor is logged in the span as `a` as well. This allows following a single event "around" or tracing log message back to the event that originally triggered them.
* Single event log reduction: Before, events used to be logged twice, once using `Display` at `DEBUG` and `Debug` at `TRACE` levels. Now, they are only logged at the `TRACE` level as `Display`, leading in a potential reduction of log sizes of 50+% in many cases.

Closes #1849 