### PR TITLE
Fix 1980 sse event for expired deploys

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Added `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
+* Added new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -500,7 +500,8 @@ impl BlockProposerReady {
         Arc::new(appendable_block.into_block_payload(accusations, random_bit))
     }
 
-    /// Prunes expired deploy information from the BlockProposer, returns the hashes of deploys pruned.
+    /// Prunes expired deploy information from the BlockProposer, returns the hashes of deploys
+    /// pruned.
     fn prune(&mut self, current_instant: Timestamp) -> Vec<DeployHash> {
         self.sets.prune(current_instant)
     }

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -264,14 +264,15 @@ impl BlockProposerReady {
                 Effects::new()
             }
             Event::Prune => {
-                let pruned_hashes = self.prune(Timestamp::now());
-                let pruned_count = pruned_hashes.total_pruned;
-                debug!(%pruned_count, "pruned deploys from buffer");
-
+                // Re-trigger timer after `PRUNE_INTERVAL`.
                 let mut effects = effect_builder
                     .set_timeout(PRUNE_INTERVAL)
                     .event(|_| Event::Prune);
 
+                // Announce pruned hashes
+                let pruned_hashes = self.prune(Timestamp::now());
+                let pruned_count = pruned_hashes.total_pruned;
+                debug!(%pruned_count, "pruned deploys from buffer");
                 effects.extend(
                     effect_builder
                         .announce_expired_deploys(pruned_hashes.expired_hashes_to_be_announced)

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::{self, Display, Formatter},
+    hash::Hash,
 };
 
 use datasize::DataSize;
@@ -61,28 +62,156 @@ impl BlockProposerDeploySets {
         let pending_deploys = prune_pending_deploys(&mut self.pending_deploys, current_instant);
         let pending_transfers = prune_pending_deploys(&mut self.pending_transfers, current_instant);
         let finalized = prune_deploys(&mut self.finalized_deploys, current_instant);
-        pending_deploys + pending_transfers + finalized
+        pending_deploys.len() + pending_transfers.len() + finalized.len()
     }
 }
 
-/// Prunes expired deploy information from an individual deploy collection, returns the total
-/// deploys pruned
+/// Retains items that satisfy the given predicate in the hash map and drains the rest,
+/// returning keys of the removed elements.
+///
+/// To be replaced with `HashMap::drain_filter` when stabilized.
+/// [https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.drain_filter]
+fn hash_map_drain_filter_in_place<K, V, F>(hash_map: &mut HashMap<K, V>, pred: F) -> Vec<K>
+where
+    K: Eq + Hash + Copy,
+    F: Fn(&V) -> bool,
+{
+    let mut drained = vec![];
+    let retained: HashMap<_, _> = hash_map
+        .drain()
+        .filter(|(k, v)| {
+            if pred(v) {
+                true
+            } else {
+                drained.push(*k);
+                false
+            }
+        })
+        .collect();
+    hash_map.extend(retained);
+    drained
+}
+
+/// Prunes expired deploy information from an individual deploy collection, returns the
+/// hashes of pruned deploys.
 pub(super) fn prune_deploys(
     deploys: &mut HashMap<DeployHash, DeployHeader>,
     current_instant: Timestamp,
-) -> usize {
-    let initial_len = deploys.len();
-    deploys.retain(|_hash, header| !header.expired(current_instant));
-    initial_len - deploys.len()
+) -> Vec<DeployHash> {
+    hash_map_drain_filter_in_place(deploys, |header| !header.expired(current_instant))
 }
 
 /// Prunes expired deploy information from an individual pending deploy collection, returns the
-/// total deploys pruned
+/// hashes of pruned deploys.
 pub(super) fn prune_pending_deploys(
     deploys: &mut HashMap<DeployHash, (DeployInfo, Timestamp)>,
     current_instant: Timestamp,
-) -> usize {
-    let initial_len = deploys.len();
-    deploys.retain(|_hash, (deploy_info, _)| !deploy_info.header.expired(current_instant));
-    initial_len - deploys.len()
+) -> Vec<DeployHash> {
+    hash_map_drain_filter_in_place(deploys, |(deploy_info, _)| {
+        !deploy_info.header.expired(current_instant)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        testing::TestRng,
+        types::{Deploy, TimeDiff},
+    };
+
+    use super::*;
+
+    /// TODO[RC]
+    fn create_test_deploy(
+        created_ago: TimeDiff,
+        ttl: TimeDiff,
+        now: Timestamp,
+        mut test_rng: &mut TestRng,
+    ) -> Deploy {
+        Deploy::random_with_timestamp_and_ttl(&mut test_rng, now - created_ago, ttl)
+    }
+
+    /// Creates a random deploy that was created 20 seconds
+    /// in the past and was valid for 10 seconds only.
+    fn create_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
+        create_test_deploy(
+            TimeDiff::from_seconds(20),
+            TimeDiff::from_seconds(10),
+            now,
+            test_rng,
+        )
+    }
+
+    /// Creates a random deploy that was created 20 seconds
+    /// in the past but is valid for a minute.
+    fn create_not_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
+        create_test_deploy(
+            TimeDiff::from_seconds(20),
+            TimeDiff::from_seconds(60),
+            now,
+            test_rng,
+        )
+    }
+
+    #[test]
+    fn prunes_pending_deploys() {
+        let mut test_rng = TestRng::new();
+        let mut deploys: HashMap<DeployHash, (DeployInfo, Timestamp)> = HashMap::new();
+        let now = Timestamp::now();
+
+        let deploy_1 = create_not_expired_deploy(now, &mut test_rng);
+        let deploy_2 = create_expired_deploy(now, &mut test_rng);
+        let deploy_3 = create_expired_deploy(now, &mut test_rng);
+        let deploy_4 = create_not_expired_deploy(now, &mut test_rng);
+        let deploy_5 = create_expired_deploy(now, &mut test_rng);
+
+        deploys.insert(*deploy_1.id(), (deploy_1.deploy_info().unwrap(), now));
+        deploys.insert(*deploy_2.id(), (deploy_2.deploy_info().unwrap(), now));
+        deploys.insert(*deploy_3.id(), (deploy_3.deploy_info().unwrap(), now));
+        deploys.insert(*deploy_4.id(), (deploy_4.deploy_info().unwrap(), now));
+        deploys.insert(*deploy_5.id(), (deploy_5.deploy_info().unwrap(), now));
+
+        // We expect deploys created with `create_expired_deploy` to be drained
+        let mut expected_drained = vec![*deploy_2.id(), *deploy_3.id(), *deploy_5.id()];
+        expected_drained.sort();
+        let mut drained = prune_pending_deploys(&mut deploys, now);
+        drained.sort();
+        assert_eq!(expected_drained, drained);
+
+        // We expect deploys created with `create_not_expired_deploy` to be retained
+        let mut expected_retained = vec![*deploy_1.id(), *deploy_4.id()];
+        expected_retained.sort();
+        let mut retained = deploys
+            .into_iter()
+            .map(|(deploy_hash, _)| deploy_hash)
+            .collect::<Vec<_>>();
+        retained.sort();
+        assert_eq!(expected_retained, retained);
+    }
+
+    mod hash_map_drain_filter_in_place {
+        use crate::components::block_proposer::deploy_sets::hash_map_drain_filter_in_place;
+
+        #[test]
+        fn returns_drained() {
+            use std::collections::HashMap;
+            let mut hash_map = HashMap::new();
+            hash_map.insert("A", 1);
+            hash_map.insert("B", 0);
+            hash_map.insert("C", 1);
+            hash_map.insert("D", 0);
+
+            let mut drained = hash_map_drain_filter_in_place(&mut hash_map, |value| *value == 0);
+            drained.sort_unstable();
+
+            let expected_drained = vec!["A", "C"];
+            assert_eq!(expected_drained, drained);
+
+            let mut expected_retained = HashMap::new();
+            expected_retained.insert("B", 0);
+            expected_retained.insert("D", 0);
+
+            assert_eq!(expected_retained, hash_map);
+        }
+    }
 }

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use datasize::DataSize;
-use tracing::warn;
 
 use super::{event::DeployInfo, BlockHeight, FinalizationQueue};
 use crate::types::{DeployHash, DeployHeader, Timestamp};

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -134,42 +134,9 @@ pub(super) fn prune_pending_deploys(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        testing::TestRng,
-        types::{Deploy, TimeDiff},
-    };
+    use crate::{testing, testing::TestRng};
 
     use super::*;
-
-    /// Creates a test deploy created at given instant and with given ttl.
-    fn create_test_deploy(
-        created_ago: TimeDiff,
-        ttl: TimeDiff,
-        now: Timestamp,
-        mut test_rng: &mut TestRng,
-    ) -> Deploy {
-        Deploy::random_with_timestamp_and_ttl(&mut test_rng, now - created_ago, ttl)
-    }
-
-    /// Creates a random deploy that is considered expired.
-    fn create_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
-        create_test_deploy(
-            TimeDiff::from_seconds(20),
-            TimeDiff::from_seconds(10),
-            now,
-            test_rng,
-        )
-    }
-
-    /// Creates a random deploy that is considered not expired.
-    fn create_not_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
-        create_test_deploy(
-            TimeDiff::from_seconds(20),
-            TimeDiff::from_seconds(60),
-            now,
-            test_rng,
-        )
-    }
 
     #[test]
     fn prunes_pending_deploys() {
@@ -177,11 +144,11 @@ mod tests {
         let mut deploys: HashMap<DeployHash, (DeployInfo, Timestamp)> = HashMap::new();
         let now = Timestamp::now();
 
-        let deploy_1 = create_not_expired_deploy(now, &mut test_rng);
-        let deploy_2 = create_expired_deploy(now, &mut test_rng);
-        let deploy_3 = create_expired_deploy(now, &mut test_rng);
-        let deploy_4 = create_not_expired_deploy(now, &mut test_rng);
-        let deploy_5 = create_expired_deploy(now, &mut test_rng);
+        let deploy_1 = testing::create_not_expired_deploy(now, &mut test_rng);
+        let deploy_2 = testing::create_expired_deploy(now, &mut test_rng);
+        let deploy_3 = testing::create_expired_deploy(now, &mut test_rng);
+        let deploy_4 = testing::create_not_expired_deploy(now, &mut test_rng);
+        let deploy_5 = testing::create_expired_deploy(now, &mut test_rng);
 
         deploys.insert(*deploy_1.id(), (deploy_1.deploy_info().unwrap(), now));
         deploys.insert(*deploy_2.id(), (deploy_2.deploy_info().unwrap(), now));

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -74,7 +74,7 @@ impl BlockProposerDeploySets {
 ///
 /// To be replaced with `HashMap::drain_filter` when stabilized.
 /// [https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.drain_filter]
-fn hash_map_drain_filter_in_place<K, V, F>(hash_map: &mut HashMap<K, V>, pred: F) -> Vec<K>
+fn hashmap_drain_filter_in_place<K, V, F>(hash_map: &mut HashMap<K, V>, pred: F) -> Vec<K>
 where
     K: Eq + Hash + Copy,
     F: Fn(&V) -> bool,
@@ -94,7 +94,7 @@ fn prune_deploys(
     deploys: &mut HashMap<DeployHash, DeployHeader>,
     current_instant: Timestamp,
 ) -> Vec<DeployHash> {
-    hash_map_drain_filter_in_place(deploys, |header| header.expired(current_instant))
+    hashmap_drain_filter_in_place(deploys, |header| header.expired(current_instant))
 }
 
 /// Prunes expired deploy information from an individual pending deploy collection, returns the
@@ -103,7 +103,7 @@ pub(super) fn prune_pending_deploys(
     deploys: &mut HashMap<DeployHash, (DeployInfo, Timestamp)>,
     current_instant: Timestamp,
 ) -> Vec<DeployHash> {
-    hash_map_drain_filter_in_place(deploys, |(deploy_info, _)| {
+    hashmap_drain_filter_in_place(deploys, |(deploy_info, _)| {
         deploy_info.header.expired(current_instant)
     })
 }
@@ -184,7 +184,7 @@ mod tests {
     }
 
     mod hash_map_drain_filter_in_place {
-        use crate::components::block_proposer::deploy_sets::hash_map_drain_filter_in_place;
+        use super::*;
 
         #[test]
         fn returns_drained() {
@@ -195,7 +195,7 @@ mod tests {
             hash_map.insert("C", 1);
             hash_map.insert("D", 0);
 
-            let mut drained = hash_map_drain_filter_in_place(&mut hash_map, |value| *value == 1);
+            let mut drained = hashmap_drain_filter_in_place(&mut hash_map, |value| *value == 1);
             drained.sort_unstable();
 
             let expected_drained = vec!["A", "C"];

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -58,7 +58,7 @@ impl Display for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    /// Prunes expired deploy information from the BlockProposerState,  returns the
+    /// Prunes expired deploy information from the BlockProposerState, returns the
     /// hashes of deploys pruned.
     pub(crate) fn prune(&mut self, current_instant: Timestamp) -> Vec<DeployHash> {
         let pending_deploys = prune_pending_deploys(&mut self.pending_deploys, current_instant);
@@ -90,7 +90,7 @@ where
 
 /// Prunes expired deploy information from an individual deploy collection, returns the
 /// hashes of deploys pruned.
-pub(super) fn prune_deploys(
+fn prune_deploys(
     deploys: &mut HashMap<DeployHash, DeployHeader>,
     current_instant: Timestamp,
 ) -> Vec<DeployHash> {

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -17,10 +17,10 @@ pub(crate) struct PruneResult {
 }
 
 impl PruneResult {
-    fn new(total_pruned: usize, expiration_to_be_announced: Vec<DeployHash>) -> Self {
+    fn new(total_pruned: usize, expired_hashes_to_be_announced: Vec<DeployHash>) -> Self {
         Self {
             total_pruned,
-            expired_hashes_to_be_announced: expiration_to_be_announced,
+            expired_hashes_to_be_announced,
         }
     }
 }

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -334,10 +334,10 @@ fn should_successfully_prune() {
 
     // now move the clock to make some things expire
     let mut pruned = proposer.prune(expired_time);
-    assert_eq!(pruned.total_pruned, 3); // Three deploy pruned
+    assert_eq!(pruned.total_pruned, 3); // Three deploys pruned
 
-    // Expired announcement created for two deploys only: deploy2 and deploy3
-    // because deploy4 did not expire and deploy1 has been finalized
+    // Expiration announcements created for two deploys only: "deploy2" and "deploy3"
+    // because "deploy4" did not expire and "deploy1" has been finalized
     assert_eq!(pruned.expired_hashes_to_be_announced.len(), 2);
     let mut hashes_to_be_announced = vec![*deploy2.id(), *deploy3.id()];
     hashes_to_be_announced.sort();

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -326,7 +326,7 @@ fn should_successfully_prune() {
 
     // test for retained values
     let pruned = proposer.prune(test_time);
-    assert_eq!(pruned, 0);
+    assert_eq!(pruned.len(), 0);
 
     assert_eq!(proposer.sets.pending_deploys.len(), 3);
     assert_eq!(proposer.sets.finalized_deploys.len(), 1);
@@ -334,7 +334,7 @@ fn should_successfully_prune() {
 
     // now move the clock to make some things expire
     let pruned = proposer.prune(expired_time);
-    assert_eq!(pruned, 3);
+    assert_eq!(pruned.len(), 3);
 
     assert_eq!(proposer.sets.pending_deploys.len(), 1); // deploy4 is still valid
     assert_eq!(proposer.sets.finalized_deploys.len(), 0);

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -326,15 +326,26 @@ fn should_successfully_prune() {
 
     // test for retained values
     let pruned = proposer.prune(test_time);
-    assert_eq!(pruned.len(), 0);
+    assert_eq!(pruned.total_pruned, 0);
 
     assert_eq!(proposer.sets.pending_deploys.len(), 3);
     assert_eq!(proposer.sets.finalized_deploys.len(), 1);
     assert!(proposer.sets.finalized_deploys.contains_key(deploy1.id()));
 
     // now move the clock to make some things expire
-    let pruned = proposer.prune(expired_time);
-    assert_eq!(pruned.len(), 3);
+    let mut pruned = proposer.prune(expired_time);
+    assert_eq!(pruned.total_pruned, 3); // Three deploy pruned
+
+    // Expired announcement created for two deploys only: deploy2 and deploy3
+    // because deploy4 did not expire and deploy1 has been finalized
+    assert_eq!(pruned.expired_hashes_to_be_announced.len(), 2);
+    let mut hashes_to_be_announced = vec![*deploy2.id(), *deploy3.id()];
+    hashes_to_be_announced.sort();
+    pruned.expired_hashes_to_be_announced.sort();
+    assert_eq!(
+        pruned.expired_hashes_to_be_announced,
+        hashes_to_be_announced
+    );
 
     assert_eq!(proposer.sets.pending_deploys.len(), 1); // deploy4 is still valid
     assert_eq!(proposer.sets.finalized_deploys.len(), 0);

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -194,9 +194,11 @@ where
                 block_hash: Box::new(block_hash),
                 execution_result,
             }),
-            Event::DeployExpired(deploy_hash) => {
-                self.broadcast(SseData::DeployExpired { deploy_hash })
-            }
+            Event::DeploysExpired(deploy_hashes) => deploy_hashes
+                .into_iter()
+                .map(|deploy_hash| self.broadcast(SseData::DeployExpired { deploy_hash }))
+                .flatten()
+                .collect(),
             Event::Fault {
                 era_id,
                 public_key,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -180,9 +180,6 @@ where
                 block: Box::new(JsonBlock::new(*block, None)),
             }),
             Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted { deploy }),
-            Event::DeployExpired(deploy_hash) => {
-                self.broadcast(SseData::DeployExpired { deploy_hash })
-            }
             Event::DeployProcessed {
                 deploy_hash,
                 deploy_header,
@@ -197,6 +194,9 @@ where
                 block_hash: Box::new(block_hash),
                 execution_result,
             }),
+            Event::DeployExpired(deploy_hash) => {
+                self.broadcast(SseData::DeployExpired { deploy_hash })
+            }
             Event::Fault {
                 era_id,
                 public_key,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -180,6 +180,10 @@ where
                 block: Box::new(JsonBlock::new(*block, None)),
             }),
             Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted { deploy }),
+            Event::DeployExpired(deploy_hash) => {
+                warn!("TODO[RC]: XXX broadcasting expired hash: {}", deploy_hash);
+                self.broadcast(SseData::DeployExpired { deploy_hash })
+            }
             Event::DeployProcessed {
                 deploy_hash,
                 deploy_header,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -181,7 +181,6 @@ where
             }),
             Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted { deploy }),
             Event::DeployExpired(deploy_hash) => {
-                warn!("TODO[RC]: XXX broadcasting expired hash: {}", deploy_hash);
                 self.broadcast(SseData::DeployExpired { deploy_hash })
             }
             Event::DeployProcessed {

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -8,13 +8,13 @@ use crate::types::{Block, BlockHash, DeployHash, DeployHeader, FinalitySignature
 pub enum Event {
     BlockAdded(Box<Block>),
     DeployAccepted(DeployHash),
-    DeployExpired(DeployHash),
     DeployProcessed {
         deploy_hash: DeployHash,
         deploy_header: Box<DeployHeader>,
         block_hash: BlockHash,
         execution_result: Box<ExecutionResult>,
     },
+    DeployExpired(DeployHash),
     Fault {
         era_id: EraId,
         public_key: PublicKey,

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey};
+use itertools::Itertools;
 
 use crate::types::{Block, BlockHash, DeployHash, DeployHeader, FinalitySignature, Timestamp};
 
@@ -14,7 +15,7 @@ pub enum Event {
         block_hash: BlockHash,
         execution_result: Box<ExecutionResult>,
     },
-    DeployExpired(DeployHash),
+    DeploysExpired(Vec<DeployHash>),
     Fault {
         era_id: EraId,
         public_key: PublicKey,
@@ -34,8 +35,12 @@ impl Display for Event {
             Event::DeployAccepted(deploy_hash) => {
                 write!(formatter, "deploy accepted {}", deploy_hash)
             }
-            Event::DeployExpired(deploy_hash) => {
-                write!(formatter, "deploy expired {}", deploy_hash)
+            Event::DeploysExpired(deploy_hashes) => {
+                write!(
+                    formatter,
+                    "deploys expired: {}",
+                    deploy_hashes.iter().join(", ")
+                )
             }
             Event::DeployProcessed { deploy_hash, .. } => {
                 write!(formatter, "deploy processed {}", deploy_hash)

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -8,6 +8,7 @@ use crate::types::{Block, BlockHash, DeployHash, DeployHeader, FinalitySignature
 pub enum Event {
     BlockAdded(Box<Block>),
     DeployAccepted(DeployHash),
+    DeployExpired(DeployHash),
     DeployProcessed {
         deploy_hash: DeployHash,
         deploy_header: Box<DeployHeader>,
@@ -32,6 +33,9 @@ impl Display for Event {
             Event::BlockAdded(block) => write!(formatter, "block added {}", block.hash()),
             Event::DeployAccepted(deploy_hash) => {
                 write!(formatter, "deploy accepted {}", deploy_hash)
+            }
+            Event::DeployExpired(deploy_hash) => {
+                write!(formatter, "deploy expired {}", deploy_hash)
             }
             Event::DeployProcessed { deploy_hash, .. } => {
                 write!(formatter, "deploy processed {}", deploy_hash)

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -41,7 +41,7 @@ use crate::types::{
     BlockHash, Deploy, DeployHash, FinalitySignature, JsonBlock, TimeDiff, Timestamp,
 };
 #[cfg(test)]
-use crate::{crypto::AsymmetricKeyExt, testing::TestRng, types::Block};
+use crate::{crypto::AsymmetricKeyExt, testing, testing::TestRng, types::Block};
 
 /// The URL root path.
 pub const SSE_API_ROOT_PATH: &str = "events";
@@ -180,7 +180,7 @@ impl SseData {
 
     /// Returns a random `SseData::DeployExpired`
     pub(super) fn random_deploy_expired(rng: &mut TestRng) -> Self {
-        let deploy = Deploy::random(rng);
+        let deploy = testing::create_expired_deploy(Timestamp::now(), rng);
         SseData::DeployExpired {
             deploy_hash: *deploy.id(),
         }

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -102,7 +102,7 @@ pub enum SseData {
         #[data_size(skip)]
         execution_result: Box<ExecutionResult>,
     },
-    /// TODO[RC]
+    /// The given deploy has expired.
     DeployExpired { deploy_hash: DeployHash },
     /// Generic representation of validator's fault in an era.
     Fault {
@@ -178,11 +178,11 @@ impl SseData {
         }
     }
 
-    /// TODO[RC]
+    /// Returns a random `SseData::DeployExpired`
     pub(super) fn random_deploy_expired(rng: &mut TestRng) -> Self {
         let deploy = Deploy::random(rng);
         SseData::DeployExpired {
-            deploy_hash: Box::new(*deploy.id()),
+            deploy_hash: *deploy.id(),
         }
     }
 

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -643,6 +643,10 @@ mod tests {
             id: Some(rng.gen()),
             data: SseData::random_deploy_processed(&mut rng),
         };
+        let deploy_expired = ServerSentEvent {
+            id: Some(rng.gen()),
+            data: SseData::random_deploy_expired(&mut rng),
+        };
         let fault = ServerSentEvent {
             id: Some(rng.gen()),
             data: SseData::random_fault(&mut rng),
@@ -660,6 +664,7 @@ mod tests {
         should_not_filter_out(&api_version, &MAIN_FILTER[..], getter.clone()).await;
         should_not_filter_out(&block_added, &MAIN_FILTER[..], getter.clone()).await;
         should_not_filter_out(&deploy_processed, &MAIN_FILTER[..], getter.clone()).await;
+        should_not_filter_out(&deploy_expired, &MAIN_FILTER[..], getter.clone()).await;
         should_not_filter_out(&fault, &MAIN_FILTER[..], getter.clone()).await;
         should_not_filter_out(&step, &MAIN_FILTER[..], getter.clone()).await;
 
@@ -673,6 +678,7 @@ mod tests {
 
         should_filter_out(&block_added, &DEPLOYS_FILTER[..], getter.clone()).await;
         should_filter_out(&deploy_processed, &DEPLOYS_FILTER[..], getter.clone()).await;
+        should_filter_out(&deploy_expired, &DEPLOYS_FILTER[..], getter.clone()).await;
         should_filter_out(&fault, &DEPLOYS_FILTER[..], getter.clone()).await;
         should_filter_out(&finality_signature, &DEPLOYS_FILTER[..], getter.clone()).await;
         should_filter_out(&step, &DEPLOYS_FILTER[..], getter.clone()).await;
@@ -685,6 +691,7 @@ mod tests {
         should_filter_out(&block_added, &SIGNATURES_FILTER[..], getter.clone()).await;
         should_filter_out(&deploy_accepted, &SIGNATURES_FILTER[..], getter.clone()).await;
         should_filter_out(&deploy_processed, &SIGNATURES_FILTER[..], getter.clone()).await;
+        should_filter_out(&deploy_expired, &SIGNATURES_FILTER[..], getter.clone()).await;
         should_filter_out(&fault, &SIGNATURES_FILTER[..], getter.clone()).await;
         should_filter_out(&step, &SIGNATURES_FILTER[..], getter).await;
     }
@@ -716,6 +723,10 @@ mod tests {
             id: None,
             data: SseData::random_deploy_processed(&mut rng),
         };
+        let malformed_deploy_expired = ServerSentEvent {
+            id: None,
+            data: SseData::random_deploy_expired(&mut rng),
+        };
         let malformed_fault = ServerSentEvent {
             id: None,
             data: SseData::random_fault(&mut rng),
@@ -738,6 +749,7 @@ mod tests {
             should_filter_out(&malformed_block_added, filter, getter.clone()).await;
             should_filter_out(&malformed_deploy_accepted, filter, getter.clone()).await;
             should_filter_out(&malformed_deploy_processed, filter, getter.clone()).await;
+            should_filter_out(&malformed_deploy_expired, filter, getter.clone()).await;
             should_filter_out(&malformed_fault, filter, getter.clone()).await;
             should_filter_out(&malformed_finality_signature, filter, getter.clone()).await;
             should_filter_out(&malformed_step, filter, getter.clone()).await;

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -182,7 +182,7 @@ impl SseData {
     pub(super) fn random_deploy_expired(rng: &mut TestRng) -> Self {
         let deploy = Deploy::random(rng);
         SseData::DeployExpired {
-            deploy_hash: Box::new(*deploy.id()), // TODO[RC] Is the hash enough?
+            deploy_hash: Box::new(*deploy.id()),
         }
     }
 

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -56,9 +56,10 @@ pub const SSE_API_SIGNATURES_PATH: &str = "sigs";
 pub const QUERY_FIELD: &str = "start_from";
 
 /// The filter associated with `/events/main` path.
-const MAIN_FILTER: [EventFilter; 4] = [
+const MAIN_FILTER: [EventFilter; 5] = [
     EventFilter::BlockAdded,
     EventFilter::DeployProcessed,
+    EventFilter::DeployExpired,
     EventFilter::Fault,
     EventFilter::Step,
 ];
@@ -102,7 +103,7 @@ pub enum SseData {
         execution_result: Box<ExecutionResult>,
     },
     /// TODO[RC]
-    DeployExpired { deploy_hash: Box<DeployHash> },
+    DeployExpired { deploy_hash: DeployHash },
     /// Generic representation of validator's fault in an era.
     Fault {
         era_id: EraId,

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -593,7 +593,6 @@ async fn should_serve_events_with_no_query(path: &str) {
     let url = url(server_address, path, None);
     let (expected_events, final_id) = fixture.all_filtered_events(path);
     let received_events = subscribe(&url, barrier, final_id, "client").await.unwrap();
-
     fixture.stop_server().await;
 
     assert_eq!(received_events, expected_events);

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -288,8 +288,6 @@ impl TestFixture {
                 EVENT_COUNT
             };
             for (id, event) in events.iter().cycle().enumerate().take(event_count as usize) {
-                println!("XXX Sending event: {:?}", event);
-
                 if server_stopper.should_stop() {
                     debug!("stopping server early");
                     return;
@@ -595,8 +593,6 @@ async fn should_serve_events_with_no_query(path: &str) {
     let url = url(server_address, path, None);
     let (expected_events, final_id) = fixture.all_filtered_events(path);
     let received_events = subscribe(&url, barrier, final_id, "client").await.unwrap();
-
-    dbg!(&received_events);
 
     fixture.stop_server().await;
 

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -32,7 +32,7 @@ use sse_server::{
 
 /// The total number of random events each `EventStreamServer` will emit by default, excluding the
 /// initial `ApiVersion` event.
-const EVENT_COUNT: u32 = 10;
+const EVENT_COUNT: u32 = 100;
 /// The maximum number of random events each `EventStreamServer` will emit, excluding the initial
 /// `ApiVersion` event.
 const MAX_EVENT_COUNT: u32 = 100_000_000;

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -608,6 +608,8 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<BlockProposerAnnouncement>,
     {
+        warn!("TODO[RC]: XXX scheduling event BlockProposerAnnouncement::DeploysExpired(hashes)");
+
         self.0
             .schedule(
                 BlockProposerAnnouncement::DeploysExpired(hashes),

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -128,7 +128,7 @@ use requests::{
     NetworkRequest, StateStoreRequest, StorageRequest,
 };
 
-use self::announcements::BlocklistAnnouncement;
+use self::announcements::{BlockProposerAnnouncement, BlocklistAnnouncement};
 use crate::components::contract_runtime::{
     BlockAndExecutionEffects, BlockExecutionError, ContractRuntimeAnnouncement, ExecutionPreState,
 };
@@ -601,6 +601,19 @@ impl<REv> EffectBuilder<REv> {
             QueueKind::Api,
         )
         .await
+    }
+
+    /// TODO[RC]: add comment
+    pub(crate) async fn announce_expired_deploys(self, hashes: Vec<DeployHash>)
+    where
+        REv: From<BlockProposerAnnouncement>,
+    {
+        self.0
+            .schedule(
+                BlockProposerAnnouncement::DeploysExpired(hashes),
+                QueueKind::Regular,
+            )
+            .await;
     }
 
     /// Announces that a network message has been received.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -603,7 +603,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Announces that a deploys have expired.
+    /// Announces that deploys have expired.
     pub(crate) async fn announce_expired_deploys(self, hashes: Vec<DeployHash>)
     where
         REv: From<BlockProposerAnnouncement>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -608,8 +608,6 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<BlockProposerAnnouncement>,
     {
-        warn!("TODO[RC]: XXX scheduling event BlockProposerAnnouncement::DeploysExpired(hashes)");
-
         self.0
             .schedule(
                 BlockProposerAnnouncement::DeploysExpired(hashes),

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -603,7 +603,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// TODO[RC]: add comment
+    /// Announces that a deploys have expired.
     pub(crate) async fn announce_expired_deploys(self, hashes: Vec<DeployHash>)
     where
         REv: From<BlockProposerAnnouncement>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -603,7 +603,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Announces that deploys have expired.
+    /// Announces which deploys have expired.
     pub(crate) async fn announce_expired_deploys(self, hashes: Vec<DeployHash>)
     where
         REv: From<BlockProposerAnnouncement>,

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
+use itertools::Itertools;
 use serde::Serialize;
 
 use casper_types::{EraId, ExecutionResult, PublicKey};
@@ -33,8 +34,7 @@ impl Display for BlockProposerAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             BlockProposerAnnouncement::DeploysExpired(hashes) => {
-                // TODO[RC]: Check how to Display pruned hashes,
-                write!(f, "{} pruned hashes", hashes.len())
+                write!(f, "pruned hashes: {}", hashes.iter().join(", "))
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -24,22 +24,6 @@ use crate::{
     utils::Source,
 };
 
-// TODO[RC]: add comments
-#[derive(Debug, Serialize)]
-pub(crate) enum BlockProposerAnnouncement {
-    DeploysExpired(Vec<DeployHash>),
-}
-
-impl Display for BlockProposerAnnouncement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            BlockProposerAnnouncement::DeploysExpired(hashes) => {
-                write!(f, "pruned hashes: {}", hashes.iter().join(", "))
-            }
-        }
-    }
-}
-
 /// Control announcements are special announcements handled directly by the runtime/runner.
 ///
 /// Reactors are never passed control announcements back in and every reactor event must be able to
@@ -167,6 +151,22 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
             ),
             DeployAcceptorAnnouncement::InvalidDeploy { deploy, source } => {
                 write!(formatter, "invalid deploy {} from {}", deploy.id(), source)
+            }
+        }
+    }
+}
+
+// A block proposer announcement.
+#[derive(Debug, Serialize)]
+pub(crate) enum BlockProposerAnnouncement {
+    DeploysExpired(Vec<DeployHash>),
+}
+
+impl Display for BlockProposerAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockProposerAnnouncement::DeploysExpired(hashes) => {
+                write!(f, "pruned hashes: {}", hashes.iter().join(", "))
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -159,6 +159,7 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 // A block proposer announcement.
 #[derive(Debug, Serialize)]
 pub(crate) enum BlockProposerAnnouncement {
+    /// Hashes of the deploys that expired.
     DeploysExpired(Vec<DeployHash>),
 }
 

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -24,8 +24,20 @@ use crate::{
 };
 
 // TODO[RC]: add comments
+#[derive(Debug, Serialize)]
 pub(crate) enum BlockProposerAnnouncement {
     DeploysExpired(Vec<DeployHash>),
+}
+
+impl Display for BlockProposerAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockProposerAnnouncement::DeploysExpired(hashes) => {
+                // TODO[RC]: Check how to Display pruned hashes,
+                write!(f, "{} pruned hashes", hashes.len())
+            }
+        }
+    }
 }
 
 /// Control announcements are special announcements handled directly by the runtime/runner.

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -23,6 +23,11 @@ use crate::{
     utils::Source,
 };
 
+// TODO[RC]: add comments
+pub(crate) enum BlockProposerAnnouncement {
+    DeploysExpired(Vec<DeployHash>),
+}
+
 /// Control announcements are special announcements handled directly by the runtime/runner.
 ///
 /// Reactors are never passed control announcements back in and every reactor event must be able to

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1128,14 +1128,23 @@ impl reactor::Reactor for Reactor {
                     hashes.len()
                 );
 
-                if !hashes.is_empty() {
+                let mut effects = Effects::new();
+                for hash in hashes {
                     let reactor_event = ParticipatingEvent::EventStreamServer(
-                        event_stream_server::Event::DeployExpired(*hashes.first().unwrap()),
+                        event_stream_server::Event::DeployExpired(hash),
                     );
-                    self.dispatch_event(effect_builder, rng, reactor_event)
-                } else {
-                    Effects::new()
+                    effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 }
+                effects
+
+                // if !hashes.is_empty() {
+                //     let reactor_event = ParticipatingEvent::EventStreamServer(
+                //         event_stream_server::Event::DeployExpired(*hashes.first().unwrap()),
+                //     );
+                //     self.dispatch_event(effect_builder, rng, reactor_event)
+                // } else {
+                //     Effects::new()
+                // }
             }
             ParticipatingEvent::LinearChainAnnouncement(
                 LinearChainAnnouncement::NewFinalitySignature(fs),

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -236,6 +236,7 @@ impl ReactorEvent for ParticipatingEvent {
             ParticipatingEvent::LinearChainAnnouncement(_) => "LinearChainAnnouncement",
             ParticipatingEvent::ChainspecLoaderAnnouncement(_) => "ChainspecLoaderAnnouncement",
             ParticipatingEvent::BlocklistAnnouncement(_) => "BlocklistAnnouncement",
+            ParticipatingEvent::BlockProposerAnnouncement(_) => "BlockProposerAnnouncement",
         }
     }
 }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1123,11 +1123,6 @@ impl reactor::Reactor for Reactor {
             ParticipatingEvent::BlockProposerAnnouncement(
                 BlockProposerAnnouncement::DeploysExpired(hashes),
             ) => {
-                warn!(
-                    "TODO[RC]: Got the DeploysExpired event with {} hashes",
-                    hashes.len()
-                );
-
                 let mut effects = Effects::new();
                 for hash in hashes {
                     let reactor_event = ParticipatingEvent::EventStreamServer(
@@ -1136,15 +1131,6 @@ impl reactor::Reactor for Reactor {
                     effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 }
                 effects
-
-                // if !hashes.is_empty() {
-                //     let reactor_event = ParticipatingEvent::EventStreamServer(
-                //         event_stream_server::Event::DeployExpired(*hashes.first().unwrap()),
-                //     );
-                //     self.dispatch_event(effect_builder, rng, reactor_event)
-                // } else {
-                //     Effects::new()
-                // }
             }
             ParticipatingEvent::LinearChainAnnouncement(
                 LinearChainAnnouncement::NewFinalitySignature(fs),

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1122,16 +1122,12 @@ impl reactor::Reactor for Reactor {
             }
             ParticipatingEvent::BlockProposerAnnouncement(
                 BlockProposerAnnouncement::DeploysExpired(hashes),
-            ) => hashes
-                .into_iter()
-                .map(|hash| {
-                    let reactor_event = ParticipatingEvent::EventStreamServer(
-                        event_stream_server::Event::DeployExpired(hash),
-                    );
-                    self.dispatch_event(effect_builder, rng, reactor_event)
-                })
-                .flatten()
-                .collect(),
+            ) => {
+                let reactor_event = ParticipatingEvent::EventStreamServer(
+                    event_stream_server::Event::DeploysExpired(hashes),
+                );
+                self.dispatch_event(effect_builder, rng, reactor_event)
+            }
             ParticipatingEvent::LinearChainAnnouncement(
                 LinearChainAnnouncement::NewFinalitySignature(fs),
             ) => {

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1122,16 +1122,16 @@ impl reactor::Reactor for Reactor {
             }
             ParticipatingEvent::BlockProposerAnnouncement(
                 BlockProposerAnnouncement::DeploysExpired(hashes),
-            ) => {
-                let mut effects = Effects::new();
-                for hash in hashes {
+            ) => hashes
+                .into_iter()
+                .map(|hash| {
                     let reactor_event = ParticipatingEvent::EventStreamServer(
                         event_stream_server::Event::DeployExpired(hash),
                     );
-                    effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
-                }
-                effects
-            }
+                    self.dispatch_event(effect_builder, rng, reactor_event)
+                })
+                .flatten()
+                .collect(),
             ParticipatingEvent::LinearChainAnnouncement(
                 LinearChainAnnouncement::NewFinalitySignature(fs),
             ) => {

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -33,6 +33,7 @@ use crate::{
     effect::{announcements::ControlAnnouncement, EffectBuilder, Effects, Responder},
     logging,
     reactor::{EventQueueHandle, QueueKind, ReactorEvent, Scheduler},
+    types::{Deploy, TimeDiff, Timestamp},
 };
 pub(crate) use condition_check_reactor::ConditionCheckReactor;
 pub(crate) use multi_stage_test_reactor::MultiStageTestReactor;
@@ -327,6 +328,35 @@ pub(crate) async fn advance_time(duration: time::Duration) {
     debug!("advanced time by {} secs", duration.as_secs());
 }
 
+/// Creates a test deploy created at given instant and with given ttl.
+pub(crate) fn create_test_deploy(
+    created_ago: TimeDiff,
+    ttl: TimeDiff,
+    now: Timestamp,
+    mut test_rng: &mut TestRng,
+) -> Deploy {
+    Deploy::random_with_timestamp_and_ttl(&mut test_rng, now - created_ago, ttl)
+}
+
+/// Creates a random deploy that is considered expired.
+pub(crate) fn create_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
+    create_test_deploy(
+        TimeDiff::from_seconds(20),
+        TimeDiff::from_seconds(10),
+        now,
+        test_rng,
+    )
+}
+
+/// Creates a random deploy that is considered not expired.
+pub(crate) fn create_not_expired_deploy(now: Timestamp, test_rng: &mut TestRng) -> Deploy {
+    create_test_deploy(
+        TimeDiff::from_seconds(20),
+        TimeDiff::from_seconds(60),
+        now,
+        test_rng,
+    )
+}
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -58,7 +58,7 @@ max_associated_keys = 100
 finality_threshold_fraction = [1, 3]
 # Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
 # therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
-minimum_round_exponent = 12
+minimum_round_exponent = 15
 # Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
 # milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
 # means 2^19 milliseconds, i.e. about 8.7 minutes.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -58,7 +58,7 @@ max_associated_keys = 100
 finality_threshold_fraction = [1, 3]
 # Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
 # therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
-minimum_round_exponent = 15
+minimum_round_exponent = 12
 # Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
 # milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
 # means 2^19 milliseconds, i.e. about 8.7 minutes.

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -116,6 +116,27 @@
       "additionalProperties": false
     },
     {
+      "description": "The given deploy has expired.",
+      "type": "object",
+      "required": [
+        "DeployExpired"
+      ],
+      "properties": {
+        "DeployExpired": {
+          "type": "object",
+          "required": [
+            "deploy_hash"
+          ],
+          "properties": {
+            "deploy_hash": {
+              "$ref": "#/definitions/DeployHash"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Generic representation of validator's fault in an era.",
       "type": "object",
       "required": [


### PR DESCRIPTION
Added new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.

Example:
```
data:{"DeployExpired":{"deploy_hash":"ba2ab9fdf43ed7a40c2a813f505fdb61a16f04a9a866409ac9b7c6d88af7c70e"}}
```

Closes #1980. 