### PR TITLE
Update cargo-casper to provide erc20 project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "assert-json-diff"
@@ -374,7 +374,7 @@ name = "cargo-casper"
 version = "1.0.0"
 dependencies = [
  "assert_cmd",
- "clap 2.33.3",
+ "clap 3.0.0-beta.4",
  "colour",
  "once_cell",
  "tempfile",
@@ -610,7 +610,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "signal-hook 0.3.9",
+ "signal-hook 0.3.10",
  "signature",
  "smallvec",
  "static_assertions",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -1660,7 +1660,7 @@ version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
- "num-bigint 0.4.0",
+ "num-bigint 0.4.2",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1806,9 +1806,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1831,15 +1831,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1848,15 +1848,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -1867,21 +1867,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -2262,9 +2262,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2401,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2453,9 +2453,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "linked-hash-map"
@@ -2495,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -2732,7 +2732,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.0",
+ "num-bigint 0.4.2",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2822,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.0",
+ "num-bigint 0.4.2",
  "num-integer",
  "num-traits",
  "serde",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -2948,9 +2948,9 @@ checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -2959,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -3262,9 +3262,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -3780,23 +3780,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9bd29cdffb8875b04f71c51058f940cf4e390bbfd2ce669c4f22cd70b492a5"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "num",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3894,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -3916,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4ebf9d3eff2c70e4092a70a9d759e01b675f8daf1442703a18e57898847830"
+checksum = "d82178225dbdeae2d5d190e8649287db6a3a32c6d24da22ae3146325aa353e4c"
 dependencies = [
  "serde",
 ]
@@ -3937,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -3950,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -3983,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4035,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
@@ -4079,9 +4078,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
  "clap 2.33.3",
  "lazy_static",
@@ -4090,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -4130,9 +4129,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4220,18 +4219,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4269,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4284,9 +4283,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4374,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4424,9 +4423,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4437,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4448,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
  "lazy_static",
 ]
@@ -4488,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4672,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
@@ -4734,9 +4733,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -4924,9 +4923,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -4936,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4951,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4963,9 +4962,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4973,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4986,9 +4985,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmi"
@@ -5016,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/ci/casper_updater/src/package.rs
+++ b/ci/casper_updater/src/package.rs
@@ -77,7 +77,9 @@ impl Package {
         relative_path: P,
         dependent_files: &'static Vec<DependentFile>,
     ) -> Self {
-        Self::new::<_, AssemblyScriptPackage>(relative_path, dependent_files)
+        let mut package = Self::new::<_, AssemblyScriptPackage>(relative_path, dependent_files);
+        package.name = format!("{} (AssemblyScript)", package.name);
+        package
     }
 
     fn new<P: AsRef<Path>, T: PackageConsts>(

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -276,7 +276,7 @@ pub mod execution_engine_testing_test_support {
     pub static DEPENDENT_FILES: Lazy<Vec<DependentFile>> = Lazy::new(|| {
         vec![
                 DependentFile::new(
-                    "execution_engine_testing/cargo_casper/src/tests_package.rs",
+                    "execution_engine_testing/cargo_casper/src/common.rs",
                     Regex::new(r#"(?m)("casper-engine-test-support",\s*)"(?:[^"]+)"#).unwrap(),
                     cargo_casper_src_test_package_rs_replacement,
                 ),

--- a/execution_engine_testing/cargo_casper/CHANGELOG.md
+++ b/execution_engine_testing/cargo_casper/CHANGELOG.md
@@ -18,6 +18,25 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## [1.3.3] - 2021-09-13
+
+### Added
+* Add support for generating an ERC-20 contract.
+
+
+
+## [1.3.2] - 2021-08-02
+
+No changes.
+
+
+
+## [1.3.1] - 2021-07-26
+
+No changes.
+
+
+
 ## [1.3.0] - 2021-07-19
 
 ### Changed
@@ -58,7 +77,10 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.3...dev
+[1.3.3]: https://github.com/casper-network/casper-node/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/casper-network/casper-node/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-casper"
 version = "1.0.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
-description = "Command line tool for creating a Wasm smart contract and tests for use on the Casper network."
+description = "A command line tool for creating a Wasm smart contract and tests for use on the Casper network."
 readme = "README.md"
 documentation = "https://docs.rs/cargo-casper"
 homepage = "https://casperlabs.io"
@@ -13,14 +13,15 @@ include = [
     "src/*.rs",
     "Cargo.lock",
     "Cargo.toml",
+    "resources/*"
 ]
 
 [dependencies]
-clap = "2"
+clap = "3.0.0-beta.4"
 colour = "0.6"
-once_cell = "1.5.2"
+once_cell = "1"
 
 [dev-dependencies]
 assert_cmd = "1"
 tempfile = "3"
-toml = "0.5.7"
+toml = "0.5.8"

--- a/execution_engine_testing/cargo_casper/resources/erc20/Makefile.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/Makefile.in
@@ -1,0 +1,28 @@
+prepare:
+	rustup target add wasm32-unknown-unknown
+
+build-erc20:
+	cd erc20_token && cargo build --release --target wasm32-unknown-unknown
+	wasm-strip erc20_token/target/wasm32-unknown-unknown/release/erc20_token.wasm 2>/dev/null | true
+
+test: build-erc20
+	mkdir -p tests/wasm
+	cp erc20_token/target/wasm32-unknown-unknown/release/erc20_token.wasm tests/wasm
+	cd tests && cargo test
+
+clippy:
+	cd erc20_token && cargo clippy --all-targets -- -D warnings
+	cd tests && cargo clippy --all-targets -- -D warnings
+
+check-lint: clippy
+	cd erc20_token && cargo fmt -- --check
+	cd tests && cargo fmt -- --check
+
+lint: clippy
+	cd erc20_token && cargo fmt
+	cd tests && cargo fmt
+
+clean:
+	cd erc20_token && cargo clean
+	cd tests && cargo clean
+	rm -rf tests/wasm

--- a/execution_engine_testing/cargo_casper/resources/erc20/integration_tests.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/integration_tests.rs.in
@@ -1,0 +1,189 @@
+#[cfg(test)]
+mod test_fixture;
+
+#[cfg(test)]
+mod tests {
+    use casper_types::{Key, U256};
+
+    use crate::test_fixture::{Sender, TestFixture};
+
+    #[test]
+    fn should_install() {
+        let fixture = TestFixture::install_contract();
+        assert_eq!(fixture.token_name(), TestFixture::TOKEN_NAME);
+        assert_eq!(fixture.token_symbol(), TestFixture::TOKEN_SYMBOL);
+        assert_eq!(fixture.token_decimals(), TestFixture::TOKEN_DECIMALS);
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply())
+        );
+    }
+
+    #[test]
+    fn should_transfer() {
+        let mut fixture = TestFixture::install_contract();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply())
+        );
+        let transfer_amount_1 = U256::from(42);
+        fixture.transfer(
+            Key::from(fixture.bob),
+            transfer_amount_1,
+            Sender(fixture.ali),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(transfer_amount_1)
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply() - transfer_amount_1)
+        );
+
+        let transfer_amount_2 = U256::from(20);
+        fixture.transfer(
+            Key::from(fixture.ali),
+            transfer_amount_2,
+            Sender(fixture.bob),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(TestFixture::token_total_supply() - transfer_amount_1 + transfer_amount_2),
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(transfer_amount_1 - transfer_amount_2)
+        );
+    }
+
+    #[test]
+    fn should_transfer_full_amount() {
+        let mut fixture = TestFixture::install_contract();
+
+        let initial_ali_balance = fixture.balance_of(Key::from(fixture.ali)).unwrap();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+
+        fixture.transfer(
+            Key::from(fixture.bob),
+            initial_ali_balance,
+            Sender(fixture.ali),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(initial_ali_balance)
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(U256::zero())
+        );
+
+        fixture.transfer(
+            Key::from(fixture.ali),
+            initial_ali_balance,
+            Sender(fixture.bob),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.bob)),
+            Some(U256::zero())
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(fixture.ali)),
+            Some(initial_ali_balance)
+        );
+    }
+
+    #[should_panic(expected = "ApiError::User(65534) [131070]")]
+    #[test]
+    fn should_not_transfer_with_insufficient_balance() {
+        let mut fixture = TestFixture::install_contract();
+
+        let initial_ali_balance = fixture.balance_of(Key::from(fixture.ali)).unwrap();
+        assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+
+        fixture.transfer(
+            Key::from(fixture.bob),
+            initial_ali_balance + U256::one(),
+            Sender(fixture.ali),
+        );
+    }
+
+    #[test]
+    fn should_transfer_from() {
+        let approve_amount = U256::from(100);
+        let transfer_amount = U256::from(42);
+        assert!(approve_amount > transfer_amount);
+
+        let mut fixture = TestFixture::install_contract();
+
+        let owner = fixture.ali;
+        let spender = fixture.bob;
+        let recipient = fixture.joe;
+
+        let owner_balance_before = fixture
+            .balance_of(Key::from(owner))
+            .expect("owner should have balance");
+        fixture.approve(Key::from(spender), approve_amount, Sender(owner));
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount)
+        );
+
+        fixture.transfer_from(
+            Key::from(owner),
+            Key::from(recipient),
+            transfer_amount,
+            Sender(spender),
+        );
+
+        assert_eq!(
+            fixture.balance_of(Key::from(owner)),
+            Some(owner_balance_before - transfer_amount),
+            "should decrease balance of the owner"
+        );
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount - transfer_amount),
+            "should decrease allowance of the spender"
+        );
+        assert_eq!(
+            fixture.balance_of(Key::from(recipient)),
+            Some(transfer_amount),
+            "recipient should receive tokens"
+        );
+    }
+
+    #[should_panic(expected = "ApiError::User(65533) [131069]")]
+    #[test]
+    fn should_not_transfer_from_more_than_approved() {
+        let approve_amount = U256::from(100);
+        let transfer_amount = U256::from(42);
+        assert!(approve_amount > transfer_amount);
+
+        let mut fixture = TestFixture::install_contract();
+
+        let owner = fixture.ali;
+        let spender = fixture.bob;
+        let recipient = fixture.joe;
+
+        fixture.approve(Key::from(spender), approve_amount, Sender(owner));
+        assert_eq!(
+            fixture.allowance(Key::from(owner), Key::from(spender)),
+            Some(approve_amount)
+        );
+
+        fixture.transfer_from(
+            Key::from(owner),
+            Key::from(recipient),
+            approve_amount + U256::one(),
+            Sender(spender),
+        );
+    }
+}
+
+fn main() {
+    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
+}

