### PR TITLE
NCTL: add pushing of logs to s3 to nightly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -671,6 +671,11 @@ name: nightly-tests-cron
 steps:
 - name: nctl-nighly-script
   image: casperlabs/node-build-u1804
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
   commands:
   - "python3 -m pip install supervisor toml"
   - "apt update && apt install lsof -y"


### PR DESCRIPTION
Changes:
- Uploads `nctl-assets-dump` to s3 on test failure.

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/217

Example:
```
2021-11-09T18:52:29.485947 [INFO] [286] NCTL :: ------------------------------------------------------------
2021-11-09T18:52:29.487557 [INFO] [286] NCTL :: Starting Scenario: itst01
2021-11-09T18:52:29.488774 [INFO] [286] NCTL :: ------------------------------------------------------------
2021-11-09T18:52:29.490244 [INFO] [286] NCTL :: Fake fail
2021-11-09T18:52:29.491484 [INFO] [286] NCTL :: Test exited with exit code 1
2021-11-09T18:52:29.492598 [INFO] [286] NCTL :: Dumping logs...
2021-11-09T18:52:29.496950 [INFO] [286] NCTL :: transient asset dump ... starts
2021-11-09T18:52:29.592164 [INFO] [286] NCTL :: transient asset dump ... complete
2021-11-09T18:52:29.593309 [INFO] [286] NCTL :: Uploading dump to s3...
2021-11-09T18:52:33.284784 [INFO] [286] NCTL :: Download the dump file: curl -O https://s3.us-east-2.amazonaws.com/nctl.casperlabs.io/nightly-logs/149_nctl_dump.tar.gz
```