### PR TITLE
Genesis should not clobber an existing blockchain

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1143,12 +1143,10 @@ impl Storage {
 
     /// Retrieves the highest block header from the storage, if one exists.
     pub fn read_highest_block_header(&self) -> Result<Option<BlockHeader>, Error> {
-        let highest_block_hash = match self.block_height_index
-            .iter()
-            .last() {
-                Some((_, highest_block_hash)) => highest_block_hash,
-                None => return Ok(None),
-            };
+        let highest_block_hash = match self.block_height_index.iter().last() {
+            Some((_, highest_block_hash)) => highest_block_hash,
+            None => return Ok(None),
+        };
         self.read_block_header_by_hash(highest_block_hash)
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1141,6 +1141,17 @@ impl Storage {
             .transpose()
     }
 
+    /// Retrieves the highest block header from the storage, if one exists.
+    pub fn read_highest_block_header(&self) -> Result<Option<BlockHeader>, Error> {
+        let highest_block_hash = match self.block_height_index
+            .iter()
+            .last() {
+                Some((_, highest_block_hash)) => highest_block_hash,
+                None => return Ok(None),
+            };
+        self.read_block_header_by_hash(highest_block_hash)
+    }
+
     /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
     /// the ancestry chain.
     fn get_blocks_while<F, Tx: Transaction>(
@@ -1329,7 +1340,7 @@ impl Storage {
     }
 
     // Retrieves a block header by hash.
-    pub(crate) fn get_block_header_by_hash(
+    pub(crate) fn read_block_header_by_hash(
         &self,
         block_hash: &BlockHash,
     ) -> Result<Option<BlockHeader>, Error> {

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -497,7 +497,7 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
 
     {
         let block_header = storage
-            .get_block_header_by_hash(block.hash())
+            .read_block_header_by_hash(block.hash())
             .expect("should not throw exception")
             .expect("should not be None");
         assert_eq!(

--- a/node/src/reactor/participating/error.rs
+++ b/node/src/reactor/participating/error.rs
@@ -53,11 +53,10 @@ pub(crate) enum Error {
     #[error("bytesrepr error: {0}")]
     BytesRepr(#[from] bytesrepr::Error),
 
-    /// Cannot run genesis on pre-existing blockchain.
-    #[error("Cannot run genesis on pre-existing blockchain. First block: {first_block_header:?}")]
+    /// Cannot run genesis on preexisting blockchain.
+    #[error("Cannot run genesis on preexisting blockchain. First block: {highest_block_header:?}")]
     CannotRunGenesisOnPreExistingBlockchain {
-        /// The first block header.  Should have height 1.
-        first_block_header: Box<BlockHeader>,
+        highest_block_header: Box<BlockHeader>,
     },
 
     /// No such switch block for upgrade era.


### PR DESCRIPTION
Before running genesis in order to create a switch block, we first check to see if we have any blocks so we don't clobber an existing blockchain.

Closes #1937
