### PR TITLE
Make fast sync exit with codes to signal version upgrade or downgrade.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -7,6 +7,7 @@ use datasize::DataSize;
 
 use crate::types::BlockHeader;
 
+pub(crate) use error::LinearChainSyncError;
 pub(crate) use operations::run_fast_sync_task;
 
 #[derive(DataSize, Debug)]

--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -138,4 +138,16 @@ pub(crate) enum LinearChainSyncError {
     /// Error getting era validators from the execution engine.
     #[error(transparent)]
     GetEraValidatorsError(#[from] GetEraValidatorsError),
+
+    #[error("Stored block has unexpected parent hash. parent: {parent:?}, child: {child:?}")]
+    UnexpectedParentHash {
+        parent: Box<BlockHeader>,
+        child: Box<BlockHeader>,
+    },
+
+    #[error("Block has a lower version than its parent.")]
+    LowerVersionThanParent {
+        parent: Box<BlockHeader>,
+        child: Box<BlockHeader>,
+    },
 }

--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -76,6 +76,15 @@ pub(crate) enum LinearChainSyncError {
         block_header_with_future_version: Box<BlockHeader>,
     },
 
+    #[error(
+        "Current version is {current_version}, but current block header has older version: \
+         {block_header_with_old_version:?}"
+    )]
+    CurrentBlockHeaderHasOldVersion {
+        current_version: ProtocolVersion,
+        block_header_with_old_version: Box<BlockHeader>,
+    },
+
     #[error(transparent)]
     BlockFetcherError(#[from] FetcherError<Block, NodeId>),
 

--- a/node/src/components/linear_chain_sync/error.rs
+++ b/node/src/components/linear_chain_sync/error.rs
@@ -150,4 +150,7 @@ pub(crate) enum LinearChainSyncError {
         parent: Box<BlockHeader>,
         child: Box<BlockHeader>,
     },
+
+    #[error("Parent block has a height of u64::MAX.")]
+    HeightOverflow { parent: Box<BlockHeader> },
 }

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -312,7 +312,11 @@ where
     JoinerEvent: From<FetcherRequest<NodeId, I>>,
     LinearChainSyncError: From<FetcherError<I, NodeId>>,
 {
-    let height = parent_header.height() + 1;
+    let height = parent_header.height().checked_add(1).ok_or_else(|| {
+        LinearChainSyncError::HeightOverflow {
+            parent: Box::new(parent_header.clone()),
+        }
+    })?;
     let mut peers = effect_builder.get_peers_in_random_order().await.into_iter();
     let item = loop {
         let peer = match peers.next() {

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -239,6 +239,7 @@ async fn get_trusted_key_block_info(
         if let Some(key_block_info) =
             KeyBlockInfo::maybe_from_block_header(&current_header_to_walk_back_from)
         {
+            check_block_version(trusted_header, &key_block_info, chainspec)?;
             break Ok(key_block_info);
         }
 
@@ -506,9 +507,8 @@ async fn fast_sync_to_most_recent(
                     trusted_key_block_info = key_block_info;
                 }
             }
-            // If we could not fetch, we can stop when the most recent header:
-            // 1. has our protocol version
-            // 2. is in the current era
+            // If we could not fetch, we can stop when the most recent header is in the current
+            // era.
             None if is_current_era(
                 &most_recent_block_header,
                 &trusted_key_block_info,

--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -341,6 +341,7 @@ where
                         ?parent_header,
                         "received block with wrong parent from peer",
                     );
+                    effect_builder.announce_disconnect_from_peer(peer).await;
                     continue;
                 }
 
@@ -367,12 +368,12 @@ where
                 break item;
             }
             Err(FetcherError::Absent { .. }) => {
-                warn!(height, tag = ?I::TAG, ?peer, "Block by height absent from peer");
+                warn!(height, tag = ?I::TAG, ?peer, "block by height absent from peer");
                 // If the peer we requested doesn't have the item, continue with the next peer
                 continue;
             }
             Err(FetcherError::TimedOut { .. }) => {
-                warn!(height, tag = ?I::TAG, ?peer, "Peer timed out");
+                warn!(height, tag = ?I::TAG, ?peer, "peer timed out");
                 // Peer timed out fetching the item, continue with the next peer
                 continue;
             }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -486,7 +486,7 @@ impl reactor::Reactor for Reactor {
                             }) => {
                                 let future_version =
                                     block_header_with_future_version.protocol_version();
-                                info!(%current_version, %future_version, "Restarting for upgrade");
+                                info!(%current_version, %future_version, "restarting for upgrade");
                                 Some(JoinerEvent::Shutdown(ExitCode::Success))
                             }
                             Err(LinearChainSyncError::CurrentBlockHeaderHasOldVersion {
@@ -494,7 +494,7 @@ impl reactor::Reactor for Reactor {
                                 block_header_with_old_version,
                             }) => {
                                 let old_version = block_header_with_old_version.protocol_version();
-                                info!(%current_version, %old_version, "Restarting for downgrade");
+                                info!(%current_version, %old_version, "restarting for downgrade");
                                 Some(JoinerEvent::Shutdown(ExitCode::DowngradeVersion))
                             }
                             Err(error) => {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -30,7 +30,7 @@ use crate::{
         event_stream_server::{DeployGetter, EventStreamServer},
         fetcher::{self, Fetcher},
         gossiper::{self, Gossiper},
-        linear_chain_sync::{self, LinearChainSyncState},
+        linear_chain_sync::{self, LinearChainSyncError, LinearChainSyncState},
         metrics::Metrics,
         network::{self, Network, NetworkIdentity, ENABLE_LIBP2P_NET_ENV_VAR},
         rest_server::{self, RestServer},
@@ -60,8 +60,8 @@ use crate::{
         EventQueueHandle, Finalize, ReactorExit,
     },
     types::{
-        Block, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy, NodeId, Tag,
-        Timestamp,
+        Block, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy, ExitCode, NodeId,
+        Tag, Timestamp,
     },
     utils::{Source, WithDir},
     NodeRng,
@@ -74,6 +74,9 @@ use crate::{
 pub(crate) enum JoinerEvent {
     /// Finished joining event.
     FinishedJoining { block_header: Box<BlockHeader> },
+
+    /// Shut down with the given exit code.
+    Shutdown(ExitCode),
 
     /// Network event.
     #[from]
@@ -325,6 +328,9 @@ impl Display for JoinerEvent {
             JoinerEvent::FinishedJoining { block_header } => {
                 write!(f, "finished joining with block header: {}", block_header)
             }
+            JoinerEvent::Shutdown(exit_code) => {
+                write!(f, "shutting down with exit code: {:?}", exit_code)
+            }
         }
     }
 }
@@ -347,6 +353,8 @@ pub(crate) struct Reactor {
     block_by_height_fetcher: Fetcher<BlockWithMetadata>,
     block_header_by_hash_fetcher: Fetcher<BlockHeader>,
     block_header_and_finality_signatures_by_height_fetcher: Fetcher<BlockHeaderWithMetadata>,
+    /// This is set to `Some` if the node should shut down.
+    exit_code: Option<ExitCode>,
     // Handles request for fetching tries from the network.
     #[data_size(skip)]
     trie_fetcher: Fetcher<Trie<Key, StoredValue>>,
@@ -472,6 +480,23 @@ impl reactor::Reactor for Reactor {
                             Ok(block_header) => Some(JoinerEvent::FinishedJoining {
                                 block_header: Box::new(block_header),
                             }),
+                            Err(LinearChainSyncError::RetrievedBlockHeaderFromFutureVersion {
+                                current_version,
+                                block_header_with_future_version,
+                            }) => {
+                                let future_version =
+                                    block_header_with_future_version.protocol_version();
+                                info!(%current_version, %future_version, "Restarting for upgrade");
+                                Some(JoinerEvent::Shutdown(ExitCode::Success))
+                            }
+                            Err(LinearChainSyncError::CurrentBlockHeaderHasOldVersion {
+                                current_version,
+                                block_header_with_old_version,
+                            }) => {
+                                let old_version = block_header_with_old_version.protocol_version();
+                                info!(%current_version, %old_version, "Restarting for downgrade");
+                                Some(JoinerEvent::Shutdown(ExitCode::DowngradeVersion))
+                            }
                             Err(error) => {
                                 fatal!(effect_builder, "{:?}", error).await;
                                 None
@@ -533,6 +558,7 @@ impl reactor::Reactor for Reactor {
                 block_by_height_fetcher,
                 block_header_by_hash_fetcher,
                 block_header_and_finality_signatures_by_height_fetcher,
+                exit_code: None,
                 deploy_acceptor,
                 event_queue_metrics,
                 rest_server,
@@ -886,11 +912,17 @@ impl reactor::Reactor for Reactor {
                 self.linear_chain_sync = LinearChainSyncState::Done(block_header);
                 Effects::new()
             }
+            JoinerEvent::Shutdown(exit_code) => {
+                self.exit_code = Some(exit_code);
+                Effects::new()
+            }
         }
     }
 
     fn maybe_exit(&self) -> Option<ReactorExit> {
-        if self.linear_chain_sync.is_synced() {
+        if let Some(exit_code) = self.exit_code {
+            Some(ReactorExit::ProcessShouldExit(exit_code))
+        } else if self.linear_chain_sync.is_synced() {
             Some(ReactorExit::ProcessShouldContinue)
         } else {
             None

--- a/node/src/types/exit_code.rs
+++ b/node/src/types/exit_code.rs
@@ -1,4 +1,5 @@
 use datasize::DataSize;
+use serde::{Deserialize, Serialize};
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
 
 /// The offset Rust uses by default when generating an exit code after being interrupted by a
@@ -9,7 +10,7 @@ const SIGNAL_OFFSET: u8 = 128;
 /// reactor to the binary.
 ///
 /// Note that a panic will result in the Rust process producing an exit code of 101.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, DataSize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, DataSize, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ExitCode {
     /// The process should exit with success.  The launcher should proceed to run the next


### PR DESCRIPTION
Makes the process exit with the codes that signal to the launcher whether to upgrade or downgrade.

Closes #1966.