### PR TITLE
Record `Identity` transform, with a correct contract address, when deploy calls it directly.

### DIFF
--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -218,7 +218,7 @@ where
         contract_hash: ContractHash,
     ) -> Result<Contract, Self::Error> {
         let key = contract_hash.into();
-        match self.get(correlation_id, &key).map_err(Into::into)? {
+        match self.read(correlation_id, &key).map_err(Into::into)? {
             Some(StoredValue::Contract(contract)) => Ok(contract),
             Some(other) => Err(execution::Error::TypeMismatch(
                 StoredValueTypeMismatch::new("Contract".to_string(), other.type_name()),
@@ -233,7 +233,7 @@ where
         contract_package_hash: ContractPackageHash,
     ) -> Result<ContractPackage, Self::Error> {
         let key = contract_package_hash.into();
-        match self.get(correlation_id, &key).map_err(Into::into)? {
+        match self.read(correlation_id, &key).map_err(Into::into)? {
             Some(StoredValue::ContractPackage(contract_package)) => Ok(contract_package),
             Some(other) => Err(execution::Error::TypeMismatch(
                 StoredValueTypeMismatch::new("ContractPackage".to_string(), other.type_name()),

--- a/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
@@ -322,7 +322,8 @@ fn assert_call_stack_matches_calls(call_stack: Vec<CallStackElement>, calls: &[C
 
 mod session {
     use casper_engine_test_support::{ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR};
-    use casper_types::{runtime_args, RuntimeArgs};
+    use casper_execution_engine::shared::transform::Transform;
+    use casper_types::{runtime_args, Key, RuntimeArgs};
 
     use super::{
         AccountExt, ARG_CALLS, ARG_CURRENT_DEPTH, CONTRACT_CALL_RECURSIVE_SUBCALL,
@@ -954,6 +955,15 @@ mod session {
 
             builder.exec(execute_request).commit().expect_success();
 
+            let transforms = builder.get_execution_journals().last().unwrap().clone();
+
+            assert!(
+                transforms.iter().any(|(key, transform)| key
+                    == &Key::Hash(current_contract_package_hash)
+                    && transform == &Transform::Identity),
+                "Missing `Identity` transform for a contract package being called."
+            );
+
             super::assert_each_context_has_correct_call_stack_info(
                 &mut builder,
                 super::stored_versioned_contract(current_contract_package_hash.into()),
@@ -1089,6 +1099,16 @@ mod session {
             .build();
 
             builder.exec(execute_request).commit().expect_success();
+
+            let transforms = builder.get_execution_journals().last().unwrap().clone();
+
+            assert!(
+                transforms
+                    .iter()
+                    .any(|(key, transform)| key == &Key::Hash(current_contract_hash)
+                        && transform == &Transform::Identity),
+                "Missing `Identity` transform for a contract being called."
+            );
 
             super::assert_each_context_has_correct_call_stack_info(
                 &mut builder,

--- a/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
@@ -86,7 +86,8 @@ fn should_fail_to_get_funds_from_faucet_stored() {
         _ => panic!("should be an error"),
     }
 
-    // Verify that even though execution failed, we still emit the `Identity` transform for the contract we called.
+    // Verify that even though execution failed, we still emit the `Identity` transform for the
+    // contract we called.
     let transforms = builder.get_execution_journals().last().unwrap().clone();
     assert!(
         transforms

--- a/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
@@ -4,9 +4,12 @@ use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::core::{
-    engine_state::{self, genesis::GenesisAccount},
-    execution,
+use casper_execution_engine::{
+    core::{
+        engine_state::{self, genesis::GenesisAccount},
+        execution,
+    },
+    shared::transform::Transform,
 };
 use casper_types::{
     account::AccountHash, runtime_args, system::mint, ApiError, Key, Motes, PublicKey, RuntimeArgs,
@@ -82,6 +85,16 @@ fn should_fail_to_get_funds_from_faucet_stored() {
             if api_error == ApiError::from(mint::Error::InvalidContext) => {}
         _ => panic!("should be an error"),
     }
+
+    // Verify that even though execution failed, we still emit the `Identity` transform for the contract we called.
+    let transforms = builder.get_execution_journals().last().unwrap().clone();
+    assert!(
+        transforms
+            .iter()
+            .any(|(key, transform)| *key == Key::Hash(contract_hash)
+                && transform == &Transform::Identity),
+        "Expected `Transform::Identity` for the called contract even for failed execution."
+    );
 }
 
 #[ignore]


### PR DESCRIPTION
For deploy types that call stored contract directly (`ExecutableDeployItem::Stored*Contract*`) we were not recording the `Transform::Identity` that we do when those contracts are called from within the body of another contract.

This PR fixes that by using `TrackingCopy::read`, method instead of `TrackingCopy::get`, that adds a proper `Transform::Identity` to the `ExecutionJournal`.

Closes https://github.com/casper-network/casper-node/issues/2470.