### PR TITLE
Add gauge metric for latest commit_step

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -19,7 +19,6 @@ pub mod rpc_server;
 #[cfg(test)]
 pub mod in_memory_network;
 pub(crate) mod metrics;
-pub(crate) mod networking_metrics;
 pub(crate) mod small_network;
 pub mod storage;
 

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -46,7 +46,7 @@ use cached_state::CachedState;
 pub use config::Config;
 use deploy_sets::{BlockProposerDeploySets, PruneResult};
 pub(crate) use event::{DeployInfo, Event};
-use metrics::BlockProposerMetrics;
+use metrics::Metrics;
 
 /// Block proposer component.
 #[derive(DataSize, Debug)]
@@ -55,7 +55,7 @@ pub(crate) struct BlockProposer {
     state: BlockProposerState,
 
     /// Metrics, present in all states.
-    metrics: BlockProposerMetrics,
+    metrics: Metrics,
 }
 
 const STATE_KEY: &[u8] = b"block proposer";
@@ -132,7 +132,7 @@ impl BlockProposer {
                 deploy_config: chainspec.deploy_config,
                 local_config,
             },
-            metrics: BlockProposerMetrics::new(registry)?,
+            metrics: Metrics::new(registry)?,
         };
 
         Ok((block_proposer, effects))

--- a/node/src/components/block_proposer/metrics.rs
+++ b/node/src/components/block_proposer/metrics.rs
@@ -5,7 +5,7 @@ use crate::unregister_metric;
 
 /// Metrics for the block proposer.
 #[derive(DataSize, Debug, Clone)]
