### PR TITLE
Add clarification comment to `mem_pool_prune_interval` parameter

### DIFF
--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -249,6 +249,7 @@ enable_mem_deduplication = true
 # Memory duplication garbage collection.
 #
 # Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -248,6 +248,7 @@ enable_mem_deduplication = true
 # Memory duplication garbage collection.
 #
 # Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
 # ===================================

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -248,6 +248,7 @@ enable_mem_deduplication = true
 # Memory duplication garbage collection.
 #
 # Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
 

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -251,6 +251,7 @@ enable_mem_deduplication = true
 # Memory duplication garbage collection.
 #
 # Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
 

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -248,6 +248,7 @@ enable_mem_deduplication = true
 # Memory duplication garbage collection.
 #
 # Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
 


### PR DESCRIPTION
This PR adds additional clarification for the `mem_pool_prune_interval` config parameter.