### PR TITLE
Do not call auction::slash contract when no validator was slashed.

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2058,54 +2058,51 @@ where
             }
         }
 
-        if step_request.run_auction {
-            let run_auction_args = RuntimeArgs::try_new(|args| {
-                args.insert(
-                    ARG_ERA_END_TIMESTAMP_MILLIS,
-                    step_request.era_end_timestamp_millis,
-                )?;
-                args.insert(
-                    ARG_EVICTED_VALIDATORS,
-                    step_request
-                        .evict_items
-                        .iter()
-                        .map(|item| item.validator_id.clone())
-                        .collect::<Vec<PublicKey>>(),
-                )?;
-                Ok(())
-            })?;
+        let run_auction_args = RuntimeArgs::try_new(|args| {
+            args.insert(
+                ARG_ERA_END_TIMESTAMP_MILLIS,
+                step_request.era_end_timestamp_millis,
+            )?;
+            args.insert(
+                ARG_EVICTED_VALIDATORS,
+                step_request
+                    .evict_items
+                    .iter()
+                    .map(|item| item.validator_id.clone())
+                    .collect::<Vec<PublicKey>>(),
+            )?;
+            Ok(())
+        })?;
 
-            let run_auction_call_stack = {
-                let system = CallStackElement::session(PublicKey::System.to_account_hash());
-                let auction = CallStackElement::stored_contract(
-                    auction_contract.contract_package_hash(),
-                    *auction_contract_hash,
-                );
-                vec![system, auction]
-            };
-            let (_, execution_result): (Option<()>, ExecutionResult) = executor
-                .exec_system_contract(
-                    DirectSystemContractCall::RunAuction,
-                    system_module,
-                    run_auction_args,
-                    &mut named_keys,
-                    Default::default(),
-                    base_key,
-                    &virtual_system_account,
-                    authorization_keys,
-                    BlockTime::default(),
-                    deploy_hash,
-                    gas_limit,
-                    step_request.protocol_version,
-                    correlation_id,
-                    Rc::clone(&tracking_copy),
-                    Phase::Session,
-                    run_auction_call_stack,
-                );
+        let run_auction_call_stack = {
+            let system = CallStackElement::session(PublicKey::System.to_account_hash());
+            let auction = CallStackElement::stored_contract(
+                auction_contract.contract_package_hash(),
+                *auction_contract_hash,
+            );
+            vec![system, auction]
+        };
+        let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
+            DirectSystemContractCall::RunAuction,
+            system_module,
+            run_auction_args,
+            &mut named_keys,
+            Default::default(),
+            base_key,
+            &virtual_system_account,
+            authorization_keys,
+            BlockTime::default(),
+            deploy_hash,
+            gas_limit,
+            step_request.protocol_version,
+            correlation_id,
+            Rc::clone(&tracking_copy),
+            Phase::Session,
+            run_auction_call_stack,
+        );
 
-            if let Some(exec_error) = execution_result.take_error() {
-                return Err(StepError::AuctionError(exec_error));
-            }
+        if let Some(exec_error) = execution_result.take_error() {
+            return Err(StepError::AuctionError(exec_error));
         }
 
         let execution_effect = tracking_copy.borrow().effect();

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2014,54 +2014,48 @@ where
             return Err(StepError::DistributeError(exec_error));
         }
 
