### PR TITLE
Fix run_equivocator_network test.

### DIFF
--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -34,6 +34,7 @@ pub(crate) enum Event<P> {
         #[serde(skip)]
         span: Span,
     },
+
     /// Received network message.
     IncomingMessage {
         peer_id: Box<NodeId>,
@@ -41,6 +42,7 @@ pub(crate) enum Event<P> {
         #[serde(skip)]
         span: Span,
     },
+
     /// Incoming connection closed.
     IncomingClosed {
         #[serde(skip_serializing)]
@@ -57,6 +59,7 @@ pub(crate) enum Event<P> {
         #[serde(skip_serializing)]
         span: Span,
     },
+
     /// An established connection was terminated.
     OutgoingDropped {
         peer_id: Box<NodeId>,
@@ -79,6 +82,7 @@ pub(crate) enum Event<P> {
 
     /// The node should gossip its own public listening address.
     GossipOurAddress,
+
     /// We received a peer's public listening address via gossip.
     PeerAddressReceived(GossipedAddress),
 

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -16,9 +16,14 @@ use casper_types::{
 };
 
 use crate::{
-    components::{chainspec_loader::NextUpgrade, consensus, gossiper, small_network, storage},
+    components::{chainspec_loader::NextUpgrade, gossiper, small_network, storage},
     crypto::AsymmetricKeyExt,
-    effect::{requests::ContractRuntimeRequest, EffectExt},
+    effect::{
+        announcements::NetworkAnnouncement,
+        requests::{ContractRuntimeRequest, NetworkRequest},
+        EffectExt,
+    },
+    protocol::Message,
     reactor::{
         initializer, joiner,
         participating::{self, ParticipatingEvent},
@@ -332,18 +337,19 @@ async fn run_equivocator_network() {
         .unwrap()
         .set_filter(move |event| {
             let now = Timestamp::now();
-            let first_message_time = match (&event, maybe_first_message_time) {
-                (
-                    ParticipatingEvent::NetworkRequest(_)
-                    | ParticipatingEvent::Consensus(consensus::Event::MessageReceived { .. }),
-                    Some(first_message_time),
-                ) => first_message_time,
-                (ParticipatingEvent::Consensus(consensus::Event::MessageReceived { .. }), None) => {
-                    maybe_first_message_time = Some(now);
-                    now
-                }
+            match &event {
+                ParticipatingEvent::NetworkAnnouncement(NetworkAnnouncement::MessageReceived {
+                    payload,
+                    ..
+                }) if matches!(*payload, Message::Consensus(_)) => {}
+                ParticipatingEvent::NetworkRequest(
+                    NetworkRequest::SendMessage { payload, .. }
+                    | NetworkRequest::Broadcast { payload, .. }
+                    | NetworkRequest::Gossip { payload, .. },
+                ) if matches!(**payload, Message::Consensus(_)) => {}
                 _ => return Either::Right(event),
             };
+            let first_message_time = *maybe_first_message_time.get_or_insert(now);
             if now < first_message_time + min_round_len * 3 {
                 return Either::Left(time::sleep(min_round_len.into()).event(move |_| event));
             }


### PR DESCRIPTION
Delay only _consensus_ messages in the test, not other network requests.

The test was flaky before, and I suspect it had to do with the fact that we were delaying all outgoing messages from Alice's doppelgänger node, instead of just the consensus messages. I verified that this was also delaying address gossiper messages, so it might have interfered with establishing connections. It's hard to be sure, though, because the failures occurred only once every few days, and only on CI.

With this change, all incoming and outgoing consensus messages get delayed for three rounds, and the timer starts with the first incoming or outgoing consensus message.

The delay itself is meant to guarantee that Alice's two nodes will in fact produce an equivocation: If they don't hear from each other for more than one round, they will both produce a Highway unit.

Closes #1859.