### PR TITLE
update cargo-casper to provide erc20 project

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,8 +28,8 @@ steps:
     image: casperlabs/node-build-u1804
     commands:
       - cargo install cargo-audit
-      - cargo generate-lockfile
-      - cargo audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
+#      - cargo generate-lockfile
+#      - cargo audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
 
 trigger:
   branch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ name = "cargo-casper"
 version = "1.3.2"
 dependencies = [
  "assert_cmd",
- "clap",
+ "clap 3.0.0-beta.4",
  "colour",
  "once_cell",
  "tempfile",
@@ -678,7 +678,7 @@ dependencies = [
  "casper-node",
  "casper-types",
  "cbindgen",
- "clap",
+ "clap 2.33.3",
  "futures",
  "hex",
  "humantime",
@@ -735,7 +735,7 @@ dependencies = [
  "casper-engine-test-support",
  "casper-execution-engine",
  "casper-types",
- "clap",
+ "clap 2.33.3",
  "criterion",
  "crossbeam-channel 0.5.1",
  "dictionary",
@@ -950,7 +950,7 @@ name = "casper-updater"
 version = "0.3.0"
 dependencies = [
  "casper-types",
- "clap",
+ "clap 2.33.3",
  "once_cell",
  "regex",
 ]
@@ -970,7 +970,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97449daf9b8c245bcad10bbc7c9f4a37c06172c18dd5f9fac340deefc309b957"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "heck",
  "indexmap",
  "log 0.4.14",
@@ -1046,10 +1046,41 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags 1.2.1",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
+dependencies = [
+ "atty",
+ "bitflags 1.2.1",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1206,7 +1237,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools 0.10.1",
@@ -2413,7 +2444,7 @@ dependencies = [
  "casper-engine-test-support",
  "casper-execution-engine",
  "casper-types",
- "clap",
+ "clap 2.33.3",
 ]
 
 [[package]]
@@ -3836,6 +3867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,12 +5283,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -5417,6 +5460,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
+	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2021-0097 --ignore RUSTSEC-2021-0098
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)

--- a/ci/casper_updater/src/package.rs
+++ b/ci/casper_updater/src/package.rs
@@ -77,7 +77,9 @@ impl Package {
         relative_path: P,
         dependent_files: &'static Vec<DependentFile>,
     ) -> Self {
-        Self::new::<_, AssemblyScriptPackage>(relative_path, dependent_files)
+        let mut package = Self::new::<_, AssemblyScriptPackage>(relative_path, dependent_files);
+        package.name = format!("{} (AssemblyScript)", package.name);
+        package
     }
 
     fn new<P: AsRef<Path>, T: PackageConsts>(

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -234,7 +234,7 @@ pub mod execution_engine_testing_test_support {
     pub static DEPENDENT_FILES: Lazy<Vec<DependentFile>> = Lazy::new(|| {
         vec![
                 DependentFile::new(
-                    "execution_engine_testing/cargo_casper/src/tests_package.rs",
+                    "execution_engine_testing/cargo_casper/src/common.rs",
                     Regex::new(r#"(?m)("casper-engine-test-support",\s*)"(?:[^"]+)"#).unwrap(),
                     cargo_casper_src_test_package_rs_replacement,
                 ),

--- a/execution_engine_testing/cargo_casper/CHANGELOG.md
+++ b/execution_engine_testing/cargo_casper/CHANGELOG.md
@@ -11,10 +11,29 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## [Unreleased]
+
+### Added
+* Add support for generating an ERC-20 contract.
+
+
+
+## [1.3.2] - 2021-08-02
+
+No changes.
+
+
+
+## [1.3.1] - 2021-07-26
+
+No changes.
+
+
+
 ## [1.3.0] - 2021-07-19
 
 ### Changed
-* Update pinned version of Rust to `nightly-2021-06-17`
+* Update pinned version of Rust to `nightly-2021-06-17`.
 
 
 
@@ -51,6 +70,9 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.2...dev
+[1.3.2]: https://github.com/casper-network/casper-node/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-casper"
 version = "1.3.2"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
-description = "Command line tool for creating a Wasm smart contract and tests for use on the Casper network."
+description = "A command line tool for creating a Wasm smart contract and tests for use on the Casper network."
 readme = "README.md"
 documentation = "https://docs.rs/cargo-casper"
 homepage = "https://casper.network"
@@ -13,14 +13,15 @@ include = [
     "src/*.rs",
     "Cargo.lock",
     "Cargo.toml",
+    "resources/*"
 ]
 
 [dependencies]
-clap = "2"
+clap = "3.0.0-beta.4"
 colour = "0.6"
-once_cell = "1.5.2"
+once_cell = "1"
 
 [dev-dependencies]
 assert_cmd = "1"
 tempfile = "3"
-toml = "0.5.7"
+toml = "0.5.8"

--- a/execution_engine_testing/cargo_casper/resources/erc20/Makefile.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/Makefile.in
@@ -1,0 +1,28 @@
+prepare:
+	rustup target add wasm32-unknown-unknown
+
+build-erc20:
+	cd erc20_token && cargo build --release --target wasm32-unknown-unknown
+	wasm-strip erc20_token/target/wasm32-unknown-unknown/release/erc20_token.wasm 2>/dev/null | true
+
+test: build-erc20
+	mkdir -p tests/wasm
+	cp erc20_token/target/wasm32-unknown-unknown/release/erc20_token.wasm tests/wasm
+	cd tests && cargo test
+
+clippy:
+	cd erc20_token && cargo clippy --all-targets -- -D warnings
+	cd tests && cargo clippy --all-targets -- -D warnings
+
+check-lint: clippy
+	cd erc20_token && cargo fmt -- --check
+	cd tests && cargo fmt -- --check
+
+lint: clippy
+	cd erc20_token && cargo fmt
+	cd tests && cargo fmt
+
+clean:
+	cd erc20_token && cargo clean
+	cd tests && cargo clean
+	rm -rf tests/wasm

--- a/execution_engine_testing/cargo_casper/resources/erc20/integration_tests.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/integration_tests.rs.in
@@ -1,0 +1,189 @@
+#[cfg(test)]
+mod test_fixture;
+
+#[cfg(test)]
+mod tests {
+    use casper_types::{Key, U256};
+
+    use crate::test_fixture::{Sender, TestFixture};
+
+    #[test]
+    fn should_install() {
+        let fixture = TestFixture::install_contract();
+        assert_eq!(fixture.token_name(), TestFixture::TOKEN_NAME);
+        assert_eq!(fixture.token_symbol(), TestFixture::TOKEN_SYMBOL);
+        assert_eq!(fixture.token_decimals(), TestFixture::TOKEN_DECIMALS);
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply())
+        );
+    }
+
+    #[test]
+    fn should_transfer() {
+        let mut fixture = TestFixture::install_contract();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply())
+        );
+        let transfer_amount_1 = U256::from(42);
+        fixture.transfer(
+            Key::from(fixture.bob),
+            transfer_amount_1,
+            Sender(fixture.ali),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(transfer_amount_1)
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply() - transfer_amount_1)
+        );
+
+        let transfer_amount_2 = U256::from(20);
+        fixture.transfer(
+            Key::from(fixture.ali),
+            transfer_amount_2,
+            Sender(fixture.bob),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply() - transfer_amount_1 + transfer_amount_2),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(transfer_amount_1 - transfer_amount_2)
+        );
+    }
+
+    #[test]
+    fn should_transfer_full_amount() {
+        let mut fixture = TestFixture::install_contract();
+
+        let initial_ali_balance = fixture.balance_of(Key::from(fixture.ali)).unwrap();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+
+        fixture.transfer(
+            Key::from(fixture.bob),
+            initial_ali_balance,
+            Sender(fixture.ali),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(initial_ali_balance)
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(U256::zero())
+        );
+
+        fixture.transfer(
+            Key::from(fixture.ali),
+            initial_ali_balance,
+            Sender(fixture.bob),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(U256::zero())
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(initial_ali_balance)
+        );
+    }
+
+    #[should_panic(expected = "ApiError::User(65534) [131070]")]
+    #[test]
+    fn should_not_transfer_with_insufficient_balance() {
+        let mut fixture = TestFixture::install_contract();
+
+        let initial_ali_balance = fixture.balance_of(Key::from(fixture.ali)).unwrap();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+
+        fixture.transfer(
+            Key::from(fixture.bob),
+            initial_ali_balance + U256::one(),
+            Sender(fixture.ali),
+        );
+    }
+
+    #[test]
+    fn should_transfer_from() {
+        let approve_amount = U256::from(100);
+        let transfer_amount = U256::from(42);
+        assert!(approve_amount > transfer_amount);
+
+        let mut fixture = TestFixture::install_contract();
+
+        let owner = fixture.ali;
+        let spender = fixture.bob;
+        let recipient = fixture.joe;
+
+        let owner_balance_before = fixture
+            .balance_of(Key::from(owner))
+            .expect("owner should have balance");
+        fixture.approve(Key::from(spender), approve_amount, Sender(owner));
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount)
+        );
+
+        fixture.transfer_from(
+            Key::from(owner),
+            Key::from(recipient),
+            transfer_amount,
+            Sender(spender),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(owner)),
+            Some(owner_balance_before - transfer_amount),
+            "should decrease balance of the owner"
+        );
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount - transfer_amount),
+            "should decrease allowance of the spender"
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(recipient)),
+            Some(transfer_amount),
+            "recipient should receive tokens"
+        );
+    }
+
+    #[should_panic(expected = "ApiError::User(65533) [131069]")]
+    #[test]
+    fn should_not_transfer_from_more_than_approved() {
+        let approve_amount = U256::from(100);
+        let transfer_amount = U256::from(42);
+        assert!(approve_amount > transfer_amount);
+
+        let mut fixture = TestFixture::install_contract();
+
+        let owner = fixture.ali;
+        let spender = fixture.bob;
+        let recipient = fixture.joe;
+
+        fixture.approve(Key::from(spender), approve_amount, Sender(owner));
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount)
+        );
+
+        fixture.transfer_from(
+            Key::from(owner),
+            Key::from(recipient),
+            approve_amount + U256::one(),
+            Sender(spender),
+        );
+    }
+}
+
+fn main() {
+    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
+}

