### PR TITLE
Handshake timeout

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.  The format
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
 * `SIGUSR1` now only dumps the queue in the debug text format.
 * Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
+* Connection handshake timeouts can now be configured (they were hardcoded at 20 seconds before).
 
 
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.  The format
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
 * `SIGUSR1` now only dumps the queue in the debug text format.
 * Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
-* Connection handshake timeouts can now be configured (they were hardcoded at 20 seconds before).
+* Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 
 
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -284,6 +284,7 @@ where
             chain_info: chain_info_source.into(),
             public_addr,
             consensus_keys,
+            handshake_timeout: cfg.handshake_timeout,
             payload_weights: cfg.estimator_weights.clone(),
         });
 

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
 
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
@@ -20,16 +19,16 @@ const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:34553";
 const DEFAULT_PUBLIC_ADDRESS: &str = "127.0.0.1:0";
 
 /// Default interval for gossiping network addresses.
-const DEFAULT_GOSSIP_INTERVAL: &str = "30sec";
+const DEFAULT_GOSSIP_INTERVAL: TimeDiff = TimeDiff::from_seconds(30);
 
 /// Default delay until initial round of address gossiping starts.
-const DEFAULT_INITIAL_GOSSIP_DELAY: &str = "5sec";
+const DEFAULT_INITIAL_GOSSIP_DELAY: TimeDiff = TimeDiff::from_seconds(5);
 
 /// Default time limit for an address to be in the pending set.
-const DEFAULT_MAX_ADDR_PENDING_TIME: &str = "60sec";
+const DEFAULT_MAX_ADDR_PENDING_TIME: TimeDiff = TimeDiff::from_seconds(60);
 
 /// Default timeout during which the handshake needs to be completed.
