### PR TITLE
GH-2463: Provide smart contract access to associated keys that signed a deploy 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-associated-key"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "add-bid"
 version = "0.1.0"
 dependencies = [
@@ -2458,6 +2466,14 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "list-authorization-keys"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
 
 [[package]]
 name = "list-named-keys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "multisig-authorization"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "named-dictionary-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,14 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "authorized-keys"
-version = "0.1.0"
-dependencies = [
- "casper-contract",
- "casper-types",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +3968,14 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "set-action-thresholds"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]

--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -56,6 +56,7 @@ pub(crate) enum FunctionIndex {
     DictionaryGetFuncIndex,
     DictionaryPutFuncIndex,
     LoadCallStack,
+    LoadAuthorizationKeys,
 }
 
 impl From<FunctionIndex> for usize {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -229,6 +229,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 1][..], Some(ValueType::I32)),
                 FunctionIndex::NewDictionaryFuncIndex.into(),
             ),
+            "casper_load_authorization_keys" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
+                FunctionIndex::LoadAuthorizationKeys.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -993,6 +993,17 @@ where
                 let ret = self.load_call_stack(call_stack_len_ptr, result_size_ptr)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
+            FunctionIndex::LoadAuthorizationKeys => {
+                // args(0) (Output) Pointer to number of authorization keys.
+                // args(1) (Output) Pointer to size in bytes of the total bytes.
+                let (len_ptr, result_size_ptr) = Args::parse(args)?;
+                self.charge_host_function_call(
+                    &HostFunction::fixed(10_000),
+                    [len_ptr, result_size_ptr],
+                )?;
+                let ret = self.load_authorization_keys(len_ptr, result_size_ptr)?;
+                Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
+            }
         }
     }
 }

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -3676,10 +3676,10 @@ where
             return Ok(Ok(()));
         }
 
-        let named_keys = CLValue::from_t(authorization_keys).map_err(Error::CLValue)?;
+        let authorization_keys = CLValue::from_t(authorization_keys).map_err(Error::CLValue)?;
 
