### PR TITLE
Do not set `no_std` when `std` feature is enabled for `casper-types`

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,7 +1,13 @@
 //! Types used to allow creation of Wasm contracts and tests for use on the Casper Platform.
 
 #![cfg_attr(
-    not(any(feature = "json-schema", feature = "datasize", feature = "gens", test)),
+    not(any(
+        feature = "json-schema",
+        feature = "datasize",
+        feature = "gens",
+        feature = "std",
+        test,
+    )),
     no_std
 )]
 #![doc(html_root_url = "https://docs.rs/casper-types/1.4.2")]


### PR DESCRIPTION
Avoid setting `no_std` if the `std` feature is enabled for `casper-types`.

This is because we `derive(thiserror::Error)` on `bytesrepr::Error` when the `std` feature is set, and `thiserror::Error` relies on the standard library.