-        let slashed_validators = match step_request.slashed_validators() {
-            Ok(slashed_validators) => slashed_validators,
-            Err(error) => {
-                error!(
-                    "failed to deserialize validator_ids for slashing: {}",
-                    error.to_string()
+        let slashed_validators: Vec<PublicKey> = step_request.slashed_validators();
+
+        if !slashed_validators.is_empty() {
+            let slash_args = {
+                let mut runtime_args = RuntimeArgs::new();
+                runtime_args
+                    .insert(ARG_VALIDATOR_PUBLIC_KEYS, slashed_validators)
+                    .map_err(|e| Error::Exec(e.into()))?;
+                runtime_args
+            };
+
+            let slash_call_stack = {
+                let system = CallStackElement::session(PublicKey::System.to_account_hash());
+                let auction = CallStackElement::stored_contract(
+                    auction_contract.contract_package_hash(),
+                    *auction_contract_hash,
                 );
-                return Err(StepError::BytesRepr(error));
+                vec![system, auction]
+            };
+            let (_, execution_result): (Option<()>, ExecutionResult) = executor
+                .exec_system_contract(
+                    DirectSystemContractCall::Slash,
+                    system_module.clone(),
+                    slash_args,
+                    &mut named_keys,
+                    Default::default(),
+                    base_key,
+                    &virtual_system_account,
+                    authorization_keys.clone(),
+                    BlockTime::default(),
+                    deploy_hash,
+                    gas_limit,
+                    step_request.protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    Phase::Session,
+                    slash_call_stack,
+                );
+
+            if let Some(exec_error) = execution_result.take_error() {
+                return Err(StepError::SlashingError(exec_error));
             }
-        };
-
-        let slash_args = {
-            let mut runtime_args = RuntimeArgs::new();
-            runtime_args
-                .insert(ARG_VALIDATOR_PUBLIC_KEYS, slashed_validators)
-                .map_err(|e| Error::Exec(e.into()))?;
-            runtime_args
-        };
-
-        let slash_call_stack = {
-            let system = CallStackElement::session(PublicKey::System.to_account_hash());
-            let auction = CallStackElement::stored_contract(
-                auction_contract.contract_package_hash(),
-                *auction_contract_hash,
-            );
-            vec![system, auction]
-        };
-        let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
-            DirectSystemContractCall::Slash,
-            system_module.clone(),
-            slash_args,
-            &mut named_keys,
-            Default::default(),
-            base_key,
-            &virtual_system_account,
-            authorization_keys.clone(),
-            BlockTime::default(),
-            deploy_hash,
-            gas_limit,
-            step_request.protocol_version,
-            correlation_id,
-            Rc::clone(&tracking_copy),
-            Phase::Session,
-            slash_call_stack,
-        );
-
-        if let Some(exec_error) = execution_result.take_error() {
-            return Err(StepError::SlashingError(exec_error));
         }
 
         if step_request.run_auction {

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -77,8 +77,6 @@ pub struct StepRequest {
     /// Compared to a slashing, evictions are deactivating a given validator, but his stake is
     /// unchanged. A further re-activation is possible.
     pub evict_items: Vec<EvictItem>,
-    /// If true an auction contract will be executed to compute new era validators.
-    pub run_auction: bool,
     /// Specifies which era validators will be returned based on `next_era_id`.
     ///
     /// Intended use is to always specify the current era id + 1 which will return computed era at
@@ -97,7 +95,6 @@ impl StepRequest {
         slash_items: Vec<SlashItem>,
         reward_items: Vec<RewardItem>,
         evict_items: Vec<EvictItem>,
-        run_auction: bool,
         next_era_id: EraId,
         era_end_timestamp_millis: u64,
     ) -> Self {
@@ -107,7 +104,6 @@ impl StepRequest {
             slash_items,
             reward_items,
             evict_items,
-            run_auction,
             next_era_id,
             era_end_timestamp_millis,
         }

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -5,9 +5,7 @@
 use std::{collections::BTreeMap, vec::Vec};
 
 use casper_hashing::Digest;
-use casper_types::{
-    bytesrepr, bytesrepr::ToBytes, CLValueError, EraId, ProtocolVersion, PublicKey,
-};
+use casper_types::{bytesrepr, CLValueError, EraId, ProtocolVersion, PublicKey};
 
 use crate::core::{
     engine_state::{execution_effect::ExecutionEffect, Error},
@@ -116,14 +114,11 @@ impl StepRequest {
     }
 
     /// Returns list of slashed validators.
-    pub fn slashed_validators(&self) -> Result<Vec<PublicKey>, bytesrepr::Error> {
-        let mut ret = vec![];
-        for slash_item in &self.slash_items {
-            let public_key: PublicKey =
-                bytesrepr::deserialize(slash_item.validator_id.clone().to_bytes()?)?;
-            ret.push(public_key);
-        }
-        Ok(ret)
+    pub fn slashed_validators(&self) -> Vec<PublicKey> {
+        self.slash_items
+            .iter()
+            .map(|si| si.validator_id.clone())
+            .collect()
     }
 
     /// Returns all reward factors.

--- a/execution_engine_testing/test_support/src/step_request_builder.rs
+++ b/execution_engine_testing/test_support/src/step_request_builder.rs
@@ -80,7 +80,6 @@ impl StepRequestBuilder {
             self.slash_items,
             self.reward_items,
             self.evict_items,
-            self.run_auction,
             self.next_era_id,
             self.era_end_timestamp_millis,
         )

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -276,7 +276,6 @@ fn commit_step(
         // Note: The Casper Network does not slash, but another network could
         slash_items: vec![],
         evict_items,
-        run_auction: true,
         next_era_id,
         era_end_timestamp_millis,
     };


### PR DESCRIPTION
This PR:
* removes `run_auction` boolean from the `StepRequest`. It was unnecessary as we always run it (it was always set to `true` as well).
* does not call `Auction::slash` endpoint if there are no validators to slash.

Closes https://github.com/casper-network/casper-node/issues/2309