### PR TITLE
Introducing better `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@
 
 # Please consider the following when creating a PR:
 # 
-# * Provide a description of this PR in simple language. This will help reviewers and contributers.
+# * Provide a list of significant changes made in this PR. This will help reviewers and contributors.
 # * Identify if any downstream impact as in to, SDKs, SmartContracts etc

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
-Please consider the following when creating a PR:
+- [ ] Closes <ISSUE>
+- [ ] Updated CHANGELOG.md
 
-* Provide a useful description of this PR, suitably verbose, aimed at helping reviewers and contributors
-* Update all relevant changelogs
-* Provide a link to the GitHub issue relating to this PR
-* Identify if any downstream impact as in to, SDKs, SmartContracts etc
+# Please consider the following when creating a PR:
+# 
+# * Provide a description of this PR in simple language. This will help reviewers and contributers.
+# * Identify if any downstream impact as in to, SDKs, SmartContracts etc


### PR DESCRIPTION
The following template provides a few tweaks to what we already have:

 - Leverages github's [task-lists][1] feature
 - Comments out the advice by default
 - Removes a run-on sentence

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists