### PR TITLE
Make Block::verify private (dev backport)

### DIFF
--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -286,8 +286,7 @@ pub(crate) fn validate_get_block_response(
     } else {
         return Ok(());
     };
-    let block = Block::from(json_block);
-    block.verify()?;
+    let block = Block::try_from(json_block)?;
     match maybe_block_identifier {
         Some(BlockIdentifier::Hash(block_hash)) => {
             if block_hash != block.hash() {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -934,8 +934,6 @@ impl Storage {
     /// Returns `Ok(true)` if the block has been successfully written, `Ok(false)` if a part of it
     /// couldn't be written because it already existed, and `Err(_)` if there was an error.
     fn write_block(&mut self, block: &Block) -> Result<bool, Error> {
-        // Validate the block prior to inserting it into the database
-        block.verify()?;
         let mut txn = self.env.begin_rw_txn()?;
         // Write the block body
         {


### PR DESCRIPTION
This should make it impossible to instantiate an invalid `Block`, where the body hash doesn't match the one in the header, or the `hash` field is different from the header's hash.

Port of #1928 from `feat-fast-sync` to `dev`.

Closes #1965.