### PR TITLE
Document cancellation safety

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -189,7 +189,7 @@ where
             if let Err(data) = sender.send(data) {
                 // If we cannot send a response down the channel, it means the original requestor is
                 // no longer interested in our response. This typically happens during shutdowns, or
-                // in cases where an originatinge external request has been cancelled.
+                // in cases where an originating external request has been cancelled.
 
                 debug!(
                     ?data,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -187,17 +187,14 @@ where
     pub(crate) async fn respond(mut self, data: T) {
         if let Some(sender) = self.sender.take() {
             if let Err(data) = sender.send(data) {
-                if self.is_shutting_down.is_set() {
-                    debug!(
-                        ?data,
-                        "ignored failure to send response to request down oneshot channel"
-                    );
-                } else {
-                    error!(
-                        ?data,
-                        "could not send response to request down oneshot channel"
-                    );
-                }
+                // If we cannot send a response down the channel, it means the original requestor is
+                // no longer interested in our response. This typically happens during shutdowns, or
+                // in cases where an originatinge external request has been cancelled.
+
+                debug!(
+                    ?data,
+                    "ignored failure to send response to request down oneshot channel"
+                );
             }
         } else {
             error!(
@@ -230,6 +227,8 @@ impl<T> Drop for Responder<T> {
                 );
             } else {
                 // This is usually a very serious error, as another component will now be stuck.
+                //
+                // See the code `make_request` for more details.
                 error!(
                     responder=?self,
                     "dropped without being responded to outside of shutdown"
@@ -445,14 +444,19 @@ impl<REv> EffectBuilder<REv> {
 
     /// Performs a request.
     ///
-    /// Given a request `Q`, that when completed will yield a result of `T`, produces a future
-    /// that will
+    /// Given a request `Q`, that when completed will yield a result of `T`, produces a future that
+    /// will
     ///
     /// 1. create an event to send the request to the respective component (thus `Q: Into<REv>`),
-    /// 2. waits for a response and returns it.
+    /// 2. wait for a response and return it.
     ///
-    /// This function is usually only used internally by effects implement on the effects builder,
+    /// This function is usually only used internally by effects implemented on the effects builder,
     /// but IO components may also make use of it.
+    ///
+    /// # Cancellation safety
+    ///
+    /// This future is cancellation safe: If it is dropped without being polled, it merely indicates
+    /// the original requestor is not longer interested in the result, which will be discarded.
     pub(crate) async fn make_request<T, Q, F>(self, f: F, queue_kind: QueueKind) -> T
     where
         T: Send + 'static,
@@ -472,8 +476,10 @@ impl<REv> EffectBuilder<REv> {
         match receiver.await {
             Ok(value) => value,
             Err(err) => {
-                // The channel should never be closed, ever. If it is, we pretend nothing happened
-                // though, instead of crashing.
+                // The channel should usually not be closed except during shutdowns, as it indicates
+                // a panic or disappearance of the remote that is supposed to process the request.
+                //
+                // If it does happen, we pretend nothing happened instead of crashing.
                 if self.event_queue.shutdown_flag().is_set() {
                     debug!(%err, ?queue_kind, channel=?type_name::<T>(), "ignoring closed channel due to shutdown")
                 } else {


### PR DESCRIPTION
Closes #2492.

This is a minor changing removing one log message and clarifying future cancellation of `make_request` in the code.