### PR TITLE
Fixes to get nctl tests working again.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CARGO_OPTS := --locked
 CARGO := $(CARGO) $(CARGO_TOOLCHAIN) $(CARGO_OPTS)
 
 DISABLE_LOGGING = RUST_LOG=MatchesNothing
-LEGACY = RUSTFLAGS='--cfg feature="casper-mainnet"'
+LEGACY = RUSTFLAGS=''
 
 # Rust Contracts
 # Directory names should match crate names

--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -90,7 +90,6 @@ where
         current_version: ProtocolVersion,
         block_header_with_future_version: Box<BlockHeader>,
     },
-
     #[error(transparent)]
     BlockHeaderFetcherError(#[from] FetcherError<BlockHeader, I>),
 

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -429,7 +429,7 @@ where
     let maybe_last_emergency_restart_era_id = chainspec.protocol_config.last_emergency_restart;
     match maybe_last_emergency_restart_era_id {
         Some(last_emergency_restart_era)
-            if last_emergency_restart_era >= trusted_block_header.era_id() =>
+            if last_emergency_restart_era > trusted_block_header.era_id() =>
         {
             return Err(
                 LinearChainSyncError::TryingToJoinBeforeLastEmergencyRestartEra {
@@ -437,7 +437,7 @@ where
                     trusted_hash,
                     trusted_block_header,
                 },
-            )
+            );
         }
         _ => {}
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -232,11 +232,6 @@ max_state_store_size = 10_737_418_240
 # If enabled, nodes will attempt to share loaded objects if possible.
 enable_mem_deduplication = false
 
-# Memory duplication garbage collection.
-#
-# Sets the frequency how often the memory pool cache is swept for free references.
-mem_pool_prune_interval = 1024
-
 
 # ===================================
 # Configuration options for gossiping

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -232,11 +232,6 @@ max_state_store_size = 10_737_418_240
 # If enabled, nodes will attempt to share loaded objects if possible.
 enable_mem_deduplication = false
 
-# Memory duplication garbage collection.
-#
-# Sets the frequency how often the memory pool cache is swept for free references.
-mem_pool_prune_interval = 1024
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/assets/compile_node.sh
+++ b/utils/nctl/sh/assets/compile_node.sh
@@ -13,9 +13,9 @@ source "$NCTL"/sh/utils/main.sh
 pushd "$NCTL_CASPER_HOME" || exit
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-    cargo build --package casper-node --features casper-mainnet
+    cargo build --package casper-node
 else
-    cargo build --release --package casper-node --features casper-mainnet
+    cargo build --release --package casper-node
 fi
 
 popd || exit

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -232,11 +232,6 @@ max_state_store_size = 10_737_418_240
 # If enabled, nodes will attempt to share loaded objects if possible.
 enable_mem_deduplication = false
 
-# Memory duplication garbage collection.
-#
-# Sets the frequency how often the memory pool cache is swept for free references.
-mem_pool_prune_interval = 1024
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/staging/build.sh
+++ b/utils/nctl/sh/staging/build.sh
@@ -50,9 +50,9 @@ function set_stage_binaries()
 
     # Set node binary.
     if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-        cargo build --package casper-node --features casper-mainnet
+        cargo build --package casper-node
     else
-        cargo build --release --package casper-node --features casper-mainnet
+        cargo build --release --package casper-node
     fi
 
     # Set client binary.


### PR DESCRIPTION
* Remove `mem_pool_prune_interval`. That doesn't exist yet on this branch.
* Don't fail if the trusted block is in the era immediately after an emergency restart.
* Don't use the `casper-mainnet` feature: nctl compiles the client without it, and the node needs to be compatible with that.
* Make `HashingAlgorithmVersion::HASH_V2_PROTOCOL_VERSION` public also without the `casper-mainnet` feature, to fix the test build.

This doesn't fix `emergency_upgrade_test.sh` yet: That failure is related to how we handle emergency upgrades with fast sync in general, not just to #1666.

Closes #1898.