### PR TITLE
Add ignore for RUSTSEC-2020-0159

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ lint: lint-contracts-rs
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2020-0071
+	$(CARGO) audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
 
 .PHONY: doc
 doc:


### PR DESCRIPTION
CHANGELOG:

- Added an ignore for RUSTSEC-2020-0159 to the audit command in the `Makefile`


Closes: #2228 
