### PR TITLE
No tick nctl storage path fix

### DIFF
--- a/utils/global-state-update-gen/src/main.rs
+++ b/utils/global-state-update-gen/src/main.rs
@@ -118,6 +118,15 @@ fn main() {
                         .help("Data storage directory containing the global state database file")
                         .takes_value(true)
                         .required(true),
+                )
+                .arg(
+                    Arg::with_name("hash")
+                        .short("s")
+                        .long("state-hash")
+                        .value_name("HEX_STRING")
+                        .help("The global state hash to be used as the base")
+                        .takes_value(true)
+                        .required(false),
                 ),
         )
         .get_matches();

--- a/utils/global-state-update-gen/src/system_contract_registry.rs
+++ b/utils/global-state-update-gen/src/system_contract_registry.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use clap::ArgMatches;
 use lmdb::{self, Cursor, Environment, EnvironmentFlags, Transaction};
 
+use casper_engine_test_support::internal::LmdbWasmTestBuilder;
 use casper_execution_engine::core::engine_state::genesis::SystemContractRegistry;
 use casper_types::{
     bytesrepr::FromBytes,
@@ -10,12 +11,19 @@ use casper_types::{
     CLValue, ContractHash, Key, StoredValue, KEY_HASH_LENGTH,
 };
 
-use crate::utils::print_entry;
+use crate::utils::{hash_from_str, print_entry};
 
 const DATABASE_NAME: &str = "PROTOCOL_DATA_STORE";
 
 pub(crate) fn generate_system_contract_registry(matches: &ArgMatches<'_>) {
     let data_dir = Path::new(matches.value_of("data_dir").unwrap_or("."));
+    match matches.value_of("hash") {
+        None => generate_system_contract_registry_using_protocol_data(data_dir),
+        Some(hash) => generate_system_contract_registry_using_global_state(data_dir, hash),
+    }
+}
+
+fn generate_system_contract_registry_using_protocol_data(data_dir: &Path) {
     let database_path = data_dir.join("data.lmdb");
 
     let env = Environment::new()
@@ -81,6 +89,27 @@ pub(crate) fn generate_system_contract_registry(matches: &ArgMatches<'_>) {
         )
     });
     assert!(remainder.is_empty());
+
+    let mut registry = SystemContractRegistry::new();
+    registry.insert(MINT.to_string(), mint_hash);
+    registry.insert(HANDLE_PAYMENT.to_string(), handle_payment_hash);
+    registry.insert(STANDARD_PAYMENT.to_string(), standard_payment_hash);
+    registry.insert(AUCTION.to_string(), auction_hash);
+
+    print_entry(
+        &Key::SystemContractRegistry,
+        &StoredValue::from(CLValue::from_t(registry).unwrap()),
+    );
+}
+
+fn generate_system_contract_registry_using_global_state(data_dir: &Path, state_hash: &str) {
+    let builder =
+        LmdbWasmTestBuilder::open_raw(data_dir, Default::default(), hash_from_str(state_hash));
+
+    let mint_hash = builder.get_system_mint_hash();
+    let handle_payment_hash = builder.get_system_handle_payment_hash();
+    let standard_payment_hash = builder.get_system_standard_payment_hash();
+    let auction_hash = builder.get_system_auction_hash();
 
     let mut registry = SystemContractRegistry::new();
     registry.insert(MINT.to_string(), mint_hash);

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -445,7 +445,6 @@ function setup_asset_global_state_toml() {
         if [ "$(echo $PROTOCOL_VERSION | tr -d '_')" -ge "140" ]; then
             # Check new data.lmdb path under ..storage/<chain_name>/
             if [ -f "$PATH_TO_NET/nodes/node-$IDX/storage/$(get_chain_name)/data.lmdb" ]; then
-                echo "GLOBAL_STATE_OUTPUT=$NCTL_CASPER_HOME/target/$NCTL_COMPILE_TARGET/global-state-update-gen system-contract-registry -d $PATH_TO_NET/nodes/node-$IDX/storage/$(get_chain_name)"
                 GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
                         system-contract-registry -d "$PATH_TO_NET"/nodes/node-"$IDX"/storage/"$(get_chain_name)")
             else

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -438,6 +438,7 @@ function setup_asset_global_state_toml() {
     local PATH_TO_NET
 
     PATH_TO_NET="$(get_path_to_net)"
+
     for IDX in $(seq 1 "$COUNT_NODES")
     do
         # if the combined integers from the PROTOCOL_VERISON >= 140 ( 1_4_0 )

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -446,10 +446,10 @@ function setup_asset_global_state_toml() {
             # Check new data.lmdb path under ..storage/<chain_name>/
             if [ -f "$PATH_TO_NET/nodes/node-$IDX/storage/$(get_chain_name)/data.lmdb" ]; then
                 GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
-                        system-contract-registry -d "$PATH_TO_NET"/nodes/node-"$IDX"/storage/"$(get_chain_name)")
+                        system-contract-registry -d "$PATH_TO_NET"/nodes/node-"$IDX"/storage/"$(get_chain_name)" -s "$(nctl-view-chain-state-root-hash node=$IDX | awk '{ print $12 }')")
             else
                 GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
-                        system-contract-registry -d "$PATH_TO_NET"/nodes/node-1/storage/"$(get_chain_name)")
+                        system-contract-registry -d "$PATH_TO_NET"/nodes/node-1/storage/"$(get_chain_name)" -s "$(nctl-view-chain-state-root-hash node=1 | awk '{ print $12 }')")
             fi
         else
 


### PR DESCRIPTION
Changes:
- moves path for data.lmdb for version >= 1.4.0
- Updates the functionailty for `global-state-update-gen`, where `system-contract-registry` takes an optional argument `state-hash` which fetches system contract hashes from the trie store as opposed to the protocol data DB
