### PR TITLE
Increse contract_as package version

### DIFF
--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {


### PR DESCRIPTION
We already have the 1.4.2 release published to npmjs, and the code still specifies 1.4.1 as a version which is also published already. To avoid conflicts we need to bump the version before next release