### PR TITLE
Remove jemalloc, swap for stats_alloc simple wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,9 @@ dependencies = [
  "signature",
  "smallvec",
  "static_assertions",
+ "stats_alloc",
  "structopt",
+ "sys-info",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4044,6 +4046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stats_alloc"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
+
+[[package]]
 name = "storage-costs"
 version = "0.1.0"
 dependencies = [
@@ -4135,6 +4143,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3e7ba888a12ddcf0084e36ae4609b055845f38022d1946b67356fbc27d5795"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,8 +549,6 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools",
- "jemalloc-ctl",
- "jemallocator",
  "k256",
  "libc",
  "linked-hash-map",
@@ -589,7 +587,6 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "structopt",
- "sys-info",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2380,38 +2377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,25 +2971,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -4189,16 +4135,6 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3e7ba888a12ddcf0084e36ae4609b055845f38022d1946b67356fbc27d5795"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -116,12 +116,6 @@ To set the threshold at which a warn-level log message is generated for a long-r
 CL_EVENT_MAX_MICROSECS=1000
 ```
 
-To set the threshold at which a queue dump will occur, use the env var `CL_MEM_DUMP_THRESHOLD_MB`. When the process reaches this level of memory allocation a dump will occur, but this will only occur once. Queue dumps can be found in `/tmp` once they are complete. For example, to set the threshold to 16000 megabytes:
-
-```
-CL_MEM_DUMP_THRESHOLD_MB=16000
-```
-
 
 ## Logging
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,8 +42,6 @@ http = "0.2.1"
 humantime = "2"
 hyper = "0.14.4"
 itertools = "0.10.0"
-jemalloc-ctl = "0.3.3"
-jemallocator = "0.3.2"
 k256 = { version = "0.7.2", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
@@ -77,7 +75,6 @@ signature = "1"
 smallvec = { version = "1", features = ["serde"] }
 static_assertions = "1"
 structopt = "0.3.14"
-sys-info = "0.8.0"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -73,8 +73,10 @@ serde_repr = "0.1.6"
 signal-hook = "0.3.4"
 signature = "1"
 smallvec = { version = "1", features = ["serde"] }
+stats_alloc = "0.1.8"
 static_assertions = "1"
 structopt = "0.3.14"
+sys-info = "0.8.0"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -5,6 +5,7 @@
 pub mod arglang;
 
 use std::{
+    alloc::System,
     env, fs,
     path::{Path, PathBuf},
     str::FromStr,
@@ -13,6 +14,7 @@ use std::{
 use anyhow::{self, Context};
 use prometheus::Registry;
 use regex::Regex;
+use stats_alloc::{StatsAlloc, INSTRUMENTED_SYSTEM};
 use structopt::StructOpt;
 use toml::{value::Table, Value};
 use tracing::{error, info, warn};
@@ -27,6 +29,11 @@ use crate::{
         WithDir,
     },
 };
+
+// We override the standard allocator to gather metrics and tune the allocator via th MALLOC_CONF
+// env var.
+#[global_allocator]
+static ALLOC: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -28,11 +28,6 @@ use crate::{
     },
 };
 
-// We override the standard allocator to gather metrics and tune the allocator via th MALLOC_CONF
-// env var.
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
 #[structopt(version = crate::VERSION_STRING_COLOR.as_str())]


### PR DESCRIPTION
As @TomVasile has pointed out, we don't report the correct values for `consumed`, @thamps-casp has previously noted that `CL_MEM_DUMP_THRESHOLD` doesn't result in a memory dump, and we don't use the related metrics reported by the node. This does not affect our node-internal `DataSize` related memory metrics.