### PR TITLE
GH-2015: Adds histogram for block execution.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Added `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
+* Added `contract_runtime_execute_block` histogram tracking execution time of a whole block.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -137,6 +137,7 @@ pub(crate) struct ContractRuntimeMetrics {
     put_trie: Histogram,
     read_trie: Histogram,
     chain_height: IntGauge,
+    exec_block: Histogram,
 }
 
 /// Value of upper bound of histogram.
@@ -176,6 +177,8 @@ const PUT_TRIE_NAME: &str = "contract_runtime_put_trie";
 const PUT_TRIE_HELP: &str = "tracking run of engine_state.put_trie in seconds.";
 const MISSING_TRIE_KEYS_NAME: &str = "contract_runtime_missing_trie_keys";
 const MISSING_TRIE_KEYS_HELP: &str = "tracking run of engine_state.missing_trie_keys in seconds.";
+const EXEC_BLOCK_NAME: &str = "contract_runtime_execute_block";
+const EXEC_BLOCK_HELP: &str = "tracking execution of all deploys in a block.";
 
 /// Create prometheus Histogram and register.
 fn register_histogram_metric(
@@ -233,6 +236,7 @@ impl ContractRuntimeMetrics {
                 MISSING_TRIE_KEYS_NAME,
                 MISSING_TRIE_KEYS_HELP,
             )?,
+            exec_block: register_histogram_metric(registry, EXEC_BLOCK_NAME, EXEC_BLOCK_HELP)?,
         })
     }
 }

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -86,7 +86,7 @@ pub(super) fn execute_finalized_block(
 
     // Flush once, after all deploys have been executed.
     engine_state.flush_environment()?;
-    
+
     metrics.exec_block.observe(start.elapsed().as_secs_f64());
 
     // If the finalized block has an era report, run the auction contract and get the upcoming era

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -57,6 +57,7 @@ pub(super) fn execute_finalized_block(
         HashMap::new();
     // Run any deploys that must be executed
     let block_time = finalized_block.timestamp().millis();
+    let start = Instant::now();
     for deploy in deploys {
         let deploy_hash = *deploy.id();
         let deploy_header = deploy.header().clone();
@@ -82,6 +83,7 @@ pub(super) fn execute_finalized_block(
         execution_results.insert(deploy_hash, (deploy_header, execution_result));
         state_root_hash = state_hash;
     }
+    metrics.exec_block.observe(start.elapsed().as_secs_f64());
 
     // Flush once, after all deploys have been executed.
     engine_state.flush_environment()?;

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -83,10 +83,11 @@ pub(super) fn execute_finalized_block(
         execution_results.insert(deploy_hash, (deploy_header, execution_result));
         state_root_hash = state_hash;
     }
-    metrics.exec_block.observe(start.elapsed().as_secs_f64());
 
     // Flush once, after all deploys have been executed.
     engine_state.flush_environment()?;
+    
+    metrics.exec_block.observe(start.elapsed().as_secs_f64());
 
     // If the finalized block has an era report, run the auction contract and get the upcoming era
     // validators


### PR DESCRIPTION
Currently, we're only measuring execution of exec/commit of a single deploy. This PR adds a new histogram that measures the execution of a whole block.

Closes https://github.com/casper-network/casper-node/issues/2015