### PR TITLE
Fix `casper-engine-test-support` CHANGELOG.

### DIFF
--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Added
+* Added `WasmTestBuilder::get_execution_journals` method for returning execution journals for all test runs.
+
+### Changed
+* `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.
 
 
 ## 2.0.3 - 2021-12-06
@@ -20,14 +25,10 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Added `WasmTestBuilder::get_balance_keys` function.
 
-
-
 ## 2.0.2 - 2021-11-24
 
 ### Changed
 * Revert the change to the path detection logic applied in v2.0.1.
-* `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.
-
 
 ## [2.0.1] - 2021-11-4
 


### PR DESCRIPTION
`WasmTestBuilder::get_execution_journals` has [not been published yet ](https://docs.rs/casper-engine-test-support/2.0.3/casper_engine_test_support/struct.WasmTestBuilder.html?search=get_execution_journals)but the CHANGELOG made it look like it has. 