### PR TITLE
GH-2398: Online map resize reintroduced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "libc",
  "linked-hash-map",
  "lmdb",
+ "lmdb-sys",
  "log",
  "num",
  "num-derive",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.10.0"
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
 lmdb = "0.8"
+lmdb-sys = "0.8"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.4.0", default-features = false }
 num-derive = "0.3.0"
@@ -62,4 +63,3 @@ test-support = []
 [[bench]]
 name = "trie_bench"
 harness = false
-

--- a/execution_engine/src/storage.rs
+++ b/execution_engine/src/storage.rs
@@ -18,3 +18,9 @@ pub(crate) const DEFAULT_TEST_MAX_DB_SIZE: usize = 52_428_800; // 50 MiB
 
 #[cfg(test)]
 pub(crate) const DEFAULT_TEST_MAX_READERS: u32 = 512;
+
+#[cfg(test)]
+pub(crate) const DEFAULT_GROW_SIZE_THRESHOLD: usize = 41_943_040; // 50 MiB * 80%
+
+#[cfg(test)]
+pub(crate) const DEFAULT_GROW_SIZE_BYTES: usize = 104_857_600; // 100 MiB

--- a/execution_engine/src/storage.rs
+++ b/execution_engine/src/storage.rs
@@ -20,7 +20,7 @@ pub(crate) const DEFAULT_TEST_MAX_DB_SIZE: usize = 52_428_800; // 50 MiB
 pub(crate) const DEFAULT_TEST_MAX_READERS: u32 = 512;
 
 #[cfg(test)]
-pub(crate) const DEFAULT_GROW_SIZE_THRESHOLD: usize = 41_943_040; // 50 MiB * 80%
+pub(crate) const DEFAULT_GROW_SIZE_THRESHOLD: usize = 41_943_040; // 40 MiB
 
 #[cfg(test)]
 pub(crate) const DEFAULT_GROW_SIZE_BYTES: usize = 104_857_600; // 100 MiB

--- a/execution_engine/src/storage/trie_store/lmdb.rs
+++ b/execution_engine/src/storage/trie_store/lmdb.rs
@@ -38,8 +38,10 @@
 //! // transactions.
 //! let tmp_dir = tempdir().unwrap();
 //! let map_size = 4096 * 2560;  // map size should be a multiple of OS page size
+//! let grow_size_threshold = 2048 * 2560;
+//! let grow_size_bytes = 4096 * 2560;
 //! let max_readers = 512;
-//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), map_size, max_readers, true).unwrap();
+//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), map_size, max_readers, true, grow_size_threshold, grow_size_bytes).unwrap();
 //! let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
 //!
 //! // First let's create a read-write transaction, persist the values, but

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -31,7 +31,8 @@ use crate::{
             operations::{self, read, read_with_proof, write, ReadResult, WriteResult},
             TrieStore,
         },
-        DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
+        DEFAULT_GROW_SIZE_BYTES, DEFAULT_GROW_SIZE_THRESHOLD, DEFAULT_TEST_MAX_DB_SIZE,
+        DEFAULT_TEST_MAX_READERS,
     },
 };
 
@@ -584,6 +585,8 @@ impl LmdbTestContext {
             DEFAULT_TEST_MAX_DB_SIZE,
             DEFAULT_TEST_MAX_READERS,
             true,
+            DEFAULT_GROW_SIZE_THRESHOLD,
+            DEFAULT_GROW_SIZE_BYTES,
         )?;
         let store = LmdbTrieStore::new(&environment, None, DatabaseFlags::empty())?;
         put_tries::<_, _, _, _, error::Error>(&environment, &store, tries)?;

--- a/execution_engine/src/storage/trie_store/tests/concurrent.rs
+++ b/execution_engine/src/storage/trie_store/tests/concurrent.rs
@@ -14,7 +14,8 @@ use crate::storage::{
     },
     trie::Trie,
     trie_store::{in_memory::InMemoryTrieStore, lmdb::LmdbTrieStore},
-    DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
+    DEFAULT_GROW_SIZE_BYTES, DEFAULT_GROW_SIZE_THRESHOLD, DEFAULT_TEST_MAX_DB_SIZE,
+    DEFAULT_TEST_MAX_READERS,
 };
 
 #[test]
@@ -26,6 +27,8 @@ fn lmdb_writer_mutex_does_not_collide_with_readers() {
             DEFAULT_TEST_MAX_DB_SIZE,
             DEFAULT_TEST_MAX_READERS,
             true,
+            DEFAULT_GROW_SIZE_THRESHOLD,
+            DEFAULT_GROW_SIZE_BYTES,
         )
         .unwrap(),
     );

