### PR TITLE
Add LMDB file size to wasm_test_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
 name = "casper-engine-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "base16",
  "casper-contract",
@@ -436,6 +437,7 @@ dependencies = [
  "get-call-stack-recursive-subcall",
  "gh-1470-regression",
  "gh-1470-regression-call",
+ "lmdb",
  "log",
  "num-rational 0.4.0",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,12 +404,14 @@ dependencies = [
  "casper-execution-engine",
  "casper-hashing",
  "casper-types",
+ "filesize",
  "lmdb",
  "log",
  "num-rational 0.4.0",
  "num-traits",
  "once_cell",
  "rand 0.8.4",
+ "tempfile",
  "version-sync",
 ]
 
@@ -1714,6 +1716,15 @@ dependencies = [
  "bitvec",
  "rand_core 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "filesize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -23,8 +23,10 @@ use std::{
     convert::TryFrom,
     iter::FromIterator,
     rc::Rc,
+    sync::Arc,
 };
 
+use lmdb::Database;
 use num::Zero;
 use num_rational::Ratio;
 use once_cell::sync::Lazy;
@@ -87,6 +89,7 @@ use crate::{
         global_state::{
             lmdb::LmdbGlobalState, scratch::ScratchGlobalState, CommitProvider, StateProvider,
         },
+        transaction_source::lmdb::LmdbEnvironment,
         trie::Trie,
     },
 };
@@ -149,6 +152,16 @@ impl EngineState<LmdbGlobalState> {
         self.state
             .put_stored_values(CorrelationId::new(), state_root_hash, stored_values)
             .map_err(Into::into)
+    }
+
+    /// Return a handle to the underlying LMDB environment.
+    pub fn lmdb_environment(&self) -> Arc<LmdbEnvironment> {
+        Arc::clone(&self.state.environment)
+    }
+
+    /// Return a handle to the underlying LMDB database.
+    pub fn lmdb_handle(&self) -> Database {
+        self.state.trie_store.db
     }
 }
 

--- a/execution_engine/src/storage/trie_store/lmdb.rs
+++ b/execution_engine/src/storage/trie_store/lmdb.rs
@@ -121,7 +121,7 @@ use crate::storage::{
 /// Wraps [`lmdb::Database`].
 #[derive(Debug, Clone)]
 pub struct LmdbTrieStore {
-    db: Database,
+    pub(crate) db: Database,
 }
 
 impl LmdbTrieStore {

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -14,12 +14,14 @@ license = "Apache-2.0"
 casper-execution-engine = { version = "1.4.3", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.2", path = "../../hashing" }
 casper-types = { version = "1.4.5", path = "../../types" }
+filesize = "0.2.0"
 lmdb = "0.8.0"
 log = "0.4.14"
 num-rational = "0.4.0"
 num-traits = "0.2.14"
 once_cell = "1.8.0"
 rand = "0.8.4"
+tempfile = "3"
 
 [dev-dependencies]
 version-sync = "0.9.3"

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -1,0 +1,178 @@
+use rand::Rng;
+
+use casper_execution_engine::{
+    core::engine_state::{
+        genesis::GenesisValidator, run_genesis_request::RunGenesisRequest, ExecConfig,
+        ExecuteRequest, GenesisAccount, RewardItem,
+    },
+    shared::system_config::auction_costs::DEFAULT_DELEGATE_COST,
+};
+use casper_types::{
+    account::AccountHash, runtime_args, system::auction, Motes, ProtocolVersion, PublicKey,
+    RuntimeArgs, SecretKey, U512,
+};
+
+use crate::{
+    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, StepRequestBuilder,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
+    DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROPOSER_PUBLIC_KEY, DEFAULT_PROTOCOL_VERSION,
+    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
+    DEFAULT_WASM_CONFIG, MINIMUM_ACCOUNT_CREATION_BALANCE, SYSTEM_ADDR,
+};
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_TARGET: &str = "target";
+const ARG_ID: &str = "id";
+
+const DELEGATION_RATE: u8 = 1;
+const ID_NONE: Option<u64> = None;
+
+/// Initial balance for delegators in our test.
+pub const DELEGATOR_INITIAL_BALANCE: u64 = 500 * 1_000_000_000u64;
+
+const VALIDATOR_BID_AMOUNT: u64 = 100;
+
+/// Amount of time to step foward between runs of the auction in our tests.
+pub const TIMESTAMP_INCREMENT_MILLIS: u64 = 30_000;
+
+/// Runs genesis, creates system, validator and delegator accounts, and funds the system account and
+/// delegator accounts.
+pub fn run_genesis_and_create_initial_accounts(
+    builder: &mut LmdbWasmTestBuilder,
+    validator_keys: &[PublicKey],
+    delegator_accounts: Vec<AccountHash>,
+    delegator_initial_balance: U512,
+) {
+    let mut genesis_accounts = vec![
+        GenesisAccount::account(
+            DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
+            Motes::new(U512::MAX), // all the monies
+            None,
+        ),
+        GenesisAccount::account(
+            DEFAULT_PROPOSER_PUBLIC_KEY.clone(),
+            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+            None,
+        ),
+    ];
+    for validator in validator_keys {
+        genesis_accounts.push(GenesisAccount::account(
+            validator.clone(),
+            Motes::new(U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE)),
+            Some(GenesisValidator::new(
+                Motes::new(U512::from(VALIDATOR_BID_AMOUNT)),
+                DELEGATION_RATE,
+            )),
+        ))
+    }
+    let run_genesis_request =
+        create_run_genesis_request(validator_keys.len() as u32 + 2, genesis_accounts);
+    builder.run_genesis(&run_genesis_request);
+
+    // Setup the system account with enough cspr
+    let transfer = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+                ARG_TARGET => *SYSTEM_ADDR,
+                ARG_AMOUNT => MINIMUM_ACCOUNT_CREATION_BALANCE,
+                ARG_ID => ID_NONE,
+        },
+    )
+    .build();
+    builder.exec(transfer);
+    builder.expect_success().commit();
+
+    for delegator_account in delegator_accounts {
+        let transfer = ExecuteRequestBuilder::transfer(
+            *DEFAULT_ACCOUNT_ADDR,
+            runtime_args! {
+                    ARG_TARGET => delegator_account,
+                    ARG_AMOUNT => delegator_initial_balance,
+                    ARG_ID => ID_NONE,
+            },
+        )
+        .build();
+        builder.exec(transfer);
+        builder.expect_success().commit();
+    }
+}
+
+fn create_run_genesis_request(
+    validator_slots: u32,
+    genesis_accounts: Vec<GenesisAccount>,
+) -> RunGenesisRequest {
+    let exec_config = {
+        ExecConfig::new(
+            genesis_accounts,
+            *DEFAULT_WASM_CONFIG,
+            *DEFAULT_SYSTEM_CONFIG,
+            validator_slots,
+            DEFAULT_AUCTION_DELAY,
+            DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+            DEFAULT_ROUND_SEIGNIORAGE_RATE,
+            DEFAULT_UNBONDING_DELAY,
+            DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+        )
+    };
+    RunGenesisRequest::new(
+        *DEFAULT_GENESIS_CONFIG_HASH,
+        *DEFAULT_PROTOCOL_VERSION,
+        exec_config,
+    )
+}
+
+/// Creates a delegation request.
+pub fn create_delegate_request(
+    delegator_public_key: PublicKey,
+    next_validator_key: PublicKey,
+    delegation_amount: U512,
+    delegator_account_hash: AccountHash,
+    contract_hash: casper_types::ContractHash,
+) -> ExecuteRequest {
+    let entry_point = auction::METHOD_DELEGATE;
+    let args = runtime_args! {
+        auction::ARG_DELEGATOR => delegator_public_key,
+        auction::ARG_VALIDATOR => next_validator_key,
+        auction::ARG_AMOUNT => delegation_amount,
+    };
+    let mut rng = rand::thread_rng();
+    let deploy_hash = rng.gen();
+    let deploy = DeployItemBuilder::new()
+        .with_address(delegator_account_hash)
+        .with_stored_session_hash(contract_hash, entry_point, args)
+        .with_empty_payment_bytes(
+            runtime_args! { ARG_AMOUNT => U512::from(DEFAULT_DELEGATE_COST), },
+        )
+        .with_authorization_keys(&[delegator_account_hash])
+        .with_deploy_hash(deploy_hash)
+        .build();
+    ExecuteRequestBuilder::new().push_deploy(deploy).build()
+}
+
+/// Generate `key_count` public keys.
+pub fn generate_public_keys(key_count: usize) -> Vec<PublicKey> {
+    let mut ret = Vec::with_capacity(key_count);
+    for _ in 0..key_count {
+        let bytes: [u8; SecretKey::ED25519_LENGTH] = rand::random();
+        let secret_key = SecretKey::ed25519_from_bytes(&bytes).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        ret.push(public_key);
+    }
+    ret
+}
+
+/// Build a step request and run the auction.
+pub fn step_and_run_auction(builder: &mut LmdbWasmTestBuilder, validator_keys: &[PublicKey]) {
+    let mut step_request_builder = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0);
+    for validator in validator_keys {
+        step_request_builder =
+            step_request_builder.with_reward_item(RewardItem::new(validator.clone(), 1));
+    }
+    let step_request = step_request_builder
+        .with_next_era_id(builder.get_era() + 1)
+        .build();
+    builder.step(step_request).expect("should step");
+}

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -8,9 +8,13 @@
 )]
 #![warn(missing_docs)]
 mod additive_map_diff;
