### PR TITLE
Reject incompatible versions during handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "datasize"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfa50a16bc31c1e8d1682876a26aa205e6669ac65645ae484064cbbc5263abc"
+checksum = "2cdaf1625dae32ea757a4a98e6f59496bb4fe80a41efb0bd57e631f6cb341770"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebcbe9ac751b6e1700a10201b44ae32fa36396b46849fdb4f7ec5fb86326de3"
+checksum = "1065db16e6dad1cfa0f50966d8405bb9f6d13f74f34d685b417f301cb32f1d86"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add new event to the main SSE server stream across all endpoints `<IP:Port>/events/*` which emits a shutdown event when the node shuts down.
 * Introducing fast-syncing to join the network, avoiding the need to execute every block to catch up.
 * Added `archival_sync` to `[node]` config section, along with archival syncing capabilities
+* Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
 
 ### Changed
 * `enable_manual_sync` configuration parameter defaults to `true`.
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.  The format
 * More node modules are now `pub(crate)`.
 * Chain automatically creates a switch block immediately after genesis or an upgrade.
 * Asymmetric connections are now swept regularly again.
+* Nodes no longer connect to nodes that do not speak the same protocol version by default.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,7 +25,7 @@ casper-node-macros = { version = "1.4.2", path = "../node_macros" }
 casper-hashing = { version = "1.4.2", path = "../hashing" }
 casper-types = { version = "1.4.2", path = "../types", features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
-datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
+datasize = { version = "0.2.10", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false, features = ["rand", "serde", "u64_backend"] }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -283,6 +283,8 @@ where
             consensus_keys,
             payload_weights: cfg.estimator_weights.clone(),
             reject_incompatible_versions: cfg.reject_incompatible_versions,
+            tarpit_version_threshold: cfg.tarpit_version_threshold,
+            tarpit_duration: cfg.tarpit_duration,
         });
 
         // Run the server task.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -517,11 +517,15 @@ where
     fn is_blockable_offense_for_outgoing(&self, error: &ConnectionError) -> bool {
         match error {
             // Potentially transient failures.
+            //
+            // Note that incompatible versions need to be considered transient, since they occur
+            // during regular upgrades.
             ConnectionError::TlsInitialization(_)
             | ConnectionError::TcpConnection(_)
             | ConnectionError::TlsHandshake(_)
             | ConnectionError::HandshakeSend(_)
-            | ConnectionError::HandshakeRecv(_) => false,
+            | ConnectionError::HandshakeRecv(_)
+            | ConnectionError::IncompatibleVersion(_) => false,
 
             // These could be candidates for blocking, but for now we decided not to.
             ConnectionError::NoPeerCertificate

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -282,6 +282,7 @@ where
             public_addr,
             consensus_keys,
             payload_weights: cfg.estimator_weights.clone(),
+            reject_incompatible_versions: cfg.reject_incompatible_versions,
         });
 
         // Run the server task.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -285,6 +285,7 @@ where
             reject_incompatible_versions: cfg.reject_incompatible_versions,
             tarpit_version_threshold: cfg.tarpit_version_threshold,
             tarpit_duration: cfg.tarpit_duration,
+            tarpit_chance: cfg.tarpit_chance,
         });
 
         // Run the server task.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -39,6 +39,7 @@ impl Default for Config {
             reject_incompatible_versions: true,
             tarpit_version_threshold: None,
             tarpit_duration: Duration::from_secs(600),
+            tarpit_chance: 0.2,
         }
     }
 }
@@ -74,6 +75,8 @@ pub struct Config {
     pub tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.
     pub tarpit_duration: Duration,
+    /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
+    pub tarpit_chance: f32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
+use casper_types::ProtocolVersion;
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +37,8 @@ impl Default for Config {
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
             reject_incompatible_versions: true,
+            tarpit_version_threshold: None,
+            tarpit_duration: Duration::from_secs(600),
         }
     }
 }
@@ -67,6 +70,10 @@ pub struct Config {
     pub estimator_weights: PayloadWeights,
     /// Whether or not to reject incompatible versions during handshake.
     pub reject_incompatible_versions: bool,
+    /// The protocol version at which (or under) tarpitting is enabled.
+    pub tarpit_version_threshold: Option<ProtocolVersion>,
+    /// If tarpitting is enabled, duration for which connections should be kept open.
+    pub tarpit_duration: Duration,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -35,6 +35,7 @@ impl Default for Config {
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
+            reject_incompatible_versions: true,
         }
     }
 }