-pub(super) struct BlockProposerMetrics {
+pub(super) struct Metrics {
     /// Amount of pending deploys
     #[data_size(skip)]
     pub(super) pending_deploys: IntGauge,
@@ -14,19 +14,19 @@ pub(super) struct BlockProposerMetrics {
     registry: Registry,
 }
 
-impl BlockProposerMetrics {
+impl Metrics {
     /// Creates a new instance of the block proposer metrics.
     pub fn new(registry: Registry) -> Result<Self, prometheus::Error> {
-        let pending_deploys = IntGauge::new("pending_deploy", "amount of pending deploys")?;
+        let pending_deploys = IntGauge::new("pending_deploy", "the number of pending deploys")?;
         registry.register(Box::new(pending_deploys.clone()))?;
-        Ok(BlockProposerMetrics {
+        Ok(Metrics {
             pending_deploys,
             registry,
         })
     }
 }
 
-impl Drop for BlockProposerMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.pending_deploys);
     }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -37,7 +37,7 @@ use crate::{
             ConsensusProtocol, EraReport, FinalizedBlock as CpFinalizedBlock, ProposedBlock,
             ProtocolOutcome,
         },
-        metrics::ConsensusMetrics,
+        metrics::Metrics,
         traits::NodeIdT,
         validator_change::ValidatorChanges,
         ActionId, Config, ConsensusMessage, Event, NewBlockPayload, ReactorEventT, ResolveValidity,
@@ -103,7 +103,7 @@ pub struct EraSupervisor<I> {
     /// The height of the next block to be executed. If this falls too far behind, we pause.
     next_executed_height: u64,
     #[data_size(skip)]
-    metrics: ConsensusMetrics,
+    metrics: Metrics,
     /// The path to the folder where unit files will be stored.
     unit_files_folder: PathBuf,
     /// The next upgrade activation point. When the era immediately before the activation point is
@@ -151,8 +151,8 @@ where
         let (root, config) = config.into_parts();
         let (secret_signing_key, public_signing_key) = config.load_keys(root)?;
         info!(our_id = %public_signing_key, "EraSupervisor pubkey",);
-        let metrics = ConsensusMetrics::new(registry)
-            .expect("failure to setup and register ConsensusMetrics");
+        let metrics =
+            Metrics::new(registry).expect("failure to setup and register ConsensusMetrics");
         let activation_era_id = protocol_config.last_activation_point;
         let auction_delay = protocol_config.auction_delay;
         #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.

--- a/node/src/components/consensus/metrics.rs
+++ b/node/src/components/consensus/metrics.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Network metrics to track Consensus
 #[derive(Debug)]
-pub(super) struct ConsensusMetrics {
+pub(super) struct Metrics {
     /// Gauge to track time between proposal and finalization.
     finalization_time: Gauge,
     /// Amount of finalized blocks.
@@ -22,11 +22,11 @@ pub(super) struct ConsensusMetrics {
     registry: Registry,
 }
 
-impl ConsensusMetrics {
+impl Metrics {
     pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
         let finalization_time = Gauge::new(
             "finalization_time",
-            "the amount of time, in milliseconds, between proposal and finalization of a block",
+            "the amount of time, in milliseconds, between proposal and finalization of the latest finalized block",
         )?;
         let finalized_block_count =
             IntGauge::new("amount_of_blocks", "the number of blocks finalized so far")?;
@@ -38,13 +38,13 @@ impl ConsensusMetrics {
             "time_of_last_finalized_block",
             "timestamp of the most recently finalized block",
         )?;
-        let current_era = IntGauge::new("current_era", "The current era")?;
+        let current_era = IntGauge::new("current_era", "the current era")?;
         registry.register(Box::new(finalization_time.clone()))?;
         registry.register(Box::new(finalized_block_count.clone()))?;
         registry.register(Box::new(current_era.clone()))?;
         registry.register(Box::new(time_of_last_proposed_block.clone()))?;
         registry.register(Box::new(time_of_last_finalized_block.clone()))?;
-        Ok(ConsensusMetrics {
+        Ok(Metrics {
             finalization_time,
             finalized_block_count,
             time_of_last_proposed_block,
@@ -71,7 +71,7 @@ impl ConsensusMetrics {
     }
 }
 
-impl Drop for ConsensusMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.finalization_time);
         unregister_metric!(self.registry, self.finalized_block_count);

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -2,6 +2,7 @@
 pub(crate) mod announcements;
 mod config;
 mod error;
+mod metrics;
 mod operations;
 mod types;
 
@@ -16,7 +17,7 @@ use std::{
 
 use datasize::DataSize;
 use lmdb::DatabaseFlags;
-use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
+use prometheus::Registry;
 use serde::Serialize;
 use tracing::{debug, info, trace};
 
@@ -47,6 +48,7 @@ use crate::{
 pub(crate) use announcements::ContractRuntimeAnnouncement;
 pub(crate) use config::Config;
 pub(crate) use error::{BlockExecutionError, ConfigError};
+use metrics::Metrics;
 pub use operations::execute_finalized_block;
 pub use types::BlockAndExecutionEffects;
 pub(crate) use types::EraValidatorsRequest;
@@ -132,7 +134,7 @@ type ExecQueue = Arc<Mutex<BTreeMap<u64, (FinalizedBlock, Vec<Deploy>, Vec<Deplo
 pub(crate) struct ContractRuntime {
     execution_pre_state: Arc<Mutex<ExecutionPreState>>,
     engine_state: Arc<EngineState<LmdbGlobalState>>,
-    metrics: Arc<ContractRuntimeMetrics>,
+    metrics: Arc<Metrics>,
     protocol_version: ProtocolVersion,
 
     /// Finalized blocks waiting for their pre-state hash to start executing.
@@ -142,126 +144,6 @@ pub(crate) struct ContractRuntime {
 impl Debug for ContractRuntime {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContractRuntime").finish()
-    }
-}
-
-/// Metrics for the contract runtime component.
-#[derive(Debug)]
-pub struct ContractRuntimeMetrics {
-    run_execute: Histogram,
-    apply_effect: Histogram,
-    commit_upgrade: Histogram,
-    run_query: Histogram,
-    commit_step: Histogram,
-    get_balance: Histogram,
-    get_validator_weights: Histogram,
-    get_era_validators: Histogram,
-    get_bids: Histogram,
-    missing_trie_keys: Histogram,
-    put_trie: Histogram,
-    get_trie: Histogram,
-    chain_height: IntGauge,
-    exec_block: Histogram,
-}
-
-/// Value of upper bound of histogram.
-const EXPONENTIAL_BUCKET_START: f64 = 0.01;
-
-/// Multiplier of previous upper bound for next bound.
-const EXPONENTIAL_BUCKET_FACTOR: f64 = 2.0;
-
-/// Bucket count, with the last bucket going to +Inf which will not be included in the results.
-/// - start = 0.01, factor = 2.0, count = 10
-/// - start * factor ^ count = 0.01 * 2.0 ^ 10 = 10.24
-/// - Values above 10.24 (f64 seconds here) will not fall in a bucket that is kept.
-const EXPONENTIAL_BUCKET_COUNT: usize = 10;
-
-const RUN_EXECUTE_NAME: &str = "contract_runtime_run_execute";
-const RUN_EXECUTE_HELP: &str = "tracking run of engine_state.run_execute in seconds.";
-const APPLY_EFFECT_NAME: &str = "contract_runtime_apply_commit";
-const APPLY_EFFECT_HELP: &str = "tracking run of engine_state.apply_effect in seconds.";
-const RUN_QUERY_NAME: &str = "contract_runtime_run_query";
-const RUN_QUERY_HELP: &str = "tracking run of engine_state.run_query in seconds.";
-const COMMIT_STEP_NAME: &str = "contract_runtime_commit_step";
-const COMMIT_STEP_HELP: &str = "tracking run of engine_state.commit_step in seconds.";
-const COMMIT_UPGRADE_NAME: &str = "contract_runtime_commit_upgrade";
-const COMMIT_UPGRADE_HELP: &str = "tracking run of engine_state.commit_upgrade in seconds";
-const GET_BALANCE_NAME: &str = "contract_runtime_get_balance";
-const GET_BALANCE_HELP: &str = "tracking run of engine_state.get_balance in seconds.";
-const GET_VALIDATOR_WEIGHTS_NAME: &str = "contract_runtime_get_validator_weights";
-const GET_VALIDATOR_WEIGHTS_HELP: &str =
-    "tracking run of engine_state.get_validator_weights in seconds.";
-const GET_ERA_VALIDATORS_NAME: &str = "contract_runtime_get_era_validators";
-const GET_ERA_VALIDATORS_HELP: &str = "tracking run of engine_state.get_era_validators in seconds.";
-const GET_BIDS_NAME: &str = "contract_runtime_get_bids";
-const GET_BIDS_HELP: &str = "tracking run of engine_state.get_bids in seconds.";
-const GET_TRIE_NAME: &str = "contract_runtime_get_trie";
-const GET_TRIE_HELP: &str = "tracking run of engine_state.get_trie in seconds.";
-const PUT_TRIE_NAME: &str = "contract_runtime_put_trie";
-const PUT_TRIE_HELP: &str = "tracking run of engine_state.put_trie in seconds.";
-const MISSING_TRIE_KEYS_NAME: &str = "contract_runtime_missing_trie_keys";
-const MISSING_TRIE_KEYS_HELP: &str = "tracking run of engine_state.missing_trie_keys in seconds.";
-const EXEC_BLOCK_NAME: &str = "contract_runtime_execute_block";
-const EXEC_BLOCK_HELP: &str = "tracking execution of all deploys in a block.";
-
-/// Create prometheus Histogram and register.
-fn register_histogram_metric(
-    registry: &Registry,
-    metric_name: &str,
-    metric_help: &str,
-) -> Result<Histogram, prometheus::Error> {
-    let common_buckets = prometheus::exponential_buckets(
-        EXPONENTIAL_BUCKET_START,
-        EXPONENTIAL_BUCKET_FACTOR,
-        EXPONENTIAL_BUCKET_COUNT,
-    )?;
-    let histogram_opts = HistogramOpts::new(metric_name, metric_help).buckets(common_buckets);
-    let histogram = Histogram::with_opts(histogram_opts)?;
-    registry.register(Box::new(histogram.clone()))?;
-    Ok(histogram)
-}
-
-impl ContractRuntimeMetrics {
-    /// Constructor of metrics which creates and registers metrics objects for use.
-    fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let chain_height = IntGauge::new("chain_height", "current chain height")?;
-        registry.register(Box::new(chain_height.clone()))?;
-        Ok(ContractRuntimeMetrics {
-            chain_height,
-            run_execute: register_histogram_metric(registry, RUN_EXECUTE_NAME, RUN_EXECUTE_HELP)?,
-            apply_effect: register_histogram_metric(
-                registry,
-                APPLY_EFFECT_NAME,
-                APPLY_EFFECT_HELP,
-            )?,
-            run_query: register_histogram_metric(registry, RUN_QUERY_NAME, RUN_QUERY_HELP)?,
-            commit_step: register_histogram_metric(registry, COMMIT_STEP_NAME, COMMIT_STEP_HELP)?,
-            commit_upgrade: register_histogram_metric(
-                registry,
-                COMMIT_UPGRADE_NAME,
-                COMMIT_UPGRADE_HELP,
-            )?,
-            get_balance: register_histogram_metric(registry, GET_BALANCE_NAME, GET_BALANCE_HELP)?,
-            get_validator_weights: register_histogram_metric(
-                registry,
-                GET_VALIDATOR_WEIGHTS_NAME,
-                GET_VALIDATOR_WEIGHTS_HELP,
-            )?,
-            get_era_validators: register_histogram_metric(
-                registry,
-                GET_ERA_VALIDATORS_NAME,
-                GET_ERA_VALIDATORS_HELP,
-            )?,
-            get_bids: register_histogram_metric(registry, GET_BIDS_NAME, GET_BIDS_HELP)?,
-            get_trie: register_histogram_metric(registry, GET_TRIE_NAME, GET_TRIE_HELP)?,
-            put_trie: register_histogram_metric(registry, PUT_TRIE_NAME, PUT_TRIE_HELP)?,
-            missing_trie_keys: register_histogram_metric(
-                registry,
-                MISSING_TRIE_KEYS_NAME,
-                MISSING_TRIE_KEYS_HELP,
-            )?,
-            exec_block: register_histogram_metric(registry, EXEC_BLOCK_NAME, EXEC_BLOCK_HELP)?,
-        })
     }
 }
 
@@ -580,7 +462,7 @@ impl ContractRuntime {
 
         let engine_state = Arc::new(EngineState::new(global_state, engine_config));
 
-        let metrics = Arc::new(ContractRuntimeMetrics::new(registry)?);
+        let metrics = Arc::new(Metrics::new(registry)?);
 
         Ok(ContractRuntime {
             execution_pre_state,
@@ -648,7 +530,7 @@ impl ContractRuntime {
     #[allow(clippy::too_many_arguments)]
     async fn execute_finalized_block_or_requeue<REv>(
         engine_state: Arc<EngineState<LmdbGlobalState>>,
-        metrics: Arc<ContractRuntimeMetrics>,
+        metrics: Arc<Metrics>,
         exec_queue: ExecQueue,
         execution_pre_state: Arc<Mutex<ExecutionPreState>>,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components/contract_runtime/metrics.rs
+++ b/node/src/components/contract_runtime/metrics.rs
@@ -1,0 +1,193 @@
+use prometheus::{self, Histogram, IntGauge, Registry};
+
+use crate::{unregister_metric, utils};
+
+/// Value of upper bound of histogram.
+const EXPONENTIAL_BUCKET_START: f64 = 0.01;
+
+/// Multiplier of previous upper bound for next bound.
+const EXPONENTIAL_BUCKET_FACTOR: f64 = 2.0;
+
+/// Bucket count, with the last bucket going to +Inf which will not be included in the results.
+/// - start = 0.01, factor = 2.0, count = 10
+/// - start * factor ^ count = 0.01 * 2.0 ^ 10 = 10.24
+/// - Values above 10.24 (f64 seconds here) will not fall in a bucket that is kept.
+const EXPONENTIAL_BUCKET_COUNT: usize = 10;
+
+const RUN_EXECUTE_NAME: &str = "contract_runtime_run_execute";
+const RUN_EXECUTE_HELP: &str = "time in seconds to execute but not commit a contract";
+
+const APPLY_EFFECT_NAME: &str = "contract_runtime_apply_commit";
+const APPLY_EFFECT_HELP: &str = "time in seconds to commit the execution effects of a contract";
+
+const COMMIT_UPGRADE_NAME: &str = "contract_runtime_commit_upgrade";
+const COMMIT_UPGRADE_HELP: &str = "time in seconds to commit an upgrade";
+
+const RUN_QUERY_NAME: &str = "contract_runtime_run_query";
+const RUN_QUERY_HELP: &str = "time in seconds to run a query in global state";
+
+const COMMIT_STEP_NAME: &str = "contract_runtime_commit_step";
+const COMMIT_STEP_HELP: &str = "time in seconds to commit the step at era end";
+
+const GET_BALANCE_NAME: &str = "contract_runtime_get_balance";
+const GET_BALANCE_HELP: &str = "time in seconds to get the balance of a purse from global state";
+
+const GET_VALIDATOR_WEIGHTS_NAME: &str = "contract_runtime_get_validator_weights";
+const GET_VALIDATOR_WEIGHTS_HELP: &str =
+    "time in seconds to get validator weights from global state";
+
+const GET_ERA_VALIDATORS_NAME: &str = "contract_runtime_get_era_validators";
+const GET_ERA_VALIDATORS_HELP: &str =
+    "time in seconds to get validators for a given era from global state";
+
+const GET_BIDS_NAME: &str = "contract_runtime_get_bids";
+const GET_BIDS_HELP: &str = "time in seconds to get bids from global state";
+
+const MISSING_TRIE_KEYS_NAME: &str = "contract_runtime_missing_trie_keys";
+const MISSING_TRIE_KEYS_HELP: &str = "time in seconds to get missing trie keys";
+
+const PUT_TRIE_NAME: &str = "contract_runtime_put_trie";
+const PUT_TRIE_HELP: &str = "time in seconds to put a trie";
+
+const GET_TRIE_NAME: &str = "contract_runtime_get_trie";
+const GET_TRIE_HELP: &str = "time in seconds to get a trie";
+
+const CHAIN_HEIGHT_NAME: &str = "chain_height";
+const CHAIN_HEIGHT_HELP: &str = "current chain height";
+
+const EXEC_BLOCK_NAME: &str = "contract_runtime_execute_block";
+const EXEC_BLOCK_HELP: &str = "time in seconds to execute all deploys in a block";
+
+/// Metrics for the contract runtime component.
+#[derive(Debug)]
+pub struct Metrics {
+    pub(super) run_execute: Histogram,
+    pub(super) apply_effect: Histogram,
+    pub(super) commit_upgrade: Histogram,
+    pub(super) run_query: Histogram,
+    pub(super) commit_step: Histogram,
+    pub(super) get_balance: Histogram,
+    pub(super) get_validator_weights: Histogram,
+    pub(super) get_era_validators: Histogram,
+    pub(super) get_bids: Histogram,
+    pub(super) missing_trie_keys: Histogram,
+    pub(super) put_trie: Histogram,
+    pub(super) get_trie: Histogram,
+    pub(super) chain_height: IntGauge,
+    pub(super) exec_block: Histogram,
+    registry: Registry,
+}
+
+impl Metrics {
+    /// Constructor of metrics which creates and registers metrics objects for use.
+    pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let common_buckets = prometheus::exponential_buckets(
+            EXPONENTIAL_BUCKET_START,
+            EXPONENTIAL_BUCKET_FACTOR,
+            EXPONENTIAL_BUCKET_COUNT,
+        )?;
+        let chain_height = IntGauge::new(CHAIN_HEIGHT_NAME, CHAIN_HEIGHT_HELP)?;
+        registry.register(Box::new(chain_height.clone()))?;
+        Ok(Metrics {
+            chain_height,
+            run_execute: utils::register_histogram_metric(
+                registry,
+                RUN_EXECUTE_NAME,
+                RUN_EXECUTE_HELP,
+                common_buckets.clone(),
+            )?,
+            apply_effect: utils::register_histogram_metric(
+                registry,
+                APPLY_EFFECT_NAME,
+                APPLY_EFFECT_HELP,
+                common_buckets.clone(),
+            )?,
+            run_query: utils::register_histogram_metric(
+                registry,
+                RUN_QUERY_NAME,
+                RUN_QUERY_HELP,
+                common_buckets.clone(),
+            )?,
+            commit_step: utils::register_histogram_metric(
+                registry,
+                COMMIT_STEP_NAME,
+                COMMIT_STEP_HELP,
+                common_buckets.clone(),
+            )?,
+            commit_upgrade: utils::register_histogram_metric(
+                registry,
+                COMMIT_UPGRADE_NAME,
+                COMMIT_UPGRADE_HELP,
+                common_buckets.clone(),
+            )?,
+            get_balance: utils::register_histogram_metric(
+                registry,
+                GET_BALANCE_NAME,
+                GET_BALANCE_HELP,
+                common_buckets.clone(),
+            )?,
+            get_validator_weights: utils::register_histogram_metric(
+                registry,
+                GET_VALIDATOR_WEIGHTS_NAME,
+                GET_VALIDATOR_WEIGHTS_HELP,
+                common_buckets.clone(),
+            )?,
+            get_era_validators: utils::register_histogram_metric(
+                registry,
+                GET_ERA_VALIDATORS_NAME,
+                GET_ERA_VALIDATORS_HELP,
+                common_buckets.clone(),
+            )?,
+            get_bids: utils::register_histogram_metric(
+                registry,
+                GET_BIDS_NAME,
+                GET_BIDS_HELP,
+                common_buckets.clone(),
+            )?,
+            get_trie: utils::register_histogram_metric(
+                registry,
+                GET_TRIE_NAME,
+                GET_TRIE_HELP,
+                common_buckets.clone(),
+            )?,
+            put_trie: utils::register_histogram_metric(
+                registry,
+                PUT_TRIE_NAME,
+                PUT_TRIE_HELP,
+                common_buckets.clone(),
+            )?,
+            missing_trie_keys: utils::register_histogram_metric(
+                registry,
+                MISSING_TRIE_KEYS_NAME,
+                MISSING_TRIE_KEYS_HELP,
+                common_buckets.clone(),
+            )?,
+            exec_block: utils::register_histogram_metric(
+                registry,
+                EXEC_BLOCK_NAME,
+                EXEC_BLOCK_HELP,
+                common_buckets,
+            )?,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.run_execute);
+        unregister_metric!(self.registry, self.apply_effect);
+        unregister_metric!(self.registry, self.commit_upgrade);
+        unregister_metric!(self.registry, self.run_query);
+        unregister_metric!(self.registry, self.commit_step);
+        unregister_metric!(self.registry, self.get_balance);
+        unregister_metric!(self.registry, self.get_validator_weights);
+        unregister_metric!(self.registry, self.get_era_validators);
+        unregister_metric!(self.registry, self.get_bids);
+        unregister_metric!(self.registry, self.missing_trie_keys);
+        unregister_metric!(self.registry, self.put_trie);
+        unregister_metric!(self.registry, self.get_trie);
+        unregister_metric!(self.registry, self.chain_height);
+        unregister_metric!(self.registry, self.exec_block);
+    }
+}

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -24,7 +24,7 @@ use crate::{
         consensus::EraReport,
         contract_runtime::{
             error::BlockExecutionError, types::StepEffectAndUpcomingEraValidators,
-            BlockAndExecutionEffects, ContractRuntimeMetrics, ExecutionPreState,
+            BlockAndExecutionEffects, ExecutionPreState, Metrics,
         },
     },
     types::{Block, Deploy, DeployHash, DeployHeader, FinalizedBlock},
@@ -33,7 +33,7 @@ use crate::{
 /// Executes a finalized block.
 pub fn execute_finalized_block(
     engine_state: &EngineState<LmdbGlobalState>,
-    metrics: Option<Arc<ContractRuntimeMetrics>>,
+    metrics: Option<Arc<Metrics>>,
     protocol_version: ProtocolVersion,
     execution_pre_state: ExecutionPreState,
     finalized_block: FinalizedBlock,
@@ -163,7 +163,7 @@ pub fn execute_finalized_block(
 /// Commits the execution effects.
 fn commit_execution_effects(
     engine_state: &EngineState<LmdbGlobalState>,
-    metrics: Option<Arc<ContractRuntimeMetrics>>,
+    metrics: Option<Arc<Metrics>>,
     state_root_hash: Digest,
     deploy_hash: DeployHash,
     execution_results: ExecutionResults,
@@ -206,7 +206,7 @@ fn commit_execution_effects(
 
 fn commit_transforms(
     engine_state: &EngineState<LmdbGlobalState>,
-    metrics: Option<Arc<ContractRuntimeMetrics>>,
+    metrics: Option<Arc<Metrics>>,
     state_root_hash: Digest,
     effects: AdditiveMap<Key, Transform>,
 ) -> Result<Digest, engine_state::Error> {
@@ -223,7 +223,7 @@ fn commit_transforms(
 
 fn execute(
     engine_state: &EngineState<LmdbGlobalState>,
-    metrics: Option<Arc<ContractRuntimeMetrics>>,
+    metrics: Option<Arc<Metrics>>,
     execute_request: ExecuteRequest,
 ) -> Result<VecDeque<EngineExecutionResult>, engine_state::Error> {
     trace!(?execute_request, "execute");
@@ -239,7 +239,7 @@ fn execute(
 
 fn commit_step(
     engine_state: &EngineState<LmdbGlobalState>,
-    maybe_metrics: Option<Arc<ContractRuntimeMetrics>>,
+    maybe_metrics: Option<Arc<Metrics>>,
     protocol_version: ProtocolVersion,
     pre_state_root_hash: Digest,
     era_report: &EraReport<PublicKey>,

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -282,7 +282,9 @@ fn commit_step(
     let start = Instant::now();
     let result = engine_state.commit_step(correlation_id, step_request);
     if let Some(metrics) = maybe_metrics {
-        metrics.commit_step.observe(start.elapsed().as_secs_f64());
+        let elapsed = start.elapsed().as_secs_f64();
+        metrics.commit_step.observe(elapsed);
+        metrics.latest_commit_step.set(elapsed);
     }
     trace!(?result, "step response");
     result

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -27,7 +27,7 @@ use crate::{
 
 pub(crate) use config::Config;
 pub(crate) use event::{Event, FetchResult};
-use metrics::FetcherMetrics;
+use metrics::Metrics;
 
 /// A helper trait constraining `Fetcher` compatible reactor events.
 pub(crate) trait ReactorEventT<T>:
@@ -175,7 +175,7 @@ where
     get_from_peer_timeout: Duration,
     responders: HashMap<T::Id, HashMap<NodeId, Vec<FetchResponder<T>>>>,
     #[data_size(skip)]
-    metrics: FetcherMetrics,
+    metrics: Metrics,
 }
 
 impl<T: Item> Fetcher<T> {
@@ -187,7 +187,7 @@ impl<T: Item> Fetcher<T> {
         Ok(Fetcher {
             get_from_peer_timeout: config.get_from_peer_timeout().into(),
             responders: HashMap::new(),
-            metrics: FetcherMetrics::new(name, registry)?,
+            metrics: Metrics::new(name, registry)?,
         })
     }
 }

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -3,7 +3,7 @@ use prometheus::{IntCounter, Registry};
 use crate::unregister_metric;
 
 #[derive(Debug)]
-pub(super) struct FetcherMetrics {
+pub(super) struct Metrics {
     /// Number of fetch requests that found an item in the storage.
     pub(super) found_in_storage: IntCounter,
     /// Number of fetch requests that fetched an item from peer.
@@ -14,18 +14,18 @@ pub(super) struct FetcherMetrics {
     registry: Registry,
 }
 
-impl FetcherMetrics {
+impl Metrics {
     pub(super) fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
         let found_in_storage = IntCounter::new(
             format!("{}_found_in_storage", name),
             format!(
-                "number of fetch requests that found {} in the storage.",
+                "number of fetch requests that found {} in local storage",
                 name
             ),
         )?;
         let found_on_peer = IntCounter::new(
             format!("{}_found_on_peer", name),
-            format!("number of fetch requests that fetched {} from peer.", name),
+            format!("number of fetch requests that fetched {} from peer", name),
         )?;
         let timeouts = IntCounter::new(
             format!("{}_timeouts", name),
@@ -35,7 +35,7 @@ impl FetcherMetrics {
         registry.register(Box::new(found_on_peer.clone()))?;
         registry.register(Box::new(timeouts.clone()))?;
 
-        Ok(FetcherMetrics {
+        Ok(Metrics {
             found_in_storage,
             found_on_peer,
             timeouts,
@@ -44,7 +44,7 @@ impl FetcherMetrics {
     }
 }
 
-impl Drop for FetcherMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.found_in_storage);
         unregister_metric!(self.registry, self.found_on_peer);

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -33,7 +33,7 @@ pub(crate) use config::Config;
 pub(crate) use event::Event;
 use gossip_table::{GossipAction, GossipTable};
 pub(crate) use message::Message;
-use metrics::GossiperMetrics;
+use metrics::Metrics;
 
 /// A helper trait whose bounds represent the requirements for a reactor event that `Gossiper` can
 /// work with.
@@ -106,7 +106,7 @@ where
     get_from_holder:
         Box<dyn Fn(EffectBuilder<REv>, T::Id, NodeId) -> Effects<Event<T>> + Send + 'static>,
     #[data_size(skip)]
-    metrics: GossiperMetrics,
+    metrics: Metrics,
 }
 
 impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
@@ -139,7 +139,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             gossip_timeout: config.gossip_request_timeout().into(),
             get_from_peer_timeout: config.get_remainder_timeout().into(),
             get_from_holder: Box::new(get_from_holder),
-            metrics: GossiperMetrics::new(name, registry)?,
+            metrics: Metrics::new(name, registry)?,
         })
     }
 
@@ -164,7 +164,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             get_from_holder: Box::new(|_, item, _| {
                 panic!("gossiper should never try to get {}", item)
             }),
-            metrics: GossiperMetrics::new(name, registry)?,
+            metrics: Metrics::new(name, registry)?,
         })
     }
 

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// `Gossiper` events.
 #[derive(Debug, Serialize)]
-pub enum Event<T: Item> {
+pub(crate) enum Event<T: Item> {
     /// A new item has been received to be gossiped.
     ItemReceived {
         item_id: T::Id,

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -4,7 +4,7 @@ use crate::unregister_metric;
 
 /// Metrics for the gossiper component.
 #[derive(Debug)]
-pub struct GossiperMetrics {
+pub(super) struct Metrics {
     /// Total number of items received by the gossiper.
     pub(super) items_received: IntCounter,
     /// Total number of gossip requests sent to peers.
@@ -19,7 +19,7 @@ pub struct GossiperMetrics {
     registry: Registry,
 }
 
-impl GossiperMetrics {
+impl Metrics {
     /// Creates a new instance of gossiper metrics, using the given prefix.
     pub fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
         let items_received = IntCounter::new(
@@ -58,7 +58,7 @@ impl GossiperMetrics {
         registry.register(Box::new(table_items_current.clone()))?;
         registry.register(Box::new(table_items_finished.clone()))?;
 
-        Ok(GossiperMetrics {
+        Ok(Metrics {
             items_received,
             times_gossiped,
             times_ran_out_of_peers,
@@ -69,7 +69,7 @@ impl GossiperMetrics {
     }
 }
 
-impl Drop for GossiperMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.items_received);
         unregister_metric!(self.registry, self.times_gossiped);

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -13,7 +13,7 @@ use prometheus::Registry;
 use tracing::{debug, error};
 
 use self::{
-    metrics::LinearChainMetrics,
+    metrics::Metrics,
     state::{Outcome, Outcomes},
 };
 use super::Component;
@@ -39,7 +39,7 @@ use state::LinearChain;
 pub(crate) struct LinearChainComponent<I> {
     linear_chain_state: LinearChain,
     #[data_size(skip)]
-    metrics: LinearChainMetrics,
+    metrics: Metrics,
     _marker: PhantomData<I>,
 }
 
@@ -50,7 +50,7 @@ impl<I> LinearChainComponent<I> {
         auction_delay: u64,
         unbonding_delay: u64,
     ) -> Result<Self, prometheus::Error> {
-        let metrics = LinearChainMetrics::new(registry)?;
+        let metrics = Metrics::new(registry)?;
         let linear_chain_state = LinearChain::new(protocol_version, auction_delay, unbonding_delay);
         Ok(LinearChainComponent {
             linear_chain_state,

--- a/node/src/components/linear_chain/metrics.rs
+++ b/node/src/components/linear_chain/metrics.rs
@@ -3,17 +3,17 @@ use prometheus::{IntGauge, Registry};
 use crate::unregister_metric;
 
 #[derive(Debug)]
-pub(super) struct LinearChainMetrics {
+pub(super) struct Metrics {
     pub(super) block_completion_duration: IntGauge,
     /// Prometheus registry used to publish metrics.
     registry: Registry,
 }
 
-impl LinearChainMetrics {
+impl Metrics {
     pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
         let block_completion_duration = IntGauge::new(
             "block_completion_duration",
-            "duration of time from consensus through execution for a block",
+            "time in milliseconds to execute a block, from finalizing it until stored locally",
         )?;
         registry.register(Box::new(block_completion_duration.clone()))?;
         Ok(Self {
@@ -23,7 +23,7 @@ impl LinearChainMetrics {
     }
 }
 
-impl Drop for LinearChainMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.block_completion_duration);
     }

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -55,7 +55,7 @@ use crate::{
 pub(crate) use config::Config;
 pub(crate) use event::Event;
 use event::{BlockByHeightResult, StopReason};
-pub(crate) use metrics::LinearChainSyncMetrics;
+use metrics::Metrics;
 pub(crate) use peers::PeersState;
 pub(crate) use state::State;
 pub(crate) use traits::ReactorEventT;
@@ -65,7 +65,7 @@ pub(crate) struct LinearChainSync<I> {
     peers: PeersState<I>,
     state: State,
     #[data_size(skip)]
-    metrics: LinearChainSyncMetrics,
+    metrics: Metrics,
     /// The next upgrade activation point.
     /// When we download the switch block of an era immediately before the activation point,
     /// we need to shut down for an upgrade.
@@ -186,7 +186,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             let linear_chain_sync = LinearChainSync {
                 peers: PeersState::new(),
                 state,
-                metrics: LinearChainSyncMetrics::new(registry)?,
+                metrics: Metrics::new(registry)?,
                 next_upgrade_activation_point,
                 stop_reason: None,
                 state_key,
@@ -225,7 +225,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         Ok(LinearChainSync {
             peers: PeersState::new(),
             state,
-            metrics: LinearChainSyncMetrics::new(registry)?,
+            metrics: Metrics::new(registry)?,
             next_upgrade_activation_point,
             stop_reason: None,
             state_key,

--- a/node/src/components/linear_chain_sync/metrics.rs
+++ b/node/src/components/linear_chain_sync/metrics.rs
@@ -1,21 +1,17 @@
 use std::time::Instant;
 
-use prometheus::{Histogram, HistogramOpts, Registry};
+use prometheus::{Histogram, Registry};
 
-#[derive(Debug)]
-pub struct LinearChainSyncMetrics {
-    get_block_by_hash: Histogram,
-    get_block_by_height: Histogram,
-    get_deploys: Histogram,
-    request_start: Instant,
-}
+use crate::{unregister_metric, utils};
 
 const GET_BLOCK_BY_HASH: &str = "linear_chain_sync_get_block_by_hash";
-const GET_BLOCK_BY_HASH_HELP: &str = "histogram of linear_chain_sync get_block_by_hash request";
+const GET_BLOCK_BY_HASH_HELP: &str =
+    "time in seconds to get block by hash during linear chain sync";
 const GET_BLOCK_BY_HEIGHT: &str = "linear_chain_sync_get_block_by_height";
-const GET_BLOCK_BY_HEIGHT_HELP: &str = "histogram of linear_chain_sync get_block_by_height request";
+const GET_BLOCK_BY_HEIGHT_HELP: &str =
+    "time in seconds to get block by height during linear chain sync";
 const GET_DEPLOYS: &str = "linear_chain_sync_get_deploys";
-const GET_DEPLOYS_HELP: &str = "histogram of linear_chain_sync get_deploys request";
+const GET_DEPLOYS_HELP: &str = "time in seconds to get deploys during linear chain sync";
 
 /// Value of upper bound of histogram.
 const EXPONENTIAL_BUCKET_START: f64 = 0.01;
@@ -24,57 +20,70 @@ const EXPONENTIAL_BUCKET_FACTOR: f64 = 2.0;
 /// Bucket count, with last going to +Inf.
 const EXPONENTIAL_BUCKET_COUNT: usize = 6;
 
-/// Create prometheus Histogram and register.
-fn register_histogram_metric(
-    registry: &Registry,
-    metric_name: &str,
-    metric_help: &str,
-) -> Result<Histogram, prometheus::Error> {
-    let common_buckets = prometheus::exponential_buckets(
-        EXPONENTIAL_BUCKET_START,
-        EXPONENTIAL_BUCKET_FACTOR,
-        EXPONENTIAL_BUCKET_COUNT,
-    )?;
-    let histogram_opts = HistogramOpts::new(metric_name, metric_help).buckets(common_buckets);
-    let histogram = Histogram::with_opts(histogram_opts)?;
-    registry.register(Box::new(histogram.clone()))?;
-    Ok(histogram)
+#[derive(Debug)]
+pub(super) struct Metrics {
+    get_block_by_hash: Histogram,
+    get_block_by_height: Histogram,
+    get_deploys: Histogram,
+    request_start: Instant,
+    registry: Registry,
 }
 
-impl LinearChainSyncMetrics {
-    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        Ok(LinearChainSyncMetrics {
-            get_block_by_hash: register_histogram_metric(
+impl Metrics {
+    pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let common_buckets = prometheus::exponential_buckets(
+            EXPONENTIAL_BUCKET_START,
+            EXPONENTIAL_BUCKET_FACTOR,
+            EXPONENTIAL_BUCKET_COUNT,
+        )?;
+        Ok(Metrics {
+            get_block_by_hash: utils::register_histogram_metric(
                 registry,
                 GET_BLOCK_BY_HASH,
                 GET_BLOCK_BY_HASH_HELP,
+                common_buckets.clone(),
             )?,
-            get_block_by_height: register_histogram_metric(
+            get_block_by_height: utils::register_histogram_metric(
                 registry,
                 GET_BLOCK_BY_HEIGHT,
                 GET_BLOCK_BY_HEIGHT_HELP,
+                common_buckets.clone(),
             )?,
-            get_deploys: register_histogram_metric(registry, GET_DEPLOYS, GET_DEPLOYS_HELP)?,
+            get_deploys: utils::register_histogram_metric(
+                registry,
+                GET_DEPLOYS,
+                GET_DEPLOYS_HELP,
+                common_buckets,
+            )?,
             request_start: Instant::now(),
+            registry: registry.clone(),
         })
     }
 
-    pub fn reset_start_time(&mut self) {
+    pub(super) fn reset_start_time(&mut self) {
         self.request_start = Instant::now();
     }
 
-    pub fn observe_get_block_by_hash(&mut self) {
+    pub(super) fn observe_get_block_by_hash(&mut self) {
         self.get_block_by_hash
             .observe(self.request_start.elapsed().as_secs_f64());
     }
 
-    pub fn observe_get_block_by_height(&mut self) {
+    pub(super) fn observe_get_block_by_height(&mut self) {
         self.get_block_by_height
             .observe(self.request_start.elapsed().as_secs_f64());
     }
 
-    pub fn observe_get_deploys(&mut self) {
+    pub(super) fn observe_get_deploys(&mut self) {
         self.get_deploys
             .observe(self.request_start.elapsed().as_secs_f64());
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.get_block_by_hash);
+        unregister_metric!(self.registry, self.get_block_by_height);
+        unregister_metric!(self.registry, self.get_deploys);
     }
 }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -32,6 +32,7 @@ mod gossiped_address;
 mod limiter;
 mod message;
 mod message_pack_format;
+mod metrics;
 mod outgoing;
 mod symmetry;
 pub(crate) mod tasks;
@@ -71,24 +72,28 @@ use tokio_util::codec::LengthDelimitedCodec;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
 use self::{
+    chain_info::ChainInfo,
     counting_format::{ConnectionId, CountingFormat, Role},
     error::{ConnectionError, Result},
     event::{IncomingConnection, OutgoingConnection},
     limiter::Limiter,
     message::ConsensusKeyPair,
     message_pack_format::MessagePackFormat,
+    metrics::Metrics,
     outgoing::{DialOutcome, DialRequest, OutgoingConfig, OutgoingManager},
     symmetry::ConnectionSymmetry,
     tasks::NetworkContext,
 };
 pub(crate) use self::{
+    config::Config,
+    error::Error,
     event::Event,
     gossiped_address::GossipedAddress,
     message::{Message, MessageKind, Payload, PayloadWeights},
 };
 use super::{consensus, contract_runtime::ContractRuntimeAnnouncement};
 use crate::{
-    components::{networking_metrics::NetworkingMetrics, Component},
+    components::Component,
     effect::{
         announcements::{BlocklistAnnouncement, NetworkAnnouncement},
         requests::{NetworkInfoRequest, NetworkRequest, StorageRequest},
@@ -100,9 +105,6 @@ use crate::{
     utils::{self, display_error, WithDir},
     NodeRng,
 };
-use chain_info::ChainInfo;
-pub(crate) use config::Config;
-pub(crate) use error::Error;
 
 const MAX_METRICS_DROP_ATTEMPTS: usize = 25;
 const DROP_RETRY_DELAY: Duration = Duration::from_millis(100);
@@ -166,7 +168,7 @@ where
 
     /// Networking metrics.
     #[data_size(skip)]
-    net_metrics: Arc<NetworkingMetrics>,
+    net_metrics: Arc<Metrics>,
 
     /// The outgoing bandwidth limiter.
     #[data_size(skip)]
@@ -245,7 +247,7 @@ where
         let mut public_addr =
             utils::resolve_address(&cfg.public_address).map_err(Error::ResolveAddr)?;
 
-        let net_metrics = Arc::new(NetworkingMetrics::new(registry)?);
+        let net_metrics = Arc::new(Metrics::new(registry)?);
 
         // We can now create a listener.
         let bind_address = utils::resolve_address(&cfg.bind_address).map_err(Error::ResolveAddr)?;
@@ -1021,7 +1023,7 @@ pub(crate) type FramedTransport<P> = tokio_serde::Framed<
 
 /// Constructs a new framed transport on a stream.
 fn framed<P>(
-    metrics: Weak<NetworkingMetrics>,
+    metrics: Weak<Metrics>,
     connection_id: ConnectionId,
     stream: Transport,
     role: Role,

--- a/node/src/components/small_network/counting_format.rs
+++ b/node/src/components/small_network/counting_format.rs
@@ -25,10 +25,10 @@ use casper_types::checksummed_hex;
 
 use casper_hashing::Digest;
 
-use super::{tls::KeyFingerprint, Message, Payload};
+use super::{tls::KeyFingerprint, Message, Metrics, Payload};
 #[cfg(test)]
 use crate::testing::TestRng;
-use crate::{components::networking_metrics::NetworkingMetrics, types::NodeId, utils};
+use crate::{types::NodeId, utils};
 
 /// Lazily-evaluated network message ID generator.
 ///
@@ -62,14 +62,14 @@ pub struct CountingFormat<F> {
     /// Our role in the connection.
     role: Role,
     /// Metrics to update.
-    metrics: Weak<NetworkingMetrics>,
+    metrics: Weak<Metrics>,
 }
 
 impl<F> CountingFormat<F> {
     /// Creates a new counting formatter.
     #[inline]
     pub(super) fn new(
-        metrics: Weak<NetworkingMetrics>,
+        metrics: Weak<Metrics>,
         connection_id: ConnectionId,
         role: Role,
         inner: F,
@@ -100,7 +100,7 @@ where
         let serialized = F::serialize(projection, item)?;
         let msg_size = serialized.len() as u64;
         let msg_kind = item.classify();
-        NetworkingMetrics::record_payload_out(this.metrics, msg_kind, msg_size);
+        Metrics::record_payload_out(this.metrics, msg_kind, msg_size);
 
         let trace_id = this
             .connection_id

--- a/node/src/components/small_network/metrics.rs
+++ b/node/src/components/small_network/metrics.rs
@@ -3,12 +3,12 @@ use std::sync::Weak;
 use prometheus::{IntCounter, IntGauge, Registry};
 use tracing::debug;
 
-use super::small_network::MessageKind;
+use super::MessageKind;
 use crate::unregister_metric;
 
 /// Network-type agnostic networking metrics.
 #[derive(Debug)]
-pub(super) struct NetworkingMetrics {
+pub(super) struct Metrics {
     /// How often a request was made by a component to broadcast.
     pub(super) broadcast_requests: IntCounter,
     /// How often a request to send a message directly to a peer was made.
@@ -54,7 +54,7 @@ pub(super) struct NetworkingMetrics {
     registry: Registry,
 }
 
-impl NetworkingMetrics {
+impl Metrics {
     /// Creates a new instance of networking metrics.
     pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
         let broadcast_requests =
@@ -151,7 +151,7 @@ impl NetworkingMetrics {
         registry.register(Box::new(out_bytes_block_transfer.clone()))?;
         registry.register(Box::new(out_bytes_other.clone()))?;
 
-        Ok(NetworkingMetrics {
+        Ok(Metrics {
             broadcast_requests,
             direct_message_requests,
             open_connections,
@@ -214,7 +214,7 @@ impl NetworkingMetrics {
     }
 }
 
-impl Drop for NetworkingMetrics {
+impl Drop for Metrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.broadcast_requests);
         unregister_metric!(self.registry, self.direct_message_requests);
@@ -229,6 +229,7 @@ impl Drop for NetworkingMetrics {
         unregister_metric!(self.registry, self.out_count_deploy_transfer);
         unregister_metric!(self.registry, self.out_count_block_transfer);
         unregister_metric!(self.registry, self.out_count_other);
+
         unregister_metric!(self.registry, self.out_bytes_protocol);
         unregister_metric!(self.registry, self.out_bytes_consensus);
         unregister_metric!(self.registry, self.out_bytes_deploy_gossip);

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -40,11 +40,10 @@ use super::{
     event::{IncomingConnection, OutgoingConnection},
     framed,
     limiter::LimiterHandle,
-    message::ConsensusKeyPair,
-    Event, FramedTransport, Message, Payload, Transport,
+    message::{ConsensusKeyPair, PayloadWeights},
+    Event, FramedTransport, Message, Metrics, Payload, Transport,
 };
 use crate::{
-    components::{networking_metrics::NetworkingMetrics, small_network::message::PayloadWeights},
     reactor::{EventQueueHandle, QueueKind},
     tls::{self, TlsCert},
     types::NodeId,
@@ -175,7 +174,7 @@ where
     /// Secret key associated with `our_cert`.
     pub(super) secret_key: Arc<PKey<Private>>,
     /// Weak reference to the networking metrics shared by all sender/receiver tasks.
-    pub(super) net_metrics: Weak<NetworkingMetrics>,
+    pub(super) net_metrics: Weak<Metrics>,
     /// Chain info extract from chainspec.
     pub(super) chain_info: ChainInfo,
     /// Our own public listening address.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -410,13 +410,16 @@ struct RunnerMetrics {
 impl RunnerMetrics {
     /// Create and register new runner metrics.
     fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let events = IntCounter::new("runner_events", "total event count")?;
+        let events = IntCounter::new(
+            "runner_events",
+            "running total count of events handled by this reactor",
+        )?;
 
         // Create an event dispatch histogram, putting extra emphasis on the area between 1-10 us.
         let event_dispatch_duration = Histogram::with_opts(
             HistogramOpts::new(
                 "event_dispatch_duration",
-                "duration of complete dispatch of a single event in nanoseconds",
+                "time in nanoseconds to dispatch an event",
             )
             .buckets(vec![
                 100.0,

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -29,7 +29,13 @@ impl EventQueueMetrics {
         let mut event_queue_gauges: HashMap<QueueKind, IntGauge> = HashMap::new();
         for queue_kind in event_queue_handle.event_queues_counts().keys() {
             let key = format!("scheduler_queue_{}_count", queue_kind.metrics_name());
-            let queue_event_counter = IntGauge::new(key, "Event in the queue.".to_string())?;
+            let queue_event_counter = IntGauge::new(
+                key,
+                format!(
+                    "current number of events in the reactor {} queue",
+                    queue_kind.metrics_name()
+                ),
+            )?;
             registry.register(Box::new(queue_event_counter.clone()))?;
             let result = event_queue_gauges.insert(*queue_kind, queue_event_counter);
             assert!(result.is_none(), "Map keys should not be overwritten.");
@@ -37,7 +43,7 @@ impl EventQueueMetrics {
 
         let event_total = IntGauge::new(
             "scheduler_queue_total_count",
-            "total count of events in queues.",
+            "current total number of events in all reactor queues",
         )?;
         registry.register(Box::new(event_total.clone()))?;
 

--- a/node/src/reactor/joiner/memory_metrics.rs
+++ b/node/src/reactor/joiner/memory_metrics.rs
@@ -5,43 +5,24 @@ use tracing::debug;
 use super::Reactor;
 use crate::unregister_metric;
 
-///Metrics for memory usage for the joiner
+/// Metrics for estimated heap memory usage for the joiner reactor.
 #[derive(Debug)]
 pub(super) struct MemoryMetrics {
-    /// Total estimated heap memory usage.
     mem_total: IntGauge,
-
-    /// Estimated heap memory usage of metrics component.
     mem_metrics: IntGauge,
-    /// Estimated heap memory usage of network component.
-    mem_network: IntGauge,
-    /// Estimated heap memory usage of small_network component.
     mem_small_network: IntGauge,
-    /// Estimated heap memory usage of address_gossiper component.
     mem_address_gossiper: IntGauge,
-    /// Estimated heap memory usage of the configuration for the validator node.
     mem_config: IntGauge,
-    /// Estimated heap memory usage for the chainspec loader component.
     mem_chainspec_loader: IntGauge,
-    /// Estimated heap memory usage of storage component.
     mem_storage: IntGauge,
-    /// Estimated heap memory usage of the contract runtime component.
     mem_contract_runtime: IntGauge,
-    /// Estimated heap memory usage of the linear chain fetcher component.
     mem_linear_chain_fetcher: IntGauge,
-    /// Estimated heap memory usage of linear chain sync.
     mem_linear_chain_sync: IntGauge,
-    /// Estimated heap memory usage of block validator component.
     mem_block_validator: IntGauge,
-    /// Estimated heap memory usage of deploy fetcher component.
     mem_deploy_fetcher: IntGauge,
-    /// Estimated heap memory usage of linear chain component.
     mem_linear_chain: IntGauge,
-
     /// Histogram detailing how long it took to estimate memory usage.
     mem_estimator_runtime_s: Histogram,
-
-    /// Instance of registry component to unregister from when being dropped.
     registry: Registry,
 }
 
@@ -50,49 +31,46 @@ impl MemoryMetrics {
     pub(super) fn new(registry: Registry) -> Result<Self, prometheus::Error> {
         let mem_total = IntGauge::new("joiner_mem_total", "total memory usage in bytes")?;
         let mem_metrics = IntGauge::new("joiner_mem_metrics", "metrics memory usage in bytes")?;
-        let mem_network = IntGauge::new("joiner_mem_network", "network memory usage in bytes")?;
-        let mem_small_network = IntGauge::new(
-            "joiner_mem_small_network",
-            "small network memory usage in bytes",
-        )?;
+        let mem_small_network =
+            IntGauge::new("joiner_mem_small_network", "network memory usage in bytes")?;
         let mem_address_gossiper = IntGauge::new(
             "joiner_mem_address_gossiper",
-            "address_gossiper memory usage in bytes",
+            "address gossiper memory usage in bytes",
         )?;
         let mem_config = IntGauge::new("joiner_mem_config", "config memory usage in bytes")?;
         let mem_chainspec_loader = IntGauge::new(
             "joiner_mem_chainspec_loader",
-            "chainspec_loader memory usage in bytes",
+            "chainspec loader memory usage in bytes",
         )?;
         let mem_storage = IntGauge::new("joiner_mem_storage", "storage memory usage in bytes")?;
         let mem_contract_runtime = IntGauge::new(
             "joiner_mem_contract_runtime",
-            "contract_runtime memory usage in bytes",
+            "contract runtime memory usage in bytes",
         )?;
         let mem_linear_chain_fetcher = IntGauge::new(
             "joiner_mem_linear_chain_fetcher",
-            "linear_chain_fetcher memory usage in bytes",
+            "linear chain fetcher memory usage in bytes",
         )?;
         let mem_linear_chain_sync = IntGauge::new(
             "joiner_mem_linear_chain_sync",
-            "linear_chain_sync memory usage in bytes",
+            "linear chain sync memory usage in bytes",
         )?;
         let mem_block_validator = IntGauge::new(
             "joiner_mem_block_validator",
-            "block_validator memory usage in bytes",
+            "block validator memory usage in bytes",
         )?;
         let mem_deploy_fetcher = IntGauge::new(
             "joiner_mem_deploy_fetcher",
-            "deploy_fetcher memory usage in bytes",
+            "deploy fetcher memory usage in bytes",
         )?;
         let mem_linear_chain = IntGauge::new(
             "joiner_mem_linear_chain",
-            "linear_chain memory usage in bytes",
+            "linear chain memory usage in bytes",
         )?;
         let mem_estimator_runtime_s = Histogram::with_opts(
             HistogramOpts::new(
                 "joiner_mem_estimator_runtime_s",
-                "time taken to estimate memory usage, in seconds",
+                "time in seconds to estimate memory usage",
             )
             // Create buckets from four nano second to eight seconds
             .buckets(prometheus::exponential_buckets(0.000_000_004, 2.0, 32)?),
@@ -100,7 +78,6 @@ impl MemoryMetrics {
 
         registry.register(Box::new(mem_total.clone()))?;
         registry.register(Box::new(mem_metrics.clone()))?;
-        registry.register(Box::new(mem_network.clone()))?;
         registry.register(Box::new(mem_small_network.clone()))?;
         registry.register(Box::new(mem_address_gossiper.clone()))?;
         registry.register(Box::new(mem_config.clone()))?;
@@ -117,7 +94,6 @@ impl MemoryMetrics {
         Ok(MemoryMetrics {
             mem_total,
             mem_metrics,
-            mem_network,
             mem_small_network,
             mem_address_gossiper,
             mem_config,
@@ -204,7 +180,6 @@ impl Drop for MemoryMetrics {
     fn drop(&mut self) {
         unregister_metric!(self.registry, self.mem_total);
         unregister_metric!(self.registry, self.mem_metrics);
-        unregister_metric!(self.registry, self.mem_network);
         unregister_metric!(self.registry, self.mem_small_network);
         unregister_metric!(self.registry, self.mem_address_gossiper);
         unregister_metric!(self.registry, self.mem_config);

--- a/node/src/reactor/participating/memory_metrics.rs
+++ b/node/src/reactor/participating/memory_metrics.rs
@@ -5,47 +5,27 @@ use tracing::debug;
 use super::Reactor;
 use crate::unregister_metric;
 
-/// Metrics for memory usage.
+/// Metrics for estimated heap memory usage for the participating reactor.
 #[derive(Debug)]
 pub(super) struct MemoryMetrics {
-    /// Total estimated heap memory usage.
     mem_total: IntGauge,
-
-    /// Estimated heap memory usage of metrics component.
     mem_metrics: IntGauge,
-    /// Estimated heap memory usage of network component.
     mem_net: IntGauge,
-    /// Estimated heap memory usage of address gossiper component.
     mem_address_gossiper: IntGauge,
-    /// Estimated heap memory usage of storage component.
     mem_storage: IntGauge,
-    /// Estimated heap memory usage of contract runtime component.
     mem_contract_runtime: IntGauge,
-    /// Estimated heap memory usage of rpc server component.
     mem_rpc_server: IntGauge,
-    /// Estimated heap memory usage of rest server component.
     mem_rest_server: IntGauge,
-    /// Estimated heap memory usage of event stream server component.
     mem_event_stream_server: IntGauge,
-    /// Estimated heap memory usage of chainspec loader component.
     mem_chainspec_loader: IntGauge,
-    /// Estimated heap memory usage of consensus component.
     mem_consensus: IntGauge,
-    /// Estimated heap memory usage of deploy fetcher component.
     mem_deploy_fetcher: IntGauge,
-    /// Estimated heap memory usage of deploy gossiper component.
     mem_deploy_gossiper: IntGauge,
-    /// Estimated heap memory usage of block_proposer component.
     mem_block_proposer: IntGauge,
-    /// Estimated heap memory usage of block validator component.
     mem_block_validator: IntGauge,
-    /// Estimated heap memory usage of linear chain component.
     mem_linear_chain: IntGauge,
-
     /// Histogram detailing how long it took to measure memory usage.
     mem_estimator_runtime_s: Histogram,
-
-    /// Instance of registry to unregister from when being dropped.
     registry: Registry,
 }
 
@@ -54,7 +34,7 @@ impl MemoryMetrics {
     pub(super) fn new(registry: Registry) -> Result<Self, prometheus::Error> {
         let mem_total = IntGauge::new("mem_total", "total memory usage in bytes")?;
         let mem_metrics = IntGauge::new("mem_metrics", "metrics memory usage in bytes")?;
-        let mem_net = IntGauge::new("mem_net", "net memory usage in bytes")?;
+        let mem_net = IntGauge::new("mem_net", "network memory usage in bytes")?;
         let mem_address_gossiper = IntGauge::new(
             "mem_address_gossiper",
             "address_gossiper memory usage in bytes",
@@ -62,39 +42,39 @@ impl MemoryMetrics {
         let mem_storage = IntGauge::new("mem_storage", "storage memory usage in bytes")?;
         let mem_contract_runtime = IntGauge::new(
             "mem_contract_runtime",
-            "contract_runtime memory usage in bytes",
+            "contract runtime memory usage in bytes",
         )?;
-        let mem_rpc_server = IntGauge::new("mem_rpc_server", "rpc_server memory usage in bytes")?;
+        let mem_rpc_server = IntGauge::new("mem_rpc_server", "rpc server memory usage in bytes")?;
         let mem_rest_server =
-            IntGauge::new("mem_rest_server", "mem_rest_server memory usage in bytes")?;
+            IntGauge::new("mem_rest_server", "rest server memory usage in bytes")?;
         let mem_event_stream_server = IntGauge::new(
             "mem_event_stream_server",
-            "mem_event_stream_server memory usage in bytes",
+            "event stream server memory usage in bytes",
         )?;
         let mem_chainspec_loader = IntGauge::new(
             "mem_chainspec_loader",
-            "chainspec_loader memory usage in bytes",
+            "chainspec loader memory usage in bytes",
         )?;
         let mem_consensus = IntGauge::new("mem_consensus", "consensus memory usage in bytes")?;
         let mem_deploy_fetcher =
-            IntGauge::new("mem_deploy_fetcher", "deploy_fetcher memory usage in bytes")?;
+            IntGauge::new("mem_deploy_fetcher", "deploy fetcher memory usage in bytes")?;
         let mem_deploy_gossiper = IntGauge::new(
             "mem_deploy_gossiper",
-            "deploy_gossiper memory usage in bytes",
+            "deploy gossiper memory usage in bytes",
         )?;
         let mem_block_proposer =
-            IntGauge::new("mem_block_proposer", "block_proposer memory usage in bytes")?;
+            IntGauge::new("mem_block_proposer", "block proposer memory usage in bytes")?;
         let mem_block_validator = IntGauge::new(
             "mem_block_validator",
-            "block_validator memory usage in bytes",
+            "block validator memory usage in bytes",
         )?;
         let mem_linear_chain =
-            IntGauge::new("mem_linear_chain", "linear_chain memory usage in bytes")?;
+            IntGauge::new("mem_linear_chain", "linear chain memory usage in bytes")?;
 
         let mem_estimator_runtime_s = Histogram::with_opts(
             HistogramOpts::new(
                 "mem_estimator_runtime_s",
-                "time taken to estimate memory usage, in seconds",
+                "time in seconds to estimate memory usage",
             )
             //  Create buckets from one nanosecond to eight seconds.
             .buckets(prometheus::exponential_buckets(0.000_000_004, 2.0, 32)?),
@@ -158,7 +138,6 @@ impl MemoryMetrics {
         let deploy_gossiper = reactor.deploy_gossiper.estimate_heap_size() as i64;
         let block_proposer = reactor.block_proposer.estimate_heap_size() as i64;
         let block_validator = reactor.block_validator.estimate_heap_size() as i64;
-
         let linear_chain = reactor.linear_chain.estimate_heap_size() as i64;
 
         let total = metrics

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -30,6 +30,7 @@ use datasize::DataSize;
 use hyper::server::{conn::AddrIncoming, Builder, Server};
 #[cfg(test)]
 use once_cell::sync::Lazy;
+use prometheus::{self, Histogram, HistogramOpts, Registry};
 use serde::Serialize;
 use thiserror::Error;
 use tracing::{error, warn};
@@ -89,7 +90,7 @@ pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddres
 
 /// An error starting one of the HTTP servers.
 #[derive(Debug, Error)]
-pub enum ListeningError {
+pub(crate) enum ListeningError {
     /// Failed to resolve address.
     #[error("failed to resolve network address: {0}")]
     ResolveAddress(ResolveAddressError),
@@ -318,7 +319,7 @@ impl<T> WithDir<T> {
 
 /// The source of a piece of data.
 #[derive(Clone, Debug, Serialize)]
-pub enum Source<I> {
+pub(crate) enum Source<I> {
     /// A peer with the wrapped ID.
     Peer(I),
     /// A client.
@@ -363,7 +364,20 @@ where
     (numerator + denominator / T::from(2)) / denominator
 }
 
-/// Used to unregister a metric from the Prometheus registry.
+/// Creates a prometheus Histogram and registers it.
+pub(crate) fn register_histogram_metric(
+    registry: &Registry,
+    metric_name: &str,
+    metric_help: &str,
+    buckets: Vec<f64>,
+) -> Result<Histogram, prometheus::Error> {
+    let histogram_opts = HistogramOpts::new(metric_name, metric_help).buckets(buckets);
+    let histogram = Histogram::with_opts(histogram_opts)?;
+    registry.register(Box::new(histogram.clone()))?;
+    Ok(histogram)
+}
+
+/// Unregisters a metric from the Prometheus registry.
 #[macro_export]
 macro_rules! unregister_metric {
     ($registry:expr, $metric:expr) => {
@@ -384,7 +398,7 @@ macro_rules! unregister_metric {
 ///
 /// Panics if `lhs` and `rhs` are not of equal length.
 #[inline]
-pub fn xor(lhs: &mut [u8], rhs: &[u8]) {
+pub(crate) fn xor(lhs: &mut [u8], rhs: &[u8]) {
     // Implementing SIMD support is left as an exercise for the reader.
     assert_eq!(lhs.len(), rhs.len(), "xor inputs should have equal length");
     lhs.iter_mut()
@@ -403,7 +417,11 @@ pub fn xor(lhs: &mut [u8], rhs: &[u8]) {
 ///
 /// Using this function is usually a potential architectural issue and it should be used very
 /// sparingly. Consider introducing a different access pattern for the value under `Arc`.
-pub async fn wait_for_arc_drop<T>(arc: Arc<T>, attempts: usize, retry_delay: Duration) -> bool {
+pub(crate) async fn wait_for_arc_drop<T>(
+    arc: Arc<T>,
+    attempts: usize,
+    retry_delay: Duration,
+) -> bool {
     // Ensure that if we do hold the last reference, we are now going to 0.
     let weak = Arc::downgrade(&arc);
     drop(arc);


### PR DESCRIPTION
This is port of #2530, and adds a new metric for instrumenting the latest time to execute the `commit_step` function. It also generally cleans up the metrics across the node.

The two commits from #2530 were cherry-picked with no changes.

Closes #2525.