### PR TITLE
Remove backtrace from Responder - keep logging self

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -176,24 +176,19 @@ impl<T: 'static + Send> Responder<T> {
 
 impl<T> Responder<T> {
     /// Send `data` to the origin of the request.
-    pub(crate) fn respond(mut self, data: T) -> impl Future<Output = ()> {
-        let caller_backtrace = backtrace::Backtrace::new();
-        async move {
-            if let Some(sender) = self.0.take() {
-                if sender.send(data).is_err() {
-                    error!(
-                        responder = ?self,
-                        ?caller_backtrace,
-                        "could not send response to request down oneshot channel"
-                    );
-                }
-            } else {
+    pub(crate) async fn respond(mut self, data: T) {
+        if let Some(sender) = self.0.take() {
+            if sender.send(data).is_err() {
                 error!(
                     responder = ?self,
-                    ?caller_backtrace,
-                    "tried to send a value down a responder channel, but it was already used"
+                    "could not send response to request down oneshot channel"
                 );
             }
+        } else {
+            error!(
+                responder = ?self,
+                "tried to send a value down a responder channel, but it was already used"
+            );
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -183,14 +183,12 @@ where
         if let Some(sender) = self.0.take() {
             if let Err(data) = sender.send(data) {
                 error!(
-                    responder = ?self,
                     ?data,
                     "could not send response to request down oneshot channel"
                 );
             }
         } else {
             error!(
-                responder = ?self,
                 ?data,
                 "tried to send a value down a responder channel, but it was already used"
             );

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -174,19 +174,24 @@ impl<T: 'static + Send> Responder<T> {
     }
 }
 
-impl<T> Responder<T> {
+impl<T> Responder<T>
+where
+    T: Debug,
+{
     /// Send `data` to the origin of the request.
     pub(crate) async fn respond(mut self, data: T) {
         if let Some(sender) = self.0.take() {
-            if sender.send(data).is_err() {
+            if let Err(data) = sender.send(data) {
                 error!(
                     responder = ?self,
+                    ?data,
                     "could not send response to request down oneshot channel"
                 );
             }
         } else {
             error!(
                 responder = ?self,
+                ?data,
                 "tried to send a value down a responder channel, but it was already used"
             );
         }

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -312,7 +312,7 @@ async fn run_equivocator_network() {
     // We configure the era to take five rounds, and delay all messages to and from one of Alice's
     // nodes until two rounds after genesis. That should guarantee that the two nodes equivocate.
     let mut chain = TestChain::new_with_keys(&mut rng, keys, stakes.clone());
-    chain.chainspec_mut().core_config.minimum_era_height = 5;
+    chain.chainspec_mut().core_config.minimum_era_height = 10;
     let protocol_config = consensus::ProtocolConfig::from(&*chain.chainspec);
 
     let mut net = chain


### PR DESCRIPTION
The purpose of this PR is to remove the backtrace from `Responder`, which was unconditionally created and is expensive. We keep logging `self`, however, so there's at least a hint in this error case.