### PR TITLE
Reimplement `ToBytes` for some of the most frequently used types.

### DIFF
--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -250,11 +250,22 @@ impl Account {
 impl ToBytes for Account {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.account_hash.to_bytes()?);
-        result.append(&mut self.named_keys.to_bytes()?);
-        result.append(&mut self.main_purse.to_bytes()?);
-        result.append(&mut self.associated_keys.to_bytes()?);
-        result.append(&mut self.action_thresholds.to_bytes()?);
+        self.account_hash().write_bytes(&mut result);
+        bytesrepr::write_tree(
+            &mut result,
+            self.named_keys(),
+            |name, writer| {
+                bytesrepr::write_string(writer, name);
+                Ok(())
+            },
+            |key, writer| {
+                key.write_bytes(writer);
+                Ok(())
+            }
+        )?;
+        self.main_purse.write_bytes(&mut result);
+        self.associated_keys().write_bytes(&mut result);
+        self.action_thresholds().write_bytes(&mut result);
         Ok(result)
     }
 

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -250,22 +250,16 @@ impl Account {
 impl ToBytes for Account {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        self.account_hash().write_bytes(&mut result);
+        self.account_hash().write_bytes(&mut result)?;
         bytesrepr::write_tree(
             &mut result,
             self.named_keys(),
-            |name, writer| {
-                bytesrepr::write_string(writer, name);
-                Ok(())
-            },
-            |key, writer| {
-                key.write_bytes(writer);
-                Ok(())
-            },
+            |name, writer| bytesrepr::write_string(writer, name),
+            |key, writer| key.write_bytes(writer),
         )?;
-        self.main_purse.write_bytes(&mut result);
-        self.associated_keys().write_bytes(&mut result);
-        self.action_thresholds().write_bytes(&mut result);
+        self.main_purse.write_bytes(&mut result)?;
+        self.associated_keys().write_bytes(&mut result)?;
+        self.action_thresholds().write_bytes(&mut result)?;
         Ok(result)
     }
 

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -261,7 +261,7 @@ impl ToBytes for Account {
             |key, writer| {
                 key.write_bytes(writer);
                 Ok(())
-            }
+            },
         )?;
         self.main_purse.write_bytes(&mut result);
         self.associated_keys().write_bytes(&mut result);

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -95,8 +95,9 @@ impl AccountHash {
         Self::new(digest)
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
         writer.extend_from_slice(&self.0);
+        Ok(())
     }
 }
 

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -94,6 +94,10 @@ impl AccountHash {
         let digest = blake2b_hash_fn(preimage);
         Self::new(digest)
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&self.0);
+    }
 }
 
 #[cfg(feature = "json-schema")]

--- a/types/src/account/action_thresholds.rs
+++ b/types/src/account/action_thresholds.rs
@@ -88,9 +88,9 @@ impl ActionThresholds {
         }
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
-        self.deployment().write_bytes(writer);
-        self.key_management().write_bytes(writer);
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.deployment().write_bytes(writer)?;
+        self.key_management().write_bytes(writer)
     }
 }
 

--- a/types/src/account/action_thresholds.rs
+++ b/types/src/account/action_thresholds.rs
@@ -87,6 +87,11 @@ impl ActionThresholds {
             ActionType::KeyManagement => self.set_key_management_threshold(new_threshold),
         }
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        self.deployment().write_bytes(writer);
+        self.key_management().write_bytes(writer);
+    }
 }
 
 impl Default for ActionThresholds {

--- a/types/src/account/associated_keys.rs
+++ b/types/src/account/associated_keys.rs
@@ -114,6 +114,14 @@ impl AssociatedKeys {
     pub fn total_keys_weight_excluding(&self, account_hash: AccountHash) -> Weight {
         self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != account_hash))
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
+        for (key, weight) in self.0.iter() {
+            key.write_bytes(writer);
+            weight.write_bytes(writer);
+        }
+    }
 }
 
 impl From<BTreeMap<AccountHash, Weight>> for AssociatedKeys {

--- a/types/src/account/associated_keys.rs
+++ b/types/src/account/associated_keys.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     account::{AccountHash, AddKeyFailure, RemoveKeyFailure, UpdateKeyFailure, Weight},
-    bytesrepr::{Error, FromBytes, ToBytes},
+    bytesrepr::{self, Error, FromBytes, ToBytes},
 };
 
 /// A mapping that represents the association of a [`Weight`] with an [`AccountHash`].