--- a/execution_engine_testing/cargo_casper/resources/erc20/main.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/main.rs.in
@@ -1,0 +1,97 @@
+#![no_std]
+#![no_main]
+
+#[cfg(not(target_arch = "wasm32"))]
+compile_error!("target arch should be wasm32: compile with '--target wasm32-unknown-unknown'");
+
+extern crate alloc;
+
+use alloc::string::String;
+
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
+use casper_erc20::{
+    constants::{
+        ADDRESS_RUNTIME_ARG_NAME, AMOUNT_RUNTIME_ARG_NAME, DECIMALS_RUNTIME_ARG_NAME,
+        NAME_RUNTIME_ARG_NAME, OWNER_RUNTIME_ARG_NAME, RECIPIENT_RUNTIME_ARG_NAME,
+        SPENDER_RUNTIME_ARG_NAME, SYMBOL_RUNTIME_ARG_NAME, TOTAL_SUPPLY_RUNTIME_ARG_NAME,
+    },
+    Address, ERC20,
+};
+use casper_types::{CLValue, U256};
+
+#[no_mangle]
+pub extern "C" fn name() {
+    let name = ERC20::default().name();
+    runtime::ret(CLValue::from_t(name).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn symbol() {
+    let symbol = ERC20::default().symbol();
+    runtime::ret(CLValue::from_t(symbol).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn decimals() {
+    let decimals = ERC20::default().decimals();
+    runtime::ret(CLValue::from_t(decimals).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn total_supply() {
+    let total_supply = ERC20::default().total_supply();
+    runtime::ret(CLValue::from_t(total_supply).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn balance_of() {
+    let address: Address = runtime::get_named_arg(ADDRESS_RUNTIME_ARG_NAME);
+    let balance = ERC20::default().balance_of(address);
+    runtime::ret(CLValue::from_t(balance).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn transfer() {
+    let recipient: Address = runtime::get_named_arg(RECIPIENT_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+
+    ERC20::default()
+        .transfer(recipient, amount)
+        .unwrap_or_revert();
+}
+
+#[no_mangle]
+pub extern "C" fn approve() {
+    let spender: Address = runtime::get_named_arg(SPENDER_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+
+    ERC20::default().approve(spender, amount).unwrap_or_revert();
+}
+
+#[no_mangle]
+pub extern "C" fn allowance() {
+    let owner: Address = runtime::get_named_arg(OWNER_RUNTIME_ARG_NAME);
+    let spender: Address = runtime::get_named_arg(SPENDER_RUNTIME_ARG_NAME);
+    let val = ERC20::default().allowance(owner, spender);
+    runtime::ret(CLValue::from_t(val).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn transfer_from() {
+    let owner: Address = runtime::get_named_arg(OWNER_RUNTIME_ARG_NAME);
+    let recipient: Address = runtime::get_named_arg(RECIPIENT_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+    ERC20::default()
+        .transfer_from(owner, recipient, amount)
+        .unwrap_or_revert();
+}
+
+#[no_mangle]
+fn call() {
+    let name: String = runtime::get_named_arg(NAME_RUNTIME_ARG_NAME);
+    let symbol: String = runtime::get_named_arg(SYMBOL_RUNTIME_ARG_NAME);
+    let decimals = runtime::get_named_arg(DECIMALS_RUNTIME_ARG_NAME);
+    let total_supply = runtime::get_named_arg(TOTAL_SUPPLY_RUNTIME_ARG_NAME);
+
+    let _token = ERC20::install(name, symbol, decimals, total_supply).unwrap_or_revert();
+}

--- a/execution_engine_testing/cargo_casper/resources/erc20/test_fixture.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/test_fixture.rs.in
@@ -1,0 +1,192 @@
+use blake2::{
+    digest::{Update, VariableOutput},
+    VarBlake2b,
+};
+use casper_engine_test_support::{Code, SessionBuilder, TestContext, TestContextBuilder};
+use casper_erc20::constants as consts;
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{FromBytes, ToBytes},
+    runtime_args, AsymmetricType, CLTyped, ContractHash, Key, PublicKey, RuntimeArgs, U256, U512,
+};
+
+const CONTRACT_ERC20_TOKEN: &str = "erc20_token.wasm";
+const CONTRACT_KEY_NAME: &str = "erc20_token_contract";
+
+fn blake2b256(item_key_string: &[u8]) -> Box<[u8]> {
+    let mut hasher = VarBlake2b::new(32).unwrap();
+    hasher.update(item_key_string);
+    hasher.finalize_boxed()
+}
+
+#[derive(Clone, Copy)]
+pub struct Sender(pub AccountHash);
+
+pub struct TestFixture {
+    context: TestContext,
+    pub ali: AccountHash,
+    pub bob: AccountHash,
+    pub joe: AccountHash,
+}
+
+impl TestFixture {
+    pub const TOKEN_NAME: &'static str = "Test ERC20";
+    pub const TOKEN_SYMBOL: &'static str = "TERC";
+    pub const TOKEN_DECIMALS: u8 = 8;
+    const TOKEN_TOTAL_SUPPLY_AS_U64: u64 = 1000;
+
+    pub fn token_total_supply() -> U256 {
+        Self::TOKEN_TOTAL_SUPPLY_AS_U64.into()
+    }
+
+    pub fn install_contract() -> TestFixture {
+        let ali = PublicKey::ed25519_from_bytes([3u8; 32]).unwrap();
+        let bob = PublicKey::ed25519_from_bytes([6u8; 32]).unwrap();
+        let joe = PublicKey::ed25519_from_bytes([9u8; 32]).unwrap();
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(ali.clone(), U512::from(500_000_000_000_000_000u64))
+            .with_public_key(bob.clone(), U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        let session_code = Code::from(CONTRACT_ERC20_TOKEN);
+        let session_args = runtime_args! {
+            consts::NAME_RUNTIME_ARG_NAME => TestFixture::TOKEN_NAME,
+            consts::SYMBOL_RUNTIME_ARG_NAME => TestFixture::TOKEN_SYMBOL,
+            consts::DECIMALS_RUNTIME_ARG_NAME => TestFixture::TOKEN_DECIMALS,
+            consts::TOTAL_SUPPLY_RUNTIME_ARG_NAME => TestFixture::token_total_supply()
+        };
+
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(ali.to_account_hash())
+            .with_authorization_keys(&[ali.to_account_hash()])
+            .build();
+
+        context.run(session);
+        TestFixture {
+            context,
+            ali: ali.to_account_hash(),
+            bob: bob.to_account_hash(),
+            joe: joe.to_account_hash(),
+        }
+    }
+
+    fn contract_hash(&self) -> ContractHash {
+        self.context
+            .get_account(self.ali)
+            .unwrap()
+            .named_keys()
+            .get(CONTRACT_KEY_NAME)
+            .unwrap()
+            .normalize()
+            .into_hash()
+            .unwrap()
+            .into()
+    }
+
+    fn query_contract<T: CLTyped + FromBytes>(&self, name: &str) -> Option<T> {
+        match self
+            .context
+            .query(self.ali, &[CONTRACT_KEY_NAME.to_string(), name.to_string()])
+        {
+            Err(_) => None,
+            Ok(maybe_value) => {
+                let value = maybe_value
+                    .into_t()
+                    .unwrap_or_else(|_| panic!("{} is not expected type.", name));
+                Some(value)
+            }
+        }
+    }
+
+    fn call(&mut self, sender: Sender, method: &str, args: RuntimeArgs) {
+        let Sender(address) = sender;
+        let code = Code::Hash(self.contract_hash().value(), method.to_string());
+        let session = SessionBuilder::new(code, args)
+            .with_address(address)
+            .with_authorization_keys(&[address])
+            .build();
+        self.context.run(session);
+    }
+
+    pub fn token_name(&self) -> String {
+        self.query_contract(consts::NAME_RUNTIME_ARG_NAME).unwrap()
+    }
+
+    pub fn token_symbol(&self) -> String {
+        self.query_contract(consts::SYMBOL_RUNTIME_ARG_NAME)
+            .unwrap()
+    }
+
+    pub fn token_decimals(&self) -> u8 {
+        self.query_contract(consts::DECIMALS_RUNTIME_ARG_NAME)
+            .unwrap()
+    }
+
+    pub fn balance_of(&self, account: Key) -> Option<U256> {
+        let item_key = base64::encode(&account.to_bytes().unwrap());
+
+        let key = Key::Hash(self.contract_hash().value());
+        let value = self
+            .context
+            .query_dictionary_item(key, Some(consts::BALANCES_KEY_NAME.to_string()), item_key)
+            .ok()?;
+
+        Some(value.into_t::<U256>().unwrap())
+    }
+
+    pub fn allowance(&self, owner: Key, spender: Key) -> Option<U256> {
+        let mut preimage = Vec::new();
+        preimage.append(&mut owner.to_bytes().unwrap());
+        preimage.append(&mut spender.to_bytes().unwrap());
+        let key_bytes = blake2b256(&preimage);
+        let allowance_item_key = hex::encode(&key_bytes);
+
+        let key = Key::Hash(self.contract_hash().value());
+
+        let value = self
+            .context
+            .query_dictionary_item(
+                key,
+                Some(consts::ALLOWANCES_KEY_NAME.to_string()),
+                allowance_item_key,
+            )
+            .ok()?;
+
+        Some(value.into_t::<U256>().unwrap())
+    }
+
+    pub fn transfer(&mut self, recipient: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::TRANSFER_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::RECIPIENT_RUNTIME_ARG_NAME => recipient,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+
+    pub fn approve(&mut self, spender: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::APPROVE_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::SPENDER_RUNTIME_ARG_NAME => spender,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+
+    pub fn transfer_from(&mut self, owner: Key, recipient: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::TRANSFER_FROM_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::OWNER_RUNTIME_ARG_NAME => owner,
+                consts::RECIPIENT_RUNTIME_ARG_NAME => recipient,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+}

--- a/execution_engine_testing/cargo_casper/resources/simple/Makefile.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/Makefile.in
@@ -1,0 +1,28 @@
+prepare:
+	rustup target add wasm32-unknown-unknown
+
+build-contract:
+	cd contract && cargo build --release --target wasm32-unknown-unknown
+	wasm-strip contract/target/wasm32-unknown-unknown/release/contract.wasm 2>/dev/null | true
+
+test: build-contract
+	mkdir -p tests/wasm
+	cp contract/target/wasm32-unknown-unknown/release/contract.wasm tests/wasm
+	cd tests && cargo test
+
+clippy:
+	cd contract && cargo clippy --all-targets -- -D warnings
+	cd tests && cargo clippy --all-targets -- -D warnings
+
+check-lint: clippy
+	cd contract && cargo fmt -- --check
+	cd tests && cargo fmt -- --check
+
+lint: clippy
+	cd contract && cargo fmt
+	cd tests && cargo fmt
+
+clean:
+	cd contract && cargo clean
+	cd tests && cargo clean
+	rm -rf tests/wasm

--- a/execution_engine_testing/cargo_casper/resources/simple/integration_tests.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/integration_tests.rs.in
@@ -1,0 +1,70 @@
+#[cfg(test)]
+mod tests {
+    use casper_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
+    use casper_types::{
+        account::AccountHash, runtime_args, PublicKey, RuntimeArgs, SecretKey, U512,
+    };
+
+    const MY_ACCOUNT: [u8; 32] = [7u8; 32];
+    // Define `KEY` constant to match that in the contract.
+    const KEY: &str = "my-key-name";
+    const VALUE: &str = "hello world";
+    const RUNTIME_ARG_NAME: &str = "message";
+    const CONTRACT_WASM: &str = "contract.wasm";
+
+    #[test]
+    fn should_store_hello_world() {
+        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        let account_addr = AccountHash::from(&public_key);
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
+        // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
+        // absolute paths.
+        let session_code = Code::from(CONTRACT_WASM);
+        let session_args = runtime_args! {
+            RUNTIME_ARG_NAME => VALUE,
+        };
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(account_addr)
+            .with_authorization_keys(&[account_addr])
+            .build();
+
+        let result_of_query: Result<Value, Error> =
+            context.run(session).query(account_addr, &[KEY.to_string()]);
+
+        let returned_value = result_of_query.expect("should be a value");
+
+        let expected_value = Value::from_t(VALUE.to_string()).expect("should construct Value");
+        assert_eq!(expected_value, returned_value);
+    }
+
+    #[test]
+    #[should_panic(expected = "ApiError::MissingArgument")]
+    fn should_error_on_missing_runtime_arg() {
+        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        let account_addr = AccountHash::from(&public_key);
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        let session_code = Code::from(CONTRACT_WASM);
+        let session_args = RuntimeArgs::new();
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(account_addr)
+            .with_authorization_keys(&[account_addr])
+            .build();
+
+        context.run(session);
+    }
+}
+
+fn main() {
+    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
+}

--- a/execution_engine_testing/cargo_casper/resources/simple/main.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/main.rs.in
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+
+#[cfg(not(target_arch = "wasm32"))]
+compile_error!("target arch should be wasm32: compile with '--target wasm32-unknown-unknown'");
+
+// We need to explicitly import the std alloc crate and `alloc::string::String` as we're in a
+// `no_std` environment.
+extern crate alloc;
+
+use alloc::string::String;
+
+use casper_contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{ApiError, Key};
+
+const KEY_NAME: &str = "my-key-name";
+const RUNTIME_ARG_NAME: &str = "message";
+
+/// An error enum which can be converted to a `u16` so it can be returned as an `ApiError::User`.
+#[repr(u16)]
+enum Error {
+    KeyAlreadyExists = 0,
+    KeyMismatch = 1,
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> Self {
+        ApiError::User(error as u16)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // The key shouldn't already exist in the named keys.
+    let missing_key = runtime::get_key(KEY_NAME);
+    if missing_key.is_some() {
+        runtime::revert(Error::KeyAlreadyExists);
+    }
+
+    // This contract expects a single runtime argument to be provided.  The arg is named "message"
+    // and will be of type `String`.
+    let value: String = runtime::get_named_arg(RUNTIME_ARG_NAME);
+
+    // Store this value under a new unforgeable reference a.k.a `URef`.
+    let value_ref = storage::new_uref(value);
+
+    // Store the new `URef` as a named key with a name of `KEY_NAME`.
+    let key = Key::URef(value_ref);
+    runtime::put_key(KEY_NAME, key);
+
+    // The key should now be able to be retrieved.  Note that if `get_key()` returns `None`, then
+    // `unwrap_or_revert()` will exit the process, returning `ApiError::None`.
+    let retrieved_key = runtime::get_key(KEY_NAME).unwrap_or_revert();
+    if retrieved_key != key {
+        runtime::revert(Error::KeyMismatch);
+    }
+}

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -3,18 +3,25 @@ use std::{fs, path::Path, process, str};
 use colour::e_red;
 use once_cell::sync::Lazy;
 
-use crate::{dependency::Dependency, FAILURE_EXIT_CODE};
+use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "1.3.2", "smart_contracts/contract"));
-pub static CL_TYPES: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-types", "1.3.2", "types"));
-pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
-    Dependency::new(
-        "casper-engine-test-support",
-        "1.3.2",
-        "execution_engine_testing/test_support",
-    )
+    Lazy::new(|| Dependency::new("casper-contract", "1.3.2"));
+pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.3.2"));
+pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> =
+    Lazy::new(|| Dependency::new("casper-engine-test-support", "1.3.2"));
+pub static PATCH_SECTION: Lazy<String> = Lazy::new(|| match ARGS.workspace_path() {
+    Some(workspace_path) => {
+        format!(
+            r#"[patch.crates-io]
+casper-engine-test-support = {{ path = "{0}/execution_engine_testing/test_support" }}
+casper-contract = {{ path = "{0}/smart_contracts/contract" }}
+casper-types = {{ path = "{0}/types" }}
+"#,
+            workspace_path.display()
+        )
+    }
+    None => String::new(),
 });
 
 pub fn print_error_and_exit(msg: &str) -> ! {

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -1,47 +1,26 @@
-use std::{
-    fs::{self, OpenOptions},
-    io::Write,
-    path::Path,
-    process::{self, Command},
-    str,
-};
+use std::{fs, path::Path, process, str};
 
 use colour::e_red;
 use once_cell::sync::Lazy;
 
-use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
+use crate::{dependency::Dependency, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-contract", "1.3.2", "smart_contracts/contract"));
 pub static CL_TYPES: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-types", "1.3.2", "types"));
+pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
+    Dependency::new(
+        "casper-engine-test-support",
+        "1.3.2",
+        "execution_engine_testing/test_support",
+    )
+});
 
 pub fn print_error_and_exit(msg: &str) -> ! {
     e_red!("error");
     eprintln!("{}", msg);
     process::exit(FAILURE_EXIT_CODE)
-}
-
-pub fn run_cargo_new(package_name: &str) {
-    let mut command = Command::new("cargo");
-    command
-        .args(&["new", "--vcs", "none"])
-        .arg(package_name)
-        .current_dir(ARGS.root_path());
-
-    let output = match command.output() {
-        Ok(output) => output,
-        Err(error) => print_error_and_exit(&format!(": failed to run '{:?}': {}", command, error)),
-    };
-
-    if !output.status.success() {
-        let stdout = str::from_utf8(&output.stdout).expect("should be valid UTF8");
-        let stderr = str::from_utf8(&output.stderr).expect("should be valid UTF8");
-        print_error_and_exit(&format!(
-            ": failed to run '{:?}':\n{}\n{}\n",
-            command, stdout, stderr
-        ));
-    }
 }
 
 pub fn create_dir_all<P: AsRef<Path>>(path: P) {
@@ -64,47 +43,6 @@ pub fn write_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
     }
 }
 
-pub fn append_to_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
-    let mut file = match OpenOptions::new().append(true).open(path.as_ref()) {
-        Ok(file) => file,
-        Err(error) => {
-            print_error_and_exit(&format!(
-                ": failed to open '{}': {}",
-                path.as_ref().display(),
-                error
-            ));
-        }
-    };
-    if let Err(error) = file.write_all(contents.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to append to '{}': {}",
-            path.as_ref().display(),
-            error
-        ));
-    }
-}
-
-pub fn remove_file<P: AsRef<Path>>(path: P) {
-    if let Err(error) = fs::remove_file(path.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to remove '{}': {}",
-            path.as_ref().display(),
-            error
-        ));
-    }
-}
-
-pub fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(source: S, destination: D) {
-    if let Err(error) = fs::copy(source.as_ref(), destination.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to copy '{}' to '{}': {}",
-            source.as_ref().display(),
-            destination.as_ref().display(),
-            error
-        ));
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::{env, fs};
@@ -115,6 +53,8 @@ pub mod tests {
 
     const CL_CONTRACT_TOML_PATH: &str = "smart_contracts/contract/Cargo.toml";
     const CL_TYPES_TOML_PATH: &str = "types/Cargo.toml";
+    const CL_ENGINE_TEST_SUPPORT_TOML_PATH: &str =
+        "execution_engine_testing/test_support/Cargo.toml";
     const PACKAGE_FIELD_NAME: &str = "package";
     const VERSION_FIELD_NAME: &str = "version";
     const PATH_PREFIX: &str = "/execution_engine_testing/cargo_casper";
@@ -166,5 +106,10 @@ pub mod tests {
     #[test]
     fn check_cl_types_version() {
         check_package_version(&*CL_TYPES, CL_TYPES_TOML_PATH);
+    }
+
+    #[test]
+    fn check_cl_engine_test_support_version() {
+        check_package_version(&*CL_ENGINE_TEST_SUPPORT, CL_ENGINE_TEST_SUPPORT_TOML_PATH);
     }
 }

--- a/execution_engine_testing/cargo_casper/src/contract_package.rs
+++ b/execution_engine_testing/cargo_casper/src/contract_package.rs
@@ -5,67 +5,32 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{
-    common::{self, CL_CONTRACT, CL_TYPES},
-    ARGS, TOOLCHAIN,
-};
+use crate::{common, erc20, simple, ProjectKind, ARGS};
 
-const PACKAGE_NAME: &str = "contract";
+static PACKAGE_NAME: Lazy<&'static str> = Lazy::new(|| match ARGS.project_kind() {
+    ProjectKind::Simple => "contract",
+    ProjectKind::Erc20 => "erc20-token",
+});
 
-const MAIN_RS_CONTENTS: &str = r#"#![cfg_attr(
-    not(target_arch = "wasm32"),
-    crate_type = "target arch should be wasm32"
-)]
-#![no_main]
-
-use casper_contract::{
-    contract_api::{runtime, storage},
-};
-use casper_types::{Key, URef};
-
-const KEY: &str = "special_value";
-const ARG_MESSAGE: &str = "message";
-
-fn store(value: String) {
-    // Store `value` under a new unforgeable reference.
-    let value_ref: URef = storage::new_uref(value);
-
-    // Wrap the unforgeable reference in a value of type `Key`.
-    let value_key: Key = value_ref.into();
-
-    // Store this key under the name "special_value" in context-local storage.
-    runtime::put_key(KEY, value_key);
-}
-
-// All session code must have a `call` entrypoint.
-#[no_mangle]
-pub extern "C" fn call() {
-    // Get the optional first argument supplied to the argument.
-    let value: String = runtime::get_named_arg(ARG_MESSAGE);
-    store(value);
-}
-"#;
+static CONTRACT_PACKAGE_ROOT: Lazy<PathBuf> =
+    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME.replace("-", "_")));
+static CARGO_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("Cargo.toml"));
+static MAIN_RS: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/main.rs"));
+static CONFIG_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join(".cargo/config.toml"));
 
 const CONFIG_TOML_CONTENTS: &str = r#"[build]
 target = "wasm32-unknown-unknown"
 "#;
 
-static CARGO_TOML: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("Cargo.toml"));
-static RUST_TOOLCHAIN: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("rust-toolchain"));
-static MAIN_RS: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("src/main.rs"));
-static CONFIG_TOML: Lazy<PathBuf> = Lazy::new(|| {
-    ARGS.root_path()
-        .join(PACKAGE_NAME)
-        .join(".cargo/config.toml")
-});
-static CARGO_TOML_ADDITIONAL_CONTENTS: Lazy<String> = Lazy::new(|| {
+static CARGO_TOML_CONTENTS: Lazy<String> = Lazy::new(|| {
     format!(
-        r#"{}
-{}
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2018"
 
+[dependencies]
+{}
 [[bin]]
 name = "{}"
 path = "src/main.rs"
@@ -73,34 +38,34 @@ bench = false
 doctest = false
 test = false
 
-[features]
-default = ["casper-contract/std", "casper-types/std", "casper-contract/test-support"]
-
 [profile.release]
+codegen-units = 1
 lto = true
 "#,
-        *CL_CONTRACT, *CL_TYPES, PACKAGE_NAME
+        *PACKAGE_NAME,
+        match ARGS.project_kind() {
+            ProjectKind::Simple => &*simple::CONTRACT_DEPENDENCIES,
+            ProjectKind::Erc20 => &*erc20::CONTRACT_DEPENDENCIES,
+        },
+        PACKAGE_NAME.replace("-", "_"),
     )
 });
 
-pub fn run_cargo_new() {
-    common::run_cargo_new(PACKAGE_NAME);
-}
+pub fn create() {
+    // Create "<PACKAGE_NAME>/src" folder and write "main.rs" inside.
+    let src_folder = MAIN_RS.parent().expect("should have parent");
+    common::create_dir_all(src_folder);
+    let main_rs_contents = match ARGS.project_kind() {
+        ProjectKind::Simple => simple::MAIN_RS_CONTENTS,
+        ProjectKind::Erc20 => erc20::MAIN_RS_CONTENTS,
+    };
+    common::write_file(&*MAIN_RS, main_rs_contents);
 
-pub fn update_cargo_toml() {
-    common::append_to_file(&*CARGO_TOML, &*CARGO_TOML_ADDITIONAL_CONTENTS);
-}
-
-pub fn add_rust_toolchain() {
-    common::write_file(&*RUST_TOOLCHAIN, format!("{}\n", TOOLCHAIN));
-}
-
-pub fn update_main_rs() {
-    common::write_file(&*MAIN_RS, MAIN_RS_CONTENTS);
-}
-
-pub fn add_config_toml() {
-    let folder = CONFIG_TOML.parent().expect("should have parent");
-    common::create_dir_all(folder);
+    // Create "<PACKAGE_NAME>/.cargo" folder and write "config.toml" inside.
+    let config_folder = CONFIG_TOML.parent().expect("should have parent");
+    common::create_dir_all(config_folder);
     common::write_file(&*CONFIG_TOML, CONFIG_TOML_CONTENTS);
+
+    // Write "<PACKAGE_NAME>/Cargo.toml".
+    common::write_file(&*CARGO_TOML, &*CARGO_TOML_CONTENTS);
 }

--- a/execution_engine_testing/cargo_casper/src/contract_package.rs
+++ b/execution_engine_testing/cargo_casper/src/contract_package.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{common, erc20, simple, ProjectKind, ARGS};
+use crate::{
+    common::{self, PATCH_SECTION},
+    erc20, simple, ProjectKind, ARGS,
+};
 
 static PACKAGE_NAME: Lazy<&'static str> = Lazy::new(|| match ARGS.project_kind() {
     ProjectKind::Simple => "contract",
@@ -41,13 +44,15 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
-"#,
+
+{}"#,
         *PACKAGE_NAME,
         match ARGS.project_kind() {
             ProjectKind::Simple => &*simple::CONTRACT_DEPENDENCIES,
             ProjectKind::Erc20 => &*erc20::CONTRACT_DEPENDENCIES,
         },
         PACKAGE_NAME.replace("-", "_"),
+        &*PATCH_SECTION
     )
 });
 

--- a/execution_engine_testing/cargo_casper/src/dependency.rs
+++ b/execution_engine_testing/cargo_casper/src/dependency.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Display, Formatter, Result};
-
 use crate::ARGS;
 
 /// Used to hold the information about the Casper dependencies which will be required by the
