### PR TITLE
Fix compiler and clippy warnings on 1.57.0

### DIFF
--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -382,20 +382,11 @@ pub enum ExecutionResultBuilderError {
 
 /// Builder object that will construct a final [`ExecutionResult`] given payment, session and
 /// finalize [`ExecutionResult`]s.
+#[derive(Default)]
 pub struct ExecutionResultBuilder {
     payment_execution_result: Option<ExecutionResult>,
     session_execution_result: Option<ExecutionResult>,
     finalize_execution_result: Option<ExecutionResult>,
-}
-
-impl Default for ExecutionResultBuilder {
-    fn default() -> Self {
-        ExecutionResultBuilder {
-            payment_execution_result: None,
-            session_execution_result: None,
-            finalize_execution_result: None,
-        }
-    }
 }
 
 impl ExecutionResultBuilder {

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -186,7 +186,7 @@ where
 
     /// Returns a mutable reference to named keys.
     pub fn named_keys_mut(&mut self) -> &mut NamedKeys {
-        &mut self.named_keys
+        self.named_keys
     }
 
     /// Checks if named keys contains a key referenced by name.

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum TrackingCopyQueryResult {
     Success {
         value: StoredValue,

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -150,7 +150,6 @@ impl Display for NextUpgrade {
 /// Basic information about the current run of the node software.
 #[derive(Clone, Debug)]
 pub(crate) struct CurrentRunInfo {
-    pub(crate) activation_point: ActivationPoint,
     pub(crate) protocol_version: ProtocolVersion,
     pub(crate) initial_state_root_hash: Digest,
     pub(crate) last_emergency_restart: Option<EraId>,
@@ -608,7 +607,6 @@ impl ChainspecLoader {
 
     fn get_current_run_info(&self) -> CurrentRunInfo {
         CurrentRunInfo {
-            activation_point: self.chainspec.protocol_config.activation_point,
             protocol_version: self.chainspec.protocol_config.version,
             initial_state_root_hash: self.initial_state_root_hash,
             last_emergency_restart: self.chainspec.protocol_config.last_emergency_restart,

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -4,7 +4,7 @@ use datasize::DataSize;
 use serde::Deserialize;
 
 use casper_hashing::Digest;
-use casper_types::{ProtocolVersion, PublicKey, SecretKey};
+use casper_types::{PublicKey, SecretKey};
 
 use crate::{
     components::consensus::{protocols::highway::config::Config as HighwayConfig, EraId},
@@ -57,8 +57,6 @@ pub(crate) struct ProtocolConfig {
     pub(crate) auction_delay: u64,
     pub(crate) unbonding_delay: u64,
     /// The network protocol version.
-    #[data_size(skip)]
-    pub(crate) protocol_version: ProtocolVersion,
     /// The first era ID after the last upgrade
     pub(crate) last_activation_point: EraId,
     /// Name of the network.
@@ -77,7 +75,6 @@ impl From<&Chainspec> for ProtocolConfig {
             minimum_era_height: chainspec.core_config.minimum_era_height,
             auction_delay: chainspec.core_config.auction_delay,
             unbonding_delay: chainspec.core_config.unbonding_delay,
-            protocol_version: chainspec.protocol_config.version,
             last_activation_point: chainspec.protocol_config.activation_point.era_id(),
             name: chainspec.network_config.name.clone(),
             genesis_timestamp: chainspec

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -48,6 +48,8 @@ impl Status {
 
 /// A map of status (faulty, inactive) by validator ID.
 #[derive(Debug)]
+// False positive, as the fields of this struct are all used in logging validator participation.
+#[allow(dead_code)]
 pub(crate) struct Participation<C>
 where
     C: Context,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -628,8 +628,14 @@ impl ContractRuntime {
         trie_keys: Vec<Digest>,
     ) -> Result<Vec<Digest>, engine_state::Error> {
         let correlation_id = CorrelationId::new();
-        self.engine_state
-            .missing_trie_keys(correlation_id, trie_keys)
+        let start = Instant::now();
+        let result = self
+            .engine_state
+            .missing_trie_keys(correlation_id, trie_keys);
+        self.metrics
+            .missing_trie_keys
+            .observe(start.elapsed().as_secs_f64());
+        result
     }
 
     pub(crate) fn set_initial_state(&mut self, sequential_block_state: ExecutionPreState) {

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -245,6 +245,7 @@ impl ServerSentEvent {
 
 /// The messages sent via the tokio broadcast channel to the handler of each client's SSE stream.
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(super) enum BroadcastChannelMessage {
     /// The message should be sent to the client as an SSE with an optional ID.  The ID should only
     /// be `None` where the `data` is `SseData::ApiVersion`.

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -223,7 +223,7 @@ async fn store_deploy(
     node_id: &NodeId,
     network: &mut Network<Reactor>,
     responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
-    mut rng: &mut TestRng,
+    rng: &mut TestRng,
 ) {
     network
         .process_injected_effect_on(node_id, announce_deploy_received(deploy.clone(), responder))
@@ -233,7 +233,7 @@ async fn store_deploy(
     network
         .crank_until(
             node_id,
-            &mut rng,
+            rng,
             move |event: &ReactorEvent| {
                 matches!(
                     event,

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -132,6 +132,7 @@ struct ClassBasedHandle {
 #[derive(Debug)]
 struct ConsumerId {
     /// The peer's ID.
+    #[allow(dead_code)]
     peer_id: NodeId,
     /// The remote node's `validator_id`.
     validator_id: Option<PublicKey>,

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -19,6 +19,7 @@ fn default_protocol_version() -> ProtocolVersion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Message<P> {
     Handshake {
         /// Network we are connected to.

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -231,8 +231,8 @@ where
             meta.file()
                 .or_else(|| field_visitor.file.as_deref())
                 .unwrap_or_default()
-                .rsplitn(2, '/')
-                .next()
+                .rsplit_once('/')
+                .map(|parts| parts.1)
                 .unwrap_or_default()
         } else {
             ""

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -333,9 +333,9 @@ pub(crate) fn create_test_deploy(
     created_ago: TimeDiff,
     ttl: TimeDiff,
     now: Timestamp,
-    mut test_rng: &mut TestRng,
+    test_rng: &mut TestRng,
 ) -> Deploy {
-    Deploy::random_with_timestamp_and_ttl(&mut test_rng, now - created_ago, ttl)
+    Deploy::random_with_timestamp_and_ttl(test_rng, now - created_ago, ttl)
 }
 
 /// Creates a random deploy that is considered expired.

--- a/node/src/testing/test_clock.rs
+++ b/node/src/testing/test_clock.rs
@@ -16,8 +16,6 @@ const TEST_CLOCK_LEEWAY: Duration = Duration::from_secs(315_569_520);
 /// A rewindable and forwardable clock for testing that does not tick on its own.
 #[derive(Debug)]
 pub struct TestClock {
-    /// The earliest moment of the `TestClock`.
-    epoch: Instant,
     /// The current time set on the clock.
     now: Instant,
 }
@@ -33,10 +31,8 @@ impl TestClock {
     ///
     /// Testing clocks will not advance unless prompted to do so.
     pub fn new() -> Self {
-        let epoch = Instant::now();
         Self {
-            epoch,
-            now: epoch + TEST_CLOCK_LEEWAY,
+            now: Instant::now() + TEST_CLOCK_LEEWAY,
         }
     }
 

--- a/node/src/utils/pid_file.rs
+++ b/node/src/utils/pid_file.rs
@@ -25,7 +25,7 @@ pub(crate) struct PidFile {
     /// The pidfile.
     ///
     /// The file will be locked for the lifetime of `PidFile`.
-    pidfile: File,
+    _pidfile: File,
     /// The pidfile location.
     path: PathBuf,
     /// Previous pidfile contents.
@@ -147,7 +147,7 @@ impl PidFile {
         pidfile.flush().map_err(PidFileError::WriteFailed)?;
 
         Ok(PidFile {
-            pidfile,
+            _pidfile: pidfile,
             path: path.as_ref().to_owned(),
             previous,
         })

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -35,6 +35,7 @@ fn get_system_contract(system_contract: SystemContractType) -> ContractHash {
             api_error::result_from(value).map(|_| hash_data_raw)
         };
         // Revert for any possible error that happened on host side
+        #[allow(clippy::redundant_closure)] // false positive
         let contract_hash_bytes = result.unwrap_or_else(|e| runtime::revert(e));
         // Deserializes a valid URef passed from the host side
         bytesrepr::deserialize(contract_hash_bytes.to_vec()).unwrap_or_revert()

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -230,7 +230,7 @@ pub trait Auction:
     /// is missing, the function call returns an error and does nothing.
     ///
     /// The function transfers motes from the source purse to the delegator's bonding purse.
-    ///    
+    ///
     /// This entry point returns the number of tokens currently delegated to a given validator.
     fn delegate(
         &mut self,
@@ -528,7 +528,7 @@ pub trait Auction:
         }
 
         let mut era_info = EraInfo::new();
-        let mut seigniorage_allocations = era_info.seigniorage_allocations_mut();
+        let seigniorage_allocations = era_info.seigniorage_allocations_mut();
 
         for (public_key, reward_factor) in reward_factors {
             let recipient = seigniorage_recipients
@@ -580,7 +580,7 @@ pub trait Auction:
                     });
             let delegator_payouts = detail::reinvest_delegator_rewards(
                 self,
-                &mut seigniorage_allocations,
+                seigniorage_allocations,
                 public_key.clone(),
                 delegator_rewards,
             )?;
@@ -593,7 +593,7 @@ pub trait Auction:
             let validator_reward = validators_part.to_integer();
             let validator_bonding_purse = detail::reinvest_validator_reward(
                 self,
-                &mut seigniorage_allocations,
+                seigniorage_allocations,
                 public_key.clone(),
                 validator_reward,
             )?;


### PR DESCRIPTION
Fix compiler and clippy warnings caused by stable Rust upgrade