--- a/execution_engine_testing/cargo_casper/resources/erc20/main.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/main.rs.in
@@ -1,0 +1,97 @@
+#![no_std]
+#![no_main]
+
+#[cfg(not(target_arch = "wasm32"))]
+compile_error!("target arch should be wasm32: compile with '--target wasm32-unknown-unknown'");
+
+extern crate alloc;
+
+use alloc::string::String;
+
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
+use casper_erc20::{
+    constants::{
+        ADDRESS_RUNTIME_ARG_NAME, AMOUNT_RUNTIME_ARG_NAME, DECIMALS_RUNTIME_ARG_NAME,
+        NAME_RUNTIME_ARG_NAME, OWNER_RUNTIME_ARG_NAME, RECIPIENT_RUNTIME_ARG_NAME,
+        SPENDER_RUNTIME_ARG_NAME, SYMBOL_RUNTIME_ARG_NAME, TOTAL_SUPPLY_RUNTIME_ARG_NAME,
+    },
+    Address, ERC20,
+};
+use casper_types::{CLValue, U256};
+
+#[no_mangle]
+pub extern "C" fn name() {
+    let name = ERC20::default().name();
+    runtime::ret(CLValue::from_t(name).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn symbol() {
+    let symbol = ERC20::default().symbol();
+    runtime::ret(CLValue::from_t(symbol).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn decimals() {
+    let decimals = ERC20::default().decimals();
+    runtime::ret(CLValue::from_t(decimals).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn total_supply() {
+    let total_supply = ERC20::default().total_supply();
+    runtime::ret(CLValue::from_t(total_supply).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn balance_of() {
+    let address: Address = runtime::get_named_arg(ADDRESS_RUNTIME_ARG_NAME);
+    let balance = ERC20::default().balance_of(address);
+    runtime::ret(CLValue::from_t(balance).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn transfer() {
+    let recipient: Address = runtime::get_named_arg(RECIPIENT_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+
+    ERC20::default()
+        .transfer(recipient, amount)
+        .unwrap_or_revert();
+}
+
+#[no_mangle]
+pub extern "C" fn approve() {
+    let spender: Address = runtime::get_named_arg(SPENDER_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+
+    ERC20::default().approve(spender, amount).unwrap_or_revert();
+}
+
+#[no_mangle]
+pub extern "C" fn allowance() {
+    let owner: Address = runtime::get_named_arg(OWNER_RUNTIME_ARG_NAME);
+    let spender: Address = runtime::get_named_arg(SPENDER_RUNTIME_ARG_NAME);
+    let val = ERC20::default().allowance(owner, spender);
+    runtime::ret(CLValue::from_t(val).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn transfer_from() {
+    let owner: Address = runtime::get_named_arg(OWNER_RUNTIME_ARG_NAME);
+    let recipient: Address = runtime::get_named_arg(RECIPIENT_RUNTIME_ARG_NAME);
+    let amount: U256 = runtime::get_named_arg(AMOUNT_RUNTIME_ARG_NAME);
+    ERC20::default()
+        .transfer_from(owner, recipient, amount)
+        .unwrap_or_revert();
+}
+
+#[no_mangle]
+fn call() {
+    let name: String = runtime::get_named_arg(NAME_RUNTIME_ARG_NAME);
+    let symbol: String = runtime::get_named_arg(SYMBOL_RUNTIME_ARG_NAME);
+    let decimals = runtime::get_named_arg(DECIMALS_RUNTIME_ARG_NAME);
+    let total_supply = runtime::get_named_arg(TOTAL_SUPPLY_RUNTIME_ARG_NAME);
+
+    let _token = ERC20::install(name, symbol, decimals, total_supply).unwrap_or_revert();
+}

--- a/execution_engine_testing/cargo_casper/resources/erc20/test_fixture.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/erc20/test_fixture.rs.in
@@ -1,0 +1,192 @@
+use blake2::{
+    digest::{Update, VariableOutput},
+    VarBlake2b,
+};
+use casper_engine_test_support::{Code, SessionBuilder, TestContext, TestContextBuilder};
+use casper_erc20::constants as consts;
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{FromBytes, ToBytes},
+    runtime_args, AsymmetricType, CLTyped, ContractHash, Key, PublicKey, RuntimeArgs, U256, U512,
+};
+
+const CONTRACT_ERC20_TOKEN: &str = "erc20_token.wasm";
+const CONTRACT_KEY_NAME: &str = "erc20_token_contract";
+
+fn blake2b256(item_key_string: &[u8]) -> Box<[u8]> {
+    let mut hasher = VarBlake2b::new(32).unwrap();
+    hasher.update(item_key_string);
+    hasher.finalize_boxed()
+}
+
+#[derive(Clone, Copy)]
+pub struct Sender(pub AccountHash);
+
+pub struct TestFixture {
+    context: TestContext,
+    pub ali: AccountHash,
+    pub bob: AccountHash,
+    pub joe: AccountHash,
+}
+
+impl TestFixture {
+    pub const TOKEN_NAME: &'static str = "Test ERC20";
+    pub const TOKEN_SYMBOL: &'static str = "TERC";
+    pub const TOKEN_DECIMALS: u8 = 8;
+    const TOKEN_TOTAL_SUPPLY_AS_U64: u64 = 1000;
+
+    pub fn token_total_supply() -> U256 {
+        Self::TOKEN_TOTAL_SUPPLY_AS_U64.into()
+    }
+
+    pub fn install_contract() -> TestFixture {
+        let ali = PublicKey::ed25519_from_bytes([3u8; 32]).unwrap();
+        let bob = PublicKey::ed25519_from_bytes([6u8; 32]).unwrap();
+        let joe = PublicKey::ed25519_from_bytes([9u8; 32]).unwrap();
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(ali.clone(), U512::from(500_000_000_000_000_000u64))
+            .with_public_key(bob.clone(), U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        let session_code = Code::from(CONTRACT_ERC20_TOKEN);
+        let session_args = runtime_args! {
+            consts::NAME_RUNTIME_ARG_NAME => TestFixture::TOKEN_NAME,
+            consts::SYMBOL_RUNTIME_ARG_NAME => TestFixture::TOKEN_SYMBOL,
+            consts::DECIMALS_RUNTIME_ARG_NAME => TestFixture::TOKEN_DECIMALS,
+            consts::TOTAL_SUPPLY_RUNTIME_ARG_NAME => TestFixture::token_total_supply()
+        };
+
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(ali.to_account_hash())
+            .with_authorization_keys(&[ali.to_account_hash()])
+            .build();
+
+        context.run(session);
+        TestFixture {
+            context,
+            ali: ali.to_account_hash(),
+            bob: bob.to_account_hash(),
+            joe: joe.to_account_hash(),
+        }
+    }
+
+    fn contract_hash(&self) -> ContractHash {
+        self.context
+            .get_account(self.ali)
+            .unwrap()
+            .named_keys()
+            .get(CONTRACT_KEY_NAME)
+            .unwrap()
+            .normalize()
+            .into_hash()
+            .unwrap()
+            .into()
+    }
+
+    fn query_contract<T: CLTyped + FromBytes>(&self, name: &str) -> Option<T> {
+        match self
+            .context
+            .query(self.ali, &[CONTRACT_KEY_NAME.to_string(), name.to_string()])
+        {
+            Err(_) => None,
+            Ok(maybe_value) => {
+                let value = maybe_value
+                    .into_t()
+                    .unwrap_or_else(|_| panic!("{} is not expected type.", name));
+                Some(value)
+            }
+        }
+    }
+
+    fn call(&mut self, sender: Sender, method: &str, args: RuntimeArgs) {
+        let Sender(address) = sender;
+        let code = Code::Hash(self.contract_hash().value(), method.to_string());
+        let session = SessionBuilder::new(code, args)
+            .with_address(address)
+            .with_authorization_keys(&[address])
+            .build();
+        self.context.run(session);
+    }
+
+    pub fn token_name(&self) -> String {
+        self.query_contract(consts::NAME_RUNTIME_ARG_NAME).unwrap()
+    }
+
+    pub fn token_symbol(&self) -> String {
+        self.query_contract(consts::SYMBOL_RUNTIME_ARG_NAME)
+            .unwrap()
+    }
+
+    pub fn token_decimals(&self) -> u8 {
+        self.query_contract(consts::DECIMALS_RUNTIME_ARG_NAME)
+            .unwrap()
+    }
+
+    pub fn balance_of(&self, account: Key) -> Option<U256> {
+        let item_key = base64::encode(&account.to_bytes().unwrap());
+
+        let key = Key::Hash(self.contract_hash().value());
+        let value = self
+            .context
+            .query_dictionary_item(key, Some(consts::BALANCES_KEY_NAME.to_string()), item_key)
+            .ok()?;
+
+        Some(value.into_t::<U256>().unwrap())
+    }
+
+    pub fn allowance(&self, owner: Key, spender: Key) -> Option<U256> {
+        let mut preimage = Vec::new();
+        preimage.append(&mut owner.to_bytes().unwrap());
+        preimage.append(&mut spender.to_bytes().unwrap());
+        let key_bytes = blake2b256(&preimage);
+        let allowance_item_key = hex::encode(&key_bytes);
+
+        let key = Key::Hash(self.contract_hash().value());
+
+        let value = self
+            .context
+            .query_dictionary_item(
+                key,
+                Some(consts::ALLOWANCES_KEY_NAME.to_string()),
+                allowance_item_key,
+            )
+            .ok()?;
+
+        Some(value.into_t::<U256>().unwrap())
+    }
+
+    pub fn transfer(&mut self, recipient: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::TRANSFER_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::RECIPIENT_RUNTIME_ARG_NAME => recipient,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+
+    pub fn approve(&mut self, spender: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::APPROVE_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::SPENDER_RUNTIME_ARG_NAME => spender,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+
+    pub fn transfer_from(&mut self, owner: Key, recipient: Key, amount: U256, sender: Sender) {
+        self.call(
+            sender,
+            consts::TRANSFER_FROM_ENTRY_POINT_NAME,
+            runtime_args! {
+                consts::OWNER_RUNTIME_ARG_NAME => owner,
+                consts::RECIPIENT_RUNTIME_ARG_NAME => recipient,
+                consts::AMOUNT_RUNTIME_ARG_NAME => amount
+            },
+        );
+    }
+}

--- a/execution_engine_testing/cargo_casper/resources/simple/Makefile.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/Makefile.in
@@ -1,0 +1,28 @@
+prepare:
+	rustup target add wasm32-unknown-unknown
+
+build-contract:
+	cd contract && cargo build --release --target wasm32-unknown-unknown
+	wasm-strip contract/target/wasm32-unknown-unknown/release/contract.wasm 2>/dev/null | true
+
+test: build-contract
+	mkdir -p tests/wasm
+	cp contract/target/wasm32-unknown-unknown/release/contract.wasm tests/wasm
+	cd tests && cargo test
+
+clippy:
+	cd contract && cargo clippy --all-targets -- -D warnings
+	cd tests && cargo clippy --all-targets -- -D warnings
+
+check-lint: clippy
+	cd contract && cargo fmt -- --check
+	cd tests && cargo fmt -- --check
+
+lint: clippy
+	cd contract && cargo fmt
+	cd tests && cargo fmt
+
+clean:
+	cd contract && cargo clean
+	cd tests && cargo clean
+	rm -rf tests/wasm

--- a/execution_engine_testing/cargo_casper/resources/simple/integration_tests.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/integration_tests.rs.in
@@ -1,0 +1,70 @@
+#[cfg(test)]
+mod tests {
+    use casper_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
+    use casper_types::{
+        account::AccountHash, runtime_args, PublicKey, RuntimeArgs, SecretKey, U512,
+    };
+
+    const MY_ACCOUNT: [u8; 32] = [7u8; 32];
+    // Define `KEY` constant to match that in the contract.
+    const KEY: &str = "my-key-name";
+    const VALUE: &str = "hello world";
+    const RUNTIME_ARG_NAME: &str = "message";
+    const CONTRACT_WASM: &str = "contract.wasm";
+
+    #[test]
+    fn should_store_hello_world() {
+        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        let account_addr = AccountHash::from(&public_key);
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
+        // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
+        // absolute paths.
+        let session_code = Code::from(CONTRACT_WASM);
+        let session_args = runtime_args! {
+            RUNTIME_ARG_NAME => VALUE,
+        };
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(account_addr)
+            .with_authorization_keys(&[account_addr])
+            .build();
+
+        let result_of_query: Result<Value, Error> =
+            context.run(session).query(account_addr, &[KEY.to_string()]);
+
+        let returned_value = result_of_query.expect("should be a value");
+
+        let expected_value = Value::from_t(VALUE.to_string()).expect("should construct Value");
+        assert_eq!(expected_value, returned_value);
+    }
+
+    #[test]
+    #[should_panic(expected = "ApiError::MissingArgument")]
+    fn should_error_on_missing_runtime_arg() {
+        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        let account_addr = AccountHash::from(&public_key);
+
+        let mut context = TestContextBuilder::new()
+            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
+            .build();
+
+        let session_code = Code::from(CONTRACT_WASM);
+        let session_args = RuntimeArgs::new();
+        let session = SessionBuilder::new(session_code, session_args)
+            .with_address(account_addr)
+            .with_authorization_keys(&[account_addr])
+            .build();
+
+        context.run(session);
+    }
+}
+
+fn main() {
+    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
+}

--- a/execution_engine_testing/cargo_casper/resources/simple/main.rs.in
+++ b/execution_engine_testing/cargo_casper/resources/simple/main.rs.in
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+
+#[cfg(not(target_arch = "wasm32"))]
+compile_error!("target arch should be wasm32: compile with '--target wasm32-unknown-unknown'");
+
+// We need to explicitly import the std alloc crate and `alloc::string::String` as we're in a
+// `no_std` environment.
+extern crate alloc;
+
+use alloc::string::String;
+
+use casper_contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{ApiError, Key};
+
+const KEY_NAME: &str = "my-key-name";
+const RUNTIME_ARG_NAME: &str = "message";
+
+/// An error enum which can be converted to a `u16` so it can be returned as an `ApiError::User`.
+#[repr(u16)]
+enum Error {
+    KeyAlreadyExists = 0,
+    KeyMismatch = 1,
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> Self {
+        ApiError::User(error as u16)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // The key shouldn't already exist in the named keys.
+    let missing_key = runtime::get_key(KEY_NAME);
+    if missing_key.is_some() {
+        runtime::revert(Error::KeyAlreadyExists);
+    }
+
+    // This contract expects a single runtime argument to be provided.  The arg is named "message"
+    // and will be of type `String`.
+    let value: String = runtime::get_named_arg(RUNTIME_ARG_NAME);
+
+    // Store this value under a new unforgeable reference a.k.a `URef`.
+    let value_ref = storage::new_uref(value);
+
+    // Store the new `URef` as a named key with a name of `KEY_NAME`.
+    let key = Key::URef(value_ref);
+    runtime::put_key(KEY_NAME, key);
+
+    // The key should now be able to be retrieved.  Note that if `get_key()` returns `None`, then
+    // `unwrap_or_revert()` will exit the process, returning `ApiError::None`.
+    let retrieved_key = runtime::get_key(KEY_NAME).unwrap_or_revert();
+    if retrieved_key != key {
+        runtime::revert(Error::KeyMismatch);
+    }
+}

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -3,18 +3,25 @@ use std::{fs, path::Path, process, str};
 use colour::e_red;
 use once_cell::sync::Lazy;
 
-use crate::{dependency::Dependency, FAILURE_EXIT_CODE};
+use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "1.0.0", "smart_contracts/contract"));
-pub static CL_TYPES: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-types", "1.0.0", "types"));
-pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
-    Dependency::new(
-        "casper-engine-test-support",
-        "1.0.0",
-        "execution_engine_testing/test_support",
-    )
+    Lazy::new(|| Dependency::new("casper-contract", "1.0.0"));
+pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.0.0"));
+pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> =
+    Lazy::new(|| Dependency::new("casper-engine-test-support", "1.0.0"));
+pub static PATCH_SECTION: Lazy<String> = Lazy::new(|| match ARGS.workspace_path() {
+    Some(workspace_path) => {
+        format!(
+            r#"[patch.crates-io]
+casper-engine-test-support = {{ path = "{0}/execution_engine_testing/test_support" }}
+casper-contract = {{ path = "{0}/smart_contracts/contract" }}
+casper-types = {{ path = "{0}/types" }}
+"#,
+            workspace_path.display()
+        )
+    }
+    None => String::new(),
 });
 
 pub fn print_error_and_exit(msg: &str) -> ! {

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -1,47 +1,26 @@
-use std::{
-    fs::{self, OpenOptions},
-    io::Write,
-    path::Path,
-    process::{self, Command},
-    str,
-};
+use std::{fs, path::Path, process, str};
 
 use colour::e_red;
 use once_cell::sync::Lazy;
 
-use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
+use crate::{dependency::Dependency, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-contract", "1.0.0", "smart_contracts/contract"));
 pub static CL_TYPES: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-types", "1.0.0", "types"));
+pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
+    Dependency::new(
+        "casper-engine-test-support",
+        "1.0.0",
+        "execution_engine_testing/test_support",
+    )
+});
 
 pub fn print_error_and_exit(msg: &str) -> ! {
     e_red!("error");
     eprintln!("{}", msg);
     process::exit(FAILURE_EXIT_CODE)
-}
-
-pub fn run_cargo_new(package_name: &str) {
-    let mut command = Command::new("cargo");
-    command
-        .args(&["new", "--vcs", "none"])
-        .arg(package_name)
-        .current_dir(ARGS.root_path());
-
-    let output = match command.output() {
-        Ok(output) => output,
-        Err(error) => print_error_and_exit(&format!(": failed to run '{:?}': {}", command, error)),
-    };
-
-    if !output.status.success() {
-        let stdout = str::from_utf8(&output.stdout).expect("should be valid UTF8");
-        let stderr = str::from_utf8(&output.stderr).expect("should be valid UTF8");
-        print_error_and_exit(&format!(
-            ": failed to run '{:?}':\n{}\n{}\n",
-            command, stdout, stderr
-        ));
-    }
 }
 
 pub fn create_dir_all<P: AsRef<Path>>(path: P) {
@@ -64,47 +43,6 @@ pub fn write_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
     }
 }
 
-pub fn append_to_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
-    let mut file = match OpenOptions::new().append(true).open(path.as_ref()) {
-        Ok(file) => file,
-        Err(error) => {
-            print_error_and_exit(&format!(
-                ": failed to open '{}': {}",
-                path.as_ref().display(),
-                error
-            ));
-        }
-    };
-    if let Err(error) = file.write_all(contents.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to append to '{}': {}",
-            path.as_ref().display(),
-            error
-        ));
-    }
-}
-
-pub fn remove_file<P: AsRef<Path>>(path: P) {
-    if let Err(error) = fs::remove_file(path.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to remove '{}': {}",
-            path.as_ref().display(),
-            error
-        ));
-    }
-}
-
-pub fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(source: S, destination: D) {
-    if let Err(error) = fs::copy(source.as_ref(), destination.as_ref()) {
-        print_error_and_exit(&format!(
-            ": failed to copy '{}' to '{}': {}",
-            source.as_ref().display(),
-            destination.as_ref().display(),
-            error
-        ));
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::{env, fs};
@@ -115,6 +53,8 @@ pub mod tests {
 
     const CL_CONTRACT_TOML_PATH: &str = "smart_contracts/contract/Cargo.toml";
     const CL_TYPES_TOML_PATH: &str = "types/Cargo.toml";
+    const CL_ENGINE_TEST_SUPPORT_TOML_PATH: &str =
+        "execution_engine_testing/test_support/Cargo.toml";
     const PACKAGE_FIELD_NAME: &str = "package";
     const VERSION_FIELD_NAME: &str = "version";
     const PATH_PREFIX: &str = "/execution_engine_testing/cargo_casper";
@@ -166,5 +106,10 @@ pub mod tests {
     #[test]
     fn check_cl_types_version() {
         check_package_version(&*CL_TYPES, CL_TYPES_TOML_PATH);
+    }
+
+    #[test]
+    fn check_cl_engine_test_support_version() {
+        check_package_version(&*CL_ENGINE_TEST_SUPPORT, CL_ENGINE_TEST_SUPPORT_TOML_PATH);
     }
 }

--- a/execution_engine_testing/cargo_casper/src/contract_package.rs
+++ b/execution_engine_testing/cargo_casper/src/contract_package.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{common, erc20, simple, ProjectKind, ARGS};
+use crate::{
+    common::{self, PATCH_SECTION},
+    erc20, simple, ProjectKind, ARGS,
+};
 
 static PACKAGE_NAME: Lazy<&'static str> = Lazy::new(|| match ARGS.project_kind() {
     ProjectKind::Simple => "contract",
@@ -41,13 +44,15 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
-"#,
+
+{}"#,
         *PACKAGE_NAME,
         match ARGS.project_kind() {
             ProjectKind::Simple => &*simple::CONTRACT_DEPENDENCIES,
             ProjectKind::Erc20 => &*erc20::CONTRACT_DEPENDENCIES,
         },
         PACKAGE_NAME.replace("-", "_"),
+        &*PATCH_SECTION
     )
 });
 

--- a/execution_engine_testing/cargo_casper/src/dependency.rs
+++ b/execution_engine_testing/cargo_casper/src/dependency.rs
@@ -23,15 +23,24 @@ impl Dependency {
     }
 
     pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
+        if default_features
+            && features.is_empty()
+            && (ARGS.workspace_path().is_none() || self.relative_path.is_empty())
+        {
+            return format!("{} = \"{}\"\n", self.name, self.version);
+        }
+
         let mut output = format!(r#"{} = {{ version = "{}""#, self.name, self.version);
 
         if let Some(workspace_path) = ARGS.workspace_path() {
-            output = format!(
-                r#"{}, path = "{}/{}""#,
-                output,
-                workspace_path.display(),
-                self.relative_path
-            );
+            if !self.relative_path.is_empty() {
+                output = format!(
+                    r#"{}, path = "{}/{}""#,
+                    output,
+                    workspace_path.display(),
+                    self.relative_path
+                );
+            }
         }
 
         if !default_features {
@@ -42,7 +51,7 @@ impl Dependency {
             output = format!("{}, features = {:?}", output, features);
         }
 
-        format!("{} }}", output)
+        format!("{} }}\n", output)
     }
 
     #[cfg(test)]

--- a/execution_engine_testing/cargo_casper/src/dependency.rs
+++ b/execution_engine_testing/cargo_casper/src/dependency.rs
@@ -1,47 +1,25 @@
-use crate::ARGS;
-
 /// Used to hold the information about the Casper dependencies which will be required by the
 /// generated Cargo.toml files.
-///
-/// The information is output in a form suitable for injection into Cargo.toml via implementing the
-/// `std::fmt::Display` trait.
 #[derive(Debug)]
 pub struct Dependency {
     name: String,
     version: String,
-    /// Path relative to "casper-node"
-    relative_path: String,
 }
 
 impl Dependency {
-    pub fn new(name: &str, version: &str, relative_path: &str) -> Self {
+    pub fn new(name: &str, version: &str) -> Self {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            relative_path: relative_path.to_string(),
         }
     }
 
     pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
-        if default_features
-            && features.is_empty()
-            && (ARGS.workspace_path().is_none() || self.relative_path.is_empty())
-        {
+        if default_features && features.is_empty() {
             return format!("{} = \"{}\"\n", self.name, self.version);
         }
 
         let mut output = format!(r#"{} = {{ version = "{}""#, self.name, self.version);
-
-        if let Some(workspace_path) = ARGS.workspace_path() {
-            if !self.relative_path.is_empty() {
-                output = format!(
-                    r#"{}, path = "{}/{}""#,
-                    output,
-                    workspace_path.display(),
-                    self.relative_path
-                );
-            }
-        }
 
         if !default_features {
             output = format!("{}, default-features = false", output);

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -1,0 +1,35 @@
+use once_cell::sync::Lazy;
+
+use crate::{
+    common::{CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_TYPES},
+    dependency::Dependency,
+};
+
+pub const MAIN_RS_CONTENTS: &str = include_str!("../resources/erc20/main.rs.in");
+pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
+    include_str!("../resources/erc20/integration_tests.rs.in");
+pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
+pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
+
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0", ""));
+
+pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}",
+        CL_CONTRACT.display_with_features(true, vec![]),
+        CL_ERC20.display_with_features(true, vec![]),
+        CL_TYPES.display_with_features(true, vec![]),
+    )
+});
+
+pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}{}{}{}",
+        Dependency::new("base64", "0.13.0", "").display_with_features(true, vec![]),
+        Dependency::new("blake2", "0.9.2", "").display_with_features(true, vec![]),
+        CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
+        CL_ERC20.display_with_features(true, vec!["std"]),
+        CL_TYPES.display_with_features(true, vec!["std"]),
+        Dependency::new("hex", "0.4.3", "").display_with_features(true, vec![]),
+    )
+});

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -11,7 +11,7 @@ pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
 pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
 pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
 
-static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0"));
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.2.0"));
 
 pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -11,7 +11,7 @@ pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
 pub const TEST_FIXTURE_RS_CONTENTS: &str = include_str!("../resources/erc20/test_fixture.rs.in");
 pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/erc20/Makefile.in");
 
-static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0", ""));
+static CL_ERC20: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-erc20", "0.1.0"));
 
 pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
@@ -25,11 +25,11 @@ pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}{}{}{}{}",
-        Dependency::new("base64", "0.13.0", "").display_with_features(true, vec![]),
-        Dependency::new("blake2", "0.9.2", "").display_with_features(true, vec![]),
+        Dependency::new("base64", "0.13.0").display_with_features(true, vec![]),
+        Dependency::new("blake2", "0.9.2").display_with_features(true, vec![]),
         CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
         CL_ERC20.display_with_features(true, vec!["std"]),
         CL_TYPES.display_with_features(true, vec!["std"]),
-        Dependency::new("hex", "0.4.3", "").display_with_features(true, vec![]),
+        Dependency::new("hex", "0.4.3").display_with_features(true, vec![]),
     )
 });

--- a/execution_engine_testing/cargo_casper/src/main.rs
+++ b/execution_engine_testing/cargo_casper/src/main.rs
@@ -7,44 +7,49 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_description, crate_name, crate_version, App, Arg};
 use once_cell::sync::Lazy;
 
 pub mod common;
 mod contract_package;
 pub mod dependency;
+mod erc20;
+mod makefile;
+mod rust_toolchain;
+mod simple;
 mod tests_package;
 mod travis_yml;
 
-const APP_NAME: &str = "cargo-casper";
-const ABOUT: &str =
-    "A command line tool for creating a Wasm contract and tests at <path> for use on the \
-     Casper Platform.";
-const TOOLCHAIN: &str = "nightly-2021-06-17";
+const USAGE: &str = r#"cargo casper [FLAGS] <path>
+    cd <path>
+    make prepare
+    make test"#;
+const AFTER_HELP: &str = r#"NOTE:
+    If no other flag is provided, a trivial example contract and tests are created"#;
+
+const ERC20_ARG_NAME: &str = "erc20";
+const ERC20_ARG_ABOUT: &str = "Create a basic ERC-20 contract and tests";
 
 const ROOT_PATH_ARG_NAME: &str = "path";
 const ROOT_PATH_ARG_VALUE_NAME: &str = "path";
-const ROOT_PATH_ARG_HELP: &str = "Path to new folder for contract and tests";
+const ROOT_PATH_ARG_ABOUT: &str = "Path to new folder for contract and tests";
 
 const WORKSPACE_PATH_ARG_NAME: &str = "workspace-path";
 const WORKSPACE_PATH_ARG_LONG: &str = "workspace-path";
 
 const FAILURE_EXIT_CODE: i32 = 101;
 
-static USAGE: Lazy<String> = Lazy::new(|| {
-    format!(
-        r#"cargo casper [FLAGS] <path>
-    rustup install {0}
-    rustup target add --toolchain {0} wasm32-unknown-unknown
-    cd <path>/tests
-    cargo test"#,
-        TOOLCHAIN
-    )
-});
 static ARGS: Lazy<Args> = Lazy::new(Args::new);
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum ProjectKind {
+    Simple,
+    Erc20,
+}
 
 #[derive(Debug)]
 struct Args {
+    project_kind: ProjectKind,
     root_path: PathBuf,
     workspace_path: Option<PathBuf>,
 }
@@ -68,23 +73,36 @@ impl Args {
             }
         });
 
