### PR TITLE
Upping open file limit on macos

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -56,7 +56,6 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, debug_span, error, info, instrument, trace, warn, Span};
 use tracing_futures::Instrument;
 
-#[cfg(target_os = "linux")]
 use utils::rlimit::{Limit, OpenFiles, ResourceLimit};
 
 use crate::{
@@ -104,7 +103,6 @@ static DISPATCH_EVENT_THRESHOLD: Lazy<Duration> = Lazy::new(|| {
         .unwrap_or_else(|_| DEFAULT_DISPATCH_EVENT_THRESHOLD)
 });
 
-#[cfg(target_os = "linux")]
 /// The desired limit for open files.
 const TARGET_OPEN_FILES_LIMIT: Limit = 64_000;
 
@@ -117,7 +115,6 @@ enum DumpFormat {
     Debug,
 }
 
-#[cfg(target_os = "linux")]
 /// Adjusts the maximum number of open file handles upwards towards the hard limit.
 fn adjust_open_files_limit() {
     // Ensure we have reasonable ulimits.
@@ -153,12 +150,6 @@ fn adjust_open_files_limit() {
             }
         }
     }
-}
-
-#[cfg(not(target_os = "linux"))]
-/// File handle limit adjustment shim.
-fn adjust_open_files_limit() {
-    info!("not on linux, not adjusting open files limit");
 }
 
 /// The value returned by a reactor on completion of the `run()` loop.

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -5,7 +5,6 @@ mod display_error;
 pub(crate) mod ds;
 mod external;
 pub(crate) mod pid_file;
-#[cfg(target_os = "linux")]
 pub(crate) mod rlimit;
 mod round_robin;
 

--- a/node/src/utils/rlimit.rs
+++ b/node/src/utils/rlimit.rs
@@ -17,10 +17,16 @@ use fmt::Formatter;
 /// A scalar limit.
 pub type Limit = libc::rlim_t;
 
+#[cfg(target_os = "linux")]
+pub type LimitResourceId = libc::__rlimit_resource_t;
+
+#[cfg(target_os = "macos")]
+pub type LimitResourceId = libc::c_int;
+
 /// A kind of limit that can be set/retrieved.
 pub trait LimitKind {
     /// The `resource` id use for libc calls.
-    const LIBC_RESOURCE: libc::__rlimit_resource_t;
+    const LIBC_RESOURCE: LimitResourceId;
 }
 
 /// Maximum number of open files (`ulimit -n`).
@@ -28,7 +34,7 @@ pub trait LimitKind {
 pub struct OpenFiles;
 
 impl LimitKind for OpenFiles {
-    const LIBC_RESOURCE: libc::__rlimit_resource_t = libc::RLIMIT_NOFILE;
+    const LIBC_RESOURCE: LimitResourceId = libc::RLIMIT_NOFILE;
 }
 
 /// Infinite resource, i.e. no limit.


### PR DESCRIPTION
 - Allows `cargo test` to run successfully
