### PR TITLE
Reinstate caching of block proposer state

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Fixed
 * Resolve an issue where `Deploys` with payment amounts exceeding the block gas limit would not be rejected.
 * Resolve issue of duplicated config option `max_associated_keys`.
+* The block proposer component now retains pending deploys and transfers across a restart.
 
 
 

--- a/node/src/components/block_proposer/cached_state.rs
+++ b/node/src/components/block_proposer/cached_state.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use super::{BlockProposerDeploySets, DeployInfo};
+use crate::types::{DeployHash, Timestamp};
+
+/// State which is put to storage and loaded on initialization.
+#[derive(Serialize, Deserialize, Default, Debug, DataSize)]
+pub(crate) struct CachedState {
+    pub(super) pending_deploys: HashMap<DeployHash, (DeployInfo, Timestamp)>,
+    pub(super) pending_transfers: HashMap<DeployHash, (DeployInfo, Timestamp)>,
+}
+
+impl From<&BlockProposerDeploySets> for CachedState {
+    fn from(sets: &BlockProposerDeploySets) -> Self {
+        CachedState {
+            pending_deploys: sets.pending_deploys.clone(),
+            pending_transfers: sets.pending_transfers.clone(),
+        }
+    }
+}

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -4,11 +4,10 @@ use std::{
     hash::Hash,
 };
 
+use datasize::DataSize;
 use itertools::{Either, Itertools};
 
-use datasize::DataSize;
-
-use super::{event::DeployInfo, BlockHeight, FinalizationQueue};
+use super::{BlockHeight, CachedState, DeployInfo, FinalizationQueue};
 use crate::types::{DeployHash, DeployHeader, Timestamp};
 
 pub(crate) struct PruneResult {
@@ -47,34 +46,34 @@ pub(super) struct BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
-    pub(super) fn from_finalized(
+    /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys and
+    /// the cached state.
+    pub(super) fn new(
         finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         next_finalized_height: u64,
+        cached_state: CachedState,
     ) -> BlockProposerDeploySets {
+        let finalized_deploys: HashMap<_, _> = finalized_deploys.into_iter().collect();
+
+        let CachedState {
+            mut pending_deploys,
+            mut pending_transfers,
+        } = cached_state;
+        pending_deploys.retain(|hash, _| !finalized_deploys.contains_key(hash));
+        pending_transfers.retain(|hash, _| !finalized_deploys.contains_key(hash));
+
         BlockProposerDeploySets {
-            finalized_deploys: finalized_deploys.into_iter().collect(),
+            pending_deploys,
+            pending_transfers,
+            finalized_deploys,
             next_finalized: next_finalized_height,
             ..Default::default()
         }
     }
-}
 
-impl Display for BlockProposerDeploySets {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "(pending:{}, finalized:{})",
-            self.pending_deploys.len() + self.pending_transfers.len(),
-            self.finalized_deploys.len()
-        )
-    }
-}
-
-impl BlockProposerDeploySets {
     /// Prunes expired deploy information from the BlockProposerState, returns the
     /// hashes of deploys pruned.
-    pub(crate) fn prune(&mut self, current_instant: Timestamp) -> PruneResult {
+    pub(super) fn prune(&mut self, current_instant: Timestamp) -> PruneResult {
         let pending_deploys = prune_pending_deploys(&mut self.pending_deploys, current_instant);
         let pending_transfers = prune_pending_deploys(&mut self.pending_transfers, current_instant);
 
@@ -89,6 +88,17 @@ impl BlockProposerDeploySets {
         PruneResult::new(
             pending_deploys.len() + pending_transfers.len() + finalized.len(),
             [pending_deploys, pending_transfers].concat(),
+        )
+    }
+}
+
+impl Display for BlockProposerDeploySets {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "(pending:{}, finalized:{})",
+            self.pending_deploys.len() + self.pending_transfers.len(),
+            self.finalized_deploys.len()
         )
     }
 }

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -52,7 +52,7 @@ impl BlockProposerDeploySets {
         finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         next_finalized_height: u64,
         cached_state: CachedState,
-    ) -> BlockProposerDeploySets {
+    ) -> (BlockProposerDeploySets, PruneResult) {
         let finalized_deploys: HashMap<_, _> = finalized_deploys.into_iter().collect();
 
         let CachedState {
@@ -62,13 +62,15 @@ impl BlockProposerDeploySets {
         pending_deploys.retain(|hash, _| !finalized_deploys.contains_key(hash));
         pending_transfers.retain(|hash, _| !finalized_deploys.contains_key(hash));
 
-        BlockProposerDeploySets {
+        let mut sets = BlockProposerDeploySets {
             pending_deploys,
             pending_transfers,
             finalized_deploys,
             next_finalized: next_finalized_height,
             ..Default::default()
-        }
+        };
+        let prune_result = sets.prune(Timestamp::now());
+        (sets, prune_result)
     }
 
     /// Prunes expired deploy information from the BlockProposerState, returns the

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::Motes;
 
-use super::BlockHeight;
+use super::{BlockHeight, CachedState};
 use crate::{
     effect::requests::BlockProposerRequest,
     types::{DeployHash, DeployHeader, DeployOrTransferHash, FinalizedBlock},
@@ -33,6 +33,8 @@ pub(crate) enum Event {
         finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         /// The height of the next expected finalized block.
         next_finalized_block: BlockHeight,
+        /// The cached state retrieved from storage.
+        cached_state: CachedState,
     },
     /// A new deploy has been received by this node and stored: it should be retrieved from storage
     /// and buffered here.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -603,14 +603,8 @@ impl Storage {
                 txn.commit()?;
                 Ok(responder.respond(()).ignore())
             }
-            #[cfg(test)]
             StateStoreRequest::Load { key, responder } => {
-                let txn = self.env.begin_ro_txn()?;
-                let bytes = match txn.get(self.state_store_db, &key) {
-                    Ok(slice) => Some(slice.to_owned()),
-                    Err(lmdb::Error::NotFound) => None,
-                    Err(err) => return Err(err.into()),
-                };
+                let bytes = self.read_state_store(&key)?;
                 Ok(responder.respond(bytes).ignore())
             }
         }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -439,7 +439,6 @@ pub(crate) enum StateStoreRequest {
         /// Notification when storing is complete.
         responder: Responder<()>,
     },
-    #[cfg(test)]
     /// Loads a piece of state from storage.
     Load {
         /// Key to load from.
@@ -460,7 +459,6 @@ impl Display for StateStoreRequest {
                     data.len()
                 )
             }
-            #[cfg(test)]
             StateStoreRequest::Load { key, .. } => {
                 write!(f, "load data from key {}", checksummed_hex::encode(key))
             }


### PR DESCRIPTION
This PR reinstates caching of the pending deploys and transfers by the block proposer, so that this information can be repopulated on startup.

It reverts some of [#1216](https://github.com/casper-network/casper-node/pull/1216).  Before that PR, the block proposer cached finalized deploys too.  This PR does not re-introduce that behavior.  Finalized deploys are still provided by the storage component on startup.

However, the pending deploys and transfers _are_ stored regularly (every 10 seconds, just after the state is purged) and are read from storage on startup.  Only those deploys (read from storage) which are also not now in the finalized deploys list are retained in the pending collections.

There is still plenty of room for improving this mechanism, but alternative approaches could be significantly more complex and should be planned out accordingly.

Closes #2248.