### PR TITLE
2404 USR1/USR2: Different formats for queue dumps.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,9 +15,11 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
 * Add new event to the main SSE server stream across all endpoints `<IP:PORT>/events/*` which emits a shutdown event when the node shuts down.
+* Add `SIGUSR2` signal handling to dump the queue in JSON format (see "Changed" section for `SIGUSR1`).
 
 ### Changed
 * `enable_manual_sync` configuration parameter defaults to `true`.
+* `SIGUSR1` now only dumps the queue in the debug text format.
 
 
 ## [1.4.2] - 2021-11-11

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -55,7 +55,10 @@ use once_cell::sync::Lazy;
 #[cfg(not(test))]
 use rand::SeedableRng;
 use signal_hook::{
-    consts::{signal::SIGUSR1, TERM_SIGNALS},
+    consts::{
+        signal::{SIGUSR1, SIGUSR2},
+        TERM_SIGNALS,
+    },
     flag,
 };
 
@@ -111,8 +114,12 @@ pub(crate) static VERSION_STRING: Lazy<String> = Lazy::new(|| version_string(fal
 pub(crate) static TERMINATION_REQUESTED: Lazy<Arc<AtomicUsize>> =
     Lazy::new(|| Arc::new(AtomicUsize::new(0)));
 
-/// Global flag that indicates the currently running reactor should dump its event queue.
-pub(crate) static QUEUE_DUMP_REQUESTED: Lazy<Arc<AtomicBool>> =
+/// Global flag indicating the running reactor should dump its event queue in JSON format.
+pub(crate) static JSON_DUMP_REQUESTED: Lazy<Arc<AtomicBool>> =
+    Lazy::new(|| Arc::new(AtomicBool::new(false)));
+
+/// Global flag indicating the running reactor should dump its event queue in debug text format.
+pub(crate) static DEBUG_DUMP_REQUESTED: Lazy<Arc<AtomicBool>> =
     Lazy::new(|| Arc::new(AtomicBool::new(false)));
 
 /// Setup UNIX signal hooks for current application.
@@ -125,7 +132,8 @@ pub(crate) fn setup_signal_hooks() {
         )
         .unwrap_or_else(|error| panic!("failed to register signal {}: {}", signal, error));
     }
-    let _ = flag::register(SIGUSR1, Arc::clone(&*QUEUE_DUMP_REQUESTED));
+    let _ = flag::register(SIGUSR1, Arc::clone(&*DEBUG_DUMP_REQUESTED));
+    let _ = flag::register(SIGUSR2, Arc::clone(&*JSON_DUMP_REQUESTED));
 }
 
 /// Constructs a new `NodeRng`.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -711,7 +711,6 @@ where
                 );
                 if let Err(error) = self.scheduler.snapshot(&mut serializer).await {
                     warn!(%error, "could not serialize snapshot to {}", output_fn);
-                    return;
                 }
             }
             DumpFormat::Debug => {

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -569,7 +569,7 @@ where
                             %threshold_bytes,
                             "node has allocated enough memory to trigger queue dump"
                         );
-                        self.dump_queues().await;
+                        self.dump_queues(DumpFormat::Debug).await;
                     }
                 }
             }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -64,7 +64,7 @@ use crate::{
     types::{ExitCode, Timestamp},
     unregister_metric,
     utils::{self, SharedFlag, WeightedRoundRobin},
-    NodeRng, QUEUE_DUMP_REQUESTED, TERMINATION_REQUESTED,
+    NodeRng, DEBUG_DUMP_REQUESTED, JSON_DUMP_REQUESTED, TERMINATION_REQUESTED,
 };
 #[cfg(test)]
 use crate::{reactor::initializer::Reactor as InitializerReactor, types::Chainspec};
