### PR TITLE
Limit incoming connections per peer

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
 * `SIGUSR1` now only dumps the queue in the debug text format.
+* Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
 
 
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -445,6 +445,25 @@ where
                 peer_consensus_public_key,
                 stream,
             } => {
+                if self.cfg.max_incoming_peer_connections != 0 {
+                    if let Some(symmetries) = self.connection_symmetries.get(&peer_id) {
+                        let incoming_count = symmetries
+                            .incoming_addrs()
+                            .map(|addrs| addrs.len())
+                            .unwrap_or_default();
+
+                        if incoming_count >= self.cfg.max_incoming_peer_connections as usize {
+                            info!(%public_addr,
+                                  %peer_id,
+                                  count=incoming_count,
+                                  limit=self.cfg.max_incoming_peer_connections,
+                                  "rejecting new incoming connection, limit for peer exceeded"
+                            );
+                            return Effects::new();
+                        }
+                    }
+                }
+
                 info!(%public_addr, "new incoming connection established");
 
                 // Learn the address the peer gave us.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -32,6 +32,7 @@ impl Default for Config {
             gossip_interval: TimeDiff::from_str(DEFAULT_GOSSIP_INTERVAL).unwrap(),
             initial_gossip_delay: TimeDiff::from_seconds(5),
             max_addr_pending_time: TimeDiff::from_seconds(60),
+            max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
@@ -58,6 +59,8 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for an address to be kept in the pending set.
     pub max_addr_pending_time: TimeDiff,
+    /// Maximum number of incoming connections per unique peer. Unlimited if `0`.
+    pub max_incoming_peer_connections: u16,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_outgoing_byte_rate_non_validators: u32,
     /// Maximum of requests answered from non-validating peers. Unlimited if 0.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -125,6 +125,10 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -125,6 +125,10 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 6553600

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -125,6 +125,10 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -129,6 +129,10 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -125,6 +125,10 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
 # The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0


### PR DESCRIPTION
Limits incoming to a maximum of 3 (default setting) per peer, identified by unique node ID. A value of 0 disables the feature.

