### PR TITLE
Add histogram tracking the time to verify a deploy before accepting it.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.  The format
 * Individual weights for traffic throttling can now be set through the configuration value
   `network.estimator_weights`.
 * Added `consensus.highway.max_request_batch_size` configuration parameter. Defaults to 20.
+* New histogram metrics `deploy_acceptor_accepted_deploy` and `deploy_acceptor_rejected_deploy` that track how long the initial verification took.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use std::fmt::Debug;
 
-use prometheus::{Registry};
+use prometheus::Registry;
 use thiserror::Error;
 use tracing::{debug, error, info};
 

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -6,7 +6,7 @@ use super::Source;
 use crate::{
     components::deploy_acceptor::Error,
     effect::{announcements::RpcServerAnnouncement, Responder},
-    types::{Deploy, NodeId},
+    types::{Deploy, NodeId, Timestamp},
 };
 use casper_types::Key;
 
@@ -25,6 +25,7 @@ pub(crate) enum Event {
         source: Source<NodeId>,
         is_new: bool,
         maybe_responder: Option<Responder<Result<(), Error>>>,
+        verification_start_timestamp: Timestamp,
     },
     /// The result of verifying `Account` exists and has meets minimum balance requirements.
     AccountVerificationResult {
@@ -33,6 +34,7 @@ pub(crate) enum Event {
         account_key: Key,
         verified: Option<bool>,
         maybe_responder: Option<Responder<Result<(), Error>>>,
+        verification_start_timestamp: Timestamp,
     },
 }
 

--- a/node/src/components/deploy_acceptor/metrics.rs
+++ b/node/src/components/deploy_acceptor/metrics.rs
@@ -1,0 +1,77 @@
+use prometheus::{Histogram, HistogramOpts, Registry};
+
+use crate::{types::Timestamp, unregister_metric};
+
+const DEPLOY_ACCEPTED_NAME: &str = "deploy_acceptor_accepted_deploy";
+const DEPLOY_ACCEPTED_HELP: &str =
+    "tracking time it took to accept a deploy in the deploy acceptor";
+const DEPLOY_REJECTED_NAME: &str = "deploy_acceptor_rejected_deploy";
+const DEPLOY_REJECTED_HELP: &str =
+    "tracking time it took to reject a deploy in the deploy acceptor";
+
+/// Value of upper bound of the first bucked. In ms.
+const EXPONENTIAL_BUCKET_START: f64 = 10.0;
+
+/// Multiplier of previous upper bound for next bound.
+const EXPONENTIAL_BUCKET_FACTOR: f64 = 2.0;
+
+/// Bucket count, with the last bucket going to +Inf which will not be included in the results.
+const EXPONENTIAL_BUCKET_COUNT: usize = 10;
+
+/// Create prometheus Histogram and register.
+fn register_histogram_metric(
+    registry: &Registry,
+    metric_name: &str,
+    metric_help: &str,
+) -> Result<Histogram, prometheus::Error> {
+    let common_buckets = prometheus::exponential_buckets(
+        EXPONENTIAL_BUCKET_START,
+        EXPONENTIAL_BUCKET_FACTOR,
+        EXPONENTIAL_BUCKET_COUNT,
+    )?;
+    let histogram_opts = HistogramOpts::new(metric_name, metric_help).buckets(common_buckets);
+    let histogram = Histogram::with_opts(histogram_opts)?;
+    registry.register(Box::new(histogram.clone()))?;
+    Ok(histogram)
+}
+#[derive(Debug)]
+pub(super) struct Metrics {
+    deploy_accepted: Histogram,
+    deploy_rejected: Histogram,
+    registry: Registry,
+}
+
+impl Metrics {
+    pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        Ok(Self {
+            deploy_accepted: register_histogram_metric(
+                registry,
+                DEPLOY_ACCEPTED_NAME,
+                DEPLOY_ACCEPTED_HELP,
+            )?,
+            deploy_rejected: register_histogram_metric(
+                registry,
+                DEPLOY_REJECTED_NAME,
+                DEPLOY_REJECTED_HELP,
+            )?,
+            registry: registry.clone(),
+        })
+    }
+
+    pub(super) fn observe_rejected(&self, start: Timestamp) {
+        self.deploy_rejected
+            .observe(start.elapsed().millis() as f64);
+    }
+
+    pub(super) fn observe_accepted(&self, start: Timestamp) {
+        self.deploy_accepted
+            .observe(start.elapsed().millis() as f64);
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.deploy_accepted);
+        unregister_metric!(self.registry, self.deploy_rejected);
+    }
+}

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -200,7 +200,7 @@ impl reactor::Reactor for Reactor {
 
     fn new(
         config: Self::Config,
-        _registry: &Registry,
+        registry: &Registry,
         _event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
@@ -218,7 +218,9 @@ impl reactor::Reactor for Reactor {
         let deploy_acceptor = DeployAcceptor::new(
             super::Config::new(VERIFY_ACCOUNTS),
             &Chainspec::from_resources("local"),
-        );
+            registry,
+        )
+        .unwrap();
 
         let reactor = Reactor {
             storage,

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -79,7 +79,7 @@ reactor!(Reactor {
             false,
             "test"
         );
-        deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec());
+        deploy_acceptor = DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec(), registry);
         deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);
     }
 

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -208,7 +208,9 @@ impl reactor::Reactor for Reactor {
         let deploy_acceptor = DeployAcceptor::new(
             deploy_acceptor::Config::new(false),
             &Chainspec::from_resources("local"),
-        );
+            registry,
+        )
+        .unwrap();
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",
             config,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -482,8 +482,11 @@ impl reactor::Reactor for Reactor {
         let block_header_by_hash_fetcher: Fetcher<BlockHeader> =
             Fetcher::new("block_header_by_hash", config.fetcher, registry)?;
 
-        let deploy_acceptor =
-            DeployAcceptor::new(config.deploy_acceptor, &*chainspec_loader.chainspec());
+        let deploy_acceptor = DeployAcceptor::new(
+            config.deploy_acceptor,
+            &*chainspec_loader.chainspec(),
+            registry,
+        )?;
 
         contract_runtime.set_initial_state(chainspec_loader.initial_execution_pre_state());
         let linear_chain = linear_chain::LinearChainComponent::new(

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -493,8 +493,12 @@ impl reactor::Reactor for Reactor {
             node_startup_instant,
         )?;
 
-        let deploy_acceptor =
-            DeployAcceptor::new(config.deploy_acceptor, &*chainspec_loader.chainspec());
+        let deploy_acceptor = DeployAcceptor::new(
+            config.deploy_acceptor,
+            &*chainspec_loader.chainspec(),
+            registry,
+        )?;
+
         let deploy_fetcher = Fetcher::new("deploy", config.fetcher, registry)?;
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",


### PR DESCRIPTION
Add new histogram metrics that track how long it takes to verify a deploy before accepting it (or rejecting).

![image](https://user-images.githubusercontent.com/5120801/133287457-4d6fd98d-2ffb-4557-8323-28677766ddfa.png)

Closes https://github.com/casper-network/casper-node/issues/2071. 