### PR TITLE
Storage tests: Era 0 support

### DIFF
--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -395,7 +395,21 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
     let mut storage = storage_fixture(&harness);
 
     // Create a random block, store and load it.
-    let block = Block::random(&mut harness.rng);
+    //
+    // We need the block to be of an era > 0.
+    let block = {
+        let era_id = EraId::from(harness.rng.gen_range(1..6));
+        let height = harness.rng.gen_range(0..10);
+        let is_switch = harness.rng.gen_bool(0.1);
+        Block::random_with_specifics(
+            &mut harness.rng,
+            era_id,
+            height,
+            ProtocolVersion::V1_0_0,
+            is_switch,
+        )
+    };
+
     let mut block_signatures = BlockSignatures::new(block.header().hash(), block.header().era_id());
 
     // Secret and Public Keys

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1473,7 +1473,7 @@ impl Block {
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        let era = rng.gen_range(1..6);
+        let era = rng.gen_range(0..6);
         let height = era * 10 + rng.gen_range(0..10);
         let is_switch = rng.gen_bool(0.1);
 


### PR DESCRIPTION
Explicitly sets parameters on the one storage test that cannot deal with era 0 blocks.

No changelog update, as there are no visible changes. A hardcoded era of 0 has been tried to verify it breaks the tests.

Closes #1789.