### PR TITLE
Port run_equivocator_network test workaround from dev to feat-fast-sync.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1095,11 +1095,6 @@ where
         self.current_era
     }
 
-    /// Returns the list of validators who equivocated in this era.
-    pub(crate) fn validators_with_evidence(&self, era_id: EraId) -> Vec<&PublicKey> {
-        self.open_eras[&era_id].consensus.validators_with_evidence()
-    }
-
     /// Returns this node's validator key.
     pub(crate) fn public_key(&self) -> &PublicKey {
         &self.public_signing_key

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -355,25 +355,11 @@ async fn run_equivocator_network() {
         });
 
     let era_count = 4;
+
     let timeout = Duration::from_secs(90 * era_count);
-
-    for era_num in 1..era_count {
-        let era_id = EraId::from(era_num);
-        info!("Waiting for {} to end.", era_id);
-        net.settle_on(&mut rng, is_in_era(era_id.successor()), timeout)
-            .await;
-        // The only era with direct evidence is era 1. After that Alice was banned or evicted.
-        for runner in net.nodes().values() {
-            let consensus = runner.participating().consensus();
-            let expected = if era_num == 1 {
-                vec![&alice_pk]
-            } else {
-                vec![]
-            };
-            assert_eq!(consensus.validators_with_evidence(era_id), expected);
-        }
-    }
-
+    info!("Waiting for {} eras to end.", era_count);
+    net.settle_on(&mut rng, is_in_era(EraId::new(era_count)), timeout)
+        .await;
     let switch_blocks = SwitchBlocks::collect(net.nodes(), era_count);
     let bids: Vec<Bids> = (0..era_count)
         .map(|era_number| switch_blocks.bids(net.nodes(), era_number))


### PR DESCRIPTION
As a workaround for #1859, the test shouldn't fail if we don't manage to produce an equivocation.