### PR TITLE
Move `Gas` and `Motes` to casper-types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "hex",
  "hex_fmt",
  "k256",
+ "num",
  "num-derive",
  "num-integer",
  "num-rational 0.4.0",
@@ -2615,6 +2616,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
+ "num-bigint 0.4.0",
  "num-complex",
  "num-integer",
  "num-iter",

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -1,15 +1,13 @@
 use std::collections::VecDeque;
 
 use casper_types::{
-    bytesrepr::FromBytes, CLTyped, CLValue, CLValueError, Key, StoredValue, TransferAddr,
+    bytesrepr::FromBytes, CLTyped, CLValue, CLValueError, Gas, Key, Motes, StoredValue,
+    TransferAddr,
 };
 
 use super::{error, execution_effect::ExecutionEffect, op::Op};
 use crate::{
-    shared::{
-        additive_map::AdditiveMap, gas::Gas, motes::Motes, newtypes::CorrelationId,
-        transform::Transform,
-    },
+    shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::StateReader,
 };
 

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, collections::BTreeMap, fmt, iter, rc::Rc};
 
 use datasize::DataSize;
+use num::Zero;
 use num_rational::Ratio;
-use num_traits::Zero;
 use parity_wasm::elements::Module;
 use rand::{
     distributions::{Distribution, Standard},
@@ -32,8 +32,8 @@ use casper_types::{
         standard_payment, AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
     AccessRights, CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash,
-    ContractWasm, ContractWasmHash, DeployHash, EntryPointType, EntryPoints, EraId, Key, Phase,
-    ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue, URef, U512,
+    ContractWasm, ContractWasmHash, DeployHash, EntryPointType, EntryPoints, EraId, Gas, Key,
+    Motes, Phase, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue, URef, U512,
 };
 
 use crate::{
@@ -44,8 +44,6 @@ use crate::{
         tracking_copy::{TrackingCopy, TrackingCopyExt},
     },
     shared::{
-        gas::Gas,
-        motes::Motes,
         newtypes::{Blake2bHash, CorrelationId},
         system_config::SystemConfig,
         wasm_config::WasmConfig,

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -43,7 +43,8 @@ use casper_types::{
         CallStackElement, AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
     AccessRights, ApiError, BlockTime, CLValue, Contract, ContractHash, DeployHash, DeployInfo,
-    Key, KeyTag, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, URef, U512,
+    Gas, Key, KeyTag, Motes, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, URef,
+    U512,
 };
 
 pub use self::{
@@ -76,8 +77,6 @@ use crate::{
     },
     shared::{
         additive_map::AdditiveMap,
-        gas::Gas,
-        motes::Motes,
         newtypes::{Blake2bHash, CorrelationId},
         transform::Transform,
         wasm_prep::Preprocessor,

--- a/execution_engine/src/core/execution/executor.rs
+++ b/execution_engine/src/core/execution/executor.rs
@@ -9,7 +9,7 @@ use casper_types::{
     bytesrepr::FromBytes,
     contracts::NamedKeys,
     system::{auction, handle_payment, mint, CallStackElement, AUCTION, HANDLE_PAYMENT, MINT},
-    BlockTime, CLTyped, CLValue, ContractPackage, DeployHash, EntryPoint, EntryPointType, Key,
+    BlockTime, CLTyped, CLValue, ContractPackage, DeployHash, EntryPoint, EntryPointType, Gas, Key,
     Phase, ProtocolVersion, RuntimeArgs, StoredValue,
 };
 
@@ -24,7 +24,7 @@ use crate::{
         runtime_context::{self, RuntimeContext},
         tracking_copy::{TrackingCopy, TrackingCopyExt},
     },
-    shared::{gas::Gas, newtypes::CorrelationId},
+    shared::newtypes::CorrelationId,
     storage::global_state::StateReader,
 };
 

--- a/execution_engine/src/core/execution/tests.rs
+++ b/execution_engine/src/core/execution/tests.rs
@@ -1,13 +1,13 @@
 use tracing::warn;
 
-use casper_types::{Key, U512};
+use casper_types::{Gas, Key, U512};
 
 use super::Error;
 use crate::{
     core::engine_state::{
         execution_effect::ExecutionEffect, execution_result::ExecutionResult, op::Op,
     },
-    shared::{gas::Gas, transform::Transform},
+    shared::transform::Transform,
 };
 
 fn on_fail_charge_test_helper<T>(

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -9,16 +9,14 @@ use casper_types::{
     bytesrepr::{self, ToBytes},
     contracts::{ContractPackageStatus, EntryPoints, NamedKeys},
     system::auction::EraInfo,
-    ContractHash, ContractPackageHash, ContractVersion, EraId, Group, Key, StoredValue, URef, U512,
+    ContractHash, ContractPackageHash, ContractVersion, EraId, Gas, Group, Key, StoredValue, URef,
+    U512,
 };
 
 use super::{args::Args, scoped_instrumenter::ScopedInstrumenter, Error, Runtime};
 use crate::{
     core::resolvers::v1_function_index::FunctionIndex,
-    shared::{
-        gas::Gas,
-        host_function_costs::{Cost, HostFunction, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY},
-    },
+    shared::host_function_costs::{Cost, HostFunction, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY},
     storage::global_state::StateReader,
 };
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -34,9 +34,9 @@ use casper_types::{
         CallStackElement, SystemContractType, AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
     AccessRights, ApiError, CLType, CLTyped, CLValue, ContractHash, ContractPackageHash,
-    ContractVersionKey, ContractWasm, DeployHash, EntryPointType, EraId, Key, NamedArg, Parameter,
-    Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, Transfer, TransferResult,
-    TransferredTo, URef, DICTIONARY_ITEM_KEY_MAX_LENGTH, U128, U256, U512,
+    ContractVersionKey, ContractWasm, DeployHash, EntryPointType, EraId, Gas, Key, NamedArg,
+    Parameter, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, Transfer,
+    TransferResult, TransferredTo, URef, DICTIONARY_ITEM_KEY_MAX_LENGTH, U128, U256, U512,
 };
 
 use crate::{
@@ -49,7 +49,6 @@ use crate::{
         Address,
     },
     shared::{
-        gas::Gas,
         host_function_costs::{Cost, HostFunction},
         wasm_config::WasmConfig,
     },

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -18,9 +18,9 @@ use casper_types::{
     contracts::NamedKeys,
     system::auction::EraInfo,
     AccessRights, BlockTime, CLType, CLValue, Contract, ContractHash, ContractPackage,
-    ContractPackageHash, DeployHash, DeployInfo, EntryPointAccess, EntryPointType, Key, KeyTag,
-    Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, Transfer, TransferAddr, URef,
-    DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_HASH_LENGTH,
+    ContractPackageHash, DeployHash, DeployInfo, EntryPointAccess, EntryPointType, Gas, Key,
+    KeyTag, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, Transfer, TransferAddr,
+    URef, DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_HASH_LENGTH,
 };
 
 use crate::{
@@ -31,7 +31,7 @@ use crate::{
         tracking_copy::{AddResult, TrackingCopy, TrackingCopyExt},
         Address,
     },
-    shared::{gas::Gas, newtypes::CorrelationId},
+    shared::newtypes::CorrelationId,
     storage::global_state::StateReader,
 };
 

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -17,8 +17,8 @@ use casper_types::{
     contracts::NamedKeys,
     system::{AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT},
     AccessRights, BlockTime, CLValue, Contract, ContractHash, DeployHash, EntryPointType,
-    EntryPoints, Key, Phase, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue, URef,
-    KEY_HASH_LENGTH, U256, U512,
+    EntryPoints, Gas, Key, Phase, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue,
+    URef, KEY_HASH_LENGTH, U256, U512,
 };
 
 use super::{Address, Error, RuntimeContext};
@@ -29,7 +29,7 @@ use crate::{
         runtime::extract_access_rights_from_keys,
         tracking_copy::TrackingCopy,
     },
-    shared::{additive_map::AdditiveMap, gas::Gas, newtypes::CorrelationId, transform::Transform},
+    shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::{
         in_memory::{InMemoryGlobalState, InMemoryGlobalStateView},
         StateProvider,

--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -5,12 +5,12 @@ use parity_wasm::elements::Module;
 use casper_types::{
     account::{Account, AccountHash},
     CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash, ContractWasm,
-    ContractWasmHash, Key, StoredValue, StoredValueTypeMismatch, URef,
+    ContractWasmHash, Key, Motes, StoredValue, StoredValueTypeMismatch, URef,
 };
 
 use crate::{
     core::{engine_state::SystemContractRegistry, execution, tracking_copy::TrackingCopy},
-    shared::{motes::Motes, newtypes::CorrelationId, wasm, wasm_prep::Preprocessor},
+    shared::{newtypes::CorrelationId, wasm, wasm_prep::Preprocessor},
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 

--- a/execution_engine/src/shared.rs
+++ b/execution_engine/src/shared.rs
@@ -2,10 +2,8 @@
 
 pub mod additive_map;
 #[macro_use]
-pub mod gas;
 pub mod host_function_costs;
 pub mod logging;
-pub mod motes;
 pub mod newtypes;
 pub mod opcode_costs;
 pub mod storage_costs;

--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -2,9 +2,10 @@ use datasize::DataSize;
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 use serde::{Deserialize, Serialize};
 
-use casper_types::bytesrepr::{self, FromBytes, ToBytes, U32_SERIALIZED_LENGTH};
-
-use super::gas::Gas;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes, U32_SERIALIZED_LENGTH},
+    Gas,
+};
 
 /// Representation of argument's cost.
 pub type Cost = u32;

--- a/execution_engine/src/shared/storage_costs.rs
+++ b/execution_engine/src/shared/storage_costs.rs
@@ -4,10 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    U512,
+    Gas, U512,
 };
-
-use super::gas::Gas;
 
 pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 625_000;
 

--- a/execution_engine_testing/test_support/src/internal/exec_with_return.rs
+++ b/execution_engine_testing/test_support/src/internal/exec_with_return.rs
@@ -11,12 +11,12 @@ use casper_execution_engine::{
         runtime::{self, Runtime},
         runtime_context::RuntimeContext,
     },
-    shared::{gas::Gas, newtypes::CorrelationId, wasm_prep::Preprocessor},
+    shared::{newtypes::CorrelationId, wasm_prep::Preprocessor},
     storage::global_state::StateProvider,
 };
 use casper_types::{
     account::AccountHash, bytesrepr::FromBytes, system::CallStackElement, BlockTime, CLTyped,
-    DeployHash, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs, URef, U512,
+    DeployHash, EntryPointType, Gas, Key, Phase, ProtocolVersion, RuntimeArgs, URef, U512,
 };
 
 use crate::internal::{utils, WasmTestBuilder, DEFAULT_WASM_CONFIG};

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -15,11 +15,9 @@ use casper_execution_engine::{
         genesis::{ExecConfig, GenesisAccount, GenesisConfig},
         run_genesis_request::RunGenesisRequest,
     },
-    shared::{
-        motes::Motes, newtypes::Blake2bHash, system_config::SystemConfig, wasm_config::WasmConfig,
-    },
+    shared::{newtypes::Blake2bHash, system_config::SystemConfig, wasm_config::WasmConfig},
 };
-use casper_types::{account::AccountHash, ProtocolVersion, PublicKey, SecretKey, U512};
+use casper_types::{account::AccountHash, Motes, ProtocolVersion, PublicKey, SecretKey, U512};
 
 use super::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 

--- a/execution_engine_testing/test_support/src/internal/utils.rs
+++ b/execution_engine_testing/test_support/src/internal/utils.rs
@@ -13,9 +13,9 @@ use casper_execution_engine::{
         run_genesis_request::RunGenesisRequest,
         Error,
     },
-    shared::{additive_map::AdditiveMap, gas::Gas, transform::Transform},
+    shared::{additive_map::AdditiveMap, transform::Transform},
 };
-use casper_types::{account::Account, Key, StoredValue};
+use casper_types::{account::Account, Gas, Key, StoredValue};
 
 use super::{DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY};
 use crate::internal::{

--- a/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
@@ -29,7 +29,6 @@ use casper_execution_engine::{
     },
     shared::{
         additive_map::AdditiveMap,
-        gas::Gas,
         logging::{self, Settings, Style},
         newtypes::{Blake2bHash, CorrelationId},
         transform::Transform,
@@ -57,7 +56,7 @@ use casper_types::{
         AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
     CLTyped, CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash, ContractWasm,
-    DeployHash, DeployInfo, EraId, Key, KeyTag, PublicKey, RuntimeArgs, StoredValue, Transfer,
+    DeployHash, DeployInfo, EraId, Gas, Key, KeyTag, PublicKey, RuntimeArgs, StoredValue, Transfer,
     TransferAddr, URef, U512,
 };
 

--- a/execution_engine_testing/test_support/src/test_context.rs
+++ b/execution_engine_testing/test_support/src/test_context.rs
@@ -1,11 +1,8 @@
-use casper_execution_engine::{
-    core::engine_state::{
-        genesis::{GenesisAccount, GenesisConfig},
-        run_genesis_request::RunGenesisRequest,
-    },
-    shared::motes::Motes,
+use casper_execution_engine::core::engine_state::{
+    genesis::{GenesisAccount, GenesisConfig},
+    run_genesis_request::RunGenesisRequest,
 };
-use casper_types::{AccessRights, Key, PublicKey, StoredValue, URef, U512};
+use casper_types::{AccessRights, Key, Motes, PublicKey, StoredValue, URef, U512};
 
 use crate::{
     internal::{InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG, DEFAULT_GENESIS_CONFIG_HASH},

--- a/execution_engine_testing/tests/src/test/gas_counter.rs
+++ b/execution_engine_testing/tests/src/test/gas_counter.rs
@@ -11,11 +11,8 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use casper_execution_engine::{
-    core::engine_state::Error,
-    shared::{gas::Gas, wasm_prep::PreprocessingError},
-};
-use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, runtime_args, RuntimeArgs};
+use casper_execution_engine::{core::engine_state::Error, shared::wasm_prep::PreprocessingError};
+use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, runtime_args, Gas, RuntimeArgs};
 
 /// Creates minimal session code that does nothing
 fn make_minimal_do_nothing() -> Vec<u8> {

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -9,14 +9,11 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
-    shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::genesis::{GenesisAccount, GenesisValidator};
 use casper_types::{
     runtime_args,
     system::auction::{DelegationRate, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID, METHOD_SLASH},
-    PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 use once_cell::sync::Lazy;
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -9,15 +9,12 @@ use casper_engine_test_support::{
     },
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::engine_state::{genesis::GenesisValidator, GenesisAccount},
-    shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::{genesis::GenesisValidator, GenesisAccount};
 use casper_types::{
     account::AccountHash,
     runtime_args,
     system::auction::{DelegationRate, ARG_DELEGATOR, ARG_VALIDATOR},
-    PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -9,10 +9,7 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
-    shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::genesis::{GenesisAccount, GenesisValidator};
 use casper_types::{
     account::AccountHash,
     runtime_args,
@@ -23,7 +20,7 @@ use casper_types::{
         },
         mint::TOTAL_SUPPLY_KEY,
     },
-    PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -9,10 +9,7 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
-    shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::genesis::{GenesisAccount, GenesisValidator};
 use casper_types::{
     account::AccountHash,
     runtime_args,
@@ -20,7 +17,7 @@ use casper_types::{
         Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
         ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH,
     },
-    PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -17,14 +17,14 @@ use casper_execution_engine::{
         },
         execution,
     },
-    shared::{motes::Motes, wasm::do_nothing_bytes, wasm_prep::PreprocessingError},
+    shared::{wasm::do_nothing_bytes, wasm_prep::PreprocessingError},
 };
 use casper_types::{
     account::AccountHash,
     contracts::DEFAULT_ENTRY_POINT_NAME,
     runtime_args,
     system::auction::{self, DelegationRate},
-    PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ENTRY_POINT_NAME: &str = "create_purse";

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -10,14 +10,13 @@ use casper_engine_test_support::{
     AccountHash, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::engine_state::{genesis::GenesisValidator, GenesisAccount, RewardItem},
-    shared::motes::Motes,
+use casper_execution_engine::core::engine_state::{
+    genesis::GenesisValidator, GenesisAccount, RewardItem,
 };
 use casper_types::{
     runtime_args,
     system::auction::{self, DelegationRate, BLOCK_REWARD, INITIAL_ERA_ID},
-    ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1160.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1160.rs
@@ -7,9 +7,9 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::engine_state::WASMLESS_TRANSFER_FIXED_GAS_PRICE,
-    shared::{gas::Gas, motes::Motes, system_config::DEFAULT_WASMLESS_TRANSFER_COST},
+    shared::system_config::DEFAULT_WASMLESS_TRANSFER_COST,
 };
-use casper_types::{runtime_args, system::mint, RuntimeArgs, U512};
+use casper_types::{runtime_args, system::mint, Gas, Motes, RuntimeArgs, U512};
 
 const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1163.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1163.rs
@@ -10,12 +10,12 @@ use casper_execution_engine::{
         engine_state::{Error, ExecuteRequest, WASMLESS_TRANSFER_FIXED_GAS_PRICE},
         execution,
     },
-    shared::{gas::Gas, motes::Motes, system_config::DEFAULT_WASMLESS_TRANSFER_COST},
+    shared::system_config::DEFAULT_WASMLESS_TRANSFER_COST,
 };
 use casper_types::{
     runtime_args,
     system::{handle_payment, mint},
-    ApiError, RuntimeArgs, U512,
+    ApiError, Gas, Motes, RuntimeArgs, U512,
 };
 
 const PRIORITIZED_GAS_PRICE: u64 = DEFAULT_GAS_PRICE * 7;

--- a/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
@@ -7,15 +7,12 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::{
-        engine_state::{self, genesis::GenesisAccount},
-        execution,
-    },
-    shared::motes::Motes,
+use casper_execution_engine::core::{
+    engine_state::{self, genesis::GenesisAccount},
+    execution,
 };
 use casper_types::{
-    account::AccountHash, runtime_args, system::mint, ApiError, Key, PublicKey, RuntimeArgs,
+    account::AccountHash, runtime_args, system::mint, ApiError, Key, Motes, PublicKey, RuntimeArgs,
     SecretKey, U512,
 };
 

--- a/execution_engine_testing/tests/src/test/regression/ee_597.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_597.rs
@@ -4,9 +4,9 @@ use casper_engine_test_support::{
     internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::core::engine_state::GenesisAccount;
 use casper_types::{
-    account::AccountHash, system::auction, ApiError, PublicKey, RuntimeArgs, SecretKey,
+    account::AccountHash, system::auction, ApiError, Motes, PublicKey, RuntimeArgs, SecretKey,
 };
 
 const CONTRACT_EE_597_REGRESSION: &str = "ee_597_regression.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -7,15 +7,12 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use casper_execution_engine::{
-    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
-    shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::genesis::{GenesisAccount, GenesisValidator};
 use casper_types::{
     account::AccountHash,
     runtime_args,
     system::auction::{self, DelegationRate},
-    ApiError, PublicKey, RuntimeArgs, SecretKey, U512,
+    ApiError, Motes, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_AMOUNT: &str = "amount";

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -11,7 +11,6 @@ use casper_execution_engine::{
         genesis::{GenesisAccount, GenesisValidator},
         RewardItem, SlashItem,
     },
-    shared::motes::Motes,
     storage::global_state::in_memory::InMemoryGlobalState,
 };
 use casper_types::{
@@ -22,7 +21,7 @@ use casper_types::{
         },
         mint::TOTAL_SUPPLY_KEY,
     },
-    CLValue, ContractHash, EraId, Key, ProtocolVersion, PublicKey, SecretKey, U512,
+    CLValue, ContractHash, EraId, Key, Motes, ProtocolVersion, PublicKey, SecretKey, U512,
 };
 
 static ACCOUNT_1_PK: Lazy<PublicKey> = Lazy::new(|| {

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -13,15 +13,12 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::{
-        engine_state::{
-            self,
-            genesis::{GenesisAccount, GenesisValidator},
-        },
-        execution,
+use casper_execution_engine::core::{
+    engine_state::{
+        self,
+        genesis::{GenesisAccount, GenesisValidator},
     },
-    shared::motes::Motes,
+    execution,
 };
 use casper_types::{
     self,
@@ -36,7 +33,7 @@ use casper_types::{
             ERA_ID_KEY, INITIAL_ERA_ID,
         },
     },
-    EraId, PublicKey, RuntimeArgs, SecretKey, U256, U512,
+    EraId, Motes, PublicKey, RuntimeArgs, SecretKey, U256, U512,
 };
 
 const ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -11,15 +11,12 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{
-    core::{
-        engine_state::{
-            genesis::{GenesisAccount, GenesisValidator},
-            Error as EngineError,
-        },
-        execution::Error,
+use casper_execution_engine::core::{
+    engine_state::{
+        genesis::{GenesisAccount, GenesisValidator},
+        Error as EngineError,
     },
-    shared::motes::Motes,
+    execution::Error,
 };
 
 use casper_types::{
@@ -32,7 +29,7 @@ use casper_types::{
         },
         mint,
     },
-    ApiError, EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    ApiError, EraId, Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -9,15 +9,13 @@ use casper_engine_test_support::{
     },
     AccountHash,
 };
-use casper_execution_engine::{
-    core::engine_state::{
-        genesis::{ExecConfig, GenesisAccount, GenesisValidator},
-        run_genesis_request::RunGenesisRequest,
-    },
-    shared::motes::Motes,
+use casper_execution_engine::core::engine_state::{
+    genesis::{ExecConfig, GenesisAccount, GenesisValidator},
+    run_genesis_request::RunGenesisRequest,
 };
 use casper_types::{
-    system::auction::DelegationRate, ProtocolVersion, PublicKey, SecretKey, StoredValue, U512,
+    system::auction::DelegationRate, Motes, ProtocolVersion, PublicKey, SecretKey, StoredValue,
+    U512,
 };
 
 const GENESIS_CONFIG_HASH: [u8; 32] = [127; 32];

--- a/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
@@ -12,9 +12,9 @@ use casper_execution_engine::{
         engine_state::{Error, MAX_PAYMENT},
         execution,
     },
-    shared::{gas::Gas, motes::Motes, transform::Transform},
+    shared::transform::Transform,
 };
-use casper_types::{account::AccountHash, runtime_args, ApiError, RuntimeArgs, U512};
+use casper_types::{account::AccountHash, runtime_args, ApiError, Gas, Motes, RuntimeArgs, U512};
 
 const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 const DO_NOTHING_WASM: &str = "do_nothing.wasm";

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -15,9 +15,7 @@ use casper_execution_engine::{
         genesis::GenesisValidator, EngineConfig, GenesisAccount, DEFAULT_MAX_QUERY_DEPTH,
     },
     shared::{
-        gas::Gas,
         host_function_costs::{Cost, HostFunction, HostFunctionCosts},
-        motes::Motes,
         opcode_costs::OpcodeCosts,
         storage_costs::StorageCosts,
         system_config::{
@@ -46,7 +44,7 @@ use casper_types::{
         auction::{self, DelegationRate},
         handle_payment, mint, AUCTION,
     },
-    EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    EraId, Gas, Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const SYSTEM_CONTRACT_HASHES_NAME: &str = "system_contract_hashes.wasm";

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -15,8 +15,6 @@ use casper_execution_engine::{
         execution::Error as ExecError,
     },
     shared::{
-        gas::Gas,
-        motes::Motes,
         system_config::{
             auction_costs::AuctionCosts, handle_payment_costs::HandlePaymentCosts,
             mint_costs::MintCosts, standard_payment_costs::StandardPaymentCosts, SystemConfig,
@@ -29,7 +27,7 @@ use casper_types::{
     account::AccountHash,
     runtime_args,
     system::{handle_payment, mint},
-    AccessRights, ApiError, EraId, Key, ProtocolVersion, RuntimeArgs, URef, U512,
+    AccessRights, ApiError, EraId, Gas, Key, Motes, ProtocolVersion, RuntimeArgs, URef, U512,
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -5,12 +5,13 @@ use derive_more::From;
 use fmt::Display;
 use serde::{Deserialize, Serialize};
 
+use casper_types::Motes;
+
 use super::BlockHeight;
 use crate::{
     effect::requests::BlockProposerRequest,
     types::{DeployHash, DeployHeader, DeployOrTransferHash, FinalizedBlock},
 };
-use casper_execution_engine::shared::motes::Motes;
 
 /// Information about a deploy.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
-use casper_execution_engine::{
-    core::engine_state::executable_deploy_item::ExecutableDeployItem, shared::gas::Gas,
-};
+use casper_execution_engine::core::engine_state::executable_deploy_item::ExecutableDeployItem;
 use casper_types::{
-    bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, RuntimeArgs, SecretKey,
+    bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, Gas, RuntimeArgs,
+    SecretKey,
 };
 use itertools::Itertools;
 

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use num::Zero;
 use once_cell::sync::Lazy;
 
-use casper_execution_engine::shared::motes::Motes;
-use casper_types::{system::auction::DelegationRate, PublicKey, SecretKey, U512};
+use casper_types::{system::auction::DelegationRate, Motes, PublicKey, SecretKey, U512};
 
 use crate::{
     types::{

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -9,10 +9,10 @@ use rand::Rng;
 use tempfile::TempDir;
 use tokio::time;
 
-use casper_execution_engine::{core::engine_state::query::GetBidsRequest, shared::motes::Motes};
+use casper_execution_engine::core::engine_state::query::GetBidsRequest;
 use casper_types::{
     system::auction::{Bids, DelegationRate},
-    EraId, PublicKey, SecretKey, U512,
+    EraId, Motes, PublicKey, SecretKey, U512,
 };
 
 use crate::{

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -6,8 +6,7 @@ use num_rational::Ratio;
 use rand::Rng;
 use tempfile::TempDir;
 
-use casper_execution_engine::shared::motes::Motes;
-use casper_types::{system::auction::DelegationRate, EraId, PublicKey, SecretKey, U512};
+use casper_types::{system::auction::DelegationRate, EraId, Motes, PublicKey, SecretKey, U512};
 
 use crate::{
     components::{gossiper, small_network, storage, storage::Storage},

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
-use casper_execution_engine::shared::gas::Gas;
-use casper_types::PublicKey;
+use casper_types::{Gas, PublicKey};
 use datasize::DataSize;
 use num_traits::Zero;
 use thiserror::Error;

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -210,12 +210,11 @@ mod tests {
 
     use casper_execution_engine::shared::{
         host_function_costs::{HostFunction, HostFunctionCosts},
-        motes::Motes,
         opcode_costs::OpcodeCosts,
         storage_costs::StorageCosts,
         wasm_config::WasmConfig,
     };
-    use casper_types::{EraId, ProtocolVersion, StoredValue, U512};
+    use casper_types::{EraId, Motes, ProtocolVersion, StoredValue, U512};
 
     use super::*;
     use crate::{

--- a/node/src/types/chainspec/accounts_config/account_config.rs
+++ b/node/src/types/chainspec/accounts_config/account_config.rs
@@ -4,10 +4,10 @@ use num::Zero;
 use rand::{distributions::Standard, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::core::engine_state::GenesisAccount;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey,
+    Motes, PublicKey,
 };
 #[cfg(test)]
 use casper_types::{SecretKey, U512};

--- a/node/src/types/chainspec/accounts_config/delegator_config.rs
+++ b/node/src/types/chainspec/accounts_config/delegator_config.rs
@@ -3,10 +3,10 @@ use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::core::engine_state::GenesisAccount;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey,
+    Motes, PublicKey,
 };
 #[cfg(test)]
 use casper_types::{SecretKey, U512};

--- a/node/src/types/chainspec/accounts_config/validator_config.rs
+++ b/node/src/types/chainspec/accounts_config/validator_config.rs
@@ -4,14 +4,13 @@ use num::Zero;
 use rand::{distributions::Standard, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use casper_execution_engine::{
-    core::engine_state::genesis::GenesisValidator, shared::motes::Motes,
-};
+use casper_execution_engine::core::engine_state::genesis::GenesisValidator;
 #[cfg(test)]
 use casper_types::U512;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     system::auction::DelegationRate,
+    Motes,
 };
 
 #[cfg(test)]

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -10,10 +10,9 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 use casper_execution_engine::core::engine_state::MAX_PAYMENT_AMOUNT;
-use casper_execution_engine::shared::motes::Motes;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    U512,
+    Motes, U512,
 };
 
 #[cfg(test)]

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -21,15 +21,14 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{info, warn};
 
-use casper_execution_engine::{
-    core::engine_state::{executable_deploy_item::ExecutableDeployItem, DeployItem},
-    shared::motes::Motes,
+use casper_execution_engine::core::engine_state::{
+    executable_deploy_item::ExecutableDeployItem, DeployItem,
 };
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     runtime_args,
     system::standard_payment::ARG_AMOUNT,
-    AsymmetricType, ExecutionResult, PublicKey, RuntimeArgs, SecretKey, Signature, U512,
+    AsymmetricType, ExecutionResult, Motes, PublicKey, RuntimeArgs, SecretKey, Signature, U512,
 };
 
 use super::{BlockHash, Item, Tag, TimeDiff, Timestamp};

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,10 +17,17 @@ bitflags = "1"
 blake2 = { version = "0.9.0", default-features = false }
 datasize = { version = "0.2.4", default-features = false }
 displaydoc = { version = "0.1", default-features = false, optional = true }
-ed25519-dalek = { version = "1.0.0", default-features = false, features = ["rand", "u64_backend"] }
+ed25519-dalek = { version = "1.0.0", default-features = false, features = [
+    "rand",
+    "u64_backend",
+] }
 hex = { version = "0.4.2", default-features = false }
 hex_fmt = "0.3.0"
-k256 = { version = "0.7.2", default-features = false, features = ["ecdsa", "zeroize"] }
+k256 = { version = "0.7.2", default-features = false, features = [
+    "ecdsa",
+    "zeroize",
+] }
+num = { version = "0.4.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-integer = { version = "0.1.42", default-features = false }
 num-rational = { version = "0.4.0", default-features = false }
@@ -59,9 +66,18 @@ std = [
     "serde_json/std",
     "serde_bytes/std",
     "schemars",
-    "thiserror"
+    "thiserror",
+    "num/std",
 ]
-no-std = ["base16/alloc", "hex/alloc", "serde/alloc", "serde_json/alloc", "serde_bytes/alloc", "displaydoc"]
+no-std = [
+    "base16/alloc",
+    "hex/alloc",
+    "serde/alloc",
+    "serde_json/alloc",
+    "serde_bytes/alloc",
+    "displaydoc",
+    "num/alloc",
+]
 gens = ["std", "proptest/std"]
 
 [[bench]]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -63,15 +63,7 @@ std = [
     "thiserror",
     "num/std",
 ]
-no-std = [
-    "base16/alloc",
-    "hex/alloc",
-    "serde/alloc",
-    "serde_json/alloc",
-    "serde_bytes/alloc",
-    "displaydoc",
-    "num/alloc",
-]
+no-std = ["base16/alloc", "hex/alloc", "serde/alloc", "serde_json/alloc", "serde_bytes/alloc", "displaydoc", "num/alloc"]
 gens = ["std", "proptest/std"]
 
 [[bench]]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,10 +17,7 @@ bitflags = "1"
 blake2 = { version = "0.9.0", default-features = false }
 datasize = { version = "0.2.4", default-features = false }
 displaydoc = { version = "0.1", default-features = false, optional = true }
-ed25519-dalek = { version = "1.0.0", default-features = false, features = [
-    "rand",
-    "u64_backend",
-] }
+ed25519-dalek = { version = "1.0.0", default-features = false, features = ["rand", "u64_backend"] }
 hex = { version = "0.4.2", default-features = false }
 hex_fmt = "0.3.0"
 k256 = { version = "0.7.2", default-features = false, features = [

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -20,10 +20,7 @@ displaydoc = { version = "0.1", default-features = false, optional = true }
 ed25519-dalek = { version = "1.0.0", default-features = false, features = ["rand", "u64_backend"] }
 hex = { version = "0.4.2", default-features = false }
 hex_fmt = "0.3.0"
-k256 = { version = "0.7.2", default-features = false, features = [
-    "ecdsa",
-    "zeroize",
-] }
+k256 = { version = "0.7.2", default-features = false, features = ["ecdsa", "zeroize"] }
 num = { version = "0.4.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-integer = { version = "0.1.42", default-features = false }

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -1,21 +1,27 @@
-use std::{fmt, iter::Sum};
+//! TODO: module doc comment.
+
+use core::{fmt, iter::Sum};
 
 use num::Zero;
 
 use crate::{Motes, U512};
 
+/// TODO: doc comment.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Gas(U512);
 
 impl Gas {
+    /// TODO: doc comment.
     pub fn new(value: U512) -> Self {
         Gas(value)
     }
 
+    /// TODO: doc comment.
     pub fn value(&self) -> U512 {
         self.0
     }
 
+    /// TODO: doc comment.
     pub fn from_motes(motes: Motes, conv_rate: u64) -> Option<Self> {
         motes
             .value()
@@ -23,10 +29,12 @@ impl Gas {
             .map(Self::new)
     }
 
+    /// TODO: doc comment.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
+    /// TODO: doc comment.
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.value()).map(Self::new)
     }
@@ -38,7 +46,7 @@ impl fmt::Display for Gas {
     }
 }
 
-impl std::ops::Add for Gas {
+impl core::ops::Add for Gas {
     type Output = Gas;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -47,7 +55,7 @@ impl std::ops::Add for Gas {
     }
 }
 
-impl std::ops::Sub for Gas {
+impl core::ops::Sub for Gas {
     type Output = Gas;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -56,7 +64,7 @@ impl std::ops::Sub for Gas {
     }
 }
 
-impl std::ops::Div for Gas {
+impl core::ops::Div for Gas {
     type Output = Gas;
 
     fn div(self, rhs: Self) -> Self::Output {
@@ -65,7 +73,7 @@ impl std::ops::Div for Gas {
     }
 }
 
-impl std::ops::Mul for Gas {
+impl core::ops::Mul for Gas {
     type Output = Gas;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -74,7 +82,7 @@ impl std::ops::Mul for Gas {
     }
 }
 
-impl std::ops::AddAssign for Gas {
+impl core::ops::AddAssign for Gas {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0
     }
@@ -92,7 +100,7 @@ impl Zero for Gas {
 
 impl Sum for Gas {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Gas::zero(), std::ops::Add::add)
+        iter.fold(Gas::zero(), core::ops::Add::add)
     }
 }
 

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -2,9 +2,7 @@ use std::{fmt, iter::Sum};
 
 use num::Zero;
 
-use casper_types::U512;
-
-use crate::shared::motes::Motes;
+use crate::{Motes, U512};
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Gas(U512);
@@ -114,9 +112,9 @@ impl From<u64> for Gas {
 
 #[cfg(test)]
 mod tests {
-    use casper_types::U512;
+    use crate::U512;
 
-    use crate::shared::{gas::Gas, motes::Motes};
+    use crate::{Gas, Motes};
 
     #[test]
     fn should_be_able_to_get_instance_of_gas() {

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -41,8 +41,7 @@ impl Gas {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
-    /// Safe subtraction method that returns an `Option<Gas>`. Returns `None` if an overflow has
-    /// occurred.
+    /// Checked integer subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.value()).map(Self::new)
     }

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -35,8 +35,7 @@ impl Gas {
             .map(Self::new)
     }
 
-    /// Safe addition method that returns an `Option<Gas>`. Returns `None` if an overflow has
-    /// occurred.
+    /// Checked integer addition. Computes `self + rhs`, returning `None` if overflow occurred.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -25,7 +25,9 @@ impl Gas {
         self.0
     }
 
-    /// Returns an `Option<Gas>`. Returns `None` if the conversion cannot be performed.
+    /// Converts the given `motes` to `Gas` by dividing them by `conv_rate`.
+    ///
+    /// Returns `None` if `conv_rate == 0`.
     pub fn from_motes(motes: Motes, conv_rate: u64) -> Option<Self> {
         motes
             .value()

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -1,4 +1,4 @@
-//! TODO: module doc comment.
+//! The `gas` module is used for working with Gas including converting to and from Motes.
 
 use core::{fmt, iter::Sum};
 
@@ -6,22 +6,22 @@ use num::Zero;
 
 use crate::{Motes, U512};
 
-/// TODO: doc comment.
+/// The `Gas` struct represents a `U512` amount of gas.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Gas(U512);
 
 impl Gas {
-    /// TODO: doc comment.
+    /// Constructs a new `Gas`.
     pub fn new(value: U512) -> Self {
         Gas(value)
     }
 
-    /// TODO: doc comment.
+    /// Returns the inner `U512` value.
     pub fn value(&self) -> U512 {
         self.0
     }
 
-    /// TODO: doc comment.
+    /// Returns an `Option<Gas>`. Returns `None` if the conversion cannot be performed.
     pub fn from_motes(motes: Motes, conv_rate: u64) -> Option<Self> {
         motes
             .value()
@@ -29,12 +29,12 @@ impl Gas {
             .map(Self::new)
     }
 
-    /// TODO: doc comment.
+    /// Safe addition method that returns an `Option<Gas>`. Returns `None` if an overflow has occurred.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
-    /// TODO: doc comment.
+    /// Safe subtraction method that returns an `Option<Gas>`. Returns `None` if an overflowhas occurred.
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.value()).map(Self::new)
     }

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -1,6 +1,10 @@
 //! The `gas` module is used for working with Gas including converting to and from Motes.
 
-use core::{fmt, iter::Sum};
+use core::{
+    fmt,
+    iter::Sum,
+    ops::{Add, AddAssign, Div, Mul, Sub},
+};
 
 use num::Zero;
 
@@ -48,7 +52,7 @@ impl fmt::Display for Gas {
     }
 }
 
-impl core::ops::Add for Gas {
+impl Add for Gas {
     type Output = Gas;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -57,7 +61,7 @@ impl core::ops::Add for Gas {
     }
 }
 
-impl core::ops::Sub for Gas {
+impl Sub for Gas {
     type Output = Gas;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -66,7 +70,7 @@ impl core::ops::Sub for Gas {
     }
 }
 
-impl core::ops::Div for Gas {
+impl Div for Gas {
     type Output = Gas;
 
     fn div(self, rhs: Self) -> Self::Output {
@@ -75,7 +79,7 @@ impl core::ops::Div for Gas {
     }
 }
 
-impl core::ops::Mul for Gas {
+impl Mul for Gas {
     type Output = Gas;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -84,7 +88,7 @@ impl core::ops::Mul for Gas {
     }
 }
 
-impl core::ops::AddAssign for Gas {
+impl AddAssign for Gas {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0
     }
@@ -102,7 +106,7 @@ impl Zero for Gas {
 
 impl Sum for Gas {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Gas::zero(), core::ops::Add::add)
+        iter.fold(Gas::zero(), Add::add)
     }
 }
 

--- a/types/src/gas.rs
+++ b/types/src/gas.rs
@@ -29,12 +29,14 @@ impl Gas {
             .map(Self::new)
     }
 
-    /// Safe addition method that returns an `Option<Gas>`. Returns `None` if an overflow has occurred.
+    /// Safe addition method that returns an `Option<Gas>`. Returns `None` if an overflow has
+    /// occurred.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
-    /// Safe subtraction method that returns an `Option<Gas>`. Returns `None` if an overflowhas occurred.
+    /// Safe subtraction method that returns an `Option<Gas>`. Returns `None` if an overflow has
+    /// occurred.
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.value()).map(Self::new)
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -34,10 +34,12 @@ pub mod crypto;
 mod deploy_info;
 mod era_id;
 mod execution_result;
+mod gas;
 #[cfg(any(feature = "gens", test))]
 pub mod gens;
 mod json_pretty_printer;
 mod key;
+mod motes;
 mod named_key;
 mod phase;
 mod protocol_version;
@@ -69,12 +71,14 @@ pub use deploy_info::DeployInfo;
 pub use execution_result::{
     ExecutionEffect, ExecutionResult, OpKind, Operation, Transform, TransformEntry,
 };
+pub use gas::Gas;
 pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
 pub use key::{
     DictionaryAddr, HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH, DICTIONARY_ITEM_KEY_MAX_LENGTH,
     KEY_DICTIONARY_LENGTH, KEY_HASH_LENGTH,
 };
+pub use motes::Motes;
 pub use named_key::NamedKey;
 pub use phase::{Phase, PHASE_SERIALIZED_LENGTH};
 pub use protocol_version::{ProtocolVersion, VersionCheckResult};

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -28,7 +28,7 @@ impl Motes {
         Motes(value)
     }
 
-    /// Safe addition method. Returns an `Option<Motes>`. Returns `None` if an overflow occurred.
+    /// Checked integer addition. Computes `self + rhs`, returning `None` if overflow occurred.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -16,7 +16,7 @@ use crate::{
     Gas, U512,
 };
 
-/// `Motes` are small amounts of cspr, expressed as `U512`.
+/// A struct representing a number of `Motes`.
 #[derive(
     DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
 )]

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -1,4 +1,4 @@
-//! TODO: module doc comment.
+//! The `motes` module is used for working with Motes.
 
 use alloc::vec::Vec;
 use core::{fmt, iter::Sum};
@@ -12,29 +12,29 @@ use crate::{
     Gas, U512,
 };
 
-/// TODO: doc comment.
+/// `Motes` are small amounts of cspr, expressed as `U512`.
 #[derive(
     DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
 )]
 pub struct Motes(U512);
 
 impl Motes {
-    /// TODO: doc comment.
+    /// Constructs a new `Motes`.
     pub fn new(value: U512) -> Motes {
         Motes(value)
     }
 
-    /// TODO: doc comment.
+    /// Safe addition method. Returns an `Option<Motes>`. Returns `None` if an overflow occurred.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
-    /// TODO: doc comment.
+    /// Returns the `U512` value.
     pub fn value(&self) -> U512 {
         self.0
     }
 
-    /// TODO: doc comment.
+    /// Returns a `Option<Motes>`. Returns `None` if the conversion cannot be performed.
     pub fn from_gas(gas: Gas, conv_rate: u64) -> Option<Self> {
         gas.value()
             .checked_mul(U512::from(conv_rate))

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -1,4 +1,7 @@
-use std::{fmt, iter::Sum};
+//! TODO: module doc comment.
+
+use alloc::vec::Vec;
+use core::{fmt, iter::Sum};
 
 use datasize::DataSize;
 use num::Zero;
@@ -9,24 +12,29 @@ use crate::{
     Gas, U512,
 };
 
+/// TODO: doc comment.
 #[derive(
     DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
 )]
 pub struct Motes(U512);
 
 impl Motes {
+    /// TODO: doc comment.
     pub fn new(value: U512) -> Motes {
         Motes(value)
     }
 
+    /// TODO: doc comment.
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
+    /// TODO: doc comment.
     pub fn value(&self) -> U512 {
         self.0
     }
 
+    /// TODO: doc comment.
     pub fn from_gas(gas: Gas, conv_rate: u64) -> Option<Self> {
         gas.value()
             .checked_mul(U512::from(conv_rate))
@@ -40,7 +48,7 @@ impl fmt::Display for Motes {
     }
 }
 
-impl std::ops::Add for Motes {
+impl core::ops::Add for Motes {
     type Output = Motes;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -49,7 +57,7 @@ impl std::ops::Add for Motes {
     }
 }
 
-impl std::ops::Sub for Motes {
+impl core::ops::Sub for Motes {
     type Output = Motes;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -58,7 +66,7 @@ impl std::ops::Sub for Motes {
     }
 }
 
-impl std::ops::Div for Motes {
+impl core::ops::Div for Motes {
     type Output = Motes;
 
     fn div(self, rhs: Self) -> Self::Output {
@@ -67,7 +75,7 @@ impl std::ops::Div for Motes {
     }
 }
 
-impl std::ops::Mul for Motes {
+impl core::ops::Mul for Motes {
     type Output = Motes;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -88,7 +96,7 @@ impl Zero for Motes {
 
 impl Sum for Motes {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Motes::zero(), std::ops::Add::add)
+        iter.fold(Motes::zero(), core::ops::Add::add)
     }
 }
 

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -33,7 +33,7 @@ impl Motes {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
 
-    /// Returns the `U512` value.
+    /// Returns the inner `U512` value.
     pub fn value(&self) -> U512 {
         self.0
     }

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -1,7 +1,11 @@
 //! The `motes` module is used for working with Motes.
 
 use alloc::vec::Vec;
-use core::{fmt, iter::Sum};
+use core::{
+    fmt,
+    iter::Sum,
+    ops::{Add, Div, Mul, Sub},
+};
 
 use datasize::DataSize;
 use num::Zero;
@@ -48,7 +52,7 @@ impl fmt::Display for Motes {
     }
 }
 
-impl core::ops::Add for Motes {
+impl Add for Motes {
     type Output = Motes;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -57,7 +61,7 @@ impl core::ops::Add for Motes {
     }
 }
 
-impl core::ops::Sub for Motes {
+impl Sub for Motes {
     type Output = Motes;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -66,7 +70,7 @@ impl core::ops::Sub for Motes {
     }
 }
 
-impl core::ops::Div for Motes {
+impl Div for Motes {
     type Output = Motes;
 
     fn div(self, rhs: Self) -> Self::Output {
@@ -75,7 +79,7 @@ impl core::ops::Div for Motes {
     }
 }
 
-impl core::ops::Mul for Motes {
+impl Mul for Motes {
     type Output = Motes;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -96,7 +100,7 @@ impl Zero for Motes {
 
 impl Sum for Motes {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Motes::zero(), core::ops::Add::add)
+        iter.fold(Motes::zero(), Add::add)
     }
 }
 

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -38,7 +38,9 @@ impl Motes {
         self.0
     }
 
-    /// Returns a `Option<Motes>`. Returns `None` if the conversion cannot be performed.
+    /// Converts the given `gas` to `Motes` by multiplying them by `conv_rate`.
+    ///
+    /// Returns `None` if an arithmetic overflow occurred.
     pub fn from_gas(gas: Gas, conv_rate: u64) -> Option<Self> {
         gas.value()
             .checked_mul(U512::from(conv_rate))

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -4,12 +4,10 @@ use datasize::DataSize;
 use num::Zero;
 use serde::{Deserialize, Serialize};
 
-use casper_types::{
+use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
-    U512,
+    Gas, U512,
 };
-
-use crate::shared::gas::Gas;
 
 #[derive(
     DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
@@ -113,9 +111,9 @@ impl FromBytes for Motes {
 
 #[cfg(test)]
 mod tests {
-    use casper_types::U512;
+    use crate::U512;
 
-    use crate::shared::{gas::Gas, motes::Motes};
+    use crate::{Gas, Motes};
 
     #[test]
     fn should_be_able_to_get_instance_of_motes() {


### PR DESCRIPTION
# About These Changes
* Moves `Gas` from EE Shared to casper-types.
* Moves `Motes` from EE Shared to casper-types.
* closes #1841 