-        let root_path_arg = Arg::with_name(ROOT_PATH_ARG_NAME)
+        let project_kind_arg = Arg::new(ERC20_ARG_NAME)
+            .takes_value(false)
+            .long(ERC20_ARG_NAME)
+            .about(ERC20_ARG_ABOUT);
+
+        let root_path_arg = Arg::new(ROOT_PATH_ARG_NAME)
             .required(true)
             .value_name(ROOT_PATH_ARG_VALUE_NAME)
-            .help(ROOT_PATH_ARG_HELP);
+            .about(ROOT_PATH_ARG_ABOUT);
 
-        let workspace_path_arg = Arg::with_name(WORKSPACE_PATH_ARG_NAME)
+        let workspace_path_arg = Arg::new(WORKSPACE_PATH_ARG_NAME)
             .long(WORKSPACE_PATH_ARG_LONG)
             .takes_value(true)
             .hidden(true);
 
-        let arg_matches = App::new(APP_NAME)
+        let arg_matches = App::new(crate_name!())
             .version(crate_version!())
-            .about(ABOUT)
-            .usage(USAGE.as_str())
+            .about(crate_description!())
+            .override_usage(USAGE)
+            .after_help(AFTER_HELP)
+            .arg(project_kind_arg)
             .arg(root_path_arg)
             .arg(workspace_path_arg)
             .get_matches_from(filtered_args_iter);
