### PR TITLE
Port logging changes to dev

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -137,7 +137,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                     State::sync_trusted_hash(hash, highest_block.map(|block| block.take_header()))
                 }
                 None if after_upgrade => {
-                    info!("No synchronization of the linear chain will be done.");
+                    info!(
+                        "No synchronization of the linear chain will be done because the node \
+                        was started right after an upgrade without a trusted hash."
+                    );
                     // Right after upgrade, no linear chain to synchronize.
                     State::Done(highest_block.map(Box::new))
                 }
@@ -149,7 +152,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                         // still be trusted – i.e. it's within the unbonding period.
                         State::sync_descendants(*highest_block.hash(), highest_block, None)
                     } else {
-                        info!("No synchronization of the linear chain will be done.");
+                        info!(
+                            "No synchronization of the linear chain will be done because there \
+                            is neither a trusted hash nor a highest block present."
+                        );
                         State::Done(None)
                     }
                 }
@@ -189,7 +195,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             chainspec.core_config.era_duration,
         );
         if matches!(state, State::None | State::Done(_)) {
-            info!("No synchronization of the linear chain will be done.");
+            info!(
+                "No synchronization of the linear chain will be done because the component is \
+                already in State::Done or in State::None."
+            );
         }
         Ok(LinearChainSync {
             peers: PeersState::new(),


### PR DESCRIPTION
This makes log messages related to the chain synchronization not being done more specific.

Closes #1867 
