### PR TITLE
Increase price of wasmless transfer

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.  The format
 * Improve doc comments to clarify behavior of the bidding functionality.
 * Document `core` and `shared` modules and their children.
 * Change parameters to `LmdbEnvironment`'s constructor enabling manual flushing to disk.
+* Increased price of native transfer to 100 million motes (0.1 CSPR).
 
 ### Fixed
 * Fix a case where user could potentially supply a refund purse as a payment purse.

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -25,10 +25,10 @@ All notable changes to this project will be documented in this file.  The format
 * Reduced visibility to `pub(crate)` in several areas, allowing some dead code to be noticed and pruned.
 * Support building and testing using stable Rust.
 * Increase price of `create_purse` to 2.5CSPR.
+* Increase price of native transfer to 100 million motes (0.1 CSPR).
 * Improve doc comments to clarify behavior of the bidding functionality.
 * Document `core` and `shared` modules and their children.
 * Change parameters to `LmdbEnvironment`'s constructor enabling manual flushing to disk.
-* Increased price of native transfer to 100 million motes (0.1 CSPR).
 
 ### Fixed
 * Fix a case where user could potentially supply a refund purse as a payment purse.

--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -16,7 +16,7 @@ use self::{
 };
 
 /// Default gas cost for a wasmless transfer.
-pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 10_000;
+pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 100_000_000;
 
 /// Definition of costs in the system.
 ///

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -183,7 +183,7 @@ write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -186,7 +186,7 @@ write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -108,7 +108,7 @@ write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -107,7 +107,7 @@ write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -108,7 +108,7 @@ write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -182,7 +182,7 @@ write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 delete = { cost = 14_000, arguments = [0, 0] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -182,7 +182,7 @@ write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 delete = { cost = 14_000, arguments = [0, 0] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -182,7 +182,7 @@ write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 delete = { cost = 14_000, arguments = [0, 0] }
 
 [system_costs]
-wasmless_transfer_cost = 10_000
+wasmless_transfer_cost = 100_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000


### PR DESCRIPTION
CHANGELOG

- Increased price of wasmless (native) transfer cost to 100 million motes (0.1 CSPR)

Closes #2128 