### PR TITLE
Fix behavior of retrieve state tool

### DIFF
--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -5,7 +5,7 @@ use jsonrpc_lite::JsonRpc;
 use thiserror::Error;
 
 use casper_node::{
-    crypto, crypto::Error as CryptoError, rpcs::chain::ParseBlockIdentifierError,
+    crypto::Error as CryptoError, rpcs::chain::ParseBlockIdentifierError,
     types::ExcessiveSizeDeployError,
 };
 use casper_types::{
@@ -136,6 +136,16 @@ pub enum Error {
         error: CryptoError,
     },
 
+    /// Hashing error.
+    #[error("Hashing error: {context}: {error}")]
+    HashingError {
+        /// Contextual description of where this error occurred including relevant paths,
+        /// filenames, etc.
+        context: &'static str,
+        /// Underlying hashing error.
+        error: casper_hashing::Error,
+    },
+
     /// Invalid `CLValue`.
     #[error("Invalid CLValue error: {0}")]
     InvalidCLValue(String),
@@ -209,9 +219,9 @@ impl From<ParseBlockIdentifierError> for Error {
                 context: "block_identifier",
                 error,
             },
-            ParseBlockIdentifierError::FromHexError(error) => Error::CryptoError {
+            ParseBlockIdentifierError::HashingError(error) => Error::HashingError {
                 context: "block_identifier",
-                error: crypto::Error::FromHex(error),
+                error,
             },
         }
     }

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -55,6 +55,7 @@ pub enum casper_error_t {
     CASPER_DEPLOY_SIZE_TOO_LARGE = -24,
     CASPER_FAILED_TO_CREATE_DICTIONARY_IDENTIFIER = -25,
     CASPER_FAILED_TO_PARSE_STATE_IDENTIFIER = -26,
+    CASPER_HASHING_ERROR = -27,
 }
 
 trait AsFFIError {
@@ -83,6 +84,7 @@ impl AsFFIError for Error {
             Error::IoError { .. } => casper_error_t::CASPER_IO_ERROR,
             Error::ToBytesError(_) => casper_error_t::CASPER_TO_BYTES_ERROR,
             Error::CryptoError { .. } => casper_error_t::CASPER_CRYPTO_ERROR,
+            Error::HashingError { .. } => casper_error_t::CASPER_HASHING_ERROR,
             Error::InvalidCLValue(_) => casper_error_t::CASPER_INVALID_CL_VALUE,
             Error::InvalidArgument { .. } => casper_error_t::CASPER_INVALID_ARGUMENT,
             Error::InvalidResponse(_) => casper_error_t::CASPER_INVALID_RESPONSE,

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -8,7 +8,6 @@ mod era_summary;
 use std::{num::ParseIntError, str};
 
 use futures::{future::BoxFuture, FutureExt};
-use hex::FromHex;
 use http::Response;
 use hyper::Body;
 use once_cell::sync::Lazy;
@@ -87,7 +86,7 @@ impl str::FromStr for BlockIdentifier {
 
         if maybe_block_identifier.len() == (Digest::LENGTH * 2) {
             let hash = Digest::from_hex(maybe_block_identifier)
-                .map_err(ParseBlockIdentifierError::FromHexError)?;
+                .map_err(ParseBlockIdentifierError::HashingError)?;
             Ok(BlockIdentifier::Hash(BlockHash::new(hash)))
         } else {
             let height = maybe_block_identifier
@@ -107,9 +106,9 @@ pub enum ParseBlockIdentifierError {
     /// Couldn't parse a height value.
     #[error("Unable to parse height from string. {0}")]
     ParseIntError(ParseIntError),
-    /// Couldn't parse a blake2bhash.
+    /// Couldn't parse a digest from the given string.
     #[error("Unable to parse digest from string. {0}")]
-    FromHexError(hex::FromHexError),
+    HashingError(casper_hashing::Error),
 }
 
 /// Params for "chain_get_block" RPC request.

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -5,9 +5,10 @@
 
 mod era_summary;
 
-use std::str;
+use std::{num::ParseIntError, str};
 
 use futures::{future::BoxFuture, FutureExt};
+use hex::FromHex;
 use http::Response;
 use hyper::Body;
 use once_cell::sync::Lazy;
@@ -74,6 +75,41 @@ pub enum BlockIdentifier {
     Hash(BlockHash),
     /// Identify and retrieve the block with its height.
     Height(u64),
+}
+
+impl str::FromStr for BlockIdentifier {
+    type Err = ParseBlockIdentifierError;
+
+    fn from_str(maybe_block_identifier: &str) -> Result<Self, Self::Err> {
+        if maybe_block_identifier.is_empty() {
+            return Err(ParseBlockIdentifierError::EmptyString);
+        }
+
+        if maybe_block_identifier.len() == (Digest::LENGTH * 2) {
+            let hash = Digest::from_hex(maybe_block_identifier)
+                .map_err(ParseBlockIdentifierError::FromHexError)?;
+            Ok(BlockIdentifier::Hash(BlockHash::new(hash)))
+        } else {
+            let height = maybe_block_identifier
+                .parse()
+                .map_err(ParseBlockIdentifierError::ParseIntError)?;
+            Ok(BlockIdentifier::Height(height))
+        }
+    }
+}
+
+/// Represents errors that can arise when parsing a [`BlockIdentifier`].
+#[derive(thiserror::Error, Debug)]
+pub enum ParseBlockIdentifierError {
+    /// String was empty.
+    #[error("Empty string is not a valid block identifier.")]
+    EmptyString,
+    /// Couldn't parse a height value.
+    #[error("Unable to parse height from string. {0}")]
+    ParseIntError(ParseIntError),
+    /// Couldn't parse a blake2bhash.
+    #[error("Unable to parse digest from string. {0}")]
+    FromHexError(hex::FromHexError),
 }
 
 /// Params for "chain_get_block" RPC request.

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -176,7 +176,7 @@ pub async fn download_block_with_deploys(
     })
 }
 
-/// Download block files from the highest (provided) block hash to genesis.
+/// Download block files from the block hash or height to genesis.
 pub async fn download_blocks(
     client: &mut Client,
     url: &str,

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -347,7 +347,7 @@ pub mod offline {
         chain_download_path: impl AsRef<Path>,
         comparator: impl Fn(u64, u64) -> u64,
     ) -> Result<Option<u64>, anyhow::Error> {
-        let lowest = if chain_download_path.as_ref().exists() {
+        let maybe_height = if chain_download_path.as_ref().exists() {
             let existing_chain = walkdir::WalkDir::new(chain_download_path);
             let mut height_comparison = None;
             for entry in existing_chain {
@@ -364,7 +364,7 @@ pub mod offline {
         } else {
             None
         };
-        Ok(lowest)
+        Ok(maybe_height)
     }
 
     /// Walks the chain-download directory and finds blocks that have already been downloaded.


### PR DESCRIPTION
Resolves #2097

New behavior is: 

Parse a BlockIdentifier from the command line argument for height.
Check on disk for each block file, download only when appropriate.