@@ -24,25 +22,40 @@ impl Dependency {
         }
     }
 
+    pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
+        if default_features
+            && features.is_empty()
+            && (ARGS.workspace_path().is_none() || self.relative_path.is_empty())
+        {
+            return format!("{} = \"{}\"\n", self.name, self.version);
+        }
+
+        let mut output = format!(r#"{} = {{ version = "{}""#, self.name, self.version);
+
+        if let Some(workspace_path) = ARGS.workspace_path() {
+            if !self.relative_path.is_empty() {
+                output = format!(
+                    r#"{}, path = "{}/{}""#,
+                    output,
+                    workspace_path.display(),
+                    self.relative_path
+                );
+            }
+        }
+
+        if !default_features {
+            output = format!("{}, default-features = false", output);
+        }
+
+        if !features.is_empty() {
+            output = format!("{}, features = {:?}", output, features);
+        }
+
+        format!("{} }}\n", output)
+    }
+
     #[cfg(test)]
     pub fn version(&self) -> &str {
         &self.version
-    }
-}
-
-impl Display for Dependency {
-    fn fmt(&self, formatter: &mut Formatter) -> Result {
-        if let Some(workspace_path) = ARGS.workspace_path() {
-            write!(
-                formatter,
-                r#"{} = {{ version = "{}", path = "{}/{}" }}"#,
-                self.name,
-                self.version,
-                workspace_path.display(),
-                self.relative_path
-            )
-        } else {
-            write!(formatter, r#"{} = "{}""#, self.name, self.version)
-        }
     }
 }

--- a/execution_engine_testing/cargo_casper/src/dependency.rs
+++ b/execution_engine_testing/cargo_casper/src/dependency.rs
@@ -1,47 +1,25 @@
-use crate::ARGS;
-
 /// Used to hold the information about the Casper dependencies which will be required by the
 /// generated Cargo.toml files.
-///
-/// The information is output in a form suitable for injection into Cargo.toml via implementing the
-/// `std::fmt::Display` trait.
 #[derive(Debug)]
 pub struct Dependency {
     name: String,
     version: String,
-    /// Path relative to "casper-node"
-    relative_path: String,
 }
 
 impl Dependency {
-    pub fn new(name: &str, version: &str, relative_path: &str) -> Self {
+    pub fn new(name: &str, version: &str) -> Self {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            relative_path: relative_path.to_string(),
         }
     }
 
     pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
-        if default_features
-            && features.is_empty()
-            && (ARGS.workspace_path().is_none() || self.relative_path.is_empty())
-        {
+        if default_features && features.is_empty() {
             return format!("{} = \"{}\"\n", self.name, self.version);
         }
 
         let mut output = format!(r#"{} = {{ version = "{}""#, self.name, self.version);
-
-        if let Some(workspace_path) = ARGS.workspace_path() {
-            if !self.relative_path.is_empty() {
-                output = format!(
-                    r#"{}, path = "{}/{}""#,
-                    output,
-                    workspace_path.display(),
-                    self.relative_path
-                );
-            }
-        }
 
         if !default_features {
             output = format!("{}, default-features = false", output);

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -1,0 +1,35 @@
+use once_cell::sync::Lazy;
+
+use crate::{
+    common::{CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_TYPES},
+    dependency::Dependency,
+};
+
+pub const MAIN_RS_CONTENTS: &str = include_str!("../resources/erc20/main.rs.in");
+pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
+    include_str!("../resources/erc20/integration_tests.rs.in");
+pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
+pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
+
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0", ""));
+
+pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}",
+        CL_CONTRACT.display_with_features(true, vec![]),
+        CL_ERC20.display_with_features(true, vec![]),
+        CL_TYPES.display_with_features(true, vec![]),
+    )
+});
+
+pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}{}{}{}",
+        Dependency::new("base64", "0.13.0", "").display_with_features(true, vec![]),
+        Dependency::new("blake2", "0.9.2", "").display_with_features(true, vec![]),
+        CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
+        CL_ERC20.display_with_features(true, vec!["std"]),
+        CL_TYPES.display_with_features(true, vec!["std"]),
+        Dependency::new("hex", "0.4.3", "").display_with_features(true, vec![]),
+    )
+});

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -11,7 +11,7 @@ pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
 pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
 pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
 