+
+        let project_kind = if arg_matches.is_present(ERC20_ARG_NAME) {
+            ProjectKind::Erc20
+        } else {
+            ProjectKind::Simple
+        };
 
         let root_path = arg_matches
             .value_of(ROOT_PATH_ARG_NAME)
@@ -96,9 +114,14 @@ impl Args {
             .map(PathBuf::from);
 
         Args {
+            project_kind,
             root_path,
             workspace_path,
         }
+    }
+
+    pub fn project_kind(&self) -> ProjectKind {
+        self.project_kind
     }
 
     pub fn root_path(&self) -> &Path {
@@ -119,49 +142,9 @@ fn main() {
     }
 
     common::create_dir_all(ARGS.root_path());
-
-    contract_package::run_cargo_new();
-    contract_package::update_cargo_toml();
-    contract_package::add_rust_toolchain();
-    contract_package::update_main_rs();
-    contract_package::add_config_toml();
-
-    tests_package::run_cargo_new();
-    tests_package::update_cargo_toml();
-    tests_package::add_rust_toolchain();
-    tests_package::add_build_rs();
-    tests_package::replace_main_rs();
-
+    contract_package::create();
+    tests_package::create();
+    rust_toolchain::create();
+    makefile::create();
     travis_yml::create();
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{env, fs};
-
-    use super::TOOLCHAIN;
-
-    const PATH_PREFIX: &str = "/execution_engine_testing/cargo_casper";
-
-    #[test]
-    fn check_toolchain_version() {
-        let mut toolchain_path = env::current_dir().unwrap().display().to_string();
-        let index = toolchain_path.find(PATH_PREFIX).unwrap_or_else(|| {
-            panic!(
-                "test should be run from within casper-node workspace: {}",
-                toolchain_path
-            )
-        });
-        toolchain_path.replace_range(index.., "/smart_contracts/rust-toolchain");
-
-        let toolchain_contents =
-            fs::read(&toolchain_path).unwrap_or_else(|_| panic!("should read {}", toolchain_path));
-        let expected_toolchain_value = String::from_utf8_lossy(&toolchain_contents)
-            .trim()
-            .to_string();
-
-        // If this fails, ensure `TOOLCHAIN` is updated to match the value in
-        // "casper-node/rust-toolchain".
-        assert_eq!(&*expected_toolchain_value, TOOLCHAIN);
-    }
 }

