### PR TITLE
Add REST server schema test

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -67,7 +67,7 @@ rand = "0.8.3"
 rand_chacha = "0.3.0"
 regex = "1"
 rmp-serde = "0.14.4"
-schemars = { version = "0.8.0", features = ["preserve_order"] }
+schemars = { version = "0.8.0", features = ["preserve_order", "impl_json_schema"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde-big-array = "0.3.0"
 serde_bytes = "0.11.5"

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -188,3 +188,30 @@ impl Finalize for RestServer {
         .boxed()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use assert_json_diff::assert_json_eq;
+    use schemars::schema_for;
+    use serde_json::Value;
+
+    use crate::types::GetStatusResult;
+
+    #[test]
+    fn schema_status() {
+        let schema_path = format!(
+            "{}/../resources/test/rest_schema_status.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let expected_schema = fs::read_to_string(schema_path).unwrap();
+        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
+
+        let actual_schema = schema_for!(GetStatusResult);
+        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
+        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+
+        assert_json_eq!(actual_schema, expected_schema);
+    }
+}

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -194,7 +194,7 @@ mod tests {
     use std::fs;
 
     use assert_json_diff::assert_json_eq;
-    use schemars::schema_for;
+    use schemars::{schema_for, JsonSchema};
     use serde_json::Value;
 
     use crate::{
@@ -202,20 +202,24 @@ mod tests {
         types::GetStatusResult,
     };
 
+    fn assert_schema<T: JsonSchema>(schema_path: String) {
+        let expected_schema = fs::read_to_string(schema_path).unwrap();
+        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
+
+        let actual_schema = schema_for!(T);
+        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
+        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+
+        assert_json_eq!(actual_schema, expected_schema);
+    }
+
     #[test]
     fn schema_status() {
         let schema_path = format!(
             "{}/../resources/test/rest_schema_status.json",
             env!("CARGO_MANIFEST_DIR")
         );
-        let expected_schema = fs::read_to_string(schema_path).unwrap();
-        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
-
-        let actual_schema = schema_for!(GetStatusResult);
-        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
-        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
-
-        assert_json_eq!(actual_schema, expected_schema);
+        assert_schema::<GetStatusResult>(schema_path);
     }
 
     #[test]
@@ -224,14 +228,7 @@ mod tests {
             "{}/../resources/test/rest_schema_validator_changes.json",
             env!("CARGO_MANIFEST_DIR")
         );
-        let expected_schema = fs::read_to_string(schema_path).unwrap();
-        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
-
-        let actual_schema = schema_for!(GetValidatorChangesResult);
-        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
-        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
-
-        assert_json_eq!(actual_schema, expected_schema);
+        assert_schema::<GetValidatorChangesResult>(schema_path);
     }
 
     #[test]
@@ -240,13 +237,6 @@ mod tests {
             "{}/../resources/test/rest_schema_rpc_schema.json",
             env!("CARGO_MANIFEST_DIR")
         );
-        let expected_schema = fs::read_to_string(schema_path).unwrap();
-        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
-
-        let actual_schema = schema_for!(OpenRpcSchema);
-        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
-        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
-
-        assert_json_eq!(actual_schema, expected_schema);
+        assert_schema::<OpenRpcSchema>(schema_path);
     }
 }

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -197,7 +197,10 @@ mod tests {
     use schemars::schema_for;
     use serde_json::Value;
 
-    use crate::{rpcs::info::GetValidatorChangesResult, types::GetStatusResult};
+    use crate::{
+        rpcs::{docs::OpenRpcSchema, info::GetValidatorChangesResult},
+        types::GetStatusResult,
+    };
 
     #[test]
     fn schema_status() {
@@ -225,6 +228,22 @@ mod tests {
         let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
 
         let actual_schema = schema_for!(GetValidatorChangesResult);
+        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
+        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+
+        assert_json_eq!(actual_schema, expected_schema);
+    }
+
+    #[test]
+    fn schema_rpc_schema() {
+        let schema_path = format!(
+            "{}/../resources/test/rest_schema_rpc_schema.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let expected_schema = fs::read_to_string(schema_path).unwrap();
+        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
+
+        let actual_schema = schema_for!(OpenRpcSchema);
         let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
         let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -197,7 +197,7 @@ mod tests {
     use schemars::schema_for;
     use serde_json::Value;
 
-    use crate::types::GetStatusResult;
+    use crate::{rpcs::info::GetValidatorChangesResult, types::GetStatusResult};
 
     #[test]
     fn schema_status() {
@@ -209,6 +209,22 @@ mod tests {
         let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
 
         let actual_schema = schema_for!(GetStatusResult);
+        let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
+        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+
+        assert_json_eq!(actual_schema, expected_schema);
+    }
+
+    #[test]
+    fn schema_validator_changes() {
+        let schema_path = format!(
+            "{}/../resources/test/rest_schema_validator_changes.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let expected_schema = fs::read_to_string(schema_path).unwrap();
+        let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
+
+        let actual_schema = schema_for!(GetValidatorChangesResult);
         let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
         let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -117,7 +117,7 @@ pub trait DocExample {
 
 /// The main schema for the casper node's RPC server, compliant with
 /// [the OpenRPC Specification](https://spec.open-rpc.org).
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct OpenRpcSchema {
     openrpc: String,
     info: OpenRpcInfoField,
@@ -288,7 +288,7 @@ impl OpenRpcSchema {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct OpenRpcInfoField {
     version: String,
     title: String,
@@ -297,26 +297,26 @@ struct OpenRpcInfoField {
     license: OpenRpcLicenseField,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct OpenRpcContactField {
     name: String,
     url: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct OpenRpcLicenseField {
     name: String,
     url: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct OpenRpcServerEntry {
     name: String,
     url: String,
 }
 
 /// The struct containing the documentation for the RPCs.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct Method {
     name: String,
     summary: String,
@@ -325,21 +325,21 @@ pub struct Method {
     examples: Vec<Example>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct SchemaParam {
     name: String,
     schema: Schema,
     required: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct ResponseResult {
     name: String,
     schema: Schema,
 }
 
 /// An example pair of request params and response result.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct Example {
     name: String,
     params: Vec<ExampleParam>,
@@ -393,19 +393,19 @@ impl Example {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct ExampleParam {
     name: String,
     value: Value,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct ExampleResult {
     name: String,
     value: Value,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 struct Components {
     schemas: Map<String, Schema>,
 }

--- a/resources/test/rest_schema_rpc_schema.json
+++ b/resources/test/rest_schema_rpc_schema.json
@@ -1,0 +1,642 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenRpcSchema",
+  "description": "The main schema for the casper node's RPC server, compliant with [the OpenRPC Specification](https://spec.open-rpc.org).",
+  "type": "object",
+  "required": [
+    "components",
+    "info",
+    "methods",
+    "openrpc",
+    "servers"
+  ],
+  "properties": {
+    "openrpc": {
+      "type": "string"
+    },
+    "info": {
+      "$ref": "#/definitions/OpenRpcInfoField"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/OpenRpcServerEntry"
+      }
+    },
+    "methods": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Method"
+      }
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "definitions": {
+    "OpenRpcInfoField": {
+      "type": "object",
+      "required": [
+        "contact",
+        "description",
+        "license",
+        "title",
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "contact": {
+          "$ref": "#/definitions/OpenRpcContactField"
+        },
+        "license": {
+          "$ref": "#/definitions/OpenRpcLicenseField"
+        }
+      }
+    },
+    "OpenRpcContactField": {
+      "type": "object",
+      "required": [
+        "name",
+        "url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "OpenRpcLicenseField": {
+      "type": "object",
+      "required": [
+        "name",
+        "url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "OpenRpcServerEntry": {
+      "type": "object",
+      "required": [
+        "name",
+        "url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "Method": {
+      "description": "The struct containing the documentation for the RPCs.",
+      "type": "object",
+      "required": [
+        "examples",
+        "name",
+        "params",
+        "result",
+        "summary"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SchemaParam"
+          }
+        },
+        "result": {
+          "$ref": "#/definitions/ResponseResult"
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Example"
+          }
+        }
+      }
+    },
+    "SchemaParam": {
+      "type": "object",
+      "required": [
+        "name",
+        "required",
+        "schema"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/Schema"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Schema": {
+      "description": "A JSON Schema.",
+      "anyOf": [
+        {
+          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false` matches nothing (always fails validation).",
+          "type": "boolean"
+        },
+        {
+          "description": "A JSON Schema object.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaObject"
+            }
+          ]
+        }
+      ]
+    },
+    "SchemaObject": {
+      "description": "A JSON Schema object.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SingleOrVec_for_InstanceType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "format": {
+          "description": "The `format` keyword.\n\nSee [JSON Schema Validation 7. A Vocabulary for Semantic Content With \"format\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-7).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "description": "The `enum` keyword.\n\nSee [JSON Schema Validation 6.1.2. \"enum\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.2)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": true
+        },
+        "const": {
+          "description": "The `const` keyword.\n\nSee [JSON Schema Validation 6.1.3. \"const\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.3)"
+        },
+        "$ref": {
+          "description": "The `$ref` keyword.\n\nSee [JSON Schema 8.2.4.1. Direct References with \"$ref\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.4.1).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "$id": {
+          "description": "The `$id` keyword.\n\nSee [JSON Schema 8.2.2. The \"$id\" Keyword](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.2).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "The `title` keyword.\n\nSee [JSON Schema Validation 9.1. \"title\" and \"description\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.1).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "The `description` keyword.\n\nSee [JSON Schema Validation 9.1. \"title\" and \"description\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.1).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default": {
+          "description": "The `default` keyword.\n\nSee [JSON Schema Validation 9.2. \"default\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.2)."
+        },
+        "deprecated": {
+          "description": "The `deprecated` keyword.\n\nSee [JSON Schema Validation 9.3. \"deprecated\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.3).",
+          "type": "boolean"
+        },
+        "readOnly": {
+          "description": "The `readOnly` keyword.\n\nSee [JSON Schema Validation 9.4. \"readOnly\" and \"writeOnly\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.4).",
+          "type": "boolean"
+        },
+        "writeOnly": {
+          "description": "The `writeOnly` keyword.\n\nSee [JSON Schema Validation 9.4. \"readOnly\" and \"writeOnly\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.4).",
+          "type": "boolean"
+        },
+        "examples": {
+          "description": "The `examples` keyword.\n\nSee [JSON Schema Validation 9.5. \"examples\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-9.5).",
+          "type": "array",
+          "items": true
+        },
+        "allOf": {
+          "description": "The `allOf` keyword.\n\nSee [JSON Schema 9.2.1.1. \"allOf\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.1.1).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "anyOf": {
+          "description": "The `anyOf` keyword.\n\nSee [JSON Schema 9.2.1.2. \"anyOf\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.1.2).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "oneOf": {
+          "description": "The `oneOf` keyword.\n\nSee [JSON Schema 9.2.1.3. \"oneOf\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.1.3).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "not": {
+          "description": "The `not` keyword.\n\nSee [JSON Schema 9.2.1.4. \"not\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.1.4).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "if": {
+          "description": "The `if` keyword.\n\nSee [JSON Schema 9.2.2.1. \"if\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.2.1).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "then": {
+          "description": "The `then` keyword.\n\nSee [JSON Schema 9.2.2.2. \"then\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.2.2).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "else": {
+          "description": "The `else` keyword.\n\nSee [JSON Schema 9.2.2.3. \"else\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.2.3).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multipleOf": {
+          "description": "The `multipleOf` keyword.\n\nSee [JSON Schema Validation 6.2.1. \"multipleOf\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.2.1).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "maximum": {
+          "description": "The `maximum` keyword.\n\nSee [JSON Schema Validation 6.2.2. \"maximum\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.2.2).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "exclusiveMaximum": {
+          "description": "The `exclusiveMaximum` keyword.\n\nSee [JSON Schema Validation 6.2.3. \"exclusiveMaximum\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.2.3).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "minimum": {
+          "description": "The `minimum` keyword.\n\nSee [JSON Schema Validation 6.2.4. \"minimum\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.2.4).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "exclusiveMinimum": {
+          "description": "The `exclusiveMinimum` keyword.\n\nSee [JSON Schema Validation 6.2.5. \"exclusiveMinimum\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.2.5).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "maxLength": {
+          "description": "The `maxLength` keyword.\n\nSee [JSON Schema Validation 6.3.1. \"maxLength\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.3.1).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "minLength": {
+          "description": "The `minLength` keyword.\n\nSee [JSON Schema Validation 6.3.2. \"minLength\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.3.2).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "pattern": {
+          "description": "The `pattern` keyword.\n\nSee [JSON Schema Validation 6.3.3. \"pattern\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.3.3).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "description": "The `items` keyword.\n\nSee [JSON Schema 9.3.1.1. \"items\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.1.1).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SingleOrVec_for_Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "additionalItems": {
+          "description": "The `additionalItems` keyword.\n\nSee [JSON Schema 9.3.1.2. \"additionalItems\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.1.2).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxItems": {
+          "description": "The `maxItems` keyword.\n\nSee [JSON Schema Validation 6.4.1. \"maxItems\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.4.1).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "minItems": {
+          "description": "The `minItems` keyword.\n\nSee [JSON Schema Validation 6.4.2. \"minItems\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.4.2).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "uniqueItems": {
+          "description": "The `uniqueItems` keyword.\n\nSee [JSON Schema Validation 6.4.3. \"uniqueItems\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.4.3).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "contains": {
+          "description": "The `contains` keyword.\n\nSee [JSON Schema 9.3.1.4. \"contains\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.1.4).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxProperties": {
+          "description": "The `maxProperties` keyword.\n\nSee [JSON Schema Validation 6.5.1. \"maxProperties\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.5.1).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "minProperties": {
+          "description": "The `minProperties` keyword.\n\nSee [JSON Schema Validation 6.5.2. \"minProperties\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.5.2).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "The `required` keyword.\n\nSee [JSON Schema Validation 6.5.3. \"required\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.5.3).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "description": "The `properties` keyword.\n\nSee [JSON Schema 9.3.2.1. \"properties\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.1).",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "patternProperties": {
+          "description": "The `patternProperties` keyword.\n\nSee [JSON Schema 9.3.2.2. \"patternProperties\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.2).",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "additionalProperties": {
+          "description": "The `additionalProperties` keyword.\n\nSee [JSON Schema 9.3.2.3. \"additionalProperties\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.3).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "propertyNames": {
+          "description": "The `propertyNames` keyword.\n\nSee [JSON Schema 9.3.2.5. \"propertyNames\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.5).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "SingleOrVec_for_InstanceType": {
+      "description": "A type which can be serialized as a single item, or multiple items.\n\nIn some contexts, a `Single` may be semantically distinct from a `Vec` containing only item.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/InstanceType"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceType"
+          }
+        }
+      ]
+    },
+    "InstanceType": {
+      "description": "The possible types of values in JSON Schema documents.\n\nSee [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+      "type": "string",
+      "enum": [
+        "null",
+        "boolean",
+        "object",
+        "array",
+        "number",
+        "string",
+        "integer"
+      ]
+    },
+    "SingleOrVec_for_Schema": {
+      "description": "A type which can be serialized as a single item, or multiple items.\n\nIn some contexts, a `Single` may be semantically distinct from a `Vec` containing only item.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Schema"
+          }
+        }
+      ]
+    },
+    "ResponseResult": {
+      "type": "object",
+      "required": [
+        "name",
+        "schema"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/Schema"
+        }
+      }
+    },
+    "Example": {
+      "description": "An example pair of request params and response result.",
+      "type": "object",
+      "required": [
+        "name",
+        "params",
+        "result"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExampleParam"
+          }
+        },
+        "result": {
+          "$ref": "#/definitions/ExampleResult"
+        }
+      }
+    },
+    "ExampleParam": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": true
+      }
+    },
+    "ExampleResult": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": true
+      }
+    },
+    "Components": {
+      "type": "object",
+      "required": [
+        "schemas"
+      ],
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        }
+      }
+    }
+  }
+}

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -1,0 +1,218 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetStatusResult",
+    "description": "Result for \"info_get_status\" RPC response.",
+    "type": "object",
+    "required": [
+      "api_version",
+      "build_version",
+      "chainspec_name",
+      "peers",
+      "starting_state_root_hash",
+      "uptime"
+    ],
+    "properties": {
+      "api_version": {
+        "description": "The RPC API version.",
+        "type": "string"
+      },
+      "chainspec_name": {
+        "description": "The chainspec name.",
+        "type": "string"
+      },
+      "starting_state_root_hash": {
+        "description": "The state root hash used at the start of the current session.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Digest"
+          }
+        ]
+      },
+      "peers": {
+        "description": "The node ID and network address of each connected peer.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PeersMap"
+          }
+        ]
+      },
+      "last_added_block_info": {
+        "description": "The minimal info of the last block from the linear chain.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/MinimalBlockInfo"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "our_public_signing_key": {
+        "description": "Our public signing key.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/PublicKey"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "round_length": {
+        "description": "The next round length if this node is a validator.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/TimeDiff"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "next_upgrade": {
+        "description": "Information about the next scheduled upgrade.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/NextUpgrade"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "build_version": {
+        "description": "The compiled node version.",
+        "type": "string"
+      },
+      "uptime": {
+        "description": "Time that passed since the node has started.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/TimeDiff"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Digest": {
+        "description": "Hex-encoded hash digest.",
+        "type": "string"
+      },
+      "PeersMap": {
+        "description": "Map of peer IDs to network addresses.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/PeerEntry"
+        }
+      },
+      "PeerEntry": {
+        "type": "object",
+        "required": [
+          "address",
+          "node_id"
+        ],
+        "properties": {
+          "node_id": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinimalBlockInfo": {
+        "description": "Minimal info of a `Block`.",
+        "type": "object",
+        "required": [
+          "creator",
+          "era_id",
+          "hash",
+          "height",
+          "state_root_hash",
+          "timestamp"
+        ],
+        "properties": {
+          "hash": {
+            "$ref": "#/definitions/BlockHash"
+          },
+          "timestamp": {
+            "$ref": "#/definitions/Timestamp"
+          },
+          "era_id": {
+            "$ref": "#/definitions/EraId"
+          },
+          "height": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "state_root_hash": {
+            "$ref": "#/definitions/Digest"
+          },
+          "creator": {
+            "$ref": "#/definitions/PublicKey"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlockHash": {
+        "description": "A cryptographic hash identifying a [`Block`](struct.Block.html).",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Digest"
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "Timestamp formatted as per RFC 3339",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "EraId": {
+        "description": "Era ID newtype.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "PublicKey": {
+        "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+        "type": "string"
+      },
+      "TimeDiff": {
+        "description": "Human-readable duration.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "NextUpgrade": {
+        "description": "Information about the next protocol upgrade.",
+        "type": "object",
+        "required": [
+          "activation_point",
+          "protocol_version"
+        ],
+        "properties": {
+          "activation_point": {
+            "$ref": "#/definitions/ActivationPoint"
+          },
+          "protocol_version": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivationPoint": {
+        "description": "The first era to which the associated protocol version applies.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/EraId"
+          },
+          {
+            "$ref": "#/definitions/Timestamp"
+          }
+        ]
+      }
+    }
+  }

--- a/resources/test/rest_schema_validator_changes.json
+++ b/resources/test/rest_schema_validator_changes.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetValidatorChangesResult",
+    "description": "Result for the \"info_get_validator_changes\" RPC.",
+    "type": "object",
+    "required": [
+      "api_version",
+      "changes"
+    ],
+    "properties": {
+      "api_version": {
+        "description": "The RPC API version.",
+        "type": "string"
+      },
+      "changes": {
+        "description": "The validators' status changes.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/JsonValidatorChanges"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "JsonValidatorChanges": {
+        "description": "The changes in a validator's status.",
+        "type": "object",
+        "required": [
+          "public_key",
+          "status_changes"
+        ],
+        "properties": {
+          "public_key": {
+            "description": "The public key of the validator.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/PublicKey"
+              }
+            ]
+          },
+          "status_changes": {
+            "description": "The set of changes to the validator's status.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/JsonValidatorStatusChange"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PublicKey": {
+        "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+        "type": "string"
+      },
+      "JsonValidatorStatusChange": {
+        "description": "A single change to a validator's status in the given era.",
+        "type": "object",
+        "required": [
+          "era_id",
+          "validator_change"
+        ],
+        "properties": {
+          "era_id": {
+            "description": "The era in which the change occurred.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/EraId"
+              }
+            ]
+          },
+          "validator_change": {
+            "description": "The change in validator status.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ValidatorChange"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "EraId": {
+        "description": "Era ID newtype.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "ValidatorChange": {
+        "description": "A change to a validator's status between two eras.",
+        "type": "string",
+        "enum": [
+          "Added",
+          "Removed",
+          "Banned",
+          "CannotPropose",
+          "SeenAsFaulty"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
This PR adds tests for checking if the Json responses returned from the following REST API paths respect the expected schema:
* `/status`
* `/validator-changes`
* `/rpc-schema`

Closes #2145.