### PR TITLE
1.4.2 versioning and CHANGELOG updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "assert-json-diff"
@@ -371,7 +371,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-casper"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "assert_cmd",
  "clap 3.0.0-beta.5",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "casper-client"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "casper-contract"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "casper-hashing"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "assert_matches",
  "base16",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node-macros"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "Inflector",
  "indexmap",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.0.0"
+version = "1.4.2"
 dependencies = [
  "base16",
  "base64",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -1693,7 +1693,7 @@ version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -2033,7 +2033,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2520,9 +2520,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "linked-hash-map"
@@ -2799,7 +2799,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2820,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2889,7 +2889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
  "serde",
@@ -3143,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "plotters"
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
@@ -3346,9 +3346,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -3480,9 +3480,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -4011,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -4247,9 +4247,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4258,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4347,18 +4347,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4376,11 +4376,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -4396,9 +4397,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4551,9 +4552,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4564,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -4840,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -4907,9 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
+checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
 dependencies = [
  "ctor",
  "version_check",
@@ -5045,9 +5046,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5225,18 +5226,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ci/publish_to_crates_io.sh
+++ b/ci/publish_to_crates_io.sh
@@ -83,5 +83,5 @@ publish node_macros
 publish node
 publish client
 publish smart_contracts/contract --features=std
-publish execution_engine_testing/test_support
+#publish execution_engine_testing/test_support
 publish execution_engine_testing/cargo_casper --allow-dirty

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.2] 2021-11-11
+
 ### Added
 * RPM package build and publish.
 * New client binary command `get-validator-changes` that returns status changes of active validators.
@@ -81,7 +84,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/37d561634adf73dab40fffa7f1f1ee47e80bf8a1...dev
+[1.4.2]: https://github.com/casper-network/casper-node/compare/v1.3.0...37d561634adf73dab40fffa7f1f1ee47e80bf8a1
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.0.0"
+version = "1.4.2"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -24,10 +24,10 @@ doc = false
 async-trait = "0.1.50"
 base16 = "0.2.1"
 base64 = "0.13.0"
-casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
-casper-node = { version = "1.0.0", path = "../node" }
-casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types" }
+casper-execution-engine = { version = "1.4.2", path = "../execution_engine" }
+casper-node = { version = "1.4.2", path = "../node" }
+casper-hashing = { version = "1.4.2", path = "../hashing" }
+casper-types = { version = "1.4.2", path = "../types" }
 clap = "2"
 humantime = "2"
 jsonrpc-lite = "0.5.0"

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.2] - 2021-11-11
+
+### Changed
+* Execution transforms are returned in their insertion order.
+
+### Removed
+* Removed `SystemContractCache` as it was not being used anymore
+
+## [1.4.0] - 2021-10-04
+
 ### Added
 * Added genesis validation step to ensure there are more genesis validators than validator slots.
 * Added a support for passing a public key as a `target` argument in native transfers.
@@ -29,13 +40,11 @@ All notable changes to this project will be documented in this file.  The format
 * Improve doc comments to clarify behavior of the bidding functionality.
 * Document `core` and `shared` modules and their children.
 * Change parameters to `LmdbEnvironment`'s constructor enabling manual flushing to disk.
-* Execution transforms are returned in their insertion order.
 
 ### Fixed
 * Fix a case where user could potentially supply a refund purse as a payment purse.
 
-### Removed
-* Removed `SystemContractCache` as it was not being used anymore
+
 
 ## [1.3.0] - 2021-07-19
 
@@ -86,7 +95,9 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/37d561634adf73dab40fffa7f1f1ee47e80bf8a1...dev
+[1.4.2]: https://github.com/casper-network/casper-node/compare/v1.4.0...37d561634adf73dab40fffa7f1f1ee47e80bf8a1
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -13,8 +13,8 @@ license-file = "../LICENSE"
 [dependencies]
 anyhow = "1.0.33"
 bincode = "1.3.1"
-casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-hashing = { version = "1.4.2", path = "../hashing" }
+casper-types = { version = "1.4.2", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
 hex-buffer-serde = "0.2.1"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/cargo_casper/CHANGELOG.md
+++ b/execution_engine_testing/cargo_casper/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+
+## [1.4.0] - 2021-10-04
+
 ### Changed
 * Support building and testing using stable Rust.
 
@@ -80,7 +84,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.3...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/casper-network/casper-node/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/casper-network/casper-node/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.3.1

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casper"
-version = "1.0.0"
+version = "1.4.2"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A command line tool for creating a Wasm smart contract and tests for use on the Casper network."

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -6,8 +6,8 @@ use once_cell::sync::Lazy;
 use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "1.0.0"));
-pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.0.0"));
+    Lazy::new(|| Dependency::new("casper-contract", "1.4.2"));
+pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.4.2"));
 pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-engine-test-support", "1.0.0"));
 pub static PATCH_SECTION: Lazy<String> = Lazy::new(|| match ARGS.workspace_path() {

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-execution-engine = { version = "1", path = "../../execution_engine", features = ["test-support"] }
-casper-hashing = { version = "1", path = "../../hashing" }
-casper-types = { version = "1", path = "../../types" }
+casper-execution-engine = { version = "1.4.2", path = "../../execution_engine", features = ["test-support"] }
+casper-hashing = { version = "1.4.2", path = "../../hashing" }
+casper-types = { version = "1.4.2", path = "../../types" }
 lmdb = "0.8.0"
 log = "0.4.14"
 num-rational = "0.4.0"

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-hashing"
-version = "1.0.0"
+version = "1.4.2"
 edition = "2018"
 description = "A library providing hashing functionality including Merkle Proof utilities."
 readme = "README.md"

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library providing hashing functionality including Merkle Proof utilities.
 
-#![doc(html_root_url = "https://docs.rs/casper-hashing/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-hashing/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.2] - 2021-11-11
+
+### Changed
+* There are now less false warnings/errors regarding dropped responders or closed channels during a shutdown, where they are expected and harmless.
+* Execution transforms are ordered by insertion order.
+
+### Removed
+* The config option `consensus.highway.unit_hashes_folder` has been removed.
+
+### Fixed
+* The block proposer component now retains pending deploys and transfers across a restart.
+
+
+## [1.4.0] - 2021-10-04
+
 ### Added
 * Add `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
 * Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
@@ -42,8 +58,6 @@ All notable changes to this project will be documented in this file.  The format
   * `[gossip][gossip_request_timeout]`
   * `[gossip][get_remainder_timeout]`
   * `[fetcher][get_from_peer_timeout]`
-* There are now less false warnings/errors regarding dropped responders or closed channels during a shutdown, where they are expected and harmless.
-* Execution transforms are ordered by insertion order.
 
 ### Removed
 * The unofficial support for nix-related derivations and support tooling has been removed.
@@ -51,12 +65,10 @@ All notable changes to this project will be documented in this file.  The format
 * Experimental support for libp2p has been removed.
 * The `isolation_reconnect_delay` configuration, which has been ignored since 1.3, has been removed.
 * The libp2p-exclusive metrics of `read_futures_in_flight`, `read_futures_total`, `write_futures_in_flight`, `write_futures_total` have been removed.
-* The config option `consensus.highway.unit_hashes_folder` has been removed.
 
 ### Fixed
 * Resolve an issue where `Deploys` with payment amounts exceeding the block gas limit would not be rejected.
 * Resolve issue of duplicated config option `max_associated_keys`.
-* The block proposer component now retains pending deploys and transfers across a restart.
 
 
 
@@ -222,7 +234,9 @@ All notable changes to this project will be documented in this file.  The format
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/37d561634adf73dab40fffa7f1f1ee47e80bf8a1...dev
+[1.4.2]: https://github.com/casper-network/casper-node/compare/v1.4.0...37d561634adf73dab40fffa7f1f1ee47e80bf8a1
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,10 +20,10 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
-casper-node-macros = { version = "1.0.0", path = "../node_macros" }
-casper-hashing = { version = "1.0.0", path = "../hashing" }
-casper-types = { version = "1.0.0", path = "../types", features = ["datasize", "gens", "json-schema"] }
+casper-execution-engine = { version = "1.4.2", path = "../execution_engine" }
+casper-node-macros = { version = "1.4.2", path = "../node_macros" }
+casper-hashing = { version = "1.4.2", path = "../hashing" }
+casper-types = { version = "1.4.2", path = "../types", features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 3, 2);
+    ProtocolVersion::from_parts(1, 4, 2);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node_macros/CHANGELOG.md
+++ b/node_macros/CHANGELOG.md
@@ -10,8 +10,10 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
-
 ## [Unreleased]
+
+
+## [1.4.0] - 2021-10-04
 
 ### Changed
 * Support building and testing using stable Rust.
@@ -58,7 +60,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-macros"
-version = "1.0.0"
+version = "1.4.2"
 authors = ["Marc Brinkmann <marc@casperlabs.io>"]
 edition = "2018"
 description = "A macro to create reactor implementations for the casper-node."

--- a/node_macros/src/lib.rs
+++ b/node_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! Generates reactors with routing from concise definitions. See `README.md` for details.
 
-#![doc(html_root_url = "https://docs.rs/casper-node-macros/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node-macros/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.3.2'
+version = '1.4.2'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.
@@ -11,7 +11,7 @@ hard_reset = true
 # in contract-runtime for computing genesis post-state hash.
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
-activation_point = 1605
+activation_point = 3000
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.3.2"
+        "version": "1.4.2"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "deploy_hash": "5C9B3B099c1378aa8E4A5F07F59Ff1fCdC69A83179427C7e67AE0377d94D93Fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76B603d386f3F4f8a5F87F597D4EAffd475433f861aF187AB5Db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block_header": {
                     "accumulated_seed": "AC979f51525CFD979b14aA7Dc0737c5154eABE0db9280EcEaa8DC8D2905B20D5",
                     "body_hash": "cD502c5393a3C8b66d6979ad7857507c9bAf5a8Ba16bA99c28378d3A970FFf42",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "changes": [
                     {
                       "public_key": "01D9BF2148748a85C89DA5aAd8ee0b0fC2D105fD39D41a4C796536354F0Ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block_hash": "13c2d7A68EcDd4B74bf4393C88915c836C863fC4bF11D7f2bD930A1BBCCAcdcb",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "era_summary": {
                     "block_hash": "13c2d7A68EcDd4B74bf4393C88915c836C863fC4bF11D7f2bD930A1BBCCAcdcb",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.3.2"
+        "version": "1.4.2"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.3.2",
+                  "api_version": "1.4.2",
                   "auction_state": {
                     "bids": [
                       {

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.0] - 2021-10-04
+
 ### Added
 * Add `no-std-helpers` feature, enabled by default, which provides no-std panic/oom handlers and a global allocator as a convenience.
 * Add new APIs for transferring tokens to the main purse associated with a public key: `transfer_to_public_key` and `transfer_from_purse_to_public_key`.
@@ -62,7 +65,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "A library for developing Casper network smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "1.0.0", path = "../../types" }
+casper-types = { version = "1.4.2", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -50,7 +50,7 @@
     all(not(test), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/CHANGELOG.md
+++ b/smart_contracts/contract_as/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.0] - 2021-10-04
+
 ### Added
 * Add function to create an account hash from a public key.
 * Add getter for public key algorithm name.
@@ -64,7 +67,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.0.0",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.0.0",
+  "version": "1.4.2",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+## [1.4.0] - 2021-10-04
+
 ### Added
 * Add `json-schema` feature, disabled by default, to enable many types to be used to produce JSON-schema data.
 * Add implicit `datasize` feature, disabled by default, to enable many types to derive the `DataSize` trait.
@@ -77,7 +80,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.3.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/casper-network/casper-node/compare/v1.0.1...v1.1.1

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -4,7 +4,7 @@
     not(any(feature = "json-schema", feature = "datasize", feature = "gens", test)),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/1.4.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
Bump to 1.4.2
Disable test_support cargo publish in CI
Updating CHANGELOG.md's to 1.4.2 commit hash