--- a/execution_engine_testing/cargo_casper/src/makefile.rs
+++ b/execution_engine_testing/cargo_casper/src/makefile.rs
@@ -1,0 +1,11 @@
+use crate::{common, erc20, simple, ProjectKind, ARGS};
+
+const FILENAME: &str = "Makefile";
+
+pub fn create() {
+    let contents = match ARGS.project_kind() {
+        ProjectKind::Simple => simple::MAKEFILE_CONTENTS,
+        ProjectKind::Erc20 => erc20::MAKEFILE_CONTENTS,
+    };
+    common::write_file(ARGS.root_path().join(FILENAME), contents);
+}

--- a/execution_engine_testing/cargo_casper/src/rust_toolchain.rs
+++ b/execution_engine_testing/cargo_casper/src/rust_toolchain.rs
@@ -1,0 +1,38 @@
+use crate::{common, ARGS};
+
+const FILENAME: &str = "rust-toolchain";
+pub const CONTENTS: &str = r#"nightly-2021-06-17
+"#;
+
+pub fn create() {
+    common::write_file(ARGS.root_path().join(FILENAME), CONTENTS);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs};
+
+    use super::CONTENTS;
+
+    const PATH_PREFIX: &str = "/execution_engine_testing/cargo_casper";
+
+    #[test]
+    fn check_toolchain_version() {
+        let mut toolchain_path = env::current_dir().unwrap().display().to_string();
+        let index = toolchain_path.find(PATH_PREFIX).unwrap_or_else(|| {
+            panic!(
+                "test should be run from within casper-node workspace: {}",
+                toolchain_path
+            )
+        });
+        toolchain_path.replace_range(index.., "/smart_contracts/rust-toolchain");
+
+        let toolchain_contents =
+            fs::read(&toolchain_path).unwrap_or_else(|_| panic!("should read {}", toolchain_path));
+        let expected_toolchain_value = String::from_utf8_lossy(&toolchain_contents).to_string();
+
+        // If this fails, ensure `CONTENTS` is updated to match the value in
+        // "casper-node/rust-toolchain".
+        assert_eq!(&*expected_toolchain_value, CONTENTS);
+    }
+}