-static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0"));
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.2.0"));
 
 pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -11,7 +11,7 @@ pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
 pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
 pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
 
-static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0", ""));
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0"));
 
 pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
@@ -25,11 +25,11 @@ pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}{}{}{}{}",
-        Dependency::new("base64", "0.13.0", "").display_with_features(true, vec![]),
-        Dependency::new("blake2", "0.9.2", "").display_with_features(true, vec![]),
+        Dependency::new("base64", "0.13.0").display_with_features(true, vec![]),
+        Dependency::new("blake2", "0.9.2").display_with_features(true, vec![]),
         CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
         CL_ERC20.display_with_features(true, vec!["std"]),
         CL_TYPES.display_with_features(true, vec!["std"]),
-        Dependency::new("hex", "0.4.3", "").display_with_features(true, vec![]),
+        Dependency::new("hex", "0.4.3").display_with_features(true, vec![]),
     )
 });

--- a/execution_engine_testing/cargo_casper/src/makefile.rs
+++ b/execution_engine_testing/cargo_casper/src/makefile.rs
@@ -1,0 +1,11 @@
+use crate::{common, erc20, simple, ProjectKind, ARGS};
+
+const FILENAME: &str = "Makefile";
+
+pub fn create() {
+    let contents = match ARGS.project_kind() {
+        ProjectKind::Simple => simple::MAKEFILE_CONTENTS,
+        ProjectKind::Erc20 => erc20::MAKEFILE_CONTENTS,
+    };
+    common::write_file(ARGS.root_path().join(FILENAME), contents);
+}

