### PR TITLE
Temporarily disable the `run_equivocator_network` test

### DIFF
--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -302,6 +302,7 @@ async fn run_participating_network() {
 }
 
 #[tokio::test]
+#[ignore = "This test fails randomly - it'll be reenabled after this issue is fixed: https://github.com/casper-network/casper-node/issues/1859"]
 async fn run_equivocator_network() {
     testing::init_logging();
 


### PR DESCRIPTION
This PR temporarily disables the `run_equivocator_network` test as it is giving the non-deterministic results.

The root-cause will be addressed in the following ticket: https://github.com/casper-network/casper-node/issues/1859