### PR TITLE
Update feature sets on casper-types and casper-contract crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,6 @@ version = "1.0.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
- "thiserror",
  "version-sync",
  "wee_alloc",
 ]
@@ -659,7 +658,6 @@ dependencies = [
  "blake2",
  "criterion",
  "datasize",
- "displaydoc",
  "ed25519-dalek",
  "getrandom 0.2.3",
  "hex",
@@ -679,7 +677,6 @@ dependencies = [
  "serde_json",
  "serde_test",
  "strum",
- "thiserror",
  "uint",
  "version-sync",
 ]
@@ -1303,17 +1300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 members = [
     "ci/casper_updater",
     "client",
@@ -25,6 +24,7 @@ default-members = [
     "execution_engine_testing/tests",
     "hashing",
     "node",
+    "types",
     "utils/global-state-update-gen",
     "utils/validation",
 ]
@@ -33,6 +33,10 @@ default-members = [
 # perf data.
 [profile.release.package.casper-engine-tests]
 debug = true
+
+[profile.release]
+codegen-units = 1
+lto = true
 
 [profile.bench]
 codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,8 @@ resources/local/chainspec.toml: generate-chainspec.sh resources/local/chainspec.
 
 .PHONY: test-rs
 test-rs: resources/local/chainspec.toml
-	$(LEGACY) $(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS)
-	$(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) -p casper-types
-	$(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) -p casper-types --no-default-features --features=std
-	cd smart_contracts/contract && $(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS)
-	cd smart_contracts/contract && $(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --no-default-features --features=std
+	$(LEGACY) $(DISABLE_LOGGING) $(CARGO) test --all-features $(CARGO_FLAGS)
+	cd smart_contracts/contract && $(DISABLE_LOGGING) $(CARGO) test $(CARGO_FLAGS) --no-default-features --features=version-sync
 
 .PHONY: test-as
 test-as: setup-as
@@ -111,11 +108,8 @@ lint-contracts-rs:
 .PHONY: lint
 lint: lint-contracts-rs
 	$(CARGO) clippy --all-targets -- -D warnings -A renamed_and_removed_lints
-	$(LEGACY) $(CARGO) clippy --all-targets -- -D warnings -A renamed_and_removed_lints
-	$(CARGO) clippy --all-targets -p casper-types -- -D warnings -A renamed_and_removed_lints
-	$(CARGO) clippy --no-default-features --features=no-std --all-targets -p casper-types -- -D warnings -A renamed_and_removed_lints
+	$(CARGO) clippy --all-targets --all-features -- -D warnings -A renamed_and_removed_lints
 	cd smart_contracts/contract && $(CARGO) clippy --all-targets -- -D warnings -A renamed_and_removed_lints
-	$(CARGO) clippy --no-default-features --features=std --all-targets --manifest-path=smart_contracts/contract/Cargo.toml -- -D warnings -A renamed_and_removed_lints
 
 .PHONY: audit
 audit:
@@ -124,8 +118,7 @@ audit:
 .PHONY: doc
 doc:
 	RUSTDOCFLAGS="-D warnings" $(CARGO) doc $(CARGO_FLAGS) --no-deps
-	RUSTDOCFLAGS="-D warnings" $(CARGO) doc $(CARGO_FLAGS) --no-deps -p casper-types
-	cd smart_contracts/contract && RUSTDOCFLAGS="-D warnings" $(CARGO) doc $(CARGO_FLAGS) --no-deps -p casper-contract
+	cd smart_contracts/contract && RUSTDOCFLAGS="-D warnings" $(CARGO) doc $(CARGO_FLAGS) --no-deps
 
 .PHONY: check-rs
 check-rs: \
@@ -202,4 +195,4 @@ setup-as: smart_contracts/contract_as/package.json
 	cd smart_contracts/contract_as && $(NPM) ci
 
 .PHONY: setup
-setup: setup-rs setup-audit setup-as
+setup: setup-rs setup-as

--- a/ci/casper_updater/Cargo.toml
+++ b/ci/casper_updater/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.3.0"
 
 [dependencies]
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
+casper-types = { path = "../../types" }
 clap = "2"
 once_cell = "1"
 regex = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,7 +26,7 @@ base64 = "0.13.0"
 casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
 casper-node = { version = "1.0.0", path = "../node" }
 casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["std"] }
+casper-types = { version = "1.0.0", path = "../types" }
 clap = "2"
 hex = { version = "0.4.2", features = ["serde"] }
 humantime = "2"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["std", "gens"] }
+casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["datasize", "gens"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["datasize", "gens"] }
+casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -129,14 +129,26 @@ pub enum StepError {
     TypeMismatch(StoredValueTypeMismatch),
     #[error("Era validators missing: {0}")]
     EraValidatorsMissing(EraId),
-    #[error(transparent)]
-    BytesRepr(#[from] bytesrepr::Error),
-    #[error(transparent)]
-    CLValueError(#[from] CLValueError),
+    #[error("{0}")]
+    BytesRepr(bytesrepr::Error),
+    #[error("{0}")]
+    CLValueError(CLValueError),
     #[error("Other engine state error: {0}")]
     OtherEngineStateError(#[from] Error),
     #[error(transparent)]
     ExecutionError(#[from] execution::Error),
+}
+
+impl From<bytesrepr::Error> for StepError {
+    fn from(error: bytesrepr::Error) -> Self {
+        StepError::BytesRepr(error)
+    }
+}
+
+impl From<CLValueError> for StepError {
+    fn from(error: CLValueError) -> Self {
+        StepError::CLValueError(error)
+    }
 }
 
 #[derive(Debug)]

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -132,10 +132,16 @@ pub enum ProtocolUpgradeError {
     UnableToRetrieveSystemContractPackage(String),
     #[error("Failed to disable previous version of system contract: {0}")]
     FailedToDisablePreviousVersion(String),
-    #[error(transparent)]
-    Bytesrepr(#[from] bytesrepr::Error),
+    #[error("{0}")]
+    Bytesrepr(bytesrepr::Error),
     #[error("Failed to insert system contract registry")]
     FailedToCreateSystemRegistry,
+}
+
+impl From<bytesrepr::Error> for ProtocolUpgradeError {
+    fn from(error: bytesrepr::Error) -> Self {
+        ProtocolUpgradeError::Bytesrepr(error)
+    }
 }
 
 pub(crate) struct SystemUpgrader<S>

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -23,10 +23,16 @@ use casper_types::{
 /// cause an overflow).
 #[derive(PartialEq, Eq, Debug, Clone, thiserror::Error)]
 pub enum Error {
-    #[error(transparent)]
+    #[error("{0}")]
     Serialization(bytesrepr::Error),
-    #[error(transparent)]
-    TypeMismatch(#[from] StoredValueTypeMismatch),
+    #[error("{0}")]
+    TypeMismatch(StoredValueTypeMismatch),
+}
+
+impl From<StoredValueTypeMismatch> for Error {
+    fn from(error: StoredValueTypeMismatch) -> Self {
+        Error::TypeMismatch(error)
+    }
 }
 
 impl From<CLValueError> for Error {

--- a/execution_engine/src/storage/error/lmdb.rs
+++ b/execution_engine/src/storage/error/lmdb.rs
@@ -15,8 +15,8 @@ pub enum Error {
     Lmdb(#[from] lmdb_external::Error),
 
     /// (De)serialization error.
-    #[error(transparent)]
-    BytesRepr(#[from] bytesrepr::Error),
+    #[error("{0}")]
+    BytesRepr(bytesrepr::Error),
 
     /// Concurrency error.
     #[error("Another thread panicked while holding a lock")]
@@ -28,6 +28,12 @@ pub enum Error {
 }
 
 impl wasmi::HostError for Error {}
+
+impl From<bytesrepr::Error> for Error {
+    fn from(error: bytesrepr::Error) -> Self {
+        Error::BytesRepr(error)
+    }
+}
 
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(_error: sync::PoisonError<T>) -> Self {

--- a/execution_engine_testing/cargo_casper/src/erc20.rs
+++ b/execution_engine_testing/cargo_casper/src/erc20.rs
@@ -25,11 +25,11 @@ pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}{}{}{}{}",
-        Dependency::new("base64", "0.13.0").display_with_features(true, vec![]),
-        Dependency::new("blake2", "0.9.2").display_with_features(true, vec![]),
+        Dependency::new("base64", "0.13.0").display_with_features(false, vec!["alloc"]),
+        Dependency::new("blake2", "0.9.2").display_with_features(false, vec![]),
         CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
-        CL_ERC20.display_with_features(true, vec!["std"]),
-        CL_TYPES.display_with_features(true, vec!["std"]),
-        Dependency::new("hex", "0.4.3").display_with_features(true, vec![]),
+        CL_ERC20.display_with_features(false, vec![]),
+        CL_TYPES.display_with_features(true, vec![]),
+        Dependency::new("hex", "0.4.3").display_with_features(false, vec!["alloc"]),
     )
 });

--- a/execution_engine_testing/cargo_casper/src/simple.rs
+++ b/execution_engine_testing/cargo_casper/src/simple.rs
@@ -18,8 +18,8 @@ pub static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}{}",
-        CL_CONTRACT.display_with_features(false, vec!["std", "test-support"]),
+        CL_CONTRACT.display_with_features(true, vec!["test-support"]),
         CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
-        CL_TYPES.display_with_features(false, vec!["std"]),
+        CL_TYPES.display_with_features(true, vec![]),
     )
 });

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-contract = { version = "1.0.0", path = "../../smart_contracts/contract", default-features = false, features = ["std"] }
+casper-contract = { version = "1.0.0", path = "../../smart_contracts/contract", default-features = false }
 casper-execution-engine = { version = "1.0.0", path = "../../execution_engine", features = ["gens"] }
-casper-types = { version = "1.0.0", path = "../../types", default-features = false, features = ["std"] }
+casper-types = { version = "1.0.0", path = "../../types" }
 casper-hashing = { version = "1.0.0", path = "../../hashing" }
 lmdb = "0.8.0"
 log = "0.4.8"

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 
 [dependencies]
 base16 = "0.2.1"
-casper-contract = { path = "../../smart_contracts/contract", default-features = false, features = ["std", "test-support"] }
+casper-contract = { path = "../../smart_contracts/contract", default-features = false, features = ["test-support"] }
 casper-engine-test-support = { path = "../test_support", features = ["test-support"] }
 casper-execution-engine = { path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { path = "../../hashing" }
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
+casper-types = { path = "../../types", features = ["datasize", "json-schema"] }
 clap = "2"
 crossbeam-channel = "0.5.0"
-dictionary = { path = "../../smart_contracts/contracts/test/dictionary", default-features = false, features = ["std"] }
-dictionary-call = { path = "../../smart_contracts/contracts/test/dictionary-call", default-features = false, features = ["std"] }
+dictionary = { path = "../../smart_contracts/contracts/test/dictionary", default-features = false }
+dictionary-call = { path = "../../smart_contracts/contracts/test/dictionary-call", default-features = false }
 env_logger = "0.8.1"
 fs_extra = "1.2.0"
-get-call-stack-recursive-subcall = { path = "../../smart_contracts/contracts/test/get-call-stack-recursive-subcall", default-features = false, features = ["std"] }
+get-call-stack-recursive-subcall = { path = "../../smart_contracts/contracts/test/get-call-stack-recursive-subcall", default-features = false }
 hex = { version = "0.4.2", features = ["serde"] }
 log = "0.4.8"
 parity-wasm = "0.41.0"
@@ -29,8 +29,8 @@ tempfile = "3"
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = "0.3.5"
-gh-1470-regression = { path = "../../smart_contracts/contracts/test/gh-1470-regression", default-features = false, features = ["std"] }
-gh-1470-regression-call = { path = "../../smart_contracts/contracts/test/gh-1470-regression-call", default-features = false, features = ["std"] }
+gh-1470-regression = { path = "../../smart_contracts/contracts/test/gh-1470-regression", default-features = false }
+gh-1470-regression-call = { path = "../../smart_contracts/contracts/test/gh-1470-regression-call", default-features = false }
 num-rational = "0.4.0"
 num-traits = "0.2.10"
 once_cell = "1.5.2"

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,7 +12,7 @@ license-file = "../LICENSE"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["std", "gens"] }
+casper-types = { version = "1.0.0", path = "../types", features = ["gens"] }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1.0.1"
 casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
 casper-node-macros = { version = "1.0.0", path = "../node_macros" }
 casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["std", "gens"] }
+casper-types = { version = "1.0.0", path = "../types", features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/types/error.rs
+++ b/node/src/types/error.rs
@@ -32,8 +32,8 @@ pub enum BlockCreationError {
 #[derive(Error, Debug)]
 pub enum BlockValidationError {
     /// Problem serializing some of a block's data into bytes
-    #[error(transparent)]
-    BytesReprError(#[from] bytesrepr::Error),
+    #[error("{0}")]
+    BytesReprError(bytesrepr::Error),
 
     /// The body hash in the header is not the same as the hash of the body of the block
     #[error(
@@ -60,4 +60,10 @@ pub enum BlockValidationError {
         /// The actual hash of the block's `BlockHeader`
         actual_block_header_hash: BlockHash,
     },
+}
+
+impl From<bytesrepr::Error> for BlockValidationError {
+    fn from(error: bytesrepr::Error) -> Self {
+        BlockValidationError::BytesReprError(error)
+    }
 }

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -14,12 +14,11 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Add explicit `no-std` feature, enabled by default and which causes a compiler error if enabled along with `std`.
+* Add `no-std-helpers` feature, enabled by default, which provides no-std panic/oom handlers and a global allocator as a convenience.
 * Add new APIs for transferring tokens to the main purse associated with a public key: `transfer_to_public_key` and `transfer_from_purse_to_public_key`.
 
-### Changed
-* Feature-gate the convenience functionality of providing a global allocator for use in `no_std` smart-contracts.
-* Change default feature set to enable new `no-std` and `provide-allocator` features.
+### Deprecated
+* Feature `std` is deprecated as it is now a no-op, since there is no benefit to linking the std lib via this crate.
 
 
 

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "casper-contract"
 version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
-description = "Library for developing Casper smart contracts."
+description = "A library for developing Casper network smart contracts."
 readme = "README.md"
 documentation = "https://docs.rs/casper-contract"
 homepage = "https://casperlabs.io"
@@ -11,15 +11,14 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "1.0.0", path = "../../types", default-features = false }
+casper-types = { version = "1.0.0", path = "../../types" }
 hex_fmt = "0.3.0"
-thiserror = "1.0.18"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 
 [features]
-default = ["no-std", "provide-allocator"]
-no-std = ["casper-types/no-std"]
-provide-allocator = ["wee_alloc"]
-std = ["casper-types/std", "version-sync"]
+default = ["no-std-helpers"]
+no-std-helpers = ["wee_alloc"]
 test-support = []
+# DEPRECATED - enabling `std` has no effect.
+std = []

--- a/smart_contracts/contract/README.md
+++ b/smart_contracts/contract/README.md
@@ -6,35 +6,45 @@
 [![Documentation](https://docs.rs/casper-contract/badge.svg)](https://docs.rs/casper-contract)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/CasperLabs/casper-node/blob/master/LICENSE)
 
-A library for developing CasperLabs smart contracts.
+A library for developing Casper network smart contracts.
+
+## no_std
+
+The crate is `no_std`, but uses the `core` and `alloc` crates.  It is recommended to build Wasm smart contracts in a
+`no_std` environment as this generally yields smaller, and hence cheaper, binaries.
 
 ## Compile-time features
 
-The crate provides a `no-std` feature which is enabled by default.  It is recommended to use the library with this
-default feature enabled to provide a `no_std` environment.  Compiling a Wasm smart contract with `no-std` enabled
-generally yields a smaller, and hence cheaper, binary.
+### `no-std-helpers`
 
-Given that the library is intended to be consumed by smart-contract binaries, and that in a no-std environment these
+Enabled by default.
+
+Given that the library is intended to be consumed by smart-contract binaries, and that in a `no_std` environment these
 will all require to provide an [alloc error handler](https://github.com/rust-lang/rust/issues/51540) and an
 [eh_personality](https://doc.rust-lang.org/unstable-book/language-features/lang-items.html#more-about-the-language-items),
-then this crate provides these when `no-std` is enabled.  This unfortunately requires the use of nightly Rust.
+then this crate provides these when `no-std-helpers` is enabled.  This unfortunately requires the use of nightly Rust.
 
-For further convenience, the crate provides a global allocator suitable for use in a `no_std` environment via the
-`provide-allocator` feature.  This is only valid if `no-std` is also enabled, and it is also enabled by default.  If you
-wish to work in a `no_std` environment with a different global allocator, then add the following to your Cargo.toml:
+For further convenience, enabling this feature also provides a global allocator suitable for use in a `no_std`
+environment.
 
-```toml
-casper-contract = { version = "1.0.0", default-features = false, features = ["no-std"] }
-```
-
-If you wish to work outside a `no_std` environment, then disable the default features and enable the `std` feature of
-this crate.  For example:
+If you wish to use a different global allocator, or provide different panic/out-of-memory handlers, then add the
+following to your Cargo.toml:
 
 ```toml
-casper-contract = { version = "1.0.0", default-features = false, features = ["std"] }
+casper-contract = { version = "1", default-features = false }
 ```
 
-The crate requires either the `no-std` feature or the `std` feature to be enabled.
+### `test-support`
+
+Disabled by default.
+
+To help support smart contract debugging, enabling the `test-support` feature makes the function
+`contract_api::runtime::print(text: &str)` available.  If the contract is being tested offchain using the
+`casper-engine-test-support` crate, then the contract can output text to the console for debugging.
+
+```toml
+casper-contract = { version = "1", features = ["test-support"] }
+```
 
 ## License
 

--- a/smart_contracts/contract/src/contract_api/account.rs
+++ b/smart_contracts/contract/src/contract_api/account.rs
@@ -1,6 +1,5 @@
 //! Functions for managing accounts.
 
-#[cfg(feature = "no-std")]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 

--- a/smart_contracts/contract/src/contract_api/mod.rs
+++ b/smart_contracts/contract/src/contract_api/mod.rs
@@ -5,14 +5,10 @@ pub mod runtime;
 pub mod storage;
 pub mod system;
 
-#[cfg(feature = "no-std")]
 use alloc::{
     alloc::{alloc, Layout},
     vec::Vec,
 };
-#[cfg(feature = "std")]
-use std::alloc::{alloc, Layout};
-
 use core::{mem, ptr::NonNull};
 
 use casper_types::{bytesrepr::ToBytes, ApiError};

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -1,6 +1,5 @@
 //! Functions for interacting with the current runtime.
 
-#[cfg(feature = "no-std")]
 use alloc::{vec, vec::Vec};
 use core::mem::MaybeUninit;
 

--- a/smart_contracts/contract/src/contract_api/storage.rs
+++ b/smart_contracts/contract/src/contract_api/storage.rs
@@ -1,10 +1,7 @@
 //! Functions for accessing and mutating local and global state.
 
-#[cfg(feature = "no-std")]
 use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};
 use core::{convert::From, mem::MaybeUninit};
-#[cfg(feature = "std")]
-use std::collections::BTreeSet;
 
 use casper_types::{
     api_error,

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -1,6 +1,5 @@
 //! Functions for interacting with the system contracts.
 
-#[cfg(feature = "no-std")]
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -3,8 +3,7 @@
 //!
 //! # `no_std`
 //!
-//! By default, the library is `no_std`, however you can enable full `std` functionality by enabling
-//! the crate's `std` feature.
+//! The library is `no_std`, but uses the `core` and `alloc` crates.
 //!
 //! # Example
 //!
@@ -46,9 +45,9 @@
 //! Support for writing smart contracts are contained in the [`contract_api`] module and its
 //! submodules.
 
-#![cfg_attr(feature = "no-std", no_std)]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
-    all(feature = "provide-allocator", not(any(test, doc))),
+    all(not(test), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
 #![doc(html_root_url = "https://docs.rs/casper-contract/1.0.0")]
@@ -59,28 +58,16 @@
 )]
 #![warn(missing_docs)]
 
-#[cfg(feature = "no-std")]
 extern crate alloc;
 
 pub mod contract_api;
 pub mod ext_ffi;
-#[cfg(all(feature = "provide-allocator", not(any(test, doc))))]
+#[cfg(all(not(test), feature = "no-std-helpers"))]
 mod no_std_handlers;
 pub mod unwrap_or_revert;
 
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!(
-    "casper-contract requires one of 'no-std' (enabled by default) or 'std' features to be enabled"
-);
-#[cfg(all(feature = "std", feature = "no-std"))]
-compile_error!(
-    "casper-contract features 'no-std' (enabled by default) and 'std' should not both be enabled"
-);
-#[cfg(all(feature = "provide-allocator", not(feature = "no-std")))]
-compile_error!("casper-contract 'provide-allocator' feature requires `no-std` to also be enabled");
-
 /// An instance of [`WeeAlloc`](https://docs.rs/wee_alloc) which allows contracts built as `no_std`
 /// to avoid having to provide a global allocator themselves.
-#[cfg(feature = "provide-allocator")]
+#[cfg(all(not(test), feature = "no-std-helpers"))]
 #[global_allocator]
 pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/smart_contracts/contract/tests/version_numbers.rs
+++ b/smart_contracts/contract/tests/version_numbers.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "std")]
+#[cfg(feature = "version-sync")]
 #[test]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");

--- a/smart_contracts/contracts/test/dictionary-call/Cargo.toml
+++ b/smart_contracts/contracts/test/dictionary-call/Cargo.toml
@@ -12,11 +12,9 @@ doctest = false
 test = false
 
 [features]
-default = ["no-std"]
-no-std = ["casper-contract/no-std", "casper-types/no-std", "dictionary/no-std"]
-std = ["casper-contract/std", "casper-types/std", "dictionary/std"]
+default = ["casper-contract/default", "dictionary/default"]
 
 [dependencies]
 casper-contract = { path = "../../../contract", default-features = false }
-casper-types = { path = "../../../../types", default-features = false }
+casper-types = { path = "../../../../types" }
 dictionary = { path = "../dictionary", default-features = false }

--- a/smart_contracts/contracts/test/dictionary/Cargo.toml
+++ b/smart_contracts/contracts/test/dictionary/Cargo.toml
@@ -12,10 +12,8 @@ doctest = false
 test = false
 
 [features]
-default = ["no-std"]
-no-std = ["casper-contract/no-std", "casper-contract/provide-allocator", "casper-types/no-std"]
-std = ["casper-contract/std", "casper-types/std"]
+default = ["casper-contract/default"]
 
 [dependencies]
 casper-contract = { path = "../../../contract", default-features = false }
-casper-types = { path = "../../../../types", default-features = false }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/get-call-stack-recursive-subcall/Cargo.toml
+++ b/smart_contracts/contracts/test/get-call-stack-recursive-subcall/Cargo.toml
@@ -12,10 +12,8 @@ doctest = false
 test = false
 
 [features]
-default = ["no-std"]
-no-std = ["casper-contract/no-std", "casper-contract/provide-allocator", "casper-types/no-std"]
-std = ["casper-contract/std", "casper-types/std"]
+default = ["casper-contract/default"]
 
 [dependencies]
 casper-contract = { path = "../../../contract", default-features = false }
-casper-types = { path = "../../../../types", default-features = false }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/gh-1470-regression-call/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-1470-regression-call/Cargo.toml
@@ -12,11 +12,9 @@ doctest = false
 test = false
 
 [features]
-default = ["no-std"]
-no-std = ["casper-contract/no-std", "casper-types/no-std", "gh-1470-regression/no-std"]
-std = ["casper-contract/std", "casper-types/std", "gh-1470-regression/std"]
+default = ["casper-contract/default", "gh-1470-regression/default"]
 
 [dependencies]
 casper-contract = { path = "../../../contract", default-features = false }
-casper-types = { path = "../../../../types", default-features = false }
+casper-types = { path = "../../../../types" }
 gh-1470-regression = { path = "../gh-1470-regression", default-features = false }

--- a/smart_contracts/contracts/test/gh-1470-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-1470-regression/Cargo.toml
@@ -12,10 +12,8 @@ doctest = false
 test = false
 
 [features]
-default = ["no-std"]
-no-std = ["casper-contract/no-std", "casper-contract/provide-allocator", "casper-types/no-std"]
-std = ["casper-contract/std", "casper-types/std"]
+default = ["casper-contract/default"]
 
 [dependencies]
 casper-contract = { path = "../../../contract", default-features = false }
-casper-types = { path = "../../../../types", default-features = false }
+casper-types = { path = "../../../../types" }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -14,13 +14,17 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Add explicit `no-std` feature, enabled by default and which causes a compiler error if enabled along with `std`.
+* Add `json-schema` feature, disabled by default, to enable many types to be used to produce JSON-schema data.
+* Add implicit `datasize` feature, disabled by default, to enable many types to derive the `DataSize` trait.
 * Add `StoredValue` types to this crate.
 
 ### Changed
 * Support building and testing using stable Rust.
 * Allow longer hex string to be presented in `json` files. Current maximum is increased from 100 to 150 characters.
-* Improved documentation and `Debug` impls for `ApiError`.
+* Improve documentation and `Debug` impls for `ApiError`.
+
+### Deprecated
+* Feature `std` is deprecated as it is now a no-op, since there is no benefit to linking the std lib via this crate.
 
 
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -3,7 +3,7 @@ name = "casper-types"
 version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
-description = "Types used to allow creation of Wasm contracts and tests for use on the Casper network."
+description = "Types shared by many casper crates for use on the Casper network."
 readme = "README.md"
 documentation = "https://docs.rs/casper-types"
 homepage = "https://casperlabs.io"
@@ -11,30 +11,29 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/types"
 license-file = "../LICENSE"
 
 [dependencies]
-base16 = { version = "0.2.1", default-features = false }
+base16 = { version = "0.2.1", default-features = false, features = ["alloc"] }
 base64 = { version = "0.13.0", default-features = false }
 bitflags = "1"
 blake2 = { version = "0.9.0", default-features = false }
-datasize = { version = "0.2.4", default-features = false }
-displaydoc = { version = "0.1", default-features = false, optional = true }
+datasize = { version = "0.2.4", optional = true }
 ed25519-dalek = { version = "1.0.0", default-features = false, features = ["rand", "u64_backend"] }
-hex = { version = "0.4.2", default-features = false }
+hex = { version = "0.4.2", default-features = false, features = ["alloc"] }
 hex_fmt = "0.3.0"
 k256 = { version = "0.7.2", default-features = false, features = ["ecdsa", "zeroize"] }
-num = { version = "0.4.0", default-features = false }
+num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 num-derive = { version = "0.3.0", default-features = false }
 num-integer = { version = "0.1.42", default-features = false }
 num-rational = { version = "0.4.0", default-features = false }
 num-traits = { version = "0.2.10", default-features = false }
-once_cell = { version = "1.5.2", default-features = false }
+once_cell = { version = "1.5.2", optional = true }
 proptest = { version = "1.0.0", optional = true }
 rand = { version = "0.8.3", default-features = false, features = ["small_rng"] }
 schemars = { version = "0.8.0", features = ["preserve_order"], optional = true }
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.59", default-features = false }
-serde_bytes = { version = "0.11.5", default-features = false }
-thiserror = { version = "1.0.20", default-features = false, optional = true }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.59", default-features = false, features = ["alloc"] }
 uint = { version = "0.9.0", default-features = false }
+version-sync = { version = "0.9", optional = true }
 
 [dev-dependencies]
 bincode = "1.3.1"
@@ -44,27 +43,12 @@ proptest = "1.0.0"
 serde_json = "1.0.55"
 serde_test = "1.0.117"
 strum = { version = "0.21", features = ["derive"] }
-version-sync = "0.9"
 
 [features]
-default = ["no-std"]
-std = [
-    "base16/std",
-    "base64/std",
-    "ed25519-dalek/std",
-    "ed25519-dalek/serde",
-    "hex/std",
-    "k256/std",
-    "once_cell/std",
-    "serde/std",
-    "serde_json/std",
-    "serde_bytes/std",
-    "schemars",
-    "thiserror",
-    "num/std",
-]
-no-std = ["base16/alloc", "hex/alloc", "serde/alloc", "serde_json/alloc", "serde_bytes/alloc", "displaydoc", "num/alloc"]
-gens = ["std", "proptest/std"]
+json-schema = ["once_cell", "schemars"]
+gens = ["proptest"]
+# DEPRECATED - enabling `std` has no effect.
+std = []
 
 [[bench]]
 name = "bytesrepr_bench"

--- a/types/README.md
+++ b/types/README.md
@@ -7,14 +7,15 @@
 [![Documentation](https://docs.rs/casper-types/badge.svg)](https://docs.rs/casper-types)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/CasperLabs/casper-node/blob/master/LICENSE)
 
+Types shared by many casper crates for use on the Casper network.
+
 ## `no_std`
 
-By default, the `no-std` feature is enabled which in turn enables a similar feature on many dependent crates.  To use
-the library in a `std` environment, disable the default features and enable the `std` feature.  For example:
+The crate is `no_std` (using the `core` and `alloc` crates) unless any of the following features are enabled:
 
-```toml
-casper-types = { version = "1.0.0", default-features = false, features = ["std"] }
-```
+* `json-schema` to enable many types to be used to produce JSON-schema data via the [`schemars`](https://crates.io/crates/schemars) crate
+* `datasize` to enable many types to derive the [`DataSize`](https://github.com/casperlabs/datasize-rs) trait
+* `gens` to enable many types to be produced in accordance with [`proptest`](https://crates.io/crates/proptest) usage for consumption within dependee crates' property testing suites
 
 ## License
 

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
+use core::fmt::{self, Display, Formatter};
 
 use bitflags::bitflags;
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use rand::{
     distributions::{Distribution, Standard},
@@ -17,7 +19,7 @@ bitflags! {
     /// A struct which behaves like a set of bitflags to define access rights associated with a
     /// [`URef`](crate::URef).
     #[allow(clippy::derive_hash_xor_eq)]
-    #[derive(DataSize)]
+    #[cfg_attr(feature = "datasize", derive(DataSize))]
     pub struct AccessRights: u8 {
         /// No permissions
         const NONE = 0;
@@ -66,8 +68,8 @@ impl AccessRights {
     }
 }
 
-impl core::fmt::Display for AccessRights {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl Display for AccessRights {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             AccessRights::NONE => write!(f, "NONE"),
             AccessRights::READ => write!(f, "READ"),

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -7,19 +7,16 @@ pub mod associated_keys;
 mod error;
 mod weight;
 
-use crate::{
-    bytesrepr::{self, FromBytes, ToBytes},
-    contracts::NamedKeys,
-    AccessRights, URef, BLAKE2B_DIGEST_LENGTH,
-};
 use alloc::{collections::BTreeSet, vec::Vec};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Debug, Display, Formatter},
+};
+
 use blake2::{
     digest::{Update, VariableOutput},
     VarBlake2b,
 };
-use core::{convert::TryFrom, fmt::Debug};
-#[cfg(feature = "std")]
-use thiserror::Error;
 
 pub use self::{
     account_hash::{AccountHash, ACCOUNT_HASH_FORMATTED_STRING_PREFIX, ACCOUNT_HASH_LENGTH},
@@ -28,6 +25,11 @@ pub use self::{
     associated_keys::AssociatedKeys,
     error::{FromStrError, SetThresholdFailure, TryFromIntError, TryFromSliceForAccountHashError},
     weight::{Weight, WEIGHT_SERIALIZED_LENGTH},
+};
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    contracts::NamedKeys,
+    AccessRights, URef, BLAKE2B_DIGEST_LENGTH,
 };
 
 /// Represents an Account in the global state.
@@ -298,28 +300,29 @@ pub fn blake2b<T: AsRef<[u8]>>(data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
 
 /// Errors that can occur while adding a new [`AccountHash`] to an account's associated keys map.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(i32)]
 pub enum AddKeyFailure {
     /// There are already maximum [`AccountHash`]s associated with the given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to add new associated key because maximum amount of keys is reached")
-    )]
     MaxKeysLimit = 1,
     /// The given [`AccountHash`] is already associated with the given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to add new associated key because given key already exists")
-    )]
     DuplicateKey = 2,
     /// Caller doesn't have sufficient permissions to associate a new [`AccountHash`] with the
     /// given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to add new associated key due to insufficient permissions")
-    )]
     PermissionDenied = 3,
+}
+
+impl Display for AddKeyFailure {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            AddKeyFailure::MaxKeysLimit => formatter.write_str(
+                "Unable to add new associated key because maximum amount of keys is reached",
+            ),
+            AddKeyFailure::DuplicateKey => formatter
+                .write_str("Unable to add new associated key because given key already exists"),
+            AddKeyFailure::PermissionDenied => formatter
+                .write_str("Unable to add new associated key due to insufficient permissions"),
+        }
+    }
 }
 
 // This conversion is not intended to be used by third party crates.
@@ -339,26 +342,31 @@ impl TryFrom<i32> for AddKeyFailure {
 
 /// Errors that can occur while removing a [`AccountHash`] from an account's associated keys map.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(i32)]
 pub enum RemoveKeyFailure {
     /// The given [`AccountHash`] is not associated with the given account.
-    #[cfg_attr(feature = "std", error("Unable to remove a key that does not exist"))]
     MissingKey = 1,
     /// Caller doesn't have sufficient permissions to remove an associated [`AccountHash`] from the
     /// given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to remove associated key due to insufficient permissions")
-    )]
     PermissionDenied = 2,
     /// Removing the given associated [`AccountHash`] would cause the total weight of all remaining
     /// `AccountHash`s to fall below one of the action thresholds for the given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to remove a key which would violate action threshold constraints")
-    )]
     ThresholdViolation = 3,
+}
+
+impl Display for RemoveKeyFailure {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            RemoveKeyFailure::MissingKey => {
+                formatter.write_str("Unable to remove a key that does not exist")
+            }
+            RemoveKeyFailure::PermissionDenied => formatter
+                .write_str("Unable to remove associated key due to insufficient permissions"),
+            RemoveKeyFailure::ThresholdViolation => formatter.write_str(
+                "Unable to remove a key which would violate action threshold constraints",
+            ),
+        }
+    }
 }
 
 // This conversion is not intended to be used by third party crates.
@@ -383,30 +391,32 @@ impl TryFrom<i32> for RemoveKeyFailure {
 /// Errors that can occur while updating the [`Weight`] of a [`AccountHash`] in an account's
 /// associated keys map.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(i32)]
 pub enum UpdateKeyFailure {
     /// The given [`AccountHash`] is not associated with the given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to update the value under an associated key that does not exist")
-    )]
     MissingKey = 1,
     /// Caller doesn't have sufficient permissions to update an associated [`AccountHash`] from the
     /// given account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to update associated key due to insufficient permissions")
-    )]
     PermissionDenied = 2,
     /// Updating the [`Weight`] of the given associated [`AccountHash`] would cause the total
     /// weight of all `AccountHash`s to fall below one of the action thresholds for the given
     /// account.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to update weight that would fall below any of action thresholds")
-    )]
     ThresholdViolation = 3,
