### PR TITLE
Add validity check for zero approvals in a Deploy

### DIFF
--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -689,6 +689,7 @@ impl Deploy {
     /// Returns true if and only if:
     ///   * the deploy hash is correct (should be the hash of the header), and
     ///   * the body hash is correct (should be the hash of the body), and
+    ///   * approvals are non empty, and
     ///   * all approvals are valid signatures of the deploy hash
     pub fn is_valid(&mut self) -> Result<(), DeployValidationFailure> {
         match self.is_valid.as_ref() {

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -862,6 +862,7 @@ fn serialize_body(payment: &ExecutableDeployItem, session: &ExecutableDeployItem
 // asymmetric_key signing verification.
 fn validate_deploy(deploy: &Deploy) -> Result<(), DeployValidationFailure> {
     if deploy.approvals.is_empty() {
+        warn!(?deploy, "deploy has no approvals");
         return Err(DeployValidationFailure::EmptyApprovals);
     }
     let serialized_body = serialize_body(&deploy.payment, &deploy.session);
@@ -878,9 +879,6 @@ fn validate_deploy(deploy: &Deploy) -> Result<(), DeployValidationFailure> {
         return Err(DeployValidationFailure::InvalidDeployHash);
     }
 
-    // We don't need to check for an empty set here. EE checks that the correct number and weight of
-    // signatures are provided when executing the deploy, so all we need to do here is check that
-    // any provided signatures are valid.
     for (index, approval) in deploy.approvals.iter().enumerate() {
         if let Err(error) = crypto::verify(&deploy.hash, &approval.signature, &approval.signer) {
             warn!(?deploy, "failed to verify approval {}: {}", index, error);

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -139,8 +139,8 @@ pub enum DeployValidationFailure {
     #[error("the provided hash does not match the actual hash of the deploy")]
     InvalidDeployHash,
 
-    /// The deploy has zero approvals
-    #[error("the deploy has zero approvals")]
+    /// The deploy has no approvals.
+    #[error("the deploy has no approvals")]
     EmptyApprovals,
 
     /// Invalid approval.


### PR DESCRIPTION
CHANGELOG:

- Added a condition during a deploy's validity check that the `approvals` field must be non-empty
- Added a new `DeployValidatorFailure` variant `EmptyApprovals` to be raised if a deploy's approvals field is empty
- Added a unit test to check that deploy's with empty approvals raise a `DeployValidationFailure`

Closes #1646 