### PR TITLE
Improve tracking in Consensus component. Unify log messages.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1110,7 +1110,9 @@ where
                     era.start_height + relative_height,
                     proposer,
                 );
-                info!(?finalized_block, "finalized block");
+                info!(era_id=?finalized_block.era_id(),
+                        height=?finalized_block.height(),
+                        timestamp=?finalized_block.timestamp(), "finalized block");
                 self.era_supervisor
                     .metrics
                     .finalized_block(&finalized_block);

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -126,6 +126,11 @@ impl<C: Context> Vertex<C> {
             _ => None,
         }
     }
+
+    /// Returns true whether unit is a proposal.
+    pub(crate) fn is_proposal(&self) -> bool {
+        self.value().is_some()
+    }
 }
 
 #[derive(Clone, DataSize, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -427,7 +427,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                 }
                 // Otherwise request the missing dependency from the sender.
                 let uuid = thread_rng().next_u64();
-                trace!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
+                debug!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let ser_msg =
                     HighwayMessage::RequestDependency(uuid, transitive_dependency).serialize();
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -542,7 +542,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     fn remove_expired<T: Ord + Clone>(
         map: &mut BTreeMap<T, PendingVertices<I, C>>,
         oldest: Timestamp,
-    )-> Vec<C::Hash> {
+    ) -> Vec<C::Hash> {
         let mut expired = vec![];
         for pvs in map.values_mut() {
             expired.extend(pvs.remove_expired(oldest));

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -346,7 +346,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Pops and returns the next entry from `vertices_to_be_added` that is not yet in the protocol
     /// state. Also returns a `ProtocolOutcome` that schedules the next action to add a vertex,
     /// unless the queue is empty, and `ProtocolOutcome`s to request missing dependencies.
-    pub(crate) fn pop_vertex_to_add<'a>(
+    pub(crate) fn pop_vertex_to_add(
         &mut self,
         highway: &Highway<C>,
         pending_values: &HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, I)>>,

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -7,7 +7,7 @@ use std::{
 use datasize::DataSize;
 use itertools::Itertools;
 use rand::{thread_rng, RngCore};
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use crate::{
     components::consensus::{
@@ -210,16 +210,16 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     pub(crate) fn purge_vertices(&mut self, oldest: Timestamp) {
         info!("purging synchronizer queues");
         let no_deps_expired = self.vertices_no_deps.remove_expired(oldest);
-        debug!(?no_deps_expired, "expired no dependencies");
+        trace!(?no_deps_expired, "expired no dependencies");
         self.requests_sent.clear();
         let to_be_added_later_expired =
             Self::remove_expired(&mut self.vertices_to_be_added_later, oldest);
-        debug!(
+        trace!(
             ?to_be_added_later_expired,
             "expired to be added later dependencies"
         );
         let awaiting_deps_expired = Self::remove_expired(&mut self.vertices_awaiting_deps, oldest);
-        debug!(?awaiting_deps_expired, "expired awaiting dependencies");
+        trace!(?awaiting_deps_expired, "expired awaiting dependencies");
     }
 
     // Returns number of elements in the `vertices_to_be_added_later` queue.
@@ -427,7 +427,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                 }
                 // Otherwise request the missing dependency from the sender.
                 let uuid = thread_rng().next_u64();
-                debug!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
+                trace!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let ser_msg =
                     HighwayMessage::RequestDependency(uuid, transitive_dependency).serialize();
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -6,6 +6,7 @@ use std::{
 
 use datasize::DataSize;
 use itertools::Itertools;
+use rand::{thread_rng, RngCore};
 use tracing::{debug, info};
 
 use crate::{
@@ -329,7 +330,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Pops and returns the next entry from `vertices_to_be_added` that is not yet in the protocol
     /// state. Also returns a `ProtocolOutcome` that schedules the next action to add a vertex,
     /// unless the queue is empty, and `ProtocolOutcome`s to request missing dependencies.
-    pub(crate) fn pop_vertex_to_add(
+    pub(crate) fn pop_vertex_to_add<'a>(
         &mut self,
         highway: &Highway<C>,
         pending_values: &HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, I)>>,
@@ -409,8 +410,10 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
                     continue;
                 }
                 // Otherwise request the missing dependency from the sender.
-                debug!(dependency = ?transitive_dependency, %sender, "requesting dependency");
-                let ser_msg = HighwayMessage::RequestDependency(transitive_dependency).serialize();
+                let uuid = thread_rng().next_u64();
+                debug!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
+                let ser_msg =
+                    HighwayMessage::RequestDependency(uuid, transitive_dependency).serialize();
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));
                 continue;
             }

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -70,11 +70,7 @@ fn purge_vertices() {
     let (maybe_pv, outcomes) =
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(maybe_pv.is_none());
-    assert_targeted_message(
-        &unwrap_single(outcomes),
-        &peer0,
-        HighwayMessage::RequestDependency(Dependency::Unit(c0)),
-    );
+    assert_targeted_message(&unwrap_single(outcomes), &peer0, Dependency::Unit(c0));
 
     // At 0x23, c0 gets enqueued and added.
     // That puts c1 back into the main queue, since its dependency is satisfied.
@@ -167,11 +163,7 @@ fn do_not_download_synchronized_dependencies() {
     let (pv, outcomes) =
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(pv.is_none());
-    assert_targeted_message(
-        &unwrap_single(outcomes),
-        &peer0,
-        HighwayMessage::RequestDependency(Dependency::Unit(c1)),
-    );
+    assert_targeted_message(&unwrap_single(outcomes), &peer0, Dependency::Unit(c1));
     // Simulate `c1` being downloaded…
     let c1_outcomes = sync.schedule_add_vertex(peer0, pvv(c1), now);
     assert!(matches!(
@@ -184,11 +176,7 @@ fn do_not_download_synchronized_dependencies() {
     let (pv, outcomes) =
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(pv.is_none());
-    assert_targeted_message(
-        &unwrap_single(outcomes),
-        &peer0,
-        HighwayMessage::RequestDependency(Dependency::Unit(c0)),
-    );
+    assert_targeted_message(&unwrap_single(outcomes), &peer0, Dependency::Unit(c0));
     // `c1` is now part of the synchronizer's state, we should not try requesting it if other
     // vertices depend on it.
     assert!(matches!(
@@ -201,11 +189,7 @@ fn do_not_download_synchronized_dependencies() {
     // `b0` depends on `c1`, that is already in the synchronizer's state, but it also depends on
     // `c0` transitively that is not yet known. We should request it, even if we had already
     // done that for `c1`.
-    assert_targeted_message(
-        &unwrap_single(outcomes),
-        &peer1,
-        HighwayMessage::RequestDependency(Dependency::Unit(c0)),
-    );
+    assert_targeted_message(&unwrap_single(outcomes), &peer1, Dependency::Unit(c0));
     // "Download" the last dependency.
     let _ = sync.schedule_add_vertex(peer0, pvv(c0), now);
     // Now, the whole chain can be added to the protocol state.
@@ -283,11 +267,7 @@ fn transitive_proposal_dependency() {
     let (pv, outcomes) =
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(pv.is_none());
-    assert_targeted_message(
-        &unwrap_single(outcomes),
-        &peer0,
-        HighwayMessage::RequestDependency(Dependency::Unit(a0)),
-    );
+    assert_targeted_message(&unwrap_single(outcomes), &peer0, Dependency::Unit(a0));
 
     // "Download" and schedule addition of a0.
     let a0_outcomes = sync.schedule_add_vertex(peer0, pvv(a0), now);
@@ -344,11 +324,14 @@ fn transitive_proposal_dependency() {
                 vec![&peer0, &peer1],
                 vec![p0, p1].into_iter().sorted().collect_vec()
             );
-            assert_eq!(msg0, msg1);
-            assert_eq!(
-                HighwayMessage::RequestDependency::<TestContext>(Dependency::Unit(c0)),
-                bincode::deserialize(msg0.as_slice()).expect("deserialization to pass")
-            );
+            let msg: HighwayMessage<TestContext> =
+                bincode::deserialize(msg0.as_slice()).expect("deserialization to pass");
+            match msg {
+                HighwayMessage::RequestDependency::<TestContext>(_, dep) => {
+                    assert_eq!(dep, Dependency::Unit(c0))
+                }
+                other => panic!("unexpected HighwayMessage variant {:?}", other),
+            }
         }
         outcomes => panic!("unexpected outcomes: {:?}", outcomes),
     }
@@ -367,14 +350,17 @@ fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {
 fn assert_targeted_message(
     outcome: &ProtocolOutcome<NodeId, TestContext>,
     peer: &NodeId,
-    expected: HighwayMessage<TestContext>,
+    expected: Dependency<TestContext>,
 ) {
     match outcome {
         ProtocolOutcome::CreatedTargetedMessage(msg, peer0) => {
             assert_eq!(peer, peer0);
             let highway_message: HighwayMessage<TestContext> =
                 bincode::deserialize(msg.as_slice()).expect("deserialization to pass");
-            assert_eq!(highway_message, expected);
+            match highway_message {
+                HighwayMessage::RequestDependency(_, got) => assert_eq!(got, expected),
+                other => panic!("unexpected variant: {:?}", other),
+            }
         }
         _ => panic!("unexpected outcome: {:?}", outcome),
     }

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -318,7 +318,7 @@ fn transitive_proposal_dependency() {
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(maybe_pv.is_none());
     match &*outcomes {
-        [ProtocolOutcome::CreatedTargetedMessage(msg0, p0), ProtocolOutcome::CreatedTargetedMessage(msg1, p1)] =>
+        [ProtocolOutcome::CreatedTargetedMessage(msg0, p0), ProtocolOutcome::CreatedTargetedMessage(_msg1, p1)] =>
         {
             assert_eq!(
                 vec![&peer0, &peer1],

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -568,7 +568,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 let hash = swu.hash();
 
                 if vertex.is_proposal() {
-                    trace!(
+                    info!(
                         ?hash,
                         ?creator,
                         creator_index = wire_unit.creator.0,


### PR DESCRIPTION
For better observability of synchronization process, we're adding a random number (UUID) to `RequestDependency` messages and log (at TRACE level) on creation (sending node) and reception (receiving node).

Also, we're not consistent w.r.t. to keywords we use for certain data types in the log messages. In some places we use dep while others dependency, unit vs hash, we don't log enough information about units to simplify debugging, etc. All of this is useful when we have to read through logs. This is also being addressed in this PR.


Closes https://github.com/casper-network/casper-node/issues/2051 and https://github.com/casper-network/casper-node/issues/2052