+}
+
+impl Display for UpdateKeyFailure {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            UpdateKeyFailure::MissingKey => formatter.write_str(
+                "Unable to update the value under an associated key that does not exist",
+            ),
+            UpdateKeyFailure::PermissionDenied => formatter
+                .write_str("Unable to update associated key due to insufficient permissions"),
+            UpdateKeyFailure::ThresholdViolation => formatter.write_str(
+                "Unable to update weight that would fall below any of action thresholds",
+            ),
+        }
+    }
 }
 
 // This conversion is not intended to be used by third party crates.

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -3,12 +3,13 @@ use core::{
     convert::{From, TryFrom},
     fmt::{Debug, Display, Formatter},
 };
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -26,7 +27,8 @@ pub const ACCOUNT_HASH_FORMATTED_STRING_PREFIX: &str = "account-hash-";
 
 /// A newtype wrapping an array which contains the raw bytes of
 /// the AccountHash, a hash of Public Key and Algorithm
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct AccountHash(pub [u8; ACCOUNT_HASH_LENGTH]);
 
 impl AccountHash {
@@ -93,7 +95,7 @@ impl AccountHash {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for AccountHash {
     fn schema_name() -> String {
         String::from("AccountHash")

--- a/types/src/account/error.rs
+++ b/types/src/account/error.rs
@@ -3,8 +3,6 @@ use core::{
     convert::TryFrom,
     fmt::{self, Display, Formatter},
 };
-#[cfg(feature = "std")]
-use thiserror::Error;
 
 // This error type is not intended to be used by third party crates.
 #[doc(hidden)]
@@ -51,33 +49,16 @@ impl Display for FromStrError {
 /// various actions) on an account.
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-#[cfg_attr(feature = "std", derive(Error))]
 pub enum SetThresholdFailure {
     /// Setting the key-management threshold to a value lower than the deployment threshold is
     /// disallowed.
-    #[cfg_attr(
-        feature = "std",
-        error("New threshold should be greater than or equal to deployment threshold")
-    )]
     KeyManagementThreshold = 1,
     /// Setting the deployment threshold to a value greater than any other threshold is disallowed.
-    #[cfg_attr(
-        feature = "std",
-        error("New threshold should be lower than or equal to key management threshold")
-    )]
     DeploymentThreshold = 2,
     /// Caller doesn't have sufficient permissions to set new thresholds.
-    #[cfg_attr(
-        feature = "std",
-        error("Unable to set action threshold due to insufficient permissions")
-    )]
     PermissionDeniedError = 3,
     /// Setting a threshold to a value greater than the total weight of associated keys is
     /// disallowed.