--- a/execution_engine/src/storage/trie_store/tests/proptests.rs
+++ b/execution_engine/src/storage/trie_store/tests/proptests.rs
@@ -10,7 +10,8 @@ use casper_types::{bytesrepr::ToBytes, Key, StoredValue};
 use crate::storage::{
     store::tests as store_tests,
     trie::{gens::trie_arb, Trie},
-    DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
+    DEFAULT_GROW_SIZE_BYTES, DEFAULT_GROW_SIZE_THRESHOLD, DEFAULT_TEST_MAX_DB_SIZE,
+    DEFAULT_TEST_MAX_READERS,
 };
 
 const DEFAULT_MIN_LENGTH: usize = 1;
@@ -54,6 +55,8 @@ fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, StoredValue>>) -> bool {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();

--- a/execution_engine/src/storage/trie_store/tests/simple.rs
+++ b/execution_engine/src/storage/trie_store/tests/simple.rs
@@ -12,7 +12,8 @@ use crate::storage::{
     },
     trie::Trie,
     trie_store::{in_memory::InMemoryTrieStore, lmdb::LmdbTrieStore, TrieStore},
-    DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
+    DEFAULT_GROW_SIZE_BYTES, DEFAULT_GROW_SIZE_THRESHOLD, DEFAULT_TEST_MAX_DB_SIZE,
+    DEFAULT_TEST_MAX_READERS,
 };
 
 fn put_succeeds<'a, K, V, S, X, E>(
@@ -52,6 +53,8 @@ fn lmdb_put_succeeds() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -111,6 +114,8 @@ fn lmdb_put_get_succeeds() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -158,6 +163,8 @@ fn lmdb_put_get_many_succeeds() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -230,6 +237,8 @@ fn lmdb_uncommitted_read_write_txn_does_not_persist() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -279,6 +288,8 @@ fn lmdb_read_write_transaction_does_not_block_read_transaction() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
 
