### PR TITLE
Add read_trie JSON-RPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64-serde"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e964e3e0a930303c7c0bdb28ebf691dd98d9eee4b8b68019d2c995710b58a18"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +486,7 @@ dependencies = [
  "backtrace",
  "base16",
  "base64",
+ "base64-serde",
  "bincode",
  "blake2",
  "bytes",

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -64,6 +64,7 @@ pub use self::{
     transfer::{TransferArgs, TransferRuntimeArgsBuilder, TransferTargetMode},
     upgrade::{UpgradeConfig, UpgradeSuccess},
 };
+
 use crate::{
     core::{
         engine_state::{

--- a/execution_engine/src/core/engine_state/query.rs
+++ b/execution_engine/src/core/engine_state/query.rs
@@ -6,6 +6,12 @@ use crate::{
 };
 
 #[derive(Debug)]
+pub enum GetKeysWithPrefixResult {
+    RootNotFound,
+    Success { keys: Vec<Key> },
+}
+
+#[derive(Debug)]
 pub enum QueryResult {
     RootNotFound,
     ValueNotFound(String),

--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -1,5 +1,6 @@
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::Distribution, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::{
@@ -84,7 +85,7 @@ pub(crate) const DEFAULT_HOST_FUNCTION_NEW_DICTIONARY: HostFunction<[Cost; 1]> =
 ///
 /// Total gas cost is equal to `cost` + sum of each argument weight multiplied by the byte size of
 /// the data.
-#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Debug, DataSize)]
+#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Debug, DataSize)]
 pub struct HostFunction<T> {
     /// How much user is charged for cost only
     cost: Cost,
@@ -189,7 +190,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct HostFunctionCosts {
     pub read_value: HostFunction<[Cost; 3]>,
     #[serde(alias = "read_value_local")]

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use datasize::DataSize;
 use pwasm_utils::rules::{InstructionType, Metering, Set};
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes, U32_SERIALIZED_LENGTH};
@@ -29,7 +30,7 @@ const NUM_FIELDS: usize = 17;
 pub const OPCODE_COSTS_SERIALIZED_LENGTH: usize = NUM_FIELDS * U32_SERIALIZED_LENGTH;
 
 // Taken (partially) from parity-ethereum
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct OpcodeCosts {
     /// Bit operations multiplier.
     pub bit: u32,

--- a/execution_engine/src/shared/storage_costs.rs
+++ b/execution_engine/src/shared/storage_costs.rs
@@ -1,5 +1,6 @@
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::{
@@ -9,7 +10,7 @@ use casper_types::{
 
 pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 625_000;
 
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct StorageCosts {
     /// Gas charged per byte stored in the global state.
     gas_per_byte: u32,

--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -5,6 +5,7 @@ pub mod standard_payment_costs;
 
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
@@ -16,7 +17,7 @@ use self::{
 
 pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 10_000;
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct SystemConfig {
     /// Wasmless transfer cost expressed in gas.
     wasmless_transfer_cost: u32,

--- a/execution_engine/src/shared/system_config/auction_costs.rs
+++ b/execution_engine/src/shared/system_config/auction_costs.rs
@@ -1,6 +1,7 @@
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_GET_ERA_VALIDATORS_COST: u32 = 10_000;
@@ -18,7 +19,7 @@ pub const DEFAULT_READ_ERA_ID_COST: u32 = 10_000;
 pub const DEFAULT_ACTIVATE_BID_COST: u32 = 10_000;
 
 /// Description of costs of calling auction entrypoints.
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct AuctionCosts {
     pub get_era_validators: u32,
     pub read_seigniorage_recipients: u32,

--- a/execution_engine/src/shared/system_config/handle_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/handle_payment_costs.rs
@@ -1,6 +1,7 @@
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_GET_PAYMENT_PURSE_COST: u32 = 10_000;
@@ -9,7 +10,7 @@ pub const DEFAULT_GET_REFUND_PURSE_COST: u32 = 10_000;
 pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 
 /// Description of costs of calling handle payment entrypoints.
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct HandlePaymentCosts {
     pub get_payment_purse: u32,
     pub set_refund_purse: u32,

--- a/execution_engine/src/shared/system_config/mint_costs.rs
+++ b/execution_engine/src/shared/system_config/mint_costs.rs
@@ -1,6 +1,7 @@
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_MINT_COST: u32 = 2_500_000_000;
@@ -11,7 +12,7 @@ pub const DEFAULT_TRANSFER_COST: u32 = 10_000;
 pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
 
 /// Description of costs of calling mint entrypoints.
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct MintCosts {
     pub mint: u32,
     pub reduce_total_supply: u32,

--- a/execution_engine/src/shared/system_config/standard_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/standard_payment_costs.rs
@@ -1,12 +1,13 @@
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_PAY_COST: u32 = 10_000;
 
 /// Description of costs of calling standard payment entrypoints.
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct StandardPaymentCosts {
     pub pay: u32,
 }

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -1,5 +1,6 @@
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
@@ -11,7 +12,7 @@ use super::{
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 64 * 1024;
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Debug, DataSize)]
 pub struct WasmConfig {
     /// Maximum amount of a heap memory (represented in 64kb pages) each contract can use.
     pub max_memory: u32,

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -24,7 +24,7 @@ use crate::storage::{
 /// Global state implemented against LMDB as a backing data store.
 pub struct LmdbGlobalState {
     /// Environment for LMDB.
-    pub(crate) environment: Arc<LmdbEnvironment>,
+    pub environment: Arc<LmdbEnvironment>,
     /// Trie store held within LMDB.
     pub(crate) trie_store: Arc<LmdbTrieStore>,
     // TODO: make this a lazy-static
@@ -60,7 +60,7 @@ impl LmdbGlobalState {
 
     /// Creates a state from an existing environment, store, and root_hash.
     /// Intended to be used for testing.
-    pub(crate) fn new(
+    pub fn new(
         environment: Arc<LmdbEnvironment>,
         trie_store: Arc<LmdbTrieStore>,
         empty_root_hash: Blake2bHash,

--- a/execution_engine/src/storage/transaction_source/lmdb.rs
+++ b/execution_engine/src/storage/transaction_source/lmdb.rs
@@ -80,21 +80,31 @@ impl LmdbEnvironment {
     ) -> Result<Self, error::Error> {
         let lmdb_flags = if manual_sync_enabled {
             // These options require that we manually call sync on the environment for the EE.
-            EnvironmentFlags::NO_SUB_DIR
-                | EnvironmentFlags::MAP_ASYNC
+            EnvironmentFlags::MAP_ASYNC
                 | EnvironmentFlags::WRITE_MAP
                 | EnvironmentFlags::NO_META_SYNC
         } else {
-            EnvironmentFlags::NO_SUB_DIR
+            EnvironmentFlags::empty()
         };
+        Self::with_flags(path, map_size, max_readers, lmdb_flags, manual_sync_enabled)
+    }
 
+    /// Constructs an environment with the given LMDB `EnvironmentFlags`.
+    pub fn with_flags<P: AsRef<Path>>(
+        path: P,
+        map_size: usize,
+        max_readers: u32,
+        env_flags: EnvironmentFlags,
+        manual_sync_enabled: bool,
+    ) -> Result<Self, error::Error> {
         let env = Environment::new()
             // Set the flag to manage our own directory like in the storage component.
-            .set_flags(lmdb_flags)
+            .set_flags(EnvironmentFlags::NO_SUB_DIR | env_flags)
             .set_max_dbs(MAX_DBS)
             .set_map_size(map_size)
             .set_max_readers(max_readers)
             .open(&path.as_ref().join(EE_DB_FILENAME))?;
+
         Ok(LmdbEnvironment {
             env,
             manual_sync_enabled,

--- a/execution_engine/src/storage/trie/merkle_proof.rs
+++ b/execution_engine/src/storage/trie/merkle_proof.rs
@@ -2,6 +2,9 @@ use std::collections::VecDeque;
 
 use casper_types::bytesrepr::{self, Bytes, FromBytes, ToBytes};
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use crate::{
     shared::newtypes::Blake2bHash,
     storage::trie::{Pointer, Trie, RADIX},
@@ -11,7 +14,7 @@ const TRIE_MERKLE_PROOF_STEP_NODE_ID: u8 = 0;
 const TRIE_MERKLE_PROOF_STEP_EXTENSION_ID: u8 = 1;
 
 /// A component of a proof that an entry exists in the Merkle trie.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum TrieMerkleProofStep {
     /// Corresponds to [`Trie::Node`]
     Node {
@@ -21,6 +24,7 @@ pub enum TrieMerkleProofStep {
         indexed_pointers_with_hole: Vec<(u8, Pointer)>,
     },
     /// Corresponds to [`Trie::Extension`]
+    #[schemars(with = "String", description = "Hex encoded extension")]
     Extension {
         /// Affix bytes.
         affix: Bytes,
@@ -106,7 +110,7 @@ impl FromBytes for TrieMerkleProofStep {
 
 /// A proof that a node with a specified `key` and `value` is present in the Merkle trie.
 /// Given a state hash `x`, one can validate a proof `p` by checking `x == p.compute_state_hash()`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
 pub struct TrieMerkleProof<K, V> {
     key: K,
     value: V,

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -6,6 +6,7 @@ use std::{
     mem::MaybeUninit,
 };
 
+use schemars::JsonSchema;
 use serde::{
     de::{self, MapAccess, Visitor},
     ser::SerializeMap,
@@ -30,11 +31,13 @@ pub(crate) const RADIX: usize = 256;
 pub type Parents<K, V> = Vec<(u8, Trie<K, V>)>;
 
 /// Represents a pointer to the next object in a Merkle Trie
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
 pub enum Pointer {
     /// Leaf pointer.
+    #[schemars(with = "String", description = "Hex encoded blake2b hash.")]
     LeafPointer(Blake2bHash),
     /// Node pointer.
+    #[schemars(with = "String", description = "Hex encoded blake2b hash.")]
     NodePointer(Blake2bHash),
 }
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -66,6 +66,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add optional in-memory deduplication of deploys, controllable via new `[storage]` config options `[enable_mem_deduplication]` and `[mem_pool_prune_interval]`.
 * Add a new event stream to SSE server accessed via `<IP:Port>/events/deploys` which emits deploys in full as they are accepted.
 * Events now log their ancestors, so detailed tracing of events is possible.
+* Adds `GetKeysWithPrefix` rpc endpoint.
+* Adds `retrieve-state` and `dry-run-deploys` in `utils/`.
 
 ### Changed
 * Major rewrite of the network component, covering connection negotiation and management, periodic housekeeping and logging.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = "0.1.50"
 backtrace = "0.3.50"
 base16 = "0.2.1"
 base64 = "0.13.0"
+base64-serde = "0.6"
 bincode = "1"
 blake2 = { version = "0.9.0", default-features = false }
 bytes = "1.0.1"

--- a/node/src/components/contract_runtime/error.rs
+++ b/node/src/components/contract_runtime/error.rs
@@ -13,7 +13,7 @@ use casper_execution_engine::core::engine_state::GetEraValidatorsError;
 
 /// Error returned from mis-configuring the contract runtime component.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ConfigError {
+pub enum ConfigError {
     /// Error initializing the LMDB environment.
     #[error("failed to initialize LMDB environment for contract runtime: {0}")]
     Lmdb(#[from] StorageLmdbError),
@@ -24,7 +24,7 @@ pub(crate) enum ConfigError {
 
 /// An error raised by a contract runtime variant.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum BlockExecutionError {
+pub enum BlockExecutionError {
     /// Currently the contract runtime can only execute one commit at a time, so we cannot handle
     /// more than one execution result.
     #[error("More than one execution result")]

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -26,7 +26,7 @@ pub(crate) use config::Config;
 pub(crate) use event::Event;
 
 #[derive(Debug, Error)]
-pub(crate) enum Error {
+pub enum Error {
     /// An invalid deploy was received from the client.
     #[error("invalid deploy: {0}")]
     InvalidDeploy(DeployValidationFailure),

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -71,6 +71,8 @@ pub(super) async fn run<REv: ReactorEventT>(
         rpcs::chain::GetEraInfoBySwitchBlock::create_filter(effect_builder, api_version);
     let rpc_get_auction_info =
         rpcs::state::GetAuctionInfo::create_filter(effect_builder, api_version);
+    let rpc_read_trie =
+        rpcs::state::read_trie::ReadTrie::create_filter(effect_builder, api_version);
     let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder, api_version);
     let rpc_get_dictionary_item =
         rpcs::state::GetDictionaryItem::create_filter(effect_builder, api_version);
@@ -107,6 +109,7 @@ pub(super) async fn run<REv: ReactorEventT>(
             .or(rpc_get_era_info)
             .or(rpc_get_auction_info)
             .or(rpc_get_account_info)
+            .or(rpc_read_trie)
             .or(rpc_get_rpcs)
             .or(rpc_get_dictionary_item)
             .or(unknown_method)

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -48,6 +48,7 @@ enum ErrorCode {
     InvalidDeploy = -32008,
     NoSuchAccount = -32009,
     FailedToGetDictionaryURef = -32010,
+    ReadTrie = -32011,
 }
 
 #[derive(Debug)]

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -72,6 +72,7 @@ use std::{
 };
 
 use datasize::DataSize;
+
 use futures::{channel::oneshot, future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use serde::Serialize;
@@ -933,7 +934,10 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Read a trie by its hash key
-    pub(crate) async fn read_trie(self, trie_key: Blake2bHash) -> Option<Trie<Key, StoredValue>>
+    pub(crate) async fn read_trie(
+        self,
+        trie_key: Blake2bHash,
+    ) -> Result<Option<Trie<Key, StoredValue>>, engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -759,7 +759,7 @@ pub(crate) enum ContractRuntimeRequest {
         /// The hash of the value to get from the `TrieStore`
         trie_key: Blake2bHash,
         /// Responder to call with the result.
-        responder: Responder<Option<Trie<Key, StoredValue>>>,
+        responder: Responder<Result<Option<Trie<Key, StoredValue>>, engine_state::Error>>,
     },
     /// Insert a trie into global storage
     PutTrie {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod utils;
 pub mod cli;
 pub mod crypto;
 pub mod types;
-pub use components::rpc_server::rpcs;
+pub use components::{contract_runtime, rpc_server::rpcs};
 
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize},

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -21,10 +21,10 @@ use rand_chacha::ChaCha20Rng;
 
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},
-    Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature,
+    Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature, FinalizedBlock,
     HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
 };
-pub(crate) use block::{BlockByHeight, BlockHeaderWithMetadata, BlockPayload, FinalizedBlock};
+pub(crate) use block::{BlockByHeight, BlockHeaderWithMetadata, BlockPayload};
 pub(crate) use chainspec::ActivationPoint;
 pub use chainspec::Chainspec;
 pub use datasize::DataSize;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1692,7 +1692,7 @@ pub(crate) mod json_compatibility {
 
     #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq, DataSize)]
     #[serde(deny_unknown_fields)]
-    struct JsonEraEnd {
+    pub struct JsonEraEnd {
         era_report: JsonEraReport,
         next_era_validator_weights: Vec<ValidatorWeight>,
     }
@@ -1733,16 +1733,26 @@ pub(crate) mod json_compatibility {
     #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq, DataSize)]
     #[serde(deny_unknown_fields)]
     pub struct JsonBlockHeader {
-        parent_hash: BlockHash,
-        state_root_hash: Digest,
-        body_hash: Digest,
-        random_bit: bool,
-        accumulated_seed: Digest,
-        era_end: Option<JsonEraEnd>,
-        timestamp: Timestamp,
-        era_id: EraId,
-        height: u64,
-        protocol_version: ProtocolVersion,
+        /// The parent hash.
+        pub parent_hash: BlockHash,
+        /// The state root hash.
+        pub state_root_hash: Digest,
+        /// The body hash.
+        pub body_hash: Digest,
+        /// Randomness bit.
+        pub random_bit: bool,
+        /// Accumulated seed.
+        pub accumulated_seed: Digest,
+        /// The era end.
+        pub era_end: Option<JsonEraEnd>,
+        /// The block timestamp.
+        pub timestamp: Timestamp,
+        /// The block era id.
+        pub era_id: EraId,
+        /// The block height.
+        pub height: u64,
+        /// The protocol version.
+        pub protocol_version: ProtocolVersion,
     }
 
     impl From<BlockHeader> for JsonBlockHeader {
@@ -1818,10 +1828,14 @@ pub(crate) mod json_compatibility {
     #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq, DataSize)]
     #[serde(deny_unknown_fields)]
     pub struct JsonBlock {
-        hash: BlockHash,
-        header: JsonBlockHeader,
-        body: JsonBlockBody,
-        proofs: Vec<JsonProof>,
+        /// `BlockHash`
+        pub hash: BlockHash,
+        /// JSON-friendly block header.
+        pub header: JsonBlockHeader,
+        /// JSON-friendly block body.
+        pub body: JsonBlockBody,
+        /// JSON-friendly list of proofs for this block.
+        pub proofs: Vec<JsonProof>,
     }
 
     impl JsonBlock {

--- a/node/src/types/json_compatibility.rs
+++ b/node/src/types/json_compatibility.rs
@@ -5,11 +5,32 @@ mod auction_state;
 mod contracts;
 mod stored_value;
 
+use base64_serde::base64_serde_type;
+use serde::{Deserialize, Serialize};
+
 pub use account::Account;
 pub use auction_state::AuctionState;
 use casper_types::{contracts::NamedKeys, NamedKey};
 pub use contracts::{Contract, ContractPackage};
 pub use stored_value::StoredValue;
+
+base64_serde_type!(Base64Standard, base64::STANDARD);
+
+/// Newtype wrapper for serializing Vec<u8> as base64.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Base64Blob(#[serde(with = "Base64Standard")] Vec<u8>);
+
+impl From<Vec<u8>> for Base64Blob {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Base64Blob> for Vec<u8> {
+    fn from(blob: Base64Blob) -> Self {
+        blob.0
+    }
+}
 
 /// A helper function to change NamedKeys into a Vec<NamedKey>
 pub fn vectorize(keys: &NamedKeys) -> Vec<NamedKey> {

--- a/node/src/types/json_compatibility/account.rs
+++ b/node/src/types/json_compatibility/account.rs
@@ -1,6 +1,8 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
+use std::{collections::BTreeMap, convert::TryFrom};
+
 use datasize::DataSize;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
@@ -8,8 +10,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{rpcs::docs::DocExample, types::json_compatibility::vectorize};
 use casper_types::{
-    account::{Account as ExecutionEngineAccount, AccountHash},
-    NamedKey, PublicKey, SecretKey, URef,
+    account::{
+        Account as ExecutionEngineAccount, AccountHash,
+        ActionThresholds as ExecutionEngineActionThresholds, AssociatedKeys, Weight,
+    },
+    key::FromStrError,
+    Key, NamedKey, PublicKey, SecretKey, URef,
 };
 
 static ACCOUNT: Lazy<Account> = Lazy::new(|| {
@@ -89,5 +95,45 @@ impl From<&ExecutionEngineAccount> for Account {
 impl DocExample for Account {
     fn doc_example() -> &'static Self {
         &*ACCOUNT
+    }
+}
+
+impl TryFrom<Account> for ExecutionEngineAccount {
+    type Error = FromStrError;
+
+    fn try_from(account: Account) -> Result<Self, Self::Error> {
+        let account_hash = account.account_hash;
+        let named_keys = {
+            let mut tmp = BTreeMap::new();
+            for named_key in account.named_keys {
+                let name = named_key.name;
+                let key_str = named_key.key;
+                let key: Key = Key::from_formatted_str(&key_str)?;
+                tmp.insert(name, key);
+            }
+            tmp
+        };
+        let main_purse = account.main_purse;
+        let associated_keys = {
+            let mut tmp = BTreeMap::new();
+            for associated_key in account.associated_keys {
+                let account_hash = associated_key.account_hash;
+                let weight = Weight::new(associated_key.weight);
+                tmp.insert(account_hash, weight);
+            }
+            AssociatedKeys::from(tmp)
+        };
+        let action_thresholds = ExecutionEngineActionThresholds::new(
+            Weight::new(account.action_thresholds.deployment),
+            Weight::new(account.action_thresholds.key_management),
+        )
+        .unwrap(); // TODO
+        Ok(ExecutionEngineAccount::new(
+            account_hash,
+            named_keys,
+            main_purse,
+            associated_keys,
+            action_thresholds,
+        ))
     }
 }

--- a/node/src/types/json_compatibility/contracts.rs
+++ b/node/src/types/json_compatibility/contracts.rs
@@ -1,14 +1,20 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+};
+
 use datasize::DataSize;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::json_compatibility::vectorize;
 use casper_types::{
-    Contract as DomainContract, ContractHash, ContractPackage as DomainContractPackage,
-    ContractPackageHash, ContractWasmHash, EntryPoint, NamedKey, ProtocolVersion, URef,
+    contracts::ContractPackageStatus, key::FromStrError, Contract as DomainContract, ContractHash,
+    ContractPackage as DomainContractPackage, ContractPackageHash, ContractVersionKey,
+    ContractWasmHash, EntryPoint, EntryPoints, Group, Key, NamedKey, ProtocolVersion, URef,
 };
 
 #[derive(
@@ -62,6 +68,38 @@ impl From<&DomainContract> for Contract {
     }
 }
 
+impl TryFrom<Contract> for DomainContract {
+    type Error = FromStrError;
+
+    fn try_from(contract: Contract) -> Result<Self, Self::Error> {
+        let contract_package_hash = contract.contract_package_hash;
+        let contract_wasm_hash = contract.contract_wasm_hash;
+        let named_keys = {
+            let mut tmp = BTreeMap::new();
+            let named_keys_vec = contract.named_keys;
+            for named_key in named_keys_vec {
+                let name = named_key.name;
+                let key_str = named_key.key;
+                let key: Key = Key::from_formatted_str(&key_str)?;
+                tmp.insert(name, key);
+            }
+            tmp
+        };
+        let entry_points = {
+            let entry_points_vec = contract.entry_points;
+            EntryPoints::from(entry_points_vec)
+        };
+        let protocol_version = contract.protocol_version;
+        Ok(DomainContract::new(
+            contract_package_hash,
+            contract_wasm_hash,
+            named_keys,
+            entry_points,
+            protocol_version,
+        ))
+    }
+}
+
 /// Contract definition, metadata, and security container.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, DataSize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -109,5 +147,52 @@ impl From<&DomainContractPackage> for ContractPackage {
             disabled_versions,
             groups,
         }
+    }
+}
+
+impl TryFrom<ContractPackage> for DomainContractPackage {
+    type Error = ();
+
+    fn try_from(contract_package: ContractPackage) -> Result<Self, Self::Error> {
+        let access_key = contract_package.access_key;
+        let versions = {
+            let mut tmp = BTreeMap::new();
+            for version in contract_package.versions {
+                let contract_version_key = ContractVersionKey::new(
+                    version.protocol_version_major,
+                    version.contract_version,
+                );
+                tmp.insert(contract_version_key, version.contract_hash);
+            }
+            tmp
+        };
+        let disabled_versions = {
+            let mut tmp = BTreeSet::new();
+            for disabled_version in contract_package.disabled_versions {
+                let contract_version_key = ContractVersionKey::new(
+                    disabled_version.protocol_version_major,
+                    disabled_version.contract_version,
+                );
+                tmp.insert(contract_version_key);
+            }
+            tmp
+        };
+        let groups = {
+            let mut tmp = BTreeMap::new();
+            for group in contract_package.groups {
+                let domain_group = Group::new(group.group);
+                let keys: BTreeSet<URef> = group.keys.into_iter().collect();
+                tmp.insert(domain_group, keys);
+            }
+            tmp
+        };
+        let lock_status = ContractPackageStatus::default(); // TODO
+        Ok(DomainContractPackage::new(
+            access_key,
+            versions,
+            disabled_versions,
+            groups,
+            lock_status,
+        ))
     }
 }

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -4,7 +4,7 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -12,10 +12,11 @@ use serde::{Deserialize, Serialize};
 use casper_types::{
     bytesrepr::{self, ToBytes},
     system::auction::{Bid, EraInfo, UnbondingPurse},
-    CLValue, DeployInfo, StoredValue as ExecutionEngineStoredValue, Transfer,
+    CLValue, ContractWasm, DeployInfo, StoredValue as ExecutionEngineStoredValue, Transfer,
 };
 
 use super::{Account, Contract, ContractPackage};
+use casper_types::bytesrepr::Bytes;
 
 /// Representation of a value stored in global state.
 ///
@@ -46,33 +47,115 @@ pub enum StoredValue {
     Withdraw(Vec<UnbondingPurse>),
 }
 
-impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
+impl TryFrom<ExecutionEngineStoredValue> for StoredValue {
     type Error = bytesrepr::Error;
 
-    fn try_from(ee_stored_value: &ExecutionEngineStoredValue) -> Result<Self, Self::Error> {
+    fn try_from(ee_stored_value: ExecutionEngineStoredValue) -> Result<Self, Self::Error> {
         let stored_value = match ee_stored_value {
-            ExecutionEngineStoredValue::CLValue(cl_value) => StoredValue::CLValue(cl_value.clone()),
-            ExecutionEngineStoredValue::Account(account) => StoredValue::Account(account.into()),
+            ExecutionEngineStoredValue::CLValue(cl_value) => StoredValue::CLValue(cl_value),
+            ExecutionEngineStoredValue::Account(account) => StoredValue::Account((&account).into()),
             ExecutionEngineStoredValue::ContractWasm(contract_wasm) => {
-                StoredValue::ContractWasm(hex::encode(&contract_wasm.to_bytes()?))
+                StoredValue::ContractWasm(hex::encode(contract_wasm.to_bytes()?))
             }
             ExecutionEngineStoredValue::Contract(contract) => {
-                StoredValue::Contract(contract.into())
+                StoredValue::Contract((&contract).into())
             }
             ExecutionEngineStoredValue::ContractPackage(contract_package) => {
-                StoredValue::ContractPackage(contract_package.into())
+                StoredValue::ContractPackage((&contract_package).into())
             }
-            ExecutionEngineStoredValue::Transfer(transfer) => StoredValue::Transfer(*transfer),
+            ExecutionEngineStoredValue::Transfer(transfer) => StoredValue::Transfer(transfer),
             ExecutionEngineStoredValue::DeployInfo(deploy_info) => {
-                StoredValue::DeployInfo(deploy_info.clone())
+                StoredValue::DeployInfo(deploy_info)
             }
-            ExecutionEngineStoredValue::EraInfo(era_info) => StoredValue::EraInfo(era_info.clone()),
-            ExecutionEngineStoredValue::Bid(bid) => StoredValue::Bid(bid.clone()),
+            ExecutionEngineStoredValue::EraInfo(era_info) => StoredValue::EraInfo(era_info),
+            ExecutionEngineStoredValue::Bid(bid) => StoredValue::Bid(bid),
             ExecutionEngineStoredValue::Withdraw(unbonding_purses) => {
-                StoredValue::Withdraw(unbonding_purses.clone())
+                StoredValue::Withdraw(unbonding_purses)
             }
         };
 
         Ok(stored_value)
+    }
+}
+
+impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
+    type Error = bytesrepr::Error;
+
+    fn try_from(ee_stored_value: &ExecutionEngineStoredValue) -> Result<Self, Self::Error> {
+        ee_stored_value.clone().try_into()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoredValueConvertError {
+    #[error("error converting from CLValue to ExecutionEngineStoredValue")]
+    CLValueInto,
+    #[error("error converting from hex string({0}) to ExecutionEngineStoredValue")]
+    HexDecode(hex::FromHexError),
+    #[error("error converting from bytesrepr to ExecutionEngineStoredValue")]
+    BytesRepr,
+    #[error("error converting from contract to ExecutionEngineStoredValue")]
+    ContractInto,
+    #[error("error converting from contract package to ExecutionEngineStoredValue")]
+    ContractPackageInto,
+}
+
+impl TryFrom<StoredValue> for ExecutionEngineStoredValue {
+    type Error = StoredValueConvertError;
+
+    fn try_from(value: StoredValue) -> Result<Self, Self::Error> {
+        match value {
+            StoredValue::CLValue(cl_value) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::CLValue(cl_value))
+            }
+            StoredValue::Account(json_account) => {
+                let account = json_account
+                    .try_into()
+                    .map_err(|_err| StoredValueConvertError::CLValueInto)?;
+                Ok(ExecutionEngineStoredValue::Account(account))
+            }
+            StoredValue::ContractWasm(hex_bytes) => {
+                let bytes = hex::decode(hex_bytes).map_err(StoredValueConvertError::HexDecode)?;
+                let bytes_vec: Bytes = bytesrepr::deserialize(bytes)
+                    .map_err(|_err| StoredValueConvertError::BytesRepr)?;
+                let contract_wasm = ContractWasm::new(bytes_vec.to_vec());
+                Ok(ExecutionEngineStoredValue::ContractWasm(contract_wasm))
+            }
+            StoredValue::Contract(json_contract) => {
+                let contract = json_contract
+                    .try_into()
+                    .map_err(|_err| StoredValueConvertError::ContractInto)?;
+                Ok(ExecutionEngineStoredValue::Contract(contract))
+            }
+            StoredValue::ContractPackage(json_contract_package) => {
+                let contract_package = json_contract_package
+                    .try_into()
+                    .map_err(|_err| StoredValueConvertError::ContractPackageInto)?;
+                Ok(ExecutionEngineStoredValue::ContractPackage(
+                    contract_package,
+                ))
+            }
+            StoredValue::Transfer(transfer) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::Transfer(transfer))
+            }
+            StoredValue::DeployInfo(deploy_info) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::DeployInfo(deploy_info))
+            }
+            StoredValue::EraInfo(era_info) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::EraInfo(era_info))
+            }
+            StoredValue::Bid(bid) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::Bid(bid))
+            }
+            StoredValue::Withdraw(withdraws) => {
+                // No conversion necessary
+                Ok(ExecutionEngineStoredValue::Withdraw(withdraws))
+            }
+        }
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -1,3 +1,5 @@
+//! TODO
+
 use alloc::{
     format,
     string::{String, ToString},
@@ -122,19 +124,32 @@ pub enum Key {
     SystemContractRegistry,
 }
 
+/// TODO
 #[derive(Debug)]
 pub enum FromStrError {
+    /// TODO
     Account(account::FromStrError),
+    /// TODO
     Hash(String),
+    /// TODO
     URef(uref::FromStrError),
+    /// TODO
     Transfer(TransferFromStrError),
+    /// TODO
     DeployInfo(String),
+    /// TODO
     EraInfo(String),
+    /// TODO
     Balance(String),
+    /// TODO
     Bid(String),
+    /// TODO
     Withdraw(String),
+    /// TODO
     Dictionary(String),
+    /// TODO
     SystemContractRegistry(String),
+    /// TODO
     UnknownPrefix,
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -38,7 +38,7 @@ mod gas;
 #[cfg(any(feature = "gens", test))]
 pub mod gens;
 mod json_pretty_printer;
-mod key;
+pub mod key;
 mod motes;
 mod named_key;
 mod phase;


### PR DESCRIPTION
Resolves part of #1993 (1/2)

The purpose of this PR is to:

- Add a JSON-RPC endpoint to read a trie as a base64 encoded blob (for backward compatibility).