-    #[cfg_attr(
-        feature = "std",
-        error("New threshold should be lower or equal than total weight of associated keys")
-    )]
     InsufficientTotalWeight = 4,
 }
 
@@ -101,6 +82,23 @@ impl TryFrom<i32> for SetThresholdFailure {
                 Ok(SetThresholdFailure::InsufficientTotalWeight)
             }
             _ => Err(TryFromIntError(())),
+        }
+    }
+}
+
+impl Display for SetThresholdFailure {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            SetThresholdFailure::KeyManagementThreshold => formatter
+                .write_str("New threshold should be greater than or equal to deployment threshold"),
+            SetThresholdFailure::DeploymentThreshold => formatter.write_str(
+                "New threshold should be lower than or equal to key management threshold",
+            ),
+            SetThresholdFailure::PermissionDeniedError => formatter
+                .write_str("Unable to set action threshold due to insufficient permissions"),
+            SetThresholdFailure::InsufficientTotalWeight => formatter.write_str(
+                "New threshold should be lower or equal than total weight of associated keys",
+            ),
         }
     }
 }

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1,25 +1,25 @@
 //! Contains serialization and deserialization code for types used throughout the system.
 mod bytes;
 
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
 use alloc::{
     alloc::{alloc, Layout},
     collections::{BTreeMap, BTreeSet, VecDeque},
     str,
     string::String,
+    vec,
     vec::Vec,
 };
 #[cfg(debug_assertions)]
 use core::any;