-        let length = named_keys.inner_bytes().len() as u32;
-        if let Err(error) = self.write_host_buffer(named_keys) {
+        let length = authorization_keys.inner_bytes().len() as u32;
+        if let Err(error) = self.write_host_buffer(authorization_keys) {
             return Ok(Err(error));
         }
 

--- a/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
@@ -13,13 +13,16 @@ use casper_types::{
     RuntimeArgs, U512,
 };
 
+const CONTRACT_ADD_ASSOCIATED_KEY: &str = "add_associated_key.wasm";
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
-const CONTRACT_AUTHORIZED_KEYS: &str = "authorized_keys.wasm";
+const CONTRACT_SET_ACTION_THRESHOLDS: &str = "set_action_thresholds.wasm";
 const ARG_KEY_MANAGEMENT_THRESHOLD: &str = "key_management_threshold";
 const ARG_DEPLOY_THRESHOLD: &str = "deploy_threshold";
 const ARG_ACCOUNT: &str = "account";
+const ARG_WEIGHT: &str = "weight";
 const KEY_1: AccountHash = AccountHash::new([254; 32]);
 const KEY_2: AccountHash = AccountHash::new([253; 32]);
+const KEY_2_WEIGHT: Weight = Weight::new(100);
 const KEY_3: AccountHash = AccountHash::new([252; 32]);
 
 #[ignore]
@@ -27,7 +30,7 @@ const KEY_3: AccountHash = AccountHash::new([252; 32]);
 fn should_deploy_with_authorized_identity_key() {
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_AUTHORIZED_KEYS,
+        CONTRACT_SET_ACTION_THRESHOLDS,
         runtime_args! {
             ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(1),
             ARG_DEPLOY_THRESHOLD => Weight::new(1),
@@ -54,7 +57,7 @@ fn should_raise_auth_failure_with_invalid_key() {
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(1),
                     ARG_DEPLOY_THRESHOLD => Weight::new(1)
@@ -103,7 +106,7 @@ fn should_raise_auth_failure_with_invalid_keys() {
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(1),
                     ARG_DEPLOY_THRESHOLD => Weight::new(1)
@@ -167,7 +170,7 @@ fn should_raise_deploy_authorization_failure() {
     // a key with weight=2.
     let exec_request_4 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_AUTHORIZED_KEYS,
+        CONTRACT_SET_ACTION_THRESHOLDS,
         runtime_args! {
             ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(4),
             ARG_DEPLOY_THRESHOLD => Weight::new(3)
@@ -200,7 +203,7 @@ fn should_raise_deploy_authorization_failure() {
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             // Next deploy will see deploy threshold == 4, keymgmnt == 5
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(5),
                     ARG_DEPLOY_THRESHOLD => Weight::new(4)
@@ -236,7 +239,7 @@ fn should_raise_deploy_authorization_failure() {
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             // change deployment threshold to 4
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(6),
                     ARG_DEPLOY_THRESHOLD => Weight::new(5)
@@ -260,7 +263,7 @@ fn should_raise_deploy_authorization_failure() {
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             // change deployment threshold to 4
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(0),
                     ARG_DEPLOY_THRESHOLD => Weight::new(0)
@@ -298,7 +301,7 @@ fn should_raise_deploy_authorization_failure() {
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             // change deployment threshold to 4
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(0),
                     ARG_DEPLOY_THRESHOLD => Weight::new(0)
@@ -358,7 +361,7 @@ fn should_authorize_deploy_with_multiple_keys() {
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(0),
                     ARG_DEPLOY_THRESHOLD => Weight::new(0),
@@ -390,7 +393,17 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
 
     let exec_request_2 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_AUTHORIZED_KEYS,
+        CONTRACT_ADD_ASSOCIATED_KEY,
+        runtime_args! {
+            ARG_ACCOUNT => KEY_2,
+            ARG_WEIGHT => KEY_2_WEIGHT,
+        },
+    )
+    .build();
+
+    let exec_request_3 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_SET_ACTION_THRESHOLDS,
         runtime_args! {
             ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(4),
             ARG_DEPLOY_THRESHOLD => Weight::new(3)
@@ -399,15 +412,17 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
     .build();
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
         // Reusing a test contract that would add new key
         .exec(exec_request_1)
         .expect_success()
-        .commit()
-        .exec(exec_request_2)
-        .expect_success()
         .commit();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    builder.exec(exec_request_3).expect_success().commit();
 
     let exec_request_3 = {
         let deploy = DeployItemBuilder::new()
@@ -416,7 +431,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
                 ARG_AMOUNT => *DEFAULT_PAYMENT,
             })
             .with_session_code(
-                CONTRACT_AUTHORIZED_KEYS,
+                CONTRACT_SET_ACTION_THRESHOLDS,
                 runtime_args! {
                     ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(0),
                     ARG_DEPLOY_THRESHOLD => Weight::new(0)
@@ -472,7 +487,7 @@ fn should_not_authorize_transfer_without_deploy_key_threshold() {
     .build();
     let update_thresholds_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_AUTHORIZED_KEYS,
+        CONTRACT_SET_ACTION_THRESHOLDS,
         runtime_args! {
             ARG_KEY_MANAGEMENT_THRESHOLD => Weight::new(5),
             ARG_DEPLOY_THRESHOLD => Weight::new(5),

--- a/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
@@ -18,7 +18,7 @@ const DEFAULT_WEIGHT: Weight = Weight::new(1);
 const CONTRACT_ADD_ASSOCIATED_KEY: &str = "add_associated_key.wasm";
 
 const CONTRACT_LIST_AUTHORIZATION_KEYS: &str = "list_authorization_keys.wasm";
-const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorized_keys";
+const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorization_keys";
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
     Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());

--- a/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
@@ -1,0 +1,167 @@
+use casper_engine_test_support::{
+    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_execution_engine::core::{engine_state::Error, execution};
+use casper_types::{
+    account::{AccountHash, Weight},
+    runtime_args,
+    system::{mint, standard_payment::ARG_AMOUNT},
+    ApiError, PublicKey, RuntimeArgs, SecretKey, U512,
+};
+use once_cell::sync::Lazy;
+
+const ARG_ACCOUNT: &str = "account";
+const ARG_WEIGHT: &str = "weight";
+const DEFAULT_WEIGHT: Weight = Weight::new(1);
+
+const CONTRACT_ADD_ASSOCIATED_KEY: &str = "add_associated_key.wasm";
+
+const CONTRACT_LIST_AUTHORIZATION_KEYS: &str = "list_authorization_keys.wasm";
+const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorized_keys";
+
+static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
+    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());
+static ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> =
+    Lazy::new(|| PublicKey::from(&*ACCOUNT_1_SECRET_KEY));
+static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_1_PUBLIC_KEY.to_account_hash());
+
+static ACCOUNT_2_SECRET_KEY: Lazy<SecretKey> =
+    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[243u8; 32]).unwrap());
+static ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> =
+    Lazy::new(|| PublicKey::from(&*ACCOUNT_2_SECRET_KEY));
+static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_2_PUBLIC_KEY.to_account_hash());
+
+const USER_ERROR_ASSERTION: u16 = 0;
+
+#[ignore]
+#[test]
+fn should_list_authorization_keys() {
+    assert!(
+        test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*DEFAULT_ACCOUNT_ADDR],
+            vec![*DEFAULT_ACCOUNT_ADDR]
+        ),
+        "one signature should match the expected authorization key"
+    );
+    assert!(
+        !test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR],
+            vec![*DEFAULT_ACCOUNT_ADDR, *ACCOUNT_1_ADDR]
+        ),
+        "two signatures are off by one"
+    );
+    assert!(
+        test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR],
+            vec![*DEFAULT_ACCOUNT_ADDR, *ACCOUNT_2_ADDR]
+        ),
+        "two signatures should match the expected list"
+    );
+    assert!(
+        test_match(
+            *ACCOUNT_1_ADDR,
+            vec![*ACCOUNT_1_ADDR],
+            vec![*ACCOUNT_1_ADDR]
+        ),
+        "one signature should match the output for non-default account"
+    );
+
+    assert!(
+        test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR, *ACCOUNT_1_ADDR],
+            vec![*ACCOUNT_1_ADDR, *ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR]
+        ),
+        "multisig matches expected list"
+    );
+    assert!(
+        !test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR, *ACCOUNT_1_ADDR],
+            vec![]
+        ),
+        "multisig is not empty"
+    );
+    assert!(
+        !test_match(
+            *DEFAULT_ACCOUNT_ADDR,
+            vec![*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR, *ACCOUNT_1_ADDR],
+            vec![*ACCOUNT_2_ADDR, *ACCOUNT_1_ADDR]
+        ),
+        "multisig does not include caller account"
+    );
+}
+
+fn test_match(
+    caller: AccountHash,
+    signatures: Vec<AccountHash>,
+    expected_authorization_keys: Vec<AccountHash>,
+) -> bool {
+    let mut builder = setup();
+    let exec_request = {
+        let session_args = runtime_args! {
+            ARG_EXPECTED_AUTHORIZATION_KEYS => expected_authorization_keys
+        };
+        let deploy_hash = [42; 32];
+
+        let deploy = DeployItemBuilder::new()
+            .with_address(caller)
+            .with_session_code(CONTRACT_LIST_AUTHORIZATION_KEYS, session_args)
+            .with_empty_payment_bytes(runtime_args! {
+                ARG_AMOUNT => *DEFAULT_PAYMENT
+            })
+            .with_authorization_keys(&signatures)
+            .with_deploy_hash(deploy_hash)
+            .build();
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+    builder.exec(exec_request).commit();
+
+    match builder.get_error() {
+        Some(Error::Exec(execution::Error::Revert(ApiError::User(USER_ERROR_ASSERTION)))) => false,
+        Some(error) => panic!("Unexpected error {:?}", error),
+        None => {
+            // Success
+            true
+        }
+    }
+}
+
+fn setup() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for account in [*ACCOUNT_1_ADDR, *ACCOUNT_2_ADDR] {
+        let add_key_request = {
+            let session_args = runtime_args! {
+                ARG_ACCOUNT => account,
+                ARG_WEIGHT => DEFAULT_WEIGHT,
+            };
+            ExecuteRequestBuilder::standard(
+                *DEFAULT_ACCOUNT_ADDR,
+                CONTRACT_ADD_ASSOCIATED_KEY,
+                session_args,
+            )
+            .build()
+        };
+
+        let transfer_request = {
+            let transfer_args = runtime_args! {
+                mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
+                mint::ARG_TARGET => account,
+                mint::ARG_ID => Option::<u64>::None,
+            };
+
+            ExecuteRequestBuilder::transfer(*DEFAULT_ACCOUNT_ADDR, transfer_args).build()
+        };
+
+        builder.exec(add_key_request).expect_success().commit();
+        builder.exec(transfer_request).expect_success().commit();
+    }
+
+    builder
+}

