### PR TITLE
Only upgrade after making sure the switch block was stored. (1.3.4 backport)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2021-0098 --ignore RUSTSEC-2021-0097 --ignore RUSTSEC-2021-0115 --ignore RUSTSEC-2020-0071
+	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2021-0098 --ignore RUSTSEC-2021-0097 --ignore RUSTSEC-2021-0115 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2021-0098 --ignore RUSTSEC-2021-0097 --ignore RUSTSEC-2021-0115
-
+	$(CARGO) audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2021-0098 --ignore RUSTSEC-2021-0097 --ignore RUSTSEC-2021-0115 --ignore RUSTSEC-2020-0071
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -49,6 +49,8 @@ use crate::{
 
 pub(crate) use cl_context::ClContext;
 pub use config::Config;
+#[cfg(test)]
+pub(crate) use config::ProtocolConfig;
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
 pub(crate) use protocols::highway::HighwayProtocol;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -798,21 +798,37 @@ where
             trace!(era = era_id.value(), "executed block in old era");
             return effects;
         }
-        if block_header.is_switch_block() && !self.should_upgrade_after(&era_id) {
-            // if the block is a switch block, we have to get the validators for the new era and
-            // create it, before we can say we handled the block
-            let new_era_id = era_id.successor();
-            let effect = get_booking_block_hash(
-                self.effect_builder,
-                new_era_id,
-                self.era_supervisor.protocol_config.auction_delay,
-                self.era_supervisor.protocol_config.last_activation_point,
-            )
-            .event(move |booking_block_hash| Event::CreateNewEra {
-                switch_block_header: Box::new(block_header),
-                booking_block_hash: Ok(booking_block_hash),
-            });
-            effects.extend(effect);
+        if block_header.is_switch_block() {
+            if let Some(era) = self.era_supervisor.active_eras.get_mut(&era_id) {
+                // This was the era's last block. Schedule deactivating this era.
+                let delay = Timestamp::now()
+                    .saturating_diff(block_header.timestamp())
+                    .into();
+                let faulty_num = era.consensus.validators_with_evidence().len();
+                let deactivate_era = move |_| Event::DeactivateEra {
+                    era_id,
+                    faulty_num,
+                    delay,
+                };
+                effects.extend(self.effect_builder.set_timeout(delay).event(deactivate_era));
+            } else {
+                error!(era = era_id.value(), %block_header, "executed block in uninitialized era");
+            }
+            // If it's not the last block before an upgrade, initialize the next era.
+            if !self.should_upgrade_after(&era_id) {
+                let new_era_id = era_id.successor();
+                let effect = get_booking_block_hash(
+                    self.effect_builder,
+                    new_era_id,
+                    self.era_supervisor.protocol_config.auction_delay,
+                    self.era_supervisor.protocol_config.last_activation_point,
+                )
+                .event(move |booking_block_hash| Event::CreateNewEra {
+                    switch_block_header: Box::new(block_header),
+                    booking_block_hash: Ok(booking_block_hash),
+                });
+                effects.extend(effect);
+            }
         }
         effects
     }
@@ -1111,17 +1127,6 @@ where
                     .era_supervisor
                     .next_block_height
                     .max(finalized_block.height() + 1);
-                if finalized_block.era_report().is_some() {
-                    // This was the era's last block. Schedule deactivating this era.
-                    let delay = Timestamp::now().saturating_diff(timestamp).into();
-                    let faulty_num = era.consensus.validators_with_evidence().len();
-                    let deactivate_era = move |_| Event::DeactivateEra {
-                        era_id,
-                        faulty_num,
-                        delay,
-                    };
-                    effects.extend(self.effect_builder.set_timeout(delay).event(deactivate_era));
-                }
                 // Request execution of the finalized block.
                 effects.extend(self.effect_builder.execute_block(finalized_block).ignore());
                 self.era_supervisor.update_consensus_pause();

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -588,6 +588,11 @@ where
             .consensus
             .validators_with_evidence()
     }
+
+    /// Returns this node's validator key.
+    pub(crate) fn public_key(&self) -> &PublicKey {
+        &self.public_signing_key
+    }
 }
 
 /// Returns an era ID in which the booking block for `era_id` lives, if we can use it.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -294,7 +294,7 @@ struct AllocatedMem {
 
 /// A runner for a reactor.
 ///
