### PR TITLE
Adding setup-as prior to npm publish.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -572,7 +572,7 @@ steps:
 - name:as-setup
 - image: casperlabs/node-build-u1804
   - commands:
-      "make setup-as"
+      - "make setup-as"
 
 - name: as-contract-publish
   image: plugins/npm

--- a/.drone.yml
+++ b/.drone.yml
@@ -569,9 +569,9 @@ steps:
     CARGO_TOKEN:
       from_secret: crates_io_token
 
-- name:as-setup
-- image: casperlabs/node-build-u1804
-  - commands:
+- name: as-setup
+  image: casperlabs/node-build-u1804
+  commands:
       - "make setup-as"
 
 - name: as-contract-publish

--- a/.drone.yml
+++ b/.drone.yml
@@ -572,7 +572,7 @@ steps:
 - name: as-setup
   image: casperlabs/node-build-u1804
   commands:
-      - "make setup-as"
+    - "make setup-as"
 
 - name: as-contract-publish
   image: plugins/npm

--- a/.drone.yml
+++ b/.drone.yml
@@ -569,6 +569,11 @@ steps:
     CARGO_TOKEN:
       from_secret: crates_io_token
 
+- name:as-setup
+- image: casperlabs/node-build-u1804
+  - commands:
+      "make setup-as"
+
 - name: as-contract-publish
   image: plugins/npm
   settings:

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -672,7 +672,6 @@ where
         };
         if let Err(error) = self.scheduler.debug_dump(&mut file).await {
             warn!(%error, "could not serialize debug snapshot to {}", debug_dump_filename);
-            return;
         }
     }
 


### PR DESCRIPTION
Due to changes in makefile, setup-as is no longer run as part of make deb.
This explicitly adds a drone step to run this prior to publish.