-const DEFAULT_HANDSHAKE_TIMEOUT: &str = "20sec";
+const DEFAULT_HANDSHAKE_TIMEOUT: TimeDiff = TimeDiff::from_seconds(20);
 
 // Default values for networking configuration:
 impl Default for Config {
@@ -38,10 +37,10 @@ impl Default for Config {
             bind_address: DEFAULT_BIND_ADDRESS.to_string(),
             public_address: DEFAULT_PUBLIC_ADDRESS.to_string(),
             known_addresses: Vec::new(),
-            gossip_interval: TimeDiff::from_str(DEFAULT_GOSSIP_INTERVAL).unwrap(),
-            initial_gossip_delay: TimeDiff::from_str(DEFAULT_INITIAL_GOSSIP_DELAY).unwrap(),
-            max_addr_pending_time: TimeDiff::from_str(DEFAULT_MAX_ADDR_PENDING_TIME).unwrap(),
-            handshake_timeout: TimeDiff::from_str(DEFAULT_HANDSHAKE_TIMEOUT).unwrap(),
+            gossip_interval: DEFAULT_GOSSIP_INTERVAL,
+            initial_gossip_delay: DEFAULT_INITIAL_GOSSIP_DELAY,
+            max_addr_pending_time: DEFAULT_MAX_ADDR_PENDING_TIME,
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
@@ -83,7 +82,7 @@ pub struct Config {
 
 #[cfg(test)]
 /// Reduced gossip interval for local testing.
-const DEFAULT_TEST_GOSSIP_INTERVAL: &str = "1sec";
+const DEFAULT_TEST_GOSSIP_INTERVAL: TimeDiff = TimeDiff::from_seconds(1);
 
 #[cfg(test)]
 /// Address used to bind all local testing networking to by default.
@@ -98,7 +97,7 @@ impl Config {
             bind_address: bind_address.to_string(),
             public_address: bind_address.to_string(),
             known_addresses: vec![bind_address.to_string()],
-            gossip_interval: TimeDiff::from_str(DEFAULT_TEST_GOSSIP_INTERVAL).unwrap(),
+            gossip_interval: DEFAULT_TEST_GOSSIP_INTERVAL,
             ..Default::default()
         }
     }
@@ -116,7 +115,7 @@ impl Config {
             known_addresses: vec![
                 SocketAddr::from((TEST_BIND_INTERFACE, known_peer_port)).to_string()
             ],
-            gossip_interval: TimeDiff::from_str(DEFAULT_TEST_GOSSIP_INTERVAL).unwrap(),
+            gossip_interval: DEFAULT_TEST_GOSSIP_INTERVAL,
             ..Default::default()
         }
     }

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -28,6 +28,9 @@ const DEFAULT_INITIAL_GOSSIP_DELAY: &str = "5sec";
 /// Default time limit for an address to be in the pending set.
 const DEFAULT_MAX_ADDR_PENDING_TIME: &str = "60sec";
 
+/// Default timeout during which the handshake needs to be completed.
+const DEFAULT_HANDSHAKE_TIMEOUT: &str = "20sec";
+
 // Default values for networking configuration:
 impl Default for Config {
     fn default() -> Self {
@@ -38,6 +41,7 @@ impl Default for Config {
             gossip_interval: TimeDiff::from_str(DEFAULT_GOSSIP_INTERVAL).unwrap(),
             initial_gossip_delay: TimeDiff::from_str(DEFAULT_INITIAL_GOSSIP_DELAY).unwrap(),
             max_addr_pending_time: TimeDiff::from_str(DEFAULT_MAX_ADDR_PENDING_TIME).unwrap(),
+            handshake_timeout: TimeDiff::from_str(DEFAULT_HANDSHAKE_TIMEOUT).unwrap(),
             max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
@@ -65,6 +69,8 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for an address to be kept in the pending set.
     pub max_addr_pending_time: TimeDiff,
+    /// Maximum allowed time for handshake completion.
+    pub handshake_timeout: TimeDiff,
     /// Maximum number of incoming connections per unique peer. Unlimited if `0`.
     pub max_incoming_peer_connections: u16,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -22,6 +22,12 @@ const DEFAULT_PUBLIC_ADDRESS: &str = "127.0.0.1:0";
 /// Default interval for gossiping network addresses.
 const DEFAULT_GOSSIP_INTERVAL: &str = "30sec";
 
+/// Default delay until initial round of address gossiping starts.
+const DEFAULT_INITIAL_GOSSIP_DELAY: &str = "5sec";
+
+/// Default time limit for an address to be in the pending set.
+const DEFAULT_MAX_ADDR_PENDING_TIME: &str = "60sec";
+
 // Default values for networking configuration:
 impl Default for Config {
     fn default() -> Self {
@@ -30,8 +36,8 @@ impl Default for Config {
             public_address: DEFAULT_PUBLIC_ADDRESS.to_string(),
             known_addresses: Vec::new(),
             gossip_interval: TimeDiff::from_str(DEFAULT_GOSSIP_INTERVAL).unwrap(),
-            initial_gossip_delay: TimeDiff::from_seconds(5),
-            max_addr_pending_time: TimeDiff::from_seconds(60),
+            initial_gossip_delay: TimeDiff::from_str(DEFAULT_INITIAL_GOSSIP_DELAY).unwrap(),
+            max_addr_pending_time: TimeDiff::from_str(DEFAULT_MAX_ADDR_PENDING_TIME).unwrap(),
             max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -125,6 +125,11 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
 # Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -125,6 +125,11 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
 # Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -125,6 +125,11 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
 # Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -129,6 +129,11 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
 # Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -125,6 +125,11 @@ initial_gossip_delay = '5sec'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
 # Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3


### PR DESCRIPTION
This PR makes the existing handshake timeout on both incoming and outgoing connections (and both directions on these) configurable, as the value was hardcoded to 20 seconds before.

Adding a timeout to incoming connections has been dropped, as with the merging of #2576, the amount of resources that can be occupied is limited anyway.