### PR TITLE
Make Block::verify private.

### DIFF
--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -299,8 +299,7 @@ pub(crate) fn validate_get_block_response(
     } else {
         return Ok(());
     };
-    let block = Block::from(json_block);
-    block.verify()?;
+    let block = Block::try_from(json_block)?;
     match maybe_block_identifier {
         Some(BlockIdentifier::Hash(block_hash)) => {
             if block_hash != block.hash() {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -295,7 +295,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
 }
 
 impl ItemFetcher<Block> for Fetcher<Block> {
-    const SAFE_TO_RESPOND_TO_ALL: bool = false;
+    const SAFE_TO_RESPOND_TO_ALL: bool = true;
 
     fn responders(
         &mut self,

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -322,16 +322,6 @@ where
                     finality_signatures,
                 } = &*item;
 
-                if let Err(error) = block.verify() {
-                    warn!(
-                        ?error,
-                        ?peer,
-                        "Error validating block from peer; banning peer.",
-                    );
-                    effect_builder.announce_disconnect_from_peer(peer).await;
-                    continue;
-                }
-
                 if let Err(error) = validate_finality_signatures(
                     block.header(),
                     trusted_validator_weights,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -986,8 +986,6 @@ impl Storage {
 
     /// Write a block to storage, updating indices as necessary
     pub fn write_block(&mut self, block: &Block) -> Result<bool, Error> {
-        // Validate the block prior to inserting it into the database
-        block.verify()?;
         let mut txn = self.env.begin_rw_txn()?;
         // Write the block body
         {

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -191,7 +191,7 @@ pub fn hash_pair(hash1: &Digest, hash2: &Digest) -> Digest {
 
 /// Hashes a [`Vec`] of [`Digest`]s into a single [`Digest`] by constructing a [Merkle tree][1].
 /// Reduces pairs of elements in the [`Vec`] by repeatedly calling [hash_pair].
-/// This hash procedure is suited to hashing [BTree]s.
+/// This hash procedure is suited to hashing binary trees.
 ///
 /// The pattern of hashing is as follows.  It is akin to [graph reduction][2]:
 ///

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1275,10 +1275,10 @@ pub struct Block {
 
 /// A temporary copy of a block that has not been validated yet.
 #[derive(Debug, Deserialize)]
-pub(crate) struct UnverifiedBlock {
-    pub(crate) hash: BlockHash,
-    pub(crate) header: BlockHeader,
-    pub(crate) body: BlockBody,
+struct UnverifiedBlock {
+    hash: BlockHash,
+    header: BlockHeader,
+    body: BlockBody,
 }
 
 impl UnverifiedBlock {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1039,9 +1039,9 @@ impl<'a, T> MerkleBlockBodyPart<'a, T> {
 /// ```
 #[derive(Debug, Clone)]
 pub struct MerkleBlockBody<'a> {
-    /// Merklized [`BlockBody::deploy_hashes`].
+    /// Merklized `BlockBody::deploy_hashes`.
     pub deploy_hashes: MerkleBlockBodyPart<'a, Vec<DeployHash>>,
-    /// Merklized [`BlockBody::transfer_hashes`].
+    /// Merklized `BlockBody::transfer_hashes`.
     pub transfer_hashes: MerkleBlockBodyPart<'a, Vec<DeployHash>>,
     /// Merklized [`BlockBody::proposer`].
     pub proposer: MerkleBlockBodyPart<'a, PublicKey>,

--- a/node/src/types/error.rs
+++ b/node/src/types/error.rs
@@ -13,8 +13,8 @@ use crate::{
 /// An error that can arise when creating a block from a finalized block and other components
 #[derive(Error, Debug)]
 pub enum BlockCreationError {
-    /// [`EraEnd`]s need both an [`EraReport`] present and a map of the next era validator weights.
-    /// If one of them is not present while trying to construct an [`EraEnd`] we must emit an
+    /// `EraEnd`s need both an `EraReport` present and a map of the next era validator weights.
+    /// If one of them is not present while trying to construct an `EraEnd` we must emit an
     /// error.
     #[error(
         "Cannot create EraEnd unless we have both an EraReport and next era validators. \
@@ -22,14 +22,14 @@ pub enum BlockCreationError {
          Next era validator weights: {maybe_next_era_validator_weights:?}"
     )]
     CouldNotCreateEraEnd {
-        /// An optional [`EraReport`] we tried to use to construct an [`EraEnd`]
+        /// An optional `EraReport` we tried to use to construct an `EraEnd`
         maybe_era_report: Option<EraReport>,
-        /// An optional map of the next era validator weights used to construct an [`EraEnd`]
+        /// An optional map of the next era validator weights used to construct an `EraEnd`
         maybe_next_era_validator_weights: Option<BTreeMap<PublicKey, U512>>,
     },
 
     /// Wrapper of [`blake2::digest::InvalidOutputSize`]; occurs when trying to construct
-    /// an [`EraEnd`].
+    /// an `EraEnd`.
     #[error(transparent)]
     Blake2bDigestInvalidOutputSize(#[from] blake2::digest::InvalidOutputSize),
 }
@@ -48,9 +48,9 @@ pub enum BlockValidationError {
          Block: {block:?}"
     )]
     UnexpectedBodyHash {
-        /// The [`Block`] with the [`BlockHeader`] with the incorrect block body hash
+        /// The `Block` with the `BlockHeader` with the incorrect block body hash
         block: Box<Block>,
-        /// The actual hash of the block's [`BlockBody`]
+        /// The actual hash of the block's `BlockBody`
         actual_block_body_hash: Digest,
     },
 
@@ -61,9 +61,9 @@ pub enum BlockValidationError {
          Block: {block:?}"
     )]
     UnexpectedBlockHash {
-        /// The [`Block`] with the incorrect [`BlockHeaderHash`]
+        /// The `Block` with the incorrect `BlockHeaderHash`
         block: Box<Block>,
-        /// The actual hash of the block's [`BlockHeader`]
+        /// The actual hash of the block's `BlockHeader`
         actual_block_header_hash: BlockHash,
     },
 }


### PR DESCRIPTION
This should make it impossible to instantiate an invalid `Block`, where the body hash doesn't match the one in the header, or the `hash` field is different from the header's hash.

Now that this gets verified on deserialization, the fetcher can respond on all `Responder`s once it got the block from one peer.

Closes #1620.