### PR TITLE
Shut down if trusted block is from an old version.

### DIFF
--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -46,10 +46,10 @@ pub(crate) enum Error {
     },
 
     #[error(
-        "network is still running an older version. Current version is {current_version}, \
-         but current block header has older version: {block_header_with_old_version:?}"
+        "the trusted block has an older version. Current version is {current_version}, \
+         but trusted block header has older version: {block_header_with_old_version:?}"
     )]
-    CurrentBlockHeaderHasOldVersion {
+    TrustedBlockHasOldVersion {
         current_version: ProtocolVersion,
         block_header_with_old_version: Box<BlockHeader>,
     },


### PR DESCRIPTION
Fast sync doesn't have the capability to sync forward across an upgrade boundary yet, so we shut down right away if the trusted block has a version lower than the current one and isn't the last block before the upgrade.

Closes #2253.