### PR TITLE
Update cargo-casper readme

### DIFF
--- a/execution_engine_testing/cargo_casper/README.md
+++ b/execution_engine_testing/cargo_casper/README.md
@@ -4,14 +4,9 @@
 
 [![Build Status](https://drone-auto-casper-network.casperlabs.io/api/badges/casper-network/casper-node/status.svg?branch=dev)](http://drone-auto-casper-network.casperlabs.io/casper-network/casper-node)
 [![Crates.io](https://img.shields.io/crates/v/cargo-casper)](https://crates.io/crates/cargo-casper)
-[![Documentation](https://docs.rs/cargo-casper/badge.svg)](https://docs.rs/cargo-casper)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/casper-network/casper-node/blob/dev/LICENSE)
 
 A command line tool for creating a Wasm smart contract and tests for use on the Casper network.
-
-## License
-
-Licensed under the [Apache License Version 2.0](https://github.com/casper-network/casper-node/blob/master/LICENSE).
 
 ---
 
@@ -33,7 +28,7 @@ cargo install cargo-casper --path=.
 
 ## Usage
 
-To create a folder "my_project" containing an example contract and a separate test crate for the contract:
+To create a folder "my_project" containing a basic example contract and a separate test crate for the contract:
 
 ```
 cargo casper my_project
@@ -45,17 +40,16 @@ This creates the following files:
 my_project/
 ├── contract
 │   ├── .cargo
-│   │   └── config
+│   │   └── config.toml
 │   ├── Cargo.toml
-│   ├── rust-toolchain
 │   └── src
 │       └── main.rs
+├── Makefile
+├── rust-toolchain
 ├── tests
-│   ├── build.rs
 │   ├── Cargo.toml
-│   ├── rust-toolchain
-│   ├── src
-│   │   └── integration_tests.rs
+│   └── src
+│       └── integration_tests.rs
 └── .travis.yml
 ```
 
@@ -64,15 +58,14 @@ my_project/
 To build the contract, the correct version of Rust must be installed along with the Wasm target:
 
 ```
-cd my_project/contract
-rustup install $(cat rust-toolchain)
-rustup target add --toolchain=$(cat rust-toolchain) wasm32-unknown-unknown
+cd my_project
+make prepare
 ```
 
 The contract can now be built using:
 
 ```
-cargo build --release
+make build-contract
 ```
 
 and will be built to `my_project/contract/target/wasm32-unknown-unknown/release/contract.wasm`.
@@ -83,8 +76,18 @@ Running the test will automatically build the contract in release mode, copy it 
 and run the test:
 
 ```
-cd my_project/tests
-cargo test
+make test
+```
+
+## ERC20 example
+
+The tool can similarly be used to create an example ERC20 contract and tests by adding the `--erc20` flag:
+
+```
+cargo casper --erc20 my_erc20_project
+cd my_erc20_project
+make prepare
+make test
 ```
 
 ## License


### PR DESCRIPTION
This PR updates the cargo-casper README file, including details of the `--erc20` option.

Closes #2104.