### PR TITLE
Disable endorsements, port #2385 to dev.

### DIFF
--- a/node/src/components/consensus/highway_core.rs
+++ b/node/src/components/consensus/highway_core.rs
@@ -45,3 +45,6 @@ mod evidence;
 pub(crate) mod highway_testing;
 
 pub(crate) use state::{State, Weight};
+
+// Enables the endorsement mechanism.
+const ENABLE_ENDORSEMENTS: bool = false;

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -15,6 +15,7 @@ use super::{
     highway::{Ping, ValidVertex, Vertex, WireUnit},
     state::{self, Panorama, State, Unit, Weight},
     validators::ValidatorIndex,
+    ENABLE_ENDORSEMENTS,
 };
 
 use crate::{
@@ -281,6 +282,9 @@ impl<C: Context> ActiveValidator<C> {
         evidence: &Evidence<C>,
         state: &State<C>,
     ) -> Vec<Effect<C>> {
+        if !ENABLE_ENDORSEMENTS {
+            return Vec::new();
+        }
         let vidx = evidence.perpetrator();
         state
             .iter_correct_hashes()
@@ -545,6 +549,9 @@ impl<C: Context> ActiveValidator<C> {
     /// We should endorse unit from honest validator that cites _an_ equivocator
     /// as honest and it cites some new message by that validator.
     fn should_endorse(&self, vhash: &C::Hash, state: &State<C>) -> bool {
+        if !ENABLE_ENDORSEMENTS {
+            return false;
+        }
         let unit = state.unit(vhash);
         !state.is_faulty(unit.creator)
             && unit

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -52,7 +52,7 @@ use tallies::Tallies;
 // endorsements again.
 pub(super) const TODO_ENDORSEMENT_EVIDENCE_DISABLED: bool = true;
 
-// Disables checking the least naivete criterion for endorsements.
+// Disables checking the limited naivete criterion for endorsements.
 const LNC_DISABLED: bool = true;
 
 /// Number of maximum-length rounds after which a validator counts as offline, if we haven't heard

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -52,6 +52,9 @@ use tallies::Tallies;
 // endorsements again.
 pub(super) const TODO_ENDORSEMENT_EVIDENCE_DISABLED: bool = true;
 
+// Disables checking the least naivete criterion for endorsements.
+const LNC_DISABLED: bool = true;
+
 /// Number of maximum-length rounds after which a validator counts as offline, if we haven't heard
 /// from them.
 const PING_TIMEOUT: u64 = 3;
@@ -973,9 +976,14 @@ impl<C: Context> State<C> {
         panorama: &Panorama<C>,
         endorsed: &BTreeSet<C::Hash>,
     ) -> Option<ValidatorIndex> {
-        let violates_lnc =
-            |eq_idx: &ValidatorIndex| !self.satisfies_lnc_for(creator, panorama, endorsed, *eq_idx);
-        panorama.iter_faulty().find(violates_lnc)
+        if LNC_DISABLED {
+            None
+        } else {
+            let violates_lnc = |eq_idx: &ValidatorIndex| {
+                !self.satisfies_lnc_for(creator, panorama, endorsed, *eq_idx)
+            };
+            panorama.iter_faulty().find(violates_lnc)
+        }
     }
 
     /// Returns `true` if there is at most one fork by the validator `eq_idx` that is cited naively

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -819,15 +819,17 @@ impl<C: Context> State<C> {
             }
         }
         // All endorsed units from the panorama of this wunit.
-        let endorsements_in_panorama = panorama
-            .iter_correct_hashes()
-            .flat_map(|hash| self.unit(hash).claims_endorsed())
-            .collect::<HashSet<_>>();
-        if endorsements_in_panorama
-            .iter()
-            .any(|&e| !wunit.endorsed.iter().any(|h| h == e))
-        {
-            return Err(UnitError::EndorsementsNotMonotonic);
+        if !LNC_DISABLED {
+            let endorsements_in_panorama = panorama
+                .iter_correct_hashes()
+                .flat_map(|hash| self.unit(hash).claims_endorsed())
+                .collect::<HashSet<_>>();
+            if endorsements_in_panorama
+                .iter()
+                .any(|&e| !wunit.endorsed.iter().any(|h| h == e))
+            {
+                return Err(UnitError::EndorsementsNotMonotonic);
+            }
         }
         if wunit.value.is_some() {
             // If this unit is a block, it must be the first unit in this round, its timestamp must

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -845,7 +845,7 @@ impl<C: Context> State<C> {
             }
         }
         for hash in &wunit.endorsed {
-            if !wunit.panorama.sees(self, hash) {
+            if !LNC_DISABLED && !wunit.panorama.sees(self, hash) {
                 return Err(UnitError::EndorsedButUnseen {
                     hash: format!("{:?}", hash),
                     wire_unit: format!("{:?}", wunit),
@@ -1145,7 +1145,11 @@ impl<C: Context> State<C> {
                 pan = pan.merge(self, &self.inclusive_panorama(prev_uhash));
             }
         }
-        let endorsed = self.seen_endorsed(&pan);
+        let endorsed = if LNC_DISABLED {
+            Default::default() // Don't cite any endorsements.
+        } else {
+            self.seen_endorsed(&pan)
+        };
         if self.validate_lnc(creator, &pan, &endorsed).is_none() {
             return pan;
         }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -329,6 +329,9 @@ fn fork_choice() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_no_equivocation() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     let mut state = State::new_test(WEIGHTS, 0);
 
     // No equivocations – incoming vote doesn't violate LNC.
@@ -347,6 +350,9 @@ fn validate_lnc_no_equivocation() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_fault_seen_directly() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Equivocation cited by one honest validator in the vote's panorama.
     // Does NOT violate LNC.
     //
@@ -369,6 +375,9 @@ fn validate_lnc_fault_seen_directly() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_one_equivocator() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Equivocation cited by two honest validators in the vote's panorama – their votes need to
     // be endorsed.
     //
@@ -404,6 +413,9 @@ fn validate_lnc_one_equivocator() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_two_equivocators() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Multiple equivocators and indirect equivocations.
     // Votes are seen as endorsed by `state` – does not violate LNC.
     //
@@ -483,6 +495,9 @@ fn validate_lnc_own_naive_citation() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_mixed_citations() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Eric's vote should not require an endorsement as his unit e0 cites equivocator Carol before
     // the fork.
     //
@@ -525,6 +540,9 @@ fn validate_lnc_mixed_citations() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_transitive_endorsement() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Endorsements should be transitive to descendants.
     // c1 doesn't have to be endorsed, it is enough that c0 is.
     //
@@ -559,6 +577,9 @@ fn validate_lnc_transitive_endorsement() -> Result<(), AddUnitError<TestContext>
 
 #[test]
 fn validate_lnc_cite_descendant_of_equivocation() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // a0 cites a descendant b1 of an equivocation vote (b0 and b0').
     // This is still detected as violation of the LNC.
     //
@@ -591,6 +612,9 @@ fn validate_lnc_cite_descendant_of_equivocation() -> Result<(), AddUnitError<Tes
 
 #[test]
 fn validate_lnc_endorse_mix_pairs() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Diagram of the DAG can be found under
     // /resources/test/dags/validate_lnc_endorse_mix_pairs.png
     //
@@ -626,6 +650,9 @@ fn validate_lnc_endorse_mix_pairs() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_shared_equiv_unit() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Diagram of the DAG can be found under
     // /resources/test/dags/validate_lnc_shared_equiv_unit.png
     let weights = &[
@@ -671,6 +698,9 @@ fn validate_lnc_shared_equiv_unit() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_four_forks() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     // Diagram of the DAG can be found under
     // /resources/test/dags/validate_lnc_four_forks.png
     let weights = &[

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -329,7 +329,7 @@ fn fork_choice() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_no_equivocation() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     let mut state = State::new_test(WEIGHTS, 0);
@@ -350,7 +350,7 @@ fn validate_lnc_no_equivocation() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_fault_seen_directly() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Equivocation cited by one honest validator in the vote's panorama.
@@ -375,7 +375,7 @@ fn validate_lnc_fault_seen_directly() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_one_equivocator() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Equivocation cited by two honest validators in the vote's panorama – their votes need to
@@ -413,7 +413,7 @@ fn validate_lnc_one_equivocator() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_two_equivocators() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Multiple equivocators and indirect equivocations.
@@ -457,7 +457,7 @@ fn validate_lnc_two_equivocators() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_own_naive_citation() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     //           a0'<-----+
@@ -498,7 +498,7 @@ fn validate_lnc_own_naive_citation() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_mixed_citations() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Eric's vote should not require an endorsement as his unit e0 cites equivocator Carol before
@@ -543,7 +543,7 @@ fn validate_lnc_mixed_citations() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_transitive_endorsement() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Endorsements should be transitive to descendants.
@@ -580,7 +580,7 @@ fn validate_lnc_transitive_endorsement() -> Result<(), AddUnitError<TestContext>
 
 #[test]
 fn validate_lnc_cite_descendant_of_equivocation() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // a0 cites a descendant b1 of an equivocation vote (b0 and b0').
@@ -615,7 +615,7 @@ fn validate_lnc_cite_descendant_of_equivocation() -> Result<(), AddUnitError<Tes
 
 #[test]
 fn validate_lnc_endorse_mix_pairs() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Diagram of the DAG can be found under
@@ -653,7 +653,7 @@ fn validate_lnc_endorse_mix_pairs() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_shared_equiv_unit() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Diagram of the DAG can be found under
@@ -701,7 +701,7 @@ fn validate_lnc_shared_equiv_unit() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_four_forks() -> Result<(), AddUnitError<TestContext>> {
-    if LNC_DISABLED {
+    if !ENABLE_ENDORSEMENTS {
         return Ok(());
     }
     // Diagram of the DAG can be found under

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -457,6 +457,9 @@ fn validate_lnc_two_equivocators() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn validate_lnc_own_naive_citation() -> Result<(), AddUnitError<TestContext>> {
+    if LNC_DISABLED {
+        return Ok(());
+    }
     //           a0'<-----+
     // Alice              |
     //           a0 <--+  |

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -552,18 +552,18 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
     // Logs the details about the received vertex.
     fn log_received_vertex(&self, vertex: &Vertex<C>) {
-        let creator = if let Some(creator) = vertex
-            .creator()
-            .and_then(|vid| self.highway.validators().id(vid))
-        {
-            creator
-        } else {
-            error!(?vertex, "invalid creator");
-            return;
-        };
-
         match vertex {
             Vertex::Unit(swu) => {
+                let creator = if let Some(creator) = vertex
+                    .creator()
+                    .and_then(|vid| self.highway.validators().id(vid))
+                {
+                    creator
+                } else {
+                    error!(?vertex, "invalid creator");
+                    return;
+                };
+
                 let wire_unit = swu.wire_unit();
                 let hash = swu.hash();
 


### PR DESCRIPTION
This ports https://github.com/casper-network/casper-node/pull/2385 to dev, disabling endorsements (including the expensive LNC check), and in addition disables creation and citation of endorsements.

Closes #2400.