@@ -64,6 +65,8 @@ pub struct Config {
     pub max_incoming_message_rate_non_validators: u32,
     /// Weight distribution for the payload impact estimator.
     pub estimator_weights: PayloadWeights,
+    /// Whether or not to reject incompatible versions during handshake.
+    pub reject_incompatible_versions: bool,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -1,6 +1,6 @@
 use std::{error, io, net::SocketAddr, result, sync::Arc};
 
-use casper_types::SecretKey;
+use casper_types::{ProtocolVersion, SecretKey};
 use datasize::DataSize;
 use openssl::{error::ErrorStack, ssl};
 use serde::Serialize;
@@ -142,6 +142,9 @@ pub enum ConnectionError {
     /// Peer reported a network name that does not match ours.
     #[error("peer is on different network: {0}")]
     WrongNetwork(String),
+    /// Peer reported an incompatible version.
+    #[error("peer is running incompatible version: {0}")]
+    IncompatibleVersion(ProtocolVersion),
     /// Peer sent a non-handshake message as its first message.
     #[error("peer did not send handshake")]
     DidNotSendHandshake,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -184,6 +184,8 @@ where
     pub(super) consensus_keys: Option<ConsensusKeyPair>,
     /// Weights to estimate payloads with.
     pub(super) payload_weights: PayloadWeights,
+    /// Whether or not to reject incompatible versions during handshake.
+    pub(super) reject_incompatible_versions: bool,
 }
 
 /// Handles an incoming connection.
@@ -359,7 +361,9 @@ where
         //
         // Since we are not using SemVer for versioning, we cannot make any assumptions about
         // compatibility, so we allow only exact version matches.
-        if protocol_version != context.chain_info.protocol_version {
+        if context.reject_incompatible_versions
+            && protocol_version != context.chain_info.protocol_version
+        {
             return Err(ConnectionError::IncompatibleVersion(protocol_version));
         }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -21,6 +21,7 @@ use openssl::{
     ssl::Ssl,
 };
 use prometheus::IntGauge;
+use rand::{rngs::OsRng, Rng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{
     net::TcpStream,
@@ -190,6 +191,8 @@ where
     pub(super) tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.
     pub(super) tarpit_duration: Duration,
+    /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
+    pub(super) tarpit_chance: f32,
 }
 
 /// Handles an incoming connection.
@@ -370,10 +373,18 @@ where
         {
             if let Some(threshold) = context.tarpit_version_threshold {
                 if protocol_version <= threshold {
-                    // If tarpitting is enabled, we hold open the connection for a specific amount
-                    // of time, to reduce load on other nodes and keep them from reconnecting.
-                    info!(duration=?context.tarpit_duration, "tarpitting node");
-                    tokio::time::sleep(context.tarpit_duration).await;
+                    let mut rng = OsRng;
+
+                    let sample = rng.gen_range(0.0f32..1.0f32);
+                    if context.tarpit_chance > sample {
+                        // If tarpitting is enabled, we hold open the connection for a specific
+                        // amount of time, to reduce load on other nodes and keep them from
+                        // reconnecting.
+                        info!(duration=?context.tarpit_duration, "tarpitting node");
+                        tokio::time::sleep(context.tarpit_duration).await;
+                    } else {
+                        debug!(p = context.tarpit_chance, "randomly not tarpitting node");
+                    }
                 }
             }
             return Err(ConnectionError::IncompatibleVersion(protocol_version));

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -375,8 +375,7 @@ where
                 if protocol_version <= threshold {
                     let mut rng = OsRng;
 
-                    let sample = rng.gen_range(0.0f32..1.0f32);
-                    if context.tarpit_chance > sample {
+                    if rng.gen_bool(context.tarpit_chance as f64) {
                         // If tarpitting is enabled, we hold open the connection for a specific
                         // amount of time, to reduce load on other nodes and keep them from
                         // reconnecting.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -379,7 +379,7 @@ where
                         // If tarpitting is enabled, we hold open the connection for a specific
                         // amount of time, to reduce load on other nodes and keep them from
                         // reconnecting.
-                        info!(duration=?context.tarpit_duration, "tarpitting node");
+                        info!(duration=?context.tarpit_duration, "randomly tarpitting node");
                         tokio::time::sleep(context.tarpit_duration).await;
                     } else {
                         debug!(p = context.tarpit_chance, "randomly not tarpitting node");

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -21,7 +21,7 @@ use openssl::{
     ssl::Ssl,
 };
 use prometheus::IntGauge;
-use rand::{rngs::OsRng, Rng};
+use rand::Rng;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{
     net::TcpStream,
@@ -373,7 +373,7 @@ where
         {
             if let Some(threshold) = context.tarpit_version_threshold {
                 if protocol_version <= threshold {
-                    let mut rng = OsRng;
+                    let mut rng = crate::new_rng();
 
                     if rng.gen_bool(context.tarpit_chance as f64) {
                         // If tarpitting is enabled, we hold open the connection for a specific

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -142,6 +142,36 @@ max_incoming_message_rate_non_validators = 0
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -141,6 +141,37 @@ max_incoming_message_rate_non_validators = 3000
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -142,6 +142,36 @@ max_incoming_message_rate_non_validators = 0
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -145,6 +145,36 @@ max_incoming_message_rate_non_validators = 0
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -142,6 +142,36 @@ max_incoming_message_rate_non_validators = 0
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server


### PR DESCRIPTION
Closes #2402.

This adds an optional (enabled by default) rejection for incompatible versions after the handshake has been established. It can be disabled through the configuration to help unstick potentially sticky situation if the nodes are by accident still compatible.

It also adds a "tarpit" functionality that will delay processing of a handshake (and communication) with a node if it is on a very old version. As these old versions will only reconnect once all their connections are gone, even one node delaying them should be sufficient to stop them in their tracks and ease their impact on the network, specifically the known node subset.