### PR TITLE
Fixes integer overflow in `u8_slice_to_bytes`.

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+* Fixed some integer casts.
 
 ## [1.4.2] - 2021-11-11
 

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, convert::TryFrom};
+use std::{
+    collections::BTreeSet,
+    convert::{TryFrom, TryInto},
+};
 
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
@@ -282,7 +285,11 @@ where
                 )?;
                 let purse = self.create_purse()?;
                 let purse_bytes = purse.into_bytes().map_err(Error::BytesRepr)?;
-                assert_eq!(dest_size, purse_bytes.len() as u32);
+                assert_eq!(
+                    dest_size,
+                    TryInto::<u32>::try_into(purse_bytes.len())
+                        .expect("Purse encoding should be small")
+                );
                 self.memory
                     .set(dest_ptr, &purse_bytes)
                     .map_err(|e| Error::Interpreter(e.into()))?;

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -5,6 +5,7 @@ use casper_types::{
     bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, Gas, RuntimeArgs,
     SecretKey,
 };
+use core::convert::TryInto;
 use itertools::Itertools;
 
 use super::*;
@@ -600,7 +601,7 @@ fn test_proposer_with(
     config.block_max_transfer_count = max_transfer_count;
     config.block_gas_limit = block_gas_limit;
     if let Some(max_block_size) = max_block_size {
-        config.max_block_size = max_block_size as u32;
+        config.max_block_size = max_block_size.try_into().unwrap();
     }
 
     for _ in 0..deploy_count {

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 * Increased `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
+* Fixed some integer casts.
 
 
 ## [1.4.0] - 2021-10-04

--- a/types/src/account/associated_keys.rs
+++ b/types/src/account/associated_keys.rs
@@ -5,6 +5,8 @@ use alloc::{
     vec::Vec,
 };
 
+use core::convert::TryInto;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -132,7 +134,12 @@ impl ToBytes for AssociatedKeys {
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
+        let length_32: u32 = self
+            .0
+            .len()
+            .try_into()
+            .map_err(|_| Error::NotRepresentable)?;
+        writer.extend_from_slice(&length_32.to_le_bytes());
         for (key, weight) in self.0.iter() {
             key.write_bytes(writer)?;
             weight.write_bytes(writer)?;

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -338,6 +338,12 @@ pub enum ApiError {
     /// assert_eq!(ApiError::from(38), ApiError::MissingSystemContractHash);
     /// ```
     MissingSystemContractHash,
+    /// Attempt to serialize a value that does not have a serialized representation.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(39), ApiError::NonRepresentableSerialization);
+    /// ```
+    NonRepresentableSerialization,
     /// Error specific to Auction contract. See
     /// [casper_types::system::auction::Error](crate::system::auction::Error).
     /// ```
@@ -392,6 +398,7 @@ impl From<bytesrepr::Error> for ApiError {
             bytesrepr::Error::Formatting => ApiError::Formatting,
             bytesrepr::Error::LeftOverBytes => ApiError::LeftOverBytes,
             bytesrepr::Error::OutOfMemory => ApiError::OutOfMemory,
+            bytesrepr::Error::NotRepresentable => ApiError::NonRepresentableSerialization,
         }
     }
 }