-use core::{mem, ptr::NonNull};
+use core::{
+    fmt::{self, Display, Formatter},
+    mem,
+    ptr::NonNull,
+};
 
 use num_integer::Integer;
 use num_rational::Ratio;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "std")]
-use thiserror::Error;
 
 pub use bytes::Bytes;
 
@@ -100,21 +100,29 @@ pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Erro
 
 /// Serialization and deserialization errors.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(u8)]
 pub enum Error {
     /// Early end of stream while deserializing.
-    #[cfg_attr(feature = "std", error("Deserialization error: early end of stream"))]
     EarlyEndOfStream = 0,
     /// Formatting error while deserializing.
-    #[cfg_attr(feature = "std", error("Deserialization error: formatting"))]
     Formatting,
     /// Not all input bytes were consumed in [`deserialize`].
-    #[cfg_attr(feature = "std", error("Deserialization error: left-over bytes"))]
     LeftOverBytes,
     /// Out of memory error.
-    #[cfg_attr(feature = "std", error("Serialization error: out of memory"))]
     OutOfMemory,
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::EarlyEndOfStream => {
+                formatter.write_str("Deserialization error: early end of stream")
+            }
+            Error::Formatting => formatter.write_str("Deserialization error: formatting"),
+            Error::LeftOverBytes => formatter.write_str("Deserialization error: left-over bytes"),
+            Error::OutOfMemory => formatter.write_str("Serialization error: out of memory"),
+        }
+    }
 }
 
 /// Deserializes `bytes` into an instance of `T`.

--- a/types/src/bytesrepr/bytes.rs
+++ b/types/src/bytesrepr/bytes.rs
@@ -5,12 +5,10 @@ use alloc::{
 use core::{
     cmp, fmt,
     iter::FromIterator,
-    mem,
     ops::{Deref, Index, Range, RangeFrom, RangeFull, RangeTo},
     slice,
 };
 
-use datasize::DataSize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -192,13 +190,14 @@ impl IntoIterator for Bytes {
     }
 }
 
