### PR TITLE
Matching exp 15 speed block counts with current MainNet.

### DIFF
--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -11,7 +11,7 @@ hard_reset = true
 # in contract-runtime for computing genesis post-state hash.
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
-activation_point = 2000
+activation_point = 2528
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 
@@ -82,9 +82,9 @@ max_block_size = 10_485_760
 # Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
 max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
-block_max_deploy_count = 75
+block_max_deploy_count = 50
 # The maximum number of wasm-less transfer deploys permitted in a single block.
-block_max_transfer_count = 1500
+block_max_transfer_count = 1250
 # The upper limit of total gas of all deploys in a block.
 block_gas_limit = 10_000_000_000_000
 # The limit of length of serialized payment code arguments.


### PR DESCRIPTION
Correcting wasm and native transfer limits to match existing at exp 15 block speed.
Adding approx mainnet activation point.