--- a/execution_engine_testing/tests/src/test/contract_api/mod.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mod.rs
@@ -11,6 +11,7 @@ mod list_authorization_keys;
 mod list_named_keys;
 mod main_purse;
 mod mint_purse;
+mod multisig_authorization;
 mod named_dictionaries;
 mod revert;
 mod subcall;

--- a/execution_engine_testing/tests/src/test/contract_api/mod.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mod.rs
@@ -7,6 +7,7 @@ mod get_blocktime;
 mod get_call_stack;
 mod get_caller;
 mod get_phase;
+mod list_authorization_keys;
 mod list_named_keys;
 mod main_purse;
 mod mint_purse;

--- a/execution_engine_testing/tests/src/test/contract_api/multisig_authorization.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/multisig_authorization.rs
@@ -1,0 +1,209 @@
+use casper_engine_test_support::{
+    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::core::{engine_state::Error, execution};
+use casper_types::{
+    account::{AccountHash, Weight},
+    runtime_args, ApiError, RuntimeArgs,
+};
+
+const CONTRACT_ADD_ASSOCIATED_KEY: &str = "add_associated_key.wasm";
+const CONTRACT_MULTISIG_AUTHORIZATION: &str = "multisig_authorization.wasm";
+const CONTRACT_KEY: &str = "contract";
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_ACCOUNT: &str = "account";
+const ARG_WEIGHT: &str = "weight";
+const DEFAULT_WEIGHT: Weight = Weight::new(1);
+const ENTRYPOINT_A: &str = "entrypoint_a";
+const ENTRYPOINT_B: &str = "entrypoint_b";
+
+const ROLE_A_KEYS: [AccountHash; 3] = [
+    AccountHash::new([1; 32]),
+    AccountHash::new([2; 32]),
+    AccountHash::new([3; 32]),
+];
+
+const ROLE_B_KEYS: [AccountHash; 3] = [
+    AccountHash::new([4; 32]),
+    AccountHash::new([5; 32]),
+    AccountHash::new([6; 32]),
+];
+
+const USER_ERROR_PERMISSION_DENIED: u16 = 0;
+
+#[ignore]
+#[test]
+fn should_verify_multisig_authorization_key_roles() {
+    // Role A tests
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_A,
+            &[*DEFAULT_ACCOUNT_ADDR,]
+        ),
+        "entrypoint A does not work with identity key"
+    );
+    assert!(
+        test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_A,
+            &[*DEFAULT_ACCOUNT_ADDR, ROLE_A_KEYS[0],]
+        ),
+        "entrypoint A works with addional role A keys"
+    );
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_A,
+            &[*DEFAULT_ACCOUNT_ADDR, ROLE_B_KEYS[0],]
+        ),
+        "entrypoint A does not allow role B key"
+    );
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_A,
+            &[
+                *DEFAULT_ACCOUNT_ADDR,
+                ROLE_B_KEYS[2],
+                ROLE_B_KEYS[1],
+                ROLE_B_KEYS[0],
+            ]
+        ),
+        "entrypoint A does not allow role B keys"
+    );
+    assert!(
+        test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_A,
+            &[
+                *DEFAULT_ACCOUNT_ADDR,
+                ROLE_A_KEYS[2],
+                ROLE_A_KEYS[1],
+                ROLE_A_KEYS[0],
+            ]
+        ),
+        "entrypoint A works with all role A keys"
+    );
+
+    // Role B tests
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_B,
+            &[*DEFAULT_ACCOUNT_ADDR,]
+        ),
+        "entrypoint B does not work with identity key"
+    );
+    assert!(
+        test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_B,
+            &[*DEFAULT_ACCOUNT_ADDR, ROLE_B_KEYS[0],]
+        ),
+        "entrypoint B works with addional role A keys"
+    );
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_B,
+            &[*DEFAULT_ACCOUNT_ADDR, ROLE_A_KEYS[0],]
+        ),
+        "entrypoint B does not allow role B key"
+    );
+    assert!(
+        !test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_B,
+            &[
+                *DEFAULT_ACCOUNT_ADDR,
+                ROLE_A_KEYS[2],
+                ROLE_A_KEYS[1],
+                ROLE_A_KEYS[0],
+            ]
+        ),
+        "entrypoint B does not allow role B keys"
+    );
+    assert!(
+        test_multisig_auth(
+            *DEFAULT_ACCOUNT_ADDR,
+            ENTRYPOINT_B,
+            &[
+                *DEFAULT_ACCOUNT_ADDR,
+                ROLE_B_KEYS[2],
+                ROLE_B_KEYS[1],
+                ROLE_B_KEYS[0],
+            ]
+        ),
+        "entrypoint B works with all role B keys"
+    );
+}
+
+fn test_multisig_auth(
+    caller: AccountHash,
+    entry_point: &str,
+    authorization_keys: &[AccountHash],
+) -> bool {
+    let mut builder = setup();
+    let exec_request = {
+        let session_args = runtime_args! {};
+        let payment_args = runtime_args! {
+            ARG_AMOUNT => *DEFAULT_PAYMENT
+        };
+        let deploy_hash = [42; 32];
+        let deploy = DeployItemBuilder::new()
+            .with_address(caller)
+            .with_stored_session_named_key(CONTRACT_KEY, entry_point, session_args)
+            .with_empty_payment_bytes(payment_args)
+            .with_authorization_keys(authorization_keys)
+            .with_deploy_hash(deploy_hash)
+            .build();
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+    builder.exec(exec_request).commit();
+
+    match builder.get_error() {
+        Some(Error::Exec(execution::Error::Revert(ApiError::User(
+            USER_ERROR_PERMISSION_DENIED,
+        )))) => false,
+        Some(error) => panic!("Unexpected error {:?}", error),
+        None => {
+            // Success
+            true
+        }
+    }
+}
+
+fn setup() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for account in ROLE_A_KEYS.iter().chain(&ROLE_B_KEYS) {
+        let add_key_request = {
+            let session_args = runtime_args! {
+                ARG_ACCOUNT => *account,
+                ARG_WEIGHT => DEFAULT_WEIGHT,
+            };
+            ExecuteRequestBuilder::standard(
+                *DEFAULT_ACCOUNT_ADDR,
+                CONTRACT_ADD_ASSOCIATED_KEY,
+                session_args,
+            )
+            .build()
+        };
+
+        builder.exec(add_key_request).expect_success().commit();
+    }
+    let install_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_MULTISIG_AUTHORIZATION,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(install_request).expect_success().commit();
+
+    builder
+}

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -63,6 +63,15 @@ extern "C" {
     /// * `value_ptr` - pointer to bytes representing the value to write under the new `URef`
     /// * `value_size` - size of the value (in bytes)
     pub fn casper_new_uref(uref_ptr: *mut u8, value_ptr: *const u8, value_size: usize);
+    /// This function loads a set of authorized keys used to sign this deploy from the host.
+    /// The data will be available through the host buffer and can be copied to Wasm memory through
+    /// [`casper_read_host_buffer`].
+    ///
+    /// # Arguments
+    ///
+    /// * `total_keys`: number of authorization keys used to sign this deploy
+    /// * `result_size`: size of the data loaded in the host
+    pub fn casper_load_authorization_keys(total_keys: *mut usize, result_size: *mut usize) -> i32;
     ///
     pub fn casper_load_named_keys(total_keys: *mut usize, result_size: *mut usize) -> i32;
     /// This function causes a `Trap`, terminating the currently running module,

--- a/smart_contracts/contract_as/assembly/externals.ts
+++ b/smart_contracts/contract_as/assembly/externals.ts
@@ -220,3 +220,9 @@ export declare function casper_blake2b(
     out_ptr: usize,
     out_size: usize,
 ): i32;
+/** @hidden */
+@external("env", "casper_load_authorization_keys")
+export declare function load_authorization_keys(
+    total_keys_ptr: usize,
+    result_size_ptr: usize,
+): i32;

--- a/smart_contracts/contract_as/assembly/key.ts
+++ b/smart_contracts/contract_as/assembly/key.ts
@@ -44,12 +44,32 @@ export class AccountHash {
         return !this.equalsTo(other);
     }
 
+    @operator(">")
+    graterThan(other: AccountHash): bool {
+        for (let i = 0; i < 32; i++) {
+            if (this.bytes[0] > other.bytes[0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @operator("<")
+    lowerThan(other: AccountHash): bool {
+        for (let i = 0; i < 32; i++) {
+            if (this.bytes[0] < other.bytes[0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static fromPublicKey(publicKey: PublicKey) : AccountHash {
         let algorithmName = publicKey.getAlgorithmName();
         let algorithmNameBytes = encodeUTF8(algorithmName);
         let publicKeyBytes = publicKey.getRawBytes();
         let dataLength = algorithmNameBytes.length + publicKeyBytes.length + 1;
-        
+
         let data = new Array<u8>(dataLength);
         for (let i=0; i < algorithmNameBytes.length; i++){
             data[i]=algorithmNameBytes[i];
@@ -60,7 +80,7 @@ export class AccountHash {
         for (let i=0; i < publicKeyBytes.length; i++) {
             data[algorithmNameBytes.length + 1 + i] = publicKeyBytes[i];
         }
-        
+
         const accountHashBytes = runtime.blake2b(data);
         return new AccountHash(accountHashBytes);
     }

--- a/smart_contracts/contracts/test/add-associated-key/Cargo.toml
+++ b/smart_contracts/contracts/test/add-associated-key/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "add-associated-key"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io"]
+edition = "2018"
+
+[[bin]]
+name = "add_associated_key"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/add-associated-key/src/main.rs
+++ b/smart_contracts/contracts/test/add-associated-key/src/main.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::{
+    contract_api::{account, runtime},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::account::{AccountHash, Weight};
+
+const ARG_ACCOUNT: &str = "account";
+const ARG_WEIGHT: &str = "weight";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let account: AccountHash = runtime::get_named_arg(ARG_ACCOUNT);
+    let weight: Weight = runtime::get_named_arg(ARG_WEIGHT);
+    account::add_associated_key(account, weight).unwrap_or_revert();
+}

--- a/smart_contracts/contracts/test/list-authorization-keys/Cargo.toml
+++ b/smart_contracts/contracts/test/list-authorization-keys/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "list-authorization-keys"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "list_authorization_keys"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/list-authorization-keys/src/main.rs
+++ b/smart_contracts/contracts/test/list-authorization-keys/src/main.rs
@@ -8,7 +8,7 @@ use alloc::collections::BTreeSet;
 use casper_contract::contract_api::runtime;
 use casper_types::{account::AccountHash, ApiError};
 
-const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorized_keys";
+const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorization_keys";
 
 #[repr(u16)]
 enum UserError {

--- a/smart_contracts/contracts/test/list-authorization-keys/src/main.rs
+++ b/smart_contracts/contracts/test/list-authorization-keys/src/main.rs
@@ -1,0 +1,34 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+
+use casper_contract::contract_api::runtime;
+use casper_types::{account::AccountHash, ApiError};
+
+const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorized_keys";
+
+#[repr(u16)]
+enum UserError {
+    AssertionFail = 0,
+}
+
+impl From<UserError> for ApiError {
+    fn from(error: UserError) -> ApiError {
+        ApiError::User(error as u16)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let expected_authorized_keys: BTreeSet<AccountHash> =
+        runtime::get_named_arg(ARG_EXPECTED_AUTHORIZATION_KEYS);
+
+    let actual_authorized_keys = runtime::list_authorization_keys();
+
+    if expected_authorized_keys != actual_authorized_keys {
+        runtime::revert(UserError::AssertionFail)
+    }
+}

--- a/smart_contracts/contracts/test/multisig-authorization/Cargo.toml
+++ b/smart_contracts/contracts/test/multisig-authorization/Cargo.toml
@@ -12,6 +12,5 @@ doctest = false
 test = false
 
 [dependencies]
-base16 = { version = "0.2.1", default-features = false }
 casper-contract = { path = "../../../contract" }
 casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/multisig-authorization/src/main.rs
+++ b/smart_contracts/contracts/test/multisig-authorization/src/main.rs
@@ -39,7 +39,8 @@ impl From<UserError> for ApiError {
     }
 }
 
-/// Checks if at least one of provided authorization keys belongs to a role defined as a slice of `AccountHash`es.
+/// Checks if at least one of provided authorization keys belongs to a role defined as a slice of
+/// `AccountHash`es.
 fn has_role_access_to(role_keys: &[AccountHash]) -> bool {
     let authorization_keys = runtime::list_authorization_keys();
     let role_b_keys: BTreeSet<AccountHash> = role_keys.iter().copied().collect();

--- a/smart_contracts/contracts/test/set-action-thresholds/Cargo.toml
+++ b/smart_contracts/contracts/test/set-action-thresholds/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "authorized-keys"
+name = "set-action-thresholds"
 version = "0.1.0"
 authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [[bin]]
-name = "authorized_keys"
+name = "set_action_thresholds"
 path = "src/main.rs"
 bench = false
 doctest = false

--- a/smart_contracts/contracts/test/set-action-thresholds/src/main.rs
+++ b/smart_contracts/contracts/test/set-action-thresholds/src/main.rs
@@ -5,22 +5,13 @@ use casper_contract::{
     contract_api::{account, runtime},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{
-    account::{AccountHash, ActionType, AddKeyFailure, Weight},
-    ApiError,
-};
+use casper_types::account::{ActionType, Weight};
 
 const ARG_KEY_MANAGEMENT_THRESHOLD: &str = "key_management_threshold";
 const ARG_DEPLOY_THRESHOLD: &str = "deploy_threshold";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    match account::add_associated_key(AccountHash::new([123; 32]), Weight::new(100)) {
-        Err(AddKeyFailure::DuplicateKey) => {}
-        Err(_) => runtime::revert(ApiError::User(50)),
-        Ok(_) => {}
-    };
-
     let key_management_threshold: Weight = runtime::get_named_arg(ARG_KEY_MANAGEMENT_THRESHOLD);
     let deploy_threshold: Weight = runtime::get_named_arg(ARG_DEPLOY_THRESHOLD);
 

--- a/smart_contracts/contracts_as/test/authorized-keys/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/authorized-keys/assembly/index.ts
@@ -2,28 +2,13 @@ import * as CL from "../../../../contract_as/assembly";
 import {Error, ErrorCode} from "../../../../contract_as/assembly/error";
 import {fromBytesString, fromBytesI32} from "../../../../contract_as/assembly/bytesrepr";
 import {arrayToTyped} from "../../../../contract_as/assembly/utils";
-import {Key, AccountHash} from "../../../../contract_as/assembly/key"
+import {Key} from "../../../../contract_as/assembly/key"
 import {addAssociatedKey, AddKeyFailure, ActionType, setActionThreshold, SetThresholdFailure} from "../../../../contract_as/assembly/account";
 
 const ARG_KEY_MANAGEMENT_THRESHOLD = "key_management_threshold";
 const ARG_DEPLOY_THRESHOLD = "deploy_threshold";
 
 export function call(): void {
-  let publicKeyBytes = new Array<u8>(32);
-  publicKeyBytes.fill(123);
-  let accountHash = new AccountHash(arrayToTyped(publicKeyBytes));
-
-  const addResult = addAssociatedKey(accountHash, 100);
-  switch (addResult) {
-    case AddKeyFailure.DuplicateKey:
-      break;
-    case AddKeyFailure.Ok:
-      break;
-    default:
-      Error.fromUserError(50).revert();
-      break;
-  }
-
   let keyManagementThresholdBytes = CL.getNamedArg(ARG_KEY_MANAGEMENT_THRESHOLD);
   let keyManagementThreshold = keyManagementThresholdBytes[0];
 
@@ -42,5 +27,5 @@ export function call(): void {
       return;
     }
   }
-  
+
 }

--- a/smart_contracts/contracts_as/test/authorized-keys/package.json
+++ b/smart_contracts/contracts_as/test/authorized-keys/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/authorized_keys.wasm   --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/set_action_thresholds.wasm   --optimize --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/list-authorization-keys/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/list-authorization-keys/assembly/index.ts
@@ -1,0 +1,35 @@
+//@ts-nocheck
+import * as CL from "../../../../contract_as/assembly";
+import {Error, ErrorCode} from "../../../../contract_as/assembly/error";
+import {fromBytesMap, fromBytesArray} from "../../../../contract_as/assembly/bytesrepr";
+import {AccountHash, Key} from "../../../../contract_as/assembly/key";
+import {listAuthorizationKeys} from "../../../../contract_as/assembly/account";
+import {checkItemsEqual} from "../../../../contract_as/assembly/utils";
+
+const ARG_EXPECTED_AUTHORIZATION_KEYS = "expected_authorization_keys";
+
+enum UserError {
+  AssertionFailure = 0,
+}
+
+export function call(): void {
+  const authorizationKeys = listAuthorizationKeys();
+  const expectedAuthorizedKeysBytes = CL.getNamedArg(ARG_EXPECTED_AUTHORIZATION_KEYS);
+  if (expectedAuthorizedKeysBytes === null) {
+      Error.fromErrorCode(ErrorCode.MissingArgument).revert();
+      return;
+  }
+
+  let expectedAuthorizedKeys = fromBytesArray<AccountHash>(expectedAuthorizedKeysBytes, AccountHash.fromBytes).unwrap();
+  expectedAuthorizedKeys.sort();
+
+  if (authorizationKeys.length != expectedAuthorizedKeys.length) {
+    Error.fromUserError(UserError.AssertionFailure as u16).revert();
+  }
+
+  for (let i = 0; i < authorizationKeys.length; i++) {
+    if (authorizationKeys[i] != expectedAuthorizedKeys[i]) {
+      Error.fromUserError(UserError.AssertionFailure as u16).revert();
+    }
+  }
+}

--- a/smart_contracts/contracts_as/test/list-authorization-keys/assembly/tsconfig.json
+++ b/smart_contracts/contracts_as/test/list-authorization-keys/assembly/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../../../../.nvm/versions/node/v10.16.3/lib/node_modules/assemblyscript/std/assembly.json",
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/smart_contracts/contracts_as/test/list-authorization-keys/index.js
+++ b/smart_contracts/contracts_as/test/list-authorization-keys/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const compiled = new WebAssembly.Module(fs.readFileSync(__dirname + "/build/do_nothing.wasm"));
+const imports = {
+  env: {
+    abort(_msg, _file, line, column) {
+       console.error("abort called at index.ts:" + line + ":" + column);
+    }
+  }
+};
+Object.defineProperty(module, "exports", {
+  get: () => new WebAssembly.Instance(compiled, imports).exports
+});

--- a/smart_contracts/contracts_as/test/list-authorization-keys/package.json
+++ b/smart_contracts/contracts_as/test/list-authorization-keys/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/list_authorization_keys.wasm   --optimize --use abort=",
+    "asbuild": "npm run asbuild:optimized"
+  },
+  "devDependencies": {
+    "assemblyscript": "^0.8.1"
+  }
+}

--- a/smart_contracts/contracts_as/test/multisig-authorization/Cargo.toml
+++ b/smart_contracts/contracts_as/test/multisig-authorization/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "multisig-authorization"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io"]
+edition = "2018"
+
+[[bin]]
+name = "multisig_authorization"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+base16 = { version = "0.2.1", default-features = false }
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts_as/test/multisig-authorization/src/main.rs
+++ b/smart_contracts/contracts_as/test/multisig-authorization/src/main.rs
@@ -1,0 +1,104 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeSet, string::ToString};
+use casper_contract::contract_api::{runtime, storage};
+use casper_types::{
+    account::AccountHash, contracts::Parameters, ApiError, CLType, EntryPoint, EntryPointAccess,
+    EntryPointType, EntryPoints,
+};
+
+const ROLE_A_KEYS: [AccountHash; 3] = [
+    AccountHash::new([1; 32]),
+    AccountHash::new([2; 32]),
+    AccountHash::new([3; 32]),
+];
+const ROLE_B_KEYS: [AccountHash; 3] = [
+    AccountHash::new([4; 32]),
+    AccountHash::new([5; 32]),
+    AccountHash::new([6; 32]),
+];
+
+const ACCESS_KEY: &str = "access_key";
+const CONTRACT_KEY: &str = "contract";
+const ENTRYPOINT_A: &str = "entrypoint_a";
+const ENTRYPOINT_B: &str = "entrypoint_b";
+const CONTRACT_PACKAGE_KEY: &str = "contract_package";
+
+#[repr(u16)]
+enum UserError {
+    /// Deploy was signed using a key that does not belong to a role.
+    PermissionDenied = 0,
+}
+
+impl From<UserError> for ApiError {
+    fn from(user_error: UserError) -> Self {
+        ApiError::User(user_error as u16)
+    }
+}
+
+/// Checks if at least one of provided authorization keys belongs to a role defined as a slice of `AccountHash`es.
+fn has_role_access_to(role_keys: &[AccountHash]) -> bool {
+    let authorization_keys = runtime::list_authorization_keys();
+    let role_b_keys: BTreeSet<AccountHash> = role_keys.iter().copied().collect();
+    (&authorization_keys).intersection(&role_b_keys).count() > 0
+}
+
+#[no_mangle]
+pub extern "C" fn entrypoint_a() {
+    if !has_role_access_to(&ROLE_A_KEYS) {
+        // None of the authorization keys used to sign this deploy matched ROLE_A
+        runtime::revert(UserError::PermissionDenied)
+    }
+
+    // Restricted code
+}
+
+#[no_mangle]
+pub extern "C" fn entrypoint_b() {
+    if !has_role_access_to(&ROLE_B_KEYS) {
+        // None of the authorization keys used to sign this deploy matched ROLE_B
+        runtime::revert(UserError::PermissionDenied)
+    }
+
+    // Restricted code
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let entry_points = {
+        let mut entry_points = EntryPoints::new();
+
+        let entrypoint_a = EntryPoint::new(
+            ENTRYPOINT_A,
+            Parameters::default(),
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Contract,
+        );
+
+        let entrypoint_b = EntryPoint::new(
+            ENTRYPOINT_B,
+            Parameters::default(),
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Contract,
+        );
+
+        entry_points.add_entry_point(entrypoint_a);
+        entry_points.add_entry_point(entrypoint_b);
+
+        entry_points
+    };
+
+    let (contract_hash, _version) = storage::new_contract(
+        entry_points,
+        None,
+        Some(CONTRACT_PACKAGE_KEY.to_string()),
+        Some(ACCESS_KEY.to_string()),
+    );
+
+    runtime::put_key(CONTRACT_KEY, contract_hash.into());
+}

--- a/types/src/account/weight.rs
+++ b/types/src/account/weight.rs
@@ -17,7 +17,7 @@ pub struct Weight(u8);
 
 impl Weight {
     /// Constructs a new `Weight`.
-    pub fn new(weight: u8) -> Weight {
+    pub const fn new(weight: u8) -> Weight {
         Weight(weight)
     }
 


### PR DESCRIPTION
Closes #2463 

This PR adds `list_authorization_keys` to the contract_api / wasm ffi, allowing smart contracts access to the set of associated `AccountHash`es that signed a deploy.

This is necessary for certain types of more advanced smart contracts that utilize multi signature accounts and need to impose some form of role based security in their app logic. For instance, a smart contract that has defined a "clerk", a "supervisor", and "registrar" roles and contains certain entrypoints or operations that are only allowed if one or more signatories of specific role(s) have signed a deploy.