### PR TITLE
Linear Chain Sync: upgrade or downgrade on version mismatch

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -791,11 +791,25 @@ where
                             .cmp(&block_to_execute.protocol_version())
                         {
                             Ordering::Less => {
+                                warn!(
+                                    block_hash = %block_to_execute.hash(),
+                                    our_version = %self.protocol_version,
+                                    block_version = %block_to_execute.protocol_version(),
+                                    "attempting to execute a block with a newer protocol version;\
+                                    shutting down to upgrade"
+                                );
                                 return effect_builder
                                     .immediately()
                                     .event(|_| Event::Shutdown(StopReason::ForUpgrade));
                             }
                             Ordering::Greater => {
+                                warn!(
+                                    block_hash = %block_to_execute.hash(),
+                                    our_version = %self.protocol_version,
+                                    block_version = %block_to_execute.protocol_version(),
+                                    "attempting to execute a block with an older protocol version;\
+                                    shutting down to downgrade"
+                                );
                                 return effect_builder
                                     .immediately()
                                     .event(|_| Event::Shutdown(StopReason::ForDowngrade));

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -78,7 +78,7 @@ pub(crate) struct LinearChainSync<I> {
     /// When we download the switch block of an era immediately before the activation point,
     /// we need to shut down for an upgrade.
     next_upgrade_activation_point: Option<ActivationPoint>,
-    stop_reason: StopReason,
+    stop_reason: Option<StopReason>,
     /// Key for storing the linear chain sync state.
     state_key: Vec<u8>,
     /// Shortest era that is allowed with the given protocol configuration.
@@ -167,7 +167,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 state,
                 metrics: LinearChainSyncMetrics::new(registry)?,
                 next_upgrade_activation_point,
-                stop_reason: StopReason::None,
+                stop_reason: None,
                 state_key,
                 shortest_era,
                 min_round_length: chainspec.highway_config.min_round_length(),
@@ -206,7 +206,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             state,
             metrics: LinearChainSyncMetrics::new(registry)?,
             next_upgrade_activation_point,
-            stop_reason: StopReason::None,
+            stop_reason: None,
             state_key,
             shortest_era,
             min_round_length: chainspec.highway_config.min_round_length(),
@@ -233,12 +233,12 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
     /// Returns `true` if we should stop for upgrade.
     pub(crate) fn stopped_for_upgrade(&self) -> bool {
-        self.stop_reason == StopReason::ForUpgrade
+        self.stop_reason == Some(StopReason::ForUpgrade)
     }
 
     /// Returns `true` if we should stop for downgrade.
     pub(crate) fn stopped_for_downgrade(&self) -> bool {
-        self.stop_reason == StopReason::ForDowngrade
+        self.stop_reason == Some(StopReason::ForDowngrade)
     }
 
     fn block_downloaded<REv>(
@@ -878,7 +878,7 @@ where
             }
             Event::Shutdown(reason) => {
                 info!(?reason, "ready for shutdown");
-                self.stop_reason = reason;
+                self.stop_reason = Some(reason);
                 Effects::new()
             }
             Event::InitializeTimeout => {

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -6,7 +6,6 @@ use datasize::DataSize;
 
 #[derive(DataSize, Debug, PartialEq)]
 pub enum StopReason {
-    None,
     ForUpgrade,
     ForDowngrade,
 }

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -2,6 +2,15 @@ use crate::types::{ActivationPoint, Block, BlockHash};
 
 use std::fmt::{Debug, Display};
 
+use datasize::DataSize;
+
+#[derive(DataSize, Debug, PartialEq)]
+pub enum StopReason {
+    None,
+    ForUpgrade,
+    ForDowngrade,
+}
+
 #[derive(Debug)]
 pub enum Event<I> {
     Start(I),
@@ -15,7 +24,7 @@ pub enum Event<I> {
     InitUpgradeShutdown,
     /// An event instructing us to shutdown if we haven't downloaded any blocks.
     InitializeTimeout,
-    Shutdown(bool),
+    Shutdown(StopReason),
 }
 
 #[derive(Debug)]
@@ -69,10 +78,10 @@ where
                 write!(f, "new upgrade activation point: {:?}", activation_point)
             }
             Event::InitUpgradeShutdown => write!(f, "shutdown for upgrade initiated"),
-            Event::Shutdown(upgrade) => write!(
+            Event::Shutdown(reason) => write!(
                 f,
-                "linear chain sync is ready for shutdown. upgrade: {}",
-                upgrade
+                "linear chain sync is ready for shutdown. reason: {:?}",
+                reason
             ),
             Event::InitializeTimeout => write!(f, "Initialize timeout"),
         }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -916,6 +916,8 @@ impl reactor::Reactor for Reactor {
     fn maybe_exit(&self) -> Option<ReactorExit> {
         if self.linear_chain_sync.stopped_for_upgrade() {
             Some(ReactorExit::ProcessShouldExit(ExitCode::Success))
+        } else if self.linear_chain_sync.stopped_for_downgrade() {
+            Some(ReactorExit::ProcessShouldExit(ExitCode::DowngradeVersion))
         } else if self.linear_chain_sync.is_synced() {
             Some(ReactorExit::ProcessShouldContinue)
         } else {


### PR DESCRIPTION
When the Linear Chain Sync component attempts to execute a block and the block's protocol version differs from its own, it will upgrade/downgrade to match the versions.

This should prevent issues when a node that missed an upgrade initially is being upgraded with a delay, with a trusted hash from after the upgrade. (The node would then execute a block with a non-matching protocol version and exit with a fatal error because the executed block wouldn't match the downloaded one.)