-/// The runner manages a reactors event queue and reactor itself and can run it either continuously
+/// The runner manages a reactor's event queue and reactor itself and can run it either continuously
 /// or in a step-by-step manner.
 #[derive(Debug)]
 pub struct Runner<R>

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -1,11 +1,13 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use anyhow::bail;
+use either::Either;
 use log::info;
 use num::Zero;
 use num_rational::Ratio;
 use rand::Rng;
 use tempfile::TempDir;
+use tokio::time;
 
 use casper_execution_engine::shared::motes::Motes;
 use casper_types::{system::auction::DelegationRate, EraId, PublicKey, SecretKey, U512};
@@ -13,8 +15,15 @@ use casper_types::{system::auction::DelegationRate, EraId, PublicKey, SecretKey,
 use crate::{
     components::{consensus, gossiper, small_network, storage},
     crypto::AsymmetricKeyExt,
-    reactor::{initializer, joiner, participating, ReactorExit, Runner},
-    testing::{self, network::Network, TestRng},
+    effect::EffectExt,
+    reactor::{
+        initializer, joiner,
+        participating::{self, Event as ParticipatingEvent},
+        ReactorExit, Runner,
+    },
+    testing::{
+        self, filter_reactor::FilterReactor, network::Network, ConditionCheckReactor, TestRng,
+    },
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
         ActivationPoint, Chainspec, Timestamp,
@@ -30,7 +39,13 @@ struct TestChain {
     chainspec: Arc<Chainspec>,
 }
 
-type Nodes = crate::testing::network::Nodes<participating::Reactor>;
+type Nodes = crate::testing::network::Nodes<FilterReactor<participating::Reactor>>;
+
+impl Runner<ConditionCheckReactor<FilterReactor<participating::Reactor>>> {
+    fn participating(&self) -> &participating::Reactor {
+        self.reactor().inner().inner()
+    }
+}
 
 impl TestChain {
     /// Instantiates a new test chain configuration.
@@ -96,6 +111,9 @@ impl TestChain {
         }
     }
 
+    fn chainspec_mut(&mut self) -> &mut Chainspec {
+        Arc::get_mut(&mut self.chainspec).unwrap()
+    }
     /// Creates an initializer/validator configuration for the `idx`th validator.
     fn create_node_config(&mut self, idx: usize, first_node_port: u16) -> participating::Config {
         // Set the network configuration.
@@ -111,7 +129,6 @@ impl TestChain {
 
         // ...and the secret key for our validator.
         cfg.consensus.secret_key_path = External::from_value(self.keys[idx].clone());
-
         // Additionally set up storage in a temporary directory.
         let (storage_cfg, temp_dir) = storage::Config::default_for_tests();
         cfg.consensus.highway.unit_hashes_folder = temp_dir.path().to_path_buf();
@@ -124,10 +141,10 @@ impl TestChain {
     async fn create_initialized_network(
         &mut self,
         rng: &mut NodeRng,
-    ) -> anyhow::Result<Network<participating::Reactor>> {
+    ) -> anyhow::Result<Network<FilterReactor<participating::Reactor>>> {
         let root = RESOURCES_PATH.join("local");
 
-        let mut network: Network<participating::Reactor> = Network::new();
+        let mut network: Network<FilterReactor<participating::Reactor>> = Network::new();
         let first_node_port = testing::unused_port_on_localhost();
 
         for idx in 0..self.keys.len() {
@@ -172,7 +189,7 @@ fn is_in_era(era_id: EraId) -> impl Fn(&Nodes) -> bool {
     move |nodes: &Nodes| {
         nodes
             .values()
-            .all(|runner| runner.reactor().inner().consensus().current_era() == era_id)
+            .all(|runner| runner.participating().consensus().current_era() == era_id)
     }
 }
 
@@ -220,13 +237,30 @@ async fn run_equivocator_network() {
     keys.push(alice_sk.clone());
     keys.push(alice_sk);
 
+    // We configure the era to take five rounds, and delay all messages to and from one of Alice's
+    // nodes until two rounds after genesis. That should guarantee that the two nodes equivocate.
     let mut chain = TestChain::new_with_keys(&mut rng, keys, stakes);
-    let protocol_config = (&*chain.chainspec).into();
+    chain.chainspec_mut().core_config.minimum_era_height = 5;
+    let protocol_config = consensus::ProtocolConfig::from(&*chain.chainspec);
 
     let mut net = chain
         .create_initialized_network(&mut rng)
         .await
         .expect("network initialization failed");
+    let genesis_time = protocol_config.genesis_timestamp.unwrap();
+    let min_round_len = chain.chainspec.highway_config.min_round_length();
+    net.reactors_mut()
+        .find(|reactor| *reactor.inner().consensus().public_key() == alice_pk)
+        .unwrap()
+        .set_filter(move |event| match event {
+            ParticipatingEvent::NetworkRequest(_)
+            | ParticipatingEvent::Consensus(consensus::Event::MessageReceived { .. })
+                if Timestamp::now() < genesis_time + min_round_len * 2 =>
+            {
+                Either::Left(time::sleep(min_round_len.into()).event(move |_| event))
+            }
+            _ => Either::Right(event),
+        });
 
     let timeout = Duration::from_secs(90);
 
@@ -238,7 +272,7 @@ async fn run_equivocator_network() {
 
         // Collect new switch block headers.
         for runner in net.nodes().values() {
-            let storage = runner.reactor().inner().storage();
+            let storage = runner.participating().storage();
             let header = storage
                 .transactional_get_switch_block_by_era_id(era_number - 1)
                 .expect("missing switch block")
@@ -289,7 +323,7 @@ async fn run_equivocator_network() {
             // We are in era N + 1 or later. There should be no direct evidence; that would mean
             // Alice equivocated twice.
             for runner in net.nodes().values() {
-                let consensus = runner.reactor().inner().consensus();
+                let consensus = runner.participating().consensus();
                 assert_eq!(
                     consensus.validators_with_evidence(header.era_id()),
                     Vec::<&PublicKey>::new()

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, iter, sync::Arc, time::Duration};
 
 use anyhow::bail;
 use either::Either;
@@ -10,23 +10,28 @@ use tempfile::TempDir;
 use tokio::time;
 
 use casper_execution_engine::shared::motes::Motes;
-use casper_types::{system::auction::DelegationRate, EraId, PublicKey, SecretKey, U512};
+use casper_types::{
+    system::auction::DelegationRate, EraId, ProtocolVersion, PublicKey, SecretKey, U512,
+};
 
 use crate::{
-    components::{consensus, gossiper, small_network, storage},
+    components::{
+        chainspec_loader::NextUpgrade, consensus, contract_runtime, gossiper, small_network,
+        storage,
+    },
     crypto::AsymmetricKeyExt,
-    effect::EffectExt,
+    effect::{requests::ContractRuntimeRequest, EffectExt},
     reactor::{
         initializer, joiner,
         participating::{self, Event as ParticipatingEvent},
-        ReactorExit, Runner,
+        Reactor, ReactorExit, Runner,
     },
     testing::{
         self, filter_reactor::FilterReactor, network::Network, ConditionCheckReactor, TestRng,
     },
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        ActivationPoint, Chainspec, Timestamp,
+        ActivationPoint, Chainspec, ExitCode, Timestamp,
     },
     utils::{External, Loadable, WithDir, RESOURCES_PATH},
     NodeRng,
@@ -114,6 +119,7 @@ impl TestChain {
     fn chainspec_mut(&mut self) -> &mut Chainspec {
         Arc::get_mut(&mut self.chainspec).unwrap()
     }
+
     /// Creates an initializer/validator configuration for the `idx`th validator.
     fn create_node_config(&mut self, idx: usize, first_node_port: u16) -> participating::Config {
         // Set the network configuration.
@@ -330,5 +336,97 @@ async fn run_equivocator_network() {
                 );
             }
         }
+    }
+}
+
+#[tokio::test]
+async fn dont_upgrade_without_switch_block() {
+    testing::init_logging();
+
+    let mut rng = crate::new_rng();
+
+    // Set up a network with only a single validator.
+    let alice_sk = Arc::new(SecretKey::random(&mut rng));
+    let alice_pk = PublicKey::from(&*alice_sk);
+    let keys: Vec<Arc<SecretKey>> = vec![alice_sk];
+    let stakes: BTreeMap<PublicKey, U512> = iter::once((alice_pk, U512::from(100))).collect();
+
+    // Eras have exactly two blocks each, and there is one block per second.
+    let mut chain = TestChain::new_with_keys(&mut rng, keys, stakes.clone());
+    chain.chainspec_mut().core_config.minimum_era_height = 2;
+    chain.chainspec_mut().core_config.era_duration = 0.into();
+    chain.chainspec_mut().highway_config.minimum_round_exponent = 10;
+
+    let mut net = chain
+        .create_initialized_network(&mut rng)
+        .await
+        .expect("network initialization failed");
+
+    // An upgrade is scheduled for era 2, after the switch block in era 1 (height 3).
+    // We artificially delay the execution of that block.
+    for runner in net.runners_mut() {
+        runner
+            .process_injected_effects(|effect_builder| {
+                let upgrade = NextUpgrade::new(
+                    ActivationPoint::EraId(2.into()),
+                    ProtocolVersion::from_parts(999, 0, 0),
+                );
+                effect_builder
+                    .announce_upgrade_activation_point_read(upgrade)
+                    .ignore()
+            })
+            .await;
+        let mut exec_request_received = false;
+        runner.reactor_mut().inner_mut().set_filter(move |event| {
+            if let ParticipatingEvent::ContractRuntime(contract_runtime::Event::Request(request)) =
+                &event
+            {
+                if let ContractRuntimeRequest::ExecuteBlock(finalized_block) = request.as_ref() {
+                    if finalized_block.era_report().is_some()
+                        && finalized_block.era_id() == EraId::from(1)
+                        && !exec_request_received
+                    {
+                        info!("delaying {}", finalized_block);
+                        exec_request_received = true;
+                        return Either::Left(
+                            time::sleep(Duration::from_secs(10)).event(move |_| event),
+                        );
+                    }
+                    info!("not delaying {}", finalized_block);
+                }
+            }
+            Either::Right(event)
+        });
+    }
+
+    // Run until the node shuts down for the upgrade.
+    let timeout = Duration::from_secs(120);
+    net.settle_on(
+        &mut rng,
+        |nodes| {
+            nodes
+                .values()
+                .all(|runner| runner.participating().maybe_exit().is_some())
+        },
+        timeout,
+    )
+    .await;
+
+    // Verify that the switch block has been stored: Even though it was delayed the node didn't
+    // restart before executing and storing it.
+    for runner in net.nodes().values() {
+        let header = runner
+            .participating()
+            .storage()
+            .read_block_header_and_finality_signatures_by_height(3)
+            .expect("failed to read from storage")
+            .expect("missing switch block")
+            .block_header;
+        assert_eq!(EraId::from(1), header.era_id());
+        assert!(header.is_switch_block());
+        assert_eq!(
+            Some(ReactorExit::ProcessShouldExit(ExitCode::Success)),
+            runner.participating().maybe_exit()
+        );
     }
 }

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -4,6 +4,7 @@
 //! `casper-node` library.
 
 mod condition_check_reactor;
+pub(crate) mod filter_reactor;
 mod multi_stage_test_reactor;
 pub mod network;
 pub mod test_clock;

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -289,10 +289,16 @@ where
         self.nodes.values().map(|runner| runner.reactor().inner())
     }
 
+    /// Returns an iterator over all runners, mutable.
+    pub(crate) fn runners_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut Runner<ConditionCheckReactor<R>>> {
+        self.nodes.values_mut()
+    }
+
     /// Returns an iterator over all reactors, mutable.
     pub fn reactors_mut(&mut self) -> impl Iterator<Item = &mut R> {
-        self.nodes
-            .values_mut()
+        self.runners_mut()
             .map(|runner| runner.reactor_mut().inner_mut())
     }
 


### PR DESCRIPTION
Backport of https://github.com/casper-network/casper-node/pull/2222 (ticket https://github.com/casper-network/casper-node/issues/2209) to version 1.3.4.

The test was adapted because the contract runtime event structure had changed since 1.3.4. Also, the commit with the `FilterReactor` from https://github.com/casper-network/casper-node/pull/1921 was required for the test.

https://github.com/casper-network/casper-node/pull/2219 and https://github.com/casper-network/casper-node/pull/2229 were included, too, otherwise CI would fail on cargo audit.