### PR TITLE
Update `WasmTestBuilder` to use `ExecutionJournal`.

### DIFF
--- a/execution_engine/src/shared/execution_journal.rs
+++ b/execution_engine/src/shared/execution_journal.rs
@@ -32,6 +32,11 @@ impl ExecutionJournal {
     pub fn push(&mut self, entry: (Key, Transform)) {
         self.0.push(entry)
     }
+
+    /// Returns an iterator over the journal entries.
+    pub fn iter(&self) -> impl Iterator<Item = &(Key, Transform)> {
+        self.0.iter()
+    }
 }
 
 impl From<&ExecutionJournal> for JsonExecutionEffect {

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Revert the change to the path detection logic applied in v2.0.1.
-
+* `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.
 
 
 ## [2.0.1] - 2021-11-4

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -29,6 +29,7 @@ use casper_execution_engine::{
     },
     shared::{
         additive_map::AdditiveMap,
+        execution_journal::ExecutionJournal,
         logging::{self, Settings, Style},
         newtypes::CorrelationId,
         transform::Transform,
@@ -91,7 +92,7 @@ pub struct WasmTestBuilder<S> {
     post_state_hash: Option<Digest>,
     /// Cached transform maps after subsequent successful runs i.e. `transforms[0]` is for first
     /// exec call etc.
-    transforms: Vec<AdditiveMap<Key, Transform>>,
+    transforms: Vec<ExecutionJournal>,
     /// Cached genesis transforms
     genesis_account: Option<Account>,
     /// Genesis transforms
@@ -463,7 +464,7 @@ where
         self.transforms.extend(
             execution_results
                 .iter()
-                .map(|res| res.execution_journal().clone().into()),
+                .map(|res| res.execution_journal().clone()),
         );
         self.exec_results.push(
             maybe_exec_results
@@ -481,7 +482,7 @@ where
 
         let effects = self.transforms.last().cloned().unwrap_or_default();
 
-        self.commit_transforms(prestate_hash, effects)
+        self.commit_transforms(prestate_hash, effects.into())
     }
 
     /// Runs a commit request, expects a successful response, and
@@ -630,7 +631,20 @@ where
     }
 
     /// Gets the transform map that's cached between runs
+    #[deprecated(
+        since = "2.1.0",
+        note = "Use `get_execution_journals` that returns transforms in the order they were created."
+    )]
     pub fn get_transforms(&self) -> Vec<AdditiveMap<Key, Transform>> {
+        self.transforms
+            .clone()
+            .into_iter()
+            .map(AdditiveMap::from)
+            .collect()
+    }
+
+    /// Gets `ExecutionJournal`s of all passed runs.
+    pub fn get_execution_journals(&self) -> Vec<ExecutionJournal> {
         self.transforms.clone()
     }
 

--- a/execution_engine_testing/tests/src/profiling/simple_transfer.rs
+++ b/execution_engine_testing/tests/src/profiling/simple_transfer.rs
@@ -125,6 +125,6 @@ fn main() {
     test_builder.exec(exec_request).expect_success().commit();
 
     if args.verbose {
-        println!("{:#?}", test_builder.get_transforms());
+        println!("{:#?}", test_builder.get_execution_journals());
     }
 }

--- a/execution_engine_testing/tests/src/test/regression/ee_460.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_460.rs
@@ -31,11 +31,12 @@ fn should_run_ee_460_no_side_effects_on_error_regression() {
     // mint uref is left untouched.
     let mint_contract_uref = builder.get_mint_contract_hash();
 
-    let transforms = &builder.get_transforms()[0];
+    let transforms = &builder.get_execution_journals()[0];
     let mint_transforms = transforms
-        .get(&mint_contract_uref.into())
+        .iter()
+        .find(|(key, _transform)| key == &mint_contract_uref.into())
         // Skips the Identity writes introduced since payment code execution for brevity of the
         // check
-        .filter(|&v| v != &Transform::Identity);
+        .filter(|(_, v)| v != &Transform::Identity);
     assert!(mint_transforms.is_none());
 }

--- a/execution_engine_testing/tests/src/test/regression/ee_584.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_584.rs
@@ -25,7 +25,7 @@ fn should_run_ee_584_no_errored_session_transforms() {
 
     assert!(builder.is_error());
 
-    let transforms = builder.get_transforms();
+    let transforms = builder.get_execution_journals();
 
     assert!(!transforms[0].iter().any(|(_, t)| {
         if let Transform::Write(StoredValue::CLValue(cl_value)) = t {

--- a/execution_engine_testing/tests/src/test/regression/ee_601.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_601.rs
@@ -2,7 +2,7 @@ use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
 };
-use casper_execution_engine::shared::transform::Transform;
+use casper_execution_engine::shared::{additive_map::AdditiveMap, transform::Transform};
 use casper_types::{runtime_args, CLValue, Key, RuntimeArgs, StoredValue};
 
 const ARG_AMOUNT: &str = "amount";
@@ -34,12 +34,10 @@ fn should_run_ee_601_pay_session_new_uref_collision() {
         .exec(exec_request);
 
     let transforms = builder.get_execution_journals();
-    let transform = &transforms[0];
+    let transform: AdditiveMap<Key, Transform> = transforms[0].clone().into();
 
-    let add_keys = if let Some((_, Transform::AddKeys(keys))) = transform
-        .clone()
-        .into_iter()
-        .find(|(key, _)| key == &Key::Account(*DEFAULT_ACCOUNT_ADDR))
+    let add_keys = if let Some(Transform::AddKeys(keys)) =
+        transform.get(&Key::Account(*DEFAULT_ACCOUNT_ADDR))
     {
         keys
     } else {

--- a/execution_engine_testing/tests/src/test/regression/ee_601.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_601.rs
@@ -33,11 +33,13 @@ fn should_run_ee_601_pay_session_new_uref_collision() {
         .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
         .exec(exec_request);
 
-    let transforms = builder.get_transforms();
+    let transforms = builder.get_execution_journals();
     let transform = &transforms[0];
 
-    let add_keys = if let Some(Transform::AddKeys(keys)) =
-        transform.get(&Key::Account(*DEFAULT_ACCOUNT_ADDR))
+    let add_keys = if let Some((_, Transform::AddKeys(keys))) = transform
+        .clone()
+        .into_iter()
+        .find(|(key, _)| key == &Key::Account(*DEFAULT_ACCOUNT_ADDR))
     {
         keys
     } else {

--- a/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use assert_matches::assert_matches;
 
 use casper_engine_test_support::{
@@ -66,7 +68,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     );
 
     let expected_transfers_count = 0;
-    let transforms = builder.get_transforms();
+    let transforms = builder.get_execution_journals();
     let transform = &transforms[1];
 
     assert_eq!(
@@ -534,7 +536,7 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
         .expect_success()
         .commit();
 
-    let transforms = builder.get_transforms();
+    let transforms = builder.get_execution_journals();
     let transforms_from_genesis = &transforms[1];
     let transforms_from_account_1 = &transforms[2];
 
@@ -547,16 +549,26 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
         .into_uref()
         .unwrap();
 
+    let transforms_from_genesis_map: HashMap<Key, Transform> =
+        transforms_from_genesis.clone().into_iter().collect();
+    let transforms_from_account_1_map: HashMap<Key, Transform> =
+        transforms_from_account_1.clone().into_iter().collect();
+
     // Confirm the two deploys have no overlapping writes except for the payment purse balance.
-    let common_write_keys = transforms_from_genesis.keys().filter(|k| {
-        *k != &Key::Balance(payment_purse.addr())
+    let common_write_keys = transforms_from_genesis.iter().filter_map(|(k, _)| {
+        if k != &Key::Balance(payment_purse.addr())
             && matches!(
                 (
-                    transforms_from_genesis.get(k),
-                    transforms_from_account_1.get(k),
+                    transforms_from_genesis_map.get(k),
+                    transforms_from_account_1_map.get(k),
                 ),
                 (Some(Transform::Write(_)), Some(Transform::Write(_)))
             )
+        {
+            Some(k)
+        } else {
+            None
+        }
     });
 
     assert_eq!(common_write_keys.count(), 0);

--- a/utils/global-state-update-gen/src/balances.rs
+++ b/utils/global-state-update-gen/src/balances.rs
@@ -40,11 +40,11 @@ pub(crate) fn generate_balances_update(matches: &ArgMatches<'_>) {
 
     builder.exec(no_wasm_transfer_request).expect_success();
 
-    let transforms = builder.get_transforms();
+    let transforms = builder.get_execution_journals();
 
-    for (key, value) in &transforms[0] {
+    for (key, value) in transforms[0].clone() {
         if let Transform::Write(val) = value {
-            print_entry(key, val);
+            print_entry(&key, &val);
         }
     }
 }


### PR DESCRIPTION
Since we started ordering transforms within a block we should also update WasmTestBuilder to track transforms in the correct order.

Closes https://github.com/casper-network/casper-node/issues/2496.