### PR TITLE
Apply doc-string to `from_public_key`

### DIFF
--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -63,7 +63,7 @@ impl AccountHash {
         Ok(AccountHash(bytes))
     }
 
-    #[doc(hidden)]
+    /// Parses a `public_key` and outputs the corresponding account hash.
     pub fn from_public_key(
         public_key: &PublicKey,
         blake2b_hash_fn: impl Fn(Vec<u8>) -> [u8; BLAKE2B_DIGEST_LENGTH],

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -63,7 +63,7 @@ impl AccountHash {
         Ok(AccountHash(bytes))
     }
 
-    /// Parses a `public_key` and outputs the corresponding account hash.
+    /// Parses a `PublicKey` and outputs the corresponding account hash.
     pub fn from_public_key(
         public_key: &PublicKey,
         blake2b_hash_fn: impl Fn(Vec<u8>) -> [u8; BLAKE2B_DIGEST_LENGTH],


### PR DESCRIPTION
CHANGELOG:

- Added a missing doc string to the `from_public_key` function in `account_hash.rs` 