@@ -115,12 +115,13 @@ impl AssociatedKeys {
         self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != account_hash))
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
         for (key, weight) in self.0.iter() {
-            key.write_bytes(writer);
-            weight.write_bytes(writer);
+            key.write_bytes(writer)?;
+            weight.write_bytes(writer)?;
         }
+        Ok(())
     }
 }
 

--- a/types/src/account/weight.rs
+++ b/types/src/account/weight.rs
@@ -25,6 +25,10 @@ impl Weight {
     pub fn value(self) -> u8 {
         self.0
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.push(self.0)
+    }
 }
 
 impl ToBytes for Weight {

--- a/types/src/account/weight.rs
+++ b/types/src/account/weight.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bytesrepr::{Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLType, CLTyped,
 };
 
@@ -26,8 +26,9 @@ impl Weight {
         self.0
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
-        writer.push(self.0)
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(self.0);
+        Ok(())
     }
 }
 

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1203,7 +1203,7 @@ pub(crate) fn write_iter<'a, V: 'a, I: IntoIterator<Item = &'a V>, FV>(
     write_fn: FV,
 ) -> Result<(), self::Error>
 where
-    FV: Fn(&V, &mut Vec<u8>) -> Result<(), self::Error>
+    FV: Fn(&V, &mut Vec<u8>) -> Result<(), self::Error>,
 {
     for element in i {
         write_fn(element, writer)?

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1158,6 +1158,24 @@ where
     assert!(*t == deserialized)
 }
 
+pub(crate) fn write_string(writer: &mut Vec<u8>, text: &str) {
+    let text_bytes = text.as_bytes();
+    writer.extend((text_bytes.len() as u32).to_le_bytes());
+    writer.extend_from_slice(text_bytes);
+}
+
+pub(crate) fn write_tree<K, V, FK, FV>(writer: &mut Vec<u8>, tree: &BTreeMap<K, V>, key_fn: FK, value_fn: FV)
+where
+    FK: Fn(&K, &mut Vec<u8>) -> (),
+    FV: Fn(&V, &mut Vec<u8>) -> (),
+{
+    writer.extend((tree.len() as u32).to_le_bytes());
+    for (k, v) in tree.iter() {
+        key_fn(k, writer);
+        value_fn(v, writer);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1164,16 +1164,37 @@ pub(crate) fn write_string(writer: &mut Vec<u8>, text: &str) {
     writer.extend_from_slice(text_bytes);
 }
 
-pub(crate) fn write_tree<K, V, FK, FV>(writer: &mut Vec<u8>, tree: &BTreeMap<K, V>, key_fn: FK, value_fn: FV)
+pub(crate) fn write_tree<K, V, FK, FV>(
+    writer: &mut Vec<u8>,
+    tree: &BTreeMap<K, V>,
+    write_key_fn: FK,
+    write_value_fn: FV,
+) -> Result<(), self::Error>
 where
-    FK: Fn(&K, &mut Vec<u8>) -> (),
-    FV: Fn(&V, &mut Vec<u8>) -> (),
+    FK: Fn(&K, &mut Vec<u8>) -> Result<(), self::Error>,
+    FV: Fn(&V, &mut Vec<u8>) -> Result<(), self::Error>,
 {
     writer.extend((tree.len() as u32).to_le_bytes());
     for (k, v) in tree.iter() {
-        key_fn(k, writer);
-        value_fn(v, writer);
+        write_key_fn(k, writer)?;
+        write_value_fn(v, writer)?;
     }
+    Ok(())
+}
+
+pub(crate) fn write_vec<V, FV>(
+    writer: &mut Vec<u8>,
+    v: &Vec<V>,
+    write_fn: FV,
+) -> Result<(), self::Error>
+where
+    FV: Fn(&V, &mut Vec<u8>) -> Result<(), self::Error>,
+{
+    writer.extend((v.len() as u32).to_le_bytes());
+    for el in v {
+        write_fn(el, writer)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1158,10 +1158,11 @@ where
     assert!(*t == deserialized)
 }
 
-pub(crate) fn write_string(writer: &mut Vec<u8>, text: &str) {
+pub(crate) fn write_string(writer: &mut Vec<u8>, text: &str) -> Result<(), self::Error> {
     let text_bytes = text.as_bytes();
     writer.extend((text_bytes.len() as u32).to_le_bytes());
     writer.extend_from_slice(text_bytes);
+    Ok(())
 }
 
 pub(crate) fn write_tree<K, V, FK, FV>(
@@ -1184,7 +1185,7 @@ where
 
 pub(crate) fn write_vec<V, FV>(
     writer: &mut Vec<u8>,
-    v: &Vec<V>,
+    v: &[V],
     write_fn: FV,
 ) -> Result<(), self::Error>
 where
@@ -1211,12 +1212,14 @@ where
     Ok(())
 }
 
-pub(crate) fn write_u32(writer: &mut Vec<u8>, u: u32) {
+pub(crate) fn write_u32(writer: &mut Vec<u8>, u: u32) -> Result<(), self::Error> {
     writer.extend(u.to_le_bytes());
+    Ok(())
 }
 
-pub(crate) fn write_u64(writer: &mut Vec<u8>, u: &u64) {
+pub(crate) fn write_u64(writer: &mut Vec<u8>, u: &u64) -> Result<(), self::Error> {
     writer.extend(u.to_le_bytes());
+    Ok(())
 }
 
 pub(crate) fn write_set<T, FT>(
@@ -1235,15 +1238,18 @@ where
 }
 
 pub(crate) fn write_u512(writer: &mut Vec<u8>, u: &crate::U512) -> Result<(), self::Error> {
-    Ok(writer.extend(u.to_bytes()?))
+    writer.extend(u.to_bytes()?);
+    Ok(())
 }
 
-pub(crate) fn write_u8(writer: &mut Vec<u8>, u: u8) {
+pub(crate) fn write_u8(writer: &mut Vec<u8>, u: u8) -> Result<(), self::Error> {
     writer.push(u);
+    Ok(())
 }
 
-pub(crate) fn write_bool(writer: &mut Vec<u8>, b: bool) {
+pub(crate) fn write_bool(writer: &mut Vec<u8>, b: bool) -> Result<(), self::Error> {
     writer.push(u8::from(b));
+    Ok(())
 }
 
 pub(crate) fn write_option<V, FV>(

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1197,6 +1197,25 @@ where
     Ok(())
 }
 
+pub(crate) fn write_u32(writer: &mut Vec<u8>, u: u32) {
+    writer.extend(u.to_le_bytes());
+}
+
+pub(crate) fn write_set<T, FT>(
+    writer: &mut Vec<u8>,
+    set: &BTreeSet<T>,
+    write_fn: FT,
+) -> Result<(), self::Error>
+where
+    FT: Fn(&T, &mut Vec<u8>) -> Result<(), self::Error>,
+{
+    writer.extend((set.len() as u32).to_le_bytes());
+    for element in set.iter() {
+        write_fn(element, writer)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/types/src/contract_wasm.rs
+++ b/types/src/contract_wasm.rs
@@ -117,6 +117,10 @@ impl ContractWasmHash {
         let bytes = HashAddr::try_from(checksummed_hex::decode(remainder)?.as_ref())?;
         Ok(ContractWasmHash(bytes))
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&self.0)
+    }
 }
 
 impl Display for ContractWasmHash {

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -228,7 +228,7 @@ impl PublicKey {
         }
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         match self {
             PublicKey::System => writer.push(SYSTEM_TAG),
             PublicKey::Ed25519(pk) => {
@@ -240,6 +240,7 @@ impl PublicKey {
                 writer.extend_from_slice(&pk.to_bytes());
             }
         }
+        Ok(())
     }
 }
 

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -227,6 +227,20 @@ impl PublicKey {
             PublicKey::Secp256k1(_) => SECP256K1,
         }
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        match self {
+            PublicKey::System => writer.push(SYSTEM_TAG),
+            PublicKey::Ed25519(pk) => {
+                writer.push(ED25519_TAG);
+                writer.extend_from_slice(pk.as_bytes());
+            }
+            PublicKey::Secp256k1(pk) => {
+                writer.push(SECP256K1_TAG);
+                writer.extend_from_slice(&pk.to_bytes());
+            }
+        }
+    }
 }
 
 impl AsymmetricType<'_> for PublicKey {

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -75,10 +75,10 @@ impl ToBytes for DeployInfo {
         let mut result = bytesrepr::allocate_buffer(self)?;
         (&self.deploy_hash).write_bytes(&mut result);
         bytesrepr::write_vec(&mut result, &self.transfers, |transfer, w| {
-            Ok(transfer.write_bytes(w))
+            transfer.write_bytes(w)
         })?;
-        (&self.from).write_bytes(&mut result);
-        (&self.source).write_bytes(&mut result);
+        (&self.from).write_bytes(&mut result)?;
+        (&self.source).write_bytes(&mut result)?;
         bytesrepr::write_u512(&mut result, &self.gas)?;
         Ok(result)
     }

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -73,11 +73,13 @@ impl FromBytes for DeployInfo {
 impl ToBytes for DeployInfo {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.deploy_hash.to_bytes()?);
-        result.append(&mut self.transfers.to_bytes()?);
-        result.append(&mut self.from.to_bytes()?);
-        result.append(&mut self.source.to_bytes()?);
-        result.append(&mut self.gas.to_bytes()?);
+        (&self.deploy_hash).write_bytes(&mut result);
+        bytesrepr::write_vec(&mut result, &self.transfers, |transfer, w| {
+            Ok(transfer.write_bytes(w))
+        })?;
+        (&self.from).write_bytes(&mut result);
+        (&self.source).write_bytes(&mut result);
+        bytesrepr::write_u512(&mut result, &self.gas)?;
         Ok(result)
     }
 

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -444,6 +444,46 @@ impl Key {
         hasher.finalize_variable(|hash| addr.clone_from_slice(hash));
         Key::Dictionary(addr)
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.push(self.tag());
+        match self {
+            Key::Account(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Hash(hash) => {
+                writer.extend_from_slice(hash);
+            }
+            Key::URef(uref) => {
+                writer.extend_from_slice(&uref.addr());
+                writer.push(uref.access_rights().bits());
+            }
+            Key::Transfer(addr) => {
+                writer.extend_from_slice(addr.as_bytes());
+            }
+            Key::DeployInfo(addr) => {
+                writer.extend_from_slice(addr.as_bytes());
+            }
+            Key::EraInfo(era_id) => {
+                writer.extend_from_slice(&era_id.to_le_bytes());
+            }
+            Key::Balance(uref_addr) => {
+                writer.extend_from_slice(uref_addr);
+            }
+            Key::Bid(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Withdraw(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Dictionary(addr) => {
+                writer.extend_from_slice(addr);
+            }
+            Key::SystemContractRegistry => {
+                writer.extend_from_slice(&[0u8; 32]);
+            }
+        };
+    }
 }
 
 impl Display for Key {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -445,7 +445,7 @@ impl Key {
         Key::Dictionary(addr)
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
         writer.push(self.tag());
         match self {
             Key::Account(account_hash) => {
@@ -483,6 +483,7 @@ impl Key {
                 writer.extend_from_slice(&[0u8; 32]);
             }
         };
+        Ok(())
     }
 }
 

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -117,6 +117,12 @@ impl ProtocolVersion {
     pub fn is_compatible_with(&self, version: &ProtocolVersion) -> bool {
         self.0.major == version.0.major
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend(self.0.major.to_le_bytes());
+        writer.extend(self.0.minor.to_le_bytes());
+        writer.extend(self.0.patch.to_le_bytes());
+    }
 }
 
 impl ToBytes for ProtocolVersion {

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -274,23 +274,20 @@ impl CLTyped for Bid {
 impl ToBytes for Bid {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        (&self.validator_public_key).write_bytes(&mut result);
-        (&self.bonding_purse).write_bytes(&mut result);
+        (&self.validator_public_key).write_bytes(&mut result)?;
+        (&self.bonding_purse).write_bytes(&mut result)?;
         bytesrepr::write_u512(&mut result, self.staked_amount())?;
-        bytesrepr::write_u8(&mut result, self.delegation_rate);
+        bytesrepr::write_u8(&mut result, self.delegation_rate)?;
         bytesrepr::write_option(&mut result, &self.vesting_schedule, |schedule, writer| {
             schedule.write_bytes(writer)
         })?;
         bytesrepr::write_tree(
             &mut result,
             self.delegators(),
-            |pk, writer| {
-                pk.write_bytes(writer);
-                Ok(())
-            },
+            |pk, writer| pk.write_bytes(writer),
             |delegator, writer| delegator.write_bytes(writer),
         )?;
-        bytesrepr::write_bool(&mut result, self.inactive);
+        bytesrepr::write_bool(&mut result, self.inactive)?;
         Ok(result)
     }
 

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -274,13 +274,23 @@ impl CLTyped for Bid {
 impl ToBytes for Bid {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.extend(self.validator_public_key.to_bytes()?);
-        result.extend(self.bonding_purse.to_bytes()?);
-        result.extend(self.staked_amount.to_bytes()?);
-        result.extend(self.delegation_rate.to_bytes()?);
-        result.extend(self.vesting_schedule.to_bytes()?);
-        result.extend(self.delegators.to_bytes()?);
-        result.extend(self.inactive.to_bytes()?);
+        (&self.validator_public_key).write_bytes(&mut result);
+        (&self.bonding_purse).write_bytes(&mut result);
+        bytesrepr::write_u512(&mut result, self.staked_amount())?;
+        bytesrepr::write_u8(&mut result, self.delegation_rate);
+        bytesrepr::write_option(&mut result, &self.vesting_schedule, |schedule, writer| {
+            schedule.write_bytes(writer)
+        })?;
+        bytesrepr::write_tree(
+            &mut result,
+            self.delegators(),
+            |pk, writer| {
+                pk.write_bytes(writer);
+                Ok(())
+            },
+            |delegator, writer| delegator.write_bytes(writer),
+        )?;
+        bytesrepr::write_bool(&mut result, self.inactive);
         Ok(result)
     }
 

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -85,7 +85,7 @@ impl VestingSchedule {
     }
 
     pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        bytesrepr::write_u64(writer, &self.initial_release_timestamp_millis);
+        bytesrepr::write_u64(writer, &self.initial_release_timestamp_millis)?;
         bytesrepr::write_option(writer, &self.locked_amounts(), |locked, w| {
             bytesrepr::write_iter(w, locked, |amount, ww| bytesrepr::write_u512(ww, amount))
         })

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -83,6 +83,13 @@ impl VestingSchedule {
             }
         })
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        bytesrepr::write_u64(writer, &self.initial_release_timestamp_millis);
+        bytesrepr::write_option(writer, &self.locked_amounts(), |locked, w| {
+            bytesrepr::write_iter(w, locked, |amount, ww| bytesrepr::write_u512(ww, amount))
+        })
+    }
 }
 
 impl ToBytes for [U512; LOCKED_AMOUNTS_LENGTH] {

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -146,10 +146,10 @@ impl Delegator {
     }
 
     pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        (&self.delegator_public_key).write_bytes(writer);
+        (&self.delegator_public_key).write_bytes(writer)?;
         bytesrepr::write_u512(writer, &self.staked_amount)?;
-        (&self.bonding_purse).write_bytes(writer);
-        (&self.validator_public_key).write_bytes(writer);
+        (&self.bonding_purse).write_bytes(writer)?;
+        (&self.validator_public_key).write_bytes(writer)?;
         bytesrepr::write_option(writer, &self.vesting_schedule, |schedule, writer| {
             schedule.write_bytes(writer)
         })

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -144,6 +144,16 @@ impl Delegator {
     pub fn vesting_schedule_mut(&mut self) -> Option<&mut VestingSchedule> {
         self.vesting_schedule.as_mut()
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        (&self.delegator_public_key).write_bytes(writer);
+        bytesrepr::write_u512(writer, &self.staked_amount)?;
+        (&self.bonding_purse).write_bytes(writer);
+        (&self.validator_public_key).write_bytes(writer);
+        bytesrepr::write_option(writer, &self.vesting_schedule, |schedule, writer| {
+            schedule.write_bytes(writer)
+        })
+    }
 }
 
 impl CLTyped for Delegator {

--- a/types/src/system/auction/era_info.rs
+++ b/types/src/system/auction/era_info.rs
@@ -82,7 +82,7 @@ impl SeigniorageAllocation {
                 validator_public_key,
                 amount,
             } => {
-                validator_public_key.write_bytes(writer);
+                validator_public_key.write_bytes(writer)?;
                 bytesrepr::write_u512(writer, amount)?;
             }
             SeigniorageAllocation::Delegator {
@@ -90,8 +90,8 @@ impl SeigniorageAllocation {
                 validator_public_key,
                 amount,
             } => {
-                delegator_public_key.write_bytes(writer);
-                validator_public_key.write_bytes(writer);
+                delegator_public_key.write_bytes(writer)?;
+                validator_public_key.write_bytes(writer)?;
                 bytesrepr::write_u512(writer, amount)?;
             }
         }

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -51,6 +51,10 @@ impl DeployHash {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&self.0);
+    }
 }
 
 #[cfg(feature = "json-schema")]
@@ -192,14 +196,16 @@ impl FromBytes for Transfer {
 impl ToBytes for Transfer {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.deploy_hash.to_bytes()?);
-        result.append(&mut self.from.to_bytes()?);
-        result.append(&mut self.to.to_bytes()?);
-        result.append(&mut self.source.to_bytes()?);
-        result.append(&mut self.target.to_bytes()?);
-        result.append(&mut self.amount.to_bytes()?);
-        result.append(&mut self.gas.to_bytes()?);
-        result.append(&mut self.id.to_bytes()?);
+        (&self.deploy_hash).write_bytes(&mut result);
+        (&self.from).write_bytes(&mut result);
+        bytesrepr::write_option(&mut result, &self.to, |to, w| Ok(to.write_bytes(w)))?;
+        (&self.source).write_bytes(&mut result);
+        (&self.target).write_bytes(&mut result);
+        bytesrepr::write_u512(&mut result, &self.amount)?;
+        bytesrepr::write_u512(&mut result, &self.gas)?;
+        bytesrepr::write_option(&mut result, &self.id, |id, w| {
+            Ok(bytesrepr::write_u64(w, id))
+        })?;
         Ok(result)
     }
 

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -197,15 +197,13 @@ impl ToBytes for Transfer {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
         (&self.deploy_hash).write_bytes(&mut result);
-        (&self.from).write_bytes(&mut result);
-        bytesrepr::write_option(&mut result, &self.to, |to, w| Ok(to.write_bytes(w)))?;
-        (&self.source).write_bytes(&mut result);
-        (&self.target).write_bytes(&mut result);
+        (&self.from).write_bytes(&mut result)?;
+        bytesrepr::write_option(&mut result, &self.to, |to, w| to.write_bytes(w))?;
+        (&self.source).write_bytes(&mut result)?;
+        (&self.target).write_bytes(&mut result)?;
         bytesrepr::write_u512(&mut result, &self.amount)?;
         bytesrepr::write_u512(&mut result, &self.gas)?;
-        bytesrepr::write_option(&mut result, &self.id, |id, w| {
-            Ok(bytesrepr::write_u64(w, id))
-        })?;
+        bytesrepr::write_option(&mut result, &self.id, |id, w| bytesrepr::write_u64(w, id))?;
         Ok(result)
     }
 
@@ -297,8 +295,9 @@ impl TransferAddr {
         Ok(TransferAddr(bytes))
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
-        writer.extend_from_slice(&self.0)
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.extend_from_slice(&self.0);
+        Ok(())
     }
 }
 

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -296,6 +296,10 @@ impl TransferAddr {
             <[u8; TRANSFER_ADDR_LENGTH]>::try_from(checksummed_hex::decode(remainder)?.as_ref())?;
         Ok(TransferAddr(bytes))
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&self.0)
+    }
 }
 
 #[cfg(feature = "json-schema")]

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -197,6 +197,11 @@ impl URef {
             .ok_or(FromStrError::InvalidAccessRights)?;
         Ok(URef(addr, access_rights))
     }
+
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+        writer.extend_from_slice(&self.0);
+        writer.push(self.1.bits());
+    }
 }
 
 #[cfg(feature = "json-schema")]

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -198,9 +198,10 @@ impl URef {
         Ok(URef(addr, access_rights))
     }
 
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
+    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
         writer.extend_from_slice(&self.0);
         writer.push(self.1.bits());
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/casper-network/casper-node/issues/2390.

**NOTE**: See the ticket description for more details.

```
mateusz@DESKTOP-O514E9R:~/casper-node$ critcmp tobytes-old tobytes-new
group                                      tobytes-new                            tobytes-old
-----                                      -----------                            -----------
bytesrepr::serialize_account               1.00    173.3±1.14ns        ? ?/sec    4.30    744.4±9.33ns        ? ?/sec
bytesrepr::serialize_bid_big               1.00    100.9±1.09µs        ? ?/sec    2.21    223.1±1.23µs        ? ?/sec
bytesrepr::serialize_bid_medium            1.00      9.8±0.11µs        ? ?/sec    2.26     22.2±0.13µs        ? ?/sec
bytesrepr::serialize_bid_small             1.00   1109.3±7.72ns        ? ?/sec    2.21      2.5±0.02µs        ? ?/sec
bytesrepr::serialize_contract              1.00    486.3±5.55ns        ? ?/sec    5.61      2.7±0.01µs        ? ?/sec
bytesrepr::serialize_contract_package      1.00    221.6±1.06ns        ? ?/sec    3.50    775.4±3.16ns        ? ?/sec
bytesrepr::serialize_deploy_info           1.00      2.0±0.05µs        ? ?/sec    5.00     10.2±0.04µs        ? ?/sec
bytesrepr::serialize_era_info              1.00    121.1±0.79µs        ? ?/sec    1.21    146.4±0.87µs        ? ?/sec
bytesrepr::serialize_transfer              1.00    340.4±2.56ns        ? ?/sec    1.14    387.2±1.63ns        ? ?/sec
```

`serialize_account` **~67%** improvement
`serialize_bid_big` **~55%** improvement
`serialize_bid_medium` **~55%** improvement
`serialize_bid_small` **~55%** improvement
`serialize_contract` **~82%** improvement
`serialize_contract_package` **~72%** improvement
`serialize_deploy_info` **~18%** improvement
`serialize_transfer` **~12%** improvement