+/// Utilities methods for running the auction in a test or bench context.
+pub mod auction;
 mod deploy_item_builder;
 mod execute_request_builder;
 mod step_request_builder;
+/// Utilities for running transfers in a test or bench context.
+pub mod transfer;
 mod upgrade_request_builder;
 pub mod utils;
 mod wasm_test_builder;

--- a/execution_engine_testing/test_support/src/transfer.rs
+++ b/execution_engine_testing/test_support/src/transfer.rs
@@ -1,0 +1,283 @@
+use casper_execution_engine::core::engine_state::ExecuteRequest;
+use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U512};
+
+use crate::{
+    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+};
+
+const CONTRACT_CREATE_ACCOUNTS: &str = "create_accounts.wasm";
+const CONTRACT_CREATE_PURSES: &str = "create_purses.wasm";
+const CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT: &str = "transfer_to_existing_account.wasm";
+const CONTRACT_TRANSFER_TO_PURSE: &str = "transfer_to_purse.wasm";
+
+/// Size of batch used in multiple execs benchmark, and multiple deploys per exec cases.
+pub const TRANSFER_BATCH_SIZE: u64 = 3;
+
+/// Test target address.
+pub const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_ID: &str = "id";
+const ARG_ACCOUNTS: &str = "accounts";
+const ARG_SEED_AMOUNT: &str = "seed_amount";
+const ARG_TOTAL_PURSES: &str = "total_purses";
+const ARG_TARGET: &str = "target";
+const ARG_TARGET_PURSE: &str = "target_purse";
+
+/// Test value for number of deploys to generate for a block.
+pub const BLOCK_TRANSFER_COUNT: usize = 2500;
+
+/// Converts an integer into an array of type [u8; 32] by converting integer
+/// into its big endian representation and embedding it at the end of the
+/// range.
+fn make_deploy_hash(i: u64) -> [u8; 32] {
+    let mut result = [128; 32];
+    result[32 - 8..].copy_from_slice(&i.to_be_bytes());
+    result
+}
+
+/// Create initial accounts and run genesis.
+pub fn create_initial_accounts_and_run_genesis(
+    builder: &mut LmdbWasmTestBuilder,
+    accounts: Vec<AccountHash>,
+    amount: U512,
+) {
+    let exec_request = create_accounts_request(accounts, amount);
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(exec_request)
+        .expect_success()
+        .commit();
+}
+
+/// Creates a request to that will call the create_accounts.wasm and create test accounts using the
+/// default account for the initial transfer.
+pub fn create_accounts_request(source_accounts: Vec<AccountHash>, amount: U512) -> ExecuteRequest {
+    ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_CREATE_ACCOUNTS,
+        runtime_args! { ARG_ACCOUNTS => source_accounts, ARG_SEED_AMOUNT => amount },
+    )
+    .build()
+}
+
+/// Create a number of test purses with an initial balance.
+pub fn create_test_purses(
+    builder: &mut LmdbWasmTestBuilder,
+    source: AccountHash,
+    total_purses: u64,
+    purse_amount: U512,
+) -> Vec<URef> {
+    let exec_request = ExecuteRequestBuilder::standard(
+        source,
+        CONTRACT_CREATE_PURSES,
+        runtime_args! { ARG_TOTAL_PURSES => total_purses, ARG_SEED_AMOUNT => purse_amount },
+    )
+    .build();
+
+    builder.exec(exec_request).expect_success().commit();
+
+    // Return creates purses for given account by filtering named keys
+    let query_result = builder
+        .query(None, Key::Account(source), &[])
+        .expect("should query target");
+    let account = query_result
+        .as_account()
+        .unwrap_or_else(|| panic!("result should be account but received {:?}", query_result));
+
+    (0..total_purses)
+        .map(|index| {
+            let purse_lookup_key = format!("purse:{}", index);
+            let purse_uref = account
+                .named_keys()
+                .get(&purse_lookup_key)
+                .and_then(Key::as_uref)
+                .unwrap_or_else(|| panic!("should get named key {} as uref", purse_lookup_key));
+            *purse_uref
+        })
+        .collect()
+}
+
+/// Uses multiple exec requests with a single deploy to transfer tokens. Executes all transfers in
+/// batch determined by value of TRANSFER_BATCH_SIZE.
+pub fn transfer_to_account_multiple_execs(
+    builder: &mut LmdbWasmTestBuilder,
+    account: AccountHash,
+    should_commit: bool,
+) {
+    let amount = U512::one();
+
+    for _ in 0..TRANSFER_BATCH_SIZE {
+        let exec_request = ExecuteRequestBuilder::standard(
+            *DEFAULT_ACCOUNT_ADDR,
+            CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
+            runtime_args! {
+                ARG_TARGET => account,
+                ARG_AMOUNT => amount,
+            },
+        )
+        .build();
+
+        let builder = builder.exec(exec_request).expect_success();
+        if should_commit {
+            builder.commit();
+        }
+    }
+}
+
+/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
+pub fn transfer_to_account_multiple_deploys(
+    builder: &mut LmdbWasmTestBuilder,
+    account: AccountHash,
+    should_commit: bool,
+) {
+    let mut exec_builder = ExecuteRequestBuilder::new();
+
+    for i in 0..TRANSFER_BATCH_SIZE {
+        let deploy = DeployItemBuilder::default()
+            .with_address(*DEFAULT_ACCOUNT_ADDR)
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT })
+            .with_session_code(
+                CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
+                runtime_args! {
+                    ARG_TARGET => account,
+                    ARG_AMOUNT => U512::one(),
+                },
+            )
+            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
+            .build();
+        exec_builder = exec_builder.push_deploy(deploy);
+    }
+
+    let exec_request = exec_builder.build();
+
+    let builder = builder.exec(exec_request).expect_success();
+    if should_commit {
+        builder.commit();
+    }
+}
+
+/// Uses multiple exec requests with a single deploy to transfer tokens from purse to purse.
+/// Executes all transfers in batch determined by value of TRANSFER_BATCH_SIZE.
+pub fn transfer_to_purse_multiple_execs(
+    builder: &mut LmdbWasmTestBuilder,
+    purse: URef,
+    should_commit: bool,
+) {
+    let amount = U512::one();
+
+    for _ in 0..TRANSFER_BATCH_SIZE {
+        let exec_request = ExecuteRequestBuilder::standard(
+            TARGET_ADDR,
+            CONTRACT_TRANSFER_TO_PURSE,
+            runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => amount },
+        )
+        .build();
+
+        let builder = builder.exec(exec_request).expect_success();
+        if should_commit {
+            builder.commit();
+        }
+    }
+}
+
+/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
+pub fn transfer_to_purse_multiple_deploys(
+    builder: &mut LmdbWasmTestBuilder,
+    purse: URef,
+    should_commit: bool,
+) {
+    let mut exec_builder = ExecuteRequestBuilder::new();
+
+    for i in 0..TRANSFER_BATCH_SIZE {
+        let deploy = DeployItemBuilder::default()
+            .with_address(TARGET_ADDR)
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
+            .with_session_code(
+                CONTRACT_TRANSFER_TO_PURSE,
+                runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => U512::one() },
+            )
+            .with_authorization_keys(&[TARGET_ADDR])
+            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
+            .build();
+        exec_builder = exec_builder.push_deploy(deploy);
+    }
+
+    let exec_request = exec_builder.build();
+
+    let builder = builder.exec(exec_request).expect_success();
+    if should_commit {
+        builder.commit();
+    }
+}
+
+/// This test simulates flushing at the end of a block.
+pub fn transfer_to_account_multiple_native_transfers(
+    builder: &mut LmdbWasmTestBuilder,
+    execute_requests: &[ExecuteRequest],
+    use_scratch: bool,
+) {
+    for exec_request in execute_requests {
+        let request = ExecuteRequest::new(
+            exec_request.parent_state_hash,
+            exec_request.block_time,
+            exec_request.deploys.clone(),
+            exec_request.protocol_version,
+            exec_request.proposer.clone(),
+        );
+        if use_scratch {
+            builder.scratch_exec_and_commit(request).expect_success();
+        } else {
+            builder.exec(request).expect_success();
+            builder.commit();
+        }
+    }
+    if use_scratch {
+        builder.write_scratch_to_lmdb();
+    }
+    // flush to disk only after entire block (simulates manual_sync_enabled=true config entry)
+    builder.flush_environment();
+
+    // WasmTestBuilder holds on to all execution results. This needs to be cleared to reduce
+    // overhead in this test - it will likely OOM without.
+    builder.clear_results();
+}
+
+/// Generate many native transfers from target_account.
+pub fn create_multiple_native_transfers_to_purses(
+    source_account: AccountHash,
+    transfer_count: usize,
+    purses: &[URef],
+) -> Vec<ExecuteRequest> {
+    let mut purse_index = 0usize;
+    let mut exec_requests = Vec::with_capacity(transfer_count);
+    for _ in 0..transfer_count {
+        let account = {
+            let account = purses[purse_index];
+            if purse_index == purses.len() - 1 {
+                purse_index = 0;
+            } else {
+                purse_index += 1;
+            }
+            account
+        };
+        let mut exec_builder = ExecuteRequestBuilder::new();
+        let runtime_args = runtime_args! {
+            ARG_TARGET => account,
+            ARG_AMOUNT => U512::one(),
+            ARG_ID => <Option<u64>>::None
+        };
+        let native_transfer = DeployItemBuilder::new()
+            .with_address(source_account)
+            .with_empty_payment_bytes(runtime_args! {})
+            .with_transfer_args(runtime_args)
+            .with_authorization_keys(&[source_account])
+            .build();
+        exec_builder = exec_builder.push_deploy(native_transfer);
+        let exec_request = exec_builder.build();
+        exec_requests.push(exec_request);
+    }
+    exec_requests
+}

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use filesize::PathExt;
-use lmdb::DatabaseFlags;
+use lmdb::{Database, DatabaseFlags};
 use log::LevelFilter;
 
 use bytesrepr::FromBytes;
