### PR TITLE
Make run_equivocator_network test more reliable.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -49,8 +49,6 @@ use crate::{
 
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::Config;
-#[cfg(test)]
-pub(crate) use config::ProtocolConfig;
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;


### PR DESCRIPTION
This is still flaky, possibly because sometimes the nodes only start a bit after the genesis timestamp. With this change, we delay messages for three rounds after the first message has been sent instead.

Locally, I cannot reproduce the failure at all.

Closes #1859 