### PR TITLE
Log backtrace when responder fails

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -179,7 +179,11 @@ impl<T> Responder<T> {
     pub(crate) async fn respond(mut self, data: T) {
         if let Some(sender) = self.0.take() {
             if sender.send(data).is_err() {
-                error!("could not send response to request down oneshot channel");
+                let backtrace = backtrace::Backtrace::new();
+                error!(
+                    ?backtrace,
+                    "could not send response to request down oneshot channel"
+                );
             }
         } else {
             error!("tried to send a value down a responder channel, but it was already used");


### PR DESCRIPTION
Introduces a `backtrace::Backtrace` to logging when a responder fails. We're currently logging only:
```
could not send response to request down oneshot channel
```
Which does not provide any resolution as to where the responder was called from or what was happening when it failed.