### PR TITLE
Add no read ahead flag to EE and storage.

### DIFF
--- a/execution_engine/src/storage/transaction_source/lmdb.rs
+++ b/execution_engine/src/storage/transaction_source/lmdb.rs
@@ -81,11 +81,12 @@ impl LmdbEnvironment {
         let lmdb_flags = if manual_sync_enabled {
             // These options require that we manually call sync on the environment for the EE.
             EnvironmentFlags::NO_SUB_DIR
+                | EnvironmentFlags::NO_READAHEAD
                 | EnvironmentFlags::MAP_ASYNC
                 | EnvironmentFlags::WRITE_MAP
                 | EnvironmentFlags::NO_META_SYNC
         } else {
-            EnvironmentFlags::NO_SUB_DIR
+            EnvironmentFlags::NO_SUB_DIR | EnvironmentFlags::NO_READAHEAD
         };
 
         let env = Environment::new()

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -432,7 +432,9 @@ impl Storage {
                 // We manage our own directory.
                 | EnvironmentFlags::NO_SUB_DIR
                 // Disable thread local storage, strongly suggested for operation with tokio.
-                | EnvironmentFlags::NO_TLS,
+                | EnvironmentFlags::NO_TLS
+                // Disable read-ahead. Our data is not storead/read in sequence that would benefit from the read-ahead.
+                | EnvironmentFlags::NO_READAHEAD,
             )
             .set_max_readers(MAX_TRANSACTIONS)
             .set_max_dbs(MAX_DB_COUNT)


### PR DESCRIPTION
Disables the read-ahead option in LMDB. Our access patterns are not sequential so the data that LMDB decided to cache in memory were usually a miss which caused a lot of page swapping and polluted the RAM unnecessarily.


Closes https://github.com/casper-network/casper-node/issues/2369