### PR TITLE
Request consensus dependencies in configurable batches.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 * Long running events now log their event type.
 * Individual weights for traffic throttling can now be set through the configuration value
   `network.estimator_weights`.
+* Added `consensus.highway.max_request_batch_size` configuration parameter. Defaults to 20.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -147,7 +147,7 @@ impl<C: Context> FinalityDetector<C> {
     /// has not been finalized yet.
     fn next_candidate<'a>(&self, state: &'a State<C>) -> Option<&'a C::Hash> {
         let fork_choice = state.fork_choice(state.panorama())?;
-        state.find_ancestor(fork_choice, self.next_height(state))
+        state.find_ancestor_proposal(fork_choice, self.next_height(state))
     }
 
     /// Returns the height of the next block that will be finalized.
@@ -187,7 +187,7 @@ impl<C: Context> FinalityDetector<C> {
         // Report inactive validators, but only if they had sufficient time to create a unit, i.e.
         // if at least one maximum-length round passed between the first and last block.
         // Safe to unwrap: Ancestor at height 0 always exists.
-        let first_bhash = state.find_ancestor(bhash, 0).unwrap();
+        let first_bhash = state.find_ancestor_proposal(bhash, 0).unwrap();
         let sufficient_time_for_activity =
             unit.timestamp >= state.unit(first_bhash).timestamp + state.params().max_round_length();
         let inactive_validators = if sufficient_time_for_activity {

--- a/node/src/components/consensus/highway_core/finality_detector/horizon.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/horizon.rs
@@ -41,7 +41,9 @@ impl<'a, C: Context> Horizon<'a, C> {
         let to_lvl0unit = |&maybe_vhash: &Option<&'a C::Hash>| {
             state
                 .swimlane(maybe_vhash?)
-                .take_while(|(_, unit)| state.find_ancestor(&unit.block, height) == Some(candidate))
+                .take_while(|(_, unit)| {
+                    state.find_ancestor_proposal(&unit.block, height) == Some(candidate)
+                })
                 .last()
                 .map(|(_, unit)| unit.seq_number)
         };

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -393,7 +393,7 @@ impl<C: Context> Highway<C> {
                 }
                 Some(Fault::Indirect) => match self.validators.id(vid) {
                     Some(vid) => GetDepOutcome::Evidence(vid.clone()),
-                    None => return GetDepOutcome::None,
+                    None => GetDepOutcome::None,
                 },
             },
             Observation::Correct(last_seen) => self

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -28,6 +28,8 @@ use crate::{
 use super::{
     endorsement::{Endorsement, EndorsementError},
     evidence::Evidence,
+    state::Observation,
+    validators::ValidatorIndex,
 };
 
 /// If a lot of rounds were skipped between two blocks, log at most this many.
@@ -370,6 +372,37 @@ impl<C: Context> Highway<C> {
             },
             Dependency::Ping(_, _) => GetDepOutcome::None, // We don't store ping signatures.
         }
+    }
+
+    /// Returns a vertex by a validator with the requested sequence number.
+    pub(crate) fn get_dependency_by_index(
+        &self,
+        vid: ValidatorIndex,
+        unit_seq: u64,
+    ) -> Result<GetDepOutcome<C>, ()> {
+        let obs = match self.state.panorama().get(vid) {
+            Some(obs) => obs,
+            None => return Err(()),
+        };
+        Ok(match obs {
+            Observation::None => GetDepOutcome::None,
+            Observation::Faulty => match self.state.maybe_fault(vid) {
+                None | Some(Fault::Banned) => GetDepOutcome::None,
+                Some(Fault::Direct(ev)) => {
+                    GetDepOutcome::Vertex(ValidVertex(Vertex::Evidence(ev.clone())))
+                }
+                Some(Fault::Indirect) => match self.validators.id(vid) {
+                    Some(vid) => GetDepOutcome::Evidence(vid.clone()),
+                    None => return Err(()),
+                },
+            },
+            Observation::Correct(last_seen) => self
+                .state
+                .find_ancestor_unit(last_seen, unit_seq)
+                .and_then(|req_hash| self.state.wire_unit(req_hash, self.instance_id))
+                .map(|swunit| GetDepOutcome::Vertex(ValidVertex(Vertex::Unit(swunit))))
+                .unwrap_or_else(|| GetDepOutcome::None),
+        })
     }
 
     pub(crate) fn handle_timer(&mut self, timestamp: Timestamp) -> Vec<Effect<C>> {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -1,4 +1,5 @@
 mod block;
+mod index_panorama;
 mod panorama;
 mod params;
 mod tallies;
@@ -12,6 +13,7 @@ pub(crate) use params::Params;
 use quanta::Clock;
 pub(crate) use weight::Weight;
 
+pub(crate) use index_panorama::{IndexObservation, IndexPanorama};
 pub(crate) use panorama::{Observation, Panorama};
 pub(super) use unit::Unit;
 
@@ -726,6 +728,7 @@ impl<C: Context> State<C> {
 
     /// Returns the ancestor of the block with the given `hash`, on the specified `height`, or
     /// `None` if the block's height is lower than that.
+    /// NOTE: Panics if used on unit hashes. For those use [`find_ancestor_unit`].
     pub(crate) fn find_ancestor<'a>(
         &'a self,
         hash: &'a C::Hash,
@@ -746,6 +749,30 @@ impl<C: Context> State<C> {
         #[allow(clippy::integer_arithmetic)]
         let i = max_i.min(block.skip_idx.len() - 1);
         self.find_ancestor(&block.skip_idx[i], height)
+    }
+
+    /// Returns the ancestor of the unit with the given `hash`, on the specified `height`, or
+    /// `None` if the unit's height is lower than that.
+    pub(crate) fn find_ancestor_unit<'a>(
+        &'a self,
+        hash: &'a C::Hash,
+        height: u64,
+    ) -> Option<&'a C::Hash> {
+        let unit = self.unit(hash);
+        if unit.seq_number < height {
+            return None;
+        }
+        if unit.seq_number == height {
+            return Some(hash);
+        }
+        #[allow(clippy::integer_arithmetic)] // block.height > height, otherwise we returned.
+        let diff = unit.seq_number - height;
+        // We want to make the greatest step 2^i such that 2^i <= diff.
+        let max_i = log2(diff) as usize;
+        // A unit at height > 0 always has at least its parent entry in skip_idx.
+        #[allow(clippy::integer_arithmetic)]
+        let i = max_i.min(unit.skip_idx.len() - 1);
+        self.find_ancestor_unit(&unit.skip_idx[i], height)
     }
 
     /// Returns an error if `swunit` is invalid. This can be called even if the dependencies are

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -728,8 +728,8 @@ impl<C: Context> State<C> {
 
     /// Returns the ancestor of the block with the given `hash`, on the specified `height`, or
     /// `None` if the block's height is lower than that.
-    /// NOTE: Panics if used on unit hashes. For those use [`find_ancestor_unit`].
-    pub(crate) fn find_ancestor<'a>(
+    /// NOTE: Panics if used on non-proposal hashes. For those use [`find_ancestor_unit`].
+    pub(crate) fn find_ancestor_proposal<'a>(
         &'a self,
         hash: &'a C::Hash,
         height: u64,
@@ -748,7 +748,7 @@ impl<C: Context> State<C> {
         // A block at height > 0 always has at least its parent entry in skip_idx.
         #[allow(clippy::integer_arithmetic)]
         let i = max_i.min(block.skip_idx.len() - 1);
-        self.find_ancestor(&block.skip_idx[i], height)
+        self.find_ancestor_proposal(&block.skip_idx[i], height)
     }
 
     /// Returns the ancestor of the unit with the given `hash`, on the specified `height`, or

--- a/node/src/components/consensus/highway_core/state/index_panorama.rs
+++ b/node/src/components/consensus/highway_core/state/index_panorama.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
 use crate::components::consensus::{
     highway_core::{
@@ -43,13 +42,11 @@ impl IndexPanorama {
         for (vid, obs) in panorama.enumerate() {
             let index_obs = match obs {
                 Observation::None => IndexObservation::None,
-                Observation::Correct(hash) => state.maybe_unit(hash).map_or_else(
-                    || {
-                        error!(?hash, "expected unit to exist in the local protocol state");
-                        IndexObservation::None
-                    },
-                    |unit| IndexObservation::Correct(unit.seq_number),
-                ),
+                Observation::Correct(hash) => state
+                    .maybe_unit(hash)
+                    .map_or(IndexObservation::None, |unit| {
+                        IndexObservation::Correct(unit.seq_number)
+                    }),
                 Observation::Faulty => IndexObservation::Faulty,
             };
             validator_map[vid] = index_obs;

--- a/node/src/components/consensus/highway_core/state/index_panorama.rs
+++ b/node/src/components/consensus/highway_core/state/index_panorama.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::components::consensus::{
     highway_core::{
@@ -42,11 +43,13 @@ impl IndexPanorama {
         for (vid, obs) in panorama.enumerate() {
             let index_obs = match obs {
                 Observation::None => IndexObservation::None,
-                Observation::Correct(hash) => state
-                    .maybe_unit(hash)
-                    .map_or(IndexObservation::None, |unit| {
-                        IndexObservation::Correct(unit.seq_number)
-                    }),
+                Observation::Correct(hash) => state.maybe_unit(hash).map_or_else(
+                    || {
+                        error!(?hash, "expected unit to exist in the local protocol state");
+                        IndexObservation::None
+                    },
+                    |unit| IndexObservation::Correct(unit.seq_number),
+                ),
                 Observation::Faulty => IndexObservation::Faulty,
             };
             validator_map[vid] = index_obs;

--- a/node/src/components/consensus/highway_core/state/index_panorama.rs
+++ b/node/src/components/consensus/highway_core/state/index_panorama.rs
@@ -1,0 +1,56 @@
+use std::fmt::Debug;
+
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use crate::components::consensus::{
+    highway_core::{
+        state::{Observation, Panorama, State},
+        validators::ValidatorMap,
+    },
+    traits::Context,
+};
+
+pub(crate) type IndexPanorama = ValidatorMap<IndexObservation>;
+
+/// The observed behavior of a validator at some point in time.
+#[derive(Clone, DataSize, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub(crate) enum IndexObservation {
+    None,
+    Faulty,
+    Correct(u64),
+}
+
+impl Debug for IndexObservation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexObservation::None => write!(f, "N"),
+            IndexObservation::Faulty => write!(f, "F"),
+            IndexObservation::Correct(seq_num) => write!(f, "{:?}", seq_num),
+        }
+    }
+}
+
+impl IndexPanorama {
+    /// Creates an instance of `IndexPanorama` out of a panorama.
+    pub(crate) fn from_panorama<'a, C: Context>(
+        panorama: &'a Panorama<C>,
+        state: &'a State<C>,
+    ) -> Self {
+        let mut validator_map: ValidatorMap<IndexObservation> =
+            ValidatorMap::from(vec![IndexObservation::None; panorama.len()]);
+        for (vid, obs) in panorama.enumerate() {
+            let index_obs = match obs {
+                Observation::None => IndexObservation::None,
+                Observation::Correct(hash) => state
+                    .maybe_unit(hash)
+                    .map_or(IndexObservation::None, |unit| {
+                        IndexObservation::Correct(unit.seq_number)
+                    }),
+                Observation::Faulty => IndexObservation::Faulty,
+            };
+            validator_map[vid] = index_obs;
+        }
+        validator_map
+    }
+}

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -98,7 +98,9 @@ impl<'a, C: Context> Tally<'a, C> {
         state: &'a State<C>,
     ) -> Option<Self> {
         let iter = self.votes.into_iter();
-        Self::try_from_iter(iter.filter(|&(b, _)| state.find_ancestor(b, height) == Some(bhash)))
+        Self::try_from_iter(
+            iter.filter(|&(b, _)| state.find_ancestor_proposal(b, height) == Some(bhash)),
+        )
     }
 }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -808,32 +808,24 @@ where
                     "received a request for a dependency"
                 );
                 match self.highway.get_dependency_by_index(vid, unit_seq_number) {
-                    Ok(index_dep) => {
-                        match index_dep {
-                            GetDepOutcome::None => {
-                                info!(
-                                    ?vid,
-                                    ?unit_seq_number,
-                                    ?sender,
-                                    "requested dependency doesn't exist"
-                                );
-                                vec![]
-                            }
-                            GetDepOutcome::Evidence(vid) => {
-                                vec![ProtocolOutcome::SendEvidence(sender, vid)]
-                            }
-                            // TODO: Should this be done via a gossip service?
-                            GetDepOutcome::Vertex(vv) => {
-                                vec![ProtocolOutcome::CreatedTargetedMessage(
-                                    HighwayMessage::NewVertex(vv.into()).serialize(),
-                                    sender,
-                                )]
-                            }
-                        }
+                    GetDepOutcome::None => {
+                        info!(
+                            ?vid,
+                            ?unit_seq_number,
+                            ?sender,
+                            "requested dependency doesn't exist"
+                        );
+                        vec![]
                     }
-                    Err(_) => {
-                        error!(?sender, "received an invalid RequestDependencyByHeight message from the sender. Disconnecting");
-                        return vec![ProtocolOutcome::Disconnect(sender)];
+                    GetDepOutcome::Evidence(vid) => {
+                        vec![ProtocolOutcome::SendEvidence(sender, vid)]
+                    }
+                    // TODO: Should this be done via a gossip service?
+                    GetDepOutcome::Vertex(vv) => {
+                        vec![ProtocolOutcome::CreatedTargetedMessage(
+                            HighwayMessage::NewVertex(vv.into()).serialize(),
+                            sender,
+                        )]
                     }
                 }
             }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -884,12 +884,11 @@ where
                     .enumerate()
                     .zip(&their_index_panorama)
                     .map(create_message)
-                    .map(|msgs| {
+                    .flat_map(|msgs| {
                         msgs.into_iter().map(|msg| {
                             ProtocolOutcome::CreatedTargetedMessage(msg.serialize(), sender.clone())
                         })
                     })
-                    .flatten()
                     .collect()
             }
         }

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -31,6 +31,10 @@ pub struct Config {
     pub max_execution_delay: u64,
     /// The maximum number of peers we request the same vertex from in parallel.
     pub max_requests_for_vertex: usize,
+    /// The maximum number of dependencies we request per validator in a batch.
+    /// Limits requests per validator in panorama - in order to get a total number of
+    /// requests, multiply by # of validators.
+    pub max_request_batch_size: usize,
     pub round_success_meter: RSMConfig,
 }
 
@@ -46,6 +50,7 @@ impl Default for Config {
             log_unit_sizes: false,
             max_execution_delay: 3,
             max_requests_for_vertex: 5,
+            max_request_batch_size: 20,
             round_success_meter: RSMConfig::default(),
         }
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -65,6 +65,11 @@ max_execution_delay = 3
 # The maximum number of peers we request the same vertex from in parallel.
 max_requests_for_vertex = 5
 
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
 [consensus.highway.round_success_meter]
 # The number of most recent rounds we will be keeping track of.
 num_rounds_to_consider = 40

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -65,6 +65,11 @@ max_execution_delay = 3
 # The maximum number of peers we request the same vertex from in parallel.
 max_requests_for_vertex = 5
 
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
 [consensus.highway.round_success_meter]
 # The number of most recent rounds we will be keeping track of.
 num_rounds_to_consider = 40


### PR DESCRIPTION
Currently (in `dev` branch), protocol state is being synchronized by requesting a single missing dependency at once - i.e. if we can't add a unit to the protocol state we request the very first missing dependency from sender (peers). Until then, the original unit is put back on the synchronization queue. For a joining node, that has a lot of protocol state to catch up, that process can be very long (in our internal tests with 100 validators, joining an era late was taking up to 1.5 hour). That kind of synchronization performance is unacceptable and we had to improve it. This also is a blocker for increasing block production rate - if it takes hours to join with blocks being produced every minute, it will be take even longer with twice as many (or more) blocks.

This PR changes the `LatestStateRequest` to include a new structure called `IndexPanorama` that, instead of latest unit hashes we had seen, contains these units' sequence numbers. Upon receiving that message, receiving node will compare latest sequence numbers of the sender with their local view of the protocol state and, depending on the result, either request up to `N` (value configurable via `consensus.highway.max_requests_per_batch`) or send up to `N` dependencies that the sender is missing. This change improves the performance drastically and, in our internal tests with 100 validators, allows for fully syncing in less than 20 minutes (previously 1.5h+).

Closes https://github.com/casper-network/casper-node/issues/2022 and https://github.com/casper-network/casper-node/issues/2041


### Before
![image](https://user-images.githubusercontent.com/5120801/133083431-5aab580f-44e5-4cde-af7d-e294b5db8a91.png)

### After
![image](https://user-images.githubusercontent.com/5120801/133083480-bbba3146-2b25-4d13-bad5-85e110c2b87c.png)
