### PR TITLE
CI-Failure: switch building contracts to a drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -132,6 +132,19 @@ type: docker
 name: package
 
 steps:
+- name: build-client-contracts
+  image: casperlabs/node-build-u1804
+  commands:
+    - make build-client-contracts
+  when:
+    branch:
+    - master
+    - dev
+    - "release-*"
+    - "feat-*"
+    event:
+    - push
+
 - name: build-wasm-package-push-to-s3
   image: casperlabs/s3cmd-build:latest
   commands:

--- a/build_wasm_package.sh
+++ b/build_wasm_package.sh
@@ -27,9 +27,6 @@ export CL_WASM_PACKAGE="$CL_OUTPUT_S3_DIR/casper-contracts.tar.gz"
 export CL_S3_BUCKET='casperlabs-cicd-artifacts'
 export CL_S3_LOCATION="wasm_contracts/${WASM_PACKAGE_VERSION}"
 
-#Build contracts
-make build-client-contracts
-
 if [ ! -d $CL_OUTPUT_S3_DIR ]; then
   mkdir -p "${CL_OUTPUT_S3_DIR}"
 fi


### PR DESCRIPTION
Removes: 
- change from https://github.com/casper-network/casper-node/pull/2584

Adds: 
- building of client contracts in drone prior to uploading to s3