@@ -525,6 +532,7 @@ impl From<ApiError> for u32 {
             ApiError::DictionaryItemKeyExceedsLength => 36,
             ApiError::InvalidDictionaryItemKey => 37,
             ApiError::MissingSystemContractHash => 38,
+            ApiError::NonRepresentableSerialization => 39,
             ApiError::AuctionError(value) => AUCTION_ERROR_OFFSET + u32::from(value),
             ApiError::ContractHeader(value) => HEADER_ERROR_OFFSET + u32::from(value),
             ApiError::Mint(value) => MINT_ERROR_OFFSET + u32::from(value),
@@ -575,6 +583,7 @@ impl From<u32> for ApiError {
             36 => ApiError::DictionaryItemKeyExceedsLength,
             37 => ApiError::InvalidDictionaryItemKey,
             38 => ApiError::MissingSystemContractHash,
+            39 => ApiError::NonRepresentableSerialization,
             USER_ERROR_MIN..=USER_ERROR_MAX => ApiError::User(value as u16),
             HP_ERROR_MIN..=HP_ERROR_MAX => ApiError::HandlePayment(value as u8),
             MINT_ERROR_MIN..=MINT_ERROR_MAX => ApiError::Mint(value as u8),
@@ -630,6 +639,7 @@ impl Debug for ApiError {
             }
             ApiError::InvalidDictionaryItemKey => write!(f, "ApiError::InvalidDictionaryItemKey")?,
             ApiError::MissingSystemContractHash => write!(f, "ApiError::MissingContractHash")?,
+            ApiError::NonRepresentableSerialization => write!(f, "ApiError::NonRepresentableSerialization")?,
             ApiError::AuctionError(value) => write!(
                 f,
                 "ApiError::AuctionError({:?})",
@@ -837,6 +847,7 @@ mod tests {
         round_trip(Err(ApiError::HostBufferEmpty));
         round_trip(Err(ApiError::HostBufferFull));
         round_trip(Err(ApiError::AllocLayout));
+        round_trip(Err(ApiError::NonRepresentableSerialization));
         round_trip(Err(ApiError::ContractHeader(0)));
         round_trip(Err(ApiError::ContractHeader(u8::MAX)));
         round_trip(Err(ApiError::Mint(0)));

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -639,7 +639,9 @@ impl Debug for ApiError {
             }
             ApiError::InvalidDictionaryItemKey => write!(f, "ApiError::InvalidDictionaryItemKey")?,
             ApiError::MissingSystemContractHash => write!(f, "ApiError::MissingContractHash")?,
-            ApiError::NonRepresentableSerialization => write!(f, "ApiError::NonRepresentableSerialization")?,
+            ApiError::NonRepresentableSerialization => {
+                write!(f, "ApiError::NonRepresentableSerialization")?
+            }
             ApiError::AuctionError(value) => write!(
                 f,
                 "ApiError::AuctionError({:?})",

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -131,7 +131,9 @@ impl Display for Error {
             Error::Formatting => formatter.write_str("Deserialization error: formatting"),
             Error::LeftOverBytes => formatter.write_str("Deserialization error: left-over bytes"),
             Error::OutOfMemory => formatter.write_str("Serialization error: out of memory"),
-            Error::NotRepresentable => formatter.write_str("Serialization error: value is not representable."),
+            Error::NotRepresentable => {
+                formatter.write_str("Serialization error: value is not representable.")
+            }
         }
     }
 }
@@ -1225,7 +1227,10 @@ where
 fn u8_slice_to_bytes(bytes: &[u8]) -> Result<Vec<u8>, Error> {
     let serialized_length = u8_slice_serialized_length(bytes);
     let mut vec = try_vec_with_capacity(serialized_length)?;
-    let length_prefix: u32 = bytes.len().try_into().map_err(|_| Error::NotRepresentable)?;
+    let length_prefix: u32 = bytes
+        .len()
+        .try_into()
+        .map_err(|_| Error::NotRepresentable)?;
     let length_prefix_bytes = length_prefix.to_le_bytes();
     vec.extend_from_slice(&length_prefix_bytes);
     vec.extend_from_slice(bytes);

--- a/types/src/transfer_result.rs
+++ b/types/src/transfer_result.rs
@@ -6,6 +6,7 @@ use crate::ApiError;
 pub type TransferResult = Result<TransferredTo, ApiError>;
 
 /// The result of a successful transfer between purses.
+/// NOTE: The variants of this type should not correspond to negative integers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TransferredTo {


### PR DESCRIPTION
Introduces a new variant of `ApiError`.

Closes #2260