### PR TITLE
GH-2443: Get auction info backwards compatibility

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -1220,14 +1220,14 @@ where
             ARG_AMOUNT => amount,
         };
 
-        let registry = self
+        let system_contract_registry = self
             .tracking_copy
             .borrow_mut()
             .get_system_contracts(self.correlation_id)
             .map_err(execution::Error::from)
             .map_err(GenesisError::ExecutionError)?;
 
-        let mint_hash = registry.get(MINT).ok_or_else(|| {
+        let mint_hash = system_contract_registry.get(MINT).ok_or_else(|| {
             error!("Missing system mint contract hash");
             GenesisError::MissingSystemContractHash(MINT.to_string())
         })?;
@@ -1277,6 +1277,7 @@ where
                 Rc::clone(&self.tracking_copy),
                 Phase::System,
                 stack,
+                system_contract_registry.clone(),
             )
             .map_err(|_| GenesisError::UnableToCreateRuntime)?;
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1474,6 +1474,7 @@ where
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let transfers = self.context.transfers().to_owned();
+        let system_contract_registry = self.context.system_contract_registry().clone();
 
         let mint_context = RuntimeContext::new(
             self.context.state(),
@@ -1494,6 +1495,7 @@ where
             phase,
             self.config,
             transfers,
+            system_contract_registry,
         );
 
         let mut mint_runtime = self.new_from_self(mint_context, stack);
@@ -1630,6 +1632,7 @@ where
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let transfers = self.context.transfers().to_owned();
+        let system_contract_registry = self.context.system_contract_registry().to_owned();
 
         let runtime_context = RuntimeContext::new(
             self.context.state(),
@@ -1650,6 +1653,7 @@ where
             phase,
             self.config,
             transfers,
+            system_contract_registry,
         );
 
         let mut runtime = self.new_from_self(runtime_context, stack);
@@ -1760,6 +1764,7 @@ where
         let phase = self.context.phase();
 
         let transfers = self.context.transfers().to_owned();
+        let system_contract_registry = self.context.system_contract_registry().to_owned();
 
         let runtime_context = RuntimeContext::new(
             self.context.state(),
@@ -1780,6 +1785,7 @@ where
             phase,
             self.config,
             transfers,
+            system_contract_registry,
         );
 
         let mut runtime = self.new_from_self(runtime_context, stack);
@@ -2048,7 +2054,7 @@ where
         // execution of a system contract.
         if !self
             .context
-            .system_contract_registry()?
+            .system_contract_registry()
             .values()
             .any(|&system_hash| system_hash == contract_hash)
         {
@@ -2255,6 +2261,7 @@ where
             self.context.phase(),
             self.config,
             self.context.transfers().to_owned(),
+            self.context.system_contract_registry().to_owned(),
         );
 
         let mut stack = self.stack.clone();

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -136,6 +136,7 @@ fn mock_runtime_context<'a>(
         Phase::Session,
         *TEST_ENGINE_CONFIG,
         Vec::default(),
+        Default::default(),
     )
 }
 
@@ -378,6 +379,7 @@ fn contract_key_addable_valid() {
         PHASE,
         EngineConfig::default(),
         Vec::default(),
+        Default::default(),
     );
 
     runtime_context