@@ -107,6 +107,15 @@ static DISPATCH_EVENT_THRESHOLD: Lazy<Duration> = Lazy::new(|| {
 #[cfg(target_os = "linux")]
 /// The desired limit for open files.
 const TARGET_OPEN_FILES_LIMIT: Limit = 64_000;
+
+/// Format for dump of event queue.
+#[derive(Copy, Clone, Debug)]
+enum DumpFormat {
+    /// JSON-encoded (using serde).
+    Json,
+    /// Text-format derived from `fmt::Debug`.
+    Debug,
+}
 
 #[cfg(target_os = "linux")]
 /// Adjusts the maximum number of open file handles upwards towards the hard limit.
@@ -566,12 +575,18 @@ where
             }
         }
 
+        // Dump event queue in JSON format if requested, stopping the world.
+        if JSON_DUMP_REQUESTED.load(Ordering::SeqCst) {
+            debug!("dumping event queue in JSON format as requested");
+            self.dump_queues(DumpFormat::Json).await;
+            JSON_DUMP_REQUESTED.store(false, Ordering::SeqCst);
+        }
+
         // Dump event queue if requested, stopping the world.
-        if QUEUE_DUMP_REQUESTED.load(Ordering::SeqCst) {
-            debug!("dumping event queue as requested");
-            self.dump_queues().await;
-            // Indicate we are done with the dump.
-            QUEUE_DUMP_REQUESTED.store(false, Ordering::SeqCst);
+        if DEBUG_DUMP_REQUESTED.load(Ordering::SeqCst) {
+            debug!("dumping event queue in debug format as requested");
+            self.dump_queues(DumpFormat::Debug).await;
+            DEBUG_DUMP_REQUESTED.store(false, Ordering::SeqCst);
         }
 
         let ((ancestor, event), queue) = self.scheduler.pop().await;
@@ -678,33 +693,40 @@ where
     }
 
     /// Handles dumping queue contents to files in /tmp.
-    async fn dump_queues(&mut self) {
+    async fn dump_queues(&mut self, format: DumpFormat) {
         let timestamp = Timestamp::now();
         self.last_queue_dump = Some(timestamp);
-        let output_fn = format!("/tmp/queue_dump-{}.json", timestamp);
-        let mut serializer = serde_json::Serializer::pretty(match File::create(&output_fn) {
-            Ok(file) => file,
-            Err(error) => {
-                warn!(%error, "could not create output file ({}) for queue snapshot", output_fn);
-                return;
-            }
-        });
 
-        if let Err(error) = self.scheduler.snapshot(&mut serializer).await {
-            warn!(%error, "could not serialize snapshot to {}", output_fn);
-            return;
-        }
-
-        let debug_dump_filename = format!("/tmp/queue_dump_debug-{}.txt", timestamp);
-        let mut file = match File::create(&debug_dump_filename) {
-            Ok(file) => file,
-            Err(error) => {
-                warn!(%error, "could not create debug output file ({}) for queue snapshot", debug_dump_filename);
-                return;
+        match format {
+            DumpFormat::Json => {
+                let output_fn = format!("/tmp/queue_dump-{}.json", timestamp);
+                let mut serializer = serde_json::Serializer::pretty(
+                    match File::create(&output_fn) {
+                        Ok(file) => file,
+                        Err(error) => {
+                            warn!(%error, "could not create output file ({}) for queue snapshot", output_fn);
+                            return;
+                        }
+                    },
+                );
+                if let Err(error) = self.scheduler.snapshot(&mut serializer).await {
+                    warn!(%error, "could not serialize snapshot to {}", output_fn);
+                    return;
+                }
             }
-        };
-        if let Err(error) = self.scheduler.debug_dump(&mut file).await {
-            warn!(%error, "could not serialize debug snapshot to {}", debug_dump_filename);
+            DumpFormat::Debug => {
+                let output_fn = format!("/tmp/queue_dump_debug-{}.txt", timestamp);
+                let mut file = match File::create(&output_fn) {
+                    Ok(file) => file,
+                    Err(error) => {
+                        warn!(%error, "could not create debug output file ({}) for queue snapshot", output_fn);
+                        return;
+                    }
+                };
+                if let Err(error) = self.scheduler.debug_dump(&mut file).await {
+                    warn!(%error, "could not serialize debug snapshot to {}", output_fn);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR causes `USR1` to dump only the debug representation of the event queue. `USR2` can be used to obtain the JSON format.

Closes #2404 