### PR TITLE
Add assert-json-diff to event_stream_server schema test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +471,7 @@ version = "1.0.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
+ "assert-json-diff",
  "async-trait",
  "backtrace",
  "base16",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -102,6 +102,7 @@ wheelbuf = "0.2.0"
 vergen = "3"
 
 [dev-dependencies]
+assert-json-diff = "2.0.1"
 fake_instant = "0.4.0"
 pnet = "0.28.0"
 pretty_assertions = "0.7.2"

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -9,11 +9,13 @@ use std::{
     time::Duration,
 };
 
+use assert_json_diff::assert_json_eq;
 use futures::{join, StreamExt};
 use http::StatusCode;
 use pretty_assertions::assert_eq;
 use reqwest::Response;
 use schemars::schema_for;
+use serde_json::Value;
 use tempfile::TempDir;
 use tokio::{
     sync::{Barrier, Notify},
@@ -1172,8 +1174,8 @@ fn schema() {
     );
     let expected_schema = fs::read_to_string(schema_path).unwrap();
     let schema = schema_for!(SseData);
-    assert_eq!(
-        serde_json::to_string_pretty(&schema).unwrap(),
-        expected_schema.trim()
-    );
+    let actual_schema = serde_json::to_string_pretty(&schema).unwrap();
+    let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+    let expected_schema: Value = serde_json::from_str(expected_schema.trim()).unwrap();
+    assert_json_eq!(actual_schema, expected_schema);
 }


### PR DESCRIPTION
This PR is a quality of life improvement for the `event_stream_server` schema test - it brings in a crate which highlights the exact differences between JSON objects, vs comparing large and often hard-to-read json strings.