@@ -336,6 +347,8 @@ fn lmdb_reads_are_isolated() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -398,6 +411,8 @@ fn lmdb_reads_are_isolated_2() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
@@ -466,6 +481,8 @@ fn lmdb_dbs_are_isolated() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store_a = LmdbTrieStore::new(&env, Some("a"), DatabaseFlags::empty()).unwrap();
@@ -530,6 +547,8 @@ fn lmdb_transactions_can_be_used_across_sub_databases() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store_a = LmdbTrieStore::new(&env, Some("a"), DatabaseFlags::empty()).unwrap();
@@ -598,6 +617,8 @@ fn lmdb_uncommitted_transactions_across_sub_databases_do_not_persist() {
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )
     .unwrap();
     let store_a = LmdbTrieStore::new(&env, Some("a"), DatabaseFlags::empty()).unwrap();

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -187,12 +187,15 @@ impl LmdbWasmTestBuilder {
         let page_size = *OS_PAGE_SIZE;
         let global_state_dir = Self::global_state_dir(data_dir);
         Self::create_global_state_dir(&global_state_dir);
+        let grow_size_threshold = ((page_size * DEFAULT_LMDB_PAGES) as f32 * 0.8) as usize;
         let environment = Arc::new(
             LmdbEnvironment::new(
                 &global_state_dir,
                 page_size * DEFAULT_LMDB_PAGES,
                 DEFAULT_MAX_READERS,
                 true,
+                grow_size_threshold,
+                page_size * DEFAULT_LMDB_PAGES,
             )
             .expect("should create LmdbEnvironment"),
         );
@@ -253,12 +256,15 @@ impl LmdbWasmTestBuilder {
         Self::initialize_logging();
         let page_size = *OS_PAGE_SIZE;
         Self::create_global_state_dir(&global_state_dir);
+        let grow_size_threshold = ((page_size * DEFAULT_LMDB_PAGES) as f32 * 0.8) as usize;
         let environment = Arc::new(
             LmdbEnvironment::new(
                 &global_state_dir,
                 page_size * DEFAULT_LMDB_PAGES,
                 DEFAULT_MAX_READERS,
                 true,
+                grow_size_threshold,
+                page_size * DEFAULT_LMDB_PAGES,
             )
             .expect("should create LmdbEnvironment"),
         );

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -538,6 +538,8 @@ impl ContractRuntime {
             contract_runtime_config.max_global_state_size(),
             contract_runtime_config.max_readers(),
             contract_runtime_config.manual_sync_enabled(),
+            contract_runtime_config.grow_size_threshold(),
+            contract_runtime_config.grow_size_bytes(),
         )?);
 
         let trie_store = Arc::new(LmdbTrieStore::new(

--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -6,6 +6,8 @@ use casper_execution_engine::shared::utils;
 const DEFAULT_MAX_GLOBAL_STATE_SIZE: usize = 805_306_368_000; // 750 GiB
 const DEFAULT_MAX_READERS: u32 = 512;
 const DEFAULT_MAX_QUERY_DEPTH: u64 = 5;
+const DEFAULT_GROW_SIZE_THRESHOLD: usize = 644_245_094_400; // 712.5 GiB (95% of default initial size)
+const DEFAULT_GROW_SIZE_BYTES: usize = 53_687_091_200; // 50 GiB
 
 /// Contract runtime configuration.
 #[derive(Clone, Copy, DataSize, Debug, Deserialize, Serialize)]
@@ -30,6 +32,13 @@ pub struct Config {
     ///
     /// Defaults to `false`.
     enable_manual_sync: Option<bool>,
+    /// Threshold for global state size that will trigger a resize upon next write transaction.
+    ///
+    /// Defaults to 644,245,094,400 == 712.5 GiB
+    grow_size_threshold: Option<usize>,
+    /// After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+    /// extra space. Defaults to 53,687,091,200 == 50 GiB
+    grow_size_bytes: Option<usize>,
 }
 
 impl Config {
@@ -52,6 +61,15 @@ impl Config {
     pub(crate) fn manual_sync_enabled(&self) -> bool {
         self.enable_manual_sync.unwrap_or(false)
     }
+
+    pub(crate) fn grow_size_threshold(&self) -> usize {
+        self.grow_size_threshold
+            .unwrap_or(DEFAULT_GROW_SIZE_THRESHOLD)
+    }
+
+    pub(crate) fn grow_size_bytes(&self) -> usize {
+        self.grow_size_bytes.unwrap_or(DEFAULT_GROW_SIZE_BYTES)
+    }
 }
 
 impl Default for Config {
@@ -61,6 +79,8 @@ impl Default for Config {
             max_readers: Some(DEFAULT_MAX_READERS),
             max_query_depth: Some(DEFAULT_MAX_QUERY_DEPTH),
             enable_manual_sync: Some(false),
+            grow_size_threshold: Some(DEFAULT_GROW_SIZE_THRESHOLD),
+            grow_size_bytes: Some(DEFAULT_GROW_SIZE_BYTES),
         }
     }
 }

--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -6,8 +6,8 @@ use casper_execution_engine::shared::utils;
 const DEFAULT_MAX_GLOBAL_STATE_SIZE: usize = 805_306_368_000; // 750 GiB
 const DEFAULT_MAX_READERS: u32 = 512;
 const DEFAULT_MAX_QUERY_DEPTH: u64 = 5;
-const DEFAULT_GROW_SIZE_THRESHOLD: usize = 644_245_094_400; // 712.5 GiB (95% of default initial size)
-const DEFAULT_GROW_SIZE_BYTES: usize = 53_687_091_200; // 50 GiB
+const DEFAULT_GROW_SIZE_THRESHOLD: usize = 107_374_182_400; // 100 GiB
+const DEFAULT_GROW_SIZE_BYTES: usize = 161_061_273_600; // 150 GiB
 
 /// Contract runtime configuration.
 #[derive(Clone, Copy, DataSize, Debug, Deserialize, Serialize)]
@@ -34,10 +34,10 @@ pub struct Config {
     enable_manual_sync: Option<bool>,
     /// Threshold for global state size that will trigger a resize upon next write transaction.
     ///
-    /// Defaults to 644,245,094,400 == 712.5 GiB
+    /// Defaults to 107,374,182,400 == 100 GiB
     grow_size_threshold: Option<usize>,
     /// After global state will exceed `grow_size_threshold` bytes it will be resized by adding
-    /// extra space. Defaults to 53,687,091,200 == 50 GiB
+    /// extra space. Defaults to 161,061,273,600 == 150 GiB
     grow_size_bytes: Option<usize>,
 }
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -326,6 +326,14 @@ verify_accounts = true
 # If unset, defaults to false.
 #enable_manual_sync = false
 
+# Threshold for global state size that will trigger a resize upon next write transaction.
+#
+# Defaults to 107,374,182,400 == 100 GiB
+#grow_size_threshold = 107374182400
+
+# After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+# extra space. Defaults to 161,061,273,600 == 150 GiB
+#grow_size_bytes = 161061273600
 
 # ========================================================
 # Configuration options for synchronizing the linear chain

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -326,6 +326,14 @@ verify_accounts = true
 # If unset, defaults to false.
 #enable_manual_sync = false
 
+# Threshold for global state size that will trigger a resize upon next write transaction.
+#
+# Defaults to 107,374,182,400 == 100 GiB
+#grow_size_threshold = 107374182400
+
+# After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+# extra space. Defaults to 161,061,273,600 == 150 GiB
+#grow_size_bytes = 161061273600
 
 # ========================================================
 # Configuration options for synchronizing the linear chain

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -325,6 +325,14 @@ verify_accounts = true
 # If unset, defaults to false.
 #enable_manual_sync = false
 
+# Threshold for global state size that will trigger a resize upon next write transaction.
+#
+# Defaults to 107,374,182,400 == 100 GiB
+#grow_size_threshold = 107374182400
+
+# After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+# extra space. Defaults to 161,061,273,600 == 150 GiB
+#grow_size_bytes = 161061273600
 
 # ========================================================
 # Configuration options for synchronizing the linear chain

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -329,6 +329,14 @@ verify_accounts = true
 # If unset, defaults to false.
 #enable_manual_sync = false
 
+# Threshold for global state size that will trigger a resize upon next write transaction.
+#
+# Defaults to 107,374,182,400 == 100 GiB
+#grow_size_threshold = 107374182400
+
+# After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+# extra space. Defaults to 161,061,273,600 == 150 GiB
+#grow_size_bytes = 161061273600
 
 # ========================================================
 # Configuration options for synchronizing the linear chain

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -325,6 +325,14 @@ verify_accounts = true
 # If unset, defaults to false.
 #enable_manual_sync = false
 
+# Threshold for global state size that will trigger a resize upon next write transaction.
+#
+# Defaults to 107,374,182,400 == 100 GiB
+#grow_size_threshold = 107374182400
+
+# After global state will exceed `grow_size_threshold` bytes it will be resized by adding
+# extra space. Defaults to 161,061,273,600 == 150 GiB
+#grow_size_bytes = 161061273600
 
 # ========================================================
 # Configuration options for synchronizing the linear chain

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -27,6 +27,8 @@ pub const LMDB_PATH: &str = "lmdb-data";
 pub const CHAIN_DOWNLOAD_PATH: &str = "chain-download";
 pub const DEFAULT_MAX_DB_SIZE: usize = 483_183_820_800; // 450 gb
 pub const DEFAULT_MAX_READERS: u32 = 512;
+pub const DEFAULT_GROW_SIZE_THRESHOLD: usize = 386_547_056_640; // 360 gb
+pub const DEFAULT_GROW_SIZE_BYTES: usize = 53_687_091_200; // 50 gb
 
 /// Specific representations of  errors from `get_block`.
 #[derive(thiserror::Error, Debug)]

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -18,7 +18,7 @@ use casper_node::{
     StorageConfig, WithDir,
 };
 
-use crate::DEFAULT_MAX_READERS;
+use crate::{DEFAULT_GROW_SIZE_BYTES, DEFAULT_GROW_SIZE_THRESHOLD, DEFAULT_MAX_READERS};
 use casper_types::ProtocolVersion;
 use lmdb::DatabaseFlags;
 
@@ -53,6 +53,8 @@ fn create_lmdb_environment(
         default_max_db_size,
         DEFAULT_MAX_READERS,
         manual_sync_enabled,
+        DEFAULT_GROW_SIZE_THRESHOLD,
+        DEFAULT_GROW_SIZE_BYTES,
     )?);
     Ok(lmdb_environment)
 }


### PR DESCRIPTION
Closes #2398 

This PR reintroduces the idea from CasperLabs/CasperLabs#1740, which tries to resize the map once a commit returns a `MapFull` error, and then it will retry with the larger size until the transaction succeeds. Unfortunately, too many parts of the codebase were changed to be reviewed and tested.

In this PR, I'm introducing a more straightforward method where a global state map resizes happens before a write transaction starts and the free space in the map falls below the configured threshold. In this case, a map resizes by adding a fixed amount of configured bytes.

I also measured new calls to LMDB:

- A check to obtain map size info always falls below ~1000us
- Map resizing operation is proportional to the new map size

Defaults chosen are:

- initial map size: 750GiB
- grow map threshold: 100GiB
- grow map bytes: 150GiB

The above means once global state free space is below 100GiB, it is automatically resized by adding 150GiB.