-impl DataSize for Bytes {
+#[cfg(feature = "datasize")]
+impl datasize::DataSize for Bytes {
     const IS_DYNAMIC: bool = true;
 
     const STATIC_HEAP_SIZE: usize = 0;
 
     fn estimate_heap_size(&self) -> usize {
-        self.0.capacity() * mem::size_of::<u8>()
+        self.0.capacity() * std::mem::size_of::<u8>()
     }
 }
 

--- a/types/src/cl_type.rs
+++ b/types/src/cl_type.rs
@@ -9,8 +9,10 @@ use alloc::{
 };
 use core::mem;
 
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
 use num_rational::Ratio;
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -47,7 +49,8 @@ const CL_TYPE_TAG_PUBLIC_KEY: u8 = 22;
 ///
 /// Provides a description of the underlying data type of a [`CLValue`](crate::CLValue).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub enum CLType {
     /// `bool` primitive.
@@ -79,25 +82,32 @@ pub enum CLType {
     /// [`PublicKey`](crate::PublicKey) system type.
     PublicKey,
     /// `Option` of a `CLType`.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Option(Box<CLType>),
     /// Variable-length list of a single `CLType` (comparable to a `Vec`).
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     List(Box<CLType>),
     /// Fixed-length list of a single `CLType` (comparable to a Rust array).
     ByteArray(u32),
     /// `Result` with `Ok` and `Err` variants of `CLType`s.
     #[allow(missing_docs)] // generated docs are explicit enough.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Result { ok: Box<CLType>, err: Box<CLType> },
     /// Map with keys of a single `CLType` and values of a single `CLType`.
     #[allow(missing_docs)] // generated docs are explicit enough.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Map {
         key: Box<CLType>,
         value: Box<CLType>,
     },
     /// 1-ary tuple of a `CLType`.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Tuple1([Box<CLType>; 1]),
     /// 2-ary tuple of `CLType`s.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Tuple2([Box<CLType>; 2]),
     /// 3-ary tuple of `CLType`s.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Tuple3([Box<CLType>; 3]),
     /// Unspecified type.
     Any,

--- a/types/src/contract_wasm.rs
+++ b/types/src/contract_wasm.rs
@@ -5,8 +5,9 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -82,7 +83,8 @@ impl Display for FromStrError {
 
 /// A newtype wrapping a `HashAddr` which is the raw bytes of
 /// the ContractWasmHash
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ContractWasmHash(HashAddr);
 
 impl ContractWasmHash {
@@ -207,7 +209,7 @@ impl TryFrom<&Vec<u8>> for ContractWasmHash {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for ContractWasmHash {
     fn schema_name() -> String {
         String::from("ContractWasmHash")

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -14,8 +14,9 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -198,7 +199,7 @@ impl Display for FromStrError {
 /// A (labelled) "user group". Each method of a versioned contract may be
 /// associated with one or more user groups which are allowed to call it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct Group(String);
 
 impl Group {
@@ -317,7 +318,8 @@ pub type Groups = BTreeMap<Group, BTreeSet<URef>>;
 
 /// A newtype wrapping a `HashAddr` which is the raw bytes of
 /// the ContractHash
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ContractHash(HashAddr);
 
 impl ContractHash {
@@ -447,7 +449,7 @@ impl TryFrom<&Vec<u8>> for ContractHash {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for ContractHash {
     fn schema_name() -> String {
         String::from("ContractHash")
@@ -463,7 +465,8 @@ impl JsonSchema for ContractHash {
 
 /// A newtype wrapping a `HashAddr` which is the raw bytes of
 /// the ContractPackageHash
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ContractPackageHash(HashAddr);
 
 impl ContractPackageHash {
@@ -589,7 +592,7 @@ impl TryFrom<&Vec<u8>> for ContractPackageHash {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for ContractPackageHash {
     fn schema_name() -> String {
         String::from("ContractPackageHash")
@@ -1134,7 +1137,7 @@ impl Default for Contract {
 /// Context of method execution
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub enum EntryPointType {
     /// Runs as session code
     Session = 0,
@@ -1178,7 +1181,7 @@ pub type Parameters = Vec<Parameter>;
 /// Type signature of a method. Order of arguments matter since can be
 /// referenced by index as well as name.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct EntryPoint {
     name: String,
     args: Parameters,
@@ -1309,7 +1312,7 @@ impl FromBytes for EntryPoint {
 /// Enum describing the possible access control options for a contract entry
 /// point (method).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub enum EntryPointAccess {
     /// Anyone can call this method (no access controls).
     Public,
@@ -1372,7 +1375,7 @@ impl FromBytes for EntryPointAccess {
 
 /// Parameter to a method
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct Parameter {
     name: String,
     cl_type: CLType,

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -14,6 +14,7 @@ use core::{
     marker::Copy,
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use ed25519_dalek::{
     ed25519::signature::Signature as _Signature, PUBLIC_KEY_LENGTH as ED25519_PUBLIC_KEY_LENGTH,
@@ -24,7 +25,7 @@ use k256::ecdsa::{
     Signature as Secp256k1Signature, SigningKey as Secp256k1SecretKey,
     VerifyingKey as Secp256k1PublicKey,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -114,15 +115,16 @@ where
 }
 
 /// A secret or private asymmetric key.
-#[derive(DataSize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub enum SecretKey {
     /// System secret key.
     System,
     /// Ed25519 secret key.
-    #[data_size(skip)] // Manually verified to have no data on the heap.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
+    // Manually verified to have no data on the heap.
     Ed25519(ed25519_dalek::SecretKey),
     /// secp256k1 secret key.
-    #[data_size(skip)]
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Secp256k1(Secp256k1SecretKey),
 }
 
@@ -187,15 +189,16 @@ impl Tagged<u8> for SecretKey {
 }
 
 /// A public asymmetric key.
-#[derive(Clone, DataSize, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub enum PublicKey {
     /// System public key.
     System,
     /// Ed25519 public key.
-    #[data_size(skip)] // Manually verified to have no data on the heap.
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Ed25519(ed25519_dalek::PublicKey),
     /// secp256k1 public key.
-    #[data_size(skip)]
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Secp256k1(Secp256k1PublicKey),
 }
 
@@ -394,7 +397,7 @@ impl<'de> Deserialize<'de> for PublicKey {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for PublicKey {
     fn schema_name() -> String {
         String::from("PublicKey")
@@ -417,15 +420,16 @@ impl CLTyped for PublicKey {
 }
 
 /// A signature of given data.
-#[derive(Clone, Copy, DataSize)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub enum Signature {
     /// System signature.  Cannot be verified.
     System,
     /// Ed25519 signature.
-    #[data_size(skip)]
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Ed25519(ed25519_dalek::Signature),
     /// Secp256k1 signature.
-    #[data_size(skip)]
+    #[cfg_attr(feature = "datasize", data_size(skip))]
     Secp256k1(Secp256k1Signature),
 }
 
@@ -646,7 +650,7 @@ impl From<Signature> for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for Signature {
     fn schema_name() -> String {
         String::from("Signature")

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,7 @@ use crate::{
 
 /// Information relating to the given Deploy.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct DeployInfo {
     /// The relevant Deploy.

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -9,12 +9,13 @@ use core::{
     str::FromStr,
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -25,20 +26,10 @@ use crate::{
 
 /// Era ID newtype.
 #[derive(
-    DataSize,
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
+    Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct EraId(u64);
 

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -15,18 +15,18 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use once_cell::sync::Lazy;
 use rand::{
     distributions::{Distribution, Standard},
     seq::SliceRandom,
     Rng,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use crate::KEY_HASH_LENGTH;
 use crate::{
     account::AccountHash,
@@ -65,7 +65,7 @@ const TRANSFORM_ADD_UINT512_TAG: u8 = 15;
 const TRANSFORM_ADD_KEYS_TAG: u8 = 16;
 const TRANSFORM_FAILURE_TAG: u8 = 17;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 static EXECUTION_RESULT: Lazy<ExecutionResult> = Lazy::new(|| {
     let operations = vec![
         Operation {
@@ -112,7 +112,7 @@ static EXECUTION_RESULT: Lazy<ExecutionResult> = Lazy::new(|| {
 
 /// The result of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub enum ExecutionResult {
     /// The result of a failed execution.
@@ -140,7 +140,7 @@ pub enum ExecutionResult {
 impl ExecutionResult {
     // This method is not intended to be used by third party crates.
     #[doc(hidden)]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "json-schema")]
     pub fn example() -> &'static Self {
         &*EXECUTION_RESULT
     }
@@ -289,7 +289,7 @@ impl FromBytes for ExecutionResult {
 
 /// The effect of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionEffect {
     /// The resulting operations.
@@ -325,7 +325,7 @@ impl FromBytes for ExecutionEffect {
 
 /// An operation performed while executing a deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Operation {
     /// The formatted string of the `Key`.
@@ -358,7 +358,7 @@ impl FromBytes for Operation {
 
 /// The type of operation performed while executing a deploy.
 #[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub enum OpKind {
     /// A read operation.
@@ -401,7 +401,7 @@ impl FromBytes for OpKind {
 
 /// A transformation performed while executing a deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct TransformEntry {
     /// The formatted string of the `Key`.
@@ -434,7 +434,7 @@ impl FromBytes for TransformEntry {
 
 /// The actual transformation performed while executing a deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub enum Transform {
     /// A transform having no effect.

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -14,6 +14,7 @@ use blake2::{
     digest::{Update, VariableOutput},
     VarBlake2b,
 };
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use hex_fmt::HexFmt;
 use rand::{
@@ -95,7 +96,8 @@ pub enum KeyTag {
 /// The type under which data (e.g. [`CLValue`](crate::CLValue)s, smart contracts, user accounts)
 /// are indexed on the network.
 #[repr(C)]
-#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash, DataSize)]
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub enum Key {
     /// A `Key` under which a user account is stored.
     Account(AccountHash),

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,11 +1,9 @@
 //! Types used to allow creation of Wasm contracts and tests for use on the Casper Platform.
-//!
-//! # `no_std`
-//!
-//! By default, the library is `no_std`, however you can enable full `std` functionality by enabling
-//! the crate's `std` feature.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(
+    not(any(feature = "json-schema", feature = "datasize", feature = "gens", test)),
+    no_std
+)]
 #![doc(html_root_url = "https://docs.rs/casper-types/1.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
@@ -14,12 +12,8 @@
 )]
 #![warn(missing_docs)]
 
-#[cfg_attr(not(any(feature = "std", test)), macro_use)]
+#[cfg_attr(not(test), macro_use)]
 extern crate alloc;
-
-#[cfg(any(feature = "std", test))]
-#[macro_use]
-extern crate std;
 
 mod access_rights;
 pub mod account;
@@ -98,13 +92,3 @@ pub use crate::{
     era_id::EraId,
     uint::{UIntParseError, U128, U256, U512},
 };
-
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!(
-    "casper-types requires one of 'std' (enabled by default) or 'no-std' features to be enabled"
-);
-
-#[cfg(all(feature = "std", feature = "no-std"))]
-compile_error!(
-    "casper-types features 'std' (enabled by default) and 'no-std' should not both be enabled"
-);

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -7,6 +7,7 @@ use core::{
     ops::{Add, Div, Mul, Sub},
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use num::Zero;
 use serde::{Deserialize, Serialize};
@@ -17,9 +18,8 @@ use crate::{
 };
 
 /// A struct representing a number of `Motes`.
-#[derive(
-    DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
-)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct Motes(U512);
 
 impl Motes {

--- a/types/src/named_key.rs
+++ b/types/src/named_key.rs
@@ -3,7 +3,7 @@
 
 use alloc::{string::String, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ use crate::bytesrepr::{self, FromBytes, ToBytes};
 
 /// A named key.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct NamedKey {
     /// The name of the entry.

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -1,9 +1,9 @@
 use alloc::{format, string::String, vec::Vec};
 use core::{convert::TryFrom, fmt, str::FromStr};
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
-
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -13,7 +13,8 @@ use crate::{
 };
 
 /// A newtype wrapping a [`SemVer`] which represents a Casper Platform protocol version.
-#[derive(Copy, Clone, DataSize, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ProtocolVersion(SemVer);
 
 /// The result of [`ProtocolVersion::check_next_version`].
@@ -168,7 +169,7 @@ impl<'de> Deserialize<'de> for ProtocolVersion {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for ProtocolVersion {
     fn schema_name() -> String {
         String::from("ProtocolVersion")

--- a/types/src/runtime_args.rs
+++ b/types/src/runtime_args.rs
@@ -5,8 +5,9 @@
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -16,9 +17,10 @@ use crate::{
 };
 
 /// Named arguments to a contract
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Debug, DataSize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
-pub struct NamedArg(#[data_size(skip)] String, CLValue);
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct NamedArg(String, CLValue);
 
 impl NamedArg {
     /// ctor
@@ -63,11 +65,10 @@ impl FromBytes for NamedArg {
 }
 
 /// Represents a collection of arguments passed to a smart contract.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Debug, Default, DataSize,
-)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
-pub struct RuntimeArgs(#[data_size(skip)] Vec<NamedArg>);
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Debug, Default)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct RuntimeArgs(Vec<NamedArg>);
 
 impl RuntimeArgs {
     /// Create an empty [`RuntimeArgs`] instance.

--- a/types/src/stored_value/type_mismatch.rs
+++ b/types/src/stored_value/type_mismatch.rs
@@ -1,16 +1,9 @@
 use alloc::string::String;
+use core::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(Error))]
-#[cfg_attr(
-    feature = "std",
-    error("Type mismatch. Expected {expected} but found {found}.")
-)]
 /// An error struct representing a type mismatch in [`StoredValue`](crate::StoredValue) operations.
 pub struct TypeMismatch {
     /// The name of the expected type.
@@ -23,5 +16,15 @@ impl TypeMismatch {
     /// Creates a new `TypeMismatch`.
     pub fn new(expected: String, found: String) -> TypeMismatch {
         TypeMismatch { expected, found }
+    }
+}
+
+impl Display for TypeMismatch {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "Type mismatch. Expected {} but found {}.",
+            self.expected, self.found
+        )
     }
 }

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -5,7 +5,7 @@ mod vesting;
 
 use alloc::{collections::BTreeMap, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,7 +19,7 @@ pub use vesting::VestingSchedule;
 
 /// An entry in the validator map.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Bid {
     /// Validator public key

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ const WEEK_MILLIS: usize = DAYS_IN_WEEK * 24 * 60 * 60 * 1000;
 const LOCKED_AMOUNTS_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEEK) + 1;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct VestingSchedule {
     initial_release_timestamp_millis: u64,

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,7 @@ use crate::{
 
 /// Represents a party delegating their stake to a validator (or "delegatee")
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Delegator {
     delegator_public_key: PublicKey,

--- a/types/src/system/auction/era_info.rs
+++ b/types/src/system/auction/era_info.rs
@@ -3,7 +3,7 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +17,7 @@ const SEIGNIORAGE_ALLOCATION_DELEGATOR_TAG: u8 = 1;
 
 /// Information about a seigniorage allocation
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub enum SeigniorageAllocation {
     /// Info about a seigniorage allocation for a validator
@@ -159,7 +159,7 @@ impl CLTyped for SeigniorageAllocation {
 
 /// Auction metadata.  Intended to be recorded at each era.
 #[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct EraInfo {
     seigniorage_allocations: Vec<SeigniorageAllocation>,

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -2,11 +2,9 @@
 use alloc::vec::Vec;
 use core::{
     convert::{TryFrom, TryInto},
+    fmt::{self, Display, Formatter},
     result,
 };
-
-#[cfg(feature = "std")]
-use thiserror::Error;
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
@@ -15,7 +13,6 @@ use crate::{
 
 /// Errors which can occur while executing the Auction contract.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[cfg_attr(test, derive(strum::EnumIter))]
 #[repr(u8)]
 pub enum Error {
@@ -24,105 +21,90 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(0, Error::MissingKey as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Missing key"))]
     MissingKey = 0,
     /// Given named key contains invalid variant.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(1, Error::InvalidKeyVariant as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid key variant"))]
     InvalidKeyVariant = 1,
     /// Value under an uref does not exist. This means the installer contract didn't work properly.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(2, Error::MissingValue as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Missing value"))]
     MissingValue = 2,
     /// ABI serialization issue while reading or writing.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(3, Error::Serialization as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Serialization error"))]
     Serialization = 3,
     /// Triggered when contract was unable to transfer desired amount of tokens into a bid purse.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(4, Error::TransferToBidPurse as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer to bid purse error"))]
     TransferToBidPurse = 4,
     /// User passed invalid amount of tokens which might result in wrong values after calculation.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(5, Error::InvalidAmount as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid amount"))]
     InvalidAmount = 5,
     /// Unable to find a bid by account hash in `active_bids` map.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(6, Error::BidNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bid not found"))]
     BidNotFound = 6,
     /// Validator's account hash was not found in the map.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(7, Error::ValidatorNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Validator not found"))]
     ValidatorNotFound = 7,
     /// Delegator's account hash was not found in the map.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(8, Error::DelegatorNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Delegator not found"))]
     DelegatorNotFound = 8,
     /// Storage problem.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(9, Error::Storage as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Storage error"))]
     Storage = 9,
     /// Raised when system is unable to bond.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(10, Error::Bonding as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bonding error"))]
     Bonding = 10,
     /// Raised when system is unable to unbond.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(11, Error::Unbonding as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unbonding error"))]
     Unbonding = 11,
     /// Raised when Mint contract is unable to release founder stake.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(12, Error::ReleaseFounderStake as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to release founder stake"))]
     ReleaseFounderStake = 12,
     /// Raised when the system is unable to determine purse balance.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(13, Error::GetBalance as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to get purse balance"))]
     GetBalance = 13,
     /// Raised when an entry point is called from invalid account context.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(14, Error::InvalidContext as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid context"))]
     InvalidContext = 14,
     /// Raised whenever a validator's funds are still locked in but an attempt to withdraw was
     /// made.
@@ -130,14 +112,12 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(15, Error::ValidatorFundsLocked as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Validator's funds are locked"))]
     ValidatorFundsLocked = 15,
     /// Raised when caller is not the system account.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(16, Error::InvalidCaller as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Function must be called by system account"))]
     InvalidCaller = 16,
     /// Raised when function is supplied a public key that does match the caller's or does not have
     /// an associated account.
@@ -145,40 +125,30 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(17, Error::InvalidPublicKey as u8);
     /// ```
-    #[cfg_attr(
-        feature = "std",
-        error(
-            "Supplied public key does not match caller's public key or has no associated account"
-        )
-    )]
     InvalidPublicKey = 17,
     /// Validator is not not bonded.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(18, Error::BondNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Validator's bond not found"))]
     BondNotFound = 18,
     /// Unable to create purse.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(19, Error::CreatePurseFailed as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to create purse"))]
     CreatePurseFailed = 19,
     /// Attempted to unbond an amount which was too large.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(20, Error::UnbondTooLarge as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unbond is too large"))]
     UnbondTooLarge = 20,
     /// Attempted to bond with a stake which was too small.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(21, Error::BondTooSmall as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bond is too small"))]
     BondTooSmall = 21,
     /// Raised when rewards are to be distributed to delegators, but the validator has no
     /// delegations.
@@ -186,7 +156,6 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(22, Error::MissingDelegations as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Validators has not received any delegations"))]
     MissingDelegations = 22,
     /// The validators returned by the consensus component should match
     /// current era validators when distributing rewards.
@@ -194,31 +163,24 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(23, Error::MismatchedEraValidators as u8);
     /// ```
-    #[cfg_attr(
-        feature = "std",
-        error("Mismatched era validator sets to distribute rewards")
-    )]
     MismatchedEraValidators = 23,
     /// Failed to mint reward tokens.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(24, Error::MintReward as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to mint rewards"))]
     MintReward = 24,
     /// Invalid number of validator slots.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(25, Error::InvalidValidatorSlotsValue as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid number of validator slots"))]
     InvalidValidatorSlotsValue = 25,
     /// Failed to reduce total supply.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(26, Error::MintReduceTotalSupply as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to reduce total supply"))]
     MintReduceTotalSupply = 26,
     /// Triggered when contract was unable to transfer desired amount of tokens into a delegators
     /// purse.
@@ -226,77 +188,66 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(27, Error::TransferToDelegatorPurse as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer to delegators purse error"))]
     TransferToDelegatorPurse = 27,
     /// Triggered when contract was unable to perform a transfer to distribute validators reward.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(28, Error::ValidatorRewardTransfer as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Reward transfer to validator error"))]
     ValidatorRewardTransfer = 28,
     /// Triggered when contract was unable to perform a transfer to distribute delegators rewards.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(29, Error::DelegatorRewardTransfer as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Rewards transfer to delegator error"))]
     DelegatorRewardTransfer = 29,
     /// Failed to transfer desired amount while withdrawing delegators reward.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(30, Error::WithdrawDelegatorReward as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Withdraw delegator reward error"))]
     WithdrawDelegatorReward = 30,
     /// Failed to transfer desired amount while withdrawing validators reward.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(31, Error::WithdrawValidatorReward as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Withdraw validator reward error"))]
     WithdrawValidatorReward = 31,
     /// Failed to transfer desired amount into unbonding purse.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(32, Error::TransferToUnbondingPurse as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer to unbonding purse error"))]
     TransferToUnbondingPurse = 32,
     /// Failed to record era info.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(33, Error::RecordEraInfo as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Record era info error"))]
     RecordEraInfo = 33,
     /// Failed to create a [`crate::CLValue`].
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(34, Error::CLValue as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("CLValue error"))]
     CLValue = 34,
     /// Missing seigniorage recipients for given era.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(35, Error::MissingSeigniorageRecipients as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Missing seigniorage recipients for given era"))]
     MissingSeigniorageRecipients = 35,
     /// Failed to transfer funds.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(36, Error::Transfer as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer error"))]
     Transfer = 36,
     /// Delegation rate exceeds rate.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(37, Error::DelegationRateTooLarge as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Delegation rate too large"))]
     DelegationRateTooLarge = 37,
     /// Raised whenever a delegator's funds are still locked in but an attempt to undelegate was
     /// made.
@@ -304,20 +255,65 @@ pub enum Error {
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(38, Error::DelegatorFundsLocked as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Delegator's funds are locked"))]
     DelegatorFundsLocked = 38,
     /// An arithmetic overflow has occurred.
     /// ```
     /// # use casper_types::system::auction::Error;
     /// assert_eq!(39, Error::ArithmeticOverflow as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Arithmetic overflow"))]
     ArithmeticOverflow = 39,
     // NOTE: These variants below and related plumbing will be removed once support for WASM
     // system contracts will be dropped.
     #[doc(hidden)]
-    #[cfg_attr(feature = "std", error("GasLimit"))]
     GasLimit,
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::MissingKey => formatter.write_str("Missing key"),
+            Error::InvalidKeyVariant => formatter.write_str("Invalid key variant"),
+            Error::MissingValue => formatter.write_str("Missing value"),
+            Error::Serialization => formatter.write_str("Serialization error"),
+            Error::TransferToBidPurse => formatter.write_str("Transfer to bid purse error"),
+            Error::InvalidAmount => formatter.write_str("Invalid amount"),
+            Error::BidNotFound => formatter.write_str("Bid not found"),
+            Error::ValidatorNotFound => formatter.write_str("Validator not found"),
+            Error::DelegatorNotFound => formatter.write_str("Delegator not found"),
+            Error::Storage => formatter.write_str("Storage error"),
+            Error::Bonding => formatter.write_str("Bonding error"),
+            Error::Unbonding => formatter.write_str("Unbonding error"),
+            Error::ReleaseFounderStake => formatter.write_str("Unable to release founder stake"),
+            Error::GetBalance => formatter.write_str("Unable to get purse balance"),
+            Error::InvalidContext => formatter.write_str("Invalid context"),
+            Error::ValidatorFundsLocked => formatter.write_str("Validator's funds are locked"),
+            Error::InvalidCaller => formatter.write_str("Function must be called by system account"),
+            Error::InvalidPublicKey => formatter.write_str("Supplied public key does not match caller's public key or has no associated account"),
+            Error::BondNotFound => formatter.write_str("Validator's bond not found"),
+            Error::CreatePurseFailed => formatter.write_str("Unable to create purse"),
+            Error::UnbondTooLarge => formatter.write_str("Unbond is too large"),
+            Error::BondTooSmall => formatter.write_str("Bond is too small"),
+            Error::MissingDelegations => formatter.write_str("Validators has not received any delegations"),
+            Error::MismatchedEraValidators => formatter.write_str("Mismatched era validator sets to distribute rewards"),
+            Error::MintReward => formatter.write_str("Failed to mint rewards"),
+            Error::InvalidValidatorSlotsValue => formatter.write_str("Invalid number of validator slots"),
+            Error::MintReduceTotalSupply => formatter.write_str("Failed to reduce total supply"),
+            Error::TransferToDelegatorPurse => formatter.write_str("Transfer to delegators purse error"),
+            Error::ValidatorRewardTransfer => formatter.write_str("Reward transfer to validator error"),
+            Error::DelegatorRewardTransfer => formatter.write_str("Rewards transfer to delegator error"),
+            Error::WithdrawDelegatorReward => formatter.write_str("Withdraw delegator reward error"),
+            Error::WithdrawValidatorReward => formatter.write_str("Withdraw validator reward error"),
+            Error::TransferToUnbondingPurse => formatter.write_str("Transfer to unbonding purse error"),
+            Error::RecordEraInfo => formatter.write_str("Record era info error"),
+            Error::CLValue => formatter.write_str("CLValue error"),
+            Error::MissingSeigniorageRecipients => formatter.write_str("Missing seigniorage recipients for given era"),
+            Error::Transfer => formatter.write_str("Transfer error"),
+            Error::DelegationRateTooLarge => formatter.write_str("Delegation rate too large"),
+            Error::DelegatorFundsLocked => formatter.write_str("Delegator's funds are locked"),
+            Error::ArithmeticOverflow => formatter.write_str("Arithmetic overflow"),
+            Error::GasLimit => formatter.write_str("GasLimit"),
+        }
+    }
 }
 
 impl CLTyped for Error {

--- a/types/src/system/auction/unbonding_purse.rs
+++ b/types/src/system/auction/unbonding_purse.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +14,7 @@ use crate::{
 
 /// Unbonding purse.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct UnbondingPurse {
     /// Bonding Purse

--- a/types/src/system/handle_payment/error.rs
+++ b/types/src/system/handle_payment/error.rs
@@ -1,9 +1,10 @@
 //! Home of the Handle Payment contract's [`enum@Error`] type.
 use alloc::vec::Vec;
-use core::{convert::TryFrom, result};
-
-#[cfg(feature = "std")]
-use thiserror::Error;
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display, Formatter},
+    result,
+};
 
 use crate::{
     bytesrepr::{self, ToBytes, U8_SERIALIZED_LENGTH},
@@ -13,7 +14,6 @@ use crate::{
 /// Errors which can occur while executing the Handle Payment contract.
 // TODO: Split this up into user errors vs. system errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(u8)]
 pub enum Error {
     // ===== User errors =====
@@ -22,21 +22,18 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(0, Error::NotBonded as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Not bonded"))]
     NotBonded = 0,
     /// There are too many bonding or unbonding attempts already enqueued to allow more.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(1, Error::TooManyEventsInQueue as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Too many events in queue"))]
     TooManyEventsInQueue = 1,
     /// At least one validator must remain bonded.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(2, Error::CannotUnbondLastValidator as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Cannot unbond last validator"))]
     CannotUnbondLastValidator = 2,
     /// Failed to bond or unbond as this would have resulted in exceeding the maximum allowed
     /// difference between the largest and smallest stakes.
@@ -44,42 +41,36 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(3, Error::SpreadTooHigh as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Spread is too high"))]
     SpreadTooHigh = 3,
     /// The given validator already has a bond or unbond attempt enqueued.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(4, Error::MultipleRequests as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Multiple requests"))]
     MultipleRequests = 4,
     /// Attempted to bond with a stake which was too small.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(5, Error::BondTooSmall as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bond is too small"))]
     BondTooSmall = 5,
     /// Attempted to bond with a stake which was too large.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(6, Error::BondTooLarge as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bond is too large"))]
     BondTooLarge = 6,
     /// Attempted to unbond an amount which was too large.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(7, Error::UnbondTooLarge as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unbond is too large"))]
     UnbondTooLarge = 7,
     /// While bonding, the transfer from source purse to the Handle Payment internal purse failed.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(8, Error::BondTransferFailed as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bond transfer failed"))]
     BondTransferFailed = 8,
     /// While unbonding, the transfer from the Handle Payment internal purse to the destination
     /// purse failed.
@@ -87,7 +78,6 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(9, Error::UnbondTransferFailed as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unbond transfer failed"))]
     UnbondTransferFailed = 9,
     // ===== System errors =====
     /// Internal error: a [`BlockTime`](crate::BlockTime) was unexpectedly out of sequence.
@@ -95,28 +85,24 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(10, Error::TimeWentBackwards as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Time went backwards"))]
     TimeWentBackwards = 10,
     /// Internal error: stakes were unexpectedly empty.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(11, Error::StakesNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Stakes not found"))]
     StakesNotFound = 11,
     /// Internal error: the Handle Payment contract's payment purse wasn't found.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(12, Error::PaymentPurseNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Payment purse not found"))]
     PaymentPurseNotFound = 12,
     /// Internal error: the Handle Payment contract's payment purse key was the wrong type.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(13, Error::PaymentPurseKeyUnexpectedType as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Payment purse has unexpected type"))]
     PaymentPurseKeyUnexpectedType = 13,
     /// Internal error: couldn't retrieve the balance for the Handle Payment contract's payment
     /// purse.
@@ -124,42 +110,36 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(14, Error::PaymentPurseBalanceNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Payment purse balance not found"))]
     PaymentPurseBalanceNotFound = 14,
     /// Internal error: the Handle Payment contract's bonding purse wasn't found.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(15, Error::BondingPurseNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bonding purse not found"))]
     BondingPurseNotFound = 15,
     /// Internal error: the Handle Payment contract's bonding purse key was the wrong type.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(16, Error::BondingPurseKeyUnexpectedType as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Bonding purse key has unexpected type"))]
     BondingPurseKeyUnexpectedType = 16,
     /// Internal error: the Handle Payment contract's refund purse key was the wrong type.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(17, Error::RefundPurseKeyUnexpectedType as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Refund purse key has unexpected type"))]
     RefundPurseKeyUnexpectedType = 17,
     /// Internal error: the Handle Payment contract's rewards purse wasn't found.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(18, Error::RewardsPurseNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Rewards purse not found"))]
     RewardsPurseNotFound = 18,
     /// Internal error: the Handle Payment contract's rewards purse key was the wrong type.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(19, Error::RewardsPurseKeyUnexpectedType as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Rewards purse has unexpected type"))]
     RewardsPurseKeyUnexpectedType = 19,
     // TODO: Put these in their own enum, and wrap them separately in `BondingError` and
     //       `UnbondingError`.
@@ -168,14 +148,12 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(20, Error::StakesKeyDeserializationFailed as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to deserialize stake's key"))]
     StakesKeyDeserializationFailed = 20,
     /// Internal error: failed to deserialize the stake's balance.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(21, Error::StakesDeserializationFailed as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to deserialize stake's balance"))]
     StakesDeserializationFailed = 21,
     /// The invoked Handle Payment function can only be called by system contracts, but was called
     /// by a user contract.
@@ -183,14 +161,12 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(22, Error::SystemFunctionCalledByUserAccount as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("System function was called by user account"))]
     SystemFunctionCalledByUserAccount = 22,
     /// Internal error: while finalizing payment, the amount spent exceeded the amount available.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(23, Error::InsufficientPaymentForAmountSpent as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Insufficient payment for amount spent"))]
     InsufficientPaymentForAmountSpent = 23,
     /// Internal error: while finalizing payment, failed to pay the validators (the transfer from
     /// the Handle Payment contract's payment purse to rewards purse failed).
@@ -198,7 +174,6 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(24, Error::FailedTransferToRewardsPurse as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer to rewards purse has failed"))]
     FailedTransferToRewardsPurse = 24,
     /// Internal error: while finalizing payment, failed to refund the caller's purse (the transfer
     /// from the Handle Payment contract's payment purse to refund purse or account's main purse
@@ -207,7 +182,6 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(25, Error::FailedTransferToAccountPurse as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Transfer to account's purse failed"))]
     FailedTransferToAccountPurse = 25,
     /// Handle Payment contract's "set_refund_purse" method can only be called by the payment code
     /// of a deploy, but was called by the session code.
@@ -215,51 +189,110 @@ pub enum Error {
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(26, Error::SetRefundPurseCalledOutsidePayment as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Set refund purse was called outside payment"))]
     SetRefundPurseCalledOutsidePayment = 26,
     /// Raised when the system is unable to determine purse balance.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(27, Error::GetBalance as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to get purse balance"))]
     GetBalance = 27,
     /// Raised when the system is unable to put named key.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(28, Error::PutKey as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to put named key"))]
     PutKey = 28,
     /// Raised when the system is unable to remove given named key.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(29, Error::RemoveKey as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Unable to remove named key"))]
     RemoveKey = 29,
     /// Failed to transfer funds.
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(30, Error::Transfer as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to transfer funds"))]
     Transfer = 30,
     /// An arithmetic overflow occurred
     /// ```
     /// # use casper_types::system::handle_payment::Error;
     /// assert_eq!(31, Error::ArithmeticOverflow as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Arithmetic overflow"))]
     ArithmeticOverflow = 31,
     // NOTE: These variants below will be removed once support for WASM system contracts will be
     // dropped.
     #[doc(hidden)]
-    #[cfg_attr(feature = "std", error("GasLimit"))]
     GasLimit = 32,
     /// Refund purse is a payment purse.
-    #[cfg_attr(feature = "std", error("Refund purse is a payment purse."))]
     RefundPurseIsPaymentPurse = 33,
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::NotBonded => formatter.write_str("Not bonded"),
+            Error::TooManyEventsInQueue => formatter.write_str("Too many events in queue"),
+            Error::CannotUnbondLastValidator => formatter.write_str("Cannot unbond last validator"),
+            Error::SpreadTooHigh => formatter.write_str("Spread is too high"),
+            Error::MultipleRequests => formatter.write_str("Multiple requests"),
+            Error::BondTooSmall => formatter.write_str("Bond is too small"),
+            Error::BondTooLarge => formatter.write_str("Bond is too large"),
+            Error::UnbondTooLarge => formatter.write_str("Unbond is too large"),
+            Error::BondTransferFailed => formatter.write_str("Bond transfer failed"),
+            Error::UnbondTransferFailed => formatter.write_str("Unbond transfer failed"),
+            Error::TimeWentBackwards => formatter.write_str("Time went backwards"),
+            Error::StakesNotFound => formatter.write_str("Stakes not found"),
+            Error::PaymentPurseNotFound => formatter.write_str("Payment purse not found"),
+            Error::PaymentPurseKeyUnexpectedType => {
+                formatter.write_str("Payment purse has unexpected type")
+            }
+            Error::PaymentPurseBalanceNotFound => {
+                formatter.write_str("Payment purse balance not found")
+            }
+            Error::BondingPurseNotFound => formatter.write_str("Bonding purse not found"),
+            Error::BondingPurseKeyUnexpectedType => {
+                formatter.write_str("Bonding purse key has unexpected type")
+            }
+            Error::RefundPurseKeyUnexpectedType => {
+                formatter.write_str("Refund purse key has unexpected type")
+            }
+            Error::RewardsPurseNotFound => formatter.write_str("Rewards purse not found"),
+            Error::RewardsPurseKeyUnexpectedType => {
+                formatter.write_str("Rewards purse has unexpected type")
+            }
+            Error::StakesKeyDeserializationFailed => {
+                formatter.write_str("Failed to deserialize stake's key")
+            }
+            Error::StakesDeserializationFailed => {
+                formatter.write_str("Failed to deserialize stake's balance")
+            }
+            Error::SystemFunctionCalledByUserAccount => {
+                formatter.write_str("System function was called by user account")
+            }
+            Error::InsufficientPaymentForAmountSpent => {
+                formatter.write_str("Insufficient payment for amount spent")
+            }
+            Error::FailedTransferToRewardsPurse => {
+                formatter.write_str("Transfer to rewards purse has failed")
+            }
+            Error::FailedTransferToAccountPurse => {
+                formatter.write_str("Transfer to account's purse failed")
+            }
+            Error::SetRefundPurseCalledOutsidePayment => {
+                formatter.write_str("Set refund purse was called outside payment")
+            }
+            Error::GetBalance => formatter.write_str("Unable to get purse balance"),
+            Error::PutKey => formatter.write_str("Unable to put named key"),
+            Error::RemoveKey => formatter.write_str("Unable to remove named key"),
+            Error::Transfer => formatter.write_str("Failed to transfer funds"),
+            Error::ArithmeticOverflow => formatter.write_str("Arithmetic overflow"),
+            Error::GasLimit => formatter.write_str("GasLimit"),
+            Error::RefundPurseIsPaymentPurse => {
+                formatter.write_str("Refund purse is a payment purse.")
+            }
+        }
+    }
 }
 
 impl TryFrom<u8> for Error {

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -1,10 +1,10 @@
 //! Home of the Mint contract's [`enum@Error`] type.
 
 use alloc::vec::Vec;
-use core::convert::{TryFrom, TryInto};
-
-#[cfg(feature = "std")]
-use thiserror::Error;
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt::{self, Display, Formatter},
+};
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
@@ -13,7 +13,6 @@ use crate::{
 
 /// Errors which can occur while executing the Mint contract.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Error))]
 #[repr(u8)]
 pub enum Error {
     /// Insufficient funds to complete the transfer.
@@ -21,21 +20,18 @@ pub enum Error {
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(0, Error::InsufficientFunds as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Insufficient funds"))]
     InsufficientFunds = 0,
     /// Source purse not found.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(1, Error::SourceNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Source not found"))]
     SourceNotFound = 1,
     /// Destination purse not found.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(2, Error::DestNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Destination not found"))]
     DestNotFound = 2,
     /// The given [`URef`](crate::URef) does not reference the account holder's purse, or such a
     /// `URef` does not have the required [`AccessRights`](crate::AccessRights).
@@ -43,7 +39,6 @@ pub enum Error {
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(3, Error::InvalidURef as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid URef"))]
     InvalidURef = 3,
     /// The source purse is not writeable (see [`URef::is_writeable`](crate::URef::is_writeable)),
     /// or the destination purse is not addable (see
@@ -52,120 +47,102 @@ pub enum Error {
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(4, Error::InvalidAccessRights as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid AccessRights"))]
     InvalidAccessRights = 4,
     /// Tried to create a new purse with a non-zero initial balance.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(5, Error::InvalidNonEmptyPurseCreation as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid non-empty purse creation"))]
     InvalidNonEmptyPurseCreation = 5,
     /// Failed to read from local or global storage.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(6, Error::Storage as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Storage error"))]
     Storage = 6,
     /// Purse not found while trying to get balance.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(7, Error::PurseNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Purse not found"))]
     PurseNotFound = 7,
     /// Unable to obtain a key by its name.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(8, Error::MissingKey as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Missing key"))]
     MissingKey = 8,
     /// Total supply not found.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(9, Error::TotalSupplyNotFound as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Total supply not found"))]
     TotalSupplyNotFound = 9,
     /// Failed to record transfer.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(10, Error::RecordTransferFailure as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to record transfer"))]
     RecordTransferFailure = 10,
     /// Invalid attempt to reduce total supply.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(11, Error::InvalidTotalSupplyReductionAttempt as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid attempt to reduce total supply"))]
     InvalidTotalSupplyReductionAttempt = 11,
     /// Failed to create new uref.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(12, Error::NewURef as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to create new uref"))]
     NewURef = 12,
     /// Failed to put key.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(13, Error::PutKey as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to put key"))]
     PutKey = 13,
     /// Failed to write to dictionary.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(14, Error::WriteDictionary as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to write dictionary"))]
     WriteDictionary = 14,
     /// Failed to create a [`crate::CLValue`].
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(15, Error::CLValue as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to create a CLValue"))]
     CLValue = 15,
     /// Failed to serialize data.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(16, Error::Serialize as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Failed to serialize data"))]
     Serialize = 16,
     /// Source and target purse [`crate::URef`]s are equal.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(17, Error::EqualSourceAndTarget as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Invalid target purse"))]
     EqualSourceAndTarget = 17,
     /// An arithmetic overflow has occurred.
     /// ```
     /// # use casper_types::system::mint::Error;
     /// assert_eq!(18, Error::ArithmeticOverflow as u8);
     /// ```
-    #[cfg_attr(feature = "std", error("Arithmetic overflow has occurred"))]
     ArithmeticOverflow = 18,
 
     // NOTE: These variants below will be removed once support for WASM system contracts will be
     // dropped.
     #[doc(hidden)]
-    #[cfg_attr(feature = "std", error("GasLimit"))]
     GasLimit = 19,
 
     /// Raised when an entry point is called from invalid account context.
-    #[cfg_attr(feature = "std", error("Invalid context"))]
     InvalidContext = 20,
 
     #[cfg(test)]
     #[doc(hidden)]
-    #[cfg_attr(feature = "std", error("Sentinel error"))]
     Sentinel,
 }
 
@@ -240,6 +217,40 @@ impl FromBytes for Error {
             // Error::Formatting as if its unable to be correctly deserialized.
             .map_err(|_| bytesrepr::Error::Formatting)?;
         Ok((error, rem))
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::InsufficientFunds => formatter.write_str("Insufficient funds"),
+            Error::SourceNotFound => formatter.write_str("Source not found"),
+            Error::DestNotFound => formatter.write_str("Destination not found"),
+            Error::InvalidURef => formatter.write_str("Invalid URef"),
+            Error::InvalidAccessRights => formatter.write_str("Invalid AccessRights"),
+            Error::InvalidNonEmptyPurseCreation => {
+                formatter.write_str("Invalid non-empty purse creation")
+            }
+            Error::Storage => formatter.write_str("Storage error"),
+            Error::PurseNotFound => formatter.write_str("Purse not found"),
+            Error::MissingKey => formatter.write_str("Missing key"),
+            Error::TotalSupplyNotFound => formatter.write_str("Total supply not found"),
+            Error::RecordTransferFailure => formatter.write_str("Failed to record transfer"),
+            Error::InvalidTotalSupplyReductionAttempt => {
+                formatter.write_str("Invalid attempt to reduce total supply")
+            }
+            Error::NewURef => formatter.write_str("Failed to create new uref"),
+            Error::PutKey => formatter.write_str("Failed to put key"),
+            Error::WriteDictionary => formatter.write_str("Failed to write dictionary"),
+            Error::CLValue => formatter.write_str("Failed to create a CLValue"),
+            Error::Serialize => formatter.write_str("Failed to serialize data"),
+            Error::EqualSourceAndTarget => formatter.write_str("Invalid target purse"),
+            Error::ArithmeticOverflow => formatter.write_str("Arithmetic overflow has occurred"),
+            Error::GasLimit => formatter.write_str("GasLimit"),
+            Error::InvalidContext => formatter.write_str("Invalid context"),
+            #[cfg(test)]
+            Error::Sentinel => formatter.write_str("Sentinel error"),
+        }
     }
 }
 

--- a/types/src/system/mod.rs
+++ b/types/src/system/mod.rs
@@ -22,23 +22,18 @@ pub use system_contract_type::{
 };
 
 mod error {
-    #[cfg(feature = "std")]
-    use thiserror::Error;
+    use core::fmt::{self, Display, Formatter};
 
     use crate::system::{auction, handle_payment, mint};
 
     /// An aggregate enum error with variants for each system contract's error.
     #[derive(Debug, Copy, Clone)]
-    #[cfg_attr(feature = "std", derive(Error))]
     pub enum Error {
         /// Contains a [`mint::Error`].
-        #[cfg_attr(feature = "std", error("Mint error: {}", _0))]
         Mint(mint::Error),
         /// Contains a [`handle_payment::Error`].
-        #[cfg_attr(feature = "std", error("HandlePayment error: {}", _0))]
         HandlePayment(handle_payment::Error),
         /// Contains a [`auction::Error`].
-        #[cfg_attr(feature = "std", error("Auction error: {}", _0))]
         Auction(auction::Error),
     }
 
@@ -57,6 +52,16 @@ mod error {
     impl From<auction::Error> for Error {
         fn from(error: auction::Error) -> Error {
             Error::Auction(error)
+        }
+    }
+
+    impl Display for Error {
+        fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+            match self {
+                Error::Mint(error) => write!(formatter, "Mint error: {}", error),
+                Error::HandlePayment(error) => write!(formatter, "HandlePayment error: {}", error),
+                Error::Auction(error) => write!(formatter, "Auction error: {}", error),
+            }
         }
     }
 }

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -8,12 +8,13 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -31,7 +32,8 @@ pub(super) const TRANSFER_ADDR_FORMATTED_STRING_PREFIX: &str = "transfer-";
 
 /// A newtype wrapping a <code>[u8; [DEPLOY_HASH_LENGTH]]</code> which is the raw bytes of the
 /// deploy hash.
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct DeployHash([u8; DEPLOY_HASH_LENGTH]);
 
 impl DeployHash {
@@ -51,7 +53,7 @@ impl DeployHash {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for DeployHash {
     fn schema_name() -> String {
         String::from("DeployHash")
@@ -113,7 +115,7 @@ impl Distribution<DeployHash> for Standard {
 
 /// Represents a transfer from one purse to another
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Transfer {
     /// Deploy that created the transfer
@@ -249,7 +251,8 @@ impl Display for FromStrError {
 
 /// A newtype wrapping a <code>[u8; [TRANSFER_ADDR_LENGTH]]</code> which is the raw bytes of the
 /// transfer address.
-#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct TransferAddr([u8; TRANSFER_ADDR_LENGTH]);
 
 impl TransferAddr {
@@ -287,7 +290,7 @@ impl TransferAddr {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for TransferAddr {
     fn schema_name() -> String {
         String::from("TransferAddr")

--- a/types/src/uint.rs
+++ b/types/src/uint.rs
@@ -34,18 +34,20 @@ use crate::bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
     clippy::reversed_empty_ranges
 )]
 mod macro_code {
+    #[cfg(feature = "datasize")]
+    use datasize::DataSize;
     use uint::construct_uint;
 
     construct_uint! {
-        #[derive(datasize::DataSize)]
+        #[cfg_attr(feature = "datasize", derive(DataSize))]
         pub struct U512(8);
     }
     construct_uint! {
-        #[derive(datasize::DataSize)]
+        #[cfg_attr(feature = "datasize", derive(DataSize))]
         pub struct U256(4);
     }
     construct_uint! {
-        #[derive(datasize::DataSize)]
+        #[cfg_attr(feature = "datasize", derive(DataSize))]
         pub struct U128(2);
     }
 }
@@ -440,7 +442,7 @@ macro_rules! impl_traits_for_uint {
             }
         }
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "json-schema")]
         impl schemars::JsonSchema for $type {
             fn schema_name() -> String {
                 format!("U{}", $total_bytes * 8)

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -9,13 +9,14 @@ use core::{
     num::ParseIntError,
 };
 
+#[cfg(feature = "datasize")]
 use datasize::DataSize;
 use hex_fmt::HexFmt;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -92,7 +93,8 @@ impl Display for FromStrError {
 /// the [`AccessRights`] of the reference.
 ///
 /// A `URef` can be used to index entities such as [`CLValue`](crate::CLValue)s, or smart contracts.
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default, DataSize)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct URef(URefAddr, AccessRights);
 
 impl URef {
@@ -198,7 +200,7 @@ impl URef {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "json-schema")]
 impl JsonSchema for URef {
     fn schema_name() -> String {
         String::from("URef")
@@ -207,7 +209,7 @@ impl JsonSchema for URef {
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
         let schema = gen.subschema_for::<String>();
         let mut schema_object = schema.into_object();
-        schema_object.metadata().description = Some("Hex-encoded, formatted URef.".to_string());
+        schema_object.metadata().description = Some(String::from("Hex-encoded, formatted URef."));
         schema_object.into()
     }
 }

--- a/types/tests/version_numbers.rs
+++ b/types/tests/version_numbers.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "version-sync")]
 #[test]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -10,6 +10,6 @@ base64 = "0.13"
 casper-engine-test-support = { path = "../../execution_engine_testing/test_support" }
 casper-execution-engine = { path = "../../execution_engine" }
 casper-hashing = { path = "../../hashing" }
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
+casper-types = { path = "../../types" }
 clap = "2.33"
 lmdb = "0.8"

--- a/utils/retrieve-state/Cargo.toml
+++ b/utils/retrieve-state/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-casper-contract = { path = "../../smart_contracts/contract", default-features = false, features = ["std"] }
+casper-contract = { path = "../../smart_contracts/contract", default-features = false }
 casper-execution-engine = { path = "../../execution_engine" }
 casper-hashing = { path = "../../hashing" }
 casper-node = { path = "../../node" }
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
+casper-types = { path = "../../types" }
 hex = "0.4.3"
 jsonrpc-lite = "0.5.0"
 lmdb = "0.8.0"

--- a/utils/validation/Cargo.toml
+++ b/utils/validation/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 base16 = "0.2.1"
 casper-execution-engine = { path = "../../execution_engine" }
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
+casper-types = { path = "../../types" }
 clap = "3.0.0-beta.2"
 derive_more = "0.99.13"
 hex = { version = "0.4.2", features = ["serde"] }

--- a/utils/validation/src/error.rs
+++ b/utils/validation/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     UnsupportedFormat(PathBuf),
     #[error("file {0} lacks extension")]
     NoExtension(PathBuf),
-    #[error(transparent)]
-    Bytesrepr(#[from] bytesrepr::Error),
+    #[error("{0}")]
+    Bytesrepr(bytesrepr::Error),
+}
+
+impl From<bytesrepr::Error> for Error {
+    fn from(error: bytesrepr::Error) -> Self {
+        Error::Bytesrepr(error)
+    }
 }

--- a/utils/validation/src/test_case.rs
+++ b/utils/validation/src/test_case.rs
@@ -3,12 +3,18 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error(transparent)]
-    Bytesrepr(#[from] bytesrepr::Error),
+    #[error("{0}")]
+    Bytesrepr(bytesrepr::Error),
     #[error("data mismatch expected {} != actual {}", base16::encode_lower(&.expected), base16::encode_lower(&.actual))]
     DataMismatch { expected: Vec<u8>, actual: Vec<u8> },
     #[error("length mismatch expected {expected} != actual {actual}")]
     LengthMismatch { expected: usize, actual: usize },
+}
+
+impl From<bytesrepr::Error> for Error {
+    fn from(error: bytesrepr::Error) -> Self {
+        Error::Bytesrepr(error)
+    }
 }
 
 pub trait TestCase {


### PR DESCRIPTION
This PR changes the `casper-types` and `casper-contract` to be `no_std` by default.

The types crate has individual features to enable support for `datasize`, `schemars` and `proptest`.  If any of these are enabled, the std library is included, but it's anticipated that smart contract authors will never need to enable these features.

Using the code in this PR locally I checked that the full set of tests run via `make check-rs` is unchanged.

The PR also adds `codegen-units = 1` and `lto = true` to the release profile in order to reduce the size of the Wasm contracts.  Due to our choice to use a single workspace, these settings are applied to all targets, even though they're only really useful for some of the targets.  However, it didn't significantly affect the overall time to execute `make check-rs` and it did reduce the size of the compiled Wasm from 5.3MB to 3.2MB.

Closes #2088.