### PR TITLE
Eras in memory

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -27,7 +27,6 @@ use datasize::DataSize;
 use derive_more::From;
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
 use casper_types::{EraId, PublicKey};
 
@@ -39,25 +38,21 @@ use crate::{
             BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest, ConsensusRequest,
             ContractRuntimeRequest, NetworkRequest, StorageRequest,
         },
-        EffectBuilder, EffectExt, Effects,
+        EffectBuilder, Effects,
     },
-    fatal,
     protocol::Message,
     reactor::ReactorEvent,
-    types::{ActivationPoint, BlockHash, BlockHeader, BlockPayload, Timestamp},
+    types::{ActivationPoint, BlockHeader, BlockPayload, Timestamp},
     NodeRng,
 };
 
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::Config;
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
-pub(crate) use era_supervisor::{bonded_eras, EraSupervisor};
+pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;
 use traits::NodeIdT;
 pub(crate) use utils::check_sufficient_finality_signatures;
-
-#[cfg(test)]
-pub(crate) use era_supervisor::oldest_bonded_era;
 
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub(crate) enum ConsensusMessage {
@@ -120,13 +115,10 @@ pub(crate) enum Event<I> {
         faulty_num: usize,
         delay: Duration,
     },
-    /// Event raised when a new era should be created: once we get the set of validators, the
-    /// booking block hash and the seed from the key block.
+    /// Event raised when a new era should be created because a new switch block is available.
     CreateNewEra {
-        /// The header of the switch block, i.e. the last block before the new era.
-        switch_block_header: Box<BlockHeader>,
-        /// `Ok(block_hash)` if the booking block was found, `Err(era_id)` if not
-        booking_block_hash: Result<BlockHash, EraId>,
+        /// The most recent switch block headers
+        switch_blocks: Vec<BlockHeader>,
     },
     /// Got the result of checking for an upgrade activation point.
     GotUpgradeActivationPoint(ActivationPoint),
@@ -217,13 +209,10 @@ impl<I: Debug> Display for Event<I> {
                 "Deactivate old {} unless additional faults are observed; faults so far: {}",
                 era_id, faulty_num
             ),
-            Event::CreateNewEra {
-                booking_block_hash,
-                switch_block_header,
-            } => write!(
+            Event::CreateNewEra { switch_blocks } => write!(
                 f,
-                "New era should be created; booking block hash: {:?}, switch block: {:?}",
-                booking_block_hash, switch_block_header
+                "New era should be created; switch blocks: {:?}",
+                switch_blocks
             ),
             Event::GotUpgradeActivationPoint(activation_point) => {
                 write!(f, "new upgrade activation point: {:?}", activation_point)
@@ -304,28 +293,8 @@ where
                 faulty_num,
                 delay,
             } => self.handle_deactivate_era(effect_builder, era_id, faulty_num, delay),
-            Event::CreateNewEra {
-                switch_block_header,
-                booking_block_hash,
-            } => {
-                let booking_block_hash = match booking_block_hash {
-                    Ok(hash) => hash,
-                    Err(era_id) => {
-                        error!(
-                            "could not find the booking block in era {}, for era {}",
-                            era_id,
-                            switch_block_header.era_id().successor()
-                        );
-                        return fatal!(effect_builder, "couldn't get the booking block hash")
-                            .ignore();
-                    }
-                };
-                self.handle_create_new_era(
-                    effect_builder,
-                    rng,
-                    *switch_block_header,
-                    booking_block_hash,
-                )
+            Event::CreateNewEra { switch_blocks } => {
+                self.create_new_era(effect_builder, rng, &switch_blocks)
             }
             Event::GotUpgradeActivationPoint(activation_point) => {
                 self.got_upgrade_activation_point(activation_point)

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 
 pub(crate) use cl_context::ClContext;
-pub(crate) use config::Config;
+pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -275,30 +275,35 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        mut rng: &mut NodeRng,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
-        let mut handling_es = self.handling_wrapper(effect_builder, &mut rng);
         match event {
             Event::Timer {
                 era_id,
                 timestamp,
                 timer_id,
-            } => handling_es.handle_timer(era_id, timestamp, timer_id),
-            Event::Action { era_id, action_id } => handling_es.handle_action(era_id, action_id),
-            Event::MessageReceived { sender, msg } => handling_es.handle_message(sender, msg),
-            Event::NewBlockPayload(new_block_payload) => {
-                handling_es.handle_new_block_payload(new_block_payload)
+            } => self.handle_timer(effect_builder, rng, era_id, timestamp, timer_id),
+            Event::Action { era_id, action_id } => {
+                self.handle_action(effect_builder, rng, era_id, action_id)
             }
-            Event::BlockAdded(block_header) => handling_es.handle_block_added(*block_header),
+            Event::MessageReceived { sender, msg } => {
+                self.handle_message(effect_builder, rng, sender, msg)
+            }
+            Event::NewBlockPayload(new_block_payload) => {
+                self.handle_new_block_payload(effect_builder, rng, new_block_payload)
+            }
+            Event::BlockAdded(block_header) => {
+                self.handle_block_added(effect_builder, *block_header)
+            }
             Event::ResolveValidity(resolve_validity) => {
-                handling_es.resolve_validity(resolve_validity)
+                self.resolve_validity(effect_builder, rng, resolve_validity)
             }
             Event::DeactivateEra {
                 era_id,
                 faulty_num,
                 delay,
-            } => handling_es.handle_deactivate_era(era_id, faulty_num, delay),
+            } => self.handle_deactivate_era(effect_builder, era_id, faulty_num, delay),
             Event::CreateNewEra {
                 switch_block_header,
                 booking_block_hash,
@@ -311,21 +316,21 @@ where
                             era_id,
                             switch_block_header.era_id().successor()
                         );
-                        return fatal!(
-                            handling_es.effect_builder,
-                            "couldn't get the booking block hash"
-                        )
-                        .ignore();
+                        return fatal!(effect_builder, "couldn't get the booking block hash")
+                            .ignore();
                     }
                 };
-                handling_es.handle_create_new_era(*switch_block_header, booking_block_hash)
+                self.handle_create_new_era(
+                    effect_builder,
+                    rng,
+                    *switch_block_header,
+                    booking_block_hash,
+                )
             }
             Event::GotUpgradeActivationPoint(activation_point) => {
-                handling_es.got_upgrade_activation_point(activation_point)
+                self.got_upgrade_activation_point(activation_point)
             }
-            Event::ConsensusRequest(ConsensusRequest::Status(responder)) => {
-                handling_es.status(responder)
-            }
+            Event::ConsensusRequest(ConsensusRequest::Status(responder)) => self.status(responder),
         }
     }
 }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -294,7 +294,7 @@ where
                 delay,
             } => self.handle_deactivate_era(effect_builder, era_id, faulty_num, delay),
             Event::CreateNewEra { switch_blocks } => {
-                self.create_new_era(effect_builder, rng, &switch_blocks)
+                self.create_new_era_effects(effect_builder, rng, &switch_blocks)
             }
             Event::GotUpgradeActivationPoint(activation_point) => {
                 self.got_upgrade_activation_point(activation_point)

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -3,12 +3,11 @@ use std::{path::Path, sync::Arc};
 use datasize::DataSize;
 use serde::Deserialize;
 
-use casper_types::{ProtocolVersion, PublicKey, SecretKey};
+use casper_types::{PublicKey, SecretKey};
 
 use crate::{
     components::consensus::{protocols::highway::config::Config as HighwayConfig, EraId},
-    crypto::hash::Digest,
-    types::{chainspec::HighwayConfig as HighwayProtocolConfig, Chainspec, TimeDiff, Timestamp},
+    types::Chainspec,
     utils::{External, LoadError, Loadable},
 };
 
@@ -77,52 +76,5 @@ impl ChainspecConsensusExt for Chainspec {
                 .saturating_sub(1)
                 .saturating_sub(self.core_config.auction_delay),
         )
-    }
-}
-
-/// Consensus protocol configuration.
-#[derive(DataSize, Debug)]
-pub(crate) struct ProtocolConfig {
-    pub(crate) highway_config: HighwayProtocolConfig,
-    pub(crate) era_duration: TimeDiff,
-    pub(crate) minimum_era_height: u64,
-    /// Number of eras before an auction actually defines the set of validators.
-    /// If you bond with a sufficient bid in era N, you will be a validator in era N +
-    /// auction_delay + 1
-    pub(crate) auction_delay: u64,
-    pub(crate) unbonding_delay: u64,
-    /// The network protocol version.
-    #[data_size(skip)]
-    pub(crate) protocol_version: ProtocolVersion,
-    /// The first era ID after the last upgrade
-    pub(crate) last_activation_point: EraId,
-    /// Name of the network.
-    pub(crate) name: String,
-    /// Genesis timestamp, if available.
-    pub(crate) genesis_timestamp: Option<Timestamp>,
-    /// The chainspec hash: All nodes in the network agree on it, and it's unique to this network.
-    pub(crate) chainspec_hash: Digest,
-    /// The last emergency restart [`EraId`] (if there was one)
-    pub(crate) last_emergency_restart: Option<EraId>,
-}
-
-impl From<&Chainspec> for ProtocolConfig {
-    fn from(chainspec: &Chainspec) -> Self {
-        ProtocolConfig {
-            highway_config: chainspec.highway_config,
-            era_duration: chainspec.core_config.era_duration,
-            minimum_era_height: chainspec.core_config.minimum_era_height,
-            auction_delay: chainspec.core_config.auction_delay,
-            unbonding_delay: chainspec.core_config.unbonding_delay,
-            protocol_version: chainspec.protocol_config.version,
-            last_activation_point: chainspec.protocol_config.activation_point.era_id(),
-            name: chainspec.network_config.name.clone(),
-            genesis_timestamp: chainspec
-                .protocol_config
-                .activation_point
-                .genesis_timestamp(),
-            chainspec_hash: chainspec.hash(),
-            last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
-        }
     }
 }

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -51,7 +51,7 @@ pub trait ChainspecConsensusExt {
 
     /// Returns the earliest era that is kept in memory. If the current era is N, that is usually N
     /// - 2, except that it's never at or before the most recent activation point.
-    fn earliest_active_era(&self, current_era: EraId) -> EraId;
+    fn earliest_open_era(&self, current_era: EraId) -> EraId;
 
     /// Returns the earliest era whose switch block is needed to initialize the given era. For era
     /// N that will usually be N - A - 1, where A is the auction delay, except that switch block
@@ -64,7 +64,7 @@ impl ChainspecConsensusExt for Chainspec {
         self.protocol_config.activation_point.era_id()
     }
 
-    fn earliest_active_era(&self, current_era: EraId) -> EraId {
+    fn earliest_open_era(&self, current_era: EraId) -> EraId {
         self.activation_era()
             .successor()
             .max(current_era.saturating_sub(2))

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -207,7 +207,7 @@ where
         for era_id in (earliest_era.value()..current_era.value()).map(EraId::from) {
             let switch_block = storage
                 .read_switch_block_header_by_era_id(era_id)?
-                .ok_or_else(|| anyhow::Error::msg("No such switch block"))?;
+                .ok_or_else(|| anyhow::Error::msg(format!("No such switch block in {}", era_id)))?;
             switch_blocks.push(switch_block);
         }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -360,7 +360,7 @@ where
             warn!(era = era_id.value(), "era already exists");
             return Effects::new();
         }
-        if self.current_era > era_id.saturating_add(2) {
+        if self.current_era > era_id.saturating_add(PAST_ACTIVE_ERAS) {
             warn!(era = era_id.value(), "trying to create obsolete era");
             return Effects::new();
         }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -35,7 +35,6 @@ use crate::{
     components::{
         consensus::{
             cl_context::{ClContext, Keypair},
-            config::ProtocolConfig,
             consensus_protocol::{
                 ConsensusProtocol, EraReport, FinalizedBlock as CpFinalizedBlock, ProposedBlock,
                 ProtocolOutcome,
@@ -74,7 +73,7 @@ type ConsensusConstructor<I> = dyn Fn(
         &HashSet<PublicKey>,       /* faulty validators that are banned in
                                     * this era */
         &HashSet<PublicKey>, // inactive validators that can't be leaders
-        &ProtocolConfig,     // the network's chainspec
+        &Chainspec,          // the network's chainspec
         &Config,             // The consensus part of the node config.
         Option<&dyn ConsensusProtocol<I, ClContext>>, // previous era's consensus instance
         Timestamp,           // start time for this era
@@ -419,7 +418,7 @@ where
             validators.clone(),
             &faulty,
             &inactive,
-            &self.chainspec.as_ref().into(),
+            self.chainspec.as_ref(),
             &self.config,
             maybe_prev_era.map(|prev_era| &*prev_era.consensus),
             start_time,

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -55,11 +55,7 @@ pub struct Era<I> {
     pub(crate) start_height: u64,
     /// Pending blocks, waiting for validation and dependencies.
     validation_states: HashMap<ProposedBlock<ClContext>, ValidationState>,
-    /// Validators banned in this and the next BONDED_ERAS eras, because they were faulty in the
-    /// previous switch block.
-    pub(crate) new_faulty: Vec<PublicKey>,
-    /// Validators that have been faulty in any of the recent BONDED_ERAS switch blocks. This
-    /// includes `new_faulty`.
+    /// Validators that have been faulty in any of the switch blocks after the booking block.
     pub(crate) faulty: HashSet<PublicKey>,
     /// Accusations collected in this era so far.
     accusations: HashSet<PublicKey>,
@@ -72,7 +68,6 @@ impl<I> Era<I> {
         consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
         start_time: Timestamp,
         start_height: u64,
-        new_faulty: Vec<PublicKey>,
         faulty: HashSet<PublicKey>,
         validators: BTreeMap<PublicKey, U512>,
     ) -> Self {
@@ -81,7 +76,6 @@ impl<I> Era<I> {
             start_time,
             start_height,
             validation_states: HashMap::new(),
-            new_faulty,
             faulty,
             accusations: HashSet::new(),
             validators,
@@ -179,7 +173,6 @@ where
             start_time,
             start_height,
             validation_states,
-            new_faulty,
             faulty,
             accusations,
             validators,
@@ -215,7 +208,6 @@ where
             .saturating_add(start_time.estimate_heap_size())
             .saturating_add(start_height.estimate_heap_size())
             .saturating_add(validation_states.estimate_heap_size())
-            .saturating_add(new_faulty.estimate_heap_size())
             .saturating_add(faulty.estimate_heap_size())
             .saturating_add(accusations.estimate_heap_size())
             .saturating_add(validators.estimate_heap_size())

--- a/node/src/components/consensus/error.rs
+++ b/node/src/components/consensus/error.rs
@@ -47,4 +47,16 @@ pub enum CreateNewEraError {
         era_id: EraId,
         last_block_header: Box<BlockHeader>,
     },
+    #[error("Attempted to create {era_id} with too few switch blocks {switch_blocks:?}.")]
+    InsufficientSwitchBlocks {
+        era_id: EraId,
+        switch_blocks: Vec<BlockHeader>,
+    },
+    #[error(
+        "Attempted to create {era_id} with switch blocks from unexpected eras: {switch_blocks:?}."
+    )]
+    WrongSwitchBlockEra {
+        era_id: EraId,
+        switch_blocks: Vec<BlockHeader>,
+    },
 }

--- a/node/src/components/consensus/error.rs
+++ b/node/src/components/consensus/error.rs
@@ -3,8 +3,9 @@ use std::collections::BTreeMap;
 use num::rational::Ratio;
 use thiserror::Error;
 
-use crate::types::BlockSignatures;
-use casper_types::{PublicKey, U512};
+use casper_types::{EraId, PublicKey, U512};
+
+use crate::types::{BlockHeader, BlockSignatures};
 
 #[derive(Error, Debug)]
 pub enum FinalitySignatureError {
@@ -34,5 +35,16 @@ pub enum FinalitySignatureError {
         signature_weight: Box<U512>,
         total_validator_weight: Box<U512>,
         finality_threshold_fraction: Ratio<u64>,
+    },
+}
+
+#[derive(Error, Debug)]
+pub enum CreateNewEraError {
+    #[error("Attempted to create era with no switch blocks.")]
+    AttemptedToCreateEraWithNoSwitchBlocks,
+    #[error("Attempted to create {era_id} with non-switch block {last_block_header:?}.")]
+    LastBlockHeaderNotASwitchBlock {
+        era_id: EraId,
+        last_block_header: Box<BlockHeader>,
     },
 }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -88,7 +88,7 @@ where
         weights.into_iter().collect(),
         &init_faulty.into_iter().collect(),
         &None.into_iter().collect(),
-        &(&chainspec).into(),
+        &chainspec,
         &config,
         None,
         start_timestamp,

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -526,9 +526,9 @@ async fn fast_sync_to_most_recent(
     // The era supervisor requires enough switch blocks to be stored in the database to be able to
     // initialize the most recent eras.
     {
-        let earliest_active_era = chainspec.earliest_active_era(most_recent_block_header.era_id());
+        let earliest_open_era = chainspec.earliest_open_era(most_recent_block_header.era_id());
         let earliest_era_needed_by_era_supervisor =
-            chainspec.earliest_switch_block_needed(earliest_active_era);
+            chainspec.earliest_switch_block_needed(earliest_open_era);
         let mut current_walk_back_header = most_recent_block_header.clone();
         while current_walk_back_header.era_id() > earliest_era_needed_by_era_supervisor {
             current_walk_back_header = *fetch_and_store_block_header(

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -11,7 +11,6 @@ use casper_types::{EraId, Key, PublicKey, U512};
 
 use crate::{
     components::{
-        consensus,
         consensus::check_sufficient_finality_signatures,
         contract_runtime::ExecutionPreState,
         fetcher::{FetchResult, FetchedData, FetcherError},
@@ -524,12 +523,9 @@ async fn fast_sync_to_most_recent(
         }
     }
 
-    // The era supervisor needs validator information from previous eras.
-    // The number of previous eras is determined by a *delay* in which consensus participants become
-    // bonded validators or unbond.
-    let delay = consensus::bonded_eras(&chainspec.into());
-    // The era supervisor requires at least to 3*delay + 1 eras back to be stored in the database.
-    let historical_eras_needed = delay.saturating_mul(3).saturating_add(1);
+    // The era supervisor requires at least auction_delay + 3 eras back to be stored in the
+    // database.
+    let historical_eras_needed = chainspec.core_config.auction_delay.saturating_add(3);
     let earliest_era_needed_by_era_supervisor = most_recent_block_header
         .era_id()
         .saturating_sub(historical_eras_needed);

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -380,16 +380,14 @@ impl RpcWithOptionalParamsExt for GetEraInfoBySwitchBlock {
                 }
             };
 
-            let era_id = match block.header().era_end() {
-                Some(_) => block.header().era_id(),
-                None => {
-                    return Ok(response_builder.success(Self::ResponseResult {
-                        api_version,
-                        era_summary: None,
-                    })?)
-                }
-            };
+            if !block.header().is_switch_block() {
+                return Ok(response_builder.success(Self::ResponseResult {
+                    api_version,
+                    era_summary: None,
+                })?);
+            }
 
+            let era_id = block.header().era_id();
             let state_root_hash = block.state_root_hash().to_owned();
             let base_key = Key::EraInfo(era_id);
             let path = Vec::new();

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -675,7 +675,7 @@ impl reactor::Reactor for Reactor {
                 vec![],
             )?;
             // Make sure the new block really is a switch block
-            if new_switch_block.header().era_end().is_none() {
+            if !new_switch_block.header().is_switch_block() {
                 return Err(Error::FailedToCreateSwitchBlockAfterGenesisOrUpgrade {
                     new_bad_block: Box::new(new_switch_block),
                 });

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -719,7 +719,7 @@ impl reactor::Reactor for Reactor {
             latest_block_header.next_block_era_id(),
             WithDir::new(root, config.consensus),
             effect_builder,
-            chainspec_loader.chainspec().as_ref().into(),
+            chainspec_loader.chainspec().clone(),
             &latest_block_header,
             maybe_next_activation_point,
             registry,

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -316,7 +316,7 @@ async fn run_equivocator_network() {
     // The first era should have been removed from memory.
     for runner in net.nodes().values() {
         let consensus = runner.reactor().inner().consensus();
-        assert!(consensus.active_era_ids().all(|era_id| era_id.value() != 1));
+        assert!(consensus.open_era_ids().all(|era_id| era_id.value() != 1));
     }
 
     // The auction delay is 1, so if Alice's equivocation was detected before the switch block in

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -273,7 +273,7 @@ async fn run_equivocator_network() {
         let expected = [alice_pk.clone()];
         // Returns true if Alice is listed as an equivocator in that block.
         let alice_is_equivocator = |header: &BlockHeader| {
-            let report = header.era_report().expect("missing era report");
+            let report = header.era_end().expect("missing era report").era_report();
             report.equivocators == expected
         };
 
@@ -334,7 +334,7 @@ async fn run_equivocator_network() {
         if validators.contains_key(&alice_pk) {
             // We've found era N: This is the last switch block that still lists Alice as a
             // validator.
-            let report = header.era_report().expect("missing era report");
+            let report = header.era_end().expect("missing era report").era_report();
             assert_eq!(*report.inactive_validators, []);
             assert_eq!(*report.equivocators, [alice_pk.clone()]);
             return;

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -14,7 +14,7 @@ use casper_types::{
 };
 
 use crate::{
-    components::{consensus, gossiper, small_network, storage},
+    components::{gossiper, small_network, storage},
     crypto::AsymmetricKeyExt,
     reactor::{initializer, joiner, participating, ReactorExit, Runner},
     testing::{self, network::Network, TestRng},
@@ -241,7 +241,6 @@ async fn run_equivocator_network() {
     keys.push(alice_sk);
 
     let mut chain = TestChain::new_with_keys(&mut rng, keys, stakes.clone());
-    let protocol_config = (&*chain.chainspec).into();
 
     let mut net = chain
         .create_initialized_network(&mut rng)
@@ -291,10 +290,7 @@ async fn run_equivocator_network() {
         );
 
         // Make sure we waited long enough for this test to include unbonding and dropping eras.
-        let oldest_bonded_era_id = consensus::oldest_bonded_era(&protocol_config, era_id);
-        let oldest_evidence_era_id =
-            consensus::oldest_bonded_era(&protocol_config, oldest_bonded_era_id);
-        if oldest_evidence_era_id.is_genesis() || era_number < 3 {
+        if era_number < 4 {
             continue;
         }
 
@@ -316,6 +312,12 @@ async fn run_equivocator_network() {
             .contains_key(&alice_pk),
         "Alice should have been evicted."
     );
+
+    // The first era should have been removed from memory.
+    for runner in net.nodes().values() {
+        let consensus = runner.reactor().inner().consensus();
+        assert!(consensus.active_era_ids().all(|era_id| era_id.value() != 1));
+    }
 
     // The auction delay is 1, so if Alice's equivocation was detected before the switch block in
     // era N, the switch block of era N should list her as faulty. Starting with the switch block

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -717,7 +717,7 @@ impl BlockHeader {
     }
 
     /// Returns reward and slashing information if this is the era's last block.
-    pub fn era_end(&self) -> Option<&EraReport> {
+    pub fn era_report(&self) -> Option<&EraReport> {
         match &self.era_end {
             Some(data) => Some(data.era_report()),
             None => None,

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -65,9 +65,11 @@ impl EraId {
     }
 
     /// Returns a successor to current era.
-    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
+    ///
+    /// For `u64::MAX`, this returns `u64::MAX` again: We want to make sure this doesn't panic, and
+    /// that era number will never be reached in practice.
     pub fn successor(self) -> EraId {
-        EraId::from(self.0 + 1)
+        EraId::from(self.0.saturating_add(1))
     }
 
     /// Returns the current era plus `x`, or `None` if that would overflow


### PR DESCRIPTION
Keep only two full eras in memory in the era supervisor, and one additional era for evidence validation only. See https://github.com/casper-network/casper-node/issues/1915 for details.

Closes https://github.com/casper-network/casper-node/issues/1915, https://github.com/casper-network/casper-node/issues/1588.