### PR TITLE
GH-2079: Bump transfer to 250m gas

### DIFF
--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -14,7 +14,7 @@ use self::{
     standard_payment_costs::StandardPaymentCosts,
 };
 
-pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 10_000;
+pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 250_000_000;
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct SystemConfig {

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -186,7 +186,7 @@ write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 250_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000


### PR DESCRIPTION
Closes #2079 

This change bumps native transfer cost from 10k gas units to 250mil (0.25CSPR) to mitigate ping pong behavior