### PR TITLE
Highway/synchronizer: pass in RNG, avoid unnecessary requests, deduplicate.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -15,6 +15,7 @@ use casper_types::bytesrepr::ToBytes;
 use crate::{
     components::consensus::{traits::Context, ActionId, TimerId},
     types::{TimeDiff, Timestamp},
+    NodeRng,
 };
 
 /// Information about the context in which a new block is created.
@@ -241,8 +242,13 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn as_any(&self) -> &dyn Any;
 
     /// Handles an incoming message (like NewUnit, RequestDependency).
-    fn handle_message(&mut self, sender: I, msg: Vec<u8>, now: Timestamp)
-        -> ProtocolOutcomes<I, C>;
+    fn handle_message(
+        &mut self,
+        rng: &mut NodeRng,
+        sender: I,
+        msg: Vec<u8>,
+        now: Timestamp,
+    ) -> ProtocolOutcomes<I, C>;
 
     /// Current instance of consensus protocol is latest era.
     fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<I, C>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -700,7 +700,10 @@ where
     /// Applies `f` to the consensus protocol of the specified era.
     fn delegate_to_era<F>(&mut self, era_id: EraId, f: F) -> Effects<Event<I>>
     where
-        F: FnOnce(&mut dyn ConsensusProtocol<I, ClContext>) -> Vec<ProtocolOutcome<I, ClContext>>,
+        F: FnOnce(
+            &mut dyn ConsensusProtocol<I, ClContext>,
+            &mut NodeRng,
+        ) -> Vec<ProtocolOutcome<I, ClContext>>,
     {
         match self.era_supervisor.active_eras.get_mut(&era_id) {
             None => {
@@ -712,7 +715,7 @@ where
                 Effects::new()
             }
             Some(era) => {
-                let outcomes = f(&mut *era.consensus);
+                let outcomes = f(&mut *era.consensus, self.rng);
                 self.handle_consensus_outcomes(era_id, outcomes)
             }
         }
@@ -724,7 +727,7 @@ where
         timestamp: Timestamp,
         timer_id: TimerId,
     ) -> Effects<Event<I>> {
-        self.delegate_to_era(era_id, move |consensus| {
+        self.delegate_to_era(era_id, move |consensus, _| {
             consensus.handle_timer(timestamp, timer_id)
         })
     }
@@ -734,7 +737,7 @@ where
         era_id: EraId,
         action_id: ActionId,
     ) -> Effects<Event<I>> {
-        self.delegate_to_era(era_id, move |consensus| {
+        self.delegate_to_era(era_id, move |consensus, _| {
             consensus.handle_action(action_id, Timestamp::now())
         })
     }
@@ -745,8 +748,8 @@ where
                 // If the era is already unbonded, only accept new evidence, because still-bonded
                 // eras could depend on that.
                 trace!(era = era_id.value(), "received a consensus message");
-                self.delegate_to_era(era_id, move |consensus| {
-                    consensus.handle_message(sender, payload, Timestamp::now())
+                self.delegate_to_era(era_id, move |consensus, rng| {
+                    consensus.handle_message(rng, sender, payload, Timestamp::now())
                 })
             }
             ConsensusMessage::EvidenceRequest { era_id, pub_key } => {
@@ -757,7 +760,7 @@ where
                 self.era_supervisor
                     .iter_past(era_id, self.era_supervisor.bonded_eras())
                     .flat_map(|e_id| {
-                        self.delegate_to_era(e_id, |consensus| {
+                        self.delegate_to_era(e_id, |consensus, _| {
                             consensus.request_evidence(sender.clone(), &pub_key)
                         })
                     })
@@ -780,7 +783,7 @@ where
             return Effects::new();
         }
         let proposed_block = ProposedBlock::new(block_payload, block_context);
-        self.delegate_to_era(era_id, move |consensus| {
+        self.delegate_to_era(era_id, move |consensus, _| {
             consensus.propose(proposed_block, Timestamp::now())
         })
     }
@@ -962,7 +965,7 @@ where
             .get_mut(&era_id)
             .map_or(false, |era| era.resolve_validity(&proposed_block, valid))
         {
-            effects.extend(self.delegate_to_era(era_id, |consensus| {
+            effects.extend(self.delegate_to_era(era_id, |consensus, _| {
                 consensus.resolve_validity(proposed_block, valid, Timestamp::now())
             }));
         }
@@ -1209,7 +1212,7 @@ where
                             continue;
                         };
                     for proposed_block in proposed_blocks {
-                        effects.extend(self.delegate_to_era(e_id, |consensus| {
+                        effects.extend(self.delegate_to_era(e_id, |consensus, _| {
                             consensus.resolve_validity(proposed_block, true, Timestamp::now())
                         }));
                     }
@@ -1220,7 +1223,7 @@ where
                 .era_supervisor
                 .iter_past_other(era_id, self.era_supervisor.bonded_eras())
                 .flat_map(|e_id| {
-                    self.delegate_to_era(e_id, |consensus| {
+                    self.delegate_to_era(e_id, |consensus, _| {
                         consensus.request_evidence(sender.clone(), &pub_key)
                     })
                 })

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -398,7 +398,7 @@ impl<C: Context> Highway<C> {
             },
             Observation::Correct(last_seen) => self
                 .state
-                .find_ancestor_unit(last_seen, unit_seq)
+                .find_in_swimlane(last_seen, unit_seq)
                 .and_then(|req_hash| self.state.wire_unit(req_hash, self.instance_id))
                 .map(|swunit| GetDepOutcome::Vertex(ValidVertex(Vertex::Unit(swunit))))
                 .unwrap_or_else(|| GetDepOutcome::None),

--- a/node/src/components/consensus/highway_core/state/index_panorama.rs
+++ b/node/src/components/consensus/highway_core/state/index_panorama.rs
@@ -18,16 +18,17 @@ pub(crate) type IndexPanorama = ValidatorMap<IndexObservation>;
 pub(crate) enum IndexObservation {
     /// We have evidence that the validator is faulty.
     Faulty,
-    /// We have that number of units from the validator.
-    /// That is also the sequence number of the first unit we are still missing.
-    Count(u64),
+    /// The next sequence number we need, i.e. the lowest one that is missing from our protocol
+    /// state. This is equal to the total number of units we have from that validator, and one more
+    /// than the highest sequence number we have.
+    NextSeq(u64),
 }
 
 impl Debug for IndexObservation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IndexObservation::Faulty => write!(f, "F"),
-            IndexObservation::Count(count) => write!(f, "{:?}", count),
+            IndexObservation::NextSeq(next_seq) => write!(f, "{:?}", next_seq),
         }
     }
 }
@@ -39,11 +40,11 @@ impl IndexPanorama {
         state: &'a State<C>,
     ) -> Self {
         let mut validator_map: ValidatorMap<IndexObservation> =
-            ValidatorMap::from(vec![IndexObservation::Count(0); panorama.len()]);
+            ValidatorMap::from(vec![IndexObservation::NextSeq(0); panorama.len()]);
         for (vid, obs) in panorama.enumerate() {
             let index_obs = match obs {
-                Observation::None => IndexObservation::Count(0),
-                Observation::Correct(hash) => IndexObservation::Count(
+                Observation::None => IndexObservation::NextSeq(0),
+                Observation::Correct(hash) => IndexObservation::NextSeq(
                     state
                         .maybe_unit(hash)
                         .map_or(0, |unit| unit.seq_number.saturating_add(1)),

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -651,13 +651,12 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                     error!(?vid, "received a request for non-existing validator");
                     vec![]
                 }
-                Some(latest_obs) => match latest_obs {
+                Some(observation) => match observation {
                     Observation::None | Observation::Faulty => {
-                        let index_panorama = format!("Count({:?})", our_count.saturating_sub(1));
                         error!(
                             ?vid,
-                            ?index_panorama,
-                            panorama=?latest_obs,
+                            our_count,
+                            ?observation,
                             "`IndexPanorama` doesn't match `state.panorama` for validator"
                         );
                         vec![]

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -625,13 +625,13 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         &self,
         rng: &mut NodeRng,
         vid: ValidatorIndex,
-        our_count: u64,
-        their_count: u64,
+        our_next_seq: u64,
+        their_next_seq: u64,
     ) -> Vec<HighwayMessage<C>> {
         let state = self.highway.state();
-        if our_count < their_count {
+        if our_next_seq < their_next_seq {
             // We're behind. Request missing vertices.
-            (our_count..their_count)
+            (our_next_seq..their_next_seq)
                 .take(self.config.max_request_batch_size)
                 .map(|unit_seq_number| {
                     let uuid = rng.next_u64();
@@ -655,13 +655,13 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                     Observation::None | Observation::Faulty => {
                         error!(
                             ?vid,
-                            our_count,
+                            our_next_seq,
                             ?observation,
                             "`IndexPanorama` doesn't match `state.panorama` for validator"
                         );
                         vec![]
                     }
-                    Observation::Correct(hash) => (their_count..our_count)
+                    Observation::Correct(hash) => (their_next_seq..our_next_seq)
                         .take(self.config.max_request_batch_size)
                         .filter_map(|seq_num| {
                             let unit = state.find_in_swimlane(hash, seq_num).unwrap();
@@ -859,9 +859,9 @@ where
                         }
 
                         (
-                            IndexObservation::Count(our_count),
-                            IndexObservation::Count(their_count),
-                        ) => self.batch_request(rng, vid, our_count, their_count),
+                            IndexObservation::NextSeq(our_next_seq),
+                            IndexObservation::NextSeq(their_next_seq),
+                        ) => self.batch_request(rng, vid, our_next_seq, their_next_seq),
                     }
                 };
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -665,7 +665,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                     Observation::Correct(hash) => (their_count..our_count)
                         .take(self.config.max_request_batch_size)
                         .filter_map(|seq_num| {
-                            let unit = state.find_ancestor_unit(hash, seq_num).unwrap();
+                            let unit = state.find_in_swimlane(hash, seq_num).unwrap();
                             state
                                 .wire_unit(unit, *self.highway.instance_id())
                                 .map(|swu| HighwayMessage::NewVertex(Vertex::Unit(swu)))


### PR DESCRIPTION
This addresses a few minor issues from https://github.com/casper-network/casper-node/pull/2062:
* The RNG is passed into the Highway protocol implementation instead of using `thread_rng`, to be in line with other modules.
* Requests for missing units start at `n + 1`, not `n`, if our latest unit is `n`.
* Deduplication of `find_in_swimlane` and `find_ancestor_unit`, which were equivalent.

Closes https://github.com/casper-network/casper-node/issues/2061