### PR TITLE
NCTL: Post-test health checks

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -42,8 +42,14 @@ function main() {
     do_await_era_change "3"
     # 11. Assert node didn't propose since being unbonded
     assert_no_proposal_walkback '6' "$AFTER_EVICTION_HASH"
-    # 12. Check for equivocators
-    assert_no_equivocators_logs
+    # 12. Run Health Checks
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario bonding complete"

--- a/utils/nctl/sh/scenarios/common/health_checks.sh
+++ b/utils/nctl/sh/scenarios/common/health_checks.sh
@@ -41,11 +41,6 @@ function assert_error_count() {
     local COUNT
     local TOTAL
 
-    if [ "$ERRORS_ALLOWED" = "ignore" ]; then
-        log_step "Error count ignored by test, continuing..."
-        return 0
-    fi
-
     log_step "Looking for errors in logs..."
 
     TOTAL='0'
@@ -54,6 +49,11 @@ function assert_error_count() {
         TOTAL=$((TOTAL + COUNT))
         log "... node-$i: ERROR COUNT = $COUNT"
     done
+
+    if [ "$ERRORS_ALLOWED" = "ignore" ]; then
+        log "Error count ignored by test, skipping $TOTAL errors..."
+        return 0
+    fi
 
     if [ "$ERRORS_ALLOWED" != "$TOTAL" ]; then
         log "ERROR: ALLOWED: $ERRORS_ALLOWED != TOTAL: $TOTAL"
@@ -71,25 +71,41 @@ function assert_error_count() {
 #              the total allowed by the test. If
 #              EQUIVS_ALLOWED is set to ignore, it will
 #              return 0.
+#
+# NOTE: Since equivocations are global we divide the total
+#       by the number of nodes it's found on. This is
+#       so we don't confuse ourselves when we expect
+#       1 but each node has the message and thus the
+#       TOTAL would print 5.
 ##########################################################
 
 function assert_equivocator_count() {
     local COUNT
     local TOTAL
-
-    if [ "$EQUIVS_ALLOWED" = "ignore" ]; then
-        log_step "Equivocator count ignored by test, continuing..."
-        return 0
-    fi
+    local GLOBAL_DIVIDER
 
     log_step "Looking for equivocators in logs..."
 
     TOTAL='0'
+    GLOBAL_DIVIDER='0'
     for i in $(seq 1 "$(get_count_of_nodes)"); do
         COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w 'validator equivocated' | wc -l)
+        if [ "$COUNT" != "0" ]; then
+            GLOBAL_DIVIDER=$((GLOBAL_DIVIDER + 1))
+        fi
+
         TOTAL=$((TOTAL + COUNT))
         log "... node-$i: EQUIV COUNT = $COUNT"
     done
+
+    if [ "$GLOBAL_DIVIDER" != "0" ]; then
+        TOTAL=$((TOTAL / GLOBAL_DIVIDER))
+    fi
+
+    if [ "$EQUIVS_ALLOWED" = "ignore" ]; then
+        log "Equivocator count ignored by test, skipping $TOTAL equivocations..."
+        return 0
+    fi
 
     if [ "$EQUIVS_ALLOWED" != "$TOTAL" ]; then
         log "ERROR: ALLOWED: $EQUIVS_ALLOWED != TOTAL: $TOTAL"
@@ -113,11 +129,6 @@ function assert_crash_count() {
     local COUNT
     local TOTAL
 
-    if [ "$CRASH_ALLOWED" = "ignore" ]; then
-        log_step "Crash count ignored by test, continuing..."
-        return 0
-    fi
-
     log_step "Looking for crashes in logs..."
 
     TOTAL='0'
@@ -126,6 +137,11 @@ function assert_crash_count() {
         TOTAL=$((TOTAL + COUNT))
         log "... node-$i: CRASH COUNT = $COUNT"
     done
+
+    if [ "$CRASH_ALLOWED" = "ignore" ]; then
+        log "Crash count ignored by test, skipping $TOTAL crashes..."
+        return 0
+    fi
 
     if [ "$CRASH_ALLOWED" != "$TOTAL" ]; then
         log "ERROR: ALLOWED: $CRASH_ALLOWED != TOTAL: $TOTAL"
@@ -149,11 +165,6 @@ function assert_restart_count() {
     local COUNT
     local TOTAL
 
-    if [ "$RESTARTS_ALLOWED" = "ignore" ]; then
-        log_step "Restart count ignored by test, continuing..."
-        return 0
-    fi
-
     log_step "Looking for restarts in logs..."
 
     TOTAL='0'
@@ -166,6 +177,11 @@ function assert_restart_count() {
         TOTAL=$((TOTAL + COUNT))
         log "... node-$i: RESTART COUNT = $COUNT"
     done
+
+    if [ "$RESTARTS_ALLOWED" = "ignore" ]; then
+        log "Restart count ignored by test, skipping $TOTAL restarts..."
+        return 0
+    fi
 
     if [ "$RESTARTS_ALLOWED" != "$TOTAL" ]; then
         log "ERROR: ALLOWED: $RESTARTS_ALLOWED != TOTAL: $TOTAL"
@@ -189,11 +205,6 @@ function assert_doppel_count() {
     local COUNT
     local TOTAL
 
-    if [ "$DOPPEL_ALLOWED" = "ignore" ]; then
-        log_step "Doppelganger count ignored by test, continuing..."
-        return 0
-    fi
-
     log_step "Looking for doppels in logs..."
 
     TOTAL='0'
@@ -202,6 +213,11 @@ function assert_doppel_count() {
         TOTAL=$((TOTAL + COUNT))
         log "... node-$i: DOPPEL COUNT = $COUNT"
     done
+
+    if [ "$DOPPEL_ALLOWED" = "ignore" ]; then
+        log "Doppelganger count ignored by test, skipping $TOTAL doppelgangers..."
+        return 0
+    fi
 
     if [ "$DOPPEL_ALLOWED" != "$TOTAL" ]; then
         log "ERROR: ALLOWED: $DOPPEL_ALLOWED != TOTAL: $TOTAL"
@@ -232,11 +248,6 @@ function assert_eject_count() {
     local TOTAL
     local GLOBAL_DIVIDER
 
-    if [ "$EJECTS_ALLOWED" = "ignore" ]; then
-        log_step "Ejection count ignored by test, continuing..."
-        return 0
-    fi
-
     log_step "Looking for ejections in logs..."
 
     TOTAL='0'
@@ -259,6 +270,11 @@ function assert_eject_count() {
 
     if [ "$GLOBAL_DIVIDER" != "0" ]; then
         TOTAL=$((TOTAL / GLOBAL_DIVIDER))
+    fi
+
+    if [ "$EJECTS_ALLOWED" = "ignore" ]; then
+        log "Ejection count ignored by test, skipping $TOTAL ejections..."
+        return 0
     fi
 
     if [ "$EJECTS_ALLOWED" != "$TOTAL" ]; then

--- a/utils/nctl/sh/scenarios/common/health_checks.sh
+++ b/utils/nctl/sh/scenarios/common/health_checks.sh
@@ -30,7 +30,7 @@ function main() {
 # Function: assert_error_count
 # Uses: Variable ERRORS_ALLOWED
 # Description: Searches the log files counting instances
-#              of equivocators. Compares count against
+#              of errors. Compares count against
 #              the total allowed by the test. If
 #              ERRORS_ALLOWED is set to ignore, it will
 #              return 0.

--- a/utils/nctl/sh/scenarios/common/health_checks.sh
+++ b/utils/nctl/sh/scenarios/common/health_checks.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+function main() {
+    log "------------------------------------------------------------"
+    log "Starting health checks..."
+    log "------------------------------------------------------------"
+
+    log "... Stopping nodes to freeze logs"
+    nctl-stop
+
+    # Check allowed vs found counts
+    assert_error_count
+    assert_equivocator_count
+    assert_restart_count
+    assert_crash_count
+    assert_eject_count
+    assert_doppel_count
+
+    log "------------------------------------------------------------"
+    log "Health checks complete"
+    log "------------------------------------------------------------"
+}
+
+##########################################################
+# Function: assert_error_count
+# Uses: Variable ERRORS_ALLOWED
+# Description: Searches the log files counting instances
+#              of equivocators. Compares count against
+#              the total allowed by the test. If
+#              ERRORS_ALLOWED is set to ignore, it will
+#              return 0.
+#
+##########################################################
+
+function assert_error_count() {
+    local COUNT
+    local TOTAL
+
+    if [ "$ERRORS_ALLOWED" = "ignore" ]; then
+        log_step "Error count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for errors in logs..."
+
+    TOTAL='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w '"level":"ERROR"' | wc -l)
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: ERROR COUNT = $COUNT"
+    done
+
+    if [ "$ERRORS_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $ERRORS_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $ERRORS_ALLOWED = TOTAL: $TOTAL"
+} 
+
+##########################################################
+# Function: assert_equivocator_count
+# Uses: Variable EQUIVS_ALLOWED
+# Description: Searches the log files counting instances
+#              of equivocators. Compares count against
+#              the total allowed by the test. If
+#              EQUIVS_ALLOWED is set to ignore, it will
+#              return 0.
+##########################################################
+
+function assert_equivocator_count() {
+    local COUNT
+    local TOTAL
+
+    if [ "$EQUIVS_ALLOWED" = "ignore" ]; then
+        log_step "Equivocator count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for equivocators in logs..."
+
+    TOTAL='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w 'validator equivocated' | wc -l)
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: EQUIV COUNT = $COUNT"
+    done
+
+    if [ "$EQUIVS_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $EQUIVS_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $EQUIVS_ALLOWED = TOTAL: $TOTAL"
+}
+
+##########################################################
+# Function: assert_crash_count
+# Uses: Variable CRASH_ALLOWED
+# Description: Searches the log files counting instances
+#              of crash messages. Compares count against
+#              the total allowed by the test. If
+#              CRASH_ALLOWED is set to ignore, it will
+#              return 0.
+##########################################################
+
+function assert_crash_count() {
+    local COUNT
+    local TOTAL
+
+    if [ "$CRASH_ALLOWED" = "ignore" ]; then
+        log_step "Crash count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for crashes in logs..."
+
+    TOTAL='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w 'previous node instance seems to have crashed' | wc -l)
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: CRASH COUNT = $COUNT"
+    done
+
+    if [ "$CRASH_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $CRASH_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $CRASH_ALLOWED = TOTAL: $TOTAL"
+}
+
+##########################################################
+# Function: assert_restart_count
+# Uses: Variable RESTARTS_ALLOWED
+# Description: Searches the log files counting instances
+#              of start ups. Compares count against
+#              the total allowed by the test. If
+#              RESTARTS_ALLOWED is set to ignore, it will
+#              return 0.
+##########################################################
+
+function assert_restart_count() {
+    local COUNT
+    local TOTAL
+
+    if [ "$RESTARTS_ALLOWED" = "ignore" ]; then
+        log_step "Restart count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for restarts in logs..."
+
+    TOTAL='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w 'node starting up' | wc -l)
+        if [ "$COUNT" != "0" ]; then
+            # Minus 1 for inital start
+            COUNT=$((COUNT - 1))
+        fi
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: RESTART COUNT = $COUNT"
+    done
+
+    if [ "$RESTARTS_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $RESTARTS_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $RESTARTS_ALLOWED = TOTAL: $TOTAL"
+}
+
+##########################################################
+# Function: assert_doppel_count
+# Uses: Variable DOPPEL_ALLOWED
+# Description: Searches the log files counting instances
+#              of doppelgangers. Compares count against
+#              the total allowed by the test. If
+#              DOPPEL_ALLOWED is set to ignore, it will
+#              return 0.
+##########################################################
+
+function assert_doppel_count() {
+    local COUNT
+    local TOTAL
+
+    if [ "$DOPPEL_ALLOWED" = "ignore" ]; then
+        log_step "Doppelganger count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for doppels in logs..."
+
+    TOTAL='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null | grep -w "received vertex from a doppelganger" | grep 'SignedWireUnit' | wc -l)
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: DOPPEL COUNT = $COUNT"
+    done
+
+    if [ "$DOPPEL_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $DOPPEL_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $DOPPEL_ALLOWED = TOTAL: $TOTAL"
+}
+
+##########################################################
+# Function: assert_eject_count
+# Uses: Variable EJECTS_ALLOWED
+# Description: Searches the log files counting instances
+#              of ejections. Compares count against
+#              the total allowed by the test. If
+#              EJECTS_ALLOWED is set to ignore, it will
+#              return 0.
+#
+# NOTE: Since ejections are global we divide the total
+#       by the number of nodes it's found on. This is
+#       so we don't confuse ourselves when we expect
+#       1 but each node has the message and thus the
+#       TOTAL would print 5. 
+##########################################################
+
+function assert_eject_count() {
+    local COUNT
+    local TOTAL
+    local GLOBAL_DIVIDER
+
+    if [ "$EJECTS_ALLOWED" = "ignore" ]; then
+        log_step "Ejection count ignored by test, continuing..."
+        return 0
+    fi
+
+    log_step "Looking for ejections in logs..."
+
+    TOTAL='0'
+    GLOBAL_DIVIDER='0'
+    for i in $(seq 1 "$(get_count_of_nodes)"); do
+        COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null \
+                | jq '.fields.finalized_block | select( . != null )' \
+                | grep 'EraReport' \
+                | grep -o 'inactive_validators: \[PublicKey.*\})' \
+                | uniq \
+                | sed  's/,/\n/g' \
+                | wc -l)
+        if [ "$COUNT" != "0" ]; then
+            GLOBAL_DIVIDER=$((GLOBAL_DIVIDER + 1))
+        fi
+
+        TOTAL=$((TOTAL + COUNT))
+        log "... node-$i: EJECT COUNT = $COUNT"
+    done
+
+    if [ "$GLOBAL_DIVIDER" != "0" ]; then
+        TOTAL=$((TOTAL / GLOBAL_DIVIDER))
+    fi
+
+    if [ "$EJECTS_ALLOWED" != "$TOTAL" ]; then
+        log "ERROR: ALLOWED: $EJECTS_ALLOWED != TOTAL: $TOTAL"
+        exit 1
+    fi
+
+    log "SUCCESS: ALLOWED: $EJECTS_ALLOWED = TOTAL: $TOTAL (divided due to global)"
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset ERRORS_ALLOWED
+unset EQUIVS_ALLOWED
+unset DOPPEL_ALLOWED
+unset CRASH_ALLOWED
+unset RESTARTS_ALLOWED
+unset EJECTS_ALLOWED
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        errors) ERRORS_ALLOWED=${VALUE} ;;
+        equivocators) EQUIVS_ALLOWED=${VALUE} ;;
+        doppels) DOPPEL_ALLOWED=${VALUE} ;;
+        crashes) CRASH_ALLOWED=${VALUE} ;;
+        restarts) RESTARTS_ALLOWED=${VALUE} ;;
+        ejections) EJECTS_ALLOWED=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+ERRORS_ALLOWED=${ERRORS_ALLOWED:-"0"}
+EQUIVS_ALLOWED=${EQUIVS_ALLOWED:-"0"}
+DOPPEL_ALLOWED=${DOPPEL_ALLOWED:-"0"}
+CRASH_ALLOWED=${CRASH_ALLOWED:-"0"}
+RESTARTS_ALLOWED=${RESTARTS_ALLOWED:-"0"}
+EJECTS_ALLOWED=${EJECTS_ALLOWED:-"0"}
+
+main

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -66,6 +66,16 @@ function do_start_node() {
     local NODE_ID=${1}
     local LFB_HASH=${2}
     log_step "starting node-$NODE_ID. Syncing from hash=${LFB_HASH}"
+
+    # Deleting the pid due to crash that gets logged
+    if [ -f "$(get_path_to_node_storage $NODE_ID)/initializer.pid" ]; then
+        log "... pid file detected, removing (<= 1.3)"
+        rm -f "$(get_path_to_node_storage $NODE_ID)/initializer.pid"
+    elif [ -f "$(get_path_to_node_storage $NODE_ID)/casper-net-1/initializer.pid" ]; then
+        log "... pid file detected, removing (1.4+)"
+        rm -f "$(get_path_to_node_storage $NODE_ID)/casper-net-1/initializer.pid"
+    fi
+
     do_node_start "$NODE_ID" "$LFB_HASH"
     sleep 1
     if [ "$(do_node_status ${NODE_ID} | awk '{ print $2 }')" != "RUNNING" ]; then

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -45,6 +45,17 @@ function main() {
     do_send_transfers
     # 10. Wait until they're all included in the chain.
     do_await_deploy_inclusion
+    # 11. Run Health Checks
+    # ... restarts=15: due to node being stopped and started
+    # ... crashes=5: expected in an emergency restart scenario?
+    # ... errors=ignore: ticket sre issue 77
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='ignore' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=5 \
+            restarts=15 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Emergency upgrade test ends"

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
@@ -67,6 +67,17 @@ function main() {
         exit 1
     fi
 
+    # 7. Run Closing Health Checks
+    # ... restarts=10: due to nodes being stopped and started
+    # ... crashes=5: expected in an emergency restart scenario?
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=5 \
+            restarts=10 \
+            ejections=0
+
     log "------------------------------------------------------------"
     log "Emergency upgrade test ends"
     log "------------------------------------------------------------"

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -56,8 +56,15 @@ function main() {
     assert_chain_progressed "4" "$STALLED_LFB"
     assert_chain_progressed "3" "$STALLED_LFB"
     assert_chain_progressed "2" "$STALLED_LFB"
-    # 18. Check for Equivocators
-    assert_no_equivocators_logs
+    # 18. Run Health Checks
+    # ... restarts=4: due to nodes being stopped and started
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='0' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=4 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario gov96 complete"

--- a/utils/nctl/sh/scenarios/itst01.sh
+++ b/utils/nctl/sh/scenarios/itst01.sh
@@ -39,8 +39,15 @@ function main() {
     check_network_sync
     do_await_era_change
     check_network_sync
-    # 9. Check for Equivocators
-    assert_no_equivocators_logs
+    # 9. Run Closing Health Checks
+    # ... restarts=1: due to node being stopped and started
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=1 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario itst01 complete"

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -45,8 +45,15 @@ function main() {
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"
     assert_chain_progressed "3" "$STALLED_LFB"
-    # 16. Check for Equivocators
-    assert_no_equivocators_logs
+    # 16. Run Health Checks
+    # ... restarts=3: due to nodes being stopped and restarted
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=3 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario itst02 complete"

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -37,8 +37,16 @@ function main() {
     do_await_n_blocks '30'
     # 8. Walkback and verify transfers were included in blocks
     check_transfer_inclusion '1' '1000'
-    # 9. Check for equivocators
-    assert_no_equivocators_logs
+    # 10. Run Health Checks
+    # ... errors=ignore: ticket sre issue 71
+    # ... restarts=1: due to node being stopped and started
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='ignore' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=1 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario itst06 complete"

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -36,8 +36,16 @@ function main() {
     do_await_n_blocks '30'
     # 8. Walkback and verify transfers were included in blocks
     check_wasm_inclusion '1' '1000'
-    # 9. Check for equivocators
-    assert_no_equivocators_logs
+    # 9. Run Health Checks
+    # ... restarts=1: due to node being stopped and started
+    # ... errors=ignore: ticket sre issue 79
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='ignore' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=1 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario itst07 complete"

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -31,6 +31,18 @@ function main() {
     do_start_node "6" "$LFB_HASH"
     # 6. Look for one of the two nodes to report as faulty
     assert_equivication "5" "6"
+    # 7. Run Health Checks
+    # ... errors=1: due to doppels being logged at ERROR level
+    # ... doppels=ignore: doppelganger purposely created in this test
+    # ... equivocators=ignore: doppelganger can cause an equivocation
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=1 \
+            equivocators='ignore' \
+            doppels='ignore' \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
+
     log "------------------------------------------------------------"
     log "Scenario itst11 complete"
     log "------------------------------------------------------------"

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -62,8 +62,18 @@ function main() {
     do_await_era_change '3'
     # 15. Assert that restarted validator is producing blocks.
     assert_node_proposed '5' '300'
-    # 16. Check for equivocators
-    assert_no_equivocators_logs
+    # 16. Run Health Checks
+    # ... errors=ignore: ticket sre issue 72
+    # ... restarts=1: due to node being stopped and started
+    # ... ejections=1: node is expected to be ejected in test
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='ignore' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=1 \
+            ejections=1
+
     log "------------------------------------------------------------"
     log "Scenario itst13 complete"
     log "------------------------------------------------------------"

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -45,8 +45,15 @@ function main() {
     do_await_era_change
     # 11. Verify all nodes are in sync
     check_network_sync
-    # 12. Check for equivication
-    assert_no_equivocation "5" "1" "100"
+    # 12. Run Health Checks
+    # ... restarts=1: due to node being stopped and started
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=1 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Scenario itst14 complete"

--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -42,8 +42,14 @@ function main() {
     # 10. Verify that its last finalized block matches other nodes'.
     # nctl-view-chain-root-hash
     do_await_full_synchronization "$NEW_NODE_ID"
-    # 11. Check for equivocators
-    assert_no_equivocators_logs
+    # 11. Run Closing Health Checks
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Syncing node complete"

--- a/utils/nctl/sh/scenarios/sync_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/sync_upgrade_test.sh
@@ -50,8 +50,16 @@ function main() {
     # 11. Wait until it's synchronized
     #     and verify that its last finalized block matches other nodes'.
     do_await_full_synchronization "$NEW_NODE_ID"
-    # 12. Check for equivocators
-    assert_no_equivocators_logs
+    # 12. Run Closing Health Checks
+    # ... restarts=6: due to nodes being stopped and started
+    # ... errors=ignore: ticket sre issue 78
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='ignore' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=6 \
+            ejections=0
 
     log "------------------------------------------------------------"
     log "Syncing node complete"


### PR DESCRIPTION
### Changes:
- Adds `health_checks.sh` to the end of each scenario run in the nightly tests.
- `health_checks.sh` checks the following and compares against allowed values. (Ignorable in case of variable counts or issues.)
    - equivocators
    - crashes
    - restarts
    - doppels
    - errors
    - ejections
- Adjusts `do_start_node` in `itst.sh` to delete pid files. This is due to stopping and starting nodes in NCTL falsely raising a crash in the logs.

### Ticket:
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/42

### Related:
**Some checks are set to ignore currently due to some unexpected errors in logs while working on this. I ticketed them for follow-up. (Note: I've yet to look at these, just captured to not forget.)**

- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/71
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/72
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/77
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/78
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/79