### PR TITLE
Use `MessageKind::StateTransfer` for transferred tries

### DIFF
--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -33,7 +33,7 @@ pub(super) struct NetworkingMetrics {
     /// Count of outgoing messages with block request/response payload.
     pub(super) out_count_block_transfer: IntCounter,
     /// Count of outgoing messages with block request/response payload.
-    pub(super) out_count_state_transfer: IntCounter,
+    pub(super) out_count_trie_transfer: IntCounter,
     /// Count of outgoing messages with other payload.
     pub(super) out_count_other: IntCounter,
 
@@ -50,7 +50,7 @@ pub(super) struct NetworkingMetrics {
     /// Volume in bytes of outgoing messages with block request/response payload.
     pub(super) out_bytes_block_transfer: IntCounter,
     /// Volume in bytes of outgoing messages with block request/response payload.
-    pub(super) out_bytes_state_transfer: IntCounter,
+    pub(super) out_bytes_trie_transfer: IntCounter,
     /// Volume in bytes of outgoing messages with other payload.
     pub(super) out_bytes_other: IntCounter,
 
@@ -109,9 +109,9 @@ impl NetworkingMetrics {
             "net_out_count_block_transfer",
             "count of outgoing messages with block request/response payload",
         )?;
-        let out_count_state_transfer = IntCounter::new(
+        let out_count_trie_transfer = IntCounter::new(
             "net_out_count_block_transfer",
-            "count of outgoing messages with state transfer payload",
+            "count of outgoing messages with trie payloads",
         )?;
         let out_count_other = IntCounter::new(
             "net_out_count_other",
@@ -142,9 +142,9 @@ impl NetworkingMetrics {
             "net_out_bytes_block_transfer",
             "volume in bytes of outgoing messages with block request/response payload",
         )?;
-        let out_bytes_state_transfer = IntCounter::new(
+        let out_bytes_trie_transfer = IntCounter::new(
             "net_out_bytes_block_transfer",
-            "volume in bytes of outgoing messages with state transfer payload",
+            "volume in bytes of outgoing messages with trie payloads",
         )?;
         let out_bytes_other = IntCounter::new(
             "net_out_bytes_other",
@@ -207,7 +207,7 @@ impl NetworkingMetrics {
             out_count_address_gossip,
             out_count_deploy_transfer,
             out_count_block_transfer,
-            out_count_state_transfer,
+            out_count_trie_transfer,
             out_count_other,
             out_bytes_protocol,
             out_bytes_consensus,
@@ -215,7 +215,7 @@ impl NetworkingMetrics {
             out_bytes_address_gossip,
             out_bytes_deploy_transfer,
             out_bytes_block_transfer,
-            out_bytes_state_transfer,
+            out_bytes_trie_transfer,
             out_bytes_other,
             read_futures_in_flight,
             read_futures_total,
@@ -253,9 +253,9 @@ impl NetworkingMetrics {
                     metrics.out_bytes_block_transfer.inc_by(size);
                     metrics.out_count_block_transfer.inc();
                 }
-                MessageKind::StateTransfer => {
-                    metrics.out_bytes_state_transfer.inc_by(size);
-                    metrics.out_count_state_transfer.inc();
+                MessageKind::TrieTransfer => {
+                    metrics.out_bytes_trie_transfer.inc_by(size);
+                    metrics.out_count_trie_transfer.inc();
                 }
                 MessageKind::Other => {
                     metrics.out_bytes_other.inc_by(size);
@@ -282,7 +282,7 @@ impl Drop for NetworkingMetrics {
         unregister_metric!(self.registry, self.out_count_address_gossip);
         unregister_metric!(self.registry, self.out_count_deploy_transfer);
         unregister_metric!(self.registry, self.out_count_block_transfer);
-        unregister_metric!(self.registry, self.out_count_state_transfer);
+        unregister_metric!(self.registry, self.out_count_trie_transfer);
         unregister_metric!(self.registry, self.out_count_other);
         unregister_metric!(self.registry, self.out_bytes_protocol);
         unregister_metric!(self.registry, self.out_bytes_consensus);
@@ -290,7 +290,7 @@ impl Drop for NetworkingMetrics {
         unregister_metric!(self.registry, self.out_bytes_address_gossip);
         unregister_metric!(self.registry, self.out_bytes_deploy_transfer);
         unregister_metric!(self.registry, self.out_bytes_block_transfer);
-        unregister_metric!(self.registry, self.out_bytes_state_transfer);
+        unregister_metric!(self.registry, self.out_bytes_trie_transfer);
         unregister_metric!(self.registry, self.out_bytes_other);
 
         unregister_metric!(self.registry, self.read_futures_in_flight);

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -32,6 +32,8 @@ pub(super) struct NetworkingMetrics {
     pub(super) out_count_deploy_transfer: IntCounter,
     /// Count of outgoing messages with block request/response payload.
     pub(super) out_count_block_transfer: IntCounter,
+    /// Count of outgoing messages with block request/response payload.
+    pub(super) out_count_state_transfer: IntCounter,
     /// Count of outgoing messages with other payload.
     pub(super) out_count_other: IntCounter,
 
@@ -47,6 +49,8 @@ pub(super) struct NetworkingMetrics {
     pub(super) out_bytes_deploy_transfer: IntCounter,
     /// Volume in bytes of outgoing messages with block request/response payload.
     pub(super) out_bytes_block_transfer: IntCounter,
+    /// Volume in bytes of outgoing messages with block request/response payload.
+    pub(super) out_bytes_state_transfer: IntCounter,
     /// Volume in bytes of outgoing messages with other payload.
     pub(super) out_bytes_other: IntCounter,
 
@@ -105,6 +109,10 @@ impl NetworkingMetrics {
             "net_out_count_block_transfer",
             "count of outgoing messages with block request/response payload",
         )?;
+        let out_count_state_transfer = IntCounter::new(
+            "net_out_count_block_transfer",
+            "count of outgoing messages with state transfer payload",
+        )?;
         let out_count_other = IntCounter::new(
             "net_out_count_other",
             "count of outgoing messages with other payload",
@@ -133,6 +141,10 @@ impl NetworkingMetrics {
         let out_bytes_block_transfer = IntCounter::new(
             "net_out_bytes_block_transfer",
             "volume in bytes of outgoing messages with block request/response payload",
+        )?;
+        let out_bytes_state_transfer = IntCounter::new(
+            "net_out_bytes_block_transfer",
+            "volume in bytes of outgoing messages with state transfer payload",
         )?;
         let out_bytes_other = IntCounter::new(
             "net_out_bytes_other",
@@ -195,6 +207,7 @@ impl NetworkingMetrics {
             out_count_address_gossip,
             out_count_deploy_transfer,
             out_count_block_transfer,
+            out_count_state_transfer,
             out_count_other,
             out_bytes_protocol,
             out_bytes_consensus,
@@ -202,6 +215,7 @@ impl NetworkingMetrics {
             out_bytes_address_gossip,
             out_bytes_deploy_transfer,
             out_bytes_block_transfer,
+            out_bytes_state_transfer,
             out_bytes_other,
             read_futures_in_flight,
             read_futures_total,
@@ -239,6 +253,10 @@ impl NetworkingMetrics {
                     metrics.out_bytes_block_transfer.inc_by(size);
                     metrics.out_count_block_transfer.inc();
                 }
+                MessageKind::StateTransfer => {
+                    metrics.out_bytes_state_transfer.inc_by(size);
+                    metrics.out_count_state_transfer.inc();
+                }
                 MessageKind::Other => {
                     metrics.out_bytes_other.inc_by(size);
                     metrics.out_count_other.inc();
@@ -264,6 +282,7 @@ impl Drop for NetworkingMetrics {
         unregister_metric!(self.registry, self.out_count_address_gossip);
         unregister_metric!(self.registry, self.out_count_deploy_transfer);
         unregister_metric!(self.registry, self.out_count_block_transfer);
+        unregister_metric!(self.registry, self.out_count_state_transfer);
         unregister_metric!(self.registry, self.out_count_other);
         unregister_metric!(self.registry, self.out_bytes_protocol);
         unregister_metric!(self.registry, self.out_bytes_consensus);
@@ -271,6 +290,7 @@ impl Drop for NetworkingMetrics {
         unregister_metric!(self.registry, self.out_bytes_address_gossip);
         unregister_metric!(self.registry, self.out_bytes_deploy_transfer);
         unregister_metric!(self.registry, self.out_bytes_block_transfer);
+        unregister_metric!(self.registry, self.out_bytes_state_transfer);
         unregister_metric!(self.registry, self.out_bytes_other);
 
         unregister_metric!(self.registry, self.read_futures_in_flight);

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -146,6 +146,8 @@ pub(crate) enum MessageKind {
     DeployTransfer,
     /// Blocks for finality signatures being transferred directly (via requests and other means).
     BlockTransfer,
+    /// Tries transferred, usually as part of fast syncing.
+    StateTransfer,
     /// Any other kind of payload (or missing classification).
     Other,
 }
@@ -159,6 +161,7 @@ impl Display for MessageKind {
             MessageKind::AddressGossip => f.write_str("address_gossip"),
             MessageKind::DeployTransfer => f.write_str("deploy_transfer"),
             MessageKind::BlockTransfer => f.write_str("block_transfer"),
+            MessageKind::StateTransfer => f.write_str("state_transfer"),
             MessageKind::Other => f.write_str("other"),
         }
     }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -147,7 +147,7 @@ pub(crate) enum MessageKind {
     /// Blocks for finality signatures being transferred directly (via requests and other means).
     BlockTransfer,
     /// Tries transferred, usually as part of fast syncing.
-    StateTransfer,
+    TrieTransfer,
     /// Any other kind of payload (or missing classification).
     Other,
 }
@@ -161,7 +161,7 @@ impl Display for MessageKind {
             MessageKind::AddressGossip => f.write_str("address_gossip"),
             MessageKind::DeployTransfer => f.write_str("deploy_transfer"),
             MessageKind::BlockTransfer => f.write_str("block_transfer"),
-            MessageKind::StateTransfer => f.write_str("state_transfer"),
+            MessageKind::TrieTransfer => f.write_str("trie_transfer"),
             MessageKind::Other => f.write_str("other"),
         }
     }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -64,8 +64,7 @@ impl Payload for Message {
                     Tag::BlockAndMetadataByHeight => MessageKind::BlockTransfer,
                     Tag::BlockHeaderByHash => MessageKind::BlockTransfer,
                     Tag::BlockHeaderAndFinalitySignaturesByHeight => MessageKind::BlockTransfer,
-                    // TODO: This is wrong
-                    Tag::Trie => MessageKind::Other,
+                    Tag::Trie => MessageKind::StateTransfer,
                 }
             }
             Message::FinalitySignature(_) => MessageKind::Consensus,

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -64,7 +64,7 @@ impl Payload for Message {
                     Tag::BlockAndMetadataByHeight => MessageKind::BlockTransfer,
                     Tag::BlockHeaderByHash => MessageKind::BlockTransfer,
                     Tag::BlockHeaderAndFinalitySignaturesByHeight => MessageKind::BlockTransfer,
-                    Tag::Trie => MessageKind::StateTransfer,
+                    Tag::Trie => MessageKind::TrieTransfer,
                 }
             }
             Message::FinalitySignature(_) => MessageKind::Consensus,


### PR DESCRIPTION
This adds a new `MessageKind` variant specifically for transferred tries named `StateTransfer` and adds the "required" metrics.


Closes #1644 