### PR TITLE
Add `write_bytes` method on `ToBytes` trait that serializes value without intermediate allocations.

### DIFF
--- a/execution_engine/src/core/runtime_context/dictionary.rs
+++ b/execution_engine/src/core/runtime_context/dictionary.rs
@@ -71,6 +71,13 @@ impl ToBytes for DictionaryValue {
             + self.seed_uref_addr.serialized_length()
             + self.dictionary_item_key_bytes.serialized_length()
     }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.cl_value.write_bytes(writer)?;
+        self.seed_uref_addr.write_bytes(writer)?;
+        self.dictionary_item_key_bytes.write_bytes(writer)?;
+        Ok(())
+    }
 }
 
 /// Inspects `key` argument whether it contains a dictionary variant, and checks if `stored_value`

--- a/execution_engine/src/storage/trie/gens.rs
+++ b/execution_engine/src/storage/trie/gens.rs
@@ -27,17 +27,19 @@ pub fn trie_pointer_block_arb() -> impl Strategy<Value = PointerBlock> {
     })
 }
 
-pub fn trie_arb() -> impl Strategy<Value = Trie<Key, StoredValue>> {
-    prop_oneof![
-        (key_arb(), stored_value_arb()).prop_map(|(key, value)| Trie::Leaf { key, value }),
-        trie_pointer_block_arb().prop_map(|pointer_block| Trie::Node {
-            pointer_block: Box::new(pointer_block)
-        }),
-        (vec(any::<u8>(), 0..32), trie_pointer_arb()).prop_map(|(affix, pointer)| {
-            Trie::Extension {
-                affix: affix.into(),
-                pointer,
-            }
-        })
-    ]
+pub fn trie_leaf_arb() -> impl Strategy<Value = Trie<Key, StoredValue>> {
+    (key_arb(), stored_value_arb()).prop_map(|(key, value)| Trie::Leaf { key, value })
+}
+
+pub fn trie_extension_arb() -> impl Strategy<Value = Trie<Key, StoredValue>> {
+    (vec(any::<u8>(), 0..32), trie_pointer_arb()).prop_map(|(affix, pointer)| Trie::Extension {
+        affix: affix.into(),
+        pointer,
+    })
+}
+
+pub fn trie_node_arb() -> impl Strategy<Value = Trie<Key, StoredValue>> {
+    trie_pointer_block_arb().prop_map(|pointer_block| Trie::Node {
+        pointer_block: Box::new(pointer_block),
+    })
 }

--- a/execution_engine/src/storage/trie/tests.rs
+++ b/execution_engine/src/storage/trie/tests.rs
@@ -70,8 +70,18 @@ mod proptests {
         }
 
         #[test]
-        fn roundtrip_trie(trie in trie_arb()) {
-            bytesrepr::test_serialization_roundtrip(&trie);
+        fn bytesrepr_roundtrip_trie_leaf(trie_leaf in trie_leaf_arb()) {
+            bytesrepr::test_serialization_roundtrip(&trie_leaf);
+        }
+
+        #[test]
+        fn bytesrepr_roundtrip_trie_extension(trie_extension in trie_extension_arb()) {
+            bytesrepr::test_serialization_roundtrip(&trie_extension);
+        }
+
+        #[test]
+        fn bytesrepr_roundtrip_trie_node(trie_node in trie_node_arb()) {
+            bytesrepr::test_serialization_roundtrip(&trie_node);
         }
 
         #[test]
@@ -87,17 +97,45 @@ mod proptests {
         }
 
         #[test]
-        fn serde_roundtrip_trie(trie in trie_arb()) {
-             let json_str = serde_json::to_string(&trie)?;
+        fn serde_roundtrip_trie_leaf(trie_leaf in trie_leaf_arb()) {
+             let json_str = serde_json::to_string(&trie_leaf)?;
              let deserialized_trie: Trie<Key, StoredValue> = serde_json::from_str(&json_str)?;
-             assert_eq!(trie, deserialized_trie)
+             assert_eq!(trie_leaf, deserialized_trie)
         }
 
         #[test]
-        fn bincode_roundtrip_trie(trie in trie_arb()) {
-           let bincode_bytes = bincode::serialize(&trie)?;
+        fn serde_roundtrip_trie_node(trie_node in trie_node_arb()) {
+             let json_str = serde_json::to_string(&trie_node)?;
+             let deserialized_trie: Trie<Key, StoredValue> = serde_json::from_str(&json_str)?;
+             assert_eq!(trie_node, deserialized_trie)
+        }
+
+        #[test]
+        fn serde_roundtrip_trie_extension(trie_extension in trie_extension_arb()) {
+             let json_str = serde_json::to_string(&trie_extension)?;
+             let deserialized_trie: Trie<Key, StoredValue> = serde_json::from_str(&json_str)?;
+             assert_eq!(trie_extension, deserialized_trie)
+        }
+
+        #[test]
+        fn bincode_roundtrip_trie_leaf(trie_leaf in trie_leaf_arb()) {
+           let bincode_bytes = bincode::serialize(&trie_leaf)?;
            let deserialized_trie = bincode::deserialize(&bincode_bytes)?;
-           assert_eq!(trie, deserialized_trie)
+           assert_eq!(trie_leaf, deserialized_trie)
+        }
+
+        #[test]
+        fn bincode_roundtrip_trie_node(trie_node in trie_node_arb()) {
+           let bincode_bytes = bincode::serialize(&trie_node)?;
+           let deserialized_trie = bincode::deserialize(&bincode_bytes)?;
+           assert_eq!(trie_node, deserialized_trie)
+        }
+
+        #[test]
+        fn bincode_roundtrip_trie_extension(trie_extension in trie_extension_arb()) {
+           let bincode_bytes = bincode::serialize(&trie_extension)?;
+           let deserialized_trie = bincode::deserialize(&bincode_bytes)?;
+           assert_eq!(trie_extension, deserialized_trie)
         }
 
         #[test]

--- a/execution_engine/src/storage/trie_store/tests/proptests.rs
+++ b/execution_engine/src/storage/trie_store/tests/proptests.rs
@@ -9,7 +9,10 @@ use casper_types::{bytesrepr::ToBytes, Key, StoredValue};
 
 use crate::storage::{
     store::tests as store_tests,
-    trie::{gens::trie_arb, Trie},
+    trie::{
+        gens::{trie_extension_arb, trie_leaf_arb, trie_node_arb},
+        Trie,
+    },
     DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
 };
 
@@ -70,12 +73,32 @@ fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, StoredValue>>) -> bool {
 
 proptest! {
     #[test]
-    fn prop_in_memory_roundtrip_succeeds(v in vec(trie_arb(), get_range())) {
+    fn prop_in_memory_roundtrip_succeeds_leaf(v in vec(trie_leaf_arb(), get_range())) {
         assert!(in_memory_roundtrip_succeeds(v))
     }
 
     #[test]
-    fn prop_lmdb_roundtrip_succeeds(v in vec(trie_arb(), get_range())) {
+    fn prop_in_memory_roundtrip_succeeds_node(v in vec(trie_node_arb(), get_range())) {
+        assert!(in_memory_roundtrip_succeeds(v))
+    }
+
+    #[test]
+    fn prop_in_memory_roundtrip_succeeds_extension(v in vec(trie_extension_arb(), get_range())) {
+        assert!(in_memory_roundtrip_succeeds(v))
+    }
+
+    #[test]
+    fn prop_lmdb_roundtrip_succeeds_leaf(v in vec(trie_leaf_arb(), get_range())) {
+        assert!(lmdb_roundtrip_succeeds(v))
+    }
+
+    #[test]
+    fn prop_lmdb_roundtrip_succeeds_node(v in vec(trie_node_arb(), get_range())) {
+        assert!(lmdb_roundtrip_succeeds(v))
+    }
+
+    #[test]
+    fn prop_lmdb_roundtrip_succeeds_extension(v in vec(trie_extension_arb(), get_range())) {
         assert!(lmdb_roundtrip_succeeds(v))
     }
 }

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -291,6 +291,12 @@ impl ToBytes for Digest {
     fn serialized_length(&self) -> usize {
         self.0.serialized_length()
     }
+
+    #[inline(always)]
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.extend_from_slice(&self.0);
+        Ok(())
+    }
 }
 
 impl FromBytes for Digest {

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -92,6 +92,11 @@ impl bytesrepr::ToBytes for AccessRights {
     fn serialized_length(&self) -> usize {
         ACCESS_RIGHTS_SERIALIZED_LENGTH
     }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(self.bits());
+        Ok(())
+    }
 }
 
 impl bytesrepr::FromBytes for AccessRights {

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -251,12 +251,7 @@ impl ToBytes for Account {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
         self.account_hash().write_bytes(&mut result)?;
-        bytesrepr::write_tree(
-            &mut result,
-            self.named_keys(),
-            |name, writer| bytesrepr::write_string(writer, name),
-            |key, writer| key.write_bytes(writer),
-        )?;
+        self.named_keys().write_bytes(&mut result)?;
         self.main_purse.write_bytes(&mut result)?;
         self.associated_keys().write_bytes(&mut result)?;
         self.action_thresholds().write_bytes(&mut result)?;
@@ -269,6 +264,15 @@ impl ToBytes for Account {
             + self.main_purse.serialized_length()
             + self.associated_keys.serialized_length()
             + self.action_thresholds.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.account_hash().write_bytes(writer)?;
+        self.named_keys().write_bytes(writer)?;
+        self.main_purse().write_bytes(writer)?;
+        self.associated_keys().write_bytes(writer)?;
+        self.action_thresholds().write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -94,11 +94,6 @@ impl AccountHash {
         let digest = blake2b_hash_fn(preimage);
         Self::new(digest)
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
-        writer.extend_from_slice(&self.0);
-        Ok(())
-    }
 }
 
 #[cfg(feature = "json-schema")]
@@ -191,6 +186,12 @@ impl ToBytes for AccountHash {
     #[inline(always)]
     fn serialized_length(&self) -> usize {
         self.0.serialized_length()
+    }
+
+    #[inline(always)]
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        writer.extend_from_slice(&self.0);
+        Ok(())
     }
 }
 

--- a/types/src/account/action_thresholds.rs
+++ b/types/src/account/action_thresholds.rs
@@ -87,11 +87,6 @@ impl ActionThresholds {
             ActionType::KeyManagement => self.set_key_management_threshold(new_threshold),
         }
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        self.deployment().write_bytes(writer)?;
-        self.key_management().write_bytes(writer)
-    }
 }
 
 impl Default for ActionThresholds {
@@ -113,6 +108,12 @@ impl ToBytes for ActionThresholds {
 
     fn serialized_length(&self) -> usize {
         2 * WEIGHT_SERIALIZED_LENGTH
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.deployment().write_bytes(writer)?;
+        self.key_management().write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/account/associated_keys.rs
+++ b/types/src/account/associated_keys.rs
@@ -114,15 +114,6 @@ impl AssociatedKeys {
     pub fn total_keys_weight_excluding(&self, account_hash: AccountHash) -> Weight {
         self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != account_hash))
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
-        for (key, weight) in self.0.iter() {
-            key.write_bytes(writer)?;
-            weight.write_bytes(writer)?;
-        }
-        Ok(())
-    }
 }
 
 impl From<BTreeMap<AccountHash, Weight>> for AssociatedKeys {
@@ -138,6 +129,15 @@ impl ToBytes for AssociatedKeys {
 
     fn serialized_length(&self) -> usize {
         self.0.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
+        for (key, weight) in self.0.iter() {
+            key.write_bytes(writer)?;
+            weight.write_bytes(writer)?;
+        }
+        Ok(())
     }
 }
 

--- a/types/src/account/weight.rs
+++ b/types/src/account/weight.rs
@@ -25,11 +25,6 @@ impl Weight {
     pub fn value(self) -> u8 {
         self.0
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        writer.push(self.0);
-        Ok(())
-    }
 }
 
 impl ToBytes for Weight {
@@ -39,6 +34,11 @@ impl ToBytes for Weight {
 
     fn serialized_length(&self) -> usize {
         WEIGHT_SERIALIZED_LENGTH
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(self.0);
+        Ok(())
     }
 }
 

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1274,8 +1274,12 @@ where
         serialized,
         t
     );
+    let mut written_bytes = vec![];
+    t.write_bytes(&mut written_bytes)
+        .expect("Unable to serialize data via write_bytes");
+    assert_eq!(serialized, written_bytes);
     let deserialized = deserialize::<T>(serialized).expect("Unable to deserialize data");
-    assert!(*t == deserialized)
+    assert!(*t == deserialized);
 }
 #[cfg(test)]
 mod tests {

--- a/types/src/bytesrepr/bytes.rs
+++ b/types/src/bytesrepr/bytes.rs
@@ -96,6 +96,11 @@ impl ToBytes for Bytes {
     fn serialized_length(&self) -> usize {
         super::vec_u8_serialized_length(&self.0)
     }
+
+    #[inline(always)]
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        super::write_u8_slice(self.as_slice(), writer)
+    }
 }
 
 impl FromBytes for Bytes {

--- a/types/src/cl_value.rs
+++ b/types/src/cl_value.rs
@@ -152,6 +152,12 @@ impl ToBytes for CLValue {
     fn serialized_length(&self) -> usize {
         self.bytes.serialized_length() + self.cl_type.serialized_length()
     }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        (&self.bytes).write_bytes(writer)?;
+        self.cl_type.append_bytes(writer)?;
+        Ok(())
+    }
 }
 
 impl FromBytes for CLValue {

--- a/types/src/contract_wasm.rs
+++ b/types/src/contract_wasm.rs
@@ -117,10 +117,6 @@ impl ContractWasmHash {
         let bytes = HashAddr::try_from(checksummed_hex::decode(remainder)?.as_ref())?;
         Ok(ContractWasmHash(bytes))
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
-        writer.extend_from_slice(&self.0)
-    }
 }
 
 impl Display for ContractWasmHash {
@@ -150,6 +146,12 @@ impl ToBytes for ContractWasmHash {
     #[inline(always)]
     fn serialized_length(&self) -> usize {
         self.0.serialized_length()
+    }
+
+    #[inline(always)]
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        self.0.write_bytes(writer)?;
+        Ok(())
     }
 }
 
@@ -275,6 +277,11 @@ impl ToBytes for ContractWasm {
 
     fn serialized_length(&self) -> usize {
         self.bytes.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        (&self.bytes).write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -227,21 +227,6 @@ impl PublicKey {
             PublicKey::Secp256k1(_) => SECP256K1,
         }
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        match self {
-            PublicKey::System => writer.push(SYSTEM_TAG),
-            PublicKey::Ed25519(pk) => {
-                writer.push(ED25519_TAG);
-                writer.extend_from_slice(pk.as_bytes());
-            }
-            PublicKey::Secp256k1(pk) => {
-                writer.push(SECP256K1_TAG);
-                writer.extend_from_slice(&pk.to_bytes());
-            }
-        }
-        Ok(())
-    }
 }
 
 impl AsymmetricType<'_> for PublicKey {
@@ -376,6 +361,21 @@ impl ToBytes for PublicKey {
                 PublicKey::Ed25519(_) => Self::ED25519_LENGTH,
                 PublicKey::Secp256k1(_) => Self::SECP256K1_LENGTH,
             }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            PublicKey::System => writer.push(SYSTEM_TAG),
+            PublicKey::Ed25519(pk) => {
+                writer.push(ED25519_TAG);
+                writer.extend_from_slice(pk.as_bytes());
+            }
+            PublicKey::Secp256k1(pk) => {
+                writer.push(SECP256K1_TAG);
+                writer.extend_from_slice(&pk.to_bytes());
+            }
+        }
+        Ok(())
     }
 }
 
@@ -614,6 +614,23 @@ impl ToBytes for Signature {
                 Signature::Ed25519(_) => Self::ED25519_LENGTH,
                 Signature::Secp256k1(_) => Self::SECP256K1_LENGTH,
             }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            Signature::System => {
+                writer.push(SYSTEM_TAG);
+            }
+            Signature::Ed25519(ed25519_signature) => {
+                writer.push(ED25519_TAG);
+                writer.extend(&ed25519_signature.to_bytes());
+            }
+            Signature::Secp256k1(signature) => {
+                writer.push(SECP256K1_TAG);
+                writer.extend_from_slice(signature.as_ref());
+            }
+        }
+        Ok(())
     }
 }
 

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -73,13 +73,11 @@ impl FromBytes for DeployInfo {
 impl ToBytes for DeployInfo {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        (&self.deploy_hash).write_bytes(&mut result);
-        bytesrepr::write_vec(&mut result, &self.transfers, |transfer, w| {
-            transfer.write_bytes(w)
-        })?;
+        (&self.deploy_hash).write_bytes(&mut result)?;
+        self.transfers.write_bytes(&mut result)?;
         (&self.from).write_bytes(&mut result)?;
         (&self.source).write_bytes(&mut result)?;
-        bytesrepr::write_u512(&mut result, &self.gas)?;
+        self.gas.write_bytes(&mut result)?;
         Ok(result)
     }
 
@@ -89,6 +87,15 @@ impl ToBytes for DeployInfo {
             + self.from.serialized_length()
             + self.source.serialized_length()
             + self.gas.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        (&self.deploy_hash).write_bytes(writer)?;
+        self.transfers.write_bytes(writer)?;
+        (&self.from).write_bytes(writer)?;
+        (&self.source).write_bytes(writer)?;
+        self.gas.write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -162,6 +162,12 @@ impl ToBytes for EraId {
     fn serialized_length(&self) -> usize {
         self.0.serialized_length()
     }
+
+    #[inline(always)]
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.0.write_bytes(writer)?;
+        Ok(())
+    }
 }
 
 impl FromBytes for EraId {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -444,47 +444,6 @@ impl Key {
         hasher.finalize_variable(|hash| addr.clone_from_slice(hash));
         Key::Dictionary(addr)
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
-        writer.push(self.tag());
-        match self {
-            Key::Account(account_hash) => {
-                writer.extend_from_slice(account_hash.as_bytes());
-            }
-            Key::Hash(hash) => {
-                writer.extend_from_slice(hash);
-            }
-            Key::URef(uref) => {
-                writer.extend_from_slice(&uref.addr());
-                writer.push(uref.access_rights().bits());
-            }
-            Key::Transfer(addr) => {
-                writer.extend_from_slice(addr.as_bytes());
-            }
-            Key::DeployInfo(addr) => {
-                writer.extend_from_slice(addr.as_bytes());
-            }
-            Key::EraInfo(era_id) => {
-                writer.extend_from_slice(&era_id.to_le_bytes());
-            }
-            Key::Balance(uref_addr) => {
-                writer.extend_from_slice(uref_addr);
-            }
-            Key::Bid(account_hash) => {
-                writer.extend_from_slice(account_hash.as_bytes());
-            }
-            Key::Withdraw(account_hash) => {
-                writer.extend_from_slice(account_hash.as_bytes());
-            }
-            Key::Dictionary(addr) => {
-                writer.extend_from_slice(addr);
-            }
-            Key::SystemContractRegistry => {
-                writer.extend_from_slice(&[0u8; 32]);
-            }
-        };
-        Ok(())
-    }
 }
 
 impl Display for Key {
@@ -642,6 +601,47 @@ impl ToBytes for Key {
             Key::Dictionary(_) => KEY_DICTIONARY_SERIALIZED_LENGTH,
             Key::SystemContractRegistry => KEY_SYSTEM_CONTRACT_REGISTRY_SERIALIZED_LENGTH,
         }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(self.tag());
+        match self {
+            Key::Account(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Hash(hash) => {
+                writer.extend_from_slice(hash);
+            }
+            Key::URef(uref) => {
+                writer.extend_from_slice(&uref.addr());
+                writer.push(uref.access_rights().bits());
+            }
+            Key::Transfer(addr) => {
+                writer.extend_from_slice(addr.as_bytes());
+            }
+            Key::DeployInfo(addr) => {
+                writer.extend_from_slice(addr.as_bytes());
+            }
+            Key::EraInfo(era_id) => {
+                writer.extend_from_slice(&era_id.to_le_bytes());
+            }
+            Key::Balance(uref_addr) => {
+                writer.extend_from_slice(uref_addr);
+            }
+            Key::Bid(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Withdraw(account_hash) => {
+                writer.extend_from_slice(account_hash.as_bytes());
+            }
+            Key::Dictionary(addr) => {
+                writer.extend_from_slice(addr);
+            }
+            Key::SystemContractRegistry => {
+                writer.extend_from_slice(&[0u8; 32]);
+            }
+        };
+        Ok(())
     }
 }
 

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -117,12 +117,6 @@ impl ProtocolVersion {
     pub fn is_compatible_with(&self, version: &ProtocolVersion) -> bool {
         self.0.major == version.0.major
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) {
-        writer.extend(self.0.major.to_le_bytes());
-        writer.extend(self.0.minor.to_le_bytes());
-        writer.extend(self.0.patch.to_le_bytes());
-    }
 }
 
 impl ToBytes for ProtocolVersion {
@@ -132,6 +126,13 @@ impl ToBytes for ProtocolVersion {
 
     fn serialized_length(&self) -> usize {
         self.value().serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        writer.extend(self.0.major.to_le_bytes());
+        writer.extend(self.0.minor.to_le_bytes());
+        writer.extend(self.0.patch.to_le_bytes());
+        Ok(())
     }
 }
 

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -150,6 +150,21 @@ impl StoredValue {
             StoredValue::Withdraw(_) => "Withdraw".to_string(),
         }
     }
+
+    fn tag(&self) -> Tag {
+        match self {
+            StoredValue::CLValue(_) => Tag::CLValue,
+            StoredValue::Account(_) => Tag::Account,
+            StoredValue::ContractWasm(_) => Tag::ContractWasm,
+            StoredValue::Contract(_) => Tag::Contract,
+            StoredValue::ContractPackage(_) => Tag::ContractPackage,
+            StoredValue::Transfer(_) => Tag::Transfer,
+            StoredValue::DeployInfo(_) => Tag::DeployInfo,
+            StoredValue::EraInfo(_) => Tag::EraInfo,
+            StoredValue::Bid(_) => Tag::Bid,
+            StoredValue::Withdraw(_) => Tag::Withdraw,
+        }
+    }
 }
 
 impl From<CLValue> for StoredValue {
@@ -331,6 +346,25 @@ impl ToBytes for StoredValue {
                 StoredValue::Bid(bid) => bid.serialized_length(),
                 StoredValue::Withdraw(unbonding_purses) => unbonding_purses.serialized_length(),
             }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(self.tag() as u8);
+        match self {
+            StoredValue::CLValue(cl_value) => cl_value.write_bytes(writer)?,
+            StoredValue::Account(account) => account.write_bytes(writer)?,
+            StoredValue::ContractWasm(contract_wasm) => contract_wasm.write_bytes(writer)?,
+            StoredValue::Contract(contract_header) => contract_header.write_bytes(writer)?,
+            StoredValue::ContractPackage(contract_package) => {
+                contract_package.write_bytes(writer)?
+            }
+            StoredValue::Transfer(transfer) => transfer.write_bytes(writer)?,
+            StoredValue::DeployInfo(deploy_info) => deploy_info.write_bytes(writer)?,
+            StoredValue::EraInfo(era_info) => era_info.write_bytes(writer)?,
+            StoredValue::Bid(bid) => bid.write_bytes(writer)?,
+            StoredValue::Withdraw(unbonding_purses) => unbonding_purses.write_bytes(writer)?,
+        };
+        Ok(())
     }
 }
 

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -276,18 +276,11 @@ impl ToBytes for Bid {
         let mut result = bytesrepr::allocate_buffer(self)?;
         (&self.validator_public_key).write_bytes(&mut result)?;
         (&self.bonding_purse).write_bytes(&mut result)?;
-        bytesrepr::write_u512(&mut result, self.staked_amount())?;
-        bytesrepr::write_u8(&mut result, self.delegation_rate)?;
-        bytesrepr::write_option(&mut result, &self.vesting_schedule, |schedule, writer| {
-            schedule.write_bytes(writer)
-        })?;
-        bytesrepr::write_tree(
-            &mut result,
-            self.delegators(),
-            |pk, writer| pk.write_bytes(writer),
-            |delegator, writer| delegator.write_bytes(writer),
-        )?;
-        bytesrepr::write_bool(&mut result, self.inactive)?;
+        self.staked_amount.write_bytes(&mut result)?;
+        self.delegation_rate.write_bytes(&mut result)?;
+        self.vesting_schedule.write_bytes(&mut result)?;
+        self.delegators().write_bytes(&mut result)?;
+        self.inactive.write_bytes(&mut result)?;
         Ok(result)
     }
 
