### PR TITLE
Proper license field for crates.io

### DIFF
--- a/ci/casper_updater/Cargo.toml
+++ b/ci/casper_updater/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 description = "A tool to update versions of all published CasperLabs packages."
 edition = "2018"
-license-file = "../../LICENSE"
+license = "Apache-2.0"
 name = "casper-updater"
 readme = "README.md"
 version = "0.3.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-client"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/client"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 [lib]
 name = "casper_client"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-execution-engine"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_engine"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.33"

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/cargo-casper"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_engine_testing/cargo_casper"
-license-file = "../../LICENSE"
+license = "Apache-2.0"
 include = [
     "src/*.rs",
     "Cargo.lock",

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/casper-engine-test-support"
 readme = "README.md"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_engine_testing/test_support"
-license-file = "../../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 casper-execution-engine = { version = "1.4.2", path = "../../execution_engine", features = ["test-support"] }

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-hashing"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/hashing"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 blake2 = "0.9.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/casper-node"
 readme = "README.md"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/node"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 default-run = "casper-node"
 
 [dependencies]

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-node-macros"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/node_macros"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 indexmap = "1.6.0"

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-contract"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contracts/contract"
-license-file = "../../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 casper-types = { version = "1.4.2", path = "../../types" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/casper-types"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/types"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This PR removes the `license-file` field from the `Cargo.toml` files, and replaces it with `license = "Apache 2.0"`.

  - This is so our crates properly register as "Apache 2.0" on crates.io
  - See https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#setting-up-a-cratesio-account