### PR TITLE
NCTL: sync nctl config.tomls with changes from PR1877

### DIFF
--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -111,16 +111,16 @@ bind_address = '0.0.0.0:34553'
 # one connection.
 known_addresses = ['127.0.0.1:34553']
 
-# The interval (in milliseconds) between each fresh round of gossiping the node's public address.
-gossip_interval = 30000
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
 
 # Minimum amount of time that has to pass before attempting to reconnect after losing all
 # connections to established nodes.
-isolation_reconnect_delay = '2s'
+isolation_reconnect_delay = '2sec'
 
 # Initial delay for starting address gossipping after the network starts. This should be slightly
 # more than the expected time required for initial connections to complete.
-initial_gossip_delay = '5s'
+initial_gossip_delay = '5sec'
 
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
@@ -258,20 +258,20 @@ infection_target = 3
 # excluding us since 80% saturation would imply 3 new infections in 15 peers.
 saturation_limit_percent = 80
 
-# The maximum duration in seconds for which to keep finished entries.
+# The maximum duration for which to keep finished entries.
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration_secs = 60
+finished_entry_duration = '60sec'
 
-# The timeout duration in seconds for a single gossip request, i.e. for a single gossip message
+# The timeout duration for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-gossip_request_timeout_secs = 10
+gossip_request_timeout = '10sec'
 
-# The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 5
+get_remainder_timeout = '5sec'
 
 
 # =================================
@@ -279,10 +279,10 @@ get_remainder_timeout_secs = 5
 # =================================
 [fetcher]
 
-# The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-get_from_peer_timeout = 3
+get_from_peer_timeout = '3sec'
 
 
 # ===================================================
@@ -332,4 +332,4 @@ sync_timeout = '1hr'
 # Deploys are only proposed in a new block if they have been received at least this long ago.
 # A longer delay makes it more likely that many proposed deploys are already known by the
 # other nodes, and don't have to be requested from the proposer afterwards.
-deploy_delay = '5seconds'
+deploy_delay = '5sec'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -115,16 +115,16 @@ bind_address = '0.0.0.0:34553'
 # one connection.
 known_addresses = ['127.0.0.1:34553']
 
-# The interval (in milliseconds) between each fresh round of gossiping the node's public address.
-gossip_interval = 30000
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
 
 # Minimum amount of time that has to pass before attempting to reconnect after losing all
 # connections to established nodes.
-isolation_reconnect_delay = '2s'
+isolation_reconnect_delay = '2sec'
 
 # Initial delay for starting address gossipping after the network starts. This should be slightly
 # more than the expected time required for initial connections to complete.
-initial_gossip_delay = '5s'
+initial_gossip_delay = '5sec'
 
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
@@ -262,20 +262,20 @@ infection_target = 3
 # excluding us since 80% saturation would imply 3 new infections in 15 peers.
 saturation_limit_percent = 80
 
-# The maximum duration in seconds for which to keep finished entries.
+# The maximum duration for which to keep finished entries.
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration_secs = 60
+finished_entry_duration = '60sec'
 
-# The timeout duration in seconds for a single gossip request, i.e. for a single gossip message
+# The timeout duration for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-gossip_request_timeout_secs = 10
+gossip_request_timeout = '10sec'
 
-# The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 5
+get_remainder_timeout = '5sec'
 
 
 # =================================
@@ -283,10 +283,10 @@ get_remainder_timeout_secs = 5
 # =================================
 [fetcher]
 
-# The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-get_from_peer_timeout = 3
+get_from_peer_timeout = '3sec'
 
 
 # ===================================================
@@ -318,6 +318,22 @@ verify_accounts = true
 # If unset, defaults to 5.
 #max_query_depth = 5
 
+
+# ========================================================
+# Configuration options for synchronizing the linear chain
+# ========================================================
 [linear_chain_sync]
-# Use sync_timeout to set the amount of time that the node will try to sync before shutting down.
-sync_timeout = "1hr"
+
+# The amount of time that the node will try to sync without making progress before shutting down.
+sync_timeout = '1hr'
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -111,16 +111,16 @@ bind_address = '0.0.0.0:34553'
 # one connection.
 known_addresses = ['127.0.0.1:34553']
 
-# The interval (in milliseconds) between each fresh round of gossiping the node's public address.
-gossip_interval = 30000
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
 
 # Minimum amount of time that has to pass before attempting to reconnect after losing all
 # connections to established nodes.
-isolation_reconnect_delay = '2s'
+isolation_reconnect_delay = '2sec'
 
 # Initial delay for starting address gossipping after the network starts. This should be slightly
 # more than the expected time required for initial connections to complete.
-initial_gossip_delay = '5s'
+initial_gossip_delay = '5sec'
 
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
@@ -258,20 +258,20 @@ infection_target = 3
 # excluding us since 80% saturation would imply 3 new infections in 15 peers.
 saturation_limit_percent = 80
 
-# The maximum duration in seconds for which to keep finished entries.
+# The maximum duration for which to keep finished entries.
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration_secs = 60
+finished_entry_duration = '60sec'
 
-# The timeout duration in seconds for a single gossip request, i.e. for a single gossip message
+# The timeout duration for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-gossip_request_timeout_secs = 10
+gossip_request_timeout = '10sec'
 
-# The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 5
+get_remainder_timeout = '5sec'
 
 
 # =================================
@@ -279,10 +279,10 @@ get_remainder_timeout_secs = 5
 # =================================
 [fetcher]
 
-# The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-get_from_peer_timeout = 3
+get_from_peer_timeout = '3sec'
 
 
 # ===================================================


### PR DESCRIPTION
Changes:
- Syncs NCTL tests with changes introduced in https://github.com/casper-network/casper-node/pull/1877