### PR TITLE
Add additional block header validation before returning `CurrentBlock…

### DIFF
--- a/node/src/components/linear_chain_sync/operations.rs
+++ b/node/src/components/linear_chain_sync/operations.rs
@@ -430,6 +430,8 @@ fn check_block_version(
 
     if is_current_era(header, trusted_key_block_info, chainspec)
         && header.protocol_version() < current_version
+        && (header.next_block_era_id() != chainspec.protocol_config.activation_point.era_id()
+            || !header.is_switch_block())
     {
         return Err(LinearChainSyncError::CurrentBlockHeaderHasOldVersion {
             current_version,


### PR DESCRIPTION
This PR solves the bug that causes the "downgrade/upgrade" loop when network was upgraded from "1.4.x" nodes to the "fast-sync" nodes.