### PR TITLE
Port Dictionary query bug fix over to dev

### DIFF
--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -48,7 +48,6 @@ enum ErrorCode {
     InvalidDeploy = -32008,
     NoSuchAccount = -32009,
     FailedToGetDictionaryURef = -32010,
-    NoDictionaryName = -32011,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
CHANGELOG:

- Ports the fix for a bug related to querying dictionary items using a `Contract` hash as an identifier

Originally closed bug ticket: [1807](https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1807)

Closes ticket: [1866](https://app.zenhub.com/workspaces/engineering-60953fafb1945f0011a3592d/issues/casper-network/casper-node/1866)