### PR TITLE
Set enable_manual_sync to false by default

### DIFF
--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
 
     /// Enable synchronizing to disk only after each block is written.
     ///
-    /// Defaults to `true`.
+    /// Defaults to `false`.
     enable_manual_sync: Option<bool>,
 }
 
@@ -61,7 +61,7 @@ impl Config {
     }
 
     pub(crate) fn manual_sync_enabled(&self) -> bool {
-        self.enable_manual_sync.unwrap_or(true)
+        self.enable_manual_sync.unwrap_or(false)
     }
 }
 
@@ -72,7 +72,7 @@ impl Default for Config {
             max_associated_keys: Some(DEFAULT_MAX_ASSOCIATED_KEYS),
             max_readers: Some(DEFAULT_MAX_READERS),
             max_query_depth: Some(DEFAULT_MAX_QUERY_DEPTH),
-            enable_manual_sync: Some(true),
+            enable_manual_sync: Some(false),
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -325,8 +325,8 @@ verify_accounts = true
 
 # Enable manual synchronizing to disk.
 #
-# If unset, defaults to true.
-#enable_manual_sync = true
+# If unset, defaults to false.
+#enable_manual_sync = false
 
 
 # ========================================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -325,8 +325,8 @@ verify_accounts = true
 
 # Enable manual synchronizing to disk.
 #
-# If unset, defaults to true.
-#enable_manual_sync = true
+# If unset, defaults to false.
+#enable_manual_sync = false
 
 
 # ========================================================

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -325,8 +325,8 @@ verify_accounts = true
 
 # Enable manual synchronizing to disk.
 #
-# If unset, defaults to true.
-#enable_manual_sync = true
+# If unset, defaults to false.
+#enable_manual_sync = false
 
 
 # ========================================================

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -329,8 +329,8 @@ verify_accounts = true
 
 # Enable manual synchronizing to disk.
 #
-# If unset, defaults to true.
-#enable_manual_sync = true
+# If unset, defaults to false.
+#enable_manual_sync = false
 
 
 # ========================================================

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -325,8 +325,8 @@ verify_accounts = true
 
 # Enable manual synchronizing to disk.
 #
-# If unset, defaults to true.
-#enable_manual_sync = true
+# If unset, defaults to false.
+#enable_manual_sync = false
 
 
 # ========================================================


### PR DESCRIPTION
As discussed in sprint planning, this PR sets enable_manual_sync to false by default.
