### PR TITLE
Don't request latest Highway protocol state in old eras.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -244,7 +244,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
         -> ProtocolOutcomes<I, C>;
 
     /// Current instance of consensus protocol is latest era.
-    fn handle_is_current(&self) -> ProtocolOutcomes<I, C>;
+    fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<I, C>;
 
     /// Triggers consensus' timer.
     fn handle_timer(&mut self, timestamp: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<I, C>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -460,6 +460,7 @@ where
         activation_era_validators: BTreeMap<PublicKey, U512>,
     ) -> HashMap<EraId, ProtocolOutcomes<I, ClContext>> {
         let mut result_map = HashMap::new();
+        let now = Timestamp::now();
 
         for era_id in self.iter_past(self.current_era, self.bonded_eras().saturating_mul(2)) {
             let new_faulty;
@@ -518,7 +519,7 @@ where
 
             let results = self.new_era(
                 era_id,
-                Timestamp::now(),
+                now,
                 validators,
                 new_faulty,
                 faulty,
@@ -537,7 +538,7 @@ where
         }
         let active_era_outcomes = self.active_eras[&self.current_era]
             .consensus
-            .handle_is_current();
+            .handle_is_current(now);
         result_map
             .entry(self.current_era)
             .or_default()
@@ -913,10 +914,11 @@ where
             .chain(&new_faulty)
             .cloned()
             .collect();
+        let now = Timestamp::now(); // TODO: This should be passed in.
         #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
         let mut outcomes = self.era_supervisor.new_era(
             era_id,
-            Timestamp::now(), // TODO: This should be passed in.
+            now,
             next_era_validators_weights.clone(),
             new_faulty,
             faulty,
@@ -928,7 +930,7 @@ where
         outcomes.extend(
             self.era_supervisor.active_eras[&era_id]
                 .consensus
-                .handle_is_current(),
+                .handle_is_current(now),
         );
         self.handle_consensus_outcomes(era_id, outcomes)
     }

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -387,7 +387,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     .flatten()
                     .find(|(vv, _)| vv.inner().id() == transitive_dependency)
                 {
-                    info!(
+                    debug!(
                         dependency = ?transitive_dependency, %sender,
                         "adding sender as a source for proposal"
                     );
@@ -409,7 +409,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     continue;
                 }
                 // Otherwise request the missing dependency from the sender.
-                info!(dependency = ?transitive_dependency, %sender, "requesting dependency");
+                debug!(dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let ser_msg = HighwayMessage::RequestDependency(transitive_dependency).serialize();
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));
                 continue;

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -101,7 +101,7 @@ where
     // * standstill alert timer,
     // * latest state request timer
     // If there are more, the tests might need to handle them.
-    assert_eq!(5, outcomes.len());
+    assert_eq!(4, outcomes.len());
     hw_proto
 }
 

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -83,10 +83,10 @@ impl Timestamp {
 
 impl Display for Timestamp {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let system_time = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_millis(self.0))
-            .expect("should be within system time limits");
-        write!(f, "{}", humantime::format_rfc3339_millis(system_time))
+        match SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(self.0)) {
+            Some(system_time) => write!(f, "{}", humantime::format_rfc3339_millis(system_time)),
+            None => write!(f, "invalid Timestamp: {} ms after the Unix epoch", self.0),
+        }
     }
 }
 


### PR DESCRIPTION
Fully synchronizing the state of all recent eras is wasteful in practice: Most of it won't be relevant anymore and we should use our bandwidth to synchronize the current era instead.
This changes the state request timer so that it's only initialized in `handle_is_current`, i.e. only in the current era.

Also contains minor improvements to logging.

This should improve #2022.