### PR TITLE
Make run_equivocator_network test simpler and less flaky.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -56,9 +56,6 @@ pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;
 use traits::NodeIdT;
 
-#[cfg(test)]
-pub(crate) use era_supervisor::oldest_bonded_era;
-
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub(crate) enum ConsensusMessage {
     /// A protocol message, to be handled by the instance in the specified era.

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -49,6 +49,8 @@ use crate::{
 
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::Config;
+#[cfg(test)]
+pub(crate) use config::ProtocolConfig;
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -590,6 +590,11 @@ where
             .consensus
             .validators_with_evidence()
     }
+
+    /// Returns this node's validator key.
+    pub(crate) fn public_key(&self) -> &PublicKey {
+        &self.public_signing_key
+    }
 }
 
 /// Returns an era ID in which the booking block for `era_id` lives, if we can use it.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -310,7 +310,7 @@ struct AllocatedMem {
 
 /// A runner for a reactor.
 ///
-/// The runner manages a reactors event queue and reactor itself and can run it either continuously
+/// The runner manages a reactor's event queue and reactor itself and can run it either continuously
 /// or in a step-by-step manner.
 #[derive(Debug)]
 pub(crate) struct Runner<R>

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -4,6 +4,7 @@
 //! `casper-node` library.
 
 mod condition_check_reactor;
+pub(crate) mod filter_reactor;
 mod multi_stage_test_reactor;
 pub(crate) mod network;
 pub(crate) mod test_clock;


### PR DESCRIPTION
This wraps the `Participating` reactor in a `FilterReactor` in the test, and delays the first few messages to and from one of the two nodes with the same key. That way, the nodes won't notice each other and will always equivocate in the first era.

Closes #1859