@@ -447,6 +449,7 @@ fn contract_key_addable_invalid() {
         PHASE,
         EngineConfig::default(),
         Vec::default(),
+        Default::default(),
     );
 
     let result = runtime_context.metered_add_gs(contract_key, named_uref_tuple);

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -126,7 +126,7 @@ impl Default for InMemoryWasmTestBuilder {
         let engine_config = EngineConfig::default();
 
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
-        let engine_state = EngineState::new(global_state, engine_config);
+        let engine_state = EngineState::new(global_state, engine_config, None);
 
         WasmTestBuilder {
             engine_state: Rc::new(engine_state),
@@ -176,7 +176,7 @@ impl InMemoryWasmTestBuilder {
         post_state_hash: Digest,
     ) -> Self {
         Self::initialize_logging();
-        let engine_state = EngineState::new(global_state, engine_config);
+        let engine_state = EngineState::new(global_state, engine_config, Some(post_state_hash));
         WasmTestBuilder {
             engine_state: Rc::new(engine_state),
             genesis_hash: Some(post_state_hash),
@@ -212,7 +212,7 @@ impl LmdbWasmTestBuilder {
 
         let global_state =
             LmdbGlobalState::empty(environment, trie_store).expect("should create LmdbGlobalState");
-        let engine_state = EngineState::new(global_state, engine_config);
+        let engine_state = EngineState::new(global_state, engine_config, None);
         WasmTestBuilder {
             engine_state: Rc::new(engine_state),
             exec_results: Vec::new(),
@@ -277,7 +277,7 @@ impl LmdbWasmTestBuilder {
 
         let global_state =
             LmdbGlobalState::empty(environment, trie_store).expect("should create LmdbGlobalState");
-        let engine_state = EngineState::new(global_state, engine_config);
+        let engine_state = EngineState::new(global_state, engine_config, Some(post_state_hash));
         WasmTestBuilder {
             engine_state: Rc::new(engine_state),
             exec_results: Vec::new(),

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -986,24 +986,29 @@ where
     }
 
     /// Gets [`EraValidators`].
-    pub fn get_era_validators(&mut self) -> EraValidators {
+    pub fn get_era_validators(&mut self, state_root_hash: Option<Digest>) -> EraValidators {
+        let state_root_hash = state_root_hash.unwrap_or_else(|| self.get_post_state_hash());
         let correlation_id = CorrelationId::new();
-        let state_hash = self.get_post_state_hash();
-        let request = GetEraValidatorsRequest::new(state_hash, *DEFAULT_PROTOCOL_VERSION);
+        let request = GetEraValidatorsRequest::new(state_root_hash, *DEFAULT_PROTOCOL_VERSION);
         self.engine_state
             .get_era_validators(correlation_id, request)
             .expect("get era validators should not error")
     }
 
     /// Gets [`ValidatorWeights`] for a given [`EraId`].
-    pub fn get_validator_weights(&mut self, era_id: EraId) -> Option<ValidatorWeights> {
-        let mut result = self.get_era_validators();
+    pub fn get_validator_weights(
+        &mut self,
+        state_root_hash: Option<Digest>,
+        era_id: EraId,
+    ) -> Option<ValidatorWeights> {
+        let mut result = self.get_era_validators(state_root_hash);
         result.remove(&era_id)
     }
 
     /// Gets [`Bids`].
-    pub fn get_bids(&mut self) -> Bids {
-        let get_bids_request = GetBidsRequest::new(self.get_post_state_hash());
+    pub fn get_bids(&mut self, state_root_hash: Option<Digest>) -> Bids {
+        let state_root_hash = state_root_hash.unwrap_or_else(|| self.get_post_state_hash());
+        let get_bids_request = GetBidsRequest::new(state_root_hash);
 
         let get_bids_result = self
             .engine_state

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -115,12 +115,14 @@ fn should_run_ee_1045_squash_validators() {
     builder.run_genesis(&run_genesis_request);
 
     let genesis_validator_weights = builder
-        .get_validator_weights(INITIAL_ERA_ID)
+        .get_validator_weights(None, INITIAL_ERA_ID)
         .expect("should have genesis validator weights");
 
     let mut new_era_id = INITIAL_ERA_ID + DEFAULT_AUCTION_DELAY + 1;
-    assert!(builder.get_validator_weights(new_era_id).is_none());
-    assert!(builder.get_validator_weights(new_era_id - 1).is_some());
+    assert!(builder.get_validator_weights(None, new_era_id).is_none());
+    assert!(builder
+        .get_validator_weights(None, new_era_id - 1)
+        .is_some());
 
     builder.exec(transfer_request_1).expect_success().commit();
 
@@ -158,14 +160,16 @@ fn should_run_ee_1045_squash_validators() {
     builder.exec(squash_request_1).expect_success().commit();
 
     // new_era_id += 1;
-    assert!(builder.get_validator_weights(new_era_id).is_none());
-    assert!(builder.get_validator_weights(new_era_id - 1).is_some());
+    assert!(builder.get_validator_weights(None, new_era_id).is_none());
+    assert!(builder
+        .get_validator_weights(None, new_era_id - 1)
+        .is_some());
 
     builder.run_auction(timestamp_millis, Vec::new());
     timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
 
     let post_round_1_auction_weights = builder
-        .get_validator_weights(new_era_id)
+        .get_validator_weights(None, new_era_id)
         .expect("should have new era validator weights computed");
 
     assert_ne!(genesis_validator_weights, post_round_1_auction_weights);
@@ -182,13 +186,15 @@ fn should_run_ee_1045_squash_validators() {
     //
     builder.exec(squash_request_2).expect_success().commit();
     new_era_id += 1;
-    assert!(builder.get_validator_weights(new_era_id).is_none());
-    assert!(builder.get_validator_weights(new_era_id - 1).is_some());
+    assert!(builder.get_validator_weights(None, new_era_id).is_none());
+    assert!(builder
+        .get_validator_weights(None, new_era_id - 1)
+        .is_some());
 
     builder.run_auction(timestamp_millis, Vec::new());
 
     let post_round_2_auction_weights = builder
-        .get_validator_weights(new_era_id)
+        .get_validator_weights(None, new_era_id)
         .expect("should have new era validator weights computed");
 
     assert_ne!(genesis_validator_weights, post_round_2_auction_weights);

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -173,7 +173,7 @@ fn validator_scores_should_reflect_delegates() {
     // Check initial weights
     {
         let era_weights = builder
-            .get_validator_weights(era)
+            .get_validator_weights(None, era)
             .expect("should get validator weights");
 
         assert_eq!(era_weights.get(&VALIDATOR_1), Some(&*VALIDATOR_1_STAKE));
@@ -192,7 +192,7 @@ fn validator_scores_should_reflect_delegates() {
         assert_eq!(builder.get_auction_delay(), auction_delay);
 
         let era_weights = builder
-            .get_validator_weights(era + auction_delay)
+            .get_validator_weights(None, era + auction_delay)
             .expect("should get validator weights");
 
         assert_eq!(era_weights.get(&VALIDATOR_1), Some(&*VALIDATOR_1_STAKE));
@@ -227,7 +227,7 @@ fn validator_scores_should_reflect_delegates() {
         assert_eq!(builder.get_auction_delay(), auction_delay);
 
         let era_weights = builder
-            .get_validator_weights(era)
+            .get_validator_weights(None, era)
             .expect("should get validator weights");
 
         let validator_1_expected_stake = *VALIDATOR_1_STAKE + *DELEGATOR_1_STAKE;
@@ -277,7 +277,7 @@ fn validator_scores_should_reflect_delegates() {
         assert_eq!(builder.get_auction_delay(), auction_delay);
 
         let era_weights = builder
-            .get_validator_weights(era)
+            .get_validator_weights(None, era)
             .expect("should get validator weights");
 
         let validator_1_expected_stake =
@@ -327,7 +327,7 @@ fn validator_scores_should_reflect_delegates() {
         assert_eq!(builder.get_auction_delay(), auction_delay);
 
         let era_weights = builder
-            .get_validator_weights(era)
+            .get_validator_weights(None, era)
             .expect("should get validator weights");
 
         let validator_1_expected_stake =

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -101,7 +101,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         .expect_success()
         .commit();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let validator_1_bid = bids.get(&VALIDATOR_1).expect("should have bid");
     let bid_purse = validator_1_bid.bonding_purse();
     assert_eq!(
@@ -208,7 +208,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         "slashing default validator should be noop because no unbonding was done"
     );
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert!(!bids.is_empty());
     assert!(bids.contains_key(&VALIDATOR_1)); // still bid upon
 
@@ -237,7 +237,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
 
     assert!(unbond_purses.get(&VALIDATOR_1_ADDR).unwrap().is_empty());
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let validator_1_bid = bids.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -161,7 +161,7 @@ fn should_run_ee_1120_slash_delegators() {
         .commit();
 
     // Ensure that initial bid entries exist for validator 1 and validator 2
-    let initial_bids: Bids = builder.get_bids();
+    let initial_bids: Bids = builder.get_bids(None);
     assert_eq!(
         initial_bids.keys().cloned().collect::<BTreeSet<_>>(),
         BTreeSet::from_iter(vec![VALIDATOR_2.clone(), VALIDATOR_1.clone()])
@@ -273,7 +273,7 @@ fn should_run_ee_1120_slash_delegators() {
 
     // Check bids before slashing
 
-    let bids_before: Bids = builder.get_bids();
+    let bids_before: Bids = builder.get_bids(None);
     assert_eq!(
         bids_before.keys().collect::<Vec<_>>(),
         initial_bids.keys().collect::<Vec<_>>()
@@ -292,7 +292,7 @@ fn should_run_ee_1120_slash_delegators() {
     builder.exec(slash_request_1).expect_success().commit();
 
     // Compare bids after slashing validator 2
-    let bids_after: Bids = builder.get_bids();
+    let bids_after: Bids = builder.get_bids(None);
     assert_ne!(bids_before, bids_after);
     assert_eq!(bids_after.len(), 2);
     let validator_2_bid = bids_after.get(&VALIDATOR_2).unwrap();
@@ -348,7 +348,7 @@ fn should_run_ee_1120_slash_delegators() {
 
     builder.exec(slash_request_2).expect_success().commit();
 
-    let bids_after: Bids = builder.get_bids();
+    let bids_after: Bids = builder.get_bids(None);
     assert_eq!(bids_after.len(), 2);
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -131,7 +131,7 @@ fn should_run_ee_1152_regression_test() {
     builder.run_auction(timestamp_millis, Vec::new());
     timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
 
-    let era_validators = builder.get_era_validators();
+    let era_validators = builder.get_era_validators(None);
 
     assert!(!era_validators.is_empty());
 

--- a/execution_engine_testing/tests/src/test/regression/gh_2443.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2443.rs
@@ -1,0 +1,105 @@
+use std::collections::BTreeMap;
+
+use casper_engine_test_support::{
+    InMemoryWasmTestBuilder, LmdbWasmTestBuilder, UpgradeRequestBuilder,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::core::engine_state::{EngineConfig, SystemContractRegistry};
+use casper_hashing::Digest;
+use casper_types::{AccessRights, CLValue, EraId, Key, ProtocolVersion, StoredValue, URef};
+
+use crate::lmdb_fixture;
+
+const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
+
+fn apply_global_state_update(
+    builder: &LmdbWasmTestBuilder,
+    post_state_hash: Digest,
+) -> BTreeMap<Key, StoredValue> {
+    let key = URef::new([0u8; 32], AccessRights::all()).into();
+
+    let system_contract_hashes = builder
+        .query(Some(post_state_hash), key, &Vec::new())
+        .expect("Must have stored system contract hashes")
+        .as_cl_value()
+        .expect("must be CLValue")
+        .clone()
+        .into_t::<SystemContractRegistry>()
+        .expect("must convert to btree map");
+
+    let mut global_state_update = BTreeMap::<Key, StoredValue>::new();
+    let registry = CLValue::from_t(system_contract_hashes)
+        .expect("must convert to StoredValue")
+        .into();
+
+    global_state_update.insert(Key::SystemContractRegistry, registry);
+
+    global_state_update
+}
+
+#[ignore]
+#[test]
+fn should_get_auction_info_work_after_genesis() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    let _bids = builder.get_bids(None);
+    let _era_validators = builder.get_era_validators(None);
+}
+
+#[ignore]
+#[test]
+fn should_get_auction_info_for_older_state_hash() {
+    let (mut builder, lmdb_fixture_state, temp_dir) =
+        lmdb_fixture::builder_from_global_state_fixture(lmdb_fixture::RELEASE_1_3_1);
+
+    let previous_protocol_version = lmdb_fixture_state.genesis_protocol_version();
+
+    let current_protocol_version = lmdb_fixture_state.genesis_protocol_version();
+
+    let new_protocol_version =
+        ProtocolVersion::from_parts(current_protocol_version.value().major + 1, 0, 0);
+
+    let state_hash_without_registry = builder.get_post_state_hash();
+
+    let global_state_update =
+        apply_global_state_update(&builder, lmdb_fixture_state.post_state_hash);
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(previous_protocol_version)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_global_state_update(global_state_update)
+            .build()
+    };
+
+    builder
+        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
+        .expect_upgrade_success();
+
+    let post_upgrade_state_hash = builder.get_post_state_hash();
+
+    let mut builder = LmdbWasmTestBuilder::open(
+        &temp_dir.path().join(lmdb_fixture::RELEASE_1_3_1),
+        EngineConfig::default(),
+        post_upgrade_state_hash,
+    );
+
+    // Bug report calls `get-auction-info` which calls `get_bids`, and `get_era_validators`.
+    // Both methods are expecting a valid auction contract hash, so we will try to query using a
+    // post state hash that is known to not have the `Key::SystemContractHashes`.
+
+    let old_bids_1 = builder.get_bids(Some(state_hash_without_registry));
+    let old_bids_2 = builder.get_bids(Some(state_hash_without_registry));
+    assert_eq!(old_bids_1, old_bids_2);
+
+    let old_era_validators_1 = builder.get_era_validators(Some(state_hash_without_registry));
+    let old_era_validators_2 = builder.get_era_validators(Some(state_hash_without_registry));
+    assert_eq!(old_era_validators_1, old_era_validators_2);
+
+    let new_bids = builder.get_bids(None);
+    let new_era_validators = builder.get_era_validators(None);
+
+    assert_eq!(old_bids_2, new_bids);
+    assert_eq!(old_era_validators_2, new_era_validators);
+}

--- a/execution_engine_testing/tests/src/test/regression/gov_116.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_116.rs
@@ -129,7 +129,7 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
     // Unlock all funds of genesis validator
     builder.run_auction(VESTING_WEEKS[0], Vec::new());
 
-    let era_validators_1: EraValidators = builder.get_era_validators();
+    let era_validators_1: EraValidators = builder.get_era_validators(None);
 
     let (last_era_1, weights_1) = era_validators_1.iter().last().unwrap();
     let genesis_validator_stake_1 = weights_1.get(&LOWEST_STAKE_VALIDATOR).unwrap();
@@ -159,7 +159,7 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
 
     builder.run_auction(VESTING_WEEKS[1], Vec::new());
 
-    let era_validators_2: EraValidators = builder.get_era_validators();
+    let era_validators_2: EraValidators = builder.get_era_validators(None);
 
     let (last_era_2, weights_2) = era_validators_2.iter().last().unwrap();
     assert!(last_era_2 > last_era_1);
@@ -202,7 +202,7 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
 
     builder.run_auction(VESTING_WEEKS[2], Vec::new());
 
-    let era_validators_3: EraValidators = builder.get_era_validators();
+    let era_validators_3: EraValidators = builder.get_era_validators(None);
     let (last_era_3, weights_3) = era_validators_3.iter().last().unwrap();
     assert!(last_era_3 > last_era_2);
 
@@ -240,7 +240,7 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
 fn should_retain_genesis_validator_slot_protection() {
     let mut builder = initialize_builder();
 
-    let era_validators_1: EraValidators = builder.get_era_validators();
+    let era_validators_1: EraValidators = builder.get_era_validators(None);
 
     let (last_era_1, weights_1) = era_validators_1.iter().last().unwrap();
     let genesis_validator_stake_1 = weights_1.get(&LOWEST_STAKE_VALIDATOR).unwrap();
@@ -255,7 +255,7 @@ fn should_retain_genesis_validator_slot_protection() {
 
     builder.run_auction(VESTING_BASE, Vec::new());
 
-    let era_validators_2: EraValidators = builder.get_era_validators();
+    let era_validators_2: EraValidators = builder.get_era_validators(None);
 
     let (last_era_2, weights_2) = era_validators_2.iter().last().unwrap();
     assert!(last_era_2 > last_era_1);
@@ -279,7 +279,7 @@ fn should_retain_genesis_validator_slot_protection() {
     builder.run_auction(VESTING_BASE + WEEK_MILLIS, Vec::new());
 
     // All genesis validator slots are protected after ~1 week
-    let era_validators_3: EraValidators = builder.get_era_validators();
+    let era_validators_3: EraValidators = builder.get_era_validators(None);
     let (last_era_3, weights_3) = era_validators_3.iter().last().unwrap();
     assert!(last_era_3 > last_era_2);
     let next_validator_set_3 = BTreeSet::from_iter(weights_3.keys().cloned());
@@ -291,7 +291,7 @@ fn should_retain_genesis_validator_slot_protection() {
         Vec::new(),
     );
 
-    let era_validators_4: EraValidators = builder.get_era_validators();
+    let era_validators_4: EraValidators = builder.get_era_validators(None);
     let (last_era_4, weights_4) = era_validators_4.iter().last().unwrap();
     assert!(last_era_4 > last_era_3);
     let next_validator_set_4 = BTreeSet::from_iter(weights_4.keys().cloned());

--- a/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
@@ -96,14 +96,14 @@ fn should_not_create_any_purse() {
     let before_auction_seigniorage: SeigniorageRecipientsSnapshot =
         builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
 
-    let bids_before_slashing: Bids = builder.get_bids();
+    let bids_before_slashing: Bids = builder.get_bids(None);
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in the genesis bids table {:?}",
         bids_before_slashing
     );
 
-    let bids_before_slashing: Bids = builder.get_bids();
+    let bids_before_slashing: Bids = builder.get_bids(None);
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in bids table before slashing {:?}",
@@ -115,12 +115,12 @@ fn should_not_create_any_purse() {
         ..
     } = builder.step(step_request_1).expect("should execute step");
 
-    let bids_after_slashing: Bids = builder.get_bids();
+    let bids_after_slashing: Bids = builder.get_bids(None);
     let account_1_bid = bids_after_slashing.get(&ACCOUNT_1_PK).unwrap();
     assert!(account_1_bid.inactive());
     assert!(account_1_bid.staked_amount().is_zero());
 
-    let bids_after_slashing: Bids = builder.get_bids();
+    let bids_after_slashing: Bids = builder.get_bids(None);
     assert_ne!(
         bids_before_slashing, bids_after_slashing,
         "bids table should be different before and after slashing"

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -35,6 +35,7 @@ mod gh_1470;
 mod gh_1688;
 mod gh_1902;
 mod gh_2280;
+mod gh_2443;
 mod gov_116;
 mod gov_74;
 mod gov_89_regression;

--- a/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
@@ -249,7 +249,7 @@ fn regression_20210831_should_fail_to_withdraw_bid() {
 
     builder.exec(add_bid_request).expect_success().commit();
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let account_1_bid_before = bids.get(&*ACCOUNT_1_PUBLIC_KEY).expect("should have bid");
     assert_eq!(
         builder.get_purse_balance(*account_1_bid_before.bonding_purse()),
@@ -306,7 +306,7 @@ fn regression_20210831_should_fail_to_withdraw_bid() {
         error_2
     );
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let account_1_bid_after = bids.get(&*ACCOUNT_1_PUBLIC_KEY).expect("should have bid");
 
     assert_eq!(
@@ -347,7 +347,7 @@ fn regression_20210831_should_fail_to_undelegate_bid() {
     builder.exec(add_bid_request).expect_success().commit();
     builder.exec(delegate_request).expect_success().commit();
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let default_account_bid_before = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");
@@ -408,7 +408,7 @@ fn regression_20210831_should_fail_to_undelegate_bid() {
         error_2
     );
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let default_account_bid_after = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");
@@ -438,7 +438,7 @@ fn regression_20210831_should_fail_to_activate_bid() {
 
     builder.exec(add_bid_request).expect_success().commit();
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let bid = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");
@@ -457,7 +457,7 @@ fn regression_20210831_should_fail_to_activate_bid() {
 
     builder.exec(withdraw_bid_request).expect_success().commit();
 
-    let bids = builder.get_bids();
+    let bids = builder.get_bids(None);
     let bid = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -101,14 +101,14 @@ fn should_step() {
     let before_auction_seigniorage: SeigniorageRecipientsSnapshot =
         builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
 
-    let bids_before_slashing: Bids = builder.get_bids();
+    let bids_before_slashing: Bids = builder.get_bids(None);
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in the genesis bids table {:?}",
         bids_before_slashing
     );
 
-    let bids_before_slashing: Bids = builder.get_bids();
+    let bids_before_slashing: Bids = builder.get_bids(None);
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in bids table before slashing {:?}",
@@ -117,12 +117,12 @@ fn should_step() {
 
     builder.step(step_request).unwrap();
 
-    let bids_after_slashing: Bids = builder.get_bids();
+    let bids_after_slashing: Bids = builder.get_bids(None);
     let account_1_bid = bids_after_slashing.get(&ACCOUNT_1_PK).unwrap();
     assert!(account_1_bid.inactive());
     assert!(account_1_bid.staked_amount().is_zero());
 
-    let bids_after_slashing: Bids = builder.get_bids();
+    let bids_after_slashing: Bids = builder.get_bids(None);
     assert_ne!(
         bids_before_slashing, bids_after_slashing,
         "bids table should be different before and after slashing"

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -193,7 +193,7 @@ fn should_add_new_bid() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
 
     assert_eq!(bids.len(), 1);
     let active_bid = bids.get(&BID_ACCOUNT_1_PK.clone()).unwrap();
@@ -251,7 +251,7 @@ fn should_increase_existing_bid() {
 
     builder.exec(exec_request_2).commit().expect_success();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
 
     assert_eq!(bids.len(), 1);
 
@@ -307,7 +307,7 @@ fn should_decrease_existing_bid() {
     .build();
     builder.exec(withdraw_request).commit().expect_success();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
 
     assert_eq!(bids.len(), 1);
 
@@ -389,7 +389,7 @@ fn should_run_delegate_and_undelegate() {
 
     let auction_hash = builder.get_auction_contract_hash();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 1);
     let active_bid = bids.get(&NON_FOUNDER_VALIDATOR_1_PK).unwrap();
     assert_eq!(
@@ -419,7 +419,7 @@ fn should_run_delegate_and_undelegate() {
 
     builder.exec(exec_request_1).commit().expect_success();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -440,7 +440,7 @@ fn should_run_delegate_and_undelegate() {
 
     builder.exec(exec_request_2).commit().expect_success();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -463,7 +463,7 @@ fn should_run_delegate_and_undelegate() {
     .build();
     builder.exec(exec_request_3).commit().expect_success();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -552,12 +552,12 @@ fn should_calculate_era_validators() {
     .build();
 
     let auction_hash = builder.get_auction_contract_hash();
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 2, "founding validators {:?}", bids);
 
     // Verify first era validators
     let first_validator_weights: ValidatorWeights = builder
-        .get_validator_weights(INITIAL_ERA_ID)
+        .get_validator_weights(None, INITIAL_ERA_ID)
         .expect("should have first era validator weights");
     assert_eq!(
         first_validator_weights
@@ -595,7 +595,7 @@ fn should_calculate_era_validators() {
     let post_era_id: EraId = builder.get_value(auction_hash, ERA_ID_KEY);
     assert_eq!(post_era_id, EraId::from(1));
 
-    let era_validators: EraValidators = builder.get_era_validators();
+    let era_validators: EraValidators = builder.get_era_validators(None);
 
     // Check if there are no missing eras after the calculation, but we don't care about what the
     // elements are
@@ -649,7 +649,7 @@ fn should_calculate_era_validators() {
 
     // Check validator weights using the API
     let era_validators_result = builder
-        .get_validator_weights(lookup_era_id)
+        .get_validator_weights(None, lookup_era_id)
         .expect("should have validator weights");
     assert_eq!(era_validators_result, *validator_weights);
 
@@ -699,7 +699,7 @@ fn should_get_first_seigniorage_recipients() {
     )
     .build();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 2);
 
     let founding_validator_1 = bids.get(&ACCOUNT_1_PK).expect("should have account 1 pk");
@@ -726,7 +726,7 @@ fn should_get_first_seigniorage_recipients() {
         Vec::new(),
     );
 
-    let mut era_validators: EraValidators = builder.get_era_validators();
+    let mut era_validators: EraValidators = builder.get_era_validators(None);
     let snapshot_size = DEFAULT_AUCTION_DELAY as usize + 1;
 
     assert_eq!(era_validators.len(), snapshot_size, "{:?}", era_validators); // eraindex==1 - ran once
@@ -753,7 +753,7 @@ fn should_get_first_seigniorage_recipients() {
     );
 
     let first_validator_weights = builder
-        .get_validator_weights(era_id)
+        .get_validator_weights(None, era_id)
         .expect("should have validator weights");
     assert_eq!(first_validator_weights, validator_weights);
 }
@@ -853,7 +853,7 @@ fn should_release_founder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         assert_eq!(bids.len(), 1);
 
         let entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -877,7 +877,7 @@ fn should_release_founder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         assert_eq!(bids.len(), 1);
 
         let entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -970,7 +970,7 @@ fn should_fail_to_get_era_validators() {
     builder.run_genesis(&run_genesis_request);
 
     assert_eq!(
-        builder.get_validator_weights(EraId::MAX),
+        builder.get_validator_weights(None, EraId::MAX),
         None,
         "should not have era validators for invalid era"
     );
@@ -1001,13 +1001,13 @@ fn should_use_era_validators_endpoint_for_first_era() {
     builder.run_genesis(&run_genesis_request);
 
     let validator_weights = builder
-        .get_validator_weights(INITIAL_ERA_ID)
+        .get_validator_weights(None, INITIAL_ERA_ID)
         .expect("should have validator weights for era 0");
 
     assert_eq!(validator_weights.len(), 1);
     assert_eq!(validator_weights[&ACCOUNT_1_PK], ACCOUNT_1_BOND.into());
 
-    let era_validators: EraValidators = builder.get_era_validators();
+    let era_validators: EraValidators = builder.get_era_validators(None);
     assert_eq!(era_validators[&EraId::from(0)], validator_weights);
 }
 
@@ -1059,15 +1059,15 @@ fn should_calculate_era_validators_multiple_new_bids() {
     builder.run_genesis(&run_genesis_request);
 
     let genesis_validator_weights = builder
-        .get_validator_weights(INITIAL_ERA_ID)
+        .get_validator_weights(None, INITIAL_ERA_ID)
         .expect("should have genesis validators for initial era");
 
     // new_era is the first era in the future where new era validator weights will be calculated
     let new_era = INITIAL_ERA_ID + DEFAULT_AUCTION_DELAY + 1;
-    assert!(builder.get_validator_weights(new_era).is_none());
+    assert!(builder.get_validator_weights(None, new_era).is_none());
     assert_eq!(
-        builder.get_validator_weights(new_era - 1).unwrap(),
-        builder.get_validator_weights(INITIAL_ERA_ID).unwrap()
+        builder.get_validator_weights(None, new_era - 1).unwrap(),
+        builder.get_validator_weights(None, INITIAL_ERA_ID).unwrap()
     );
 
     assert_eq!(
@@ -1128,7 +1128,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
     );
     // Verify first era validators
     let new_validator_weights: ValidatorWeights = builder
-        .get_validator_weights(new_era)
+        .get_validator_weights(None, new_era)
         .expect("should have first era validator weights");
 
     // check that the new computed era has exactly the state we expect
@@ -1521,7 +1521,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
 
-    let bids_before: Bids = builder.get_bids();
+    let bids_before: Bids = builder.get_bids(None);
     let validator_1_bid = bids_before
         .get(&*VALIDATOR_1)
         .expect("should have validator 1 bid");
@@ -1557,7 +1557,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         .commit()
         .expect_success();
 
-    let bids_after: Bids = builder.get_bids();
+    let bids_after: Bids = builder.get_bids(None);
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
@@ -1769,7 +1769,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         .commit()
         .expect_success();
 
-    let bids_after: Bids = builder.get_bids();
+    let bids_after: Bids = builder.get_bids(None);
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
@@ -1865,7 +1865,7 @@ fn should_handle_evictions() {
     };
 
     let latest_validators = |builder: &mut InMemoryWasmTestBuilder| {
-        let era_validators: EraValidators = builder.get_era_validators();
+        let era_validators: EraValidators = builder.get_era_validators(None);
         let validators = era_validators
             .iter()
             .rev()
@@ -2231,7 +2231,7 @@ fn should_setup_genesis_delegators() {
         U512::from(DELEGATOR_1_BALANCE)
     );
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(
         bids.keys().cloned().collect::<BTreeSet<_>>(),
         BTreeSet::from_iter(vec![ACCOUNT_1_PK.clone(), ACCOUNT_2_PK.clone(),])
@@ -2460,7 +2460,7 @@ fn should_not_undelegate_vfta_holder_stake() {
     }
 
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         let delegator = bids
             .get(&*VALIDATOR_1)
             .expect("should have validator")
@@ -2488,7 +2488,7 @@ fn should_not_undelegate_vfta_holder_stake() {
     .build();
 
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         let delegator = bids
             .get(&*VALIDATOR_1)
             .expect("should have validator")
@@ -2646,7 +2646,7 @@ fn should_release_vfta_holder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         assert_eq!(bids.len(), 1);
 
         let bid_entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -2672,7 +2672,7 @@ fn should_release_vfta_holder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_bids();
+        let bids: Bids = builder.get_bids(None);
         assert_eq!(bids.len(), 1);
 
         let bid_entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -2897,7 +2897,7 @@ fn should_reset_delegators_stake_after_slashing() {
 
     // Check bids before slashing
 
-    let bids_1: Bids = builder.get_bids();
+    let bids_1: Bids = builder.get_bids(None);
 
     let validator_1_delegator_stakes_1: U512 = bids_1
         .get(&NON_FOUNDER_VALIDATOR_1_PK)
@@ -2932,7 +2932,7 @@ fn should_reset_delegators_stake_after_slashing() {
     builder.exec(slash_request_1).expect_success().commit();
 
     // Compare bids after slashing validator 2
-    let bids_2: Bids = builder.get_bids();
+    let bids_2: Bids = builder.get_bids(None);
     assert_ne!(bids_1, bids_2);
 
     let validator_1_bid_2 = bids_2
@@ -2979,7 +2979,7 @@ fn should_reset_delegators_stake_after_slashing() {
     builder.exec(slash_request_2).expect_success().commit();
 
     // Compare bids after slashing validator 2
-    let bids_3: Bids = builder.get_bids();
+    let bids_3: Bids = builder.get_bids(None);
     assert_ne!(bids_3, bids_2);
     assert_ne!(bids_3, bids_1);
 
@@ -3258,7 +3258,7 @@ fn should_delegate_and_redelegate() {
         delegator_1_purse_balance_after
     );
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 2);
 
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
@@ -3778,7 +3778,7 @@ fn should_continue_auction_state_from_release_1_4_x() {
         delegator_4_purse_balance_after
     );
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert_eq!(bids.len(), 3);
 
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
@@ -4066,7 +4066,7 @@ fn should_transfer_to_main_purse_when_validator_is_no_longer_active() {
 
     let delegator_4_purse_balance_after = builder.get_purse_balance(delegator_4_purse);
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
 
     assert!(bids[&NON_FOUNDER_VALIDATOR_1_PK].inactive());
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -69,7 +69,7 @@ static GENESIS_ROUND_SEIGNIORAGE_RATE: Lazy<Ratio<U512>> = Lazy::new(|| {
 });
 
 fn get_validator_bid(builder: &mut InMemoryWasmTestBuilder, validator: PublicKey) -> Option<Bid> {
-    let mut bids: Bids = builder.get_bids();
+    let mut bids: Bids = builder.get_bids(None);
     bids.remove(&validator)
 }
 
@@ -133,7 +133,7 @@ fn get_delegator_staked_amount(
     validator: PublicKey,
     delegator: PublicKey,
 ) -> U512 {
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let validator_bid = bids.get(&validator).expect("should have validator entry");
 
     let delegator_entry = validator_bid

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -87,7 +87,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let default_account_bid = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");
@@ -187,7 +187,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .unwrap()
         .is_empty());
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let default_account_bid = bids.get(&DEFAULT_ACCOUNT_PUBLIC_KEY).unwrap();
     assert!(default_account_bid.inactive());
     assert!(default_account_bid.staked_amount().is_zero());
@@ -432,7 +432,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
     let bid_purse = *bid.bonding_purse();
     assert_eq!(
@@ -530,7 +530,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .unwrap()
         .is_empty());
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert!(!bids.is_empty());
 
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
@@ -609,7 +609,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
     let bid_purse = *bid.bonding_purse();
     assert_eq!(
@@ -723,7 +723,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         .unwrap()
         .is_empty());
 
-    let bids: Bids = builder.get_bids();
+    let bids: Bids = builder.get_bids(None);
     assert!(!bids.is_empty());
 
     let bid = bids.get(&default_public_key_arg).expect("should have bid");

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -429,6 +429,7 @@ impl ContractRuntime {
         max_associated_keys: u32,
         max_runtime_call_stack_height: u32,
         registry: &Registry,
+        state_root_hash: Option<Digest>,
     ) -> Result<Self, ConfigError> {
         // TODO: This is bogus, get rid of this
         let execution_pre_state = Arc::new(Mutex::new(ExecutionPreState {
@@ -460,7 +461,11 @@ impl ContractRuntime {
             system_config,
         );
 
-        let engine_state = Arc::new(EngineState::new(global_state, engine_config));
+        let engine_state = Arc::new(EngineState::new(
+            global_state,
+            engine_config,
+            state_root_hash,
+        ));
 
         let metrics = Arc::new(Metrics::new(registry)?);
 

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -217,6 +217,11 @@ impl Reactor {
             &chainspec_loader.chainspec().network_config.name,
         )?;
 
+        let maybe_state_root_hash = storage
+            .read_highest_block()?
+            .map(|block| block.state_root_hash())
+            .copied();
+
         let contract_runtime = ContractRuntime::new(
             chainspec_loader.chainspec().protocol_config.version,
             storage.root_path(),
@@ -229,6 +234,7 @@ impl Reactor {
                 .core_config
                 .max_runtime_call_stack_height,
             registry,
+            maybe_state_root_hash,
         )?;
 
         // TODO: This integrity check is misplaced, it should be part of the components

--- a/utils/global-state-update-gen/src/auction_utils.rs
+++ b/utils/global-state-update-gen/src/auction_utils.rs
@@ -73,7 +73,7 @@ pub fn find_large_bids(
         .min()
         .unwrap();
     builder
-        .get_bids()
+        .get_bids(None)
         .into_iter()
         .filter(|(_pkey, bid)| bid.staked_amount() >= min_bid)
         .map(|(pkey, _bid)| pkey)


### PR DESCRIPTION
Closes #2443 

This PR fixes a problem of the `get-auction-state` query for pre #1814 (introduction of `Key::SystemContractRegistry`) by passing down a state root hash to a ContractRuntime component based on the highest block (if found). 

The query requests a registry on the EE side using a user-provided state root hash. If there's no registry, the query uses a fallback state hash. Any further use of the system contract registry uses the cached value rather than always queried.

In a particular case, when block storage can't provide a fallback state root hash (i.e., new networks with no block) to create new ContractRuntime, it is internally set after genesis in EE or set after the upgrade.