### PR TITLE
Resolve duplicated max_associated_keys config option

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -51,7 +51,10 @@ All notable changes to this project will be documented in this file.  The format
 * The libp2p-exclusive metrics of `read_futures_in_flight`, `read_futures_total`, `write_futures_in_flight`, `write_futures_total` have been removed.
 
 ### Fixed
-* Resolved an issue where `Deploys` with payment amounts exceeding the block gas limit would not be rejected.
+* Resolve an issue where `Deploys` with payment amounts exceeding the block gas limit would not be rejected.
+* Resolve issue of duplicated config option `max_associated_keys`.
+
+
 
 ## [1.3.2] - 2021-08-02
 
@@ -59,10 +62,14 @@ All notable changes to this project will be documented in this file.  The format
 * Resolve an issue in the `state_get_dictionary_item` JSON-RPC when a `ContractHash` is used.
 * Corrected network state engine to hold in blocked state for full 10 minutes when encountering out of order race condition.
 
+
+
 ## [1.3.1] - 2021-07-26
 
 ### Fixed
 * Parametrized sync_timeout and increased value to stop possible post upgrade restart loop.
+
+
 
 ## [1.3.0] - 2021-07-19
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -490,6 +490,7 @@ impl ContractRuntime {
         contract_runtime_config: &Config,
         wasm_config: WasmConfig,
         system_config: SystemConfig,
+        max_associated_keys: u32,
         registry: &Registry,
     ) -> Result<Self, ConfigError> {
         // TODO: This is bogus, get rid of this
@@ -516,7 +517,7 @@ impl ContractRuntime {
         let global_state = LmdbGlobalState::empty(environment, trie_store)?;
         let engine_config = EngineConfig::new(
             contract_runtime_config.max_query_depth(),
-            contract_runtime_config.max_associated_keys(),
+            max_associated_keys,
             wasm_config,
             system_config,
         );

--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -6,7 +6,6 @@ use casper_execution_engine::shared::utils;
 const DEFAULT_MAX_GLOBAL_STATE_SIZE: usize = 805_306_368_000; // 750 GiB
 const DEFAULT_MAX_READERS: u32 = 512;
 const DEFAULT_MAX_QUERY_DEPTH: u64 = 5;
-const DEFAULT_MAX_ASSOCIATED_KEYS: u32 = 100;
 
 /// Contract runtime configuration.
 #[derive(Clone, Copy, DataSize, Debug, Deserialize, Serialize)]
@@ -27,11 +26,6 @@ pub struct Config {
     ///
     /// Defaults to 5.
     max_query_depth: Option<u64>,
-    /// The maximum number of associated keys per account.
-    ///
-    /// Defaults to 100.
-    max_associated_keys: Option<u32>,
-
     /// Enable synchronizing to disk only after each block is written.
     ///
     /// Defaults to `false`.
@@ -55,11 +49,6 @@ impl Config {
         self.max_query_depth.unwrap_or(DEFAULT_MAX_QUERY_DEPTH)
     }
 
-    pub(crate) fn max_associated_keys(&self) -> u32 {
-        self.max_associated_keys
-            .unwrap_or(DEFAULT_MAX_ASSOCIATED_KEYS)
-    }
-
     pub(crate) fn manual_sync_enabled(&self) -> bool {
         self.enable_manual_sync.unwrap_or(false)
     }
@@ -69,7 +58,6 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             max_global_state_size: Some(DEFAULT_MAX_GLOBAL_STATE_SIZE),
-            max_associated_keys: Some(DEFAULT_MAX_ASSOCIATED_KEYS),
             max_readers: Some(DEFAULT_MAX_READERS),
             max_query_depth: Some(DEFAULT_MAX_QUERY_DEPTH),
             enable_manual_sync: Some(false),

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -48,6 +48,8 @@ use crate::{
     NodeRng,
 };
 
+const MAX_ASSOCIATED_KEYS: u32 = 100;
+
 /// Top-level event for the reactor.
 #[derive(Debug, From, Serialize)]
 #[must_use]
@@ -201,6 +203,7 @@ impl reactor::Reactor for Reactor {
             &contract_runtime_config,
             WasmConfig::default(),
             SystemConfig::default(),
+            MAX_ASSOCIATED_KEYS,
             registry,
         )
         .unwrap();

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -223,6 +223,7 @@ impl Reactor {
             &config.value().contract_runtime,
             chainspec_loader.chainspec().wasm_config,
             chainspec_loader.chainspec().system_costs_config,
+            chainspec_loader.chainspec().core_config.max_associated_keys,
             registry,
         )?;
 


### PR DESCRIPTION
This PR deduplicates the `max_associated_keys` config option.

Closes [#73](https://github.com/casper-network/Governance/issues/73).