### PR TITLE
Add backtrace to Responder

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -176,17 +176,20 @@ impl<T: 'static + Send> Responder<T> {
 
 impl<T> Responder<T> {
     /// Send `data` to the origin of the request.
-    pub(crate) async fn respond(mut self, data: T) {
-        if let Some(sender) = self.0.take() {
-            if sender.send(data).is_err() {
-                let backtrace = backtrace::Backtrace::new();
-                error!(
-                    ?backtrace,
-                    "could not send response to request down oneshot channel"
-                );
+    pub(crate) fn respond(mut self, data: T) -> impl Future {
+        let caller_backtrace = backtrace::Backtrace::new();
+        async move {
+            if let Some(sender) = self.0.take() {
+                if sender.send(data).is_err() {
+                    error!(
+                        responder = ?self,
+                        ?caller_backtrace,
+                        "could not send response to request down oneshot channel"
+                    );
+                }
+            } else {
+                error!("tried to send a value down a responder channel, but it was already used");
             }
-        } else {
-            error!("tried to send a value down a responder channel, but it was already used");
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -176,7 +176,7 @@ impl<T: 'static + Send> Responder<T> {
 
 impl<T> Responder<T> {
     /// Send `data` to the origin of the request.
-    pub(crate) fn respond(mut self, data: T) -> impl Future {
+    pub(crate) fn respond(mut self, data: T) -> impl Future<Output = ()> {
         let caller_backtrace = backtrace::Backtrace::new();
         async move {
             if let Some(sender) = self.0.take() {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -188,7 +188,11 @@ impl<T> Responder<T> {
                     );
                 }
             } else {
-                error!("tried to send a value down a responder channel, but it was already used");
+                error!(
+                    responder = ?self,
+                    ?caller_backtrace,
+                    "tried to send a value down a responder channel, but it was already used"
+                );
             }
         }
     }


### PR DESCRIPTION
Followup to #1894 - but this time hoist the backtrace capture outside of the `async` context, allowing it to capture the call site.

Here's a playground showing how the output is improved:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=241f419c72dd01d5f0ab0aec70fce2a3
