### PR TITLE
Rename config option to verifiable_chunked_hash_activation.

### DIFF
--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -118,10 +118,10 @@ impl Digest {
     /// 1 2 4 5 8 9
     /// │ │ │ │ │ │
     /// └─3 └─6 └─10
-    ///    │   │   │
-    ///    └───7   │
-    ///        │   │
-    ///        └───11
+    ///   │   │   │
+    ///   └───7   │
+    ///       │   │
+    ///       └───11
     /// ```
     ///
     /// Finally hashes the number of elements with the resulting hash. In the example above the

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add ability to force DB integrity checks to run on node start by setting env var `CL_RUN_INTEGRITY_CHECKS=1`.
 * Add ability to force DB integrity checks to run on node start by adding non-numeric contents to the initializer.pid file.
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
-* Add `merkle_tree_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
+* Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * Added `max_parallel_deploy_fetches` and `max_parallel_trie_fetches` config options to the `[node]` section to control how many requests are made in parallel while syncing.
 * Added `archival_sync` to `[node]` config section, along with archival syncing capabilities
 * Introducing fast-syncing to join the network, avoiding the need to execute every block to catch up.

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -296,8 +296,11 @@ impl ChainSynchronizer {
                 let initial_pre_state = ExecutionPreState::new(
                     upgrade_block_header.height() + 1,
                     post_state_hash,
-                    upgrade_block_header
-                        .hash(self.chainspec.protocol_config.merkle_tree_hash_activation),
+                    upgrade_block_header.hash(
+                        self.chainspec
+                            .protocol_config
+                            .verifiable_chunked_hash_activation,
+                    ),
                     upgrade_block_header.accumulated_seed(),
                 );
                 let finalized_block = FinalizedBlock::new(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -242,8 +242,10 @@ where
     }
 
     /// Returns the merkle tree hash activation from the chainspec.
-    fn merkle_tree_hash_activation(&self) -> EraId {
-        self.chainspec.protocol_config.merkle_tree_hash_activation
+    fn verifiable_chunked_hash_activation(&self) -> EraId {
+        self.chainspec
+            .protocol_config
+            .verifiable_chunked_hash_activation
     }
 
     /// Returns a list of status changes of active validators.
@@ -405,7 +407,7 @@ where
         let auction_delay = self.chainspec.core_config.auction_delay as usize;
         let booking_block_hash =
             if let Some(booking_block) = switch_blocks.iter().rev().nth(auction_delay) {
-                booking_block.hash(self.merkle_tree_hash_activation())
+                booking_block.hash(self.verifiable_chunked_hash_activation())
             } else {
                 // If there's no booking block for the `era_id`
                 // (b/c it would have been from before Genesis, upgrade or emergency restart),
@@ -681,7 +683,7 @@ where
         let mut effects = if self.is_validator_in(&our_pk, era_id) {
             effect_builder
                 .announce_created_finality_signature(FinalitySignature::new(
-                    block_header.hash(self.merkle_tree_hash_activation()),
+                    block_header.hash(self.verifiable_chunked_hash_activation()),
                     era_id,
                     &our_sk,
                     our_pk,

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -40,7 +40,7 @@ pub fn execute_finalized_block(
     finalized_block: FinalizedBlock,
     deploys: Vec<Deploy>,
     transfers: Vec<Deploy>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<BlockAndExecutionEffects, BlockExecutionError> {
     if finalized_block.height() != execution_pre_state.next_block_height {
         return Err(BlockExecutionError::WrongBlockHeight {
@@ -162,7 +162,7 @@ pub fn execute_finalized_block(
         finalized_block,
         next_era_validator_weights,
         protocol_version,
-        merkle_tree_hash_activation,
+        verifiable_chunked_hash_activation,
     )?);
 
     Ok(BlockAndExecutionEffects {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -493,10 +493,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },
@@ -597,10 +594,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -493,7 +493,10 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                ref
+                contract_package_identifier
+                @
+                ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },
@@ -594,7 +597,10 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                ref
+                contract_package_identifier
+                @
+                ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -416,7 +416,7 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            chainspec.protocol_config.merkle_tree_hash_activation,
+            chainspec.protocol_config.verifiable_chunked_hash_activation,
         )
         .unwrap();
 
@@ -689,9 +689,9 @@ async fn run_deploy_acceptor_without_timeout(
 
     let chainspec = Chainspec::from_resources("local");
 
-    let block = Box::new(Block::random_with_merkle_tree_hash_activation(
+    let block = Box::new(Block::random_with_verifiable_chunked_hash_activation(
         &mut rng,
-        chainspec.protocol_config.merkle_tree_hash_activation,
+        chainspec.protocol_config.verifiable_chunked_hash_activation,
     ));
     // Create a responder to assert that the block was successfully injected into storage.
     let (block_sender, block_receiver) = oneshot::channel();

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -260,7 +260,7 @@ where
 {
     get_from_peer_timeout: Duration,
     responders: HashMap<T::Id, HashMap<NodeId, Vec<FetchResponder<T>>>>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
     #[data_size(skip)]
     metrics: Metrics,
 }
@@ -270,18 +270,18 @@ impl<T: Item> Fetcher<T> {
         name: &str,
         config: Config,
         registry: &Registry,
-        merkle_tree_hash_activation: EraId,
+        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, prometheus::Error> {
         Ok(Fetcher {
             get_from_peer_timeout: config.get_from_peer_timeout().into(),
             responders: HashMap::new(),
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
             metrics: Metrics::new(name, registry)?,
         })
     }
 
-    fn merkle_tree_hash_activation(&self) -> EraId {
-        self.merkle_tree_hash_activation
+    fn verifiable_chunked_hash_activation(&self) -> EraId {
+        self.verifiable_chunked_hash_activation
     }
 }
 
@@ -532,19 +532,19 @@ where
                 None => self.failed_to_get_from_storage(effect_builder, id, peer),
             },
             Event::GotRemotely {
-                merkle_tree_hash_activation: _,
+                verifiable_chunked_hash_activation: _,
                 item,
                 source,
             } => {
                 match source {
                     Source::Peer(peer) => {
                         self.metrics.found_on_peer.inc();
-                        if let Err(err) = item.validate(self.merkle_tree_hash_activation()) {
+                        if let Err(err) = item.validate(self.verifiable_chunked_hash_activation()) {
                             warn!(?peer, ?err, ?item, "Peer sent invalid item, banning peer");
                             effect_builder.announce_disconnect_from_peer(peer).ignore()
                         } else {
                             self.signal(
-                                item.id(self.merkle_tree_hash_activation()),
+                                item.id(self.verifiable_chunked_hash_activation()),
                                 Ok(FetchedData::FromPeer { item, peer }),
                                 peer,
                             )
@@ -573,19 +573,19 @@ where
 pub(crate) struct FetcherBuilder<'a> {
     config: FetcherConfig,
     registry: &'a Registry,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 }
 
 impl<'a> FetcherBuilder<'a> {
     pub(crate) fn new(
         config: FetcherConfig,
         registry: &'a Registry,
-        merkle_tree_hash_activation: EraId,
+        verifiable_chunked_hash_activation: EraId,
     ) -> Self {
         Self {
             config,
             registry,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         }
     }
 
@@ -597,7 +597,7 @@ impl<'a> FetcherBuilder<'a> {
             name,
             self.config,
             self.registry,
-            self.merkle_tree_hash_activation,
+            self.verifiable_chunked_hash_activation,
         )
     }
 }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -92,7 +92,7 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .merkle_tree_hash_activation,
+                .verifiable_chunked_hash_activation,
         );
         deploy_acceptor = DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec(), registry);
         deploy_fetcher = Fetcher::<Deploy>(
@@ -102,7 +102,7 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .merkle_tree_hash_activation);
+                .verifiable_chunked_hash_activation);
     }
 
     events: {

--- a/node/src/components/fetcher/trie_fetcher.rs
+++ b/node/src/components/fetcher/trie_fetcher.rs
@@ -113,7 +113,7 @@ where
     I: Debug + Eq + Clone,
 {
     partial_chunks: HashMap<Digest, PartialChunks<I>>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 }
 
 #[derive(DataSize, Debug, From)]
@@ -157,10 +157,10 @@ impl<I> TrieFetcher<I>
 where
     I: Debug + Clone + Hash + Send + Eq + 'static,
 {
-    pub(crate) fn new(merkle_tree_hash_activation: EraId) -> Self {
+    pub(crate) fn new(verifiable_chunked_hash_activation: EraId) -> Self {
         TrieFetcher {
             partial_chunks: Default::default(),
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         }
     }
 
@@ -176,7 +176,7 @@ where
             + From<ControlAnnouncement>
             + From<BlocklistAnnouncement<I>>,
     {
-        let TrieOrChunkId(_index, hash) = trie_or_chunk.id(self.merkle_tree_hash_activation);
+        let TrieOrChunkId(_index, hash) = trie_or_chunk.id(self.verifiable_chunked_hash_activation);
         match trie_or_chunk {
             TrieOrChunk::Trie(trie) => match self.partial_chunks.remove(&hash) {
                 None => {

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -207,8 +207,8 @@ impl reactor::Reactor for Reactor {
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let network = NetworkController::create_node(event_queue, rng);
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = rng.gen_range(0..=10);
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = rng.gen_range(0..=10);
 
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
@@ -220,7 +220,7 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            merkle_tree_hash_activation.into(),
+            verifiable_chunked_hash_activation.into(),
         )
         .unwrap();
 
@@ -234,7 +234,7 @@ impl reactor::Reactor for Reactor {
             MAX_ASSOCIATED_KEYS,
             DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
             registry,
-            merkle_tree_hash_activation.into(),
+            verifiable_chunked_hash_activation.into(),
         )
         .unwrap();
 
@@ -385,9 +385,7 @@ impl reactor::Reactor for Reactor {
                         ),
                     )
                 }
-                other
-                @
-                (NetResponse::Block(_)
+                other @ (NetResponse::Block(_)
                 | NetResponse::GossipedAddress(_)
                 | NetResponse::BlockAndMetadataByHeight(_)
                 | NetResponse::BlockHeaderByHash(_)
@@ -395,9 +393,7 @@ impl reactor::Reactor for Reactor {
                     fatal!(effect_builder, "unexpected net response: {:?}", other).ignore()
                 }
             },
-            other
-            @
-            (Event::ConsensusMessageIncoming(_)
+            other @ (Event::ConsensusMessageIncoming(_)
             | Event::FinalitySignatureIncoming(_)
             | Event::AddressGossiperIncoming(_)
             | Event::TrieRequestIncoming(_)

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -385,7 +385,9 @@ impl reactor::Reactor for Reactor {
                         ),
                     )
                 }
-                other @ (NetResponse::Block(_)
+                other
+                @
+                (NetResponse::Block(_)
                 | NetResponse::GossipedAddress(_)
                 | NetResponse::BlockAndMetadataByHeight(_)
                 | NetResponse::BlockHeaderByHash(_)
@@ -393,7 +395,9 @@ impl reactor::Reactor for Reactor {
                     fatal!(effect_builder, "unexpected net response: {:?}", other).ignore()
                 }
             },
-            other @ (Event::ConsensusMessageIncoming(_)
+            other
+            @
+            (Event::ConsensusMessageIncoming(_)
             | Event::FinalitySignatureIncoming(_)
             | Event::AddressGossiperIncoming(_)
             | Event::TrieRequestIncoming(_)

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -41,7 +41,7 @@ pub(crate) struct LinearChainComponent<I> {
     metrics: Metrics,
     /// If true, the process should stop execution to allow an upgrade to proceed.
     stop_for_upgrade: bool,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
     _marker: PhantomData<I>,
 }
 
@@ -53,7 +53,7 @@ impl<I> LinearChainComponent<I> {
         unbonding_delay: u64,
         finality_threshold_fraction: Ratio<u64>,
         next_upgrade_activation_point: Option<ActivationPoint>,
-        merkle_tree_hash_activation: EraId,
+        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, prometheus::Error> {
         let metrics = Metrics::new(registry)?;
         let linear_chain_state = LinearChain::new(
@@ -67,7 +67,7 @@ impl<I> LinearChainComponent<I> {
             linear_chain_state,
             metrics,
             stop_for_upgrade: false,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
             _marker: PhantomData,
         })
     }
@@ -76,8 +76,8 @@ impl<I> LinearChainComponent<I> {
         self.stop_for_upgrade
     }
 
-    fn merkle_tree_hash_activation(&self) -> EraId {
-        self.merkle_tree_hash_activation
+    fn verifiable_chunked_hash_activation(&self) -> EraId {
+        self.verifiable_chunked_hash_activation
     }
 }
 
@@ -181,7 +181,7 @@ where
                     .set(completion_duration as i64);
                 let outcomes = self
                     .linear_chain_state
-                    .handle_put_block(block, self.merkle_tree_hash_activation());
+                    .handle_put_block(block, self.verifiable_chunked_hash_activation());
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::FinalitySignatureReceived(fs, gossiped) => {

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -246,14 +246,15 @@ impl LinearChain {
     pub(super) fn handle_put_block(
         &mut self,
         block: Box<Block>,
-        merkle_tree_hash_activation: EraId,
+        verifiable_chunked_hash_activation: EraId,
     ) -> Outcomes {
         let mut outcomes = Vec::new();
         let signatures = self.new_block(&*block);
         self.latest_block = Some(*block.clone());
-        if let Some(key_block_info) =
-            KeyBlockInfo::maybe_from_block_header(block.header(), merkle_tree_hash_activation)
-        {
+        if let Some(key_block_info) = KeyBlockInfo::maybe_from_block_header(
+            block.header(),
+            verifiable_chunked_hash_activation,
+        ) {
             let current_era = key_block_info.era_id();
             self.key_block_info.insert(current_era, key_block_info);
             if let Some(old_era_id) = self.lowest_acceptable_era_id(current_era).checked_sub(1) {
@@ -475,11 +476,11 @@ mod tests {
             others => panic!("unexpected outcome: {:?}", others),
         }
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
         let block_stored_outcomes =
-            lc.handle_put_block(Box::new(block.clone()), merkle_tree_hash_activation);
+            lc.handle_put_block(Box::new(block.clone()), verifiable_chunked_hash_activation);
         match &*block_stored_outcomes {
             [Outcome::AnnounceBlock(announced_block)] => {
                 assert_eq!(&**announced_block, &block);
@@ -573,10 +574,10 @@ mod tests {
             outcomes,
         );
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
-        let outcomes = lc.handle_put_block(block.clone(), merkle_tree_hash_activation);
+        let outcomes = lc.handle_put_block(block.clone(), verifiable_chunked_hash_activation);
         // `sig_a` and `sig_b` are valid and created by bonded validators.
         let expected_outcomes = {
             let mut tmp = vec![];
@@ -695,8 +696,8 @@ mod tests {
             None,
         );
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
         // Set the latest known block so that we can trigger the following checks.
         let block = Block::random_with_specifics(
@@ -705,13 +706,13 @@ mod tests {
             10,
             ProtocolVersion::V1_0_0,
             false,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
 
         let put_block_outcomes =
-            lc.handle_put_block(Box::new(block.clone()), merkle_tree_hash_activation);
+            lc.handle_put_block(Box::new(block.clone()), verifiable_chunked_hash_activation);
         assert_eq!(put_block_outcomes.len(), 1);
         assert_eq!(
             lc.latest_block(),
@@ -751,8 +752,8 @@ mod tests {
             None,
         );
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
         // Set the latest known block so that we can trigger the following checks.
         let block = Box::new(Block::random_with_specifics(
@@ -761,7 +762,7 @@ mod tests {
             10,
             ProtocolVersion::V1_0_0,
             false,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         ));
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
@@ -769,7 +770,8 @@ mod tests {
         let expected_outcomes = vec![Outcome::StoreBlock(block.clone(), HashMap::new())];
         assert_equal(expected_outcomes, new_block_outcomes);
 
-        let put_block_outcomes = lc.handle_put_block(block.clone(), merkle_tree_hash_activation);
+        let put_block_outcomes =
+            lc.handle_put_block(block.clone(), verifiable_chunked_hash_activation);
         // Verify that all outcomes are expected.
         assert_equal(vec![Outcome::AnnounceBlock(block)], put_block_outcomes);
         let valid_sig = FinalitySignature::random_for_block(block_hash, block_era.value());
@@ -823,8 +825,8 @@ mod tests {
             .map(|sk| (PublicKey::from(sk), 100.into()))
             .collect();
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
         // The switch block in era 1 defines how many validators need to sign the one in era 2.
         let block = Box::new(
@@ -835,12 +837,12 @@ mod tests {
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true),
                 Some(validators.clone()),
                 protocol_version,
-                merkle_tree_hash_activation,
+                verifiable_chunked_hash_activation,
             )
             .unwrap(),
         );
 
-        let outcomes = lc.handle_put_block(block.clone(), merkle_tree_hash_activation);
+        let outcomes = lc.handle_put_block(block.clone(), verifiable_chunked_hash_activation);
         assert_equal(vec![Outcome::AnnounceBlock(block)], outcomes);
 
         // The switch block in era 2 is the last before the upgrade.
@@ -852,7 +854,7 @@ mod tests {
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true),
                 Some(validators),
                 protocol_version,
-                merkle_tree_hash_activation,
+                verifiable_chunked_hash_activation,
             )
             .unwrap(),
         );
@@ -885,7 +887,7 @@ mod tests {
                 Outcome::AnnounceSignature(signatures[0].clone()),
                 Outcome::StoreBlockSignatures(*stored_sigs.clone(), false),
             ],
-            lc.handle_put_block(block, merkle_tree_hash_activation),
+            lc.handle_put_block(block, verifiable_chunked_hash_activation),
         );
 
         // Two signatures is not enough for an upgrade yet: The upgrade flag is false.
@@ -941,8 +943,8 @@ mod tests {
             .map(|sk| (PublicKey::from(sk), 100.into()))
             .collect();
 
-        // `merkle_tree_hash_activation` can be chosen arbitrarily
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..=10));
+        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
 
         // The switch block in era 1 defines how many validators need to sign the one in era 2.
         let block = Box::new(
@@ -953,11 +955,11 @@ mod tests {
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true),
                 Some(validators.clone()),
                 protocol_version,
-                merkle_tree_hash_activation,
+                verifiable_chunked_hash_activation,
             )
             .unwrap(),
         );
-        let outcomes = lc.handle_put_block(block.clone(), merkle_tree_hash_activation);
+        let outcomes = lc.handle_put_block(block.clone(), verifiable_chunked_hash_activation);
         assert_equal(vec![Outcome::AnnounceBlock(block)], outcomes);
 
         // The switch block in era 2 is the last before the upgrade.
@@ -969,7 +971,7 @@ mod tests {
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true),
                 Some(validators),
                 protocol_version,
-                merkle_tree_hash_activation,
+                verifiable_chunked_hash_activation,
             )
             .unwrap(),
         );
@@ -993,7 +995,7 @@ mod tests {
             expected_sigs.insert_proof(fs.public_key.clone(), fs.signature);
         }
 
-        let outcomes = lc.handle_put_block(block.clone(), merkle_tree_hash_activation);
+        let outcomes = lc.handle_put_block(block.clone(), verifiable_chunked_hash_activation);
         assert_equal(
             vec![
                 Outcome::AnnounceBlock(block),

--- a/node/src/components/small_network/gossiped_address.rs
+++ b/node/src/components/small_network/gossiped_address.rs
@@ -34,11 +34,14 @@ impl Item for GossipedAddress {
     const TAG: Tag = Tag::GossipedAddress;
     const ID_IS_COMPLETE_ITEM: bool = true;
 
-    fn validate(&self, _merkle_tree_hash_activation: EraId) -> Result<(), Self::ValidationError> {
+    fn validate(
+        &self,
+        _verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, _merkle_tree_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
         *self
     }
 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -377,7 +377,7 @@ pub struct Storage {
     /// The most recent era in which the network was manually restarted.
     last_emergency_restart: Option<EraId>,
     /// The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 }
 
 /// A storage component event.
@@ -471,7 +471,7 @@ impl Storage {
         network_name: &str,
         finality_threshold_fraction: Ratio<u64>,
         last_emergency_restart: Option<EraId>,
-        merkle_tree_hash_activation: EraId,
+        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, FatalStorageError> {
         let config = cfg.value();
 
@@ -546,20 +546,20 @@ impl Storage {
                 if block_header.era_id() >= invalid_era
                     && block_header.protocol_version() < protocol_version
                 {
-                    if block_header.hashing_algorithm_version(merkle_tree_hash_activation)
+                    if block_header.hashing_algorithm_version(verifiable_chunked_hash_activation)
                         == HashingAlgorithmVersion::V1
                     {
                         let _ = deleted_block_body_hashes_v1.insert(*block_header.body_hash());
                     }
-                    let _ =
-                        deleted_block_hashes.insert(block_header.hash(merkle_tree_hash_activation));
+                    let _ = deleted_block_hashes
+                        .insert(block_header.hash(verifiable_chunked_hash_activation));
                     cursor.del(WriteFlags::empty())?;
                     continue;
                 }
             }
 
             if should_check_integrity {
-                let found_block_header_hash = block_header.hash(merkle_tree_hash_activation);
+                let found_block_header_hash = block_header.hash(verifiable_chunked_hash_activation);
                 if raw_key != found_block_header_hash.as_ref() {
                     return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
                         queried_block_hash_bytes: raw_key.to_vec(),
@@ -573,12 +573,12 @@ impl Storage {
                 &mut block_height_index,
                 &mut switch_block_era_id_index,
                 &block_header,
-                merkle_tree_hash_activation,
+                verifiable_chunked_hash_activation,
             )?;
 
             let mut body_txn = env.begin_ro_txn()?;
             let maybe_block_body =
-                match block_header.hashing_algorithm_version(merkle_tree_hash_activation) {
+                match block_header.hashing_algorithm_version(verifiable_chunked_hash_activation) {
                     HashingAlgorithmVersion::V1 => {
                         body_txn.get_value(block_body_v1_db, block_header.body_hash())?
                     }
@@ -597,13 +597,13 @@ impl Storage {
                     Block::new_from_header_and_body(
                         block_header.clone(),
                         block_body.clone(),
-                        merkle_tree_hash_activation,
+                        verifiable_chunked_hash_activation,
                     )?;
                 }
 
                 insert_to_deploy_index(
                     &mut deploy_hash_index,
-                    block_header.hash(merkle_tree_hash_activation),
+                    block_header.hash(verifiable_chunked_hash_activation),
                     &block_body,
                 )?;
             }
@@ -623,7 +623,7 @@ impl Storage {
                 .map(Digest::as_ref)
                 .collect(),
             should_check_integrity,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         )?;
         initialize_block_body_v2_db(
             &env,
@@ -633,7 +633,7 @@ impl Storage {
             &transfer_hashes_db,
             &proposer_db,
             should_check_integrity,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         )?;
         initialize_block_metadata_db(
             &env,
@@ -664,7 +664,7 @@ impl Storage {
             serialized_item_pool: ObjectPool::new(config.mem_pool_prune_interval),
             finality_threshold_fraction,
             last_emergency_restart,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         })
     }
 
@@ -1106,7 +1106,7 @@ impl Storage {
                 let mut txn = self.env.begin_rw_txn()?;
                 if !txn.put_value(
                     self.block_header_db,
-                    &block_header.hash(self.merkle_tree_hash_activation),
+                    &block_header.hash(self.verifiable_chunked_hash_activation),
                     &block_header,
                     false,
                 )? {
@@ -1121,7 +1121,7 @@ impl Storage {
                     &mut self.block_height_index,
                     &mut self.switch_block_era_id_index,
                     &block_header,
-                    self.merkle_tree_hash_activation,
+                    self.verifiable_chunked_hash_activation,
                 )?;
                 txn.commit()?;
                 responder.respond(true).ignore()
@@ -1156,7 +1156,7 @@ impl Storage {
     /// couldn't be written because it already existed, and `Err(_)` if there was an error.
     pub fn write_block(&mut self, block: &Block) -> Result<bool, FatalStorageError> {
         // Validate the block prior to inserting it into the database
-        block.verify(self.merkle_tree_hash_activation)?;
+        block.verify(self.verifiable_chunked_hash_activation)?;
         let mut txn = self.env.begin_rw_txn()?;
         // Write the block body
         {
@@ -1164,7 +1164,7 @@ impl Storage {
             let block_body = block.body();
             let success = match block
                 .header()
-                .hashing_algorithm_version(self.merkle_tree_hash_activation)
+                .hashing_algorithm_version(self.verifiable_chunked_hash_activation)
             {
                 HashingAlgorithmVersion::V1 => {
                     self.put_single_block_body_v1(&mut txn, block_body_hash, block_body)?
@@ -1189,11 +1189,11 @@ impl Storage {
             &mut self.block_height_index,
             &mut self.switch_block_era_id_index,
             block.header(),
-            self.merkle_tree_hash_activation,
+            self.verifiable_chunked_hash_activation,
         )?;
         insert_to_deploy_index(
             &mut self.deploy_hash_index,
-            block.header().hash(self.merkle_tree_hash_activation),
+            block.header().hash(self.verifiable_chunked_hash_activation),
             block.body(),
         )?;
         txn.commit()?;
@@ -1392,7 +1392,7 @@ impl Storage {
             Some(block_header) => block_header,
             None => return Ok(None),
         };
-        let found_block_header_hash = block_header.hash(self.merkle_tree_hash_activation);
+        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
         if found_block_header_hash != *block_hash {
             return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
                 queried_block_hash_bytes: block_hash.as_ref().to_vec(),
@@ -1521,7 +1521,7 @@ impl Storage {
         let block = Block::new_from_header_and_body(
             block_header,
             block_body,
-            self.merkle_tree_hash_activation,
+            self.verifiable_chunked_hash_activation,
         )?;
         Ok(Some(block))
     }
@@ -1531,7 +1531,7 @@ impl Storage {
         tx: &mut Tx,
         block_header: &BlockHeader,
     ) -> Result<Option<BlockBody>, LmdbExtError> {
-        match block_header.hashing_algorithm_version(self.merkle_tree_hash_activation) {
+        match block_header.hashing_algorithm_version(self.verifiable_chunked_hash_activation) {
             HashingAlgorithmVersion::V1 => {
                 self.get_single_block_body_v1(tx, block_header.body_hash())
             }
@@ -1614,7 +1614,7 @@ impl Storage {
                 block: Block::new_from_header_and_body(
                     block_header,
                     block_body,
-                    self.merkle_tree_hash_activation,
+                    self.verifiable_chunked_hash_activation,
                 )?,
                 finality_signatures: block_signatures,
             }))
@@ -1668,9 +1668,10 @@ impl Storage {
                 return Ok(None);
             }
         }
-        let block_signatures = match self
-            .get_finality_signatures(tx, &block_header.hash(self.merkle_tree_hash_activation))?
-        {
+        let block_signatures = match self.get_finality_signatures(
+            tx,
+            &block_header.hash(self.verifiable_chunked_hash_activation),
+        )? {
             None => return Ok(None),
             Some(block_signatures) => block_signatures,
         };
@@ -1769,9 +1770,9 @@ fn insert_to_block_header_indices(
     block_height_index: &mut BTreeMap<u64, BlockHash>,
     switch_block_era_id_index: &mut BTreeMap<EraId, BlockHash>,
     block_header: &BlockHeader,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<(), FatalStorageError> {
-    let block_hash = block_header.hash(merkle_tree_hash_activation);
+    let block_hash = block_header.hash(verifiable_chunked_hash_activation);
     if let Some(first) = block_height_index.get(&block_header.height()) {
         if *first != block_hash {
             return Err(FatalStorageError::DuplicateBlockIndex {
@@ -2062,7 +2063,7 @@ fn initialize_block_body_v1_db(
     block_body_v1_db: &Database,
     deleted_block_body_hashes_raw: &HashSet<&[u8]>,
     should_check_integrity: bool,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<(), FatalStorageError> {
     info!("initializing v1 block body database");
     let mut txn = env.begin_rw_txn()?;
@@ -2096,7 +2097,7 @@ fn initialize_block_body_v1_db(
             let block_body = lmdb_ext::deserialize(raw_val)?;
             if let Some(block_header) = block_body_hash_to_header_map.get(&block_body_hash) {
                 let actual_hashing_algorithm_version =
-                    block_header.hashing_algorithm_version(merkle_tree_hash_activation);
+                    block_header.hashing_algorithm_version(verifiable_chunked_hash_activation);
                 if expected_hashing_algorithm_version != actual_hashing_algorithm_version {
                     return Err(FatalStorageError::UnexpectedHashingAlgorithmVersion {
                         expected_hashing_algorithm_version,
@@ -2107,7 +2108,7 @@ fn initialize_block_body_v1_db(
                 Block::new_from_header_and_body(
                     block_header.to_owned(),
                     block_body,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )?;
             } else {
                 // Should be unreachable because we just deleted all block bodies that aren't
@@ -2206,7 +2207,7 @@ fn garbage_collect_block_body_v2_db(
     transfer_hashes_db: &Database,
     proposer_db: &Database,
     block_body_hash_to_header_map: &BTreeMap<Digest, BlockHeader>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<(), FatalStorageError> {
     // This will store all the keys that are reachable from a block header, in all the parts
     // databases (we're basically doing a mark-and-sweep below).
@@ -2220,7 +2221,7 @@ fn garbage_collect_block_body_v2_db(
     ];
 
     for (body_hash, header) in block_body_hash_to_header_map {
-        if header.hashing_algorithm_version(merkle_tree_hash_activation)
+        if header.hashing_algorithm_version(verifiable_chunked_hash_activation)
             != HashingAlgorithmVersion::V2
         {
             // We're only interested in body hashes for V2 blocks here
@@ -2236,7 +2237,7 @@ fn garbage_collect_block_body_v2_db(
                     Some(slice) => slice,
                     None => {
                         return Err(FatalStorageError::CouldNotFindBlockBodyPart {
-                            block_hash: header.hash(merkle_tree_hash_activation),
+                            block_hash: header.hash(verifiable_chunked_hash_activation),
                             merkle_linked_list_node_hash: current_digest,
                         })
                     }
@@ -2289,7 +2290,7 @@ fn initialize_block_body_v2_db(
     transfer_hashes_db: &Database,
     proposer_db: &Database,
     should_check_integrity: bool,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<(), FatalStorageError> {
     info!("initializing v2 block body database");
 
@@ -2312,7 +2313,7 @@ fn initialize_block_body_v2_db(
                 }
             };
             let actual_hashing_algorithm_version =
-                block_header.hashing_algorithm_version(merkle_tree_hash_activation);
+                block_header.hashing_algorithm_version(verifiable_chunked_hash_activation);
             if expected_hashing_algorithm_version != actual_hashing_algorithm_version {
                 return Err(FatalStorageError::UnexpectedHashingAlgorithmVersion {
                     expected_hashing_algorithm_version,
@@ -2335,7 +2336,7 @@ fn initialize_block_body_v2_db(
                     Block::new_from_header_and_body(
                         block_header.to_owned(),
                         block_body,
-                        merkle_tree_hash_activation,
+                        verifiable_chunked_hash_activation,
                     )?;
                 }
                 None => {

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -907,7 +907,7 @@ pub(crate) fn handle_fetch_response<R, T>(
     rng: &mut NodeRng,
     sender: NodeId,
     serialized_item: &[u8],
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Effects<<R as Reactor>::Event>
 where
     T: Item,
@@ -917,7 +917,7 @@ where
     match fetcher::Event::<T>::from_get_response_serialized_item(
         sender,
         serialized_item,
-        merkle_tree_hash_activation,
+        verifiable_chunked_hash_activation,
     ) {
         Some(fetcher_event) => {
             Reactor::dispatch_event(reactor, effect_builder, rng, fetcher_event.into())

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -212,7 +212,7 @@ impl Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .merkle_tree_hash_activation,
+                .verifiable_chunked_hash_activation,
         )?;
 
         let contract_runtime = ContractRuntime::new(
@@ -230,7 +230,7 @@ impl Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .merkle_tree_hash_activation,
+                .verifiable_chunked_hash_activation,
         )?;
 
         if should_check_integrity {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -552,10 +552,10 @@ impl reactor::Reactor for Reactor {
             sync_effects,
         ));
 
-        let merkle_tree_hash_activation = chainspec_loader
+        let verifiable_chunked_hash_activation = chainspec_loader
             .chainspec()
             .protocol_config
-            .merkle_tree_hash_activation;
+            .verifiable_chunked_hash_activation;
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
         let rest_server = RestServer::new(
             config.rest_server.clone(),
@@ -572,7 +572,7 @@ impl reactor::Reactor for Reactor {
         )?;
 
         let fetcher_builder =
-            FetcherBuilder::new(config.fetcher, registry, merkle_tree_hash_activation);
+            FetcherBuilder::new(config.fetcher, registry, verifiable_chunked_hash_activation);
 
         let deploy_fetcher = fetcher_builder.build("deploy")?;
         let block_by_height_fetcher = fetcher_builder.build("block_by_height")?;
@@ -582,7 +582,7 @@ impl reactor::Reactor for Reactor {
         let block_header_by_hash_fetcher = fetcher_builder.build("block_header")?;
 
         let trie_or_chunk_fetcher = fetcher_builder.build("trie_or_chunk")?;
-        let trie_fetcher = TrieFetcher::new(merkle_tree_hash_activation);
+        let trie_fetcher = TrieFetcher::new(verifiable_chunked_hash_activation);
 
         let deploy_acceptor = DeployAcceptor::new(
             config.deploy_acceptor,
@@ -655,7 +655,7 @@ impl reactor::Reactor for Reactor {
                     self.dispatch_event(effect_builder, rng, JoinerEvent::EventStreamServer(event));
 
                 let event = fetcher::Event::GotRemotely {
-                    merkle_tree_hash_activation: None,
+                    verifiable_chunked_hash_activation: None,
                     item: deploy,
                     source,
                 };
@@ -887,7 +887,7 @@ impl reactor::Reactor for Reactor {
                     self.chainspec_loader
                         .chainspec()
                         .protocol_config
-                        .merkle_tree_hash_activation,
+                        .verifiable_chunked_hash_activation,
                 )
             }
 
@@ -933,11 +933,11 @@ impl Reactor {
         sender: NodeId,
         message: NetResponse,
     ) -> Effects<JoinerEvent> {
-        let merkle_tree_hash_activation = self
+        let verifiable_chunked_hash_activation = self
             .chainspec_loader
             .chainspec()
             .protocol_config
-            .merkle_tree_hash_activation;
+            .verifiable_chunked_hash_activation;
         match message {
             NetResponse::Deploy(ref serialized_item) => {
                 reactor::handle_fetch_response::<Self, Deploy>(
@@ -946,7 +946,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )
             }
             NetResponse::Block(ref serialized_item) => {
@@ -956,7 +956,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )
             }
             NetResponse::GossipedAddress(_) => {
@@ -977,7 +977,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )
             }
             NetResponse::BlockHeaderByHash(ref serialized_item) => {
@@ -987,7 +987,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )
             }
             NetResponse::BlockHeaderAndFinalitySignaturesByHeight(ref serialized_item) => {
@@ -997,7 +997,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    merkle_tree_hash_activation,
+                    verifiable_chunked_hash_activation,
                 )
             }
         }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -680,7 +680,7 @@ impl reactor::Reactor for Reactor {
             "deploy",
             config.fetcher,
             registry,
-            chainspec.protocol_config.merkle_tree_hash_activation,
+            chainspec.protocol_config.verifiable_chunked_hash_activation,
         )?;
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",
@@ -738,7 +738,7 @@ impl reactor::Reactor for Reactor {
 
         contract_runtime.set_initial_state(ExecutionPreState::from_block_header(
             &latest_block_header,
-            chainspec.protocol_config.merkle_tree_hash_activation,
+            chainspec.protocol_config.verifiable_chunked_hash_activation,
         ));
 
         let block_validator = BlockValidator::new(Arc::clone(chainspec));
@@ -749,7 +749,7 @@ impl reactor::Reactor for Reactor {
             chainspec.core_config.unbonding_delay,
             chainspec.highway_config.finality_threshold_fraction,
             maybe_next_activation_point,
-            chainspec.protocol_config.merkle_tree_hash_activation,
+            chainspec.protocol_config.verifiable_chunked_hash_activation,
         )?;
 
         effects.extend(reactor::wrap_effects(
@@ -977,7 +977,7 @@ impl reactor::Reactor for Reactor {
                 ));
 
                 let event = fetcher::Event::GotRemotely {
-                    merkle_tree_hash_activation: None,
+                    verifiable_chunked_hash_activation: None,
                     item: deploy,
                     source,
                 };
@@ -1113,7 +1113,7 @@ impl reactor::Reactor for Reactor {
                             self.chainspec_loader
                                 .chainspec()
                                 .protocol_config
-                                .merkle_tree_hash_activation,
+                                .verifiable_chunked_hash_activation,
                         ),
                     });
                 let reactor_event_es = ParticipatingEvent::EventStreamServer(

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -36,7 +36,7 @@ struct TomlProtocol {
     hard_reset: bool,
     activation_point: ActivationPoint,
     last_emergency_restart: Option<EraId>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 }
 
 /// A chainspec configuration as laid out in the TOML-encoded configuration file.
@@ -60,7 +60,9 @@ impl From<&Chainspec> for TomlChainspec {
             hard_reset: chainspec.protocol_config.hard_reset,
             activation_point: chainspec.protocol_config.activation_point,
             last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
-            merkle_tree_hash_activation: chainspec.protocol_config.merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation: chainspec
+                .protocol_config
+                .verifiable_chunked_hash_activation,
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
@@ -112,7 +114,9 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
         activation_point: toml_chainspec.protocol.activation_point,
         global_state_update,
         last_emergency_restart: toml_chainspec.protocol.last_emergency_restart,
-        merkle_tree_hash_activation: toml_chainspec.protocol.merkle_tree_hash_activation,
+        verifiable_chunked_hash_activation: toml_chainspec
+            .protocol
+            .verifiable_chunked_hash_activation,
     };
 
     Ok(Chainspec {

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -34,7 +34,7 @@ pub struct ProtocolConfig {
     /// The era ID in which the last emergency restart happened.
     pub(crate) last_emergency_restart: Option<EraId>,
     /// The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-    pub(crate) merkle_tree_hash_activation: EraId,
+    pub(crate) verifiable_chunked_hash_activation: EraId,
 }
 
 impl ProtocolConfig {
@@ -96,7 +96,7 @@ impl ProtocolConfig {
         );
         let activation_point = ActivationPoint::random(rng);
         let last_emergency_restart = rng.gen::<bool>().then(|| rng.gen());
-        let merkle_tree_hash_activation = EraId::from(rng.gen_range(0..5));
+        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..5));
 
         ProtocolConfig {
             version: protocol_version,
@@ -104,7 +104,7 @@ impl ProtocolConfig {
             activation_point,
             global_state_update: None,
             last_emergency_restart,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         }
     }
 }
@@ -117,7 +117,7 @@ impl ToBytes for ProtocolConfig {
         buffer.extend(self.activation_point.to_bytes()?);
         buffer.extend(self.global_state_update.to_bytes()?);
         buffer.extend(self.last_emergency_restart.to_bytes()?);
-        buffer.extend(self.merkle_tree_hash_activation.to_bytes()?);
+        buffer.extend(self.verifiable_chunked_hash_activation.to_bytes()?);
         Ok(buffer)
     }
 
@@ -127,7 +127,7 @@ impl ToBytes for ProtocolConfig {
             + self.activation_point.serialized_length()
             + self.global_state_update.serialized_length()
             + self.last_emergency_restart.serialized_length()
-            + self.merkle_tree_hash_activation.serialized_length()
+            + self.verifiable_chunked_hash_activation.serialized_length()
     }
 }
 
@@ -140,14 +140,14 @@ impl FromBytes for ProtocolConfig {
         let (activation_point, remainder) = ActivationPoint::from_bytes(remainder)?;
         let (global_state_update, remainder) = Option::<GlobalStateUpdate>::from_bytes(remainder)?;
         let (last_emergency_restart, remainder) = Option::<EraId>::from_bytes(remainder)?;
-        let (merkle_tree_hash_activation, remainder) = EraId::from_bytes(remainder)?;
+        let (verifiable_chunked_hash_activation, remainder) = EraId::from_bytes(remainder)?;
         let protocol_config = ProtocolConfig {
             version,
             hard_reset,
             activation_point,
             global_state_update,
             last_emergency_restart,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         };
         Ok((protocol_config, remainder))
     }
@@ -228,7 +228,7 @@ mod tests {
         let upgrade_era = EraId::from(5);
         let previous_era = upgrade_era.saturating_sub(1);
 
-        let merkle_tree_hash_activation = EraId::from(0);
+        let verifiable_chunked_hash_activation = EraId::from(0);
 
         let mut rng = crate::new_rng();
         let protocol_config = ProtocolConfig {
@@ -237,7 +237,7 @@ mod tests {
             activation_point: ActivationPoint::EraId(upgrade_era),
             global_state_update: None,
             last_emergency_restart: None,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         };
 
         // The block before this protocol version: a switch block with previous era and version.
@@ -247,7 +247,7 @@ mod tests {
             100,
             past_version,
             true,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         assert!(protocol_config.is_last_block_before_activation(block.header()));
 
@@ -258,7 +258,7 @@ mod tests {
             100,
             past_version,
             true,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -269,7 +269,7 @@ mod tests {
             100,
             current_version,
             true,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
         let block = Block::random_with_specifics(
@@ -278,7 +278,7 @@ mod tests {
             100,
             future_version,
             true,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -289,7 +289,7 @@ mod tests {
             100,
             past_version,
             false,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -1347,12 +1347,15 @@ impl Item for Deploy {
     const TAG: Tag = Tag::Deploy;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(&self, _merkle_tree_hash_activation: EraId) -> Result<(), Self::ValidationError> {
+    fn validate(
+        &self,
+        _verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError> {
         // TODO: Validate approvals later, and only if the approvers are actually authorized!
         validate_deploy(self)
     }
 
-    fn id(&self, _merkle_tree_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
         *self.id()
     }
 }

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -64,10 +64,13 @@ pub(crate) trait Item:
     const ID_IS_COMPLETE_ITEM: bool;
 
     /// Checks cryptographic validity of the item, and returns an error if invalid.
-    fn validate(&self, merkle_tree_hash_activation: EraId) -> Result<(), Self::ValidationError>;
+    fn validate(
+        &self,
+        verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError>;
 
     /// The ID of the specific item.
-    fn id(&self, merkle_tree_hash_activation: EraId) -> Self::Id;
+    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id;
 }
 
 /// Error type simply conveying that chunk validation failed.
@@ -81,7 +84,10 @@ impl Item for TrieOrChunk {
     const TAG: Tag = Tag::Trie;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(&self, _merkle_tree_hash_activation: EraId) -> Result<(), Self::ValidationError> {
+    fn validate(
+        &self,
+        _verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError> {
         match self {
             TrieOrChunk::Trie(_) => Ok(()),
             TrieOrChunk::ChunkWithProof(chunk) => {
@@ -90,7 +96,7 @@ impl Item for TrieOrChunk {
         }
     }
 
-    fn id(&self, _merkle_tree_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
         match self {
             TrieOrChunk::Trie(trie) => {
                 let node_bytes = trie.to_bytes().expect("Could not serialize trie to bytes");
@@ -110,11 +116,14 @@ impl Item for BlockHeader {
     const TAG: Tag = Tag::BlockHeaderByHash;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(&self, _merkle_tree_hash_activation: EraId) -> Result<(), Self::ValidationError> {
+    fn validate(
+        &self,
+        _verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, merkle_tree_hash_activation: EraId) -> Self::Id {
-        self.hash(merkle_tree_hash_activation)
+    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id {
+        self.hash(verifiable_chunked_hash_activation)
     }
 }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -15,7 +15,7 @@ activation_point = '${TIMESTAMP}'
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-merkle_tree_hash_activation = 2
+verifiable_chunked_hash_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -17,7 +17,7 @@ activation_point = 3000
 
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
 # TODO: Set this to the same value as the upgrade to the first version supporting Merkle tree-based hashing.
-merkle_tree_hash_activation = 9999
+verifiable_chunked_hash_activation = 9999
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -2,7 +2,7 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-merkle_tree_hash_activation = 0
+verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -2,7 +2,7 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-merkle_tree_hash_activation = 0
+verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -3,7 +3,7 @@ version = '1.0.0'
 hard_reset = false
 activation_point = 1
 last_emergency_restart = 99
-merkle_tree_hash_activation = 0
+verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/utils/dry-run-deploys/src/main.rs
+++ b/utils/dry-run-deploys/src/main.rs
@@ -57,10 +57,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let lmdb_path = normalize_path(&opts.lmdb_path)?;
 
     // TODO: Consider reading the proper `chainspec` in the `dry-run-deploys` tool.
-    let merkle_tree_hash_activation = EraId::from(0u64);
+    let verifiable_chunked_hash_activation = EraId::from(0u64);
 
     // Create a separate lmdb for block/deploy storage at chain_download_path.
-    let storage = create_storage(&chain_download_path, merkle_tree_hash_activation)
+    let storage = create_storage(&chain_download_path, verifiable_chunked_hash_activation)
         .expect("should create storage");
 
     let max_db_size = opts
@@ -81,8 +81,10 @@ async fn main() -> Result<(), anyhow::Error> {
         opts.manual_sync_enabled,
     )?;
 
-    let mut execution_pre_state =
-        ExecutionPreState::from_block_header(&previous_block_header, merkle_tree_hash_activation);
+    let mut execution_pre_state = ExecutionPreState::from_block_header(
+        &previous_block_header,
+        verifiable_chunked_hash_activation,
+    );
     let mut execute_count = 0;
 
     let highest_height_in_chain = storage.read_highest_block()?;
@@ -140,7 +142,7 @@ async fn main() -> Result<(), anyhow::Error> {
             finalized_block,
             deploys,
             transfers,
-            merkle_tree_hash_activation,
+            verifiable_chunked_hash_activation,
         )?;
         let elapsed_micros = start.elapsed().as_micros() as u64;
         execution_time_hist
@@ -155,7 +157,7 @@ async fn main() -> Result<(), anyhow::Error> {
             "state root hash mismatch"
         );
         execution_pre_state =
-            ExecutionPreState::from_block_header(&header, merkle_tree_hash_activation);
+            ExecutionPreState::from_block_header(&header, verifiable_chunked_hash_activation);
         execute_count += 1;
         if opts.verbose {
             eprintln!(

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-merkle_tree_hash_activation = 2,
+verifiable_chunked_hash_activation = 2,
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2,
+verifiable_chunked_hash_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-merkle_tree_hash_activation = 2,
+verifiable_chunked_hash_activation = 2,
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2,
+verifiable_chunked_hash_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-merkle_tree_hash_activation = 2,
+verifiable_chunked_hash_activation = 2,
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2,
+verifiable_chunked_hash_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/retrieve-state/src/main.rs
+++ b/utils/retrieve-state/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let url = address_to_url(initial_server_address);
 
     // TODO: Consider reading the proper `chainspec` in the `retrieve-state` tool.
-    let merkle_tree_hash_activation = EraId::from(0u64);
+    let verifiable_chunked_hash_activation = EraId::from(0u64);
 
     let maybe_highest_block = opts.highest_block;
     let maybe_download_block = opts
@@ -186,8 +186,9 @@ async fn main() -> Result<(), anyhow::Error> {
                 fs::create_dir_all(&chain_download_path)?;
             }
 
-            let mut storage = create_storage(&chain_download_path, merkle_tree_hash_activation)
-                .expect("should create storage");
+            let mut storage =
+                create_storage(&chain_download_path, verifiable_chunked_hash_activation)
+                    .expect("should create storage");
             info!("Downloading all blocks to genesis...");
             let (downloaded, read_from_disk) = retrieve_state::download_or_read_blocks(
                 &client,

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -130,7 +130,7 @@ pub fn normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, anyhow::Error> 
 
 pub fn create_storage(
     chain_download_path: impl AsRef<Path>,
-    merkle_tree_hash_activation: EraId,
+    verifiable_chunked_hash_activation: EraId,
 ) -> Result<Storage, anyhow::Error> {
     let chain_download_path = normalize_path(chain_download_path)?;
     let mut storage_config = StorageConfig::default();
@@ -143,7 +143,7 @@ pub fn create_storage(
         "test",
         Ratio::new(1, 3),
         None,
-        merkle_tree_hash_activation,
+        verifiable_chunked_hash_activation,
     )?)
 }
 


### PR DESCRIPTION
`verifiable_chunked_hash_activation` is more descriptive: The more user-visible feature is that chunks of big trie leaves and individual fields of blocks can now be downloaded and verified without having the rest of the trie leaf or block.

Relates to #1665.
