### PR TITLE
Make Highway timers configurable; request state periodically from a random peer.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.  The format
 * Added `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
 
 ### Changed
+* The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):
+  * `standstill_timeout` causes the node to restart if no progress is made.
+  * `request_state_interval` makes the node periodically request the latest state from a peer.
+  * `log_synchronizer_interval` periodically logs the number of entries in the synchronizer queues.
 * Add support for providing node uptime via the addition of an `uptime` parameter in the response to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Support building and testing using stable Rust.
 * Log chattiness in `debug` or lower levels has been reduced and performance at `info` or higher slightly improved.

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -36,7 +36,8 @@ use crate::{
         announcements::{BlocklistAnnouncement, ConsensusAnnouncement},
         requests::{
             BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest, ConsensusRequest,
-            ContractRuntimeRequest, LinearChainRequest, NetworkRequest, StorageRequest,
+            ContractRuntimeRequest, LinearChainRequest, NetworkInfoRequest, NetworkRequest,
+            StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -245,6 +246,7 @@ pub(crate) trait ReactorEventT<I>:
     + From<Event<I>>
     + Send
     + From<NetworkRequest<I, Message>>
+    + From<NetworkInfoRequest<I>>
     + From<BlockProposerRequest>
     + From<ConsensusAnnouncement>
     + From<BlockValidationRequest<I>>
@@ -261,6 +263,7 @@ impl<REv, I> ReactorEventT<I> for REv where
         + From<Event<I>>
         + Send
         + From<NetworkRequest<I, Message>>
+        + From<NetworkInfoRequest<I>>
         + From<BlockProposerRequest>
         + From<ConsensusAnnouncement>
         + From<BlockValidationRequest<I>>

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -48,7 +48,7 @@ impl Config {
 /// Consensus protocol configuration.
 #[derive(DataSize, Debug)]
 pub(crate) struct ProtocolConfig {
-    pub(crate) highway_config: HighwayProtocolConfig,
+    pub(crate) highway: HighwayProtocolConfig,
     pub(crate) era_duration: TimeDiff,
     pub(crate) minimum_era_height: u64,
     /// Number of eras before an auction actually defines the set of validators.
@@ -72,7 +72,7 @@ pub(crate) struct ProtocolConfig {
 impl From<&Chainspec> for ProtocolConfig {
     fn from(chainspec: &Chainspec) -> Self {
         ProtocolConfig {
-            highway_config: chainspec.highway_config,
+            highway: chainspec.highway_config,
             era_duration: chainspec.core_config.era_duration,
             minimum_era_height: chainspec.core_config.minimum_era_height,
             auction_delay: chainspec.core_config.auction_delay,

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -144,6 +144,7 @@ pub(crate) type ProtocolOutcomes<I, C> = Vec<ProtocolOutcome<I, C>>;
 pub(crate) enum ProtocolOutcome<I, C: Context> {
     CreatedGossipMessage(Vec<u8>),
     CreatedTargetedMessage(Vec<u8>, I),
+    CreatedMessageToRandomPeer(Vec<u8>),
     InvalidIncomingMessage(Vec<u8>, I, Error),
     ScheduleTimer(Timestamp, TimerId),
     QueueAction(ActionId),

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1030,6 +1030,17 @@ where
                     .send_message(to, message.into())
                     .ignore()
             }
+            ProtocolOutcome::CreatedMessageToRandomPeer(payload) => {
+                let message = ConsensusMessage::Protocol { era_id, payload };
+                let effect_builder = self.effect_builder;
+                async move {
+                    let peers = effect_builder.get_peers_in_random_order().await;
+                    if let Some(to) = peers.into_iter().next() {
+                        effect_builder.send_message(to, message.into()).await;
+                    }
+                }
+                .ignore()
+            }
             ProtocolOutcome::ScheduleTimer(timestamp, timer_id) => {
                 let timediff = timestamp.saturating_diff(Timestamp::now());
                 self.effect_builder

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -108,6 +108,7 @@ fn purge_vertices() {
     // * b0: in the main queue
     // * c2: waiting for dependency c1 to be added
     let purge_vertex_timeout = 0x20;
+    #[allow(clippy::integer_arithmetic)]
     sync.purge_vertices((0x41 - purge_vertex_timeout).into());
 
     // The main queue should now contain only c1. If we remove it, the synchronizer is empty.

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -44,7 +44,6 @@ use crate::{
     types::{TimeDiff, Timestamp},
 };
 
-pub use self::config::Config as HighwayConfig;
 use self::round_success_meter::RoundSuccessMeter;
 
 /// Never allow more than this many units in a piece of evidence for conflicting endorsements,
@@ -63,8 +62,8 @@ const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
 const TIMER_ID_STANDSTILL_ALERT: TimerId = TimerId(4);
 /// The timer for logging synchronizer queue size.
 const TIMER_ID_SYNCHRONIZER_LOG: TimerId = TimerId(5);
-/// The timer to check for initial progress.
-const TIMER_ID_PROGRESS_ALERT: TimerId = TimerId(6);
+/// The timer to request the latest state from a random peer.
+const TIMER_ID_REQUEST_STATE: TimerId = TimerId(6);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 pub(crate) const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -87,16 +86,7 @@ where
     /// The panorama snapshot. This is updated periodically, and if it does not change for too
     /// long, an alert is raised.
     last_panorama: Panorama<C>,
-    /// If the current era's protocol state has not progressed for this long, request the latest
-    /// state from peers.
-    standstill_timeout: TimeDiff,
-    /// If after another `standstill_timeout` there is no progress, raise
-    /// `ProtocolOutcome::StandstillAlert` and shut down.
-    shutdown_on_standstill: bool,
-    /// Log inactive or faulty validators periodically, with this interval.
-    log_participation_interval: TimeDiff,
-    /// Whether to log the size of every incoming and outgoing serialized unit.
-    log_unit_sizes: bool,
+    config: config::Config,
 }
 
 impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
@@ -141,10 +131,8 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             "cannot start era with total weight 0"
         );
 
-        let highway_config = &protocol_config.highway_config;
-
         let total_weight = u128::from(validators.total_weight());
-        let ftt_fraction = highway_config.finality_threshold_fraction;
+        let ftt_fraction = protocol_config.highway.finality_threshold_fraction;
         assert!(
             ftt_fraction < 1.into(),
             "finality threshold must be less than 100%"
@@ -158,9 +146,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             .map(|highway_proto| highway_proto.next_era_round_succ_meter(era_start_time.max(now)))
             .unwrap_or_else(|| {
                 RoundSuccessMeter::new(
-                    highway_config.minimum_round_exponent,
-                    highway_config.minimum_round_exponent,
-                    highway_config.maximum_round_exponent,
+                    protocol_config.highway.minimum_round_exponent,
+                    protocol_config.highway.minimum_round_exponent,
+                    protocol_config.highway.maximum_round_exponent,
                     era_start_time.max(now),
                     config.into(),
                 )
@@ -177,7 +165,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         // Allow about as many units as part of evidence for conflicting endorsements as we expect
         // a validator to create during an era. After that, they can endorse two conflicting forks
         // without getting faulty.
-        let min_round_len = state::round_len(highway_config.minimum_round_exponent);
+        let min_round_len = state::round_len(protocol_config.highway.minimum_round_exponent);
         let min_rounds_per_era = protocol_config
             .minimum_era_height
             .max((TimeDiff::from(1) + protocol_config.era_duration) / min_round_len);
@@ -188,9 +176,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         let params = Params::new(
             seed,
             BLOCK_REWARD,
-            (highway_config.reduced_reward_multiplier * BLOCK_REWARD).to_integer(),
-            highway_config.minimum_round_exponent,
-            highway_config.maximum_round_exponent,
+            (protocol_config.highway.reduced_reward_multiplier * BLOCK_REWARD).to_integer(),
+            protocol_config.highway.minimum_round_exponent,
+            protocol_config.highway.maximum_round_exponent,
             init_round_exp,
             protocol_config.minimum_era_height,
             era_start_time,
@@ -207,14 +195,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway,
             round_success_meter,
-            synchronizer: Synchronizer::new(config.highway.clone(), validators_count, instance_id),
+            synchronizer: Synchronizer::new(validators_count, instance_id),
             pvv_cache: Default::default(),
             evidence_only: false,
             last_panorama,
-            standstill_timeout: config.highway.standstill_timeout,
-            shutdown_on_standstill: config.highway.shutdown_on_standstill,
-            log_participation_interval: config.highway.log_participation_interval,
-            log_unit_sizes: config.highway.log_unit_sizes,
+            config: config.highway.clone(),
         });
 
         (hw_proto, outcomes)
@@ -223,23 +208,37 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     fn initialize_timers(
         now: Timestamp,
         era_start_time: Timestamp,
-        highway_config: &HighwayConfig,
+        config: &config::Config,
     ) -> ProtocolOutcomes<I, C> {
-        vec![
-            ProtocolOutcome::ScheduleTimer(
-                now + highway_config.pending_vertex_timeout,
-                TIMER_ID_PURGE_VERTICES,
-            ),
-            ProtocolOutcome::ScheduleTimer(
-                now.max(era_start_time) + highway_config.log_participation_interval,
+        let mut outcomes = vec![ProtocolOutcome::ScheduleTimer(
+            now + config.pending_vertex_timeout,
+            TIMER_ID_PURGE_VERTICES,
+        )];
+        if let Some(interval) = config.log_participation_interval {
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now.max(era_start_time) + interval,
                 TIMER_ID_LOG_PARTICIPATION,
-            ),
-            ProtocolOutcome::ScheduleTimer(
-                now.max(era_start_time) + highway_config.standstill_timeout,
-                TIMER_ID_PROGRESS_ALERT,
-            ),
-            ProtocolOutcome::ScheduleTimer(now + TimeDiff::from(5_000), TIMER_ID_SYNCHRONIZER_LOG),
-        ]
+            ));
+        }
+        if let Some(interval) = config.log_synchronizer_interval {
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now + interval,
+                TIMER_ID_SYNCHRONIZER_LOG,
+            ));
+        }
+        if let Some(interval) = config.request_state_interval {
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now + interval,
+                TIMER_ID_REQUEST_STATE,
+            ));
+        }
+        if let Some(timeout) = config.standstill_timeout {
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now.max(era_start_time) + timeout,
+                TIMER_ID_STANDSTILL_ALERT,
+            ));
+        }
+        outcomes
     }
 
     fn process_av_effects<E>(&mut self, av_effects: E, now: Timestamp) -> ProtocolOutcomes<I, C>
@@ -310,9 +309,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     /// dependencies or validation. Recursively schedules events to add everything that is
     /// unblocked now.
     fn add_vertex(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
-        let (maybe_pending_vertex, mut outcomes) = self
-            .synchronizer
-            .pop_vertex_to_add(&self.highway, &self.pending_values);
+        let (maybe_pending_vertex, mut outcomes) = self.synchronizer.pop_vertex_to_add(
+            &self.highway,
+            &self.pending_values,
+            self.config.max_requests_for_vertex,
+        );
         let pending_vertex = match maybe_pending_vertex {
             None => return outcomes,
             Some(pending_vertex) => pending_vertex,
@@ -453,9 +454,9 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         info!(?participation, %instance_id, "validator participation");
     }
 
-    /// If the `log_unit_sizes` flag is set and the vertex is a unit, logs its serialized size.
+    /// Logs the vertex' serialized size.
     fn log_unit_size(&self, vertex: &Vertex<C>, log_msg: &str) {
-        if self.log_unit_sizes {
+        if self.config.log_unit_sizes {
             if let Some(hash) = vertex.unit_hash() {
                 let size = HighwayMessage::NewVertex(vertex.clone()).serialize().len();
                 info!(size, %hash, "{}", log_msg);
@@ -471,76 +472,56 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             .map_or(false, is_switch)
     }
 
-    // Check if we've made any progress since joining.
-    // If we haven't, we might have been left alone in the era and we should request the state from
-    // peers.
-    fn handle_progress_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    /// Request the latest state from a random peer.
+    fn handle_request_state_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
         if self.evidence_only || self.finalized_switch_block() {
             return vec![]; // Era has ended. No further progress is expected.
         }
-        if self.last_panorama == *self.highway.state().panorama() {
-            info!(
-                instance_id = ?self.highway.instance_id(),
-                "no progress in the last {}, creating latest state request",
-                self.standstill_timeout,
-            );
-            // We haven't made any progress. Request latest panorama from peers and schedule
-            // standstill alert. If we still won't progress by the time
-            // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
-            let mut outcomes = self.latest_state_request();
-            if self.shutdown_on_standstill {
-                outcomes.push(ProtocolOutcome::ScheduleTimer(
-                    now + self.standstill_timeout,
-                    TIMER_ID_STANDSTILL_ALERT,
-                ));
-            }
-            return outcomes;
-        }
-
-        if !self.shutdown_on_standstill {
-            debug!(
-                instance_id = ?self.highway.instance_id(),
-                "progress detected; not requesting latest state",
-            );
-            return vec![];
-        }
         debug!(
             instance_id = ?self.highway.instance_id(),
-            "progress detected; scheduling next standstill check in {}",
-            self.standstill_timeout,
+            "requesting latest state from random peer",
         );
-        // Record the current panorama and schedule the next standstill check.
-        self.last_panorama = self.highway.state().panorama().clone();
-        vec![ProtocolOutcome::ScheduleTimer(
-            now + self.standstill_timeout,
-            TIMER_ID_STANDSTILL_ALERT,
-        )]
+        // We haven't made any progress. Request latest panorama from peers and schedule
+        // standstill alert. If we still won't progress by the time
+        // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
+        let mut outcomes = self.latest_state_request();
+        if let Some(interval) = self.config.request_state_interval {
+            outcomes.push(ProtocolOutcome::ScheduleTimer(
+                now + interval,
+                TIMER_ID_REQUEST_STATE,
+            ));
+        }
+        outcomes
     }
 
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
     fn handle_standstill_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
-        if self.evidence_only || self.finalized_switch_block() || !self.shutdown_on_standstill {
+        if self.evidence_only || self.finalized_switch_block() {
             // Era has ended and no further progress is expected, or shutdown on standstill is
             // turned off.
             return vec![];
         }
+        let timeout = match self.config.standstill_timeout {
+            None => return vec![],
+            Some(timeout) => timeout,
+        };
         if self.last_panorama == *self.highway.state().panorama() {
             info!(
                 instance_id = ?self.highway.instance_id(),
                 "no progress in the last {}, raising standstill alert",
-                self.standstill_timeout,
+                timeout,
             );
             return vec![ProtocolOutcome::StandstillAlert]; // No progress within the timeout.
         }
         debug!(
             instance_id = ?self.highway.instance_id(),
             "progress detected; scheduling next standstill check in {}",
-            self.standstill_timeout,
+            timeout,
         );
         // Record the current panorama and schedule the next standstill check.
         self.last_panorama = self.highway.state().panorama().clone();
         vec![ProtocolOutcome::ScheduleTimer(
-            now + self.standstill_timeout,
+            now + timeout,
             TIMER_ID_STANDSTILL_ALERT,
         )]
     }
@@ -669,9 +650,7 @@ where
                 }
 
                 match pvv.timestamp() {
-                    Some(timestamp)
-                        if timestamp > now + self.synchronizer.pending_vertex_timeout() =>
-                    {
+                    Some(timestamp) if timestamp > now + self.config.pending_vertex_timeout => {
                         trace!("received a vertex with a timestamp far in the future; dropping");
                         vec![]
                     }
@@ -780,29 +759,30 @@ where
                 self.synchronizer.add_past_due_stored_vertices(now)
             }
             TIMER_ID_PURGE_VERTICES => {
-                self.synchronizer.purge_vertices(now);
+                let oldest = now.saturating_sub(self.config.pending_vertex_timeout);
+                self.synchronizer.purge_vertices(oldest);
                 self.pvv_cache.clear();
-                let next_time = now + self.synchronizer.pending_vertex_timeout();
+                let next_time = now + self.config.pending_vertex_timeout;
                 vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
             }
             TIMER_ID_LOG_PARTICIPATION => {
                 self.log_participation();
-                if !self.evidence_only && !self.finalized_switch_block() {
-                    let next_time = now + self.log_participation_interval;
-                    vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
-                } else {
-                    vec![]
+                match self.config.log_participation_interval {
+                    Some(interval) if !self.evidence_only && !self.finalized_switch_block() => {
+                        vec![ProtocolOutcome::ScheduleTimer(now + interval, timer_id)]
+                    }
+                    _ => vec![],
                 }
             }
-            TIMER_ID_PROGRESS_ALERT => self.handle_progress_alert_timer(now),
+            TIMER_ID_REQUEST_STATE => self.handle_request_state_timer(now),
             TIMER_ID_STANDSTILL_ALERT => self.handle_standstill_alert_timer(now),
             TIMER_ID_SYNCHRONIZER_LOG => {
                 self.synchronizer.log_len();
-                if !self.finalized_switch_block() {
-                    let next_timer = Timestamp::now() + TimeDiff::from(5_000);
-                    vec![ProtocolOutcome::ScheduleTimer(next_timer, timer_id)]
-                } else {
-                    vec![]
+                match self.config.log_synchronizer_interval {
+                    Some(interval) if !self.finalized_switch_block() => {
+                        vec![ProtocolOutcome::ScheduleTimer(now + interval, timer_id)]
+                    }
+                    _ => vec![],
                 }
             }
             _ => unreachable!("unexpected timer ID"),

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -481,9 +481,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             instance_id = ?self.highway.instance_id(),
             "requesting latest state from random peer",
         );
-        // We haven't made any progress. Request latest panorama from peers and schedule
-        // standstill alert. If we still won't progress by the time
-        // `TIMER_ID_STANDSTILL_ALERT` is handled, it means we're stuck.
+        // Request latest state from a peer and schedule the next request.
         let mut outcomes = self.latest_state_request();
         if let Some(interval) = self.config.request_state_interval {
             outcomes.push(ProtocolOutcome::ScheduleTimer(

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -16,14 +16,14 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
-    /// If the current era's protocol state has not progressed for this long, request the latest
-    /// state from peers.
-    pub standstill_timeout: TimeDiff,
-    /// If another `standstill_timeout` passes assume we failed to join the network and restart.
-    #[serde(default = "default_shutdown_on_standstill")]
-    pub shutdown_on_standstill: bool,
+    /// If the initial era's protocol state has not progressed for this long, restart.
+    pub standstill_timeout: Option<TimeDiff>,
+    /// Request the latest protocol state from a random peer periodically, with this interval.
+    pub request_state_interval: Option<TimeDiff>,
     /// Log inactive or faulty validators periodically, with this interval.
-    pub log_participation_interval: TimeDiff,
+    pub log_participation_interval: Option<TimeDiff>,
+    /// Log synchronizer state periodically, with this interval.
+    pub log_synchronizer_interval: Option<TimeDiff>,
     /// Log the size of every incoming and outgoing serialized unit.
     pub log_unit_sizes: bool,
     /// The maximum number of blocks by which execution is allowed to lag behind finalization.
@@ -34,18 +34,15 @@ pub struct Config {
     pub round_success_meter: RSMConfig,
 }
 
-fn default_shutdown_on_standstill() -> bool {
-    false
-}
-
 impl Default for Config {
     fn default() -> Self {
         Config {
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
-            standstill_timeout: "1min".parse().unwrap(),
-            shutdown_on_standstill: false,
-            log_participation_interval: "10sec".parse().unwrap(),
+            standstill_timeout: None,
+            request_state_interval: Some("10sec".parse().unwrap()),
+            log_participation_interval: Some("10sec".parse().unwrap()),
+            log_synchronizer_interval: Some("5sec".parse().unwrap()),
             log_unit_sizes: false,
             max_execution_delay: 3,
             max_requests_for_vertex: 5,

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -74,9 +74,8 @@ where
         secret_key_path: Default::default(),
         highway: HighwayConfig {
             pending_vertex_timeout: "1min".parse().unwrap(),
-            standstill_timeout: STANDSTILL_TIMEOUT.parse().unwrap(),
-            shutdown_on_standstill: true,
-            log_participation_interval: "10sec".parse().unwrap(),
+            standstill_timeout: Some(STANDSTILL_TIMEOUT.parse().unwrap()),
+            log_participation_interval: Some("10sec".parse().unwrap()),
             max_execution_delay: 3,
             ..HighwayConfig::default()
         },
@@ -95,13 +94,14 @@ where
         0,
         start_timestamp,
     );
-    // We expect for messages:
+    // We expect five messages:
     // * log participation timer,
     // * log synchronizer queue length timer,
     // * purge synchronizer queue timer,
-    // * inactivity timer,
+    // * standstill alert timer,
+    // * latest state request timer
     // If there are more, the tests might need to handle them.
-    assert_eq!(4, outcomes.len());
+    assert_eq!(5, outcomes.len());
     hw_proto
 }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -55,7 +55,7 @@ use futures::{future::BoxFuture, FutureExt};
 use openssl::{error::ErrorStack as OpenSslErrorStack, pkey};
 use pkey::{PKey, Private};
 use prometheus::Registry;
-use rand::seq::IteratorRandom;
+use rand::seq::{IteratorRandom, SliceRandom};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
@@ -856,6 +856,11 @@ where
             Event::NetworkInfoRequest { req } => match *req {
                 NetworkInfoRequest::GetPeers { responder } => {
                     responder.respond(self.peers()).ignore()
+                }
+                NetworkInfoRequest::GetPeersInRandomOrder { responder } => {
+                    let mut peers_vec: Vec<NodeId> = self.peers().keys().cloned().collect();
+                    peers_vec.shuffle(rng);
+                    responder.respond(peers_vec).ignore()
                 }
             },
             Event::PeerAddressReceived(gossiped_address) => {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -590,6 +590,19 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets the current network peers in a random order.
+    pub async fn get_peers_in_random_order<I>(self) -> Vec<I>
+    where
+        REv: From<NetworkInfoRequest<I>>,
+        I: Send + 'static,
+    {
+        self.make_request(
+            |responder| NetworkInfoRequest::GetPeersInRandomOrder { responder },
+            QueueKind::Api,
+        )
+        .await
+    }
+
     /// Announces that a network message has been received.
     pub(crate) async fn announce_message_received<I, P>(self, sender: I, payload: P)
     where

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -186,6 +186,12 @@ pub(crate) enum NetworkInfoRequest<I> {
         // TODO - change the `String` field to a `libp2p::Multiaddr` once small_network is removed.
         responder: Responder<BTreeMap<I, String>>,
     },
+    /// Get the peers in random order.
+    GetPeersInRandomOrder {
+        /// Responder to be called with all connected peers.
+        /// Responds with a vector in a random order.
+        responder: Responder<Vec<I>>,
+    },
 }
 
 impl<I> Display for NetworkInfoRequest<I>
@@ -195,6 +201,9 @@ where
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             NetworkInfoRequest::GetPeers { responder: _ } => write!(formatter, "get peers"),
+            NetworkInfoRequest::GetPeersInRandomOrder { responder: _ } => {
+                write!(formatter, "get peers in random order")
+            }
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-standstill_timeout = '3min'
+standstill_timeout = '10min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -43,15 +43,17 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# If the current era's protocol state has not progressed for this long, request the latest state
-# from peers.
-standstill_timeout = '5min'
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = false
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
 
 # Log the size of every incoming and outgoing serialized unit.
 log_unit_sizes = false

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-# standstill_timeout = '30min'
+standstill_timeout = '3min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -44,13 +44,16 @@ unit_hashes_folder = "/var/lib/casper/casper-node"
 pending_vertex_timeout = '30min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-standstill_timeout = '5min'
+# standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = false
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
 
 # Log the size of every incoming and outgoing serialized unit.
 log_unit_sizes = false

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-standstill_timeout = '3min'
+standstill_timeout = '10min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -43,15 +43,17 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# If the current era's protocol state has not progressed for this long, request the latest state
-# from peers.
-standstill_timeout = '5min'
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = false
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
 
 # Log the size of every incoming and outgoing serialized unit.
 log_unit_sizes = false

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-# standstill_timeout = '30min'
+standstill_timeout = '3min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -48,7 +48,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-standstill_timeout = '3min'
+standstill_timeout = '1min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -48,7 +48,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-# standstill_timeout = '30min'
+standstill_timeout = '3min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -47,15 +47,17 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# If the current era's protocol state has not progressed for this long, request the latest state
-# from peers.
-standstill_timeout = '30sec'
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = false
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
 
 # Log the size of every incoming and outgoing serialized unit.
 log_unit_sizes = false

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-standstill_timeout = '3min'
+standstill_timeout = '10min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -43,15 +43,17 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
-# If the current era's protocol state has not progressed for this long, request the latest state
-# from peers.
-standstill_timeout = '5min'
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = false
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
 
 # Log the size of every incoming and outgoing serialized unit.
 log_unit_sizes = false

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -44,7 +44,7 @@ unit_hashes_folder = "../node-storage"
 pending_vertex_timeout = '1min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-# standstill_timeout = '30min'
+standstill_timeout = '3min'
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'


### PR DESCRIPTION
This separates the standstill alert — restart if no progress is made — from requesting the latest protocol state, and makes those timers configurable separately. The latest protocol state is requested from only one peer instead of from everyone.

Closes #1914.