### PR TITLE
Improve error reporting in validation tool

### DIFF
--- a/utils/validation/src/error.rs
+++ b/utils/validation/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 use casper_types::bytesrepr;
 
+use crate::test_case;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -18,6 +20,8 @@ pub enum Error {
     NoExtension(PathBuf),
     #[error("{0}")]
     Bytesrepr(bytesrepr::Error),
+    #[error(transparent)]
+    TestCase(#[from] test_case::Error),
 }
 
 impl From<bytesrepr::Error> for Error {

--- a/utils/validation/src/test_case.rs
+++ b/utils/validation/src/test_case.rs
@@ -1,4 +1,5 @@
 use casper_types::bytesrepr;
+use hex::FromHexError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -9,6 +10,12 @@ pub enum Error {
     DataMismatch { expected: Vec<u8>, actual: Vec<u8> },
     #[error("length mismatch expected {expected} != actual {actual}")]
     LengthMismatch { expected: usize, actual: usize },
+    #[error("expected JSON string in output field")]
+    WrongOutputType,
+    #[error("not a valid hex string")]
+    Hex(#[from] FromHexError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 }
 
 impl From<bytesrepr::Error> for Error {


### PR DESCRIPTION
Closes #1988 

This PR improves error reporting in a validation tool. This change will make parsing the data structures lazy, and possible errors will be reported when a test case is run instead of failing at parsing time without running any valid test cases.