--- a/execution_engine_testing/cargo_casper/src/rust_toolchain.rs
+++ b/execution_engine_testing/cargo_casper/src/rust_toolchain.rs
@@ -1,0 +1,38 @@
+use crate::{common, ARGS};
+
+const FILENAME: &str = "rust-toolchain";
+pub const CONTENTS: &str = r#"nightly-2021-06-17
+"#;
+
+pub fn create() {
+    common::write_file(ARGS.root_path().join(FILENAME), CONTENTS);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs};
+
+    use super::CONTENTS;
+
+    const PATH_PREFIX: &str = "/execution_engine_testing/cargo_casper";
+
+    #[test]
+    fn check_toolchain_version() {
+        let mut toolchain_path = env::current_dir().unwrap().display().to_string();
+        let index = toolchain_path.find(PATH_PREFIX).unwrap_or_else(|| {
+            panic!(
+                "test should be run from within casper-node workspace: {}",
+                toolchain_path
+            )
+        });
+        toolchain_path.replace_range(index.., "/rust-toolchain");
+
+        let toolchain_contents =
+            fs::read(&toolchain_path).unwrap_or_else(|_| panic!("should read {}", toolchain_path));
+        let expected_toolchain_value = String::from_utf8_lossy(&toolchain_contents).to_string();
+
+        // If this fails, ensure `CONTENTS` is updated to match the value in
+        // "casper-node/rust-toolchain".
+        assert_eq!(&*expected_toolchain_value, CONTENTS);
+    }
+}