@@ -326,9 +326,8 @@ impl LmdbWasmTestBuilder {
         None
     }
 
-
     /// Execute and commit transforms from an ExecuteRequest into a scratch global state.
-    /// You MUST call scratch_flush to flush these changes to LmdbGlobalState.
+    /// You MUST call write_scratch_to_lmdb to flush these changes to LmdbGlobalState.
     pub fn scratch_exec_and_commit(&mut self, mut exec_request: ExecuteRequest) -> &mut Self {
         if self.scratch_engine_state.is_none() {
             self.scratch_engine_state = Some(self.engine_state.get_scratch_engine_state());
@@ -379,6 +378,16 @@ impl LmdbWasmTestBuilder {
             );
         }
         self
+    }
+
+    /// Returns a handle to the underlying LMDB environment.
+    pub fn lmdb_environment(&self) -> Arc<LmdbEnvironment> {
+        self.engine_state.lmdb_environment()
+    }
+
+    /// Returns a handle to the underlying LMDB database.
+    pub fn lmdb_handle(&self) -> Database {
+        self.engine_state.lmdb_handle()
     }
 }
 

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ed Hastings <ed@casperlabs.io>, Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1"
 base16 = "0.2.1"
 casper-contract = { path = "../../smart_contracts/contract", default-features = false, features = ["test-support"] }
 casper-engine-test-support = { path = "../test_support", features = ["test-support"] }