--- a/execution_engine_testing/cargo_casper/src/simple.rs
+++ b/execution_engine_testing/cargo_casper/src/simple.rs
@@ -1,0 +1,25 @@
+use once_cell::sync::Lazy;
+
+use crate::common::{CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_TYPES};
+
+pub const MAIN_RS_CONTENTS: &str = include_str!("../resources/simple/main.rs.in");
+pub const INTEGRATION_TESTS_RS_CONTENTS: &str =
+    include_str!("../resources/simple/integration_tests.rs.in");
+pub const MAKEFILE_CONTENTS: &str = include_str!("../resources/simple/Makefile.in");
+
+pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}",
+        CL_CONTRACT.display_with_features(true, vec![]),
+        CL_TYPES.display_with_features(true, vec![]),
+    )
+});
+
+pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{}{}{}",
+        CL_CONTRACT.display_with_features(false, vec!["std", "test-support"]),
+        CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
+        CL_TYPES.display_with_features(false, vec!["std"]),
+    )
+});

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -5,167 +5,59 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{
-    common::{self, CL_CONTRACT, CL_TYPES},
-    dependency::Dependency,
-    ARGS, TOOLCHAIN,
-};
+use crate::{common, erc20, simple, ProjectKind, ARGS};
 
 const PACKAGE_NAME: &str = "tests";
 