--- a/execution_engine_testing/cargo_casper/src/simple.rs
+++ b/execution_engine_testing/cargo_casper/src/simple.rs
@@ -1,0 +1,25 @@
+use once_cell::sync::Lazy;
+
+use crate::common::{CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_TYPES};
+
+pub const MAIN_RS_CONTENTS: &str = include_str!("../resources/simple/main.rs.in");
+pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
+    include_str!("../resources/simple/integration_tests.rs.in");
+pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/simple/Makefile.in");
+
+pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}",
+        CL_CONTRACT.display_with_features(true, vec![]),
+        CL_TYPES.display_with_features(true, vec![]),
+    )
+});
+
+pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}",
+        CL_CONTRACT.display_with_features(false, vec!["std", "test-support"]),
+        CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
+        CL_TYPES.display_with_features(false, vec!["std"]),
+    )
+});

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{common, erc20, simple, ProjectKind, ARGS};
+use crate::{
+    common::{self, PATCH_SECTION},
+    erc20, simple, ProjectKind, ARGS,
+};
 
 const PACKAGE_NAME: &str = "tests";
 
@@ -30,11 +33,13 @@ name = "integration-tests"
 path = "src/integration_tests.rs"
 bench = false
 doctest = false
-"#,
+
+{}"#,
         match ARGS.project_kind() {
             ProjectKind::Simple => &*simple::TEST_DEPENDENCIES,
             ProjectKind::Erc20 => &*erc20::TEST_DEPENDENCIES,
         },
