### PR TITLE
Enable the casper-mainnet feature by default in manifests

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -56,7 +56,7 @@ warp = "0.3.0"
 warp-json-rpc = "0.3.0"
 
 [features]
-default = ["ffi"]
+default = ["ffi", "casper-mainnet"]
 ffi = ["cbindgen"]
 casper-mainnet = ["casper-node/casper-mainnet"]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -112,6 +112,7 @@ reqwest = { version = "0.11.3", features = ["stream"] }
 tokio = { version = "1", features = ["test-util"] }
 
 [features]
+default = ['casper-mainnet']
 vendored-openssl = ['openssl/vendored']
 casper-mainnet = []
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1284,7 +1284,7 @@ pub enum HashingAlgorithmVersion {
 impl HashingAlgorithmVersion {
     #[cfg(feature = "casper-mainnet")]
     pub(crate) const HASH_V2_PROTOCOL_VERSION: ProtocolVersion =
-        // TODO: restore that to 1.4.0 when fast sync is merged
+        // TODO: restore that to the actual switchover version when fast sync is merged
         ProtocolVersion::from_parts(9001, 0, 0);
 
     #[cfg(not(feature = "casper-mainnet"))]


### PR DESCRIPTION
This adds the `casper-mainnet` feature to the set of default features in the node and the client. This feature is responsible for keeping the software on the legacy hashing scheme in protocol versions up to the one where we will switch to fast sync, and should be enabled in all builds intended for use in the mainnet.