### PR TITLE
Perform account checks on deploys from clients only.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byteorder"
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "b82485a532ef0af18878ad4281f73e58161cdba1db7918176e9294f0ca5498a5"
 dependencies = [
  "dyn-clone",
  "indexmap",
@@ -3765,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "791c2c848cff1abaeae34fef7e70da5f93171d9eea81ce0fe969a1df627a61a8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4138,9 +4138,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4292,9 +4292,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4432,9 +4432,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4496,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "version-sync"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb94ca10ca0cf44f5d926ac977f0cac2d13e9789aa4bbe9d9388de445e61028"
+checksum = "a7a3e43f07cfb6ad1a7f6fedaf1144e59750b728c04a24a053035379b2e4584d"
 dependencies = [
  "proc-macro2",
  "pulldown-cmark",
@@ -5106,18 +5106,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -277,39 +277,39 @@ impl DeployAcceptor {
                 )
             }
             Some(account) => {
-                let authorization_keys = event_metadata
-                    .deploy
-                    .approvals()
-                    .iter()
-                    .map(|approval| approval.signer().to_account_hash())
-                    .collect();
-                if !account.can_authorize(&authorization_keys) {
-                    let error = Error::InvalidDeployParameters {
-                        prestate_hash,
-                        failure: DeployParameterFailure::InvalidAssociatedKeys,
-                    };
-                    debug!(?authorization_keys, "account authorization invalid");
-                    return self.handle_invalid_deploy_result(
-                        effect_builder,
-                        event_metadata,
-                        error,
-                        verification_start_timestamp,
-                    );
-                }
-                if !account.can_deploy_with(&authorization_keys) {
-                    let error = Error::InvalidDeployParameters {
-                        prestate_hash,
-                        failure: DeployParameterFailure::InsufficientDeploySignatureWeight,
-                    };
-                    debug!(?authorization_keys, "insufficient deploy signature weight");
-                    return self.handle_invalid_deploy_result(
-                        effect_builder,
-                        event_metadata,
-                        error,
-                        verification_start_timestamp,
-                    );
-                }
                 if event_metadata.source.from_client() {
+                    let authorization_keys = event_metadata
+                        .deploy
+                        .approvals()
+                        .iter()
+                        .map(|approval| approval.signer().to_account_hash())
+                        .collect();
+                    if !account.can_authorize(&authorization_keys) {
+                        let error = Error::InvalidDeployParameters {
+                            prestate_hash,
+                            failure: DeployParameterFailure::InvalidAssociatedKeys,
+                        };
+                        debug!(?authorization_keys, "account authorization invalid");
+                        return self.handle_invalid_deploy_result(
+                            effect_builder,
+                            event_metadata,
+                            error,
+                            verification_start_timestamp,
+                        );
+                    }
+                    if !account.can_deploy_with(&authorization_keys) {
+                        let error = Error::InvalidDeployParameters {
+                            prestate_hash,
+                            failure: DeployParameterFailure::InsufficientDeploySignatureWeight,
+                        };
+                        debug!(?authorization_keys, "insufficient deploy signature weight");
+                        return self.handle_invalid_deploy_result(
+                            effect_builder,
+                            event_metadata,
+                            error,
+                            verification_start_timestamp,
+                        );
+                    }
                     effect_builder
                         .check_purse_balance(prestate_hash, account.main_purse())
                         .event(move |maybe_balance_value| Event::GetBalanceResult {


### PR DESCRIPTION
CHANGELOG:

- Changed the behavior of the deploy acceptor to never perform account checks on deploys sent by peers.
- Added two tests to ensure account checks for deploys sent by peers don't occur


Closes #2130 