### PR TITLE
Add additional logging to linear sync

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -401,12 +401,11 @@ where
                 transfers,
                 responder,
             } => {
-                trace!(
+                let block_height = finalized_block.height();
+                info!(
                     ?protocol_version,
-                    ?execution_pre_state,
-                    ?finalized_block,
-                    ?deploys,
-                    "execute block request"
+                    %block_height,
+                    "executing block"
                 );
                 let engine_state = Arc::clone(&self.engine_state);
                 let metrics = Arc::clone(&self.metrics);
@@ -420,7 +419,7 @@ where
                         deploys,
                         transfers,
                     );
-                    trace!(?result, "execute block response");
+                    info!(?protocol_version, %block_height, "finished executing block");
                     responder.respond(result).await
                 })
                 .ignore()


### PR DESCRIPTION
CHANGELOG:

- Port logging changes made to `linear_chain_sync` and `contract_runtime` from the `1.3.4` to `1.4.0`


Closes #2224 
