### PR TITLE
Emergency upgrades

### DIFF
--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -737,7 +737,7 @@ pub(super) async fn run_chain_sync_task(
         }
         // If the trusted hash specifies the last block before the emergency restart, we have to
         // compute the immediate switch block ourselves, since there's no other way to verify that
-        // block. We just sync the trie there and and return, so the upgrade can be applied.
+        // block. We just sync the trie there and return, so the upgrade can be applied.
         if trusted_block_header.is_switch_block()
             && trusted_block_header.next_block_era_id() == last_emergency_restart_era
         {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1486,7 +1486,7 @@ impl Storage {
         let block_body = match maybe_block_body {
             Some(block_body) => block_body,
             None => {
-                warn!(
+                info!(
                     ?block_header,
                     "retrieved block header but block body is missing from database"
                 );

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -72,7 +72,7 @@ function log_step() {
 
 function do_await_genesis_era_to_complete() {
     log_step "awaiting genesis era to complete"
-    while [ "$(get_chain_era)" != "1" ]; do
+    while [ "$(get_chain_era)" != "2" ]; do
         sleep 1.0
     done
 }


### PR DESCRIPTION
They work just like regular upgrades except that we can't _download_ the immediate switch block: we have to create it ourselves, because after an emergency restart the pre-restart validators might not be trustworthy anymore.

Keeping #1665 open for now until some of the other fixes have been merged too, and can be tested together with this.

We also set the log level for `retrieved block header but block body is missing from database` to INFO, because fast sync is expected to download some headers without bodies.

Closes #2583.
