### PR TITLE
Small network: Code readability and docs

### DIFF
--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -37,7 +37,7 @@
 //! The following chart illustrates the lifecycle of an outgoing connection.
 //!
 //! ```text
-//!                   forgot (after n tries)
+//!                   forget (after n tries)
 //!          ┌────────────────────────────────────┐
 //!          │                 learn              ▼
 //!          │               ┌──────────────  unknown/forgotten

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -37,22 +37,24 @@
 //! The following chart illustrates the lifecycle of an outgoing connection.
 //!
 //! ```text
-//!                            learn
-//!                          ┌──────────────  unknown/forgotten
-//!                          │ ┌───────────►  (implicit state)
-//!                          │ │
-//!                          │ │ exceed fail  │
-//!                          │ │ limit        │ block
-//!                          │ │              │
-//!                          │ │              │
-//!                          │ │              ▼
-//!     ┌─────────┐ fail,    │ │        ┌─────────┐
-//!     │         │ sweep    │ │  block │         │
-//!     │ Waiting │◄───────┐ │ │ ┌─────►│ Blocked │◄──────────┐
-//! ┌───┤         │        │ │ │ │      │         │           │
-//! │   └────┬────┘        │ │ │ │      └────┬────┘           │
-//! │ block  │             │ │ │ │           │                │
-//! │        │ timeout     │ ▼ │ │           │ redeem,        │
+//!                   forgot (after n tries)
+//!          ┌────────────────────────────────────┐
+//!          │                 learn              ▼
+//!          │               ┌──────────────  unknown/forgotten
+//!          │               │                (implicit state)
+//!          │               │
+//!          │               │                │
+//!          │               │                │ block
+//!          │               │                │
+//!          │               │                │
+//!          │               │                ▼
+//!     ┌────┴────┐          │          ┌─────────┐
+//!     │         │  fail    │    block │         │
+//!     │ Waiting │◄───────┐ │   ┌─────►│ Blocked │◄──────────┐
+//! ┌───┤         │        │ │   │      │         │           │
+//! │   └────┬────┘        │ │   │      └────┬────┘           │
+//! │ block  │             │ │   │           │                │
+//! │        │ timeout     │ ▼   │           │ redeem,        │
 //! │        │        ┌────┴─────┴───┐       │ block timeout  │
 //! │        │        │              │       │                │
 //! │        └───────►│  Connecting  │◄──────┘                │


### PR DESCRIPTION
Fixes a wrong state transition and a confusing label in the `outgoing.rs` state chart docs. Additionally, makes the `handle_dial_outcome` implementation a little less confusing.

This PR has no changelog entry, since it does not change anything visible to the end user.

Closes #1891 and closes #1889 