### PR TITLE
Fix the balance test

### DIFF
--- a/utils/global-state-update-gen/src/balances.rs
+++ b/utils/global-state-update-gen/src/balances.rs
@@ -1,7 +1,7 @@
 use clap::ArgMatches;
 
 use casper_engine_test_support::{DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder};
-use casper_execution_engine::shared::transform::Transform;
+use casper_execution_engine::shared::{additive_map::AdditiveMap, transform::Transform};
 use casper_types::{
     account::AccountHash, runtime_args, system::mint, AsymmetricType, Key, PublicKey, RuntimeArgs,
     U512,
@@ -40,9 +40,15 @@ pub(crate) fn generate_balances_update(matches: &ArgMatches<'_>) {
 
     builder.exec(no_wasm_transfer_request).expect_success();
 
-    let transforms = builder.get_execution_journals();
+    // Combine the journal into an AdditiveMap in order to collapse Writes and Adds into just Writes
+    let transforms = builder
+        .get_execution_journals()
+        .into_iter()
+        .map(AdditiveMap::from)
+        .next()
+        .unwrap();
 
-    for (key, value) in transforms[0].clone() {
+    for (key, value) in transforms {
         if let Transform::Write(val) = value {
             print_entry(&key, &val);
         }


### PR DESCRIPTION
This fixes the recent nightly failure in the emergency update test for balances.

When transferring funds to a new account, it is first created with a balance of 0, and then funds are added to it. This creates two transforms, a `Write` and an `AddUInt512`. Since `global-state-update-gen` only dumps the `Write`s to the update file, the addition was effectively ignored and the balance remained at 0.

Converting the `ExecutionJournal` to an `AdditiveMap` combines these into a single `Write`, causing the utility to generate a correct file and the test to pass again.

Fixes https://github.com/casper-network/sre/issues/292