@@ -299,6 +292,17 @@ impl ToBytes for Bid {
             + self.vesting_schedule.serialized_length()
             + self.delegators.serialized_length()
             + self.inactive.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        (&self.validator_public_key).write_bytes(writer)?;
+        (&self.bonding_purse).write_bytes(writer)?;
+        self.staked_amount.write_bytes(writer)?;
+        self.delegation_rate.write_bytes(writer)?;
+        self.vesting_schedule.write_bytes(writer)?;
+        self.delegators().write_bytes(writer)?;
+        self.inactive.write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -83,13 +83,6 @@ impl VestingSchedule {
             }
         })
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        bytesrepr::write_u64(writer, &self.initial_release_timestamp_millis)?;
-        bytesrepr::write_option(writer, &self.locked_amounts(), |locked, w| {
-            bytesrepr::write_iter(w, locked, |amount, ww| bytesrepr::write_u512(ww, amount))
-        })
-    }
 }
 
 impl ToBytes for [U512; LOCKED_AMOUNTS_LENGTH] {
@@ -138,6 +131,12 @@ impl ToBytes for VestingSchedule {
     fn serialized_length(&self) -> usize {
         self.initial_release_timestamp_millis.serialized_length()
             + self.locked_amounts.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        (&self.initial_release_timestamp_millis).write_bytes(writer)?;
+        self.locked_amounts().write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -144,16 +144,6 @@ impl Delegator {
     pub fn vesting_schedule_mut(&mut self) -> Option<&mut VestingSchedule> {
         self.vesting_schedule.as_mut()
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        (&self.delegator_public_key).write_bytes(writer)?;
-        bytesrepr::write_u512(writer, &self.staked_amount)?;
-        (&self.bonding_purse).write_bytes(writer)?;
-        (&self.validator_public_key).write_bytes(writer)?;
-        bytesrepr::write_option(writer, &self.vesting_schedule, |schedule, writer| {
-            schedule.write_bytes(writer)
-        })
-    }
 }
 
 impl CLTyped for Delegator {
@@ -179,6 +169,15 @@ impl ToBytes for Delegator {
             + self.bonding_purse.serialized_length()
             + self.validator_public_key.serialized_length()
             + self.vesting_schedule.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.delegator_public_key.write_bytes(writer)?;
+        self.staked_amount.write_bytes(writer)?;
+        self.bonding_purse.write_bytes(writer)?;
+        self.validator_public_key.write_bytes(writer)?;
+        self.vesting_schedule.write_bytes(writer)?;
+        Ok(())
     }
 }
 

--- a/types/src/system/auction/unbonding_purse.rs
+++ b/types/src/system/auction/unbonding_purse.rs
@@ -100,6 +100,15 @@ impl ToBytes for UnbondingPurse {
             + self.era_of_creation.serialized_length()
             + self.amount.serialized_length()
     }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.bonding_purse.write_bytes(writer)?;
+        self.validator_public_key.write_bytes(writer)?;
+        self.unbonder_public_key.write_bytes(writer)?;
+        self.era_of_creation.write_bytes(writer)?;
+        self.amount.write_bytes(writer)?;
+        Ok(())
+    }
 }
 
 impl FromBytes for UnbondingPurse {

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -197,12 +197,6 @@ impl URef {
             .ok_or(FromStrError::InvalidAccessRights)?;
         Ok(URef(addr, access_rights))
     }
-
-    pub(crate) fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
-        writer.extend_from_slice(&self.0);
-        writer.push(self.1.bits());
-        Ok(())
-    }
 }
 
 #[cfg(feature = "json-schema")]
@@ -249,6 +243,12 @@ impl bytesrepr::ToBytes for URef {
 
     fn serialized_length(&self) -> usize {
         UREF_SERIALIZED_LENGTH
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), self::Error> {
+        writer.extend_from_slice(&self.0);
+        self.1.write_bytes(writer)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/casper-network/casper-node/issues/2412.

This PR builds on top of https://github.com/casper-network/casper-node/pull/2391 and adds an actual method `write_bytes` to `ToBytes` trait. Most of the code is being moved from a method `write_bytes` on some type `T` to an implementation `ToBytes for T`. 

By implementing `ToBytes::write_bytes` on the top-level structures (like `Trie`), we were able to improve serialization from 50% up to 90%:
```
group                            trie-dev                               trie-latest
-----                            --------                               -----------
serialize_trie_leaf              3.74     95.2±0.74ns        ? ?/sec    1.00     25.4±0.53ns        ? ?/sec
serialize_trie_node              8.69      2.6±0.04µs        ? ?/sec    1.00    297.3±7.81ns        ? ?/sec
serialize_trie_node_pointer      2.27     47.3±0.54ns        ? ?/sec    1.00     20.9±0.15ns        ? ?/sec
```