### PR TITLE
Updated to chainspec.toml and config for block speed increase improvements.

### DIFF
--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -65,7 +65,7 @@ minimum_round_exponent = 15
 # Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
 # milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
 # means 2^19 milliseconds, i.e. about 8.7 minutes.
-maximum_round_exponent = 18
+maximum_round_exponent = 17
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -42,14 +42,14 @@ unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.
 #
 # Annual issuance: 8%
-# Minimum round exponent: 16
+# Minimum round exponent: 15
 # Ticks per year: 31536000000
 #
-# (1+0.08)^((2^16)/31536000000)-1 is expressed as a fractional number below
+# (1+0.08)^((2^15)/31536000000)-1 is expressed as a fractional number below
 # Python:
 # from fractions import Fraction
-# Fraction((1 + 0.08)**((2**16)/31536000000) - 1).limit_denominator(1000000000)
-round_seigniorage_rate = [147, 919121747]
+# Fraction((1 + 0.08)**((2**15)/31536000000) - 1).limit_denominator(1000000000)
+round_seigniorage_rate = [7, 87535408]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
 
@@ -61,7 +61,7 @@ max_associated_keys = 100
 finality_threshold_fraction = [1, 3]
 # Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
 # therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
-minimum_round_exponent = 16
+minimum_round_exponent = 15
 # Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
 # milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
 # means 2^19 milliseconds, i.e. about 8.7 minutes.
@@ -82,9 +82,9 @@ max_block_size = 10_485_760
 # Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
 max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
-block_max_deploy_count = 100
+block_max_deploy_count = 75
 # The maximum number of wasm-less transfer deploys permitted in a single block.
-block_max_transfer_count = 2500
+block_max_transfer_count = 1500
 # The upper limit of total gas of all deploys in a block.
 block_gas_limit = 10_000_000_000_000
 # The limit of length of serialized payment code arguments.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -346,4 +346,4 @@ sync_timeout = '1hr'
 # Deploys are only proposed in a new block if they have been received at least this long ago.
 # A longer delay makes it more likely that many proposed deploys are already known by the
 # other nodes, and don't have to be requested from the proposer afterwards.
-#deploy_delay = '1min'
+deploy_delay = '15sec'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -44,7 +44,10 @@ unit_hashes_folder = "/var/lib/casper/casper-node"
 pending_vertex_timeout = '30min'
 
 # If the current era's protocol state has not progressed for this long, shut down.
-# standstill_timeout = '30min'
+standstill_timeout = '30min'
+
+# If after another `standstill_timeout` there still was no progress, shut down.
+shutdown_on_standstill = true
 
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -46,9 +46,6 @@ pending_vertex_timeout = '30min'
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '30min'
 
-# If after another `standstill_timeout` there still was no progress, shut down.
-shutdown_on_standstill = true
-
 # Request the latest protocol state from a random peer periodically, with this interval.
 request_state_interval = '20sec'
 


### PR DESCRIPTION
Chainspec.toml changes for exp 15 (32s) blocks and seniorage calcs
Reducing deploy_delay from 1min to 15sec for default in config