+        &*PATCH_SECTION
     )
 });
 

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -5,168 +5,59 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{
-    common::{self, CL_CONTRACT, CL_TYPES},
-    dependency::Dependency,
-    ARGS, TOOLCHAIN,
-};
+use crate::{common, erc20, simple, ProjectKind, ARGS};
 
 const PACKAGE_NAME: &str = "tests";
 
-const INTEGRATION_TESTS_RS_CONTENTS: &str = r#"#[cfg(test)]
-mod tests {
-    use casper_engine_test_support::{
-        Code, Error, SessionBuilder, TestContextBuilder, Value,
-    };
-    use casper_types::{runtime_args, RuntimeArgs, U512, account::AccountHash, PublicKey, SecretKey};
+static CONTRACT_PACKAGE_ROOT: Lazy<PathBuf> = Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME));
+static CARGO_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("Cargo.toml"));
+static INTEGRATION_TESTS_RS: Lazy<PathBuf> =
+    Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/integration_tests.rs"));
+static TEST_FIXTURE_RS: Lazy<PathBuf> =
+    Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/test_fixture.rs"));
 
-    const MY_ACCOUNT: [u8; 32] = [7u8; 32];
-    // define KEY constant to match that in the contract
-    const KEY: &str = "special_value";
-    const VALUE: &str = "hello world";
-    const ARG_MESSAGE: &str = "message";
-
-    #[test]
-    fn should_store_hello_world() {
-        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
-        let public_key = PublicKey::from(&secret_key);
-        let account_addr = AccountHash::from(&public_key);
-
-        let mut context = TestContextBuilder::new()
-            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
-            .build();
-
-        // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
-        // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
-        // absolute paths.
-        let session_code = Code::from("contract.wasm");
-        let session_args = runtime_args! {
-            ARG_MESSAGE => VALUE,
-        };
-        let session = SessionBuilder::new(session_code, session_args)
-            .with_address(account_addr)
-            .with_authorization_keys(&[account_addr])
-            .build();
-
-        let result_of_query: Result<Value, Error> =
-            context.run(session).query(account_addr, &[KEY.to_string()]);
-
-        let returned_value = result_of_query.expect("should be a value");
-
-        let expected_value = Value::from_t(VALUE.to_string()).expect("should construct Value");
-        assert_eq!(expected_value, returned_value);
-    }
-}
-
-fn main() {
-    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
-}
-"#;
-
-const BUILD_RS_CONTENTS: &str = r#"use std::{env, fs, path::PathBuf, process::Command};
-
-const CONTRACT_ROOT: &str = "../contract";
-const CONTRACT_CARGO_TOML: &str = "../contract/Cargo.toml";
-const CONTRACT_MAIN_RS: &str = "../contract/src/main.rs";
-const BUILD_ARGS: [&str; 2] = ["build", "--release"];
-const WASM_FILENAME: &str = "contract.wasm";
-const ORIGINAL_WASM_DIR: &str = "../contract/target/wasm32-unknown-unknown/release";
-const NEW_WASM_DIR: &str = "wasm";
-
-fn main() {
-    // Watch contract source files for changes.
-    println!("cargo:rerun-if-changed={}", CONTRACT_CARGO_TOML);
-    println!("cargo:rerun-if-changed={}", CONTRACT_MAIN_RS);
-
-    // Build the contract.
-    let output = Command::new("cargo")
-        .current_dir(CONTRACT_ROOT)
-        .args(&BUILD_ARGS)
-        .output()
-        .expect("Expected to build Wasm contracts");
-    assert!(
-        output.status.success(),
-        "Failed to build Wasm contracts:\n{:?}",
-        output
-    );
-
-    // Move the compiled Wasm file to our own build folder ("wasm/contract.wasm").
-    let new_wasm_dir = env::current_dir().unwrap().join(NEW_WASM_DIR);
-    let _ = fs::create_dir(&new_wasm_dir);
-
-    let original_wasm_file = PathBuf::from(ORIGINAL_WASM_DIR).join(WASM_FILENAME);
-    let copied_wasm_file = new_wasm_dir.join(WASM_FILENAME);
-    fs::copy(original_wasm_file, copied_wasm_file).unwrap();
-}
-"#;
-
-static CARGO_TOML: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("Cargo.toml"));
-static RUST_TOOLCHAIN: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("rust-toolchain"));
-static BUILD_RS: Lazy<PathBuf> = Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("build.rs"));
-static MAIN_RS: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("src/main.rs"));
-static INTEGRATION_TESTS_RS: Lazy<PathBuf> = Lazy::new(|| {
-    ARGS.root_path()
-        .join(PACKAGE_NAME)
-        .join("src/integration_tests.rs")
-});
-static ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
-    Dependency::new(
-        "casper-engine-test-support",
-        "1.3.2",
-        "execution_engine_testing/test_support",
-    )
-});
-static CARGO_TOML_ADDITIONAL_CONTENTS: Lazy<String> = Lazy::new(|| {
+static CARGO_TOML_CONTENTS: Lazy<String> = Lazy::new(|| {
     format!(
-        r#"
+        r#"[package]
+name = "tests"
+version = "0.1.0"
+edition = "2018"
+
 [dev-dependencies]
 {}
-{}
-{}
-
 [[bin]]
 name = "integration-tests"
 path = "src/integration_tests.rs"
-
-[features]
-default = ["casper-contract/std", "casper-types/std", "casper-engine-test-support/test-support", "casper-contract/test-support""#,
-        *CL_CONTRACT, *CL_TYPES, *ENGINE_TEST_SUPPORT,
+bench = false
+doctest = false
+"#,
+        match ARGS.project_kind() {
+            ProjectKind::Simple => &*simple::TEST_DEPENDENCIES,
+            ProjectKind::Erc20 => &*erc20::TEST_DEPENDENCIES,
+        },
     )
 });
 
-pub fn run_cargo_new() {
-    common::run_cargo_new(PACKAGE_NAME);
-}
-
-pub fn update_cargo_toml() {
-    let cargo_toml_additional_contents = format!("{}{}\n", &*CARGO_TOML_ADDITIONAL_CONTENTS, "]");
-    common::append_to_file(&*CARGO_TOML, cargo_toml_additional_contents);
-}
-
-pub fn add_rust_toolchain() {
-    common::write_file(&*RUST_TOOLCHAIN, format!("{}\n", TOOLCHAIN));
-}
-
-pub fn add_build_rs() {
-    common::write_file(&*BUILD_RS, BUILD_RS_CONTENTS);
-}
-
-pub fn replace_main_rs() {
-    common::remove_file(&*MAIN_RS);
-    common::write_file(&*INTEGRATION_TESTS_RS, INTEGRATION_TESTS_RS_CONTENTS);
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    const ENGINE_TEST_SUPPORT_TOML_PATH: &str = "execution_engine_testing/test_support/Cargo.toml";
-
-    #[test]
-    fn check_engine_test_support_version() {
-        common::tests::check_package_version(&*ENGINE_TEST_SUPPORT, ENGINE_TEST_SUPPORT_TOML_PATH);
+pub fn create() {
+    // Create "tests/src" folder and write test files inside.
+    let tests_folder = INTEGRATION_TESTS_RS.parent().expect("should have parent");
+    common::create_dir_all(tests_folder);
+    match ARGS.project_kind() {
+        ProjectKind::Simple => {
+            common::write_file(
+                &*INTEGRATION_TESTS_RS,
+                &*simple::INTEGRATION_TESTS_RS_CONTENTS,
+            );
+        }
+        ProjectKind::Erc20 => {
+            common::write_file(
+                &*INTEGRATION_TESTS_RS,
+                &*erc20::INTEGRATION_TESTS_RS_CONTENTS,
+            );
+            common::write_file(&*TEST_FIXTURE_RS, &*erc20::TEST_FIXTURE_RS_CONTENTS);
+        }
     }
+
+    // Write "tests/Cargo.toml".
+    common::write_file(&*CARGO_TOML, &*CARGO_TOML_CONTENTS);
 }

--- a/execution_engine_testing/cargo_casper/src/travis_yml.rs
+++ b/execution_engine_testing/cargo_casper/src/travis_yml.rs
@@ -3,8 +3,9 @@ use crate::{common, ARGS};
 const FILENAME: &str = ".travis.yml";
 const CONTENTS: &str = r#"language: rust
 script:
-  - cd tests && cargo build
-  - cd tests && cargo test
+  - make prepare
+  - make check-lint
+  - make test
 "#;
 
 pub fn create() {

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -45,7 +45,7 @@ fn output_from_command(mut command: Command) -> Output {
     }
 }
 
-fn run_tool_and_resulting_tests() {
+fn run_tool_and_resulting_tests(maybe_extra_flag: Option<&str>) {
     let temp_dir = tempfile::tempdir().unwrap().into_path();
 
     // Run 'cargo-casper <test dir>/<subdir> --workspace-path=<path to casper-node root>'
@@ -53,6 +53,9 @@ fn run_tool_and_resulting_tests() {
     let test_dir = temp_dir.join(subdir);
     let mut tool_cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     tool_cmd.arg(&test_dir);
+    if let Some(extra_flag) = maybe_extra_flag {
+        tool_cmd.arg(extra_flag);
+    }
     tool_cmd.arg(&*WORKSPACE_PATH_ARG);
 
     // The CI environment doesn't have a Git user configured, so we can set the env var `USER` for
@@ -85,6 +88,11 @@ fn run_tool_and_resulting_tests() {
 }
 
 #[test]
-fn should_run_casperlabs_node() {
-    run_tool_and_resulting_tests();
+fn should_run_cargo_casper_for_simple_example() {
+    run_tool_and_resulting_tests(None);
+}
+
+#[test]
+fn should_run_cargo_casper_for_erc20_example() {
+    run_tool_and_resulting_tests(Some("--erc20"));
 }

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -35,9 +35,11 @@ fn output_from_command(mut command: Command) -> Output {
         Ok(output) => output,
         Err(error) => {
             panic!(
-                "\nFailed to execute {:?}\n===== stderr begin =====\n{}\n===== stderr end =====\n",
+                "\nFailed to execute {:?}\n===== stderr begin =====\n{}\n===== stderr end \
+                =====\n===== stdout begin =====\n{}\n===== stdout end =====\n",
                 command,
-                String::from_utf8_lossy(&error.as_output().unwrap().stderr)
+                String::from_utf8_lossy(&error.as_output().unwrap().stderr),
+                String::from_utf8_lossy(&error.as_output().unwrap().stdout)
             );
         }
     }
@@ -59,10 +61,22 @@ fn run_tool_and_resulting_tests() {
     let tool_output = output_from_command(tool_cmd);
     assert_eq!(SUCCESS_EXIT_CODE, tool_output.status.code().unwrap());
 
-    // Run 'cargo test' in the 'tests' folder of the generated project.  This builds the Wasm
-    // contract as well as the tests.
-    let mut test_cmd = Command::new(env!("CARGO"));
-    test_cmd.arg("test").current_dir(test_dir.join("tests"));
+    // Run 'make test' in the root of the generated project.  This builds the Wasm contract as well
+    // as the tests.  This requires the use of a nightly version of Rust, so we use rustup to
+    // execute the appropriate cargo version.
+    let mut test_cmd = Command::new("rustup");
+    let nightly_version = fs::read_to_string(format!(
+        "{}/../../rust-toolchain",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+    test_cmd
+        .arg("run")
+        .arg(nightly_version.trim())
+        .arg("make")
+        .arg("test")
+        .current_dir(test_dir);
+
     let test_output = output_from_command(test_cmd);
     assert_eq!(SUCCESS_EXIT_CODE, test_output.status.code().unwrap());
 


### PR DESCRIPTION
This PR upgrades the functionality of `cargo-casper` to include an option to generate an ERC-20 token contract and tests.

The generated source files are exact copies of the example and its tests in the erc20 repository.

The integration tests for `cargo-casper` have been updated to also run the tool with the `--erc20` flag.

Closes #2034.