### PR TITLE
Sufficient Signatures

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -384,7 +384,7 @@ impl ItemFetcher<BlockHeaderWithMetadata> for Fetcher<BlockHeaderWithMetadata> {
         peer: NodeId,
     ) -> Effects<Event<BlockHeaderWithMetadata>> {
         effect_builder
-            .get_block_header_at_height_with_metadata_from_storage(id)
+            .get_block_header_and_sufficient_finality_signatures_by_height_from_storage(id)
             .event(move |result| Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -351,7 +351,7 @@ impl ItemFetcher<BlockWithMetadata> for Fetcher<BlockWithMetadata> {
         peer: NodeId,
     ) -> Effects<Event<BlockWithMetadata>> {
         effect_builder
-            .get_block_at_height_with_metadata_from_storage(id)
+            .get_block_and_sufficient_finality_signatures_by_height_from_storage(id)
             .event(move |result| Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -8,8 +8,6 @@ use futures::FutureExt;
 use tempfile::TempDir;
 use thiserror::Error;
 
-use casper_types::ProtocolVersion;
-
 use super::*;
 use crate::{
     components::{deploy_acceptor, in_memory_network::NetworkController, storage},
@@ -75,10 +73,9 @@ reactor!(Reactor {
         network = infallible InMemoryNetwork::<Message>(event_queue, rng);
         storage = Storage(
             &WithDir::new(cfg.temp_dir.path(), cfg.storage_config),
+            chainspec_loader.chainspec().clone(),
             chainspec_loader.hard_reset_to_start_of_era(),
-            ProtocolVersion::from_parts(1, 0, 0),
             false,
-            "test"
         );
         deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec());
         deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Display, Formatter},
     iter,
+    sync::Arc,
 };
 
 use derive_more::From;
@@ -180,10 +181,9 @@ impl reactor::Reactor for Reactor {
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
         let storage = Storage::new(
             &storage_withdir,
+            Arc::new(Chainspec::from_resources("local")),
             None,
-            ProtocolVersion::from_parts(1, 0, 0),
             false,
-            "test",
         )
         .unwrap();
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1030,7 +1030,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the requested block and its associated metadata.
+    /// Gets the requested block and its finality signatures.
     pub(crate) async fn get_block_at_height_with_metadata_from_storage(
         self,
         block_height: u64,
@@ -1040,6 +1040,24 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHeight {
+                block_height,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Get a block and sufficient finality signatures from storage.
+    pub(crate) async fn get_block_and_sufficient_finality_signatures_by_height_from_storage(
+        self,
+        block_height: u64,
+    ) -> Option<BlockWithMetadata>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
                 block_height,
                 responder,
             },

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1067,8 +1067,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the requested block and its associated metadata.
-    #[allow(dead_code)]
-    pub(crate) async fn get_block_header_at_height_with_metadata_from_storage(
+    pub(crate) async fn get_block_header_and_sufficient_finality_signatures_by_height_from_storage(
         self,
         block_height: u64,
     ) -> Option<BlockHeaderWithMetadata>
@@ -1076,7 +1075,7 @@ impl<REv> EffectBuilder<REv> {
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::GetBlockHeaderAndMetadataByHeight {
+            |responder| StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
                 block_height,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -265,8 +265,8 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
-    /// Retrieve block header with metadata by height.
-    GetBlockHeaderAndMetadataByHeight {
+    /// Retrieve block header with sufficient finality signatures by height.
+    GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
         /// Height of block to get header of.
         block_height: u64,
         /// Responder to call with the result.  Returns `None` if the block header doesn't exist in
@@ -439,7 +439,10 @@ impl Display for StorageRequest {
             StorageRequest::GetFinalizedDeploys { ttl, .. } => {
                 write!(formatter, "get finalized deploys, ttl: {:?}", ttl)
             }
-            StorageRequest::GetBlockHeaderAndMetadataByHeight { block_height, .. } => {
+            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
+                block_height,
+                ..
+            } => {
                 write!(
                     formatter,
                     "get block and metadata for block by height: {}",

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -273,6 +273,14 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeaderWithMetadata>>,
     },
+    /// Retrieves a block header with sufficient finality signatures by height.
+    GetBlockAndSufficientFinalitySignaturesByHeight {
+        /// Height of block to get header of.
+        block_height: u64,
+        /// Responder to call with the result.  Returns `None` if the block header doesn't exist or
+        /// does not have sufficient finality signatures by height.
+        responder: Responder<Option<BlockWithMetadata>>,
+    },
     /// Retrieve all transfers in a block with given hash.
     GetBlockTransfers {
         /// Hash of block to get transfers of.
@@ -440,6 +448,16 @@ impl Display for StorageRequest {
             }
             StorageRequest::PutBlockHeader { block_header, .. } => {
                 write!(formatter, "put block header: {}", block_header)
+            }
+            StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
+                block_height,
+                ..
+            } => {
+                write!(
+                    formatter,
+                    "get block and sufficient finality signatures by height: {}",
+                    block_height
+                )
             }
         }
     }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -200,10 +200,9 @@ impl Reactor {
         let storage_config = config.map_ref(|cfg| cfg.storage.clone());
         let storage = Storage::new(
             &storage_config,
+            chainspec_loader.chainspec().clone(),
             hard_reset_to_start_of_era,
-            chainspec_loader.chainspec().protocol_config.version,
             crashed,
-            &chainspec_loader.chainspec().network_config.name,
         )?;
 
         let contract_runtime = ContractRuntime::new(

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -420,13 +420,8 @@ impl Reactor {
             }
             Tag::BlockAndMetadataByHeight => {
                 Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_height| {
-                    let chainspec = self.chainspec_loader.chainspec();
                     self.storage
-                        .read_block_and_sufficient_finality_signatures_by_height(
-                            block_height,
-                            chainspec.highway_config.finality_threshold_fraction,
-                            chainspec.protocol_config.last_emergency_restart,
-                        )
+                        .read_block_and_sufficient_finality_signatures_by_height(block_height)
                 })
             }
             Tag::GossipedAddress => {
@@ -440,12 +435,9 @@ impl Reactor {
             }
             Tag::BlockHeaderAndFinalitySignaturesByHeight => {
                 Self::respond_to_fetch(effect_builder, serialized_id, sender, |block_height| {
-                    let chainspec = self.chainspec_loader.chainspec();
                     self.storage
                         .read_block_header_and_sufficient_finality_signatures_by_height(
                             block_height,
-                            chainspec.highway_config.finality_threshold_fraction,
-                            chainspec.protocol_config.last_emergency_restart,
                         )
                 })
             }


### PR DESCRIPTION
Ensure that when we fetch blocks or block headers by height, we make sure we have a sufficient amount of finality signatures for consensus when checking local storage.

Closes #1997