@@ -18,6 +19,7 @@ dictionary-call = { path = "../../smart_contracts/contracts/test/dictionary-call
 env_logger = "0.8.1"
 fs_extra = "1.2.0"
 get-call-stack-recursive-subcall = { path = "../../smart_contracts/contracts/test/get-call-stack-recursive-subcall", default-features = false }
+lmdb = "0.8"
 log = "0.4.8"
 parity-wasm = "0.41.0"
 rand = "0.8.3"

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -29,9 +29,6 @@ tempfile = "3"
 wabt = "0.10.0"
 wasmi = "0.8.0"
 
-# REMOVE ME
-criterion = { version = "0.3.5", features = ["html_reports"]}
-
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = { version = "0.3.5", features = ["html_reports"]}
@@ -58,11 +55,6 @@ harness = false
 [[bin]]
 name = "disk_use"
 path = "bin/disk_use.rs"
-
-# REMOVE ME
-[[bin]]
-name = "auction_bench"
-path = "benches/auction_bench.rs"
 
 [[bin]]
 name = "state-initializer"

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -27,6 +27,9 @@ tempfile = "3"
 wabt = "0.10.0"
 wasmi = "0.8.0"
 
+# REMOVE ME
+criterion = { version = "0.3.5", features = ["html_reports"]}
+
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = { version = "0.3.5", features = ["html_reports"]}
@@ -49,6 +52,15 @@ harness = false
 [[bench]]
 name = "auction_bench"
 harness = false
+
+[[bin]]
+name = "disk_use"
+path = "bin/disk_use.rs"
+
+# REMOVE ME
+[[bin]]
+name = "auction_bench"
+path = "benches/auction_bench.rs"
 
 [[bin]]
 name = "state-initializer"

--- a/execution_engine_testing/tests/benches/auction_bench.rs
+++ b/execution_engine_testing/tests/benches/auction_bench.rs
@@ -1,132 +1,16 @@
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
+use casper_execution_engine::core::engine_state::EngineConfig;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
 };
-use rand::Rng;
 use tempfile::TempDir;
 
 use casper_engine_test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, StepRequestBuilder,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
-    DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROPOSER_PUBLIC_KEY, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
-    DEFAULT_WASM_CONFIG, MINIMUM_ACCOUNT_CREATION_BALANCE, SYSTEM_ADDR,
+    auction::{DELEGATOR_INITIAL_BALANCE, TIMESTAMP_INCREMENT_MILLIS},
+    LmdbWasmTestBuilder,
 };
