### PR TITLE
Collapse separate address generators into one

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -739,9 +739,7 @@ where
     protocol_version: ProtocolVersion,
     correlation_id: CorrelationId,
     exec_config: ExecConfig,
-    uref_address_generator: Rc<RefCell<AddressGenerator>>,
-    hash_address_generator: Rc<RefCell<AddressGenerator>>,
-    transfer_address_generator: Rc<RefCell<AddressGenerator>>,
+    address_generator: Rc<RefCell<AddressGenerator>>,
     executor: Executor,
     tracking_copy: Rc<RefCell<TrackingCopy<<S as StateProvider>::Reader>>>,
     system_module: Module,
@@ -765,15 +763,8 @@ where
 
         let phase = Phase::System;
         let genesis_config_hash_bytes = genesis_config_hash.as_ref();
-        let uref_address_generator = {
-            let generator = AddressGenerator::new(genesis_config_hash_bytes, phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let hash_address_generator = {
-            let generator = AddressGenerator::new(genesis_config_hash_bytes, phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let transfer_address_generator = {
+
+        let address_generator = {
             let generator = AddressGenerator::new(genesis_config_hash_bytes, phase);
             Rc::new(RefCell::new(generator))
         };
@@ -797,9 +788,7 @@ where
             protocol_version,
             correlation_id,
             exec_config,
-            uref_address_generator,
-            hash_address_generator,
-            transfer_address_generator,
+            address_generator,
             executor,
             tracking_copy,
             system_module,
@@ -814,7 +803,7 @@ where
         let round_seigniorage_rate_uref =
             {
                 let round_seigniorage_rate_uref = self
-                    .uref_address_generator
+                    .address_generator
                     .borrow_mut()
                     .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -836,7 +825,7 @@ where
 
         let total_supply_uref = {
             let total_supply_uref = self
-                .uref_address_generator
+                .address_generator
                 .borrow_mut()
                 .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -863,7 +852,7 @@ where
         let entry_points = mint::mint_entry_points();
 
         let access_key = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -903,7 +892,7 @@ where
         let entry_points = handle_payment::handle_payment_entry_points();
 
         let access_key = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -1035,7 +1024,7 @@ where
             self.initial_seigniorage_recipients(&validators, auction_delay);
 
         let era_id_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1048,7 +1037,7 @@ where
         named_keys.insert(ERA_ID_KEY.into(), era_id_uref.into());
 
         let era_end_timestamp_millis_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1064,7 +1053,7 @@ where
         );
 
         let initial_seigniorage_recipients_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1088,7 +1077,7 @@ where
 
         let validator_slots = self.exec_config.validator_slots();
         let validator_slots_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1101,7 +1090,7 @@ where
         named_keys.insert(VALIDATOR_SLOTS_KEY.into(), validator_slots_uref.into());
 
         let auction_delay_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1114,7 +1103,7 @@ where
         named_keys.insert(AUCTION_DELAY_KEY.into(), auction_delay_uref.into());
 
         let locked_funds_period_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1131,7 +1120,7 @@ where
 
         let unbonding_delay = self.exec_config.unbonding_delay();
         let unbonding_delay_uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.tracking_copy.borrow_mut().write(
@@ -1146,7 +1135,7 @@ where
         let entry_points = auction::auction_entry_points();
 
         let access_key = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -1163,7 +1152,7 @@ where
         let entry_points = standard_payment::standard_payment_entry_points();
 
         let access_key = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
@@ -1277,9 +1266,7 @@ where
                 Default::default(),
                 deploy_hash,
                 Gas::new(U512::MAX),
-                Rc::clone(&self.hash_address_generator),
-                Rc::clone(&self.uref_address_generator),
-                Rc::clone(&self.transfer_address_generator),
+                Rc::clone(&self.address_generator),
                 self.protocol_version,
                 self.correlation_id,
                 Rc::clone(&self.tracking_copy),
@@ -1305,11 +1292,11 @@ where
     ) -> (ContractPackageHash, ContractHash) {
         let protocol_version = self.protocol_version;
         let contract_wasm_hash =
-            ContractWasmHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
+            ContractWasmHash::new(self.address_generator.borrow_mut().new_hash_address());
         let contract_hash =
-            ContractHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
+            ContractHash::new(self.address_generator.borrow_mut().new_hash_address());
         let contract_package_hash =
-            ContractPackageHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
+            ContractPackageHash::new(self.address_generator.borrow_mut().new_hash_address());
 
         let contract_wasm = ContractWasm::new(vec![]);
         let contract = Contract::new(

--- a/execution_engine/src/core/execution/executor.rs
+++ b/execution_engine/src/core/execution/executor.rs
@@ -130,15 +130,7 @@ impl Executor {
             extract_access_rights_from_keys(keys)
         };
 
-        let hash_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let uref_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let target_address_generator = {
+        let address_generator = {
             let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
             Rc::new(RefCell::new(generator))
         };
@@ -162,9 +154,7 @@ impl Executor {
             deploy_hash,
             gas_limit,
             gas_counter,
-            hash_address_generator,
-            uref_address_generator,
-            target_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -300,15 +290,7 @@ impl Executor {
         R::Error: Into<Error>,
     {
         // use host side standard payment
-        let hash_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let uref_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let transfer_address_generator = {
+        let address_generator = {
             let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
             Rc::new(RefCell::new(generator))
         };
@@ -325,9 +307,7 @@ impl Executor {
             blocktime,
             deploy_hash,
             payment_gas_limit,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             Rc::clone(&tracking_copy),
@@ -455,15 +435,7 @@ impl Executor {
             }
         }
 
-        let hash_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let uref_address_generator = {
-            let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
-            Rc::new(RefCell::new(generator))
-        };
-        let transfer_address_generator = {
+        let address_generator = {
             let generator = AddressGenerator::new(deploy_hash.as_bytes(), phase);
             Rc::new(RefCell::new(generator))
         };
@@ -487,9 +459,7 @@ impl Executor {
             blocktime,
             deploy_hash,
             gas_limit,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             tracking_copy,
@@ -533,9 +503,7 @@ impl Executor {
         blocktime: BlockTime,
         deploy_hash: DeployHash,
         gas_limit: Gas,
-        hash_address_generator: Rc<RefCell<AddressGenerator>>,
-        uref_address_generator: Rc<RefCell<AddressGenerator>>,
-        transfer_address_generator: Rc<RefCell<AddressGenerator>>,
+        address_generator: Rc<RefCell<AddressGenerator>>,
         protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
@@ -562,9 +530,7 @@ impl Executor {
             blocktime,
             deploy_hash,
             gas_limit,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             tracking_copy,
@@ -624,9 +590,7 @@ impl Executor {
         blocktime: BlockTime,
         deploy_hash: DeployHash,
         gas_limit: Gas,
-        hash_address_generator: Rc<RefCell<AddressGenerator>>,
-        uref_address_generator: Rc<RefCell<AddressGenerator>>,
-        transfer_address_generator: Rc<RefCell<AddressGenerator>>,
+        address_generator: Rc<RefCell<AddressGenerator>>,
         protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
@@ -659,9 +623,7 @@ impl Executor {
             deploy_hash,
             gas_limit,
             gas_counter,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             phase,

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1443,9 +1443,7 @@ where
         let deploy_hash = self.context.get_deploy_hash();
         let gas_limit = self.context.gas_limit();
         let gas_counter = self.context.gas_counter();
-        let hash_address_generator = self.context.hash_address_generator();
-        let uref_address_generator = self.context.uref_address_generator();
-        let transfer_address_generator = self.context.transfer_address_generator();
+        let address_generator = self.context.address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let transfers = self.context.transfers().to_owned();
@@ -1463,9 +1461,7 @@ where
             deploy_hash,
             gas_limit,
             gas_counter,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -1589,9 +1585,7 @@ where
         let deploy_hash = self.context.get_deploy_hash();
         let gas_limit = self.context.gas_limit();
         let gas_counter = self.context.gas_counter();
-        let fn_store_id = self.context.hash_address_generator();
-        let address_generator = self.context.uref_address_generator();
-        let transfer_address_generator = self.context.transfer_address_generator();
+        let address_generator = self.context.address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let transfers = self.context.transfers().to_owned();
@@ -1609,9 +1603,7 @@ where
             deploy_hash,
             gas_limit,
             gas_counter,
-            fn_store_id,
             address_generator,
-            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -1718,9 +1710,7 @@ where
         let deploy_hash = self.context.get_deploy_hash();
         let gas_limit = self.context.gas_limit();
         let gas_counter = self.context.gas_counter();
-        let fn_store_id = self.context.hash_address_generator();
-        let address_generator = self.context.uref_address_generator();
-        let transfer_address_generator = self.context.transfer_address_generator();
+        let address_generator = self.context.address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
 
@@ -1739,9 +1729,7 @@ where
             deploy_hash,
             gas_limit,
             gas_counter,
-            fn_store_id,
             address_generator,
-            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -2225,9 +2213,7 @@ where
             self.context.get_deploy_hash(),
             self.context.gas_limit(),
             self.context.gas_counter(),
-            self.context.hash_address_generator(),
-            self.context.uref_address_generator(),
-            self.context.transfer_address_generator(),
+            self.context.address_generator(),
             protocol_version,
             self.context.correlation_id(),
             self.context.phase(),

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -111,9 +111,7 @@ pub struct RuntimeContext<'a, R> {
     deploy_hash: DeployHash,
     gas_limit: Gas,
     gas_counter: Gas,
-    hash_address_generator: Rc<RefCell<AddressGenerator>>,
-    uref_address_generator: Rc<RefCell<AddressGenerator>>,
-    transfer_address_generator: Rc<RefCell<AddressGenerator>>,
+    address_generator: Rc<RefCell<AddressGenerator>>,
     protocol_version: ProtocolVersion,
     correlation_id: CorrelationId,
     phase: Phase,
@@ -142,9 +140,7 @@ where
         deploy_hash: DeployHash,
         gas_limit: Gas,
         gas_counter: Gas,
-        hash_address_generator: Rc<RefCell<AddressGenerator>>,
-        uref_address_generator: Rc<RefCell<AddressGenerator>>,
-        transfer_address_generator: Rc<RefCell<AddressGenerator>>,
+        address_generator: Rc<RefCell<AddressGenerator>>,
         protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         phase: Phase,
@@ -164,9 +160,7 @@ where
             base_key,
             gas_limit,
             gas_counter,
-            hash_address_generator,
-            uref_address_generator,
-            transfer_address_generator,
+            address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -328,18 +322,8 @@ where
     }
 
     /// Returns new shared instance of an address generator.
-    pub fn uref_address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
-        Rc::clone(&self.uref_address_generator)
-    }
-
-    /// Returns new shared instance of a hash generator.
-    pub fn hash_address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
-        Rc::clone(&self.hash_address_generator)
-    }
-
-    /// Returns new shared instance of a transfer address generator.
-    pub fn transfer_address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
-        Rc::clone(&self.transfer_address_generator)
+    pub fn address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
+        Rc::clone(&self.address_generator)
     }
 
     /// Returns new shared instance of a tracking copy.
@@ -387,13 +371,13 @@ where
 
     /// Generates new deterministic hash for uses as an address.
     pub fn new_hash_address(&mut self) -> Result<[u8; KEY_HASH_LENGTH], Error> {
-        Ok(self.hash_address_generator.borrow_mut().new_hash_address())
+        Ok(self.address_generator.borrow_mut().new_hash_address())
     }
 
     /// Creates new [`URef`] instance.
     pub fn new_uref(&mut self, value: StoredValue) -> Result<URef, Error> {
         let uref = self
-            .uref_address_generator
+            .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
         self.insert_uref(uref);
@@ -408,10 +392,7 @@ where
 
     /// Creates a new transfer address using a transfer address generator.
     pub fn new_transfer_addr(&mut self) -> Result<TransferAddr, Error> {
-        let transfer_addr = self
-            .transfer_address_generator
-            .borrow_mut()
-            .create_address();
+        let transfer_addr = self.address_generator.borrow_mut().create_address();
         Ok(TransferAddr::new(transfer_addr))
     }
 


### PR DESCRIPTION
CHANGELOG:

- Refactored the EE to use only one `AddressGenerator` instead of three separate address generators 


