### PR TITLE
Fix bug in Deploy acceptor

### DIFF
--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -210,9 +210,14 @@ impl TransferRuntimeArgsBuilder {
 
     /// Resolves a transfer target mode.
     ///
-    /// User has to specify a "target" argument which could be either an existing purse [`URef`] or
-    /// an account hash. If the "target" account hash is not existing, then a special variant is
-    /// returned that indicates that the system has to create new account first.
+    /// User has to specify a "target" argument which must be one of the following types:
+    ///   * an existing purse [`URef`]
+    ///   * a 32-byte array, interpreted as an account hash
+    ///   * a [`Key::Account`], from which the account hash is extracted
+    ///   * a [`PublicKey`], which is converted to an account hash
+    ///
+    /// If the "target" account hash is not existing, then a special variant is returned that
+    /// indicates that the system has to create new account first.
     ///
     /// Returns [`TransferTargetMode`] with a resolved variant.
     fn resolve_transfer_target_mode<R>(

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -111,12 +111,6 @@ pub(crate) enum DeployParameterFailure {
     /// Failed to parse payment "amount" runtime argument.
     #[error("failed to parse payment 'amount' runtime argument as U512")]
     FailedToParsePaymentAmount,
-    /// Failed to parse transfer "amount" runtime argument.
-    #[error("failed to parse transfer 'amount' runtime argument as U512")]
-    FailedToParseTransferAmount,
-    /// Missing transfer "amount" runtime argument.
-    #[error("missing transfer 'amount' runtime argument")]
-    MissingTransferAmount,
     /// Missing transfer "target" runtime argument.
     #[error("missing transfer 'target' runtime argument")]
     MissingTransferTarget,
@@ -527,25 +521,8 @@ impl DeployAcceptor {
 
         match session {
             ExecutableDeployItem::Transfer { args } => {
-                if let Some(value) = args.get(ARG_AMOUNT) {
-                    if value.clone().into_t::<U512>().is_err() {
-                        debug!("failed to parse transfer amount in native transfer object");
-                        return self.handle_invalid_deploy_result(
-                            effect_builder,
-                            event_metadata,
-                            make_error(DeployParameterFailure::FailedToParseTransferAmount),
-                            verification_start_timestamp,
-                        );
-                    }
-                } else {
-                    debug!("native transfer object is missing transfer amount");
-                    return self.handle_invalid_deploy_result(
-                        effect_builder,
-                        event_metadata,
-                        make_error(DeployParameterFailure::MissingTransferAmount),
-                        verification_start_timestamp,
-                    );
-                }
+                // We rely on the `Deploy::is_config_compliant` to check
+                // that the transfer amount arg is present and is a valid U512.
 
                 if args.get(ARG_TARGET).is_none() {
                     debug!("native transfer object is missing transfer argument");

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -418,7 +418,8 @@ impl DeployAcceptor {
                 );
             }
             ExecutableDeployItem::ModuleBytes { module_bytes, args } => {
-                if !module_bytes.is_empty() {
+                // module bytes being empty implies the payment executable is standard payment.
+                if module_bytes.is_empty() {
                     if let Some(value) = args.get(ARG_AMOUNT) {
                         if value.clone().into_t::<U512>().is_err() {
                             debug!("failed to parse payment amount in payment logic");

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -1238,7 +1238,7 @@ async fn should_reject_deploy_with_mangled_transfer_amount() {
     assert!(matches!(
         result,
         Err(super::Error::InvalidDeployConfiguration(
-            DeployConfigurationFailure::InvalidTransferAmount
+            DeployConfigurationFailure::FailedToParseTransferAmount
         ))
     ))
 }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -163,9 +163,9 @@ impl TestScenario {
     }
 
     fn deploy(&self, rng: &mut NodeRng) -> Deploy {
-        let mut deploy = Deploy::random_valid_native_transfer(rng);
         match self {
             TestScenario::FromPeerInvalidDeploy | TestScenario::FromClientInvalidDeploy => {
+                let mut deploy = Deploy::random_valid_native_transfer(rng);
                 deploy.invalidate();
                 deploy
             }
@@ -178,17 +178,19 @@ impl TestScenario {
             | TestScenario::AccountWithInvalidAssociatedKeys
             | TestScenario::AccountWithInsufficientWeight
             | TestScenario::AccountWithUnknownBalance
-            | TestScenario::BalanceCheckForDeploySentByPeer => deploy,
+            | TestScenario::BalanceCheckForDeploySentByPeer => {
+                Deploy::random_valid_native_transfer(rng)
+            }
             TestScenario::DeployWithCustomPaymentContract(contract_scenario) => {
                 match contract_scenario {
                     ContractScenario::Valid | ContractScenario::MissingContractAtName => {
-                        deploy.random_with_valid_custom_payment_contract_by_name(rng)
+                        Deploy::random_with_valid_custom_payment_contract_by_name(rng)
                     }
                     ContractScenario::MissingEntryPoint => {
-                        deploy.random_with_missing_entry_point_in_payment_contract(rng)
+                        Deploy::random_with_missing_entry_point_in_payment_contract(rng)
                     }
                     ContractScenario::MissingContractAtHash => {
-                        deploy.random_with_missing_payment_contract_by_hash(rng)
+                        Deploy::random_with_missing_payment_contract_by_hash(rng)
                     }
                 }
             }
@@ -196,46 +198,46 @@ impl TestScenario {
                 match contract_package_scenario {
                     ContractPackageScenario::Valid
                     | ContractPackageScenario::MissingPackageAtName => {
-                        deploy.random_with_valid_custom_payment_package_by_name(rng)
+                        Deploy::random_with_valid_custom_payment_package_by_name(rng)
                     }
                     ContractPackageScenario::MissingPackageAtHash => {
-                        deploy.random_with_missing_payment_package_by_hash(rng)
+                        Deploy::random_with_missing_payment_package_by_hash(rng)
                     }
                     ContractPackageScenario::MissingContractVersion => {
-                        deploy.random_with_nonexistent_contract_version_in_payment_package(rng)
+                        Deploy::random_with_nonexistent_contract_version_in_payment_package(rng)
                     }
                 }
             }
             TestScenario::DeployWithSessionContract(contract_scenario) => match contract_scenario {
                 ContractScenario::Valid | ContractScenario::MissingContractAtName => {
-                    deploy.random_with_valid_session_contract_by_name(rng)
+                    Deploy::random_with_valid_session_contract_by_name(rng)
                 }
                 ContractScenario::MissingContractAtHash => {
-                    deploy.random_with_missing_session_contract_by_hash(rng)
+                    Deploy::random_with_missing_session_contract_by_hash(rng)
                 }
                 ContractScenario::MissingEntryPoint => {
-                    deploy.random_with_missing_entry_point_in_session_contract(rng)
+                    Deploy::random_with_missing_entry_point_in_session_contract(rng)
                 }
             },
             TestScenario::DeployWithSessionContractPackage(contract_package_scenario) => {
                 match contract_package_scenario {
                     ContractPackageScenario::Valid
                     | ContractPackageScenario::MissingPackageAtName => {
-                        deploy.random_with_valid_session_package_by_name(rng)
+                        Deploy::random_with_valid_session_package_by_name(rng)
                     }
                     ContractPackageScenario::MissingPackageAtHash => {
-                        deploy.random_with_missing_session_package_by_hash(rng)
+                        Deploy::random_with_missing_session_package_by_hash(rng)
                     }
                     ContractPackageScenario::MissingContractVersion => {
-                        deploy.random_with_nonexistent_contract_version_in_session_package(rng)
+                        Deploy::random_with_nonexistent_contract_version_in_session_package(rng)
                     }
                 }
             }
             TestScenario::DeployWithEmptySessionModuleBytes => {
-                deploy.random_with_empty_session_module_bytes(rng)
+                Deploy::random_with_empty_session_module_bytes(rng)
             }
             TestScenario::DeployWithNativeTransferInPayment => {
-                deploy.random_with_native_transfer_in_payment_logic(rng)
+                Deploy::random_with_native_transfer_in_payment_logic(rng)
             }
         }
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -852,18 +852,22 @@ impl Deploy {
                 .args()
                 .get(ARG_AMOUNT)
                 .ok_or_else(|| {
-                    info!("missing transfer amount");
+                    info!("missing transfer 'amount' runtime argument");
                     DeployConfigurationFailure::MissingTransferAmount
                 })?
                 .clone()
                 .into_t::<U512>()
                 .map_err(|_| {
-                    info!("failed to parse transfer amount");
+                    info!("failed to parse transfer 'amount' runtime argument as a U512");
                     DeployConfigurationFailure::FailedToParseTransferAmount
                 })?;
             let minimum = U512::from(config.native_transfer_minimum_motes);
             if attempted < minimum {
-                info!("insufficient transfer amount");
+                info!(
+                    minimum = %config.native_transfer_minimum_motes,
+                    amount = %attempted,
+                    "insufficient transfer amount"
+                );
                 return Err(DeployConfigurationFailure::InsufficientTransferAmount {
                     minimum,
                     attempted,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -956,6 +956,25 @@ impl Deploy {
         )
     }
 
+    pub(crate) fn random_without_payment_amount(rng: &mut TestRng) -> Self {
+        let payment = ExecutableDeployItem::ModuleBytes {
+            module_bytes: Bytes::new(),
+            args: RuntimeArgs::default(),
+        };
+        Self::random_transfer_with_payment(rng, payment)
+    }
+
+    pub(crate) fn random_with_mangled_payment_amount(rng: &mut TestRng) -> Self {
+        let payment_args = runtime_args! {
+            "amount" => "invalid-argument"
+        };
+        let payment = ExecutableDeployItem::ModuleBytes {
+            module_bytes: Bytes::new(),
+            args: payment_args,
+        };
+        Self::random_transfer_with_payment(rng, payment)
+    }
+
     pub(crate) fn random_with_valid_custom_payment_contract_by_name(rng: &mut TestRng) -> Self {
         let payment = ExecutableDeployItem::StoredContractByName {
             name: "Test".to_string(),
@@ -1070,6 +1089,40 @@ impl Deploy {
             version: Some(6u32),
             entry_point: "non-existent-entry-point".to_string(),
             args: Default::default(),
+        };
+        Self::random_transfer_with_session(rng, session)
+    }
+
+    pub(crate) fn random_without_transfer_target(rng: &mut TestRng) -> Self {
+        let transfer_args = runtime_args! {
+            "amount" => *MAX_PAYMENT,
+            "source" => PublicKey::random(rng).to_account_hash(),
+        };
+        let session = ExecutableDeployItem::Transfer {
+            args: transfer_args,
+        };
+        Self::random_transfer_with_session(rng, session)
+    }
+
+    pub(crate) fn random_without_transfer_amount(rng: &mut TestRng) -> Self {
+        let transfer_args = runtime_args! {
+            "source" => PublicKey::random(rng).to_account_hash(),
+            "target" => PublicKey::random(rng).to_account_hash(),
+        };
+        let session = ExecutableDeployItem::Transfer {
+            args: transfer_args,
+        };
+        Self::random_transfer_with_session(rng, session)
+    }
+
+    pub(crate) fn random_with_mangled_transfer_amount(rng: &mut TestRng) -> Self {
+        let transfer_args = runtime_args! {
+            "amount" => "mangled-transfer-amount",
+            "source" => PublicKey::random(rng).to_account_hash(),
+            "target" => PublicKey::random(rng).to_account_hash(),
+        };
+        let session = ExecutableDeployItem::Transfer {
+            args: transfer_args,
         };
         Self::random_transfer_with_session(rng, session)
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -167,12 +167,12 @@ pub enum DeployConfigurationFailure {
         got: usize,
     },
 
-    /// Missing payment amount.
-    #[error("missing payment argument amount")]
+    /// Missing payment "amount" runtime argument.
+    #[error("missing payment 'amount' runtime argument ")]
     MissingPaymentAmount,
 
-    /// Failed to parse payment amount.
-    #[error("failed to parse payment amount as U512")]
+    /// Failed to parse payment "amount" runtime argument.
+    #[error("failed to parse payment 'amount' as U512")]
     FailedToParsePaymentAmount,
 
     /// The payment amount associated with the deploy exceeds the block gas limit.
@@ -184,12 +184,12 @@ pub enum DeployConfigurationFailure {
         got: U512,
     },
 
-    /// Missing transfer amount.
-    #[error("missing transfer amount")]
+    /// Missing payment "amount" runtime argument
+    #[error("missing transfer 'amount' runtime argument")]
     MissingTransferAmount,
 
-    /// Invalid transfer amount.
-    #[error("invalid transfer amount")]
+    /// Failed to parse transfer "amount" runtime argument.
+    #[error("failed to parse transfer 'amount' as U512")]
     FailedToParseTransferAmount,
 
     /// Insufficient transfer amount.


### PR DESCRIPTION
CHANGELOG:

- Fixed a bug in the deploy acceptor that bypassed checks on deploys using standard payment.
- Removed two redundant errors in `DeployParameterFailure`.
- Added 5 tests around the deploy acceptor to check for arguments in native transfer and standard payment.
- Added tests in deploy to check for arguments in native transfer.

Closes #2120 