### PR TITLE
NCTL: nightly run fixes

### DIFF
--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -320,6 +320,10 @@ function assert_no_proposal_walkback() {
     local JSON_OUT
     local PROPOSER
 
+    # normalize hashes
+    WALKBACK_HASH=$(echo $WALKBACK_HASH |  tr '[:upper:]' '[:lower:]')
+    CHECK_HASH=$(echo $CHECK_HASH | tr '[:upper:]' '[:lower:]')
+
     log_step "Checking proposers: Walking back to hash $WALKBACK_HASH..."
 
     while [ "$CHECK_HASH" != "$WALKBACK_HASH" ]; do
@@ -334,9 +338,13 @@ function assert_no_proposal_walkback() {
             log "BLOCK HASH $CHECK_HASH: PROPOSER=$PROPOSER, NODE_KEY_HEX=$PUBLIC_KEY_HEX"
             unset CHECK_HASH
             CHECK_HASH=$(echo $JSON_OUT | jq -r '.result.block.header.parent_hash')
+            # normalize
+            CHECK_HASH=$(echo $CHECK_HASH | tr '[:upper:]' '[:lower:]')
             log "Checking next hash: $CHECK_HASH"
         fi
     done
+    log "Walkback Completed!"
+    log "CHECK_HASH: $CHECK_HASH = WALKBACK_HASH: $WALKBACK_HASH"
     log "Node $NODE_ID didn't propose! [expected]"
 }
 

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -54,7 +54,7 @@ function main() {
             equivocators=0 \
             doppels=0 \
             crashes=5 \
-            restarts=15 \
+            restarts=20 \
             ejections=0
 
     log "------------------------------------------------------------"

--- a/utils/nctl/sh/scenarios/sync_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/sync_upgrade_test.sh
@@ -58,7 +58,7 @@ function main() {
             equivocators=0 \
             doppels=0 \
             crashes=0 \
-            restarts=6 \
+            restarts=7 \
             ejections=0
 
     log "------------------------------------------------------------"


### PR DESCRIPTION
Changes:
- changes `assert_no_proposal_walkback` to compare hashes in lowercase
- temporarily bumps restart threshold in `emergency_upgrade_test.sh` and `sync_upgrade_test.sh`

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/263