### PR TITLE
Port 1.4.3 changes to dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,6 @@ dependencies = [
  "serde_json",
  "serde_test",
  "strum",
- "thiserror",
  "uint",
  "version-sync",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "wabt",
+ "wasmi",
 ]
 
 [[package]]
@@ -784,6 +786,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2014,6 +2025,12 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+
+[[package]]
+name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -3172,7 +3189,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8588067671d03c9f4254b2e66fecb4d8b93b5d3e703195b84f311cd137e32130"
 dependencies = [
- "glob",
+ "glob 0.3.0",
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
@@ -4857,6 +4874,29 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wabt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wabt-sys",
+]
+
+[[package]]
+name = "wabt-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
+dependencies = [
+ "cc",
+ "cmake",
+ "glob 0.2.11",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "casper-client"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "casper-contract"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.4.2"
+version = "1.4.5"
 dependencies = [
  "base16",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "regression_20211110"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,13 @@ test-contracts-as: build-contracts-rs build-contracts-as
 .PHONY: test-contracts
 test-contracts: test-contracts-rs test-contracts-as
 
+.PHONY: check-std-features
+check-std-features:
+	cd types && $(CARGO) check --all-targets --no-default-features --features=std
+	cd types && $(CARGO) check --all-targets --features=std
+	cd smart_contracts/contract && $(CARGO) check --all-targets --no-default-features --features=std
+	cd smart_contracts/contract && $(CARGO) check --all-targets --features=std
+
 .PHONY: check-format
 check-format:
 	$(CARGO_PINNED_NIGHTLY) fmt --all -- --check
@@ -126,6 +133,7 @@ check-rs: \
 	doc \
 	lint \
 	audit \
+	check-std-features \
 	test-rs \
 	test-contracts-rs
 

--- a/ci/publish_to_crates_io.sh
+++ b/ci/publish_to_crates_io.sh
@@ -82,5 +82,6 @@ publish execution_engine
 publish node_macros
 publish node
 publish client
-publish smart_contracts/contract --features=std
-#publish execution_engine_testing/test_support
+publish smart_contracts/contract
+publish execution_engine_testing/test_support
+publish execution_engine_testing/cargo_casper --allow-dirty

--- a/ci/publish_to_crates_io.sh
+++ b/ci/publish_to_crates_io.sh
@@ -84,4 +84,3 @@ publish node
 publish client
 publish smart_contracts/contract
 publish execution_engine_testing/test_support
-publish execution_engine_testing/cargo_casper --allow-dirty

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -14,7 +14,15 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 
-## [1.4.2] 2021-11-11
+
+## 1.4.3 - 2021-12-06
+
+### Changed
+* Updated dependencies, in particular `casper-types` to use fixed checksummed-hex format.
+
+
+
+## [1.4.2] - 2021-11-11
 
 ### Added
 * RPM package build and publish.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -24,10 +24,10 @@ doc = false
 async-trait = "0.1.50"
 base16 = "0.2.1"
 base64 = "0.13.0"
-casper-execution-engine = { version = "1.4.2", path = "../execution_engine" }
-casper-node = { version = "1.4.2", path = "../node" }
+casper-execution-engine = { version = "1.4.3", path = "../execution_engine" }
+casper-node = { version = "1.4.3", path = "../node" }
 casper-hashing = { version = "1.4.2", path = "../hashing" }
-casper-types = { version = "1.4.2", path = "../types" }
+casper-types = { version = "1.4.5", path = "../types" }
 clap = "2"
 humantime = "2"
 jsonrpc-lite = "0.5.0"

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -14,6 +14,16 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 
+
+## 1.4.3 - 2021-12-06
+
+### Changed
+* Auction contract now handles minting into an existing purse.
+* Default maximum stack size in `WasmConfig` changed to 188.
+* Default behavior of LMDB changed to use [`NO_READAHEAD`](https://docs.rs/lmdb/0.8.0/lmdb/struct.EnvironmentFlags.html#associatedconstant.NO_READAHEAD)
+
+
+
 ## [1.4.2] - 2021-11-11
 
 ### Changed

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.  The format
 * Default maximum stack size in `WasmConfig` changed to 188.
 * Default behavior of LMDB changed to use [`NO_READAHEAD`](https://docs.rs/lmdb/0.8.0/lmdb/struct.EnvironmentFlags.html#associatedconstant.NO_READAHEAD)
 
+### Fixed
+* Fix a case where an unlocked and partially unbonded genesis validator with smaller stake incorrectly occupies slot for a non-genesis validator with higher stake.
+
 
 
 ## [1.4.2] - 2021-11-11

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.3" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 anyhow = "1.0.33"
 bincode = "1.3.1"
 casper-hashing = { version = "1.4.2", path = "../hashing" }
-casper-types = { version = "1.4.2", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-types = { version = "1.4.5", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
 hex-buffer-serde = "0.2.1"
@@ -62,4 +62,3 @@ test-support = []
 [[bench]]
 name = "trie_bench"
 harness = false
-

--- a/execution_engine/src/core/engine_state/engine_config.rs
+++ b/execution_engine/src/core/engine_state/engine_config.rs
@@ -4,20 +4,21 @@ use crate::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
 
 /// Default value for a maximum query depth configuration option.
 pub const DEFAULT_MAX_QUERY_DEPTH: u64 = 5;
-/// Default value for maximum max associated keys configuration option.
+/// Default value for maximum associated keys configuration option.
 pub const DEFAULT_MAX_ASSOCIATED_KEYS: u32 = 100;
+/// Default value for maximum runtime call stack height configuration option.
+pub const DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT: u32 = 12;
 
 /// The runtime configuration of the execution engine
 #[derive(Debug, Copy, Clone)]
 pub struct EngineConfig {
     /// Max query depth of the engine.
     pub(crate) max_query_depth: u64,
-
     /// Maximum number of associated keys (i.e. map of
     /// [`AccountHash`](casper_types::account::AccountHash)s to
     /// [`Weight`](casper_types::account::Weight)s) for a single account.
     max_associated_keys: u32,
-
+    max_runtime_call_stack_height: u32,
     wasm_config: WasmConfig,
     system_config: SystemConfig,
 }
@@ -27,6 +28,7 @@ impl Default for EngineConfig {
         EngineConfig {
             max_query_depth: DEFAULT_MAX_QUERY_DEPTH,
             max_associated_keys: DEFAULT_MAX_ASSOCIATED_KEYS,
+            max_runtime_call_stack_height: DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
             wasm_config: WasmConfig::default(),
             system_config: SystemConfig::default(),
         }
@@ -38,12 +40,14 @@ impl EngineConfig {
     pub fn new(
         max_query_depth: u64,
         max_associated_keys: u32,
+        max_runtime_call_stack_height: u32,
         wasm_config: WasmConfig,
         system_config: SystemConfig,
     ) -> EngineConfig {
         EngineConfig {
             max_query_depth,
             max_associated_keys,
+            max_runtime_call_stack_height,
             wasm_config,
             system_config,
         }
@@ -52,6 +56,11 @@ impl EngineConfig {
     /// Returns the current max associated keys config.
     pub fn max_associated_keys(&self) -> u32 {
         self.max_associated_keys
+    }
+
+    /// Returns the current max runtime call stack height config.
+    pub fn max_runtime_call_stack_height(&self) -> u32 {
+        self.max_runtime_call_stack_height
     }
 
     /// Returns the current wasm config.

--- a/execution_engine/src/core/engine_state/era_validators.rs
+++ b/execution_engine/src/core/engine_state/era_validators.rs
@@ -6,7 +6,7 @@ use datasize::DataSize;
 use casper_hashing::Digest;
 use casper_types::ProtocolVersion;
 
-use crate::core::engine_state::error::Error;
+use crate::core::{engine_state::error::Error, runtime::stack::RuntimeStackOverflow};
 
 /// An enum that represents all possible error conditions of a `get_era_validators` request.
 #[derive(Debug, Error, DataSize)]
@@ -20,6 +20,12 @@ pub enum GetEraValidatorsError {
     /// EraValidators missing
     #[error("Era validators missing")]
     EraValidatorsMissing,
+}
+
+impl From<RuntimeStackOverflow> for GetEraValidatorsError {
+    fn from(overflow: RuntimeStackOverflow) -> Self {
+        GetEraValidatorsError::Other(Error::from(overflow))
+    }
 }
 
 impl GetEraValidatorsError {

--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -9,6 +9,7 @@ use crate::{
     core::{
         engine_state::{genesis::GenesisError, upgrade::ProtocolUpgradeError},
         execution,
+        runtime::stack,
     },
     shared::wasm_prep,
     storage,
@@ -78,6 +79,9 @@ pub enum Error {
     /// Missing system contract hash.
     #[error("Missing system contract hash: {0}")]
     MissingSystemContractHash(String),
+    /// An attempt to push to the runtime stack while already at the maximum height.
+    #[error("Runtime stack overflow")]
+    RuntimeStackOverflow,
 }
 
 impl Error {
@@ -117,6 +121,12 @@ impl From<mint::Error> for Error {
 impl From<GenesisError> for Error {
     fn from(genesis_error: GenesisError) -> Self {
         Self::Genesis(Box::new(genesis_error))
+    }
+}
+
+impl From<stack::RuntimeStackOverflow> for Error {
+    fn from(_: stack::RuntimeStackOverflow) -> Self {
+        Self::RuntimeStackOverflow
     }
 }
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -53,7 +53,7 @@ use casper_types::{
 pub use self::{
     balance::{BalanceRequest, BalanceResult},
     deploy_item::DeployItem,
-    engine_config::{EngineConfig, DEFAULT_MAX_QUERY_DEPTH},
+    engine_config::{EngineConfig, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT},
     era_validators::{GetEraValidatorsError, GetEraValidatorsRequest},
     error::Error,
     executable_deploy_item::{ExecutableDeployItem, ExecutableDeployItemIdentifier},
@@ -76,6 +76,7 @@ use crate::{
             upgrade::{ProtocolUpgradeError, SystemUpgrader},
         },
         execution::{self, DirectSystemContractCall, Executor},
+        runtime::RuntimeStack,
         tracking_copy::{TrackingCopy, TrackingCopyExt},
     },
     shared::{
@@ -751,13 +752,17 @@ where
             Ok(mode) => match mode {
                 TransferTargetMode::Unknown | TransferTargetMode::PurseExists(_) => { /* noop */ }
                 TransferTargetMode::CreateAccount(public_key) => {
-                    let create_purse_call_stack = {
+                    let create_purse_stack = {
                         let system = CallStackElement::session(PublicKey::System.to_account_hash());
                         let mint = CallStackElement::stored_contract(
                             mint_contract.contract_package_hash(),
                             *mint_contract_hash,
                         );
-                        vec![system, mint]
+                        let mut stack =
+                            RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                        stack.push(system)?;
+                        stack.push(mint)?;
+                        stack
                     };
                     let (maybe_uref, execution_result): (Option<URef>, ExecutionResult) = executor
                         .exec_system_contract(
@@ -776,7 +781,7 @@ where
                             correlation_id,
                             Rc::clone(&tracking_copy),
                             Phase::Session,
-                            create_purse_call_stack,
+                            create_purse_stack,
                         );
                     match maybe_uref {
                         Some(main_purse) => {
@@ -850,13 +855,17 @@ where
                 Some(_) => {}
             }
 
-            let get_payment_purse_call_stack = {
+            let get_payment_purse_stack = {
                 let system = CallStackElement::session(PublicKey::System.to_account_hash());
                 let handle_payment = CallStackElement::stored_contract(
                     handle_payment_contract.contract_package_hash(),
                     *handle_payment_contract_hash,
                 );
-                vec![system, handle_payment]
+                let mut stack =
+                    RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                stack.push(system)?;
+                stack.push(handle_payment)?;
+                stack
             };
             let (maybe_payment_uref, get_payment_purse_result): (Option<URef>, ExecutionResult) =
                 executor.exec_system_contract(
@@ -875,7 +884,7 @@ where
                     correlation_id,
                     Rc::clone(&tracking_copy),
                     Phase::Payment,
-                    get_payment_purse_call_stack,
+                    get_payment_purse_stack,
                 );
 
             payment_uref = match maybe_payment_uref {
@@ -902,13 +911,17 @@ where
                 Err(error) => return Ok(make_charged_execution_failure(Error::Exec(error.into()))),
             };
 
-            let transfer_to_payment_purse_call_stack = {
+            let transfer_to_payment_purse_stack = {
                 let system = CallStackElement::session(PublicKey::System.to_account_hash());
                 let mint = CallStackElement::stored_contract(
                     mint_contract.contract_package_hash(),
                     *mint_contract_hash,
                 );
-                vec![system, mint]
+                let mut stack =
+                    RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                stack.push(system)?;
+                stack.push(mint)?;
+                stack
             };
             let (actual_result, payment_result): (Option<Result<(), u8>>, ExecutionResult) =
                 executor.exec_system_contract(
@@ -927,7 +940,7 @@ where
                     correlation_id,
                     Rc::clone(&tracking_copy),
                     Phase::Payment,
-                    transfer_to_payment_purse_call_stack,
+                    transfer_to_payment_purse_stack,
                 );
 
             if let Some(error) = payment_result.as_error().cloned() {
@@ -996,13 +1009,16 @@ where
             }
         };
 
-        let transfer_call_stack = {
+        let transfer_stack = {
             let deploy_account = CallStackElement::session(deploy_item.address);
             let mint = CallStackElement::stored_contract(
                 mint_contract.contract_package_hash(),
                 *mint_contract_hash,
             );
-            vec![deploy_account, mint]
+            let mut stack = RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+            stack.push(deploy_account)?;
+            stack.push(mint)?;
+            stack
         };
         let (_, mut session_result): (Option<Result<(), u8>>, ExecutionResult) = executor
             .exec_system_contract(
@@ -1021,7 +1037,7 @@ where
                 correlation_id,
                 Rc::clone(&tracking_copy),
                 Phase::Session,
-                transfer_call_stack,
+                transfer_stack,
             );
 
         // User is already charged fee for wasmless contract, and we need to make sure we will not
@@ -1066,13 +1082,17 @@ where
             let tc = tracking_copy.borrow();
             let finalization_tc = Rc::new(RefCell::new(tc.fork()));
 
-            let finalize_payment_call_stack = {
+            let finalize_payment_stack = {
                 let system = CallStackElement::session(PublicKey::System.to_account_hash());
                 let handle_payment = CallStackElement::stored_contract(
                     handle_payment_contract.contract_package_hash(),
                     *handle_payment_contract_hash,
                 );
-                vec![system, handle_payment]
+                let mut stack =
+                    RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                stack.push(system)?;
+                stack.push(handle_payment)?;
+                stack
             };
             let extra_keys = [Key::from(payment_uref), Key::from(proposer_purse)];
 
@@ -1093,7 +1113,7 @@ where
                     correlation_id,
                     finalization_tc,
                     Phase::FinalizePayment,
-                    finalize_payment_call_stack,
+                    finalize_payment_stack,
                 );
 
             finalize_result
@@ -1306,7 +1326,10 @@ where
                 }
             };
 
-            let payment_call_stack = payment_metadata.initial_call_stack()?;
+            let payment_stack = RuntimeStack::from_call_stack_elements(
+                payment_metadata.initial_call_stack()?,
+                self.config.max_runtime_call_stack_height() as usize,
+            )?;
 
             // payment_code_spec_2: execute payment code
             let payment_base_key = payment_metadata.base_key;
@@ -1337,7 +1360,7 @@ where
                     correlation_id,
                     Rc::clone(&tracking_copy),
                     phase,
-                    payment_call_stack,
+                    payment_stack,
                 )
             } else {
                 executor.exec(
@@ -1356,7 +1379,7 @@ where
                     Rc::clone(&tracking_copy),
                     phase,
                     &payment_package,
-                    payment_call_stack,
+                    payment_stack,
                 )
             }
         };
@@ -1490,7 +1513,10 @@ where
         let post_payment_tracking_copy = tracking_copy.borrow();
         let session_tracking_copy = Rc::new(RefCell::new(post_payment_tracking_copy.fork()));
 
-        let session_call_stack = session_metadata.initial_call_stack()?;
+        let session_stack = RuntimeStack::from_call_stack_elements(
+            session_metadata.initial_call_stack()?,
+            self.config.max_runtime_call_stack_height() as usize,
+        )?;
 
         let session_base_key = session_metadata.base_key;
         let session_module = session_metadata.module;
@@ -1537,7 +1563,7 @@ where
                 Rc::clone(&session_tracking_copy),
                 Phase::Session,
                 &session_package,
-                session_call_stack,
+                session_stack,
             )
         };
         debug!("Session result: {:?}", session_result);
@@ -1655,13 +1681,17 @@ where
 
             let gas_limit = Gas::new(U512::from(std::u64::MAX));
 
-            let handle_payment_call_stack = {
+            let handle_payment_stack = {
                 let deploy_account = CallStackElement::session(deploy_item.address);
                 let handle_payment = CallStackElement::stored_contract(
                     handle_payment_contract.contract_package_hash(),
                     *handle_payment_contract_hash,
                 );
-                vec![deploy_account, handle_payment]
+                let mut stack =
+                    RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                stack.push(deploy_account)?;
+                stack.push(handle_payment)?;
+                stack
             };
             let extra_keys = [
                 payment_purse_key,
@@ -1685,7 +1715,7 @@ where
                     correlation_id,
                     finalization_tc,
                     Phase::FinalizePayment,
-                    handle_payment_call_stack,
+                    handle_payment_stack,
                 );
 
             finalize_result
@@ -1831,13 +1861,16 @@ where
             DeployHash::new(Digest::hash(&bytes).value())
         };
 
-        let get_era_validators_call_stack = {
+        let get_era_validators_stack = {
             let system = CallStackElement::session(PublicKey::System.to_account_hash());
             let auction = CallStackElement::stored_contract(
                 auction_contract.contract_package_hash(),
                 *auction_contract_hash,
             );
-            vec![system, auction]
+            let mut stack = RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+            stack.push(system)?;
+            stack.push(auction)?;
+            stack
         };
         let (era_validators, execution_result): (Option<EraValidators>, ExecutionResult) = executor
             .exec_system_contract(
@@ -1856,7 +1889,7 @@ where
                 correlation_id,
                 Rc::clone(&tracking_copy),
                 Phase::Session,
-                get_era_validators_call_stack,
+                get_era_validators_stack,
             );
 
         if let Some(error) = execution_result.take_error() {
@@ -1985,13 +2018,16 @@ where
             Ok(())
         })?;
 
-        let distribute_rewards_call_stack = {
+        let distribute_rewards_stack = {
             let system = CallStackElement::session(PublicKey::System.to_account_hash());
             let auction = CallStackElement::stored_contract(
                 auction_contract.contract_package_hash(),
                 *auction_contract_hash,
             );
-            vec![system, auction]
+            let mut stack = RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+            stack.push(system)?;
+            stack.push(auction)?;
+            stack
         };
         let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
             DirectSystemContractCall::DistributeRewards,
@@ -2009,7 +2045,7 @@ where
             correlation_id,
             Rc::clone(&tracking_copy),
             Phase::Session,
-            distribute_rewards_call_stack,
+            distribute_rewards_stack,
         );
 
         if let Some(exec_error) = execution_result.take_error() {
@@ -2027,13 +2063,17 @@ where
                 runtime_args
             };
 
-            let slash_call_stack = {
+            let slash_stack = {
                 let system = CallStackElement::session(PublicKey::System.to_account_hash());
                 let auction = CallStackElement::stored_contract(
                     auction_contract.contract_package_hash(),
                     *auction_contract_hash,
                 );
-                vec![system, auction]
+                let mut stack =
+                    RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+                stack.push(system)?;
+                stack.push(auction)?;
+                stack
             };
             let (_, execution_result): (Option<()>, ExecutionResult) = executor
                 .exec_system_contract(
@@ -2052,7 +2092,7 @@ where
                     correlation_id,
                     Rc::clone(&tracking_copy),
                     Phase::Session,
-                    slash_call_stack,
+                    slash_stack,
                 );
 
             if let Some(exec_error) = execution_result.take_error() {
@@ -2076,13 +2116,16 @@ where
             Ok(())
         })?;
 
-        let run_auction_call_stack = {
+        let run_auction_stack = {
             let system = CallStackElement::session(PublicKey::System.to_account_hash());
             let auction = CallStackElement::stored_contract(
                 auction_contract.contract_package_hash(),
                 *auction_contract_hash,
             );
-            vec![system, auction]
+            let mut stack = RuntimeStack::new(self.config.max_runtime_call_stack_height() as usize);
+            stack.push(system)?;
+            stack.push(auction)?;
+            stack
         };
         let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
             DirectSystemContractCall::RunAuction,
@@ -2100,7 +2143,7 @@ where
             correlation_id,
             Rc::clone(&tracking_copy),
             Phase::Session,
-            run_auction_call_stack,
+            run_auction_stack,
         );
 
         if let Some(exec_error) = execution_result.take_error() {

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -8,7 +8,7 @@ use casper_hashing::Digest;
 use casper_types::{bytesrepr, CLValueError, EraId, ProtocolVersion, PublicKey};
 
 use crate::{
-    core::{engine_state::Error, execution},
+    core::{engine_state::Error, execution, runtime::stack::RuntimeStackOverflow},
     shared::execution_journal::ExecutionJournal,
 };
 
@@ -177,6 +177,12 @@ impl From<bytesrepr::Error> for StepError {
 impl From<CLValueError> for StepError {
     fn from(error: CLValueError) -> Self {
         StepError::CLValueError(error)
+    }
+}
+
+impl From<RuntimeStackOverflow> for StepError {
+    fn from(overflow: RuntimeStackOverflow) -> Self {
+        StepError::OtherEngineStateError(Error::from(overflow))
     }
 }
 

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -8,7 +8,11 @@ use casper_types::{
     ContractPackageHash, ContractVersionKey, ContractWasmHash, Key, StoredValueTypeMismatch, URef,
 };
 
-use crate::{core::resolvers::error::ResolverError, shared::wasm_prep, storage};
+use crate::{
+    core::{resolvers::error::ResolverError, runtime::stack},
+    shared::wasm_prep,
+    storage,
+};
 
 /// Possible execution errors.
 #[derive(Error, Debug, Clone)]
@@ -156,6 +160,9 @@ pub enum Error {
     /// Missing system contract hash.
     #[error("Missing system contract hash: {0}")]
     MissingSystemContractHash(String),
+    /// An attempt to push to the runtime stack which is already at the maximum height.
+    #[error("Runtime stack overflow")]
+    RuntimeStackOverflow,
 }
 
 impl From<wasm_prep::PreprocessingError> for Error {
@@ -251,5 +258,11 @@ impl From<system::Error> for Error {
 impl From<CLValueError> for Error {
     fn from(e: CLValueError) -> Self {
         Error::CLValue(e)
+    }
+}
+
+impl From<stack::RuntimeStackOverflow> for Error {
+    fn from(_: stack::RuntimeStackOverflow) -> Self {
+        Error::RuntimeStackOverflow
     }
 }

--- a/execution_engine/src/core/execution/executor.rs
+++ b/execution_engine/src/core/execution/executor.rs
@@ -8,7 +8,7 @@ use casper_types::{
     account::{Account, AccountHash},
     bytesrepr::FromBytes,
     contracts::NamedKeys,
-    system::{auction, handle_payment, mint, CallStackElement, AUCTION, HANDLE_PAYMENT, MINT},
+    system::{auction, handle_payment, mint, AUCTION, HANDLE_PAYMENT, MINT},
     BlockTime, CLTyped, CLValue, ContractPackage, DeployHash, EntryPoint, EntryPointType, Gas, Key,
     Phase, ProtocolVersion, RuntimeArgs, StoredValue,
 };
@@ -17,7 +17,7 @@ use crate::{
     core::{
         engine_state::{execution_result::ExecutionResult, EngineConfig},
         execution::{address_generator::AddressGenerator, Error},
-        runtime::{extract_access_rights_from_keys, instance_and_memory, Runtime},
+        runtime::{extract_access_rights_from_keys, instance_and_memory, Runtime, RuntimeStack},
         runtime_context::{self, RuntimeContext},
         tracking_copy::{TrackingCopy, TrackingCopyExt},
     },
@@ -107,7 +107,7 @@ impl Executor {
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         phase: Phase,
         contract_package: &ContractPackage,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> ExecutionResult
     where
         R: StateReader<Key, StoredValue>,
@@ -160,7 +160,7 @@ impl Executor {
             transfers,
         );
 
-        let mut runtime = Runtime::new(self.config, memory, module, context, call_stack);
+        let mut runtime = Runtime::new(self.config, memory, module, context, stack);
 
         let accounts_access_rights = {
             let keys: Vec<Key> = account.named_keys().values().cloned().collect();
@@ -173,7 +173,7 @@ impl Executor {
             |uref| runtime_context::uref_has_access_rights(uref, &accounts_access_rights)
         ));
 
-        let call_stack = runtime.call_stack().to_owned();
+        let stack = runtime.stack().clone();
 
         if runtime.is_mint(base_key) {
             match runtime.call_host_mint(
@@ -182,7 +182,7 @@ impl Executor {
                 &mut runtime.context().named_keys().to_owned(),
                 &args,
                 Default::default(),
-                call_stack,
+                stack,
             ) {
                 Ok(_value) => {
                     return ExecutionResult::Success {
@@ -207,7 +207,7 @@ impl Executor {
                 &mut runtime.context().named_keys().to_owned(),
                 &args,
                 Default::default(),
-                call_stack,
+                stack,
             ) {
                 Ok(_value) => {
                     return ExecutionResult::Success {
@@ -232,7 +232,7 @@ impl Executor {
                 &mut runtime.context().named_keys().to_owned(),
                 &args,
                 Default::default(),
-                call_stack,
+                stack,
             ) {
                 Ok(_value) => {
                     return ExecutionResult::Success {
@@ -281,7 +281,7 @@ impl Executor {
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         phase: Phase,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> ExecutionResult
     where
         R: StateReader<Key, StoredValue>,
@@ -310,7 +310,7 @@ impl Executor {
             correlation_id,
             Rc::clone(&tracking_copy),
             phase,
-            call_stack,
+            stack,
         ) {
             Ok((_instance, runtime)) => runtime,
             Err(error) => {
@@ -363,7 +363,7 @@ impl Executor {
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         phase: Phase,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> (Option<T>, ExecutionResult)
     where
         R: StateReader<Key, StoredValue>,
@@ -462,7 +462,7 @@ impl Executor {
             correlation_id,
             tracking_copy,
             phase,
-            call_stack,
+            stack,
         ) {
             Ok((instance, runtime)) => (instance, runtime),
             Err(error) => {
@@ -506,7 +506,7 @@ impl Executor {
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         phase: Phase,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Result<T, Error>
     where
         R: StateReader<Key, StoredValue>,
@@ -533,7 +533,7 @@ impl Executor {
             correlation_id,
             tracking_copy,
             phase,
-            call_stack,
+            stack,
         )?;
 
         let error: wasmi::Error = match instance.invoke_export(entry_point_name, &[], &mut runtime)
@@ -593,7 +593,7 @@ impl Executor {
         correlation_id: CorrelationId,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         phase: Phase,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Result<(ModuleRef, Runtime<'a, R>), Error>
     where
         R: StateReader<Key, StoredValue>,
@@ -632,7 +632,7 @@ impl Executor {
         let (instance, memory) =
             instance_and_memory(module.clone(), protocol_version, self.config.wasm_config())?;
 
-        let runtime = Runtime::new(self.config, memory, module, runtime_context, call_stack);
+        let runtime = Runtime::new(self.config, memory, module, runtime_context, stack);
 
         Ok((instance, runtime))
     }
@@ -688,7 +688,7 @@ impl DirectSystemContractCall {
     {
         let entry_point_name = self.entry_point_name();
 
-        let call_stack = runtime.call_stack().to_owned();
+        let stack = runtime.stack().clone();
 
         let result = match self {
             DirectSystemContractCall::Slash
@@ -699,7 +699,7 @@ impl DirectSystemContractCall {
                 named_keys,
                 runtime_args,
                 extra_keys,
-                call_stack,
+                stack,
             ),
             DirectSystemContractCall::FinalizePayment => runtime.call_host_handle_payment(
                 protocol_version,
@@ -707,7 +707,7 @@ impl DirectSystemContractCall {
                 named_keys,
                 runtime_args,
                 extra_keys,
-                call_stack,
+                stack,
             ),
             DirectSystemContractCall::CreatePurse | DirectSystemContractCall::Transfer => runtime
                 .call_host_mint(
@@ -716,7 +716,7 @@ impl DirectSystemContractCall {
                     named_keys,
                     runtime_args,
                     extra_keys,
-                    call_stack,
+                    stack,
                 ),
             DirectSystemContractCall::GetEraValidators => runtime.call_host_auction(
                 protocol_version,
@@ -724,7 +724,7 @@ impl DirectSystemContractCall {
                 named_keys,
                 runtime_args,
                 extra_keys,
-                call_stack,
+                stack,
             ),
 
             DirectSystemContractCall::GetPaymentPurse => runtime.call_host_handle_payment(
@@ -733,7 +733,7 @@ impl DirectSystemContractCall {
                 named_keys,
                 runtime_args,
                 extra_keys,
-                call_stack,
+                stack,
             ),
         };
 

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -196,12 +196,13 @@ where
         .map_err(|_| Error::CLValue)?;
 
         let gas_counter = self.gas_counter();
-        let mut call_stack = self.call_stack().clone();
-        let call_stack_element = self
-            .get_system_contract_stack_frame(MINT)
-            .map_err(|_| Error::Storage)?;
-        call_stack.push(call_stack_element);
-
+        let mut stack = self.stack().clone();
+        stack
+            .push(
+                self.get_system_contract_stack_frame(MINT)
+                    .map_err(|_| Error::Storage)?,
+            )
+            .map_err(|_| Error::RuntimeStackOverflow)?;
         let cl_value = self
             .call_host_mint(
                 self.context.protocol_version(),
@@ -209,7 +210,7 @@ where
                 &mut NamedKeys::default(),
                 &args_values,
                 &[],
-                call_stack,
+                stack,
             )
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Transfer))?;
         self.set_gas_counter(gas_counter);
@@ -235,11 +236,13 @@ where
         .map_err(|_| Error::CLValue)?;
 
         let gas_counter = self.gas_counter();
-        let mut call_stack = self.call_stack().clone();
+        let mut stack = self.stack().clone();
         let call_stack_element = self
             .get_system_contract_stack_frame(MINT)
             .map_err(|_| Error::Storage)?;
-        call_stack.push(call_stack_element);
+        stack
+            .push(call_stack_element)
+            .map_err(|_| Error::RuntimeStackOverflow)?;
 
         let mint_contract_hash = self.get_mint_contract().map_err(|exec_error| {
             <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue)
@@ -269,7 +272,7 @@ where
                 &mut mint_named_keys,
                 &args_values,
                 &[],
-                call_stack,
+                stack,
             )
             .map_err(|error| <Option<Error>>::from(error).unwrap_or(Error::MintError))?;
         self.set_gas_counter(gas_counter);

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -237,13 +237,12 @@ where
 
         let gas_counter = self.gas_counter();
         let mut stack = self.stack().clone();
-        let call_stack_element = self
-            .get_system_contract_stack_frame(MINT)
-            .map_err(|_| Error::Storage)?;
         stack
-            .push(call_stack_element)
+            .push(
+                self.get_system_contract_stack_frame(MINT)
+                    .map_err(|_| Error::Storage)?,
+            )
             .map_err(|_| Error::RuntimeStackOverflow)?;
-
         let mint_contract_hash = self.get_mint_contract().map_err(|exec_error| {
             <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue)
         })?;

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -5,6 +5,7 @@ mod externals;
 mod handle_payment_internal;
 mod host_function_flag;
 mod mint_internal;
+pub mod stack;
 mod standard_payment_internal;
 
 use std::{
@@ -54,6 +55,7 @@ use crate::{
     },
     storage::global_state::StateReader,
 };
+pub use stack::{RuntimeStack, RuntimeStackFrame, RuntimeStackOverflow};
 
 use self::host_function_flag::HostFunctionFlag;
 
@@ -64,7 +66,7 @@ pub struct Runtime<'a, R> {
     module: Module,
     host_buffer: Option<CLValue>,
     context: RuntimeContext<'a, R>,
-    call_stack: Vec<CallStackElement>,
+    stack: RuntimeStack,
     host_function_flag: HostFunctionFlag,
 }
 
@@ -985,48 +987,44 @@ where
         memory: MemoryRef,
         module: Module,
         context: RuntimeContext<'a, R>,
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Self {
-        Self::check_preconditions(&call_stack);
+        Self::check_preconditions(&stack);
         Runtime {
             config,
             memory,
             module,
             host_buffer: None,
             context,
-            call_stack,
+            stack,
             host_function_flag: HostFunctionFlag::default(),
         }
     }
 
     /// Creates a new runtime instance by cloning the config, memory, module and host function flag
     /// from `self`.
-    fn new_from_self(
-        &self,
-        context: RuntimeContext<'a, R>,
-        call_stack: Vec<CallStackElement>,
-    ) -> Self {
-        Self::check_preconditions(&call_stack);
+    fn new_from_self(&self, context: RuntimeContext<'a, R>, stack: RuntimeStack) -> Self {
+        Self::check_preconditions(&stack);
         Runtime {
             config: self.config,
             memory: self.memory.clone(),
             module: self.module.clone(),
             host_buffer: None,
             context,
-            call_stack,
+            stack,
             host_function_flag: self.host_function_flag.clone(),
         }
     }
 
     /// Preconditions that would render the system inconsistent if violated. Those are strictly
     /// programming errors.
-    fn check_preconditions(call_stack: &[CallStackElement]) {
-        if call_stack.is_empty() {
+    fn check_preconditions(stack: &RuntimeStack) {
+        if stack.is_empty() {
             error!("Call stack should not be empty while creating a new Runtime instance");
             debug_assert!(false);
         }
 
-        if call_stack.first().unwrap().contract_hash().is_some() {
+        if stack.first_frame().unwrap().contract_hash().is_some() {
             error!("First element of the call stack should always represent a Session call");
             debug_assert!(false);
         }
@@ -1081,9 +1079,9 @@ where
         self.context.charge_system_contract_call(amount)
     }
 
-    /// Returns current call stack.
-    pub fn call_stack(&self) -> &Vec<CallStackElement> {
-        &self.call_stack
+    /// Runtime stack.
+    pub(crate) fn stack(&self) -> &RuntimeStack {
+        &self.stack
     }
 
     /// Returns bytes from the WASM memory instance.
@@ -1258,7 +1256,7 @@ where
 
     /// Gets the immediate caller of the current execution
     fn get_immediate_caller(&self) -> Option<&CallStackElement> {
-        self.call_stack().iter().rev().nth(1)
+        self.stack.previous_frame()
     }
 
     /// Checks if immediate caller is of session type of the same account as the provided account
@@ -1303,7 +1301,7 @@ where
             // Exit early if the host buffer is already occupied
             return Ok(Err(ApiError::HostBufferFull));
         }
-        let call_stack = self.call_stack();
+        let call_stack = self.stack.call_stack_elements();
         let call_stack_len = call_stack.len() as u32;
         let call_stack_len_bytes = call_stack_len.to_le_bytes();
 
@@ -1440,7 +1438,7 @@ where
         named_keys: &mut NamedKeys,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Result<CLValue, Error> {
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
@@ -1482,7 +1480,7 @@ where
             transfers,
         );
 
-        let mut mint_runtime = self.new_from_self(mint_context, call_stack);
+        let mut mint_runtime = self.new_from_self(mint_context, stack);
 
         let system_config = self.config.system_config();
         let mint_costs = system_config.mint_costs();
@@ -1586,7 +1584,7 @@ where
         named_keys: &mut NamedKeys,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Result<CLValue, Error> {
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
@@ -1628,7 +1626,7 @@ where
             transfers,
         );
 
-        let mut runtime = self.new_from_self(runtime_context, call_stack);
+        let mut runtime = self.new_from_self(runtime_context, stack);
 
         let system_config = self.config.system_config();
         let handle_payment_costs = system_config.handle_payment_costs();
@@ -1705,7 +1703,7 @@ where
         named_keys: &mut NamedKeys,
         runtime_args: &RuntimeArgs,
         extra_keys: &[Key],
-        call_stack: Vec<CallStackElement>,
+        stack: RuntimeStack,
     ) -> Result<CLValue, Error> {
         let access_rights = {
             let mut keys: Vec<Key> = named_keys.values().cloned().collect();
@@ -1748,7 +1746,7 @@ where
             transfers,
         );
 
-        let mut runtime = self.new_from_self(runtime_context, call_stack);
+        let mut runtime = self.new_from_self(runtime_context, stack);
 
         let system_config = self.config.system_config();
         let auction_costs = system_config.auction_costs();
@@ -2124,12 +2122,12 @@ where
             }
 
             if self.is_mint(key) {
-                let mut call_stack = self.call_stack.to_owned();
+                let mut stack = self.stack.clone();
                 let call_stack_element = CallStackElement::stored_contract(
                     contract.contract_package_hash(),
                     contract_hash,
                 );
-                call_stack.push(call_stack_element);
+                stack.push(call_stack_element)?;
 
                 return self.call_host_mint(
                     self.context.protocol_version(),
@@ -2137,15 +2135,15 @@ where
                     &mut named_keys,
                     &args,
                     &extra_keys,
-                    call_stack,
+                    stack,
                 );
             } else if self.is_handle_payment(key) {
-                let mut call_stack = self.call_stack.to_owned();
+                let mut stack = self.stack.clone();
                 let call_stack_element = CallStackElement::stored_contract(
                     contract.contract_package_hash(),
                     contract_hash,
                 );
-                call_stack.push(call_stack_element);
+                stack.push(call_stack_element)?;
 
                 return self.call_host_handle_payment(
                     self.context.protocol_version(),
@@ -2153,15 +2151,15 @@ where
                     &mut named_keys,
                     &args,
                     &extra_keys,
-                    call_stack,
+                    stack,
                 );
             } else if self.is_auction(key) {
-                let mut call_stack = self.call_stack.to_owned();
+                let mut stack = self.stack.clone();
                 let call_stack_element = CallStackElement::stored_contract(
                     contract.contract_package_hash(),
                     contract_hash,
                 );
-                call_stack.push(call_stack_element);
+                stack.push(call_stack_element)?;
 
                 return self.call_host_auction(
                     self.context.protocol_version(),
@@ -2169,7 +2167,7 @@ where
                     &mut named_keys,
                     &args,
                     &extra_keys,
-                    call_stack,
+                    stack,
                 );
             }
 
@@ -2224,7 +2222,7 @@ where
             self.context.transfers().to_owned(),
         );
 
-        let mut call_stack = self.call_stack.to_owned();
+        let mut stack = self.stack.clone();
 
         let call_stack_element = match entry_point.entry_point_type() {
             EntryPointType::Session => CallStackElement::stored_session(
@@ -2237,9 +2235,9 @@ where
             }
         };
 
-        call_stack.push(call_stack_element);
+        stack.push(call_stack_element)?;
 
-        let mut runtime = Runtime::new(config, memory, module, context, call_stack);
+        let mut runtime = Runtime::new(config, memory, module, context, stack);
 
         let result = instance.invoke_export(entry_point_name, &[], &mut runtime);
 

--- a/execution_engine/src/core/runtime/stack.rs
+++ b/execution_engine/src/core/runtime/stack.rs
@@ -1,0 +1,188 @@
+//! Runtime stacks.
+
+use casper_types::system::CallStackElement;
+
+/// A runtime stack frame.
+///
+/// Currently it aliases to a [`CallStackElement`].
+///
+/// NOTE: Once we need to add more data to a stack frame we should make this a newtype, rather than
+/// change [`CallStackElement`].
+pub type RuntimeStackFrame = CallStackElement;
+
+/// The runtime stack.
+#[derive(Clone)]
+pub struct RuntimeStack {
+    frames: Vec<RuntimeStackFrame>,
+    max_height: usize,
+}
+
+/// Error returned on an attempt to pop off an empty stack.
+#[cfg(test)]
+#[derive(Debug)]
+struct RuntimeStackUnderflow;
+
+/// Error returned on an attempt to push to a stack already at the maximum height.
+#[derive(Debug)]
+pub struct RuntimeStackOverflow;
+
+impl RuntimeStack {
+    /// Creates an empty stack.
+    pub fn new(max_height: usize) -> Self {
+        Self {
+            frames: Vec::with_capacity(max_height),
+            max_height,
+        }
+    }
+
+    /// Is the stack empty?
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// The height of the stack.
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// The current stack frame.
+    pub fn current_frame(&self) -> Option<&RuntimeStackFrame> {
+        self.frames.last()
+    }
+
+    /// The previous stack frame.
+    pub fn previous_frame(&self) -> Option<&RuntimeStackFrame> {
+        self.frames.iter().nth_back(1)
+    }
+
+    /// The first stack frame.
+    pub fn first_frame(&self) -> Option<&RuntimeStackFrame> {
+        self.frames.first()
+    }
+
+    /// Pops the current frame from the stack.
+    #[cfg(test)]
+    fn pop(&mut self) -> Result<(), RuntimeStackUnderflow> {
+        self.frames.pop().ok_or(RuntimeStackUnderflow)?;
+        Ok(())
+    }
+
+    /// Pushes a frame onto the stack.
+    pub fn push(&mut self, frame: RuntimeStackFrame) -> Result<(), RuntimeStackOverflow> {
+        if self.len() < self.max_height {
+            self.frames.push(frame);
+            Ok(())
+        } else {
+            Err(RuntimeStackOverflow)
+        }
+    }
+
+    // It is here for backwards compatibility only.
+    /// A view of the stack in the previous stack format.
+    pub fn call_stack_elements(&self) -> &Vec<CallStackElement> {
+        &self.frames
+    }
+
+    // It is here for backwards compatibility only.
+    /// Creates a stack from the previous stack format.
+    pub fn from_call_stack_elements(
+        frames: Vec<CallStackElement>,
+        max_height: usize,
+    ) -> Result<Self, RuntimeStackOverflow> {
+        if frames.len() > max_height {
+            Err(RuntimeStackOverflow)
+        } else {
+            Ok(RuntimeStack { frames, max_height })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::convert::TryInto;
+
+    use casper_types::account::{AccountHash, ACCOUNT_HASH_LENGTH};
+
+    use super::*;
+
+    fn nth_frame(n: usize) -> CallStackElement {
+        let mut bytes = [0_u8; ACCOUNT_HASH_LENGTH];
+        let n: u32 = n.try_into().unwrap();
+        bytes[0..4].copy_from_slice(&n.to_le_bytes());
+        CallStackElement::session(AccountHash::new(bytes))
+    }
+
+    #[allow(clippy::redundant_clone)]
+    #[test]
+    fn stack_should_respect_max_height_after_clone() {
+        const MAX_HEIGHT: usize = 3;
+        let mut stack = RuntimeStack::new(MAX_HEIGHT);
+        stack.push(nth_frame(1)).unwrap();
+
+        let mut stack2 = stack.clone();
+        stack2.push(nth_frame(2)).unwrap();
+        stack2.push(nth_frame(3)).unwrap();
+        stack2.push(nth_frame(4)).unwrap_err();
+        assert_eq!(stack2.len(), MAX_HEIGHT);
+    }
+
+    #[test]
+    fn stack_should_work_as_expected() {
+        const MAX_HEIGHT: usize = 6;
+
+        let mut stack = RuntimeStack::new(MAX_HEIGHT);
+        assert!(stack.is_empty());
+        assert_eq!(stack.len(), 0);
+        assert_eq!(stack.current_frame(), None);
+        assert_eq!(stack.previous_frame(), None);
+        assert_eq!(stack.first_frame(), None);
+
+        stack.push(nth_frame(0)).unwrap();
+        assert!(!stack.is_empty());
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.current_frame(), Some(&nth_frame(0)));
+        assert_eq!(stack.previous_frame(), None);
+        assert_eq!(stack.first_frame(), Some(&nth_frame(0)));
+
+        let mut n: usize = 1;
+        while stack.push(nth_frame(n)).is_ok() {
+            n += 1;
+            assert!(!stack.is_empty());
+            assert_eq!(stack.len(), n);
+            assert_eq!(stack.current_frame(), Some(&nth_frame(n - 1)));
+            assert_eq!(stack.previous_frame(), Some(&nth_frame(n - 2)));
+            assert_eq!(stack.first_frame(), Some(&nth_frame(0)));
+        }
+        assert!(!stack.is_empty());
+        assert_eq!(stack.len(), MAX_HEIGHT);
+        assert_eq!(stack.current_frame(), Some(&nth_frame(MAX_HEIGHT - 1)));
+        assert_eq!(stack.previous_frame(), Some(&nth_frame(MAX_HEIGHT - 2)));
+        assert_eq!(stack.first_frame(), Some(&nth_frame(0)));
+
+        while stack.len() >= 3 {
+            stack.pop().unwrap();
+            n = n.checked_sub(1).unwrap();
+            assert!(!stack.is_empty());
+            assert_eq!(stack.len(), n);
+            assert_eq!(stack.current_frame(), Some(&nth_frame(n - 1)));
+            assert_eq!(stack.previous_frame(), Some(&nth_frame(n - 2)));
+            assert_eq!(stack.first_frame(), Some(&nth_frame(0)));
+        }
+
+        stack.pop().unwrap();
+        assert!(!stack.is_empty());
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.current_frame(), Some(&nth_frame(0)));
+        assert_eq!(stack.previous_frame(), None);
+        assert_eq!(stack.first_frame(), Some(&nth_frame(0)));
+
+        stack.pop().unwrap();
+        assert!(stack.is_empty());
+        assert_eq!(stack.len(), 0);
+        assert_eq!(stack.current_frame(), None);
+        assert_eq!(stack.previous_frame(), None);
+        assert_eq!(stack.first_frame(), None);
+
+        assert!(stack.pop().is_err());
+    }
+}

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.4.2")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.4.3")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -12,7 +12,7 @@ use super::{
 /// Default maximum number of pages of the Wasm memory.
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 /// Default maximum stack height.
-pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 64 * 1024;
+pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 188;
 
 /// Configuration of the Wasm execution environment.
 ///

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+
+## 2.0.3 - 2021-12-06
+
+### Added
+* Added `WasmTestBuilder::get_balance_keys` function.
+
+
+
+## 2.0.2 - 2021-11-24
+
 ### Changed
 * Revert the change to the path detection logic applied in v2.0.1.
 * `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "2.0.1" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.3" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license = "Apache-2.0"
 
 [dependencies]
-casper-execution-engine = { version = "1.4.2", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "1.4.3", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.2", path = "../../hashing" }
-casper-types = { version = "1.4.2", path = "../../types" }
+casper-types = { version = "1.4.5", path = "../../types" }
 lmdb = "0.8.0"
 log = "0.4.14"
 num-rational = "0.4.0"

--- a/execution_engine_testing/test_support/src/execute_request_builder.rs
+++ b/execution_engine_testing/test_support/src/execute_request_builder.rs
@@ -88,6 +88,28 @@ impl ExecuteRequestBuilder {
         ExecuteRequestBuilder::new().push_deploy(deploy)
     }
 
+    /// Returns an [`ExecuteRequest`] from a module bytes.
+    pub fn module_bytes(
+        account_hash: AccountHash,
+        module_bytes: Vec<u8>,
+        session_args: RuntimeArgs,
+    ) -> Self {
+        let mut rng = rand::thread_rng();
+        let deploy_hash: [u8; 32] = rng.gen();
+
+        let deploy = DeployItemBuilder::new()
+            .with_address(account_hash)
+            .with_session_bytes(module_bytes, session_args)
+            .with_empty_payment_bytes(runtime_args! {
+                ARG_AMOUNT => *DEFAULT_PAYMENT
+            })
+            .with_authorization_keys(&[account_hash])
+            .with_deploy_hash(deploy_hash)
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy)
+    }
+
     /// Returns an [`ExecuteRequest`] that will call a stored contract by hash.
     pub fn contract_call_by_hash(
         sender: AccountHash,

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/2.0.1")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/2.0.3")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -24,6 +24,8 @@ rand = "0.8.3"
 serde = "1"
 serde_json = "1"
 tempfile = "3"
+wabt = "0.10.0"
+wasmi = "0.8.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -147,7 +147,8 @@ fn should_run_ee_1152_regression_test() {
         .with_protocol_version(ProtocolVersion::V1_0_0)
         // Next era id is used for returning future era validators, which we don't need to inspect
         // in this test.
-        .with_next_era_id(era_id);
+        .with_next_era_id(era_id)
+        .with_era_end_timestamp_millis(timestamp_millis);
 
     for (public_key, _stake) in trusted_era_validators.clone().into_iter() {
         let reward_amount = BLOCK_REWARD / trusted_era_validators.len() as u64;

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -9,7 +9,10 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{
-        engine_state::{EngineConfig, Error, ExecuteRequest, DEFAULT_MAX_QUERY_DEPTH},
+        engine_state::{
+            EngineConfig, Error, ExecuteRequest, DEFAULT_MAX_QUERY_DEPTH,
+            DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+        },
         execution::Error as ExecError,
     },
     shared::{
@@ -276,6 +279,7 @@ fn should_run_ee_966_regression_when_growing_mem_after_upgrade() {
     let engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         *DOUBLED_WASM_MEMORY_LIMIT,
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/regression/gh_2280.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2280.rs
@@ -6,7 +6,9 @@ use casper_engine_test_support::{
     DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
 use casper_execution_engine::{
-    core::engine_state::{EngineConfig, UpgradeConfig, DEFAULT_MAX_QUERY_DEPTH},
+    core::engine_state::{
+        EngineConfig, UpgradeConfig, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+    },
     shared::{
         host_function_costs::{Cost, HostFunction, HostFunctionCosts},
         opcode_costs::OpcodeCosts,
@@ -711,6 +713,7 @@ fn make_engine_config(new_mint_costs: MintCosts, new_wasm_config: WasmConfig) ->
     EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         new_wasm_config,
         new_system_config,
     )

--- a/execution_engine_testing/tests/src/test/regression/gov_116.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_116.rs
@@ -1,0 +1,308 @@
+use std::{collections::BTreeSet, iter::FromIterator};
+
+use num_traits::Zero;
+use once_cell::sync::Lazy;
+
+use casper_engine_test_support::{
+    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_VALIDATOR_SLOTS, MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_execution_engine::core::engine_state::{genesis::GenesisValidator, GenesisAccount};
+use casper_types::{
+    runtime_args,
+    system::{
+        auction::{self, DelegationRate, EraValidators, VESTING_SCHEDULE_LENGTH_MILLIS},
+        mint,
+    },
+    Motes, PublicKey, RuntimeArgs, SecretKey, U256, U512,
+};
+
+const MINIMUM_BONDED_AMOUNT: u64 = 1_000;
+
+/// Validator with smallest stake will withdraw most of his stake to ensure we did move time forward
+/// to unlock his whole vesting schedule.
+const WITHDRAW_AMOUNT: u64 = MINIMUM_BONDED_AMOUNT - 1;
+
+/// Initial lockup period
+const VESTING_BASE: u64 = DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+
+const DAY_MILLIS: u64 = 24 * 60 * 60 * 1000;
+const WEEK_MILLIS: u64 = 7 * DAY_MILLIS;
+const DELEGATION_RATE: DelegationRate = 0;
+
+/// Simplified vesting weeks for testing purposes. Each element is used as an argument to
+/// run_auction call.
+const VESTING_WEEKS: [u64; 3] = [
+    // Passes the vesting schedule (aka initial lockup + schedule length)
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64,
+    // One week after
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64 + WEEK_MILLIS,
+    // Two weeks after
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64 + (2 * WEEK_MILLIS),
+];
+
+static GENESIS_VALIDATOR_PUBLIC_KEYS: Lazy<BTreeSet<PublicKey>> = Lazy::new(|| {
+    let mut set = BTreeSet::new();
+    for i in 1..=DEFAULT_VALIDATOR_SLOTS {
+        let mut secret_key_bytes = [255u8; 32];
+        U256::from(i).to_big_endian(&mut secret_key_bytes);
+        let secret_key = SecretKey::secp256k1_from_bytes(secret_key_bytes).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        set.insert(public_key);
+    }
+    set
+});
+
+static GENESIS_VALIDATORS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
+    let mut vec = Vec::with_capacity(GENESIS_VALIDATOR_PUBLIC_KEYS.len());
+
+    for (index, public_key) in GENESIS_VALIDATOR_PUBLIC_KEYS.iter().enumerate() {
+        let account = GenesisAccount::account(
+            public_key.clone(),
+            Motes::new(U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)),
+            Some(GenesisValidator::new(
+                Motes::new(U512::from(index + 1) * 1_000),
+                DelegationRate::zero(),
+            )),
+        );
+        vec.push(account);
+    }
+
+    vec
+});
+
+static LOWEST_STAKE_VALIDATOR: Lazy<PublicKey> = Lazy::new(|| {
+    let mut genesis_accounts: Vec<&GenesisAccount> = GENESIS_ACCOUNTS.iter().collect();
+    genesis_accounts.sort_by_key(|genesis_account| genesis_account.staked_amount());
+
+    // Finds a genesis validator with lowest stake
+    let genesis_account = genesis_accounts
+        .into_iter()
+        .find(|genesis_account| {
+            genesis_account.is_validator() && genesis_account.staked_amount() > Motes::zero()
+        })
+        .unwrap();
+
+    assert_eq!(
+        genesis_account.staked_amount(),
+        Motes::new(U512::from(MINIMUM_BONDED_AMOUNT))
+    );
+
+    genesis_account.public_key()
+});
+
+static GENESIS_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
+    let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+    tmp.append(&mut GENESIS_VALIDATORS.clone());
+    tmp
+});
+
+fn initialize_builder() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let run_genesis_request = utils::create_run_genesis_request(GENESIS_ACCOUNTS.clone());
+    builder.run_genesis(&run_genesis_request);
+
+    let fund_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            mint::ARG_TARGET => PublicKey::System.to_account_hash(),
+            mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
+            mint::ARG_ID => <Option<u64>>::None,
+        },
+    )
+    .build();
+
+    builder.exec(fund_request).expect_success().commit();
+
+    builder
+}
+
+#[ignore]
+#[test]
+fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elapsed() {
+    let lowest_stake_validator_addr = LOWEST_STAKE_VALIDATOR.to_account_hash();
+
+    let mut builder = initialize_builder();
+
+    // Unlock all funds of genesis validator
+    builder.run_auction(VESTING_WEEKS[0], Vec::new());
+
+    let era_validators_1: EraValidators = builder.get_era_validators();
+
+    let (last_era_1, weights_1) = era_validators_1.iter().last().unwrap();
+    let genesis_validator_stake_1 = weights_1.get(&LOWEST_STAKE_VALIDATOR).unwrap();
+    let next_validator_set_1 = BTreeSet::from_iter(weights_1.keys().cloned());
+    assert_eq!(
+        next_validator_set_1,
+        GENESIS_VALIDATOR_PUBLIC_KEYS.clone(),
+        "expected validator set should be unchanged"
+    );
+
+    let withdraw_bid_request = {
+        let auction_hash = builder.get_auction_contract_hash();
+        let session_args = runtime_args! {
+            auction::ARG_PUBLIC_KEY => LOWEST_STAKE_VALIDATOR.clone(),
+            auction::ARG_AMOUNT => U512::from(WITHDRAW_AMOUNT),
+        };
+        ExecuteRequestBuilder::contract_call_by_hash(
+            lowest_stake_validator_addr,
+            auction_hash,
+            auction::METHOD_WITHDRAW_BID,
+            session_args,
+        )
+        .build()
+    };
+
+    builder.exec(withdraw_bid_request).expect_success().commit();
+
+    builder.run_auction(VESTING_WEEKS[1], Vec::new());
+
+    let era_validators_2: EraValidators = builder.get_era_validators();
+
+    let (last_era_2, weights_2) = era_validators_2.iter().last().unwrap();
+    assert!(last_era_2 > last_era_1);
+    let genesis_validator_stake_2 = weights_2.get(&LOWEST_STAKE_VALIDATOR).unwrap();
+
+    let next_validator_set_2 = BTreeSet::from_iter(weights_2.keys().cloned());
+    assert_eq!(next_validator_set_2, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
+
+    assert!(
+        genesis_validator_stake_1 > genesis_validator_stake_2,
+        "stake should decrease in future era"
+    );
+
+    let stake_diff = if genesis_validator_stake_1 > genesis_validator_stake_2 {
+        genesis_validator_stake_1 - genesis_validator_stake_2
+    } else {
+        genesis_validator_stake_2 - genesis_validator_stake_1
+    };
+
+    assert_eq!(stake_diff, U512::from(WITHDRAW_AMOUNT));
+
+    // Add nonfounding validator higher than `unbonding_account` has after unlocking & withdrawing
+
+    // New validator bids with the original stake of unbonding_account to take his place in future
+    // era. We know that unbonding_account has now smaller stake than before.
+
+    let add_bid_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        builder.get_auction_contract_hash(),
+        auction::METHOD_ADD_BID,
+        runtime_args! {
+            auction::ARG_PUBLIC_KEY => DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
+            auction::ARG_AMOUNT => *genesis_validator_stake_1,
+            auction::ARG_DELEGATION_RATE => DELEGATION_RATE,
+        },
+    )
+    .build();
+
+    builder.exec(add_bid_request).expect_success().commit();
+
+    builder.run_auction(VESTING_WEEKS[2], Vec::new());
+
+    let era_validators_3: EraValidators = builder.get_era_validators();
+    let (last_era_3, weights_3) = era_validators_3.iter().last().unwrap();
+    assert!(last_era_3 > last_era_2);
+
+    assert_eq!(
+        weights_3.len(),
+        DEFAULT_VALIDATOR_SLOTS as usize,
+        "auction incorrectly computed more than slots than available"
+    );
+
+    assert!(
+        weights_3.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        "new non-genesis validator should replace a genesis validator with smaller stake"
+    );
+
+    assert!(
+        !weights_3.contains_key(&LOWEST_STAKE_VALIDATOR),
+        "unbonded account should be out of the set"
+    );
+
+    let next_validator_set_3 = BTreeSet::from_iter(weights_3.keys().cloned());
+    let expected_validators = {
+        let mut pks = GENESIS_VALIDATOR_PUBLIC_KEYS.clone();
+        pks.remove(&LOWEST_STAKE_VALIDATOR);
+        pks.insert(DEFAULT_ACCOUNT_PUBLIC_KEY.clone());
+        pks
+    };
+    assert_eq!(
+        next_validator_set_3, expected_validators,
+        "actual next validator set does not match expected validator set"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_retain_genesis_validator_slot_protection() {
+    let mut builder = initialize_builder();
+
+    let era_validators_1: EraValidators = builder.get_era_validators();
+
+    let (last_era_1, weights_1) = era_validators_1.iter().last().unwrap();
+    let genesis_validator_stake_1 = weights_1.get(&LOWEST_STAKE_VALIDATOR).unwrap();
+    // One higher than the lowest stake
+    let winning_stake = *genesis_validator_stake_1 + U512::one();
+    let next_validator_set_1 = BTreeSet::from_iter(weights_1.keys().cloned());
+    assert_eq!(
+        next_validator_set_1,
+        GENESIS_VALIDATOR_PUBLIC_KEYS.clone(),
+        "expected validator set should be unchanged"
+    );
+
+    builder.run_auction(VESTING_BASE, Vec::new());
+
+    let era_validators_2: EraValidators = builder.get_era_validators();
+
+    let (last_era_2, weights_2) = era_validators_2.iter().last().unwrap();
+    assert!(last_era_2 > last_era_1);
+    let next_validator_set_2 = BTreeSet::from_iter(weights_2.keys().cloned());
+    assert_eq!(next_validator_set_2, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
+
+    let add_bid_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        builder.get_auction_contract_hash(),
+        auction::METHOD_ADD_BID,
+        runtime_args! {
+            auction::ARG_PUBLIC_KEY => DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
+            auction::ARG_AMOUNT => winning_stake,
+            auction::ARG_DELEGATION_RATE => DELEGATION_RATE,
+        },
+    )
+    .build();
+
+    builder.exec(add_bid_request).expect_success().commit();
+
+    builder.run_auction(VESTING_BASE + WEEK_MILLIS, Vec::new());
+
+    // All genesis validator slots are protected after ~1 week
+    let era_validators_3: EraValidators = builder.get_era_validators();
+    let (last_era_3, weights_3) = era_validators_3.iter().last().unwrap();
+    assert!(last_era_3 > last_era_2);
+    let next_validator_set_3 = BTreeSet::from_iter(weights_3.keys().cloned());
+    assert_eq!(next_validator_set_3, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
+
+    // After 13 weeks ~ 91 days lowest stake validator is dropped and replaced with higher bid
+    builder.run_auction(
+        VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64,
+        Vec::new(),
+    );
+
+    let era_validators_4: EraValidators = builder.get_era_validators();
+    let (last_era_4, weights_4) = era_validators_4.iter().last().unwrap();
+    assert!(last_era_4 > last_era_3);
+    let next_validator_set_4 = BTreeSet::from_iter(weights_4.keys().cloned());
+    let expected_validators = {
+        let mut pks = GENESIS_VALIDATOR_PUBLIC_KEYS.clone();
+        pks.remove(&LOWEST_STAKE_VALIDATOR);
+        pks.insert(DEFAULT_ACCOUNT_PUBLIC_KEY.clone());
+        pks
+    };
+    assert_eq!(
+        next_validator_set_4, expected_validators,
+        "actual next validator set does not match expected validator set"
+    );
+}

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,0 +1,177 @@
+use once_cell::sync::Lazy;
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::{
+    core::{
+        engine_state::{
+            EngineConfig, Error, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+        },
+        execution::Error as ExecError,
+    },
+    shared::wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+};
+use casper_types::{EraId, ProtocolVersion, RuntimeArgs};
+
+const I32_WASM_SIZE_BYTES: usize = 8;
+const ARITY_INTERPRETER_LIMIT: usize = wasmi::DEFAULT_CALL_STACK_LIMIT / I32_WASM_SIZE_BYTES;
+const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
+const I32_WAT_TYPE: &str = "i64";
+const NEW_WASM_STACK_HEIGHT: u32 = 16;
+
+static OLD_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| *DEFAULT_PROTOCOL_VERSION);
+static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
+    ProtocolVersion::from_parts(
+        OLD_PROTOCOL_VERSION.value().major,
+        OLD_PROTOCOL_VERSION.value().minor,
+        OLD_PROTOCOL_VERSION.value().patch + 1,
+    )
+});
+
+fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
+    let mut call_args = String::new();
+    for i in 0..arity {
+        call_args.push_str(&format!("({}.const {}) ", arg_type, i));
+    }
+
+    let mut func_params = String::new();
+    for i in 0..arity {
+        func_params.push_str(&format!("(param $arg{} {}) ", i, arg_type));
+    }
+
+    // This wasm module contains a function with a specified amount of arguments in it.
+    let wat = format!(
+        r#"(module
+        (func $call (call $func {call_args}) (return))
+        (func $func {func_params} (return))
+        (export "func" (func $func))
+        (export "call" (func $call))
+        (memory $memory 1)
+      )"#,
+        call_args = call_args,
+        func_params = func_params
+    );
+    wabt::wat2wasm(wat).expect("should parse wat")
+}
+
+fn initialize_builder() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder
+}
+
+#[ignore]
+#[test]
+fn should_verify_interpreter_stack_limit() {
+    let mut builder = initialize_builder();
+
+    // This runs out of the interpreter stack limit
+    let module_bytes = make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE);
+    let exec = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+    builder.exec(exec).expect_failure().commit();
+
+    let error = builder.get_error().expect("should have error");
+
+    // For default stack height of 64 * 1024 with a function that takes 16384 i32 arguments it will
+    // fail with following message: Function #0 reading/validation error: At instruction
+    // GetGlobal(0)(@16386): Stack: exceeded stack limit 16384 But due to the default being
+    // small it fails with Unreachable from within the stack height limiter.
+    assert!(
+        matches!(&error, Error::Exec(ExecError::Interpreter(s)) if s.contains("Unreachable")),
+        "{:?}",
+        error
+    );
+}
+
+#[ignore]
+#[test]
+fn should_observe_stack_height_limit() {
+    let mut builder = initialize_builder();
+
+    assert!(WasmConfig::default().max_stack_height > NEW_WASM_STACK_HEIGHT);
+
+    // This runs out of the interpreter stack limit
+    let exec_request_1 = {
+        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+
+        ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build()
+    };
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    {
+        // We need to perform an upgrade to be able to observe new max wasm stack height.
+        let new_engine_config = EngineConfig::new(
+            DEFAULT_MAX_QUERY_DEPTH,
+            DEFAULT_MAX_ASSOCIATED_KEYS,
+            DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+            WasmConfig::new(
+                DEFAULT_WASM_MAX_MEMORY,
+                NEW_WASM_STACK_HEIGHT,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ),
+            Default::default(),
+        );
+
+        let mut upgrade_request = UpgradeRequestBuilder::new()
+            .with_current_protocol_version(*OLD_PROTOCOL_VERSION)
+            .with_new_protocol_version(*NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .build();
+
+        builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
+    }
+
+    // This runs out of the interpreter stack limit.
+    // An amount of args equal to the new limit fails because there's overhead of `fn call` that
+    // adds 1 to the height.
+    let exec_request_2 = {
+        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+
+        ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .with_protocol_version(*NEW_PROTOCOL_VERSION)
+        .build()
+    };
+
+    builder.exec(exec_request_2).expect_failure().commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(&error, Error::Exec(ExecError::Interpreter(s)) if s.contains("Unreachable")),
+        "{:?}",
+        error
+    );
+
+    // But new limit minus one runs fine
+    let exec_request_3 = {
+        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE);
+
+        ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .with_protocol_version(*NEW_PROTOCOL_VERSION)
+        .build()
+    };
+
+    builder.exec(exec_request_3).expect_success().commit();
+}

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -35,6 +35,7 @@ mod gh_1470;
 mod gh_1688;
 mod gh_1902;
 mod gh_2280;
+mod gov_74;
 mod gov_89_regression;
 mod regression_20210707;
 mod regression_20210831;

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -39,4 +39,5 @@ mod gov_89_regression;
 mod regression_20210707;
 mod regression_20210831;
 mod regression_20210924;
+mod regression_20211110;
 mod transforms_must_be_ordered;

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -35,6 +35,7 @@ mod gh_1470;
 mod gh_1688;
 mod gh_1902;
 mod gh_2280;
+mod gov_116;
 mod gov_74;
 mod gov_89_regression;
 mod regression_20210707;

--- a/execution_engine_testing/tests/src/test/regression/regression_20211110.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20211110.rs
@@ -1,0 +1,93 @@
+use casper_engine_test_support::{
+    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::core::{
+    engine_state::Error as CoreError, execution::Error as ExecError,
+};
+use casper_types::{
+    account::AccountHash,
+    runtime_args,
+    system::{mint, standard_payment},
+    ContractHash, Key, RuntimeArgs, U512,
+};
+
+const RECURSE_ENTRYPOINT: &str = "recurse";
+const ARG_TARGET: &str = "target";
+const CONTRACT_HASH_NAME: &str = "regression-contract-hash";
+const REGRESSION_20211110_CONTRACT: &str = "regression_20211110.wasm";
+
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([111; 32]);
+const INSTALL_COST: u64 = 30_000_000_000;
+const STARTING_BALANCE: u64 = 100_000_000_000;
+
+#[ignore]
+#[test]
+fn regression_20211110() {
+    let mut funds: u64 = STARTING_BALANCE;
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let transfer_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            mint::ARG_TARGET => ACCOUNT_1_ADDR,
+            mint::ARG_AMOUNT => U512::from(funds),
+            mint::ARG_ID => Option::<u64>::None
+        },
+    )
+    .build();
+
+    let install_request = {
+        let session_args = runtime_args! {};
+        let payment_args = runtime_args! {
+            standard_payment::ARG_AMOUNT => U512::from(INSTALL_COST)
+        };
+        let deploy_item = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_empty_payment_bytes(payment_args)
+            .with_session_code(REGRESSION_20211110_CONTRACT, session_args)
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([42; 32])
+            .build();
+
+        ExecuteRequestBuilder::from_deploy_item(deploy_item).build()
+    };
+
+    builder.exec(transfer_request).expect_success().commit();
+    builder.exec(install_request).expect_success().commit();
+
+    funds = funds.checked_sub(INSTALL_COST).unwrap();
+
+    let contract_hash: ContractHash =
+        match builder.get_expected_account(ACCOUNT_1_ADDR).named_keys()[CONTRACT_HASH_NAME] {
+            Key::Hash(addr) => addr.into(),
+            _ => panic!("Couldn't find regression contract."),
+        };
+
+    let recurse_request = {
+        let payment_args = runtime_args! {
+            standard_payment::ARG_AMOUNT => U512::from(funds),
+        };
+        let session_args = runtime_args! {
+            ARG_TARGET => contract_hash
+        };
+        let deploy_item = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_empty_payment_bytes(payment_args)
+            .with_stored_session_hash(contract_hash, RECURSE_ENTRYPOINT, session_args)
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([43; 32])
+            .build();
+        ExecuteRequestBuilder::from_deploy_item(deploy_item).build()
+    };
+
+    builder.exec(recurse_request).expect_failure();
+
+    let error = builder.get_error().expect("should have returned an error");
+    assert!(matches!(
+        error,
+        CoreError::Exec(ExecError::RuntimeStackOverflow)
+    ));
+}

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -10,7 +10,9 @@ use casper_engine_test_support::{
 #[cfg(not(feature = "use-as-wasm"))]
 use casper_execution_engine::shared::system_config::auction_costs::DEFAULT_ADD_BID_COST;
 use casper_execution_engine::{
-    core::engine_state::{EngineConfig, DEFAULT_MAX_QUERY_DEPTH},
+    core::engine_state::{
+        EngineConfig, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+    },
     shared::{
         host_function_costs::{HostFunction, HostFunctionCosts},
         opcode_costs::OpcodeCosts,
@@ -159,6 +161,7 @@ fn initialize_isolated_storage_costs() -> InMemoryWasmTestBuilder {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         *STORAGE_COSTS_ONLY,
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -9,7 +9,9 @@ use casper_engine_test_support::{
 };
 
 use casper_execution_engine::{
-    core::engine_state::{EngineConfig, DEFAULT_MAX_QUERY_DEPTH},
+    core::engine_state::{
+        EngineConfig, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+    },
     shared::{
         host_function_costs::HostFunctionCosts,
         opcode_costs::{
@@ -132,6 +134,7 @@ fn should_allow_only_wasm_costs_patch_version() {
     let engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         new_wasm_config,
         SystemConfig::default(),
     );
@@ -173,6 +176,7 @@ fn should_allow_only_wasm_costs_minor_version() {
     let engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         new_wasm_config,
         SystemConfig::default(),
     );
@@ -666,6 +670,7 @@ fn should_increase_max_associated_keys_after_upgrade() {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         DEFAULT_MAX_ASSOCIATED_KEYS + 1,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         *DEFAULT_WASM_CONFIG,
         new_system_config,
     );

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -10,6 +10,7 @@ use casper_engine_test_support::{
 use casper_execution_engine::{
     core::engine_state::{
         genesis::GenesisValidator, EngineConfig, GenesisAccount, DEFAULT_MAX_QUERY_DEPTH,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
     },
     shared::{
         host_function_costs::{Cost, HostFunction, HostFunctionCosts},
@@ -192,6 +193,7 @@ fn upgraded_add_bid_and_withdraw_bid_have_expected_costs() {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         new_max_associated_keys,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         WasmConfig::default(),
         new_system_config,
     );
@@ -430,6 +432,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         new_max_associated_keys,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         WasmConfig::default(),
         new_system_config,
     );
@@ -869,6 +872,7 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         new_max_associated_keys,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         new_wasm_config,
         new_system_config,
     );

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -9,7 +9,7 @@ use casper_execution_engine::{
     core::{
         engine_state::{
             EngineConfig, Error as CoreError, DEFAULT_MAX_QUERY_DEPTH,
-            WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+            DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT, WASMLESS_TRANSFER_FIXED_GAS_PRICE,
         },
         execution::Error as ExecError,
     },
@@ -972,6 +972,7 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
     let new_engine_config = EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
         new_max_associated_keys,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
         WasmConfig::default(),
         new_system_config,
     );

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -12,9 +12,15 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Added
+* Add new event to the main SSE server stream across all endpoints `<IP:PORT>/events/*` which emits a shutdown event when the node shuts down.
+
 
 
 ## 1.4.3 - 2021-12-06
+
+### Added
+* Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
 
 ### Changed
 * `enable_manual_sync` configuration parameter defaults to `true`.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -12,12 +12,15 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
-### Added
-* Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
-* Add new event to the main SSE server stream across all endpoints `<IP:PORT>/events/*` which emits a shutdown event when the node shuts down.
+
+
+## 1.4.3 - 2021-12-06
 
 ### Changed
 * `enable_manual_sync` configuration parameter defaults to `true`.
+* Default behavior of LMDB changed to use [`NO_READAHEAD`](https://docs.rs/lmdb/0.8.0/lmdb/struct.EnvironmentFlags.html#associatedconstant.NO_READAHEAD)
+
+
 
 
 ## [1.4.2] - 2021-11-11

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-
 ## [1.4.2] - 2021-11-11
 
 ### Changed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.3" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,10 +20,10 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "1.4.2", path = "../execution_engine" }
+casper-execution-engine = { version = "1.4.3", path = "../execution_engine" }
 casper-node-macros = { version = "1.4.2", path = "../node_macros" }
 casper-hashing = { version = "1.4.2", path = "../hashing" }
-casper-types = { version = "1.4.2", path = "../types", features = ["datasize", "gens", "json-schema"] }
+casper-types = { version = "1.4.5", path = "../types", features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -537,6 +537,7 @@ where
 }
 
 impl ContractRuntime {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         protocol_version: ProtocolVersion,
         storage_dir: &Path,
@@ -544,6 +545,7 @@ impl ContractRuntime {
         wasm_config: WasmConfig,
         system_config: SystemConfig,
         max_associated_keys: u32,
+        max_runtime_call_stack_height: u32,
         registry: &Registry,
     ) -> Result<Self, ConfigError> {
         // TODO: This is bogus, get rid of this
@@ -571,6 +573,7 @@ impl ContractRuntime {
         let engine_config = EngineConfig::new(
             contract_runtime_config.max_query_depth(),
             max_associated_keys,
+            max_runtime_call_stack_height,
             wasm_config,
             system_config,
         );

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -9,13 +9,10 @@ use crate::{
     types::{Block, Deploy, NodeId, Timestamp},
 };
 
-use casper_execution_engine::core::engine_state::executable_deploy_item::{
-    ContractIdentifier, ContractPackageIdentifier,
-};
 use casper_hashing::Digest;
 use casper_types::{
     account::{Account, AccountHash},
-    Contract, ContractPackage, U512,
+    Contract, ContractHash, ContractPackage, ContractPackageHash, ContractVersion, U512,
 };
 
 /// A utility struct to hold duplicated information across events.
@@ -81,7 +78,7 @@ pub(crate) enum Event {
         event_metadata: EventMetadata,
         prestate_hash: Digest,
         is_payment: bool,
-        contract_identifier: ContractIdentifier,
+        contract_hash: ContractHash,
         maybe_contract: Option<Contract>,
         verification_start_timestamp: Timestamp,
     },
@@ -90,7 +87,8 @@ pub(crate) enum Event {
         event_metadata: EventMetadata,
         prestate_hash: Digest,
         is_payment: bool,
-        contract_package_identifier: ContractPackageIdentifier,
+        contract_package_hash: ContractPackageHash,
+        maybe_package_version: Option<ContractVersion>,
         maybe_contract_package: Option<ContractPackage>,
         verification_start_timestamp: Timestamp,
     },

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -125,6 +125,10 @@ enum TestScenario {
     FromPeerMissingAccount,
     FromPeerAccountWithInsufficientWeight,
     FromPeerAccountWithInvalidAssociatedKeys,
+    FromPeerCustomPaymentContract(ContractScenario),
+    FromPeerCustomPaymentContractPackage(ContractPackageScenario),
+    FromPeerSessionContract(ContractScenario),
+    FromPeerSessionContractPackage(ContractPackageScenario),
     FromClientInvalidDeploy,
     FromClientMissingAccount,
     FromClientInsufficientBalance,
@@ -133,10 +137,10 @@ enum TestScenario {
     FromClientAccountWithInsufficientWeight,
     FromClientAccountWithInvalidAssociatedKeys,
     AccountWithUnknownBalance,
-    DeployWithCustomPaymentContract(ContractScenario),
-    DeployWithCustomPaymentContractPackage(ContractPackageScenario),
-    DeployWithSessionContract(ContractScenario),
-    DeployWithSessionContractPackage(ContractPackageScenario),
+    FromClientCustomPaymentContract(ContractScenario),
+    FromClientCustomPaymentContractPackage(ContractPackageScenario),
+    FromClientSessionContract(ContractScenario),
+    FromClientSessionContractPackage(ContractPackageScenario),
     DeployWithNativeTransferInPayment,
     DeployWithEmptySessionModuleBytes,
     DeployWithoutPaymentAmount,
@@ -159,6 +163,10 @@ impl TestScenario {
             | TestScenario::FromPeerMissingAccount
             | TestScenario::FromPeerAccountWithInsufficientWeight
             | TestScenario::FromPeerAccountWithInvalidAssociatedKeys
+            | TestScenario::FromPeerCustomPaymentContract(_)
+            | TestScenario::FromPeerCustomPaymentContractPackage(_)
+            | TestScenario::FromPeerSessionContract(_)
+            | TestScenario::FromPeerSessionContractPackage(_)
             | TestScenario::ShouldAcceptExpiredDeploySentByPeer => {
                 Source::Peer(NodeId::random(rng))
             }
@@ -175,10 +183,10 @@ impl TestScenario {
             | TestScenario::DeployWithMangledTransferAmount
             | TestScenario::DeployWithoutTransferAmount
             | TestScenario::DeployWithoutTransferTarget
-            | TestScenario::DeployWithCustomPaymentContract(_)
-            | TestScenario::DeployWithCustomPaymentContractPackage(_)
-            | TestScenario::DeployWithSessionContract(_)
-            | TestScenario::DeployWithSessionContractPackage(_)
+            | TestScenario::FromClientCustomPaymentContract(_)
+            | TestScenario::FromClientCustomPaymentContractPackage(_)
+            | TestScenario::FromClientSessionContract(_)
+            | TestScenario::FromClientSessionContractPackage(_)
             | TestScenario::DeployWithEmptySessionModuleBytes
             | TestScenario::DeployWithNativeTransferInPayment
             | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => Source::Client,
@@ -221,7 +229,8 @@ impl TestScenario {
                 Deploy::random_with_mangled_transfer_amount(rng)
             }
 
-            TestScenario::DeployWithCustomPaymentContract(contract_scenario) => {
+            TestScenario::FromPeerCustomPaymentContract(contract_scenario)
+            | TestScenario::FromClientCustomPaymentContract(contract_scenario) => {
                 match contract_scenario {
                     ContractScenario::Valid | ContractScenario::MissingContractAtName => {
                         Deploy::random_with_valid_custom_payment_contract_by_name(rng)
@@ -234,7 +243,8 @@ impl TestScenario {
                     }
                 }
             }
-            TestScenario::DeployWithCustomPaymentContractPackage(contract_package_scenario) => {
+            TestScenario::FromPeerCustomPaymentContractPackage(contract_package_scenario)
+            | TestScenario::FromClientCustomPaymentContractPackage(contract_package_scenario) => {
                 match contract_package_scenario {
                     ContractPackageScenario::Valid
                     | ContractPackageScenario::MissingPackageAtName => {
@@ -248,7 +258,9 @@ impl TestScenario {
                     }
                 }
             }
-            TestScenario::DeployWithSessionContract(contract_scenario) => match contract_scenario {
+            TestScenario::FromPeerSessionContract(contract_scenario)
+            | TestScenario::FromClientSessionContract(contract_scenario) => match contract_scenario
+            {
                 ContractScenario::Valid | ContractScenario::MissingContractAtName => {
                     Deploy::random_with_valid_session_contract_by_name(rng)
                 }
@@ -259,7 +271,8 @@ impl TestScenario {
                     Deploy::random_with_missing_entry_point_in_session_contract(rng)
                 }
             },
-            TestScenario::DeployWithSessionContractPackage(contract_package_scenario) => {
+            TestScenario::FromPeerSessionContractPackage(contract_package_scenario)
+            | TestScenario::FromClientSessionContractPackage(contract_package_scenario) => {
                 match contract_package_scenario {
                     ContractPackageScenario::Valid
                     | ContractPackageScenario::MissingPackageAtName => {
@@ -312,19 +325,23 @@ impl TestScenario {
             | TestScenario::DeployWithoutTransferTarget
             | TestScenario::BalanceCheckForDeploySentByPeer
             | TestScenario::ShouldNotAcceptExpiredDeploySentByClient => false,
-            TestScenario::DeployWithCustomPaymentContract(contract_scenario)
-            | TestScenario::DeployWithSessionContract(contract_scenario) => match contract_scenario
+            TestScenario::FromPeerCustomPaymentContract(contract_scenario)
+            | TestScenario::FromPeerSessionContract(contract_scenario)
+            | TestScenario::FromClientCustomPaymentContract(contract_scenario)
+            | TestScenario::FromClientSessionContract(contract_scenario) => match contract_scenario
             {
-                ContractScenario::Valid => true,
-                ContractScenario::MissingContractAtName
+                ContractScenario::Valid
+                | ContractScenario::MissingContractAtName => true,
                 | ContractScenario::MissingContractAtHash
                 | ContractScenario::MissingEntryPoint => false,
             },
-            TestScenario::DeployWithCustomPaymentContractPackage(contract_package_scenario)
-            | TestScenario::DeployWithSessionContractPackage(contract_package_scenario) => {
+            TestScenario::FromPeerCustomPaymentContractPackage(contract_package_scenario)
+            | TestScenario::FromPeerSessionContractPackage(contract_package_scenario)
+            | TestScenario::FromClientCustomPaymentContractPackage(contract_package_scenario)
+            | TestScenario::FromClientSessionContractPackage(contract_package_scenario) => {
                 match contract_package_scenario {
-                    ContractPackageScenario::Valid => true,
-                    ContractPackageScenario::MissingPackageAtName
+                    ContractPackageScenario::Valid
+                    | ContractPackageScenario::MissingPackageAtName => true,
                     | ContractPackageScenario::MissingPackageAtHash
                     | ContractPackageScenario::MissingContractVersion => false,
                 }
@@ -453,10 +470,16 @@ impl reactor::Reactor for Reactor {
                             }
                         } else {
                             match self.test_scenario {
-                                TestScenario::DeployWithCustomPaymentContractPackage(
+                                TestScenario::FromPeerCustomPaymentContractPackage(
                                     contract_package_scenario,
                                 )
-                                | TestScenario::DeployWithSessionContractPackage(
+                                | TestScenario::FromPeerSessionContractPackage(
+                                    contract_package_scenario,
+                                )
+                                | TestScenario::FromClientCustomPaymentContractPackage(
+                                    contract_package_scenario,
+                                )
+                                | TestScenario::FromClientSessionContractPackage(
                                     contract_package_scenario,
                                 ) => match contract_package_scenario {
                                     ContractPackageScenario::Valid
@@ -470,8 +493,10 @@ impl reactor::Reactor for Reactor {
                                     }
                                     _ => QueryResult::ValueNotFound(String::new()),
                                 },
-                                TestScenario::DeployWithSessionContract(contract_scenario)
-                                | TestScenario::DeployWithCustomPaymentContract(
+                                TestScenario::FromPeerSessionContract(contract_scenario)
+                                | TestScenario::FromPeerCustomPaymentContract(contract_scenario)
+                                | TestScenario::FromClientSessionContract(contract_scenario)
+                                | TestScenario::FromClientCustomPaymentContract(
                                     contract_scenario,
                                 ) => match contract_scenario {
                                     ContractScenario::Valid
@@ -486,8 +511,10 @@ impl reactor::Reactor for Reactor {
                         }
                     } else if let Key::Hash(_) = query_request.key() {
                         match self.test_scenario {
-                            TestScenario::DeployWithSessionContract(contract_scenario)
-                            | TestScenario::DeployWithCustomPaymentContract(contract_scenario) => {
+                            TestScenario::FromPeerSessionContract(contract_scenario)
+                            | TestScenario::FromPeerCustomPaymentContract(contract_scenario)
+                            | TestScenario::FromClientSessionContract(contract_scenario)
+                            | TestScenario::FromClientCustomPaymentContract(contract_scenario) => {
                                 match contract_scenario {
                                     ContractScenario::Valid
                                     | ContractScenario::MissingEntryPoint => QueryResult::Success {
@@ -500,10 +527,16 @@ impl reactor::Reactor for Reactor {
                                     }
                                 }
                             }
-                            TestScenario::DeployWithSessionContractPackage(
+                            TestScenario::FromPeerSessionContractPackage(
                                 contract_package_scenario,
                             )
-                            | TestScenario::DeployWithCustomPaymentContractPackage(
+                            | TestScenario::FromPeerCustomPaymentContractPackage(
+                                contract_package_scenario,
+                            )
+                            | TestScenario::FromClientSessionContractPackage(
+                                contract_package_scenario,
+                            )
+                            | TestScenario::FromClientCustomPaymentContractPackage(
                                 contract_package_scenario,
                             ) => match contract_package_scenario {
                                 ContractPackageScenario::Valid
@@ -742,42 +775,45 @@ async fn run_deploy_acceptor_without_timeout(
                     })
                 )
             }
-            // Check that executable items with valid contracts are successfully stored.
-            // Conversely, ensure that invalid contracts will raise the invalid deploy
-            // announcement.
-            TestScenario::DeployWithCustomPaymentContract(contract_scenario)
-            | TestScenario::DeployWithSessionContract(contract_scenario) => match contract_scenario
+            // Check that executable items with valid contracts are successfully stored. Conversely,
+            // ensure that invalid contracts will raise the invalid deploy announcement.
+            TestScenario::FromPeerCustomPaymentContract(contract_scenario)
+            | TestScenario::FromPeerSessionContract(contract_scenario)
+            | TestScenario::FromClientCustomPaymentContract(contract_scenario)
+            | TestScenario::FromClientSessionContract(contract_scenario) => match contract_scenario
             {
-                ContractScenario::Valid => matches!(
+                ContractScenario::Valid | ContractScenario::MissingContractAtName => matches!(
                     event,
                     Event::DeployAcceptorAnnouncement(
                         DeployAcceptorAnnouncement::AcceptedNewDeploy { .. }
                     )
                 ),
-                ContractScenario::MissingContractAtHash
-                | ContractScenario::MissingContractAtName
-                | ContractScenario::MissingEntryPoint => matches!(
-                    event,
-                    Event::DeployAcceptorAnnouncement(
-                        DeployAcceptorAnnouncement::InvalidDeploy { .. }
+                ContractScenario::MissingContractAtHash | ContractScenario::MissingEntryPoint => {
+                    matches!(
+                        event,
+                        Event::DeployAcceptorAnnouncement(
+                            DeployAcceptorAnnouncement::InvalidDeploy { .. }
+                        )
                     )
-                ),
+                }
             },
             // Check that executable items with valid contract packages are successfully stored.
             // Conversely, ensure that invalid contract packages will raise the invalid deploy
             // announcement.
-            TestScenario::DeployWithCustomPaymentContractPackage(contract_package_scenario)
-            | TestScenario::DeployWithSessionContractPackage(contract_package_scenario) => {
+            TestScenario::FromPeerCustomPaymentContractPackage(contract_package_scenario)
+            | TestScenario::FromPeerSessionContractPackage(contract_package_scenario)
+            | TestScenario::FromClientCustomPaymentContractPackage(contract_package_scenario)
+            | TestScenario::FromClientSessionContractPackage(contract_package_scenario) => {
                 match contract_package_scenario {
-                    ContractPackageScenario::Valid => matches!(
+                    ContractPackageScenario::Valid
+                    | ContractPackageScenario::MissingPackageAtName => matches!(
                         event,
                         Event::DeployAcceptorAnnouncement(
                             DeployAcceptorAnnouncement::AcceptedNewDeploy { .. }
                         )
                     ),
                     ContractPackageScenario::MissingContractVersion
-                    | ContractPackageScenario::MissingPackageAtHash
-                    | ContractPackageScenario::MissingPackageAtName => matches!(
+                    | ContractPackageScenario::MissingPackageAtHash => matches!(
                         event,
                         Event::DeployAcceptorAnnouncement(
                             DeployAcceptorAnnouncement::InvalidDeploy { .. }
@@ -999,30 +1035,24 @@ async fn should_accept_repeated_valid_deploy_from_client() {
 }
 
 #[tokio::test]
-async fn should_accept_deploy_with_valid_custom_payment() {
-    let test_scenario = TestScenario::DeployWithCustomPaymentContract(ContractScenario::Valid);
+async fn should_accept_deploy_with_valid_custom_payment_from_client() {
+    let test_scenario = TestScenario::FromClientCustomPaymentContract(ContractScenario::Valid);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_custom_payment_contract_by_name() {
+async fn should_accept_deploy_with_missing_custom_payment_contract_by_name_from_client() {
     let test_scenario =
-        TestScenario::DeployWithCustomPaymentContract(ContractScenario::MissingContractAtName);
+        TestScenario::FromClientCustomPaymentContract(ContractScenario::MissingContractAtName);
     let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::InvalidDeployParameters {
-            failure: DeployParameterFailure::NonexistentContractAtName { .. },
-            ..
-        })
-    ))
+    assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_custom_payment_contract_by_hash() {
+async fn should_reject_deploy_with_missing_custom_payment_contract_by_hash_from_client() {
     let test_scenario =
-        TestScenario::DeployWithCustomPaymentContract(ContractScenario::MissingContractAtHash);
+        TestScenario::FromClientCustomPaymentContract(ContractScenario::MissingContractAtHash);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(matches!(
         result,
@@ -1034,9 +1064,9 @@ async fn should_reject_deploy_with_missing_custom_payment_contract_by_hash() {
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_entry_point_custom_payment() {
+async fn should_reject_deploy_with_missing_entry_point_custom_payment_from_client() {
     let test_scenario =
-        TestScenario::DeployWithCustomPaymentContract(ContractScenario::MissingEntryPoint);
+        TestScenario::FromClientCustomPaymentContract(ContractScenario::MissingEntryPoint);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(matches!(
         result,
@@ -1048,31 +1078,25 @@ async fn should_reject_deploy_with_missing_entry_point_custom_payment() {
 }
 
 #[tokio::test]
-async fn should_accept_deploy_with_valid_payment_contract_package_by_name() {
+async fn should_accept_deploy_with_valid_payment_contract_package_by_name_from_client() {
     let test_scenario =
-        TestScenario::DeployWithCustomPaymentContractPackage(ContractPackageScenario::Valid);
+        TestScenario::FromClientCustomPaymentContractPackage(ContractPackageScenario::Valid);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_payment_contract_package_at_name() {
-    let test_scenario = TestScenario::DeployWithCustomPaymentContractPackage(
+async fn should_accept_deploy_with_missing_payment_contract_package_at_name_from_client() {
+    let test_scenario = TestScenario::FromClientCustomPaymentContractPackage(
         ContractPackageScenario::MissingPackageAtName,
     );
     let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::InvalidDeployParameters {
-            failure: DeployParameterFailure::NonexistentContractPackageAtName { .. },
-            ..
-        })
-    ))
+    assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_payment_contract_package_at_hash() {
-    let test_scenario = TestScenario::DeployWithCustomPaymentContractPackage(
+async fn should_reject_deploy_with_missing_payment_contract_package_at_hash_from_client() {
+    let test_scenario = TestScenario::FromClientCustomPaymentContractPackage(
         ContractPackageScenario::MissingPackageAtHash,
     );
     let result = run_deploy_acceptor(test_scenario).await;
@@ -1086,8 +1110,8 @@ async fn should_reject_deploy_with_missing_payment_contract_package_at_hash() {
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_payment_contract_package() {
-    let test_scenario = TestScenario::DeployWithCustomPaymentContractPackage(
+async fn should_reject_deploy_with_missing_version_in_payment_contract_package_from_client() {
+    let test_scenario = TestScenario::FromClientCustomPaymentContractPackage(
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_deploy_acceptor(test_scenario).await;
@@ -1101,16 +1125,24 @@ async fn should_reject_deploy_with_missing_version_in_payment_contract_package()
 }
 
 #[tokio::test]
-async fn should_accept_deploy_with_valid_session_contract() {
-    let test_scenario = TestScenario::DeployWithSessionContract(ContractScenario::Valid);
+async fn should_accept_deploy_with_valid_session_contract_from_client() {
+    let test_scenario = TestScenario::FromClientSessionContract(ContractScenario::Valid);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_session_contract_by_hash() {
+async fn should_accept_deploy_with_missing_session_contract_by_name_from_client() {
     let test_scenario =
-        TestScenario::DeployWithSessionContract(ContractScenario::MissingContractAtHash);
+        TestScenario::FromClientSessionContract(ContractScenario::MissingContractAtName);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_session_contract_by_hash_from_client() {
+    let test_scenario =
+        TestScenario::FromClientSessionContract(ContractScenario::MissingContractAtHash);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(matches!(
         result,
@@ -1122,23 +1154,9 @@ async fn should_reject_deploy_with_missing_session_contract_by_hash() {
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_session_contract_by_name() {
+async fn should_reject_deploy_with_missing_entry_point_in_session_contract_from_client() {
     let test_scenario =
-        TestScenario::DeployWithSessionContract(ContractScenario::MissingContractAtName);
-    let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::InvalidDeployParameters {
-            failure: DeployParameterFailure::NonexistentContractAtName { .. },
-            ..
-        })
-    ))
-}
-
-#[tokio::test]
-async fn should_reject_deploy_with_missing_entry_point_in_session_contract() {
-    let test_scenario =
-        TestScenario::DeployWithSessionContract(ContractScenario::MissingEntryPoint);
+        TestScenario::FromClientSessionContract(ContractScenario::MissingEntryPoint);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(matches!(
         result,
@@ -1150,31 +1168,25 @@ async fn should_reject_deploy_with_missing_entry_point_in_session_contract() {
 }
 
 #[tokio::test]
-async fn should_accept_deploy_with_valid_session_contract_package() {
+async fn should_accept_deploy_with_valid_session_contract_package_from_client() {
     let test_scenario =
-        TestScenario::DeployWithSessionContractPackage(ContractPackageScenario::Valid);
+        TestScenario::FromClientSessionContractPackage(ContractPackageScenario::Valid);
     let result = run_deploy_acceptor(test_scenario).await;
     assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_session_contract_package_at_name() {
-    let test_scenario = TestScenario::DeployWithSessionContractPackage(
+async fn should_accept_deploy_with_missing_session_contract_package_at_name_from_client() {
+    let test_scenario = TestScenario::FromClientSessionContractPackage(
         ContractPackageScenario::MissingPackageAtName,
     );
     let result = run_deploy_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::InvalidDeployParameters {
-            failure: DeployParameterFailure::NonexistentContractPackageAtName { .. },
-            ..
-        })
-    ))
+    assert!(result.is_ok())
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_session_contract_package_at_hash() {
-    let test_scenario = TestScenario::DeployWithSessionContractPackage(
+async fn should_reject_deploy_with_missing_session_contract_package_at_hash_from_client() {
+    let test_scenario = TestScenario::FromClientSessionContractPackage(
         ContractPackageScenario::MissingPackageAtHash,
     );
     let result = run_deploy_acceptor(test_scenario).await;
@@ -1188,8 +1200,185 @@ async fn should_reject_deploy_with_missing_session_contract_package_at_hash() {
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_session_contract_package() {
-    let test_scenario = TestScenario::DeployWithCustomPaymentContractPackage(
+async fn should_reject_deploy_with_missing_version_in_session_contract_package_from_client() {
+    let test_scenario = TestScenario::FromClientCustomPaymentContractPackage(
+        ContractPackageScenario::MissingContractVersion,
+    );
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::InvalidContractAtVersion { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_valid_custom_payment_from_peer() {
+    let test_scenario = TestScenario::FromPeerCustomPaymentContract(ContractScenario::Valid);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_missing_custom_payment_contract_by_name_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerCustomPaymentContract(ContractScenario::MissingContractAtName);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_custom_payment_contract_by_hash_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerCustomPaymentContract(ContractScenario::MissingContractAtHash);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractAtHash { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_entry_point_custom_payment_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerCustomPaymentContract(ContractScenario::MissingEntryPoint);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractEntryPoint { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_valid_payment_contract_package_by_name_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerCustomPaymentContractPackage(ContractPackageScenario::Valid);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_missing_payment_contract_package_at_name_from_peer() {
+    let test_scenario = TestScenario::FromPeerCustomPaymentContractPackage(
+        ContractPackageScenario::MissingPackageAtName,
+    );
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_payment_contract_package_at_hash_from_peer() {
+    let test_scenario = TestScenario::FromPeerCustomPaymentContractPackage(
+        ContractPackageScenario::MissingPackageAtHash,
+    );
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractPackageAtHash { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_version_in_payment_contract_package_from_peer() {
+    let test_scenario = TestScenario::FromPeerCustomPaymentContractPackage(
+        ContractPackageScenario::MissingContractVersion,
+    );
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::InvalidContractAtVersion { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_valid_session_contract_from_peer() {
+    let test_scenario = TestScenario::FromPeerSessionContract(ContractScenario::Valid);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_missing_session_contract_by_name_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerSessionContract(ContractScenario::MissingContractAtName);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_session_contract_by_hash_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerSessionContract(ContractScenario::MissingContractAtHash);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractAtHash { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_entry_point_in_session_contract_from_peer() {
+    let test_scenario = TestScenario::FromPeerSessionContract(ContractScenario::MissingEntryPoint);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractEntryPoint { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_valid_session_contract_package_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerSessionContractPackage(ContractPackageScenario::Valid);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_accept_deploy_with_missing_session_contract_package_at_name_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerSessionContractPackage(ContractPackageScenario::MissingPackageAtName);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(result.is_ok())
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_session_contract_package_at_hash_from_peer() {
+    let test_scenario =
+        TestScenario::FromPeerSessionContractPackage(ContractPackageScenario::MissingPackageAtHash);
+    let result = run_deploy_acceptor(test_scenario).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidDeployParameters {
+            failure: DeployParameterFailure::NonexistentContractPackageAtHash { .. },
+            ..
+        })
+    ))
+}
+
+#[tokio::test]
+async fn should_reject_deploy_with_missing_version_in_session_contract_package_from_peer() {
+    let test_scenario = TestScenario::FromPeerCustomPaymentContractPackage(
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_deploy_acceptor(test_scenario).await;

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -17,7 +17,10 @@ use thiserror::Error;
 use tokio::time;
 use tracing::debug;
 
-use casper_execution_engine::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
+use casper_execution_engine::{
+    core::engine_state::DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+    shared::{system_config::SystemConfig, wasm_config::WasmConfig},
+};
 use casper_types::ProtocolVersion;
 
 use super::*;
@@ -204,6 +207,7 @@ impl reactor::Reactor for Reactor {
             WasmConfig::default(),
             SystemConfig::default(),
             MAX_ASSOCIATED_KEYS,
+            DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
             registry,
         )
         .unwrap();

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 2);
+    ProtocolVersion::from_parts(1, 4, 3);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.2")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.3")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -224,6 +224,10 @@ impl Reactor {
             chainspec_loader.chainspec().wasm_config,
             chainspec_loader.chainspec().system_costs_config,
             chainspec_loader.chainspec().core_config.max_associated_keys,
+            chainspec_loader
+                .chainspec()
+                .core_config
+                .max_runtime_call_stack_height,
             registry,
         )?;
 

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -30,6 +30,8 @@ pub struct CoreConfig {
     pub(crate) round_seigniorage_rate: Ratio<u64>,
     /// Maximum number of associated keys for a single account.
     pub(crate) max_associated_keys: u32,
+    /// Maximum height of contract runtime call stack.
+    pub(crate) max_runtime_call_stack_height: u32,
 }
 
 #[cfg(test)]
@@ -47,6 +49,7 @@ impl CoreConfig {
             rng.gen_range(1..1_000_000_000),
         );
         let max_associated_keys = rng.gen();
+        let max_runtime_call_stack_height = rng.gen();
 
         CoreConfig {
             era_duration,
@@ -57,6 +60,7 @@ impl CoreConfig {
             unbonding_delay,
             round_seigniorage_rate,
             max_associated_keys,
+            max_runtime_call_stack_height,
         }
     }
 }
@@ -72,6 +76,7 @@ impl ToBytes for CoreConfig {
         buffer.extend(self.unbonding_delay.to_bytes()?);
         buffer.extend(self.round_seigniorage_rate.to_bytes()?);
         buffer.extend(self.max_associated_keys.to_bytes()?);
+        buffer.extend(self.max_runtime_call_stack_height.to_bytes()?);
         Ok(buffer)
     }
 
@@ -84,6 +89,7 @@ impl ToBytes for CoreConfig {
             + self.unbonding_delay.serialized_length()
             + self.round_seigniorage_rate.serialized_length()
             + self.max_associated_keys.serialized_length()
+            + self.max_runtime_call_stack_height.serialized_length()
     }
 }
 
@@ -97,6 +103,7 @@ impl FromBytes for CoreConfig {
         let (unbonding_delay, remainder) = u64::from_bytes(remainder)?;
         let (round_seigniorage_rate, remainder) = Ratio::<u64>::from_bytes(remainder)?;
         let (max_associated_keys, remainder) = FromBytes::from_bytes(remainder)?;
+        let (max_runtime_call_stack_height, remainder) = FromBytes::from_bytes(remainder)?;
         let config = CoreConfig {
             era_duration,
             minimum_era_height,
@@ -106,6 +113,7 @@ impl FromBytes for CoreConfig {
             unbonding_delay,
             round_seigniorage_rate,
             max_associated_keys,
+            max_runtime_call_stack_height,
         };
         Ok((config, remainder))
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -997,15 +997,15 @@ impl Deploy {
     pub(crate) fn random_with_missing_payment_contract_by_hash(rng: &mut TestRng) -> Self {
         let payment = ExecutableDeployItem::StoredContractByHash {
             hash: [19; 32].into(),
-            entry_point: "non-existent-entry-point".to_string(),
+            entry_point: "call".to_string(),
             args: Default::default(),
         };
         Self::random_transfer_with_payment(rng, payment)
     }
 
     pub(crate) fn random_with_missing_entry_point_in_payment_contract(rng: &mut TestRng) -> Self {
-        let payment = ExecutableDeployItem::StoredContractByName {
-            name: "Test".to_string(),
+        let payment = ExecutableDeployItem::StoredContractByHash {
+            hash: [19; 32].into(),
             entry_point: "non-existent-entry-point".to_string(),
             args: Default::default(),
         };
@@ -1035,8 +1035,8 @@ impl Deploy {
     pub(crate) fn random_with_nonexistent_contract_version_in_payment_package(
         rng: &mut TestRng,
     ) -> Self {
-        let payment = ExecutableDeployItem::StoredVersionedContractByName {
-            name: "Test".to_string(),
+        let payment = ExecutableDeployItem::StoredVersionedContractByHash {
+            hash: [19; 32].into(),
             version: Some(6u32),
             entry_point: "non-existent-entry-point".to_string(),
             args: Default::default(),
@@ -1063,8 +1063,8 @@ impl Deploy {
     }
 
     pub(crate) fn random_with_missing_entry_point_in_session_contract(rng: &mut TestRng) -> Self {
-        let session = ExecutableDeployItem::StoredContractByName {
-            name: "Test".to_string(),
+        let session = ExecutableDeployItem::StoredContractByHash {
+            hash: [19; 32].into(),
             entry_point: "non-existent-entry-point".to_string(),
             args: Default::default(),
         };
@@ -1094,8 +1094,8 @@ impl Deploy {
     pub(crate) fn random_with_nonexistent_contract_version_in_session_package(
         rng: &mut TestRng,
     ) -> Self {
-        let session = ExecutableDeployItem::StoredVersionedContractByName {
-            name: "Test".to_string(),
+        let session = ExecutableDeployItem::StoredVersionedContractByHash {
+            hash: [19; 32].into(),
             version: Some(6u32),
             entry_point: "non-existent-entry-point".to_string(),
             args: Default::default(),

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -97,7 +97,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 65_536
+max_stack_height = 188
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -49,6 +49,8 @@ unbonding_delay = 14
 round_seigniorage_rate = [15_959, 6_204_824_582_392]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -84,9 +84,9 @@ max_block_size = 10_485_760
 # Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
 max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
-block_max_deploy_count = 75
+block_max_deploy_count = 50
 # The maximum number of wasm-less transfer deploys permitted in a single block.
-block_max_transfer_count = 1500
+block_max_transfer_count = 1250
 # The upper limit of total gas of all deploys in a block.
 block_gas_limit = 10_000_000_000_000
 # The limit of length of serialized payment code arguments.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -52,6 +52,8 @@ unbonding_delay = 7
 round_seigniorage_rate = [7, 87535408]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -100,7 +100,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 65_536
+max_stack_height = 188
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.2'
+version = '1.4.3'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -314,7 +314,7 @@ verify_accounts = true
 # If unset, defaults to 805,306,368,000 == 750 GiB.
 #
 # The size should be a multiple of the OS page size.
-#max_global_state_size = 805306368000
+max_global_state_size = 1_099_511_627_776
 
 # Optional depth limit to use for global state queries.
 #

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.2"
+        "version": "1.4.3"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "deploy_hash": "5C9b3b099C1378Aa8e4A5F07f59fF1FCDc69a83179427c7e67Ae0377d94d93FA"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480C3248Ef76B603D386F3F4F8a5F87F597d4EaffD475433f861af187Ab5Db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block_header": {
                     "accumulated_seed": "ac979F51525cfD979b14aA7Dc0737C5154eABe0DB9280eceaa8Dc8D2905B20d5",
                     "body_hash": "Cd502c5393A3c8B66d6979Ad7857507c9BAf5a8Ba16BA99c28378D3A970FFf42",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "changes": [
                     {
                       "public_key": "01D9bf2148748A85c89DA5AAd8ee0b0FC2D105fd39D41A4c796536354f0AE2900C",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block_hash": "13C2D7a68ECDD4b74BF4393C88915C836c863fC4bf11d7f2Bd930A1bBCcACdcb",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "era_summary": {
                     "block_hash": "13C2D7a68ECDD4b74BF4393C88915C836c863fC4bf11d7f2Bd930A1bBCcACdcb",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.2"
+        "version": "1.4.3"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.2",
+                  "api_version": "1.4.3",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -15,8 +15,8 @@ auction_delay = 3
 locked_funds_period = '90days'
 round_seigniorage_rate = [6_414, 623_437_335_209]
 unbonding_delay = 14
-# Maximum number of associated keys for a single account.
 max_associated_keys = 100
+max_runtime_call_stack_height = 12
 
 [highway]
 finality_threshold_fraction = [2, 25]

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -16,6 +16,7 @@ locked_funds_period = '90days'
 round_seigniorage_rate = [6_414, 623_437_335_209]
 unbonding_delay = 14
 max_associated_keys = 100
+max_runtime_call_stack_height = 12
 
 [highway]
 finality_threshold_fraction = [2, 25]

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -17,6 +17,7 @@ locked_funds_period = '90days'
 round_seigniorage_rate = [6_414, 623_437_335_209]
 unbonding_delay = 14
 max_associated_keys = 100
+max_runtime_call_stack_height = 12
 
 [highway]
 finality_threshold_fraction = [2, 25]

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.3" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "A library for developing Casper network smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license = "Apache-2.0"
 
 [dependencies]
-casper-types = { version = "1.4.2", path = "../../types" }
+casper-types = { version = "1.4.5", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -50,7 +50,7 @@
     all(not(test), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/1.4.2")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/1.4.3")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contracts/test/regression_20211110/Cargo.toml
+++ b/smart_contracts/contracts/test/regression_20211110/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "regression_20211110"
+version = "0.1.0"
+authors = ["Luís Fernando Schultz Xavier da Silveira <luis@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "regression_20211110"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/regression_20211110/src/main.rs
+++ b/smart_contracts/contracts/test/regression_20211110/src/main.rs
@@ -1,0 +1,42 @@
+#![no_std]
+#![no_main]
+
+#[macro_use]
+extern crate alloc;
+
+use casper_contract::contract_api::{runtime, storage};
+use casper_types::{
+    runtime_args, CLType, CLTyped, ContractHash, EntryPoint, EntryPointAccess, EntryPointType,
+    EntryPoints, Parameter, RuntimeArgs,
+};
+
+const RECURSE_ENTRYPOINT: &str = "recurse";
+const ARG_TARGET: &str = "target";
+const CONTRACT_HASH_NAME: &str = "regression-contract-hash";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mut entry_points = EntryPoints::new();
+    entry_points.add_entry_point(EntryPoint::new(
+        RECURSE_ENTRYPOINT,
+        vec![Parameter::new(ARG_TARGET, ContractHash::cl_type())],
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    ));
+
+    let (contract_hash, _contract_version) =
+        storage::new_locked_contract(entry_points, None, None, None);
+
+    runtime::put_key(CONTRACT_HASH_NAME, contract_hash.into());
+}
+
+#[no_mangle]
+pub extern "C" fn recurse() {
+    let target: ContractHash = runtime::get_named_arg(ARG_TARGET);
+    let _ret: () = runtime::call_contract(
+        target,
+        RECURSE_ENTRYPOINT,
+        runtime_args! { ARG_TARGET => target },
+    );
+}

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -28,7 +28,42 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [1.4.0] - 2021-10-04
+
+## 1.4.5 - 2021-12-06
+
+### Added
+* Add function to `auction::MintProvider` trait to support minting into an existing purse.
+
+### Changed
+* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests. 
+
+
+
+## [1.4.4] - 2021-11-18
+
+### Fixed
+* Revert the accidental change to the `std` feature causing a broken build when this feature is enabled.
+
+
+
+## [1.4.3] - 2021-11-17 [YANKED]
+
+
+
+## [1.4.2] - 2021-11-13 [YANKED]
+
+### Added
+* Add checksummed hex encoding following a scheme similar to [EIP-55](https://eips.ethereum.org/EIPS/eip-55).
+
+
+
+## [1.4.1] - 2021-10-23
+
+No changes.
+
+
+
+## [1.4.0] - 2021-10-21 [YANKED]
 
 ### Added
 * Add `json-schema` feature, disabled by default, to enable many types to be used to produce JSON-schema data.
@@ -94,7 +129,10 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-node/compare/v1.4.0...dev
+[unreleased]: https://github.com/casper-network/casper-node/compare/24fc4027a...dev
+[1.4.3]: https://github.com/casper-network/casper-node/compare/2be27b3f5...24fc4027a
+[1.4.2]: https://github.com/casper-network/casper-node/compare/v1.4.1...2be27b3f5
+[1.4.1]: https://github.com/casper-network/casper-node/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/casper-network/casper-node/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/casper-network/casper-node/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/casper-network/casper-node/compare/v1.1.1...v1.2.0

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Changed
-* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests.
+* Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 
 
 
@@ -25,17 +25,6 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests.
-
-
-
-
-## 1.4.5 - 2021-12-06
-
-### Added
-* Add function to `auction::MintProvider` trait to support minting into an existing purse.
-
-### Changed
-* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests. 
 
 
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Changed
+* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests.
+
 
 
 ## 1.4.5 - 2021-12-06
@@ -21,8 +24,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add function to `auction::MintProvider` trait to support minting into an existing purse.
 
 ### Changed
-* Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
-* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests. 
+* Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests.
 
 
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+
+
+## 1.4.5 - 2021-12-06
+
+### Added
+* Add function to `auction::MintProvider` trait to support minting into an existing purse.
+
 ### Changed
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 * Change checksummed hex implementation to use 32 byte rather than 64 byte blake2b digests. 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -32,7 +32,6 @@ schemars = { version = "=0.8.5", features = ["preserve_order"], optional = true 
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
 serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"] }
-thiserror = { version = "1.0.29", optional = true }
 uint = { version = "0.9.0", default-features = false }
 version-sync = { version = "0.9", optional = true }
 
@@ -49,7 +48,8 @@ strum = { version = "0.21", features = ["derive"] }
 [features]
 json-schema = ["once_cell", "schemars"]
 gens = ["proptest"]
-std = ["thiserror"]
+# DEPRECATED - enabling `std` has no effect.
+std = []
 
 [[bench]]
 name = "bytesrepr_bench"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "1.4.2" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.5" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -106,7 +106,6 @@ pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Erro
 
 /// Serialization and deserialization errors.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
 #[repr(u8)]
 pub enum Error {
     /// Early end of stream while deserializing.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/1.4.2")]
+#![doc(html_root_url = "https://docs.rs/casper-types/1.4.5")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     CLType, CLTyped, PublicKey, URef, U512,
 };
 
-pub use vesting::VestingSchedule;
+pub use vesting::{VestingSchedule, VESTING_SCHEDULE_LENGTH_MILLIS};
 
 /// An entry in the validator map.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -108,6 +108,17 @@ impl Bid {
     /// Gets the bonding purse of the provided bid
     pub fn bonding_purse(&self) -> &URef {
         &self.bonding_purse
+    }
+
+    /// Checks if a bid is still locked under a vesting schedule.
+    ///
+    /// Returns true if a timestamp falls below the initial lockup period + 91 days release
+    /// schedule, otherwise false.
+    pub fn is_locked(&self, timestamp_millis: u64) -> bool {
+        match self.vesting_schedule {
+            Some(vesting_schedule) => vesting_schedule.is_vesting(timestamp_millis),
+            None => false,
+        }
     }
 
     /// Gets the staked amount of the provided bid

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -13,11 +13,15 @@ use crate::{
     U512,
 };
 
-const VESTING_SCHEDULE_LENGTH_DAYS: usize = 91;
+const DAY_MILLIS: usize = 24 * 60 * 60 * 1000;
 const DAYS_IN_WEEK: usize = 7;
+const WEEK_MILLIS: usize = DAYS_IN_WEEK * DAY_MILLIS;
 
-const WEEK_MILLIS: usize = DAYS_IN_WEEK * 24 * 60 * 60 * 1000;
-
+/// Length of total vesting schedule in days.
+const VESTING_SCHEDULE_LENGTH_DAYS: usize = 91;
+/// Length of total vesting schedule expressed in days.
+pub const VESTING_SCHEDULE_LENGTH_MILLIS: u64 =
+    VESTING_SCHEDULE_LENGTH_DAYS as u64 * DAY_MILLIS as u64;
 /// 91 days / 7 days in a week = 13 weeks
 const LOCKED_AMOUNTS_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEEK) + 1;
 
@@ -71,17 +75,30 @@ impl VestingSchedule {
     }
 
     pub fn locked_amount(&self, timestamp_millis: u64) -> Option<U512> {
-        self.locked_amounts.map(|locked_amounts| {
-            assert!(u64::MAX as usize <= usize::MAX);
+        let locked_amounts = self.locked_amounts.as_ref()?;
+
+        let index = {
             let index_timestamp =
-                (timestamp_millis - self.initial_release_timestamp_millis) as usize;
-            let index = index_timestamp / WEEK_MILLIS;
-            if index < LOCKED_AMOUNTS_LENGTH {
-                locked_amounts[index]
-            } else {
-                U512::zero()
-            }
-        })
+                timestamp_millis.checked_sub(self.initial_release_timestamp_millis)?;
+            (index_timestamp as usize).checked_div(WEEK_MILLIS)?
+        };
+
+        let locked_amount = if index < LOCKED_AMOUNTS_LENGTH {
+            locked_amounts[index]
+        } else {
+            U512::zero()
+        };
+
+        Some(locked_amount)
+    }
+
+    /// Checks if this vesting schedule is still under the vesting
+    pub(crate) fn is_vesting(&self, timestamp_millis: u64) -> bool {
+        let vested_period = self
+            .initial_release_timestamp_millis()
+            .saturating_add(VESTING_SCHEDULE_LENGTH_MILLIS as u64);
+
+        timestamp_millis < vested_period
     }
 }
 
@@ -191,11 +208,20 @@ mod tests {
 
     /// Default lock-in period of 90 days
     const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * 24 * 60 * 60 * 1000;
+    const RELEASE_TIMESTAMP: u64 = DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    const STAKE: u64 = 140;
+
+    #[test]
+    fn test_locked_amount_check_should_not_panic() {
+        let mut vesting_schedule = VestingSchedule::new(RELEASE_TIMESTAMP);
+        vesting_schedule.initialize(U512::from(STAKE));
+
+        assert_eq!(vesting_schedule.locked_amount(0), None);
+        assert_eq!(vesting_schedule.locked_amount(RELEASE_TIMESTAMP - 1), None);
+    }
 
     #[test]
     fn test_locked_amount() {
-        const STAKE: u64 = 140;
-        const RELEASE_TIMESTAMP: u64 = DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
         let mut vesting_schedule = VestingSchedule::new(RELEASE_TIMESTAMP);
         vesting_schedule.initialize(U512::from(STAKE));
 

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -267,10 +267,19 @@ pub enum Error {
     // system contracts will be dropped.
     #[doc(hidden)]
     GasLimit = 40,
-
+    /// Too many frames on the runtime stack.
+    /// ```
+    /// # use casper_types::system::auction::Error;
+    /// assert_eq!(41, Error::RuntimeStackOverflow as u8);
+    /// ```
+    RuntimeStackOverflow = 41,
     /// An error that is raised when there is an error in the mint contract that cannot
     /// be mapped to a specific auction error.
-    MintError = 41,
+    /// ```
+    /// # use casper_types::system::auction::Error;
+    /// assert_eq!(42, Error::MintError as u8);
+    /// ```
+    MintError = 42,
 }
 
 impl Display for Error {
@@ -316,6 +325,7 @@ impl Display for Error {
             Error::DelegationRateTooLarge => formatter.write_str("Delegation rate too large"),
             Error::DelegatorFundsLocked => formatter.write_str("Delegator's funds are locked"),
             Error::ArithmeticOverflow => formatter.write_str("Arithmetic overflow"),
+            Error::RuntimeStackOverflow => formatter.write_str("Runtime stack overflow"),
             Error::MintError => formatter.write_str("An error in the mint contract execution"),
             Error::GasLimit => formatter.write_str("GasLimit"),
         }
@@ -388,6 +398,7 @@ impl TryFrom<u8> for Error {
             d if d == Error::GasLimit as u8 => Ok(Error::GasLimit),
             d if d == Error::ArithmeticOverflow as u8 => Ok(Error::ArithmeticOverflow),
             d if d == Error::GasLimit as u8 => Ok(Error::GasLimit),
+            d if d == Error::RuntimeStackOverflow as u8 => Ok(Error::RuntimeStackOverflow),
             d if d == Error::MintError as u8 => Ok(Error::MintError),
             _ => Err(TryFromU8ForError(())),
         }

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -395,7 +395,6 @@ impl TryFrom<u8> for Error {
             d if d == Error::Transfer as u8 => Ok(Error::Transfer),
             d if d == Error::DelegationRateTooLarge as u8 => Ok(Error::DelegationRateTooLarge),
             d if d == Error::DelegatorFundsLocked as u8 => Ok(Error::DelegatorFundsLocked),
-            d if d == Error::GasLimit as u8 => Ok(Error::GasLimit),
             d if d == Error::ArithmeticOverflow as u8 => Ok(Error::ArithmeticOverflow),
             d if d == Error::GasLimit as u8 => Ok(Error::GasLimit),
             d if d == Error::RuntimeStackOverflow as u8 => Ok(Error::RuntimeStackOverflow),

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -95,7 +95,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 65_536
+max_stack_height = 188
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -47,6 +47,8 @@ unbonding_delay = 14
 round_seigniorage_rate = [0, 1]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -95,7 +95,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 65_536
+max_stack_height = 188
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -47,6 +47,8 @@ unbonding_delay = 14
 round_seigniorage_rate = [15_959, 6_204_824_582_392]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -95,7 +95,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 65_536
+max_stack_height = 188
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -47,6 +47,8 @@ unbonding_delay = 14
 round_seigniorage_rate = [15_959, 6_204_824_582_392]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -312,7 +312,8 @@ pub async fn download_trie(
         .await?;
         if let Some(blob) = read_result.maybe_trie_bytes {
             let bytes: Vec<u8> = blob.into();
-            let (trie, _): (Trie<Key, StoredValue>, _) = FromBytes::from_bytes(&bytes)?;
+            let (trie, _): (Trie<Key, StoredValue>, _) =
+                FromBytes::from_bytes(&bytes).map_err(anyhow::Error::msg)?;
             let mut missing_descendants = engine_state
                 .put_trie_and_find_missing_descendant_trie_keys(CorrelationId::new(), &trie)?;
             outstanding_tries.append(&mut missing_descendants);


### PR DESCRIPTION
PRs that we already backported. There's one manual commit where I've run through a dry run of 1.4.3 merge and applied the remaining changes that we backported but modified without changing dev again.

I cherry-picked squashed PRs that weren't backports. All PRs were squashed into one commit before cherry-picking.

- `#13` deploy acceptor fix
- `#14` Call stack
- `#22` stack height
- `#25` version bumps
- `#27` Validator slots