-const INTEGRATION_TESTS_RS_CONTENTS: &str = r#"#[cfg(test)]
-mod tests {
-    use casper_engine_test_support::{
-        Code, Error, SessionBuilder, TestContextBuilder, Value,
-    };
-    use casper_types::{runtime_args, RuntimeArgs, U512, account::AccountHash, PublicKey, SecretKey};
+static CONTRACT_PACKAGE_ROOT: Lazy<PathBuf> = Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME));
+static CARGO_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("Cargo.toml"));
+static INTEGRATION_TESTS_RS: Lazy<PathBuf> =
+    Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/integration_tests.rs"));
+static TEST_FIXTURE_RS: Lazy<PathBuf> =
+    Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/test_fixture.rs"));
 
-    const MY_ACCOUNT: [u8; 32] = [7u8; 32];
-    // define KEY constant to match that in the contract
-    const KEY: &str = "special_value";
-    const VALUE: &str = "hello world";
-    const ARG_MESSAGE: &str = "message";
-
-    #[test]
-    fn should_store_hello_world() {
-        let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
-        let public_key = PublicKey::from(&secret_key);
-        let account_addr = AccountHash::from(&public_key);
-
-        let mut context = TestContextBuilder::new()
-            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
-            .build();
-
-        // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
-        // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
-        // absolute paths.
-        let session_code = Code::from("contract.wasm");
-        let session_args = runtime_args! {
-            ARG_MESSAGE => VALUE,
-        };
-        let session = SessionBuilder::new(session_code, session_args)
-            .with_address(account_addr)
-            .with_authorization_keys(&[account_addr])
-            .build();
-
-        let result_of_query: Result<Value, Error> =
-            context.run(session).query(account_addr, &[KEY.to_string()]);
-
-        let returned_value = result_of_query.expect("should be a value");
-
-        let expected_value = Value::from_t(VALUE.to_string()).expect("should construct Value");
-        assert_eq!(expected_value, returned_value);
-    }
-}
-
-fn main() {
-    panic!("Execute \"cargo test\" to test the contract, not \"cargo run\".");
-}
-"#;
-
-const BUILD_RS_CONTENTS: &str = r#"use std::{env, fs, path::PathBuf, process::Command};
-
-const CONTRACT_ROOT: &str = "../contract";
-const CONTRACT_CARGO_TOML: &str = "../contract/Cargo.toml";
-const CONTRACT_MAIN_RS: &str = "../contract/src/main.rs";
-const BUILD_ARGS: [&str; 2] = ["build", "--release"];
-const WASM_FILENAME: &str = "contract.wasm";
-const ORIGINAL_WASM_DIR: &str = "../contract/target/wasm32-unknown-unknown/release";
-const NEW_WASM_DIR: &str = "wasm";
-
-fn main() {
-    // Watch contract source files for changes.
-    println!("cargo:rerun-if-changed={}", CONTRACT_CARGO_TOML);
-    println!("cargo:rerun-if-changed={}", CONTRACT_MAIN_RS);
-
-    // Build the contract.
-    let output = Command::new("cargo")
-        .current_dir(CONTRACT_ROOT)
-        .args(&BUILD_ARGS)
-        .output()
-        .expect("Expected to build Wasm contracts");
-    assert!(
-        output.status.success(),
-        "Failed to build Wasm contracts:\n{:?}",
-        output
-    );
-
-    // Move the compiled Wasm file to our own build folder ("wasm/contract.wasm").
-    let new_wasm_dir = env::current_dir().unwrap().join(NEW_WASM_DIR);
-    let _ = fs::create_dir(&new_wasm_dir);
-
-    let original_wasm_file = PathBuf::from(ORIGINAL_WASM_DIR).join(WASM_FILENAME);
-    let copied_wasm_file = new_wasm_dir.join(WASM_FILENAME);
-    fs::copy(original_wasm_file, copied_wasm_file).unwrap();
-}
-"#;
-
-static CARGO_TOML: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("Cargo.toml"));
-static RUST_TOOLCHAIN: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("rust-toolchain"));
-static BUILD_RS: Lazy<PathBuf> = Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("build.rs"));
-static MAIN_RS: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME).join("src/main.rs"));
-static INTEGRATION_TESTS_RS: Lazy<PathBuf> = Lazy::new(|| {
-    ARGS.root_path()
-        .join(PACKAGE_NAME)
-        .join("src/integration_tests.rs")
-});
-static ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
-    Dependency::new(
-        "casper-engine-test-support",
-        "1.0.0",
-        "execution_engine_testing/test_support",
-    )
-});
-static CARGO_TOML_ADDITIONAL_CONTENTS: Lazy<String> = Lazy::new(|| {
+static CARGO_TOML_CONTENTS: Lazy<String> = Lazy::new(|| {
     format!(
-        r#"
+        r#"[package]
+name = "tests"
+version = "0.1.0"
+edition = "2018"
+
 [dev-dependencies]
 {}
-{}
-{}
-
 [[bin]]
 name = "integration-tests"
 path = "src/integration_tests.rs"
+bench = false
+doctest = false
 "#,
-        CL_CONTRACT.display_with_features(false, vec!["std", "test-support"]),
-        CL_TYPES.display_with_features(false, vec!["std"]),
-        ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
+        match ARGS.project_kind() {
+            ProjectKind::Simple => &*simple::TEST_DEPENDENCIES,
+            ProjectKind::Erc20 => &*erc20::TEST_DEPENDENCIES,
+        },
     )
 });
 
-pub fn run_cargo_new() {
-    common::run_cargo_new(PACKAGE_NAME);
-}
-
-pub fn update_cargo_toml() {
-    common::append_to_file(&*CARGO_TOML, &*CARGO_TOML_ADDITIONAL_CONTENTS);
-}
-
-pub fn add_rust_toolchain() {
-    common::write_file(&*RUST_TOOLCHAIN, format!("{}\n", TOOLCHAIN));
-}
-
-pub fn add_build_rs() {
-    common::write_file(&*BUILD_RS, BUILD_RS_CONTENTS);
-}
-
-pub fn replace_main_rs() {
-    common::remove_file(&*MAIN_RS);
-    common::write_file(&*INTEGRATION_TESTS_RS, INTEGRATION_TESTS_RS_CONTENTS);
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    const ENGINE_TEST_SUPPORT_TOML_PATH: &str = "execution_engine_testing/test_support/Cargo.toml";
-
-    #[test]
-    fn check_engine_test_support_version() {
-        common::tests::check_package_version(&*ENGINE_TEST_SUPPORT, ENGINE_TEST_SUPPORT_TOML_PATH);
+pub fn create() {
+    // Create "tests/src" folder and write test files inside.
+    let tests_folder = INTEGRATION_TESTS_RS.parent().expect("should have parent");
+    common::create_dir_all(tests_folder);
+    match ARGS.project_kind() {
+        ProjectKind::Simple => {
+            common::write_file(
+                &*INTEGRATION_TESTS_RS,
+                &*simple::INTEGRATION_TESTS_RS_CONTENTS,
+            );
+        }
+        ProjectKind::Erc20 => {
+            common::write_file(
+                &*INTEGRATION_TESTS_RS,
+                &*erc20::INTEGRATION_TESTS_RS_CONTENTS,
+            );
+            common::write_file(&*TEST_FIXTURE_RS, &*erc20::TEST_FIXTURE_RS_CONTENTS);
+        }
     }
+
+    // Write "tests/Cargo.toml".
+    common::write_file(&*CARGO_TOML, &*CARGO_TOML_CONTENTS);
 }

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
-use crate::{common, erc20, simple, ProjectKind, ARGS};
+use crate::{
+    common::{self, PATCH_SECTION},
+    erc20, simple, ProjectKind, ARGS,
+};
 
 const PACKAGE_NAME: &str = "tests";
 
@@ -30,11 +33,13 @@ name = "integration-tests"
 path = "src/integration_tests.rs"
 bench = false
 doctest = false
-"#,
+
+{}"#,
         match ARGS.project_kind() {
             ProjectKind::Simple => &*simple::TEST_DEPENDENCIES,
             ProjectKind::Erc20 => &*erc20::TEST_DEPENDENCIES,
         },
+        &*PATCH_SECTION
     )
 });
 

--- a/execution_engine_testing/cargo_casper/src/travis_yml.rs
+++ b/execution_engine_testing/cargo_casper/src/travis_yml.rs
@@ -3,8 +3,9 @@ use crate::{common, ARGS};
 const FILENAME: &str = ".travis.yml";
 const CONTENTS: &str = r#"language: rust
 script:
-  - cd tests && cargo build
-  - cd tests && cargo test
+  - make prepare
+  - make check-lint
+  - make test
 "#;
 
 pub fn create() {

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -45,7 +45,7 @@ fn output_from_command(mut command: Command) -> Output {
     }
 }
 
-fn run_tool_and_resulting_tests() {
+fn run_tool_and_resulting_tests(maybe_extra_flag: Option<&str>) {
     let temp_dir = tempfile::tempdir().unwrap().into_path();
 
     // Run 'cargo-casper <test dir>/<subdir> --workspace-path=<path to casper-node root>'
@@ -53,6 +53,9 @@ fn run_tool_and_resulting_tests() {
     let test_dir = temp_dir.join(subdir);
     let mut tool_cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     tool_cmd.arg(&test_dir);
+    if let Some(extra_flag) = maybe_extra_flag {
+        tool_cmd.arg(extra_flag);
+    }
     tool_cmd.arg(&*WORKSPACE_PATH_ARG);
 
     // The CI environment doesn't have a Git user configured, so we can set the env var `USER` for
@@ -85,6 +88,11 @@ fn run_tool_and_resulting_tests() {
 }
 
 #[test]
-fn should_run_casperlabs_node() {
-    run_tool_and_resulting_tests();
+fn should_run_cargo_casper_for_simple_example() {
+    run_tool_and_resulting_tests(None);
+}
+
+#[test]
+fn should_run_cargo_casper_for_erc20_example() {
+    run_tool_and_resulting_tests(Some("--erc20"));
 }

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -35,9 +35,11 @@ fn output_from_command(mut command: Command) -> Output {
         Ok(output) => output,
         Err(error) => {
             panic!(
-                "\nFailed to execute {:?}\n===== stderr begin =====\n{}\n===== stderr end =====\n",
+                "\nFailed to execute {:?}\n===== stderr begin =====\n{}\n===== stderr end \
+                =====\n===== stdout begin =====\n{}\n===== stdout end =====\n",
                 command,
-                String::from_utf8_lossy(&error.as_output().unwrap().stderr)
+                String::from_utf8_lossy(&error.as_output().unwrap().stderr),
+                String::from_utf8_lossy(&error.as_output().unwrap().stdout)
             );
         }
     }
@@ -59,9 +61,9 @@ fn run_tool_and_resulting_tests() {
     let tool_output = output_from_command(tool_cmd);
     assert_eq!(SUCCESS_EXIT_CODE, tool_output.status.code().unwrap());
 
-    // Run 'cargo test' in the 'tests' folder of the generated project.  This builds the Wasm
-    // contract as well as the tests.  This requires the use of a nightly version of Rust, so we use
-    // rustup to execute the appropriate cargo version.
+    // Run 'make test' in the root of the generated project.  This builds the Wasm contract as well
+    // as the tests.  This requires the use of a nightly version of Rust, so we use rustup to
+    // execute the appropriate cargo version.
     let mut test_cmd = Command::new("rustup");
     let nightly_version = fs::read_to_string(format!(
         "{}/../../smart_contracts/rust-toolchain",
@@ -71,9 +73,10 @@ fn run_tool_and_resulting_tests() {
     test_cmd
         .arg("run")
         .arg(nightly_version.trim())
-        .arg("cargo")
+        .arg("make")
         .arg("test")
-        .current_dir(test_dir.join("tests"));
+        .current_dir(test_dir);
+
     let test_output = output_from_command(test_cmd);
     assert_eq!(SUCCESS_EXIT_CODE, test_output.status.code().unwrap());
 


### PR DESCRIPTION
This PR ports the changes in #2059 which upgrades the functionality of `cargo-casper` to include an option to generate an ERC-20 token contract and tests.

The generated source files are exact copies of the example and its tests in the erc20 repository.

The integration tests for `cargo-casper` have been updated to also run the tool with the `--erc20` flag.

Closes #2034.