### PR TITLE
Some fixes for Fast Sync & NCTL

### DIFF
--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -40,7 +40,7 @@ where
     loop {
         for peer in effect_builder.get_peers_in_random_order().await {
             trace!(
-                "Attempting to fetch {:?} with id {:?} from {:?}",
+                "attempting to fetch {:?} with id {:?} from {:?}",
                 T::TAG,
                 id,
                 peer
@@ -48,7 +48,7 @@ where
             match effect_builder.fetch::<T, NodeId>(id, peer).await {
                 Ok(fetched_data @ FetchedData::FromStorage { .. }) => {
                     trace!(
-                        "Did not get {:?} with id {:?} from {:?}, got from storage instead",
+                        "did not get {:?} with id {:?} from {:?}, got from storage instead",
                         T::TAG,
                         id,
                         peer
@@ -56,7 +56,7 @@ where
                     return Ok(fetched_data);
                 }
                 Ok(fetched_data @ FetchedData::FromPeer { .. }) => {
-                    trace!("Fetched {:?} with id {:?} from {:?}", T::TAG, id, peer);
+                    trace!("fetched {:?} with id {:?} from {:?}", T::TAG, id, peer);
                     return Ok(fetched_data);
                 }
                 Err(FetcherError::Absent { .. }) => {
@@ -64,7 +64,7 @@ where
                         ?id,
                         tag = ?T::TAG,
                         ?peer,
-                        "Fast sync could not fetch; trying next peer",
+                        "fast sync could not fetch; trying next peer",
                     )
                 }
                 Err(FetcherError::TimedOut { .. }) => {
@@ -72,7 +72,7 @@ where
                         ?id,
                         tag = ?T::TAG,
                         ?peer,
-                        "Peer timed out",
+                        "peer timed out",
                     );
                 }
                 Err(error @ FetcherError::CouldNotConstructGetRequest { .. }) => return Err(error),
@@ -356,7 +356,7 @@ where
                     warn!(
                         ?error,
                         ?peer,
-                        "Error validating block from peer; banning peer.",
+                        "error validating block from peer; banning peer.",
                     );
                     effect_builder.announce_disconnect_from_peer(peer).await;
                     continue;
@@ -697,7 +697,7 @@ pub(crate) async fn run_fast_sync_task(
     {
         warn!(
             ?trusted_block_header,
-            "Timestamp of trusted hash is older than \
+            "timestamp of trusted hash is older than \
              era_duration * (unbonding_delay - auction_delay)"
         );
     }
@@ -754,7 +754,7 @@ pub(crate) async fn run_fast_sync_task(
         height = most_recent_block_header.height(),
         now = %Timestamp::now(),
         block_timestamp = %most_recent_block_header.timestamp(),
-        "Fetching and executing blocks to synchronize to current",
+        "fetching and executing blocks to synchronize to current",
     );
     loop {
         let block = match fetch_and_store_next::<BlockWithMetadata>(
@@ -770,7 +770,7 @@ pub(crate) async fn run_fast_sync_task(
                     era = most_recent_block_header.era_id().value(),
                     height = most_recent_block_header.height(),
                     timestamp = %most_recent_block_header.timestamp(),
-                    "Couldn't download a more recent block; finishing syncing",
+                    "couldn't download a more recent block; finishing syncing",
                 );
                 break;
             }
@@ -791,7 +791,7 @@ pub(crate) async fn run_fast_sync_task(
             height = block.height(),
             now = %Timestamp::now(),
             block_timestamp = %block.timestamp(),
-            "Executing block",
+            "executing block",
         );
         let block_and_execution_effects = effect_builder
             .execute_finalized_block(
@@ -832,7 +832,7 @@ pub(crate) async fn run_fast_sync_task(
                 era = most_recent_block_header.era_id().value(),
                 height = most_recent_block_header.height(),
                 timestamp = %most_recent_block_header.timestamp(),
-                "Synchronized up to the current era; finishing syncing",
+                "synchronized up to the current era; finishing syncing",
             );
             break;
         }
@@ -843,7 +843,7 @@ pub(crate) async fn run_fast_sync_task(
         height = most_recent_block_header.height(),
         now = %Timestamp::now(),
         block_timestamp = %most_recent_block_header.timestamp(),
-        "Finished synchronizing",
+        "finished synchronizing",
     );
 
     Ok(most_recent_block_header)

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -100,7 +100,7 @@ impl NetworkingMetrics {
             "count of outgoing messages with block request/response payload",
         )?;
         let out_count_trie_transfer = IntCounter::new(
-            "net_out_count_block_transfer",
+            "net_out_count_trie_transfer",
             "count of outgoing messages with trie payloads",
         )?;
         let out_count_other = IntCounter::new(
@@ -133,7 +133,7 @@ impl NetworkingMetrics {
             "volume in bytes of outgoing messages with block request/response payload",
         )?;
         let out_bytes_trie_transfer = IntCounter::new(
-            "net_out_bytes_block_transfer",
+            "net_out_bytes_trie_transfer",
             "volume in bytes of outgoing messages with trie payloads",
         )?;
         let out_bytes_other = IntCounter::new(
@@ -153,6 +153,7 @@ impl NetworkingMetrics {
         registry.register(Box::new(out_count_address_gossip.clone()))?;
         registry.register(Box::new(out_count_deploy_transfer.clone()))?;
         registry.register(Box::new(out_count_block_transfer.clone()))?;
+        registry.register(Box::new(out_count_trie_transfer.clone()))?;
         registry.register(Box::new(out_count_other.clone()))?;
 
         registry.register(Box::new(out_bytes_protocol.clone()))?;
@@ -161,6 +162,7 @@ impl NetworkingMetrics {
         registry.register(Box::new(out_bytes_address_gossip.clone()))?;
         registry.register(Box::new(out_bytes_deploy_transfer.clone()))?;
         registry.register(Box::new(out_bytes_block_transfer.clone()))?;
+        registry.register(Box::new(out_bytes_trie_transfer.clone()))?;
         registry.register(Box::new(out_bytes_other.clone()))?;
 
         Ok(NetworkingMetrics {


### PR DESCRIPTION
This fixes some issues with running fast sync code using NCTL:
- some metrics weren't being correctly registered, which led to errors being printed in the logs and NCTL tests failing,
- nodes weren't finishing syncing correctly after the network was stalled for a significant amount of time.
Related to #2070 , but doesn't close it yet.
