### PR TITLE
Backport fix to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ lint: lint-contracts-rs
 
 .PHONY: audit
 audit:
-	$(CARGO) audit
+	$(CARGO) audit --ignore RUSTSEC-2020-0071
 
 .PHONY: doc
 doc:


### PR DESCRIPTION
CHANGELOG:

    Add ignore RUSTSEC-2020-0071 to Makefile

Closes #2220