### PR TITLE
GH-2399: Optimize store lookup

### DIFF
--- a/execution_engine/src/storage/store/mod.rs
+++ b/execution_engine/src/storage/store/mod.rs
@@ -24,12 +24,12 @@ pub trait Store<K, V> {
     fn get<T>(&self, txn: &T, key: &K) -> Result<Option<V>, Self::Error>
     where
         T: Readable<Handle = Self::Handle>,
-        K: ToBytes,
+        K: AsRef<[u8]>,
         V: FromBytes,
         Self::Error: From<T::Error>,
     {
         let handle = self.handle();
-        match txn.read(handle, &key.to_bytes()?)? {
+        match txn.read(handle, key.as_ref())? {
             None => Ok(None),
             Some(value_bytes) => {
                 let value = bytesrepr::deserialize(value_bytes.into())?;
@@ -43,12 +43,12 @@ pub trait Store<K, V> {
     fn put<T>(&self, txn: &mut T, key: &K, value: &V) -> Result<(), Self::Error>
     where
         T: Writable<Handle = Self::Handle>,
-        K: ToBytes,
+        K: AsRef<[u8]>,
         V: ToBytes,
         Self::Error: From<T::Error>,
     {
         let handle = self.handle();
-        txn.write(handle, &key.to_bytes()?, &value.to_bytes()?)
+        txn.write(handle, key.as_ref(), &value.to_bytes()?)
             .map_err(Into::into)
     }
 }

--- a/execution_engine/src/storage/store/store_ext.rs
+++ b/execution_engine/src/storage/store/store_ext.rs
@@ -17,7 +17,7 @@ pub trait StoreExt<K, V>: Store<K, V> {
     ) -> Result<Vec<Option<V>>, Self::Error>
     where
         T: Readable<Handle = Self::Handle>,
-        K: ToBytes + 'a,
+        K: AsRef<[u8]> + 'a,
         V: FromBytes,
         Self::Error: From<T::Error>,
     {
@@ -38,7 +38,7 @@ pub trait StoreExt<K, V>: Store<K, V> {
     ) -> Result<(), Self::Error>
     where
         T: Writable<Handle = Self::Handle>,
-        K: ToBytes + 'a,
+        K: AsRef<[u8]> + 'a,
         V: ToBytes + 'a,
         Self::Error: From<T::Error>,
     {

--- a/execution_engine/src/storage/store/tests.rs
+++ b/execution_engine/src/storage/store/tests.rs
@@ -14,7 +14,7 @@ fn roundtrip<'a, K, V, X, S>(
     items: &BTreeMap<K, V>,
 ) -> Result<Vec<Option<V>>, S::Error>
 where
-    K: ToBytes,
+    K: AsRef<[u8]>,
     V: ToBytes + FromBytes,
     X: TransactionSource<'a, Handle = S::Handle>,
     S: Store<K, V>,
@@ -34,7 +34,7 @@ pub fn roundtrip_succeeds<'a, K, V, X, S>(
     items: BTreeMap<K, V>,
 ) -> Result<bool, S::Error>
 where
-    K: ToBytes,
+    K: AsRef<[u8]>,
     V: ToBytes + FromBytes + Clone + PartialEq,
     X: TransactionSource<'a, Handle = S::Handle>,
     S: Store<K, V>,

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -340,7 +340,7 @@ mod tests {
 
     use proptest_attr_macro::proptest;
 
-    use casper_types::bytesrepr;
+    use casper_types::bytesrepr::{self, ToBytes};
 
     use crate::{ChunkWithProof, Digest};
 
@@ -585,5 +585,15 @@ mod tests {
         ];
 
         assert_eq!(expected, serialized);
+    }
+
+    #[test]
+    fn should_assert_simple_digest_serialization_format() {
+        let digest_bytes = [0; 32];
+
+        assert_eq!(
+            Digest(digest_bytes).to_bytes().unwrap(),
+            digest_bytes.to_vec()
+        );
     }
 }


### PR DESCRIPTION
Closes #2399

This PR avoids using `ToBytes` for `Store<K, V>` keys as `K` is always a `Digest` in the production code and since `digest.to_bytes() == digest` we can specialize on `AsRef<[u8]>` rather than `ToBytes` and avoid extra allocation of a temporary `Vec`.