### PR TITLE
Avoid passing named keys into call_host_ functions.

### DIFF
--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1437,11 +1437,12 @@ where
         &mut self,
         protocol_version: ProtocolVersion,
         entry_point_name: &str,
-        named_keys: &mut NamedKeys,
+        contract: Contract,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
         call_stack: Vec<CallStackElement>,
     ) -> Result<CLValue, Error> {
+        let mut named_keys = contract.named_keys().to_owned();
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
             keys.extend(extra_keys);
@@ -1464,7 +1465,7 @@ where
         let mint_context = RuntimeContext::new(
             self.context.state(),
             EntryPointType::Contract,
-            named_keys,
+            &mut named_keys,
             access_rights,
             runtime_args.to_owned(),
             authorization_keys,
@@ -1583,11 +1584,12 @@ where
         &mut self,
         protocol_version: ProtocolVersion,
         entry_point_name: &str,
-        named_keys: &mut NamedKeys,
+        contract: Contract,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
         call_stack: Vec<CallStackElement>,
     ) -> Result<CLValue, Error> {
+        let mut named_keys = contract.named_keys().to_owned();
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
             keys.extend(extra_keys);
@@ -1610,7 +1612,7 @@ where
         let runtime_context = RuntimeContext::new(
             self.context.state(),
             EntryPointType::Contract,
-            named_keys,
+            &mut named_keys,
             access_rights,
             runtime_args.to_owned(),
             authorization_keys,
@@ -1702,11 +1704,12 @@ where
         &mut self,
         protocol_version: ProtocolVersion,
         entry_point_name: &str,
-        named_keys: &mut NamedKeys,
+        contract: Contract,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
         call_stack: Vec<CallStackElement>,
     ) -> Result<CLValue, Error> {
+        let mut named_keys = contract.named_keys().to_owned();
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
             keys.extend(extra_keys);
@@ -1730,7 +1733,7 @@ where
         let runtime_context = RuntimeContext::new(
             self.context.state(),
             EntryPointType::Contract,
-            named_keys,
+            &mut named_keys,
             access_rights,
             runtime_args.to_owned(),
             authorization_keys,
@@ -2134,7 +2137,7 @@ where
                 return self.call_host_mint(
                     self.context.protocol_version(),
                     entry_point.name(),
-                    &mut named_keys,
+                    contract,
                     &args,
                     &extra_keys,
                     call_stack,
@@ -2150,7 +2153,7 @@ where
                 return self.call_host_handle_payment(
                     self.context.protocol_version(),
                     entry_point.name(),
-                    &mut named_keys,
+                    contract,
                     &args,
                     &extra_keys,
                     call_stack,
@@ -2166,7 +2169,7 @@ where
                 return self.call_host_auction(
                     self.context.protocol_version(),
                     entry_point.name(),
-                    &mut named_keys,
+                    contract,
                     &args,
                     &extra_keys,
                     call_stack,


### PR DESCRIPTION
In this PR I have removed named keys from the signatures of the following functions:
* `Runtime::call_host_mint()`
* `Runtime::call_host_auction()`
* `Runtime::call_host_handle_payment()`

Now we look up and pass in a `Contract`  instance, which these functions take named keys from.