### PR TITLE
Ban peers sending invalid data

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -56,7 +56,7 @@ use crate::{
         fetcher::{FetchedData, FetcherError},
     },
     effect::{
-        announcements::{ContractRuntimeAnnouncement, ControlAnnouncement},
+        announcements::{BlocklistAnnouncement, ContractRuntimeAnnouncement, ControlAnnouncement},
         requests::{ContractRuntimeRequest, FetcherRequest, NetworkInfoRequest, StorageRequest},
         EffectBuilder, EffectExt, EffectOptionExt, Effects,
     },
@@ -563,7 +563,8 @@ where
         + From<FetcherRequest<I, BlockHeader>>
         + From<FetcherRequest<I, Trie<Key, StoredValue>>>
         + From<FetcherRequest<I, BlockHeaderWithMetadata>>
-        + From<NetworkInfoRequest<I>>,
+        + From<NetworkInfoRequest<I>>
+        + From<BlocklistAnnouncement<I>>,
 {
     type Event = Event<I>;
     type ConstructionError = Infallible;

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -17,6 +17,7 @@ use crate::{
         linear_chain_sync::error::{FinalitySignatureError, LinearChainSyncError},
     },
     effect::{
+        announcements::BlocklistAnnouncement,
         requests::{ContractRuntimeRequest, FetcherRequest, NetworkInfoRequest, StorageRequest},
         EffectBuilder,
     },
@@ -244,7 +245,8 @@ async fn fetch_and_store_block_header_by_height<REv, I>(
 where
     REv: From<FetcherRequest<I, BlockHeaderWithMetadata>>
         + From<NetworkInfoRequest<I>>
-        + From<StorageRequest>,
+        + From<StorageRequest>
+        + From<BlocklistAnnouncement<I>>,
     I: Eq + Debug + Clone + Send + 'static,
 {
     for peer in effect_builder.get_peers_in_random_order().await {
@@ -270,7 +272,7 @@ where
                         ?peer,
                         "Error validating finality signatures from peer.",
                     );
-                    // TODO: ban peer
+                    effect_builder.announce_disconnect_from_peer(peer).await;
                     continue;
                 }
 
@@ -322,6 +324,7 @@ async fn fetch_and_store_block_by_height<REv, I>(
 where
     REv: From<FetcherRequest<I, BlockWithMetadata>>
         + From<NetworkInfoRequest<I>>
+        + From<BlocklistAnnouncement<I>>
         + From<StorageRequest>,
     I: Eq + Debug + Clone + Send + 'static,
 {
@@ -343,7 +346,7 @@ where
                         ?peer,
                         "Error validating finality signatures from peer.",
                     );
-                    // TODO: ban peer
+                    effect_builder.announce_disconnect_from_peer(peer).await;
                     continue;
                 }
 
@@ -358,7 +361,7 @@ where
                         ?peer,
                         "Error validating finality signatures from peer.",
                     );
-                    // TODO: ban peer
+                    effect_builder.announce_disconnect_from_peer(peer).await;
                     continue;
                 }
 
@@ -434,6 +437,7 @@ where
         + From<FetcherRequest<I, Deploy>>
         + From<FetcherRequest<I, Trie<Key, StoredValue>>>
         + From<NetworkInfoRequest<I>>
+        + From<BlocklistAnnouncement<I>>
         + From<StorageRequest>,
     I: Eq + Debug + Clone + Send + 'static,
 {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -209,7 +209,7 @@ pub enum Event {
     #[from]
     NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<NodeId, Message>),
 
-    /// Network announcement.
+    /// Blocklist announcement.
     #[from]
     BlocklistAnnouncement(#[serde(skip_serializing)] BlocklistAnnouncement<NodeId>),
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1272,7 +1272,8 @@ impl HashingAlgorithmVersion {
         ProtocolVersion::from_parts(1, 4, 0);
 
     #[cfg(not(feature = "casper-mainnet"))]
-    const HASH_V2_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(0, 0, 0);
+    pub(crate) const HASH_V2_PROTOCOL_VERSION: ProtocolVersion =
+        ProtocolVersion::from_parts(0, 0, 0);
 
     fn from_protocol_version(protocol_version: &ProtocolVersion) -> Self {
         if *protocol_version < Self::HASH_V2_PROTOCOL_VERSION {


### PR DESCRIPTION
Peers shouldn't be able to send invalid data to others without consequences. This PR introduces using the banning mechanism from `small_network` when a joining node is being sent invalid blocks, signatures, or simply data that can't be parsed.

Closes #1618 