### PR TITLE
Deserialize from LMDB slice

### DIFF
--- a/execution_engine/src/storage/store/mod.rs
+++ b/execution_engine/src/storage/store/mod.rs
@@ -32,7 +32,7 @@ pub trait Store<K, V> {
         match txn.read(handle, &key.to_bytes()?)? {
             None => Ok(None),
             Some(value_bytes) => {
-                let value = bytesrepr::deserialize(value_bytes.into())?;
+                let value = bytesrepr::deserialize_slice(value_bytes)?;
                 Ok(Some(value))
             }
         }

--- a/execution_engine/src/storage/transaction_source/in_memory.rs
+++ b/execution_engine/src/storage/transaction_source/in_memory.rs
@@ -48,12 +48,12 @@ impl Transaction for InMemoryReadTransaction {
 }
 
 impl Readable for InMemoryReadTransaction {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
         let sub_view = match self.view.get(&handle) {
             Some(view) => view,
             None => return Ok(None),
         };
-        Ok(sub_view.get(&Bytes::from(key)).cloned())
+        Ok(sub_view.get(&Bytes::from(key)).map(Bytes::as_slice))
     }
 }
 
@@ -95,12 +95,12 @@ impl<'a> Transaction for InMemoryReadWriteTransaction<'a> {
 }
 
 impl<'a> Readable for InMemoryReadWriteTransaction<'a> {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
         let sub_view = match self.view.get(&handle) {
             Some(view) => view,
             None => return Ok(None),
         };
-        Ok(sub_view.get(&Bytes::from(key)).cloned())
+        Ok(sub_view.get(&Bytes::from(key)).map(Bytes::as_slice))
     }
 }
 

--- a/execution_engine/src/storage/transaction_source/lmdb.rs
+++ b/execution_engine/src/storage/transaction_source/lmdb.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use casper_types::bytesrepr::Bytes;
 use lmdb::{
     self, Database, Environment, EnvironmentFlags, RoTransaction, RwTransaction, WriteFlags,
 };
@@ -25,9 +24,9 @@ impl<'a> Transaction for RoTransaction<'a> {
 }
 
 impl<'a> Readable for RoTransaction<'a> {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
         match lmdb::Transaction::get(self, handle, &key) {
-            Ok(bytes) => Ok(Some(Bytes::from(bytes))),
+            Ok(bytes) => Ok(Some(bytes)),
             Err(lmdb::Error::NotFound) => Ok(None),
             Err(e) => Err(e),
         }
@@ -45,9 +44,9 @@ impl<'a> Transaction for RwTransaction<'a> {
 }
 
 impl<'a> Readable for RwTransaction<'a> {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
         match lmdb::Transaction::get(self, handle, &key) {
-            Ok(bytes) => Ok(Some(Bytes::from(bytes))),
+            Ok(bytes) => Ok(Some(bytes)),
             Err(lmdb::Error::NotFound) => Ok(None),
             Err(e) => Err(e),
         }

--- a/execution_engine/src/storage/transaction_source/mod.rs
+++ b/execution_engine/src/storage/transaction_source/mod.rs
@@ -1,5 +1,3 @@
-use casper_types::bytesrepr::Bytes;
-
 /// In-memory implementation of transaction source.
 pub mod in_memory;
 /// LMDB implementation of transaction source.
@@ -28,7 +26,7 @@ pub trait Transaction: Sized {
 /// A transaction with the capability to read from a given [`Handle`](Transaction::Handle).
 pub trait Readable: Transaction {
     /// Returns the value from the corresponding key from a given [`Transaction::Handle`].
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error>;
 }
 
 /// A transaction with the capability to write to a given [`Handle`](Transaction::Handle).

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -139,6 +139,19 @@ pub fn deserialize<T: FromBytes>(bytes: Vec<u8>) -> Result<T, Error> {
     }
 }
 
+/// Deserializes slice of bbytes into an instance of `T`.
+///
+/// Returns an error if the bytes cannot be deserialized into `T` or if not all of the input bytes
+/// are consumed in the operation.
+pub fn deserialize_slice<T: FromBytes>(bytes: &[u8]) -> Result<T, Error> {
+    let (t, remainder) = T::from_bytes(bytes)?;
+    if remainder.is_empty() {
+        Ok(t)
+    } else {
+        Err(Error::LeftOverBytes)
+    }
+}
+
 /// Serializes `t` into a `Vec<u8>`.
 pub fn serialize(t: impl ToBytes) -> Result<Vec<u8>, Error> {
     t.into_bytes()


### PR DESCRIPTION
This PR avoids allocating temporary Vec to deserialize data from the data returned by `lmdb::Transaction::get.`.