-use casper_execution_engine::{
-    core::engine_state::{
-        genesis::GenesisValidator, run_genesis_request::RunGenesisRequest, EngineConfig,
-        ExecConfig, ExecuteRequest, GenesisAccount, RewardItem,
-    },
-    shared::system_config::auction_costs::DEFAULT_DELEGATE_COST,
-};
-use casper_types::{
-    account::AccountHash,
-    runtime_args,
-    system::auction::{self},
-    Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
-};
-
-const ARG_AMOUNT: &str = "amount";
-const ARG_TARGET: &str = "target";
-const ARG_ID: &str = "id";
-
-const DELEGATION_AMOUNT: u64 = 42;
-const DELEGATION_RATE: u8 = 1;
-const DELEGATOR_INITIAL_BALANCE: u64 = 500 * 1_000_000_000u64;
-
-const VALIDATOR_BID_AMOUNT: u64 = 100;
-const TIMESTAMP_INCREMENT_MILLIS: u64 = 30_000;
-
-/// Runs genesis, creates system, validator and delegator accounts, and funds the system account and
-/// delegator accounts.
-fn run_genesis_and_create_initial_accounts(
-    data_dir: &Path,
-    validator_keys: &[PublicKey],
-    delegator_accounts: Vec<AccountHash>,
-) -> LmdbWasmTestBuilder {
-    let engine_config = EngineConfig::default();
-    let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
-
-    let mut genesis_accounts = vec![
-        GenesisAccount::account(
-            DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
-            Motes::new(U512::MAX), // all the monies
-            None,
-        ),
-        GenesisAccount::account(
-            DEFAULT_PROPOSER_PUBLIC_KEY.clone(),
-            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            None,
-        ),
-    ];
-    for validator in validator_keys {
-        genesis_accounts.push(GenesisAccount::account(
-            validator.clone(),
-            Motes::new(U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE)),
-            Some(GenesisValidator::new(
-                Motes::new(U512::from(VALIDATOR_BID_AMOUNT)),
-                DELEGATION_RATE,
-            )),
-        ))
-    }
-    let run_genesis_request =
-        create_run_genesis_request(validator_keys.len() as u32 + 2, genesis_accounts);
-    builder.run_genesis(&run_genesis_request);
-
-    // Setup the system account with enough cspr
-    let transfer = ExecuteRequestBuilder::transfer(
-        *DEFAULT_ACCOUNT_ADDR,
-        runtime_args! {
-                ARG_TARGET => *SYSTEM_ADDR,
-                ARG_AMOUNT => MINIMUM_ACCOUNT_CREATION_BALANCE,
-                ARG_ID => <Option<u64>>::None,
-        },
-    )
-    .build();
-    builder.exec(transfer);
-    builder.expect_success().commit();
-
-    for delegator_account in delegator_accounts {
-        let transfer = ExecuteRequestBuilder::transfer(
-            *DEFAULT_ACCOUNT_ADDR,
-            runtime_args! {
-                    ARG_TARGET => delegator_account,
-                    ARG_AMOUNT => DELEGATOR_INITIAL_BALANCE,
-                    ARG_ID => <Option<u64>>::None,
-            },
-        )
-        .build();
-        builder.exec(transfer);
-        builder.expect_success().commit();
-    }
-    builder
-}
-
-fn create_run_genesis_request(
-    validator_slots: u32,
-    genesis_accounts: Vec<GenesisAccount>,
-) -> RunGenesisRequest {
-    let exec_config = {
-        ExecConfig::new(
-            genesis_accounts,
-            *DEFAULT_WASM_CONFIG,
-            *DEFAULT_SYSTEM_CONFIG,
-            validator_slots,
-            DEFAULT_AUCTION_DELAY,
-            DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
-            DEFAULT_ROUND_SEIGNIORAGE_RATE,
-            DEFAULT_UNBONDING_DELAY,
-            DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-        )
-    };
-    RunGenesisRequest::new(
-        *DEFAULT_GENESIS_CONFIG_HASH,
-        *DEFAULT_PROTOCOL_VERSION,
-        exec_config,
-    )
-}
+use casper_types::U512;
 
 fn setup_bench_run_auction(
     group: &mut BenchmarkGroup<WallTime>,
@@ -134,17 +18,20 @@ fn setup_bench_run_auction(
     delegator_count: usize,
 ) {
     // Setup delegator public keys
-    let delegator_keys = generate_public_keys(delegator_count);
-    let validator_keys = generate_public_keys(validator_count);
+    let delegator_keys = casper_engine_test_support::auction::generate_public_keys(delegator_count);
+    let validator_keys = casper_engine_test_support::auction::generate_public_keys(validator_count);
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = run_genesis_and_create_initial_accounts(
-        data_dir.path(),
+    let engine_config = EngineConfig::default();
+    let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir.as_ref(), engine_config);
+    casper_engine_test_support::auction::run_genesis_and_create_initial_accounts(
+        &mut builder,
         &validator_keys,
         delegator_keys
             .iter()
             .map(|pk| pk.to_account_hash())
             .collect::<Vec<_>>(),
+        U512::from(DELEGATOR_INITIAL_BALANCE),
     );
 
     let contract_hash = builder.get_auction_contract_hash();
@@ -158,12 +45,12 @@ fn setup_bench_run_auction(
 
         assert_eq!(U512::from(DELEGATOR_INITIAL_BALANCE), balance);
 
-        let delegation_amount = U512::from(DELEGATION_AMOUNT);
+        let delegation_amount = U512::from(42);
         let delegator_account_hash = delegator_public_key.to_account_hash();
         let next_validator_key = next_validator_iter
             .next()
             .expect("should produce values forever");
-        let delegate = create_delegate_request(
+        let delegate = casper_engine_test_support::auction::create_delegate_request(
             delegator_public_key,
             next_validator_key.clone(),
             delegation_amount,
@@ -186,62 +73,13 @@ fn setup_bench_run_auction(
         |b| {
             b.iter(|| {
                 era_end_timestamp += TIMESTAMP_INCREMENT_MILLIS;
-                step_and_run_auction(&mut builder, &validator_keys)
+                casper_engine_test_support::auction::step_and_run_auction(
+                    &mut builder,
+                    &validator_keys,
+                );
             })
         },
     );
-}
-
-fn create_delegate_request(
-    delegator_public_key: PublicKey,
-    next_validator_key: PublicKey,
-    delegation_amount: U512,
-    delegator_account_hash: AccountHash,
-    contract_hash: casper_types::ContractHash,
-) -> ExecuteRequest {
-    let entry_point = auction::METHOD_DELEGATE;
-    let args = runtime_args! {
-        auction::ARG_DELEGATOR => delegator_public_key,
-        auction::ARG_VALIDATOR => next_validator_key,
-        auction::ARG_AMOUNT => delegation_amount,
-    };
-    let mut rng = rand::thread_rng();
-    let deploy_hash = rng.gen();
-    let deploy = DeployItemBuilder::new()
-        .with_address(delegator_account_hash)
-        .with_stored_session_hash(contract_hash, entry_point, args)
-        .with_empty_payment_bytes(
-            runtime_args! { ARG_AMOUNT => U512::from(DEFAULT_DELEGATE_COST), },
-        )
-        .with_authorization_keys(&[delegator_account_hash])
-        .with_deploy_hash(deploy_hash)
-        .build();
-    ExecuteRequestBuilder::new().push_deploy(deploy).build()
-}
-
-fn generate_public_keys(key_count: usize) -> Vec<PublicKey> {
-    let mut ret = Vec::with_capacity(key_count);
-    for _ in 0..key_count {
-        let bytes: [u8; SecretKey::ED25519_LENGTH] = rand::random();
-        let secret_key = SecretKey::ed25519_from_bytes(&bytes).unwrap();
-        let public_key = PublicKey::from(&secret_key);
-        ret.push(public_key);
-    }
-    ret
-}
-
-fn step_and_run_auction(builder: &mut LmdbWasmTestBuilder, validator_keys: &[PublicKey]) {
-    let mut step_request_builder = StepRequestBuilder::new()
-        .with_parent_state_hash(builder.get_post_state_hash())
-        .with_protocol_version(ProtocolVersion::V1_0_0);
-    for validator in validator_keys {
-        step_request_builder =
-            step_request_builder.with_reward_item(RewardItem::new(validator.clone(), 1));
-    }
-    let step_request = step_request_builder
-        .with_next_era_id(builder.get_era() + 1)
-        .build();
-    builder.step(step_request).expect("should step");
 }
 
 pub fn auction_bench(c: &mut Criterion) {

--- a/execution_engine_testing/tests/benches/transfer_bench.rs
+++ b/execution_engine_testing/tests/benches/transfer_bench.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
 use criterion::{
     criterion_group, criterion_main,
@@ -8,216 +8,23 @@ use criterion::{
 use tempfile::TempDir;
 
 use casper_engine_test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    transfer,
+    transfer::{BLOCK_TRANSFER_COUNT, TARGET_ADDR, TRANSFER_BATCH_SIZE},
+    LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::core::engine_state::{EngineConfig, ExecuteRequest};
-use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U512};
-
-const CONTRACT_CREATE_ACCOUNTS: &str = "create_accounts.wasm";
-const CONTRACT_CREATE_PURSES: &str = "create_purses.wasm";
-const CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT: &str = "transfer_to_existing_account.wasm";
-const CONTRACT_TRANSFER_TO_PURSE: &str = "transfer_to_purse.wasm";
-
-/// Size of batch used in multiple execs benchmark, and multiple deploys per exec cases.
-const TRANSFER_BATCH_SIZE: u64 = 3;
-const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
-const ARG_AMOUNT: &str = "amount";
-const ARG_ID: &str = "id";
-const ARG_ACCOUNTS: &str = "accounts";
-const ARG_SEED_AMOUNT: &str = "seed_amount";
-const ARG_TOTAL_PURSES: &str = "total_purses";
-const ARG_TARGET: &str = "target";
-const ARG_TARGET_PURSE: &str = "target_purse";
-
-const BLOCK_TRANSFER_COUNT: usize = 2500;
-
-/// Converts an integer into an array of type [u8; 32] by converting integer
-/// into its big endian representation and embedding it at the end of the
-/// range.
-fn make_deploy_hash(i: u64) -> [u8; 32] {
-    let mut result = [128; 32];
-    result[32 - 8..].copy_from_slice(&i.to_be_bytes());
-    result
-}
-
-fn bootstrap(data_dir: &Path, accounts: Vec<AccountHash>, amount: U512) -> LmdbWasmTestBuilder {
-    let exec_request = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_CREATE_ACCOUNTS,
-        runtime_args! { ARG_ACCOUNTS => accounts, ARG_SEED_AMOUNT => amount },
-    )
-    .build();
-
-    let engine_config = EngineConfig::default();
-
-    let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
-
-    builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
-        .exec(exec_request)
-        .expect_success()
-        .commit();
-
-    builder
-}
-
-fn create_purses(
-    builder: &mut LmdbWasmTestBuilder,
-    source: AccountHash,
-    total_purses: u64,
-    purse_amount: U512,
-) -> Vec<URef> {
-    let exec_request = ExecuteRequestBuilder::standard(
-        source,
-        CONTRACT_CREATE_PURSES,
-        runtime_args! { ARG_TOTAL_PURSES => total_purses, ARG_SEED_AMOUNT => purse_amount },
-    )
-    .build();
-
-    builder.exec(exec_request).expect_success().commit();
-
-    // Return creates purses for given account by filtering named keys
-    let query_result = builder
-        .query(None, Key::Account(source), &[])
-        .expect("should query target");
-    let account = query_result
-        .as_account()
-        .unwrap_or_else(|| panic!("result should be account but received {:?}", query_result));
-
-    (0..total_purses)
-        .map(|index| {
-            let purse_lookup_key = format!("purse:{}", index);
-            let purse_uref = account
-                .named_keys()
-                .get(&purse_lookup_key)
-                .and_then(Key::as_uref)
-                .unwrap_or_else(|| panic!("should get named key {} as uref", purse_lookup_key));
-            *purse_uref
-        })
-        .collect()
-}
-
-/// Uses multiple exec requests with a single deploy to transfer tokens. Executes all transfers in
-/// batch determined by value of TRANSFER_BATCH_SIZE.
-fn transfer_to_account_multiple_execs(
-    builder: &mut LmdbWasmTestBuilder,
-    account: AccountHash,
-    should_commit: bool,
-) {
-    let amount = U512::one();
-
-    for _ in 0..TRANSFER_BATCH_SIZE {
-        let exec_request = ExecuteRequestBuilder::standard(
-            *DEFAULT_ACCOUNT_ADDR,
-            CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
-            runtime_args! {
-                ARG_TARGET => account,
-                ARG_AMOUNT => amount,
-            },
-        )
-        .build();
-
-        let builder = builder.exec(exec_request).expect_success();
-        if should_commit {
-            builder.commit();
-        }
-    }
-}
-
-/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
-fn transfer_to_account_multiple_deploys(
-    builder: &mut LmdbWasmTestBuilder,
-    account: AccountHash,
-    should_commit: bool,
-) {
-    let mut exec_builder = ExecuteRequestBuilder::new();
-
-    for i in 0..TRANSFER_BATCH_SIZE {
-        let deploy = DeployItemBuilder::default()
-            .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT })
-            .with_session_code(
-                CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
-                runtime_args! {
-                    ARG_TARGET => account,
-                    ARG_AMOUNT => U512::one(),
-                },
-            )
-            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
-            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
-            .build();
-        exec_builder = exec_builder.push_deploy(deploy);
-    }
-
-    let exec_request = exec_builder.build();
-
-    let builder = builder.exec(exec_request).expect_success();
-    if should_commit {
-        builder.commit();
-    }
-}
-
-/// Uses multiple exec requests with a single deploy to transfer tokens from purse to purse.
-/// Executes all transfers in batch determined by value of TRANSFER_BATCH_SIZE.
-fn transfer_to_purse_multiple_execs(
-    builder: &mut LmdbWasmTestBuilder,
-    purse: URef,
-    should_commit: bool,
-) {
-    let amount = U512::one();
-
-    for _ in 0..TRANSFER_BATCH_SIZE {
-        let exec_request = ExecuteRequestBuilder::standard(
-            TARGET_ADDR,
-            CONTRACT_TRANSFER_TO_PURSE,
-            runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => amount },
-        )
-        .build();
-
-        let builder = builder.exec(exec_request).expect_success();
-        if should_commit {
-            builder.commit();
-        }
-    }
-}
-
-/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
-fn transfer_to_purse_multiple_deploys(
-    builder: &mut LmdbWasmTestBuilder,
-    purse: URef,
-    should_commit: bool,
-) {
-    let mut exec_builder = ExecuteRequestBuilder::new();
-
-    for i in 0..TRANSFER_BATCH_SIZE {
-        let deploy = DeployItemBuilder::default()
-            .with_address(TARGET_ADDR)
-            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
-            .with_session_code(
-                CONTRACT_TRANSFER_TO_PURSE,
-                runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => U512::one() },
-            )
-            .with_authorization_keys(&[TARGET_ADDR])
-            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
-            .build();
-        exec_builder = exec_builder.push_deploy(deploy);
-    }
-
-    let exec_request = exec_builder.build();
-
-    let builder = builder.exec(exec_request).expect_success();
-    if should_commit {
-        builder.commit();
-    }
-}
+use casper_types::U512;
 
 pub fn transfer_to_existing_accounts(group: &mut BenchmarkGroup<WallTime>, should_commit: bool) {
     let target_account = TARGET_ADDR;
     let bootstrap_accounts = vec![target_account];
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = bootstrap(data_dir.path(), bootstrap_accounts.clone(), U512::one());
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
+        bootstrap_accounts.clone(),
+        U512::one(),
+    );
 
     group.bench_function(
         format!(
@@ -227,13 +34,22 @@ pub fn transfer_to_existing_accounts(group: &mut BenchmarkGroup<WallTime>, shoul
         |b| {
             b.iter(|| {
                 // Execute multiple deploys with multiple exec requests
-                transfer_to_account_multiple_execs(&mut builder, target_account, should_commit)
+                transfer::transfer_to_account_multiple_execs(
+                    &mut builder,
+                    target_account,
+                    should_commit,
+                )
             })
         },
     );
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = bootstrap(data_dir.path(), bootstrap_accounts, U512::one());
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
+        bootstrap_accounts,
+        U512::one(),
+    );
 
     group.bench_function(
         format!(
@@ -243,7 +59,11 @@ pub fn transfer_to_existing_accounts(group: &mut BenchmarkGroup<WallTime>, shoul
         |b| {
             b.iter(|| {
                 // Execute multiple deploys with a single exec request
-                transfer_to_account_multiple_deploys(&mut builder, target_account, should_commit)
+                transfer::transfer_to_account_multiple_deploys(
+                    &mut builder,
+                    target_account,
+                    should_commit,
+                )
             })
         },
     );
@@ -262,48 +82,19 @@ pub fn multiple_native_transfers<M>(
     let bootstrap_accounts = vec![target_account];
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = bootstrap(
-        data_dir.path(),
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
         bootstrap_accounts,
         U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
     );
 
     let purse_amount = U512::one();
-    let purses = create_purses(
-        &mut builder,
-        target_account,
-        purse_count as u64,
-        purse_amount,
-    );
 
-    let mut purse_index = 0usize;
-    let mut exec_requests = Vec::with_capacity(transfer_count);
-    for _ in 0..transfer_count {
-        let account = {
-            let account = purses[purse_index];
-            if purse_index == purses.len() - 1 {
-                purse_index = 0;
-            } else {
-                purse_index += 1;
-            }
-            account
-        };
-        let mut exec_builder = ExecuteRequestBuilder::new();
-        let runtime_args = runtime_args! {
-            ARG_TARGET => account,
-            ARG_AMOUNT => U512::one(),
-            ARG_ID => <Option<u64>>::None
-        };
-        let native_transfer = DeployItemBuilder::new()
-            .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_empty_payment_bytes(runtime_args! {})
-            .with_transfer_args(runtime_args)
-            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
-            .build();
-        exec_builder = exec_builder.push_deploy(native_transfer);
-        let exec_request = exec_builder.build();
-        exec_requests.push(exec_request);
-    }
+    let purses = transfer::create_test_purses(&mut builder, target_account, 100, purse_amount);
+
+    let exec_requests =
+        transfer::create_multiple_native_transfers_to_purses(*DEFAULT_ACCOUNT_ADDR, 2500, &purses);
 
     let criterion_metric_name = std::any::type_name::<M>();
 
@@ -317,46 +108,14 @@ pub fn multiple_native_transfers<M>(
         ),
         |b| {
             b.iter(|| {
-                transfer_to_account_multiple_native_transfers(
+                transfer::transfer_to_account_multiple_native_transfers(
                     &mut builder,
                     &exec_requests,
                     use_scratch,
-                )
-            })
+                );
+            });
         },
     );
-}
-
-/// This test simulates flushing at the end of a block.
-fn transfer_to_account_multiple_native_transfers(
-    builder: &mut LmdbWasmTestBuilder,
-    execute_requests: &[ExecuteRequest],
-    use_scratch: bool,
-) {
-    for exec_request in execute_requests {
-        let request = ExecuteRequest::new(
-            exec_request.parent_state_hash,
-            exec_request.block_time,
-            exec_request.deploys.clone(),
-            exec_request.protocol_version,
-            exec_request.proposer.clone(),
-        );
-        if use_scratch {
-            builder.scratch_exec_and_commit(request).expect_success();
-        } else {
-            builder.exec(request).expect_success();
-            builder.commit();
-        }
-    }
-    if use_scratch {
-        builder.write_scratch_to_lmdb();
-    }
-    // flush to disk only after entire block (simulates manual_sync_enabled=true config entry)
-    builder.flush_environment();
-
-    // WasmTestBuilder holds on to all execution results. This needs to be cleared to reduce
-    // overhead in this test - it will likely OOM without.
-    builder.clear_results();
 }
 
 pub fn transfer_to_existing_purses(group: &mut BenchmarkGroup<WallTime>, should_commit: bool) {
@@ -364,14 +123,15 @@ pub fn transfer_to_existing_purses(group: &mut BenchmarkGroup<WallTime>, should_
     let bootstrap_accounts = vec![target_account];
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = bootstrap(
-        data_dir.path(),
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
         bootstrap_accounts.clone(),
         U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE) * 10,
     );
 
     let purse_amount = U512::one();
-    let purses = create_purses(&mut builder, target_account, 1, purse_amount);
+    let purses = transfer::create_test_purses(&mut builder, target_account, 1, purse_amount);
 
     group.bench_function(
         format!(
@@ -382,18 +142,23 @@ pub fn transfer_to_existing_purses(group: &mut BenchmarkGroup<WallTime>, should_
             let target_purse = purses[0];
             b.iter(|| {
                 // Execute multiple deploys with multiple exec request
-                transfer_to_purse_multiple_execs(&mut builder, target_purse, should_commit)
+                transfer::transfer_to_purse_multiple_execs(
+                    &mut builder,
+                    target_purse,
+                    should_commit,
+                )
             })
         },
     );
 
     let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = bootstrap(
-        data_dir.path(),
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
         bootstrap_accounts,
         U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE) * 10,
     );
-    let purses = create_purses(&mut builder, TARGET_ADDR, 1, U512::one());
+    let purses = transfer::create_test_purses(&mut builder, TARGET_ADDR, 1, U512::one());
 
     group.bench_function(
         format!(
@@ -404,7 +169,11 @@ pub fn transfer_to_existing_purses(group: &mut BenchmarkGroup<WallTime>, should_
             let target_purse = purses[0];
             b.iter(|| {
                 // Execute multiple deploys with a single exec request
-                transfer_to_purse_multiple_deploys(&mut builder, target_purse, should_commit)
+                transfer::transfer_to_purse_multiple_deploys(
+                    &mut builder,
+                    target_purse,
+                    should_commit,
+                )
             })
         },
     );

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -1,10 +1,164 @@
+use std::{collections::HashMap, error::Error};
+
+use casper_execution_engine::storage::trie::Trie;
+use casper_hashing::Digest;
+use lmdb::{Cursor, Transaction};
 use tempfile::TempDir;
 
 use casper_engine_test_support::{
     auction::{self},
     transfer, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_types::U512;
+use casper_types::{account::AccountHash, bytesrepr::FromBytes, Key, StoredValue, U512};
+
+const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
+
+fn transfer_disk_use(transfer_count: usize, purse_count: usize) -> Result<(), Box<dyn Error>> {
+    let data_dir = TempDir::new().expect("should create temp dir");
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+
+    let purse_amount = U512::one();
+    transfer::create_initial_accounts_and_run_genesis(
+        &mut builder,
+        vec![TARGET_ADDR],
+        purse_amount.clone(),
+    );
+
+    let purses = transfer::create_test_purses(
+        &mut builder,
+        *DEFAULT_ACCOUNT_ADDR,
+        purse_count as u64,
+        purse_amount,
+    );
+
+    let exec_requests = transfer::create_multiple_native_transfers_to_purses(
+        *DEFAULT_ACCOUNT_ADDR,
+        transfer_count,
+        &purses,
+    );
+
+    let mut total_transfers = 0;
+    println!("on_disk_size_bytes, transfer_count",);
+
+    total_transfers += exec_requests.len();
+    transfer::transfer_to_account_multiple_native_transfers(&mut builder, &exec_requests, true);
+    println!(
+        "{}, {}",
+        builder.lmdb_on_disk_size().unwrap(),
+        total_transfers
+    );
+
+    let env = builder.lmdb_environment();
+    let db = builder.lmdb_handle();
+    let env = env.env();
+
+    let txn = env.begin_ro_txn()?;
+    let mut cursor = txn.open_ro_cursor(db)?;
+    let mut record_count = 0;
+    let mut largest_record = 0;
+
+    let mut key_tags = HashMap::<String, usize>::new();
+    let mut stored_value_tags = HashMap::<String, usize>::new();
+    let mut trie_value_lengths = HashMap::<(String, String), Vec<usize>>::new();
+    let mut pointer_block_lengths = Vec::new();
+    let mut extension_node_lengths = Vec::new();
+    let mut total_value_bytes_read = 0;
+    let mut total_key_bytes_read = 0;
+
+    for (key, value) in cursor.iter() {
+        // count key len
+        total_key_bytes_read += key.len();
+
+        let (_key, _rest) = Digest::from_bytes(key).expect("should deserialize");
+        let byte_len = value.len();
+
+        // count value len
+        total_value_bytes_read += byte_len;
+
+        let (trie, _remainder) =
+            Trie::<Key, StoredValue>::from_bytes(value).expect("should be a trie");
+
+        match trie {
+            Trie::Leaf { key, value } => {
+                let key_tag = key.type_string();
+                let stored_value_tag = value.type_name();
+
+                *key_tags.entry(key_tag.clone()).or_default() += 1;
+                *stored_value_tags
+                    .entry(stored_value_tag.clone())
+                    .or_default() += 1;
+                let trie_length_values = trie_value_lengths
+                    .entry((key_tag, stored_value_tag))
+                    .or_default();
+                trie_length_values.push(byte_len);
+            }
+            Trie::Node { pointer_block: _ } => {
+                pointer_block_lengths.push(byte_len);
+            }
+            Trie::Extension {
+                affix: _,
+                pointer: _,
+            } => extension_node_lengths.push(byte_len),
+        }
+
+        record_count += 1;
+        let serialized_len = value.len();
+        if largest_record < serialized_len {
+            println!("found new largest DB entry with len {}", serialized_len);
+            largest_record = serialized_len;
+        }
+    }
+
+    println!("key_tag, count");
+    for (key_tag, count) in key_tags {
+        println!("\"{}\", {}", key_tag, count);
+    }
+
+    println!("stored_value_tag, count");
+    for (stored_value_tag, count) in stored_value_tags {
+        println!("\"{}\", {}", stored_value_tag, count);
+    }
+
+    println!("key_tag, stored_value_tag, average_len, max_len, count, sum_total_bytes");
+    for ((key_tag, stored_value_tag), lengths) in trie_value_lengths {
+        if lengths.is_empty() {
+            continue;
+        }
+        let total: usize = lengths.iter().sum::<usize>();
+        let average_len: usize = total / lengths.len();
+        let max_len: usize = *lengths.iter().max().unwrap();
+        println!(
+            "\"{}\", \"{}\", {}, {}, {}, {}",
+            key_tag,
+            stored_value_tag,
+            average_len,
+            max_len,
+            lengths.len(),
+            total,
+        );
+    }
+
+    println!(
+        "processed {} db records total, {} key bytes read, {} value bytes read, {} total bytes read, {} lmdb file size in bytes",
+        record_count,
+        total_key_bytes_read,
+        total_value_bytes_read,
+        total_value_bytes_read + total_key_bytes_read,
+        builder.lmdb_on_disk_size().unwrap()
+    );
+    println!(
+        "{} pointer blocks consuming {} bytes",
+        pointer_block_lengths.len(),
+        pointer_block_lengths.iter().sum::<usize>()
+    );
+    println!(
+        "{} extension nodes consuming {} bytes",
+        extension_node_lengths.len(),
+        extension_node_lengths.iter().sum::<usize>()
+    );
+
+    Ok(())
+}
 
 // Generate multiple purses as well as transfer requests between them with the specified count.
 pub fn multiple_native_transfers(
@@ -89,6 +243,7 @@ pub fn multiple_native_transfers(
 }
 
 fn main() {
+    transfer_disk_use(2500, 100).unwrap();
     for purse_count in [100] {
         for transfer_count in [2500usize] {
             // baseline, one deploy per exec request

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -1,0 +1,99 @@
+use tempfile::TempDir;
+
+use casper_engine_test_support::{
+    auction::{self},
+    transfer, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_types::U512;
+
+// Generate multiple purses as well as transfer requests between them with the specified count.
+pub fn multiple_native_transfers(
+    transfer_count: usize,
+    purse_count: usize,
+    use_scratch: bool,
+    run_auction: bool,
+) {
+    let data_dir = TempDir::new().expect("should create temp dir");
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    let delegator_keys = auction::generate_public_keys(100);
+    let validator_keys = auction::generate_public_keys(100);
+
+    auction::run_genesis_and_create_initial_accounts(
+        &mut builder,
+        &validator_keys,
+        delegator_keys
+            .iter()
+            .map(|pk| pk.to_account_hash())
+            .collect::<Vec<_>>(),
+        U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
+    );
+    let contract_hash = builder.get_auction_contract_hash();
+    let mut next_validator_iter = validator_keys.iter().cycle();
+    for delegator_public_key in delegator_keys {
+        let delegation_amount = U512::from(42);
+        let delegator_account_hash = delegator_public_key.to_account_hash();
+        let next_validator_key = next_validator_iter
+            .next()
+            .expect("should produce values forever");
+        let delegate = auction::create_delegate_request(
+            delegator_public_key,
+            next_validator_key.clone(),
+            delegation_amount,
+            delegator_account_hash,
+            contract_hash,
+        );
+        builder.exec(delegate);
+        builder.expect_success();
+        builder.commit();
+        builder.clear_results();
+    }
+
+    let purse_amount = U512::one();
+
+    let purses = transfer::create_test_purses(
+        &mut builder,
+        *DEFAULT_ACCOUNT_ADDR,
+        purse_count as u64,
+        purse_amount,
+    );
+
+    let exec_requests = transfer::create_multiple_native_transfers_to_purses(
+        *DEFAULT_ACCOUNT_ADDR,
+        transfer_count,
+        &purses,
+    );
+
+    let mut total_transfers = 0;
+    println!("on_disk_size_bytes, transfer_count",);
+
+    // 5 eras, of 30 blocks each, with `transfer_count` transfers.
+    for _ in 0..5 {
+        for _ in 0..30 {
+            total_transfers += exec_requests.len();
+            transfer::transfer_to_account_multiple_native_transfers(
+                &mut builder,
+                &exec_requests,
+                use_scratch,
+            );
+            println!(
+                "{}, {}",
+                builder.lmdb_on_disk_size().unwrap(),
+                total_transfers
+            );
+        }
+        if run_auction {
+            println!("running auction");
+            auction::step_and_run_auction(&mut builder, &validator_keys);
+        }
+    }
+}
+
+fn main() {
+    for purse_count in [100] {
+        for transfer_count in [2500usize] {
+            // baseline, one deploy per exec request
+            multiple_native_transfers(transfer_count, purse_count, false, false);
+            multiple_native_transfers(transfer_count, purse_count, true, false);
+        }
+    }
+}

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -21,7 +21,7 @@ fn transfer_disk_use(transfer_count: usize, purse_count: usize) -> Result<(), Bo
     transfer::create_initial_accounts_and_run_genesis(
         &mut builder,
         vec![TARGET_ADDR],
-        purse_amount.clone(),
+        purse_amount,
     );
 
     let purses = transfer::create_test_purses(


### PR DESCRIPTION
Resolves #2481 

This PR (which should be reviewed after https://github.com/casper-network/casper-node/pull/2277 merges to dev):

- adds `lmdb_on_disk_size` method to WasmTestBuilder.
- extracts a significant amount of the logic in `transfer_bench` and `auction_bench` into utility methods within execution_engine_testing, for reuse.
- `disk_use` binary target that will run a series of tests against the trie to measure disk use with transfers and auction code that was extracted in the previous point.
