### PR TITLE
Fix nightly failure in itst02.sh

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -405,6 +405,10 @@ where
             }
         }
 
+        outcomes
+    }
+
+    fn prune_unit_files(&self) {
         let valid_unit_files: HashSet<_> = self
             .active_eras
             .iter()
@@ -416,7 +420,7 @@ where
             Err(err) => {
                 warn!(?err, path=?self.unit_files_folder, "could not read the unit files folder");
                 // if we couldn't clean up the unit files, we just return
-                return outcomes;
+                return;
             }
         };
 
@@ -446,8 +450,6 @@ where
                 warn!(?err, ?path, "could not delete unit file");
             }
         }
-
-        outcomes
     }
 
     /// Returns `true` if the specified era is active and bonded.
@@ -573,6 +575,9 @@ where
             );
             result_map.insert(era_id, results);
         }
+
+        self.prune_unit_files();
+
         let active_era_outcomes = self.active_eras[&self.current_era]
             .consensus
             .handle_is_current(now);
@@ -983,6 +988,7 @@ where
             switch_block_header.timestamp(),
             switch_block_header.height() + 1,
         );
+        self.era_supervisor.prune_unit_files();
         outcomes.extend(
             self.era_supervisor.active_eras[&era_id]
                 .consensus


### PR DESCRIPTION
This changes when the unit files are being cleaned up, from after creation of any era, to after initialization of all the eras or creation of any later era. Removal of the files after each era creation on initialization caused validators to remove too much, because some eras weren't consider active yet, and subsequently equivocate.

Closes #2290 