### PR TITLE
Reject expired deploys sent from a client

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -64,12 +64,12 @@ pub(crate) enum Error {
     },
 
     /// The deploy received by the node from the client has expired.
-    #[error("deploy received by the node expired at {deploy_expiry_timestamp} with node's time at {node_current_timestamp}")]
+    #[error("deploy received by the node expired at {deploy_expiry_timestamp} with node's time at {current_node_timestamp}")]
     ExpiredDeploy {
         /// The timestamp when the deploy expires.
         deploy_expiry_timestamp: Timestamp,
         /// The timestamp when the node validated the expiry timestamp.
-        node_current_timestamp: Timestamp,
+        current_node_timestamp: Timestamp,
     },
 }
 
@@ -208,19 +208,21 @@ impl DeployAcceptor {
         }
 
         // We only perform expiry checks on deploys received from the client.
-        let node_current_timestamp = Timestamp::now();
-        if source.from_client() && deploy.header().expired(node_current_timestamp) {
-            let time_of_expiry = deploy.header().expires();
-            debug!(%deploy, "deploy has expired");
-            return self.handle_invalid_deploy_result(
-                effect_builder,
-                EventMetadata::new(deploy, source, maybe_responder),
-                Error::ExpiredDeploy {
-                    deploy_expiry_timestamp: time_of_expiry,
-                    node_current_timestamp,
-                },
-                verification_start_timestamp,
-            );
+        if source.from_client() {
+            let current_node_timestamp = Timestamp::now();
+            if deploy.header().expired(current_node_timestamp) {
+                let time_of_expiry = deploy.header().expires();
+                debug!(%deploy, "deploy has expired");
+                return self.handle_invalid_deploy_result(
+                    effect_builder,
+                    EventMetadata::new(deploy, source, maybe_responder),
+                    Error::ExpiredDeploy {
+                        deploy_expiry_timestamp: time_of_expiry,
+                        current_node_timestamp,
+                    },
+                    verification_start_timestamp,
+                );
+            }
         }
 
         if self.verify_accounts {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -64,8 +64,8 @@ pub(crate) enum Error {
     },
 
     /// The deploy received by the node from the client has expired.
-    #[error("deploy received by the node from the client has expired")]
-    ExpiredDeploy,
+    #[error("deploy received by the node expired at {0}")]
+    ExpiredDeploy(Timestamp),
 }
 
 /// A representation of the way in which a deploy failed validation checks.
@@ -204,11 +204,12 @@ impl DeployAcceptor {
 
         // We only perform expiry checks on deploys received from the client.
         if source.from_client() && deploy.header().expired(Timestamp::now()) {
+            let time_of_expiry = deploy.header().expires();
             debug!(%deploy, "deploy has expired");
             return self.handle_invalid_deploy_result(
                 effect_builder,
                 EventMetadata::new(deploy, source, maybe_responder),
-                Error::ExpiredDeploy,
+                Error::ExpiredDeploy(time_of_expiry),
                 verification_start_timestamp,
             );
         }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -1295,7 +1295,7 @@ async fn should_reject_deploy_with_mangled_transfer_amount() {
 async fn should_reject_expired_deploy_from_client() {
     let test_scenario = TestScenario::ShouldNotAcceptExpiredDeploySentByClient;
     let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(result, Err(super::Error::ExpiredDeploy)))
+    assert!(matches!(result, Err(super::Error::ExpiredDeploy(_))))
 }
 
 #[tokio::test]

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -145,6 +145,8 @@ enum TestScenario {
     DeployWithoutTransferTarget,
     DeployWithoutTransferAmount,
     BalanceCheckForDeploySentByPeer,
+    ShouldNotAcceptExpiredDeploySentByClient,
+    ShouldAcceptExpiredDeploySentByPeer,
 }
 
 impl TestScenario {
@@ -156,7 +158,8 @@ impl TestScenario {
             | TestScenario::BalanceCheckForDeploySentByPeer
             | TestScenario::FromPeerMissingAccount
             | TestScenario::FromPeerAccountWithInsufficientWeight
-            | TestScenario::FromPeerAccountWithInvalidAssociatedKeys => {
+            | TestScenario::FromPeerAccountWithInvalidAssociatedKeys
+            | TestScenario::ShouldAcceptExpiredDeploySentByPeer => {
                 Source::Peer(NodeId::random(rng))
             }
             TestScenario::FromClientInvalidDeploy
@@ -177,7 +180,8 @@ impl TestScenario {
             | TestScenario::DeployWithSessionContract(_)
             | TestScenario::DeployWithSessionContractPackage(_)
             | TestScenario::DeployWithEmptySessionModuleBytes
-            | TestScenario::DeployWithNativeTransferInPayment => Source::Client,
+            | TestScenario::DeployWithNativeTransferInPayment
+            | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => Source::Client,
         }
     }
 
@@ -275,6 +279,10 @@ impl TestScenario {
             TestScenario::DeployWithNativeTransferInPayment => {
                 Deploy::random_with_native_transfer_in_payment_logic(rng)
             }
+            TestScenario::ShouldAcceptExpiredDeploySentByPeer
+            | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => {
+                Deploy::random_expired_deploy(rng)
+            }
         }
     }
 
@@ -286,7 +294,8 @@ impl TestScenario {
             | TestScenario::FromPeerAccountWithInsufficientWeight // account check skipped if from peer
             | TestScenario::FromPeerAccountWithInvalidAssociatedKeys // account check skipped if from peer
             | TestScenario::FromClientRepeatedValidDeploy
-            | TestScenario::FromClientValidDeploy => true,
+            | TestScenario::FromClientValidDeploy
+            | TestScenario::ShouldAcceptExpiredDeploySentByPeer=> true,
             TestScenario::FromPeerInvalidDeploy
             | TestScenario::FromClientInsufficientBalance
             | TestScenario::FromClientMissingAccount
@@ -301,7 +310,8 @@ impl TestScenario {
             | TestScenario::DeployWithMangledTransferAmount
             | TestScenario::DeployWithoutTransferAmount
             | TestScenario::DeployWithoutTransferTarget
-            | TestScenario::BalanceCheckForDeploySentByPeer => false,
+            | TestScenario::BalanceCheckForDeploySentByPeer
+            | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => false,
             TestScenario::DeployWithCustomPaymentContract(contract_scenario)
             | TestScenario::DeployWithSessionContract(contract_scenario) => match contract_scenario
             {
@@ -722,7 +732,8 @@ async fn run_deploy_acceptor_without_timeout(
             | TestScenario::DeployWithMangledPaymentAmount
             | TestScenario::DeployWithMangledTransferAmount
             | TestScenario::DeployWithoutTransferTarget
-            | TestScenario::DeployWithoutTransferAmount => {
+            | TestScenario::DeployWithoutTransferAmount
+            | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => {
                 matches!(
                     event,
                     Event::DeployAcceptorAnnouncement(DeployAcceptorAnnouncement::InvalidDeploy {
@@ -790,7 +801,8 @@ async fn run_deploy_acceptor_without_timeout(
             TestScenario::FromPeerValidDeploy
             | TestScenario::FromPeerMissingAccount
             | TestScenario::FromPeerAccountWithInvalidAssociatedKeys
-            | TestScenario::FromPeerAccountWithInsufficientWeight => {
+            | TestScenario::FromPeerAccountWithInsufficientWeight
+            | TestScenario::ShouldAcceptExpiredDeploySentByPeer => {
                 matches!(
                     event,
                     Event::DeployAcceptorAnnouncement(
@@ -1277,6 +1289,20 @@ async fn should_reject_deploy_with_mangled_transfer_amount() {
             DeployConfigurationFailure::FailedToParseTransferAmount
         ))
     ))
+}
+
+#[tokio::test]
+async fn should_reject_expired_deploy_from_client() {
+    let test_scenario = TestScenario::ShouldNotAcceptExpiredDeploySentByClient;
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(result, Err(super::Error::ExpiredDeploy)))
+}
+
+#[tokio::test]
+async fn should_accept_expired_deploy_from_peer() {
+    let test_scenario = TestScenario::ShouldAcceptExpiredDeploySentByPeer;
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
 }
 
 #[tokio::test]

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -1295,7 +1295,7 @@ async fn should_reject_deploy_with_mangled_transfer_amount() {
 async fn should_reject_expired_deploy_from_client() {
     let test_scenario = TestScenario::ShouldNotAcceptExpiredDeploySentByClient;
     let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(result, Err(super::Error::ExpiredDeploy(_))))
+    assert!(matches!(result, Err(super::Error::ExpiredDeploy { .. })))
 }
 
 #[tokio::test]

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -954,7 +954,7 @@ impl Deploy {
         };
         let secret_key = SecretKey::random(rng);
         Deploy::new(
-            deploy.header.timestamp,
+            Timestamp::now(),
             deploy.header.ttl,
             deploy.header.gas_price,
             deploy.header.dependencies,
@@ -1143,6 +1143,23 @@ impl Deploy {
             args: Default::default(),
         };
         Self::random_transfer_with_session(rng, session)
+    }
+
+    pub(crate) fn random_expired_deploy(rng: &mut TestRng) -> Self {
+        let deploy = Self::random_valid_native_transfer(rng);
+        let secret_key = SecretKey::random(rng);
+
+        Deploy::new(
+            Timestamp::zero(),
+            TimeDiff::from_seconds(1u32),
+            deploy.header.gas_price,
+            deploy.header.dependencies,
+            deploy.header.chain_name,
+            deploy.payment,
+            deploy.session,
+            &secret_key,
+            None,
+        )
     }
 
     /// Creates a deploy with native transfer as payment code.


### PR DESCRIPTION
CHANGELOG:

- Modified the DeployAcceptor to reject expired deploys received from a client.
- Added two tests to ensure the correct behavior

Closes #2330 