### PR TITLE
Fix feature set on casper-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,6 +4074,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std-feature-regression"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+]
+
+[[package]]
 name = "storage-costs"
 version = "0.1.0"
 dependencies = [

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -144,6 +144,8 @@ mod tests {
         let added_validator = PublicKey::random(&mut rng);
         era1_metadata.validators.insert(&added_validator);
 
+        // False positive by clippy.
+        #[allow(clippy::redundant_clone)]
         let expected_change = vec![(added_validator.clone(), ValidatorChange::Added)];
         let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
         assert_eq!(expected_change, actual_change.0);
@@ -165,6 +167,8 @@ mod tests {
         let removed_validator = PublicKey::random(&mut rng);
         era0_metadata.validators.insert(&removed_validator);
 
+        // False positive by clippy.
+        #[allow(clippy::redundant_clone)]
         let expected_change = vec![(removed_validator.clone(), ValidatorChange::Removed)];
         let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
         assert_eq!(expected_change, actual_change.0)

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -20,5 +20,6 @@ wee_alloc = { version = "0.4.5", optional = true }
 default = ["no-std-helpers"]
 no-std-helpers = ["wee_alloc"]
 test-support = []
-# DEPRECATED - enabling `std` has no effect.
+# DEPRECATED - will be removed in a future release.
+# Enabling `std` overrides the default `no-std-helpers` feature and causes casper-contract to import the Rust std lib.
 std = []

--- a/smart_contracts/contract/README.md
+++ b/smart_contracts/contract/README.md
@@ -34,6 +34,9 @@ following to your Cargo.toml:
 casper-contract = { version = "1", default-features = false }
 ```
 
+Note that this feature will effectively be disabled by enabling the deprecated `std` feature.  The `std` feature will be
+removed in an upcoming release.
+
 ### `test-support`
 
 Disabled by default.

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -47,7 +47,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(
-    all(not(test), feature = "no-std-helpers"),
+    all(not(test), not(feature = "std"), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
 #![doc(html_root_url = "https://docs.rs/casper-contract/1.4.0")]
@@ -57,16 +57,19 @@
     test(attr(forbid(warnings)))
 )]
 #![warn(missing_docs)]
+
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod contract_api;
 pub mod ext_ffi;
-#[cfg(all(not(test), feature = "no-std-helpers"))]
+#[cfg(all(not(test), not(feature = "std"), feature = "no-std-helpers"))]
 mod no_std_handlers;
 pub mod unwrap_or_revert;
 
 /// An instance of [`WeeAlloc`](https://docs.rs/wee_alloc) which allows contracts built as `no_std`
 /// to avoid having to provide a global allocator themselves.
-#[cfg(all(not(test), feature = "no-std-helpers"))]
+#[cfg(all(not(test), not(feature = "std"), feature = "no-std-helpers"))]
 #[global_allocator]
 pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/smart_contracts/contracts/test/std-feature-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/std-feature-regression/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "std-feature-regression"
+version = "0.1.0"
+authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "std_feature_regression"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract", features = ["std"] }

--- a/smart_contracts/contracts/test/std-feature-regression/README.md
+++ b/smart_contracts/contracts/test/std-feature-regression/README.md
@@ -1,0 +1,7 @@
+This contract exists purely to ensure the `std` feature of the `casper-contract` crate continues to be usable in a
+backwards compatible manner.
+
+Compiling the contract successfully is enough; it doesn't need to be run.
+
+The contract specifies `#![no_std]` but by enabling the `casper-contract/std` feature, that should link the std lib,
+providing the std global allocator.

--- a/smart_contracts/contracts/test/std-feature-regression/src/main.rs
+++ b/smart_contracts/contracts/test/std-feature-regression/src/main.rs
@@ -1,0 +1,9 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::runtime;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let _named_keys = runtime::list_named_keys();
+}


### PR DESCRIPTION
This PR fixes an accidental breaking change in the Rust features of the `casper-contract` crate, introduced in the 1.4.0 version.

The previous 1.3.x behavior has been reinstated, whereby if the `std` feature is enabled, `casper-contract` does not provide the `wee-alloc` allocator, and instead explicitly imports the std library with its allocator.

There is also a regression test added in the form of a test contract which enables the `std` feature of `casper-contract`.

Furthermore these changes were tested against the [Payment Contract Example](https://github.com/casper-ecosystem/payment-example) and [Casper Keys Manager](https://github.com/casper-ecosystem/keys-manager) with their recent changes ([#3](https://github.com/casper-ecosystem/payment-example/pull/3/files) and [#18](https://github.com/casper-ecosystem/keys-manager/pull/18/files) respectively) reverted.

Closes #2261.