### PR TITLE
Rename chainspec setting to block_hash_v2_activation.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add ability to force DB integrity checks to run on node start by setting env var `CL_RUN_INTEGRITY_CHECKS=1`.
 * Add ability to force DB integrity checks to run on node start by adding non-numeric contents to the initializer.pid file.
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
-* Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
+* Add `block_hash_v2_activation` to the chainspec to specify the first era in which the new Merkle tree-based block hashing scheme is used.
 * Added `max_parallel_deploy_fetches` and `max_parallel_trie_fetches` config options to the `[node]` section to control how many requests are made in parallel while syncing.
 * Added `archival_sync` to `[node]` config section, along with archival syncing capabilities
 * Introducing fast-syncing to join the network, avoiding the need to execute every block to catch up.

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -296,11 +296,8 @@ impl ChainSynchronizer {
                 let initial_pre_state = ExecutionPreState::new(
                     upgrade_block_header.height() + 1,
                     post_state_hash,
-                    upgrade_block_header.hash(
-                        self.chainspec
-                            .protocol_config
-                            .verifiable_chunked_hash_activation,
-                    ),
+                    upgrade_block_header
+                        .hash(self.chainspec.protocol_config.block_hash_v2_activation),
                     upgrade_block_header.accumulated_seed(),
                 );
                 let finalized_block = FinalizedBlock::new(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -242,10 +242,8 @@ where
     }
 
     /// Returns the merkle tree hash activation from the chainspec.
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.chainspec
-            .protocol_config
-            .verifiable_chunked_hash_activation
+    fn block_hash_v2_activation(&self) -> EraId {
+        self.chainspec.protocol_config.block_hash_v2_activation
     }
 
     /// Returns a list of status changes of active validators.
@@ -407,7 +405,7 @@ where
         let auction_delay = self.chainspec.core_config.auction_delay as usize;
         let booking_block_hash =
             if let Some(booking_block) = switch_blocks.iter().rev().nth(auction_delay) {
-                booking_block.hash(self.verifiable_chunked_hash_activation())
+                booking_block.hash(self.block_hash_v2_activation())
             } else {
                 // If there's no booking block for the `era_id`
                 // (b/c it would have been from before Genesis, upgrade or emergency restart),
@@ -683,7 +681,7 @@ where
         let mut effects = if self.is_validator_in(&our_pk, era_id) {
             effect_builder
                 .announce_created_finality_signature(FinalitySignature::new(
-                    block_header.hash(self.verifiable_chunked_hash_activation()),
+                    block_header.hash(self.block_hash_v2_activation()),
                     era_id,
                     &our_sk,
                     our_pk,

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -40,7 +40,7 @@ pub fn execute_finalized_block(
     finalized_block: FinalizedBlock,
     deploys: Vec<Deploy>,
     transfers: Vec<Deploy>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Result<BlockAndExecutionEffects, BlockExecutionError> {
     if finalized_block.height() != execution_pre_state.next_block_height {
         return Err(BlockExecutionError::WrongBlockHeight {
@@ -162,7 +162,7 @@ pub fn execute_finalized_block(
         finalized_block,
         next_era_validator_weights,
         protocol_version,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )?);
 
     Ok(BlockAndExecutionEffects {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -416,7 +416,7 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            chainspec.protocol_config.verifiable_chunked_hash_activation,
+            chainspec.protocol_config.block_hash_v2_activation,
         )
         .unwrap();
 
@@ -689,9 +689,9 @@ async fn run_deploy_acceptor_without_timeout(
 
     let chainspec = Chainspec::from_resources("local");
 
-    let block = Box::new(Block::random_with_verifiable_chunked_hash_activation(
+    let block = Box::new(Block::random_with_block_hash_v2_activation(
         &mut rng,
-        chainspec.protocol_config.verifiable_chunked_hash_activation,
+        chainspec.protocol_config.block_hash_v2_activation,
     ));
     // Create a responder to assert that the block was successfully injected into storage.
     let (block_sender, block_receiver) = oneshot::channel();

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -55,11 +55,11 @@ pub(crate) enum Event<T: Item> {
     },
     /// An announcement from a different component that we have accepted and stored the given item.
     GotRemotely {
-        // TODO[RC]: `verifiable_chunked_hash_activation` is scattered around, because this is a
+        // TODO[RC]: `block_hash_v2_activation` is scattered around, because this is a
         // piece of information obtained in the top-level code (read from the chainspec),
         // but required across all the layers, including the very bottom ones. At some
         // point we should consider refactoring to get rid of such "tramp data".
-        verifiable_chunked_hash_activation: Option<EraId>,
+        block_hash_v2_activation: Option<EraId>,
         item: Box<T>,
         source: Source<NodeId>,
     },
@@ -77,11 +77,11 @@ impl<T: Item> Event<T> {
     pub(crate) fn from_get_response_serialized_item(
         peer: NodeId,
         serialized_item: &[u8],
-        verifiable_chunked_hash_activation: EraId,
+        block_hash_v2_activation: EraId,
     ) -> Option<Self> {
         match bincode::deserialize::<FetchedOrNotFound<T, T::Id>>(serialized_item) {
             Ok(FetchedOrNotFound::Fetched(item)) => Some(Event::GotRemotely {
-                verifiable_chunked_hash_activation: Some(verifiable_chunked_hash_activation),
+                block_hash_v2_activation: Some(block_hash_v2_activation),
                 item: Box::new(item),
                 source: Source::Peer(peer),
             }),
@@ -107,7 +107,7 @@ impl From<DeployAcceptorAnnouncement<NodeId>> for Event<Deploy> {
         match announcement {
             DeployAcceptorAnnouncement::AcceptedNewDeploy { deploy, source } => {
                 Event::GotRemotely {
-                    verifiable_chunked_hash_activation: None,
+                    block_hash_v2_activation: None,
                     item: deploy,
                     source,
                 }
@@ -136,21 +136,20 @@ impl<T: Item> Display for Event<T> {
                 }
             }
             Event::GotRemotely {
-                verifiable_chunked_hash_activation,
+                block_hash_v2_activation,
                 item,
                 source,
             } => {
-                // If `verifiable_chunked_hash_activation` is not present here then our T is an
+                // If `block_hash_v2_activation` is not present here then our T is an
                 // object that doesn't require the activation point to calculate its
                 // `id`, hence we can provide any value to the `id()` method, as
                 // it'll be ignored.
-                let verifiable_chunked_hash_activation =
-                    verifiable_chunked_hash_activation.unwrap_or_default();
+                let block_hash_v2_activation = block_hash_v2_activation.unwrap_or_default();
 
                 write!(
                     formatter,
                     "got {} from {}",
-                    item.id(verifiable_chunked_hash_activation),
+                    item.id(block_hash_v2_activation),
                     source
                 )
             }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -92,7 +92,7 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .verifiable_chunked_hash_activation,
+                .block_hash_v2_activation,
         );
         deploy_acceptor = DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec(), registry);
         deploy_fetcher = Fetcher::<Deploy>(
@@ -102,7 +102,7 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .verifiable_chunked_hash_activation);
+                .block_hash_v2_activation);
     }
 
     events: {

--- a/node/src/components/fetcher/trie_fetcher.rs
+++ b/node/src/components/fetcher/trie_fetcher.rs
@@ -113,7 +113,7 @@ where
     I: Debug + Eq + Clone,
 {
     partial_chunks: HashMap<Digest, PartialChunks<I>>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 }
 
 #[derive(DataSize, Debug, From)]
@@ -157,10 +157,10 @@ impl<I> TrieFetcher<I>
 where
     I: Debug + Clone + Hash + Send + Eq + 'static,
 {
-    pub(crate) fn new(verifiable_chunked_hash_activation: EraId) -> Self {
+    pub(crate) fn new(block_hash_v2_activation: EraId) -> Self {
         TrieFetcher {
             partial_chunks: Default::default(),
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         }
     }
 
@@ -176,7 +176,7 @@ where
             + From<ControlAnnouncement>
             + From<BlocklistAnnouncement<I>>,
     {
-        let TrieOrChunkId(_index, hash) = trie_or_chunk.id(self.verifiable_chunked_hash_activation);
+        let TrieOrChunkId(_index, hash) = trie_or_chunk.id(self.block_hash_v2_activation);
         match trie_or_chunk {
             TrieOrChunk::Trie(trie) => match self.partial_chunks.remove(&hash) {
                 None => {

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -207,8 +207,8 @@ impl reactor::Reactor for Reactor {
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let network = NetworkController::create_node(event_queue, rng);
 
-        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-        let verifiable_chunked_hash_activation = rng.gen_range(0..=10);
+        // `block_hash_v2_activation` can be chosen arbitrarily
+        let block_hash_v2_activation = rng.gen_range(0..=10);
 
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
@@ -220,7 +220,7 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            verifiable_chunked_hash_activation.into(),
+            block_hash_v2_activation.into(),
         )
         .unwrap();
 
@@ -234,7 +234,7 @@ impl reactor::Reactor for Reactor {
             MAX_ASSOCIATED_KEYS,
             DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
             registry,
-            verifiable_chunked_hash_activation.into(),
+            block_hash_v2_activation.into(),
         )
         .unwrap();
 

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -41,7 +41,7 @@ pub(crate) struct LinearChainComponent<I> {
     metrics: Metrics,
     /// If true, the process should stop execution to allow an upgrade to proceed.
     stop_for_upgrade: bool,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
     _marker: PhantomData<I>,
 }
 
@@ -53,7 +53,7 @@ impl<I> LinearChainComponent<I> {
         unbonding_delay: u64,
         finality_threshold_fraction: Ratio<u64>,
         next_upgrade_activation_point: Option<ActivationPoint>,
-        verifiable_chunked_hash_activation: EraId,
+        block_hash_v2_activation: EraId,
     ) -> Result<Self, prometheus::Error> {
         let metrics = Metrics::new(registry)?;
         let linear_chain_state = LinearChain::new(
@@ -67,7 +67,7 @@ impl<I> LinearChainComponent<I> {
             linear_chain_state,
             metrics,
             stop_for_upgrade: false,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
             _marker: PhantomData,
         })
     }
@@ -76,8 +76,8 @@ impl<I> LinearChainComponent<I> {
         self.stop_for_upgrade
     }
 
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.verifiable_chunked_hash_activation
+    fn block_hash_v2_activation(&self) -> EraId {
+        self.block_hash_v2_activation
     }
 }
 
@@ -181,7 +181,7 @@ where
                     .set(completion_duration as i64);
                 let outcomes = self
                     .linear_chain_state
-                    .handle_put_block(block, self.verifiable_chunked_hash_activation());
+                    .handle_put_block(block, self.block_hash_v2_activation());
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::FinalitySignatureReceived(fs, gossiped) => {

--- a/node/src/components/small_network/gossiped_address.rs
+++ b/node/src/components/small_network/gossiped_address.rs
@@ -34,14 +34,11 @@ impl Item for GossipedAddress {
     const TAG: Tag = Tag::GossipedAddress;
     const ID_IS_COMPLETE_ITEM: bool = true;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self, _block_hash_v2_activation: EraId) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _block_hash_v2_activation: EraId) -> Self::Id {
         *self
     }
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -62,7 +62,7 @@ fn new_config(harness: &ComponentHarness<UnitTestEvent>) -> Config {
 /// Panics if setting up the storage fixture fails.
 fn storage_fixture(
     harness: &ComponentHarness<UnitTestEvent>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Storage {
     let cfg = new_config(harness);
     Storage::new(
@@ -73,7 +73,7 @@ fn storage_fixture(
         "test",
         Ratio::new(1, 3),
         None,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )
     .expect("could not create storage component fixture")
 }
@@ -88,7 +88,7 @@ fn storage_fixture(
 fn storage_fixture_with_hard_reset(
     harness: &ComponentHarness<UnitTestEvent>,
     reset_era_id: EraId,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Storage {
     let cfg = new_config(harness);
     Storage::new(
@@ -99,7 +99,7 @@ fn storage_fixture_with_hard_reset(
         "test",
         Ratio::new(1, 3),
         None,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )
     .expect("could not create storage component fixture")
 }
@@ -115,7 +115,7 @@ fn storage_fixture_with_hard_reset_and_protocol_version(
     harness: &ComponentHarness<UnitTestEvent>,
     reset_era_id: EraId,
     protocol_version: ProtocolVersion,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Storage {
     let cfg = new_config(harness);
     Storage::new(
@@ -126,7 +126,7 @@ fn storage_fixture_with_hard_reset_and_protocol_version(
         "test",
         Ratio::new(1, 3),
         None,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )
     .expect("could not create storage component fixture")
 }
@@ -316,10 +316,10 @@ fn put_execution_results(
 fn get_block_of_non_existing_block_returns_none() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let response = get_block(&mut harness, &mut storage, block_hash);
@@ -332,7 +332,7 @@ fn get_block_of_non_existing_block_returns_none() {
 fn switch_block_for_block_header(
     block_header: &BlockHeader,
     validator_weights: BTreeMap<PublicKey, U512>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Block {
     let finalized_block = FinalizedBlock::new(
         BlockPayload::new(vec![], vec![], vec![], false),
@@ -362,7 +362,7 @@ fn switch_block_for_block_header(
         finalized_block,
         Some(validator_weights),
         block_header.protocol_version(),
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )
     .expect("Could not create block")
 }
@@ -372,13 +372,13 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
     const MAX_ERA: u64 = 6;
 
     // Test both legacy and merkle based hashing schemes.
-    let verifiable_chunked_hash_activations = vec![EraId::from(0), EraId::from(MAX_ERA + 1)];
+    let block_hash_v2_activations = vec![EraId::from(0), EraId::from(MAX_ERA + 1)];
 
-    for verifiable_chunked_hash_activation in verifiable_chunked_hash_activations {
+    for block_hash_v2_activation in block_hash_v2_activations {
         thread::spawn(move || {
             let mut harness = ComponentHarness::default();
 
-            let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+            let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
             // Create a random block, store and load it.
             //
@@ -397,12 +397,12 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
                     height,
                     ProtocolVersion::V1_0_0,
                     is_switch,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             };
 
             let mut block_signatures = BlockSignatures::new(
-                block.header().hash(verifiable_chunked_hash_activation),
+                block.header().hash(block_hash_v2_activation),
                 block.header().era_id(),
             );
 
@@ -419,7 +419,7 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
                     signature,
                     ..
                 } = FinalitySignature::new(
-                    block.header().hash(verifiable_chunked_hash_activation),
+                    block.header().hash(block_hash_v2_activation),
                     block.header().era_id(),
                     &alice_secret_key,
                     alice_public_key.clone(),
@@ -433,7 +433,7 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
                     signature,
                     ..
                 } = FinalitySignature::new(
-                    block.header().hash(verifiable_chunked_hash_activation),
+                    block.header().hash(block_hash_v2_activation),
                     block.header().era_id(),
                     &bob_secret_key,
                     bob_public_key.clone(),
@@ -481,7 +481,7 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
             let switch_block = switch_block_for_block_header(
                 block.header(),
                 genesis_validator_weights,
-                verifiable_chunked_hash_activation,
+                block_hash_v2_activation,
             );
             let was_new = put_block(&mut harness, &mut storage, Box::new(switch_block));
             assert!(was_new, "putting switch block should have returned `true`");
@@ -525,19 +525,19 @@ fn test_get_block_header_and_sufficient_finality_signatures_by_height() {
 fn can_retrieve_block_by_height() {
     struct BlockData {
         era_id: EraId,
-        verifiable_chunked_hash_activation: EraId,
+        block_hash_v2_activation: EraId,
     }
 
     let block_specs = vec![
         // Generates v1 blocks
         BlockData {
             era_id: EraId::from(1),
-            verifiable_chunked_hash_activation: EraId::from(5),
+            block_hash_v2_activation: EraId::from(5),
         },
         // Generates v2 blocks
         BlockData {
             era_id: EraId::from(1),
-            verifiable_chunked_hash_activation: EraId::from(0),
+            block_hash_v2_activation: EraId::from(0),
         },
     ];
 
@@ -552,7 +552,7 @@ fn can_retrieve_block_by_height() {
                 33,
                 ProtocolVersion::from_parts(1, 5, 0),
                 true,
-                block_spec.verifiable_chunked_hash_activation,
+                block_spec.block_hash_v2_activation,
             ));
             let block_14 = Box::new(Block::random_with_specifics(
                 &mut harness.rng,
@@ -560,7 +560,7 @@ fn can_retrieve_block_by_height() {
                 14,
                 ProtocolVersion::from_parts(1, 5, 0),
                 false,
-                block_spec.verifiable_chunked_hash_activation,
+                block_spec.block_hash_v2_activation,
             ));
             let block_99 = Box::new(Block::random_with_specifics(
                 &mut harness.rng,
@@ -568,11 +568,10 @@ fn can_retrieve_block_by_height() {
                 99,
                 ProtocolVersion::from_parts(1, 5, 0),
                 true,
-                block_spec.verifiable_chunked_hash_activation,
+                block_spec.block_hash_v2_activation,
             ));
 
-            let mut storage =
-                storage_fixture(&harness, block_spec.verifiable_chunked_hash_activation);
+            let mut storage = storage_fixture(&harness, block_spec.block_hash_v2_activation);
 
             // Both block at ID and highest block should return `None` initially.
             assert!(get_block_at_height(&mut storage, 0).is_none());
@@ -680,10 +679,10 @@ fn can_retrieve_block_by_height() {
 fn different_block_at_height_is_fatal() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     // Create two different blocks at the same height.
     let block_44_a = Box::new(Block::random_with_specifics(
@@ -692,7 +691,7 @@ fn different_block_at_height_is_fatal() {
         44,
         ProtocolVersion::V1_0_0,
         false,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     ));
     let block_44_b = Box::new(Block::random_with_specifics(
         &mut harness.rng,
@@ -700,7 +699,7 @@ fn different_block_at_height_is_fatal() {
         44,
         ProtocolVersion::V1_0_0,
         false,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     ));
 
     let was_new = put_block(&mut harness, &mut storage, block_44_a.clone());
@@ -717,10 +716,10 @@ fn different_block_at_height_is_fatal() {
 fn get_vec_of_non_existing_deploy_returns_nones() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let deploy_id = DeployHash::random(&mut harness.rng);
     let response = get_deploys(&mut harness, &mut storage, smallvec![deploy_id]);
@@ -735,10 +734,10 @@ fn get_vec_of_non_existing_deploy_returns_nones() {
 fn can_retrieve_store_and_load_deploys() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     // Create a random deploy, store and load it.
     let deploy = Box::new(Deploy::random(&mut harness.rng));
@@ -777,10 +776,10 @@ fn can_retrieve_store_and_load_deploys() {
 fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let total = 1000;
     let batch_size = 25;
@@ -807,10 +806,10 @@ fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
 fn store_execution_results_for_two_blocks() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let deploy = Deploy::random(&mut harness.rng);
 
@@ -863,10 +862,10 @@ fn store_execution_results_for_two_blocks() {
 fn store_random_execution_results() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     // We store results for two different blocks. Each block will have five deploys executed in it,
     // with two of these deploys being shared by both blocks, while the remaining three are unique
@@ -972,10 +971,10 @@ fn store_random_execution_results() {
 fn store_execution_results_twice_for_same_block_deploy_pair() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let deploy_hash = DeployHash::random(&mut harness.rng);
@@ -996,10 +995,10 @@ fn store_execution_results_twice_for_same_block_deploy_pair() {
 fn store_identical_execution_results() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let deploy_hash = DeployHash::random(&mut harness.rng);
@@ -1024,10 +1023,10 @@ struct StateData {
 fn test_legacy_interface() {
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let deploy = Box::new(Deploy::random(&mut harness.rng));
     let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
@@ -1050,9 +1049,9 @@ fn random_block_at_height(
     height: u64,
     block_generator: fn(&mut TestRng) -> (Block, EraId),
 ) -> (Box<Block>, EraId) {
-    let (mut block, verifiable_chunked_hash_activation) = (block_generator)(rng);
-    block.set_height(height, verifiable_chunked_hash_activation);
-    (Box::new(block), verifiable_chunked_hash_activation)
+    let (mut block, block_hash_v2_activation) = (block_generator)(rng);
+    block.set_height(height, block_hash_v2_activation);
+    (Box::new(block), block_hash_v2_activation)
 }
 
 #[test]
@@ -1063,10 +1062,10 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
         thread::spawn(move || {
             let mut harness = ComponentHarness::default();
 
-            let (block, verifiable_chunked_hash_activation) =
+            let (block, block_hash_v2_activation) =
                 random_block_at_height(&mut harness.rng, 42, block_generator);
 
-            let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+            let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
             // Create some sample data.
             let deploy = Deploy::random(&mut harness.rng);
@@ -1088,7 +1087,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
                 .on_disk(on_disk)
                 .rng(rng)
                 .build();
-            let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+            let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
             let actual_block = get_block(&mut harness, &mut storage, *block.hash())
                 .expect("missing block we stored earlier");
@@ -1119,10 +1118,10 @@ fn should_hard_reset() {
     let blocks_per_era = 3;
     let mut harness = ComponentHarness::default();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(harness.rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(harness.rng.gen_range(0..=10));
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     // Create and store 8 blocks, 0-2 in era 0, 3-5 in era 1, and 6,7 in era 2.
     let blocks: Vec<Block> = (0..blocks_count)
@@ -1134,7 +1133,7 @@ fn should_hard_reset() {
                 height as u64,
                 ProtocolVersion::V1_0_0,
                 is_switch,
-                verifiable_chunked_hash_activation,
+                block_hash_v2_activation,
             )
         })
         .collect();
@@ -1190,7 +1189,7 @@ fn should_hard_reset() {
         let mut storage = storage_fixture_with_hard_reset(
             &harness,
             EraId::from(reset_era as u64),
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
 
         // Check highest block is the last from the previous era, or `None` if resetting to era 0.
@@ -1407,10 +1406,10 @@ fn should_garbage_collect() {
     let blocks_per_era = 3;
 
     // Ensure blocks are created with the Merkle hashing scheme
-    let verifiable_chunked_hash_activation = EraId::from(0);
+    let block_hash_v2_activation = EraId::from(0);
 
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     // Create and store 9 blocks, 0-2 in era 0, 3-5 in era 1, and 6-8 in era 2.
     let blocks: Vec<Block> = (0..blocks_count)
@@ -1423,7 +1422,7 @@ fn should_garbage_collect() {
                 height as u64,
                 ProtocolVersion::from_parts(1, 4, 0),
                 is_switch,
-                verifiable_chunked_hash_activation,
+                block_hash_v2_activation,
             )
         })
         .collect();
@@ -1450,7 +1449,7 @@ fn should_garbage_collect() {
             EraId::from(reset_era as u64),
             ProtocolVersion::from_parts(1, 5, 0), /* this is needed because blocks with later
                                                    * versions aren't removed on hard resets */
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
 
         // Hard reset should remove headers, but not block bodies
@@ -1473,7 +1472,7 @@ fn should_garbage_collect() {
             &storage.transfer_hashes_db,
             &storage.proposer_db,
             &block_header_map,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         )
         .unwrap();
         txn.commit().unwrap();
@@ -1493,10 +1492,10 @@ fn can_put_and_get_block() {
     let mut harness = ComponentHarness::default();
 
     // Create a random block using the legacy hashing scheme, store and load it.
-    let (block, verifiable_chunked_hash_activation) = Block::random_v1(&mut harness.rng);
+    let (block, block_hash_v2_activation) = Block::random_v1(&mut harness.rng);
     let block = Box::new(block);
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
 
     let was_new = put_block(&mut harness, &mut storage, block.clone());
     assert!(was_new, "putting block should have returned `true`");
@@ -1531,9 +1530,9 @@ fn can_put_and_get_blocks_v2() {
     let era_id = harness.rng.gen_range(0..10).into();
 
     // Ensure the Merkle hashing algorithm is used.
-    let verifiable_chunked_hash_activation = era_id;
+    let block_hash_v2_activation = era_id;
 
-    let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
+    let mut storage = storage_fixture(&harness, block_hash_v2_activation);
     let protocol_version = ProtocolVersion::from_parts(1, 5, 0);
 
     let height = harness.rng.gen_range(0..100);
@@ -1547,7 +1546,7 @@ fn can_put_and_get_blocks_v2() {
             height + i,
             protocol_version,
             i == num_blocks - 1,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
 
         blocks.push(block.clone());

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -907,7 +907,7 @@ pub(crate) fn handle_fetch_response<R, T>(
     rng: &mut NodeRng,
     sender: NodeId,
     serialized_item: &[u8],
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Effects<<R as Reactor>::Event>
 where
     T: Item,
@@ -917,7 +917,7 @@ where
     match fetcher::Event::<T>::from_get_response_serialized_item(
         sender,
         serialized_item,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     ) {
         Some(fetcher_event) => {
             Reactor::dispatch_event(reactor, effect_builder, rng, fetcher_event.into())

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -212,7 +212,7 @@ impl Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .verifiable_chunked_hash_activation,
+                .block_hash_v2_activation,
         )?;
 
         let contract_runtime = ContractRuntime::new(
@@ -230,7 +230,7 @@ impl Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .verifiable_chunked_hash_activation,
+                .block_hash_v2_activation,
         )?;
 
         if should_check_integrity {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -552,10 +552,10 @@ impl reactor::Reactor for Reactor {
             sync_effects,
         ));
 
-        let verifiable_chunked_hash_activation = chainspec_loader
+        let block_hash_v2_activation = chainspec_loader
             .chainspec()
             .protocol_config
-            .verifiable_chunked_hash_activation;
+            .block_hash_v2_activation;
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
         let rest_server = RestServer::new(
             config.rest_server.clone(),
@@ -572,7 +572,7 @@ impl reactor::Reactor for Reactor {
         )?;
 
         let fetcher_builder =
-            FetcherBuilder::new(config.fetcher, registry, verifiable_chunked_hash_activation);
+            FetcherBuilder::new(config.fetcher, registry, block_hash_v2_activation);
 
         let deploy_fetcher = fetcher_builder.build("deploy")?;
         let block_by_height_fetcher = fetcher_builder.build("block_by_height")?;
@@ -582,7 +582,7 @@ impl reactor::Reactor for Reactor {
         let block_header_by_hash_fetcher = fetcher_builder.build("block_header")?;
 
         let trie_or_chunk_fetcher = fetcher_builder.build("trie_or_chunk")?;
-        let trie_fetcher = TrieFetcher::new(verifiable_chunked_hash_activation);
+        let trie_fetcher = TrieFetcher::new(block_hash_v2_activation);
 
         let deploy_acceptor = DeployAcceptor::new(
             config.deploy_acceptor,
@@ -655,7 +655,7 @@ impl reactor::Reactor for Reactor {
                     self.dispatch_event(effect_builder, rng, JoinerEvent::EventStreamServer(event));
 
                 let event = fetcher::Event::GotRemotely {
-                    verifiable_chunked_hash_activation: None,
+                    block_hash_v2_activation: None,
                     item: deploy,
                     source,
                 };
@@ -887,7 +887,7 @@ impl reactor::Reactor for Reactor {
                     self.chainspec_loader
                         .chainspec()
                         .protocol_config
-                        .verifiable_chunked_hash_activation,
+                        .block_hash_v2_activation,
                 )
             }
 
@@ -933,11 +933,11 @@ impl Reactor {
         sender: NodeId,
         message: NetResponse,
     ) -> Effects<JoinerEvent> {
-        let verifiable_chunked_hash_activation = self
+        let block_hash_v2_activation = self
             .chainspec_loader
             .chainspec()
             .protocol_config
-            .verifiable_chunked_hash_activation;
+            .block_hash_v2_activation;
         match message {
             NetResponse::Deploy(ref serialized_item) => {
                 reactor::handle_fetch_response::<Self, Deploy>(
@@ -946,7 +946,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             }
             NetResponse::Block(ref serialized_item) => {
@@ -956,7 +956,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             }
             NetResponse::GossipedAddress(_) => {
@@ -977,7 +977,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             }
             NetResponse::BlockHeaderByHash(ref serialized_item) => {
@@ -987,7 +987,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             }
             NetResponse::BlockHeaderAndFinalitySignaturesByHeight(ref serialized_item) => {
@@ -997,7 +997,7 @@ impl Reactor {
                     rng,
                     sender,
                     serialized_item,
-                    verifiable_chunked_hash_activation,
+                    block_hash_v2_activation,
                 )
             }
         }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -680,7 +680,7 @@ impl reactor::Reactor for Reactor {
             "deploy",
             config.fetcher,
             registry,
-            chainspec.protocol_config.verifiable_chunked_hash_activation,
+            chainspec.protocol_config.block_hash_v2_activation,
         )?;
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",
@@ -738,7 +738,7 @@ impl reactor::Reactor for Reactor {
 
         contract_runtime.set_initial_state(ExecutionPreState::from_block_header(
             &latest_block_header,
-            chainspec.protocol_config.verifiable_chunked_hash_activation,
+            chainspec.protocol_config.block_hash_v2_activation,
         ));
 
         let block_validator = BlockValidator::new(Arc::clone(chainspec));
@@ -749,7 +749,7 @@ impl reactor::Reactor for Reactor {
             chainspec.core_config.unbonding_delay,
             chainspec.highway_config.finality_threshold_fraction,
             maybe_next_activation_point,
-            chainspec.protocol_config.verifiable_chunked_hash_activation,
+            chainspec.protocol_config.block_hash_v2_activation,
         )?;
 
         effects.extend(reactor::wrap_effects(
@@ -977,7 +977,7 @@ impl reactor::Reactor for Reactor {
                 ));
 
                 let event = fetcher::Event::GotRemotely {
-                    verifiable_chunked_hash_activation: None,
+                    block_hash_v2_activation: None,
                     item: deploy,
                     source,
                 };
@@ -1113,7 +1113,7 @@ impl reactor::Reactor for Reactor {
                             self.chainspec_loader
                                 .chainspec()
                                 .protocol_config
-                                .verifiable_chunked_hash_activation,
+                                .block_hash_v2_activation,
                         ),
                     });
                 let reactor_event_es = ParticipatingEvent::EventStreamServer(

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -53,11 +53,7 @@ impl TestChain {
     /// Instantiates a new test chain configuration.
     ///
     /// Generates secret keys for `size` validators and creates a matching chainspec.
-    async fn new(
-        size: usize,
-        verifiable_chunked_hash_activation: EraId,
-        rng: &mut NodeRng,
-    ) -> Self {
+    async fn new(size: usize, block_hash_v2_activation: EraId, rng: &mut NodeRng) -> Self {
         assert!(
             size >= 1,
             "Network size must have at least one node (size: {})",
@@ -82,7 +78,7 @@ impl TestChain {
         Self::new_with_keys(
             first_node_secret_key_with_stake,
             other_secret_keys_with_stakes,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
             rng,
         )
         .await
@@ -94,7 +90,7 @@ impl TestChain {
     async fn new_with_keys(
         first_node_secret_key_with_stake: SecretKeyWithStake,
         other_secret_keys_with_stakes: Vec<SecretKeyWithStake>,
-        verifiable_chunked_hash_activation: EraId,
+        block_hash_v2_activation: EraId,
         rng: &mut NodeRng,
     ) -> Self {
         // Load the `local` chainspec.
@@ -130,8 +126,7 @@ impl TestChain {
         chainspec.core_config.auction_delay = 1;
         chainspec.core_config.unbonding_delay = 3;
 
-        chainspec.protocol_config.verifiable_chunked_hash_activation =
-            verifiable_chunked_hash_activation;
+        chainspec.protocol_config.block_hash_v2_activation = block_hash_v2_activation;
 
         // Assign a port for the first node (TODO: this has a race condition)
         let first_node_port = testing::unused_port_on_localhost();
@@ -270,13 +265,12 @@ async fn run_participating_network() {
 
     let mut rng = crate::new_rng();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(rng.gen_range(0..=10));
 
     // Instantiate a new chain with a fixed size.
     const NETWORK_SIZE: usize = 5;
-    let mut chain =
-        TestChain::new(NETWORK_SIZE, verifiable_chunked_hash_activation, &mut rng).await;
+    let mut chain = TestChain::new(NETWORK_SIZE, block_hash_v2_activation, &mut rng).await;
 
     // Wait for all nodes to agree on one era.
     for era_num in 1..=2 {
@@ -314,13 +308,13 @@ async fn run_equivocator_network() {
 
     let other_secret_keys_with_stakes = vec![alice_sk.clone(), alice_sk];
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(rng.gen_range(0..=10));
 
     let mut chain = TestChain::new_with_keys(
         first_node_secret_key_with_stake,
         other_secret_keys_with_stakes,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
         &mut rng,
     )
     .await;
@@ -351,7 +345,7 @@ fn first_node_storage(net: &Network<MultiStageTestReactor>) -> &Storage {
 
 async fn await_switch_block(
     switch_block_era_num: u64,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
     net: &mut Network<MultiStageTestReactor>,
     rng: &mut NodeRng,
 ) -> BlockHeader {
@@ -377,7 +371,7 @@ async fn await_switch_block(
     info!(
         "Found block hash for Era {}: {:?}",
         switch_block_era_num,
-        switch_block_header.hash(verifiable_chunked_hash_activation)
+        switch_block_header.hash(block_hash_v2_activation)
     );
     switch_block_header
 }
@@ -391,16 +385,11 @@ async fn test_joiner_at_genesis() {
 
     let mut rng = crate::new_rng();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
+    // `block_hash_v2_activation` can be chosen arbitrarily
+    let block_hash_v2_activation = EraId::from(rng.gen_range(0..=10));
 
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, block_hash_v2_activation, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -413,7 +402,7 @@ async fn test_joiner_at_genesis() {
     let start_era = 2;
     let _ = await_switch_block(
         start_era,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
         &mut chain.network,
         &mut rng,
     )
@@ -423,7 +412,7 @@ async fn test_joiner_at_genesis() {
         .read_block_header_by_height(2)
         .expect("should not have storage error")
         .expect("should have block header")
-        .hash(verifiable_chunked_hash_activation);
+        .hash(block_hash_v2_activation);
 
     // Have a node join the network with that hash
     info!("Joining with trusted hash {}", trusted_hash);
@@ -468,15 +457,10 @@ async fn test_archival_sync() {
     const ERA_TO_JOIN: u64 = 3;
 
     // We need to make sure we're in the Merkle-based hashing scheme.
-    let verifiable_chunked_hash_activation = EraId::from(ERA_TO_JOIN - 1);
+    let block_hash_v2_activation = EraId::from(ERA_TO_JOIN - 1);
 
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, block_hash_v2_activation, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -486,14 +470,10 @@ async fn test_archival_sync() {
 
     // Get the first switch block hash
     // As part of the chain sync process, we will need to retrieve the first switch block
-    let switch_block_hash = await_switch_block(
-        1,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await
-    .hash(verifiable_chunked_hash_activation);
+    let switch_block_hash =
+        await_switch_block(1, block_hash_v2_activation, &mut chain.network, &mut rng)
+            .await
+            .hash(block_hash_v2_activation);
 
     info!("Waiting for Era {} to end", ERA_TO_JOIN);
     chain
@@ -548,7 +528,7 @@ async fn test_archival_sync() {
             .expect("must read from storage")
             .expect("must have highest block header");
         // Check every block and its state root going back to genesis
-        let mut block_hash = highest_block_header.hash(verifiable_chunked_hash_activation);
+        let mut block_hash = highest_block_header.hash(block_hash_v2_activation);
         loop {
             let block = storage
                 .read_block(&block_hash)
@@ -580,21 +560,16 @@ async fn test_joiner() {
 
     const ERA_TO_JOIN: u64 = 3;
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily.
-    // Ideally, we should run this test two times with `verifiable_chunked_hash_activation`
+    // `block_hash_v2_activation` can be chosen arbitrarily.
+    // Ideally, we should run this test two times with `block_hash_v2_activation`
     // set to "before" and "after" the `ERA_TO_JOIN`. But because this test is
     // time consuming, we randomize the activation point so it randomly falls
     // ahead or behind the era.
-    let verifiable_chunked_hash_activation: u64 = rng.gen_range(0..=(ERA_TO_JOIN * 2));
-    let verifiable_chunked_hash_activation = EraId::from(verifiable_chunked_hash_activation);
+    let block_hash_v2_activation: u64 = rng.gen_range(0..=(ERA_TO_JOIN * 2));
+    let block_hash_v2_activation = EraId::from(block_hash_v2_activation);
 
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, block_hash_v2_activation, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -604,14 +579,10 @@ async fn test_joiner() {
 
     // Get the first switch block hash
     // As part of the chain sync process, we will need to retrieve the first switch block
-    let switch_block_hash = await_switch_block(
-        1,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await
-    .hash(verifiable_chunked_hash_activation);
+    let switch_block_hash =
+        await_switch_block(1, block_hash_v2_activation, &mut chain.network, &mut rng)
+            .await
+            .hash(block_hash_v2_activation);
 
     info!("Waiting for Era {} to end", ERA_TO_JOIN);
     chain
@@ -665,20 +636,15 @@ async fn test_joiner_network() {
 
     const START_ERA: u64 = 2;
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily.
-    // Ideally, we should run this test two times with `verifiable_chunked_hash_activation`
+    // `block_hash_v2_activation` can be chosen arbitrarily.
+    // Ideally, we should run this test two times with `block_hash_v2_activation`
     // set to "before" and "after" the `ERA_TO_JOIN`. But because this test is
     // time consuming, we randomize the activation point so it randomly falls
     // ahead or behind the era.
-    let verifiable_chunked_hash_activation: u64 = rng.gen_range(0..=(START_ERA * 2));
-    let verifiable_chunked_hash_activation = EraId::from(verifiable_chunked_hash_activation);
+    let block_hash_v2_activation: u64 = rng.gen_range(0..=(START_ERA * 2));
+    let block_hash_v2_activation = EraId::from(block_hash_v2_activation);
 
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, block_hash_v2_activation, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -689,7 +655,7 @@ async fn test_joiner_network() {
     // Get the first switch block hash
     await_switch_block(
         START_ERA,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
         &mut chain.network,
         &mut rng,
     )
@@ -699,7 +665,7 @@ async fn test_joiner_network() {
         .read_block_header_by_height(2)
         .expect("should not have storage error")
         .expect("should have block header")
-        .hash(verifiable_chunked_hash_activation);
+        .hash(block_hash_v2_activation);
 
     // Have a node join the network with that hash
     info!("Joining with trusted hash {}", trusted_block_hash);

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -36,7 +36,7 @@ struct TomlProtocol {
     hard_reset: bool,
     activation_point: ActivationPoint,
     last_emergency_restart: Option<EraId>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 }
 
 /// A chainspec configuration as laid out in the TOML-encoded configuration file.
@@ -60,9 +60,7 @@ impl From<&Chainspec> for TomlChainspec {
             hard_reset: chainspec.protocol_config.hard_reset,
             activation_point: chainspec.protocol_config.activation_point,
             last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
-            verifiable_chunked_hash_activation: chainspec
-                .protocol_config
-                .verifiable_chunked_hash_activation,
+            block_hash_v2_activation: chainspec.protocol_config.block_hash_v2_activation,
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
@@ -114,9 +112,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
         activation_point: toml_chainspec.protocol.activation_point,
         global_state_update,
         last_emergency_restart: toml_chainspec.protocol.last_emergency_restart,
-        verifiable_chunked_hash_activation: toml_chainspec
-            .protocol
-            .verifiable_chunked_hash_activation,
+        block_hash_v2_activation: toml_chainspec.protocol.block_hash_v2_activation,
     };
 
     Ok(Chainspec {

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -34,7 +34,7 @@ pub struct ProtocolConfig {
     /// The era ID in which the last emergency restart happened.
     pub(crate) last_emergency_restart: Option<EraId>,
     /// The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-    pub(crate) verifiable_chunked_hash_activation: EraId,
+    pub(crate) block_hash_v2_activation: EraId,
 }
 
 impl ProtocolConfig {
@@ -96,7 +96,7 @@ impl ProtocolConfig {
         );
         let activation_point = ActivationPoint::random(rng);
         let last_emergency_restart = rng.gen::<bool>().then(|| rng.gen());
-        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..5));
+        let block_hash_v2_activation = EraId::from(rng.gen_range(0..5));
 
         ProtocolConfig {
             version: protocol_version,
@@ -104,7 +104,7 @@ impl ProtocolConfig {
             activation_point,
             global_state_update: None,
             last_emergency_restart,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         }
     }
 }
@@ -117,7 +117,7 @@ impl ToBytes for ProtocolConfig {
         buffer.extend(self.activation_point.to_bytes()?);
         buffer.extend(self.global_state_update.to_bytes()?);
         buffer.extend(self.last_emergency_restart.to_bytes()?);
-        buffer.extend(self.verifiable_chunked_hash_activation.to_bytes()?);
+        buffer.extend(self.block_hash_v2_activation.to_bytes()?);
         Ok(buffer)
     }
 
@@ -127,7 +127,7 @@ impl ToBytes for ProtocolConfig {
             + self.activation_point.serialized_length()
             + self.global_state_update.serialized_length()
             + self.last_emergency_restart.serialized_length()
-            + self.verifiable_chunked_hash_activation.serialized_length()
+            + self.block_hash_v2_activation.serialized_length()
     }
 }
 
@@ -140,14 +140,14 @@ impl FromBytes for ProtocolConfig {
         let (activation_point, remainder) = ActivationPoint::from_bytes(remainder)?;
         let (global_state_update, remainder) = Option::<GlobalStateUpdate>::from_bytes(remainder)?;
         let (last_emergency_restart, remainder) = Option::<EraId>::from_bytes(remainder)?;
-        let (verifiable_chunked_hash_activation, remainder) = EraId::from_bytes(remainder)?;
+        let (block_hash_v2_activation, remainder) = EraId::from_bytes(remainder)?;
         let protocol_config = ProtocolConfig {
             version,
             hard_reset,
             activation_point,
             global_state_update,
             last_emergency_restart,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         };
         Ok((protocol_config, remainder))
     }
@@ -228,7 +228,7 @@ mod tests {
         let upgrade_era = EraId::from(5);
         let previous_era = upgrade_era.saturating_sub(1);
 
-        let verifiable_chunked_hash_activation = EraId::from(0);
+        let block_hash_v2_activation = EraId::from(0);
 
         let mut rng = crate::new_rng();
         let protocol_config = ProtocolConfig {
@@ -237,7 +237,7 @@ mod tests {
             activation_point: ActivationPoint::EraId(upgrade_era),
             global_state_update: None,
             last_emergency_restart: None,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         };
 
         // The block before this protocol version: a switch block with previous era and version.
@@ -247,7 +247,7 @@ mod tests {
             100,
             past_version,
             true,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
         assert!(protocol_config.is_last_block_before_activation(block.header()));
 
@@ -258,7 +258,7 @@ mod tests {
             100,
             past_version,
             true,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -269,7 +269,7 @@ mod tests {
             100,
             current_version,
             true,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
         let block = Block::random_with_specifics(
@@ -278,7 +278,7 @@ mod tests {
             100,
             future_version,
             true,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -289,7 +289,7 @@ mod tests {
             100,
             past_version,
             false,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -1347,15 +1347,12 @@ impl Item for Deploy {
     const TAG: Tag = Tag::Deploy;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self, _block_hash_v2_activation: EraId) -> Result<(), Self::ValidationError> {
         // TODO: Validate approvals later, and only if the approvers are actually authorized!
         validate_deploy(self)
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _block_hash_v2_activation: EraId) -> Self::Id {
         *self.id()
     }
 }

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -64,13 +64,10 @@ pub(crate) trait Item:
     const ID_IS_COMPLETE_ITEM: bool;
 
     /// Checks cryptographic validity of the item, and returns an error if invalid.
-    fn validate(
-        &self,
-        verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError>;
+    fn validate(&self, block_hash_v2_activation: EraId) -> Result<(), Self::ValidationError>;
 
     /// The ID of the specific item.
-    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id;
+    fn id(&self, block_hash_v2_activation: EraId) -> Self::Id;
 }
 
 /// Error type simply conveying that chunk validation failed.
@@ -84,10 +81,7 @@ impl Item for TrieOrChunk {
     const TAG: Tag = Tag::Trie;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self, _block_hash_v2_activation: EraId) -> Result<(), Self::ValidationError> {
         match self {
             TrieOrChunk::Trie(_) => Ok(()),
             TrieOrChunk::ChunkWithProof(chunk) => {
@@ -96,7 +90,7 @@ impl Item for TrieOrChunk {
         }
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self, _block_hash_v2_activation: EraId) -> Self::Id {
         match self {
             TrieOrChunk::Trie(trie) => {
                 let node_bytes = trie.to_bytes().expect("Could not serialize trie to bytes");
@@ -116,14 +110,11 @@ impl Item for BlockHeader {
     const TAG: Tag = Tag::BlockHeaderByHash;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self, _block_hash_v2_activation: EraId) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id {
-        self.hash(verifiable_chunked_hash_activation)
+    fn id(&self, block_hash_v2_activation: EraId) -> Self::Id {
+        self.hash(block_hash_v2_activation)
     }
 }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -15,7 +15,7 @@ activation_point = '${TIMESTAMP}'
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2
+block_hash_v2_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -17,7 +17,7 @@ activation_point = 3000
 
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
 # TODO: Set this to the same value as the upgrade to the first version supporting Merkle tree-based hashing.
-verifiable_chunked_hash_activation = 9999
+block_hash_v2_activation = 9999
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -2,7 +2,7 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-verifiable_chunked_hash_activation = 0
+block_hash_v2_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -2,7 +2,7 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-verifiable_chunked_hash_activation = 0
+block_hash_v2_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -3,7 +3,7 @@ version = '1.0.0'
 hard_reset = false
 activation_point = 1
 last_emergency_restart = 99
-verifiable_chunked_hash_activation = 0
+block_hash_v2_activation = 0
 
 [network]
 name = 'test-chain'

--- a/utils/dry-run-deploys/src/main.rs
+++ b/utils/dry-run-deploys/src/main.rs
@@ -57,10 +57,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let lmdb_path = normalize_path(&opts.lmdb_path)?;
 
     // TODO: Consider reading the proper `chainspec` in the `dry-run-deploys` tool.
-    let verifiable_chunked_hash_activation = EraId::from(0u64);
+    let block_hash_v2_activation = EraId::from(0u64);
 
     // Create a separate lmdb for block/deploy storage at chain_download_path.
-    let storage = create_storage(&chain_download_path, verifiable_chunked_hash_activation)
+    let storage = create_storage(&chain_download_path, block_hash_v2_activation)
         .expect("should create storage");
 
     let max_db_size = opts
@@ -81,10 +81,8 @@ async fn main() -> Result<(), anyhow::Error> {
         opts.manual_sync_enabled,
     )?;
 
-    let mut execution_pre_state = ExecutionPreState::from_block_header(
-        &previous_block_header,
-        verifiable_chunked_hash_activation,
-    );
+    let mut execution_pre_state =
+        ExecutionPreState::from_block_header(&previous_block_header, block_hash_v2_activation);
     let mut execute_count = 0;
 
     let highest_height_in_chain = storage.read_highest_block()?;
@@ -142,7 +140,7 @@ async fn main() -> Result<(), anyhow::Error> {
             finalized_block,
             deploys,
             transfers,
-            verifiable_chunked_hash_activation,
+            block_hash_v2_activation,
         )?;
         let elapsed_micros = start.elapsed().as_micros() as u64;
         execution_time_hist
@@ -157,7 +155,7 @@ async fn main() -> Result<(), anyhow::Error> {
             "state root hash mismatch"
         );
         execution_pre_state =
-            ExecutionPreState::from_block_header(&header, verifiable_chunked_hash_activation);
+            ExecutionPreState::from_block_header(&header, block_hash_v2_activation);
         execute_count += 1;
         if opts.verbose {
             eprintln!(

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2
+block_hash_v2_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2
+block_hash_v2_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -13,7 +13,7 @@ hard_reset = false
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2
+block_hash_v2_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/utils/retrieve-state/src/main.rs
+++ b/utils/retrieve-state/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let url = address_to_url(initial_server_address);
 
     // TODO: Consider reading the proper `chainspec` in the `retrieve-state` tool.
-    let verifiable_chunked_hash_activation = EraId::from(0u64);
+    let block_hash_v2_activation = EraId::from(0u64);
 
     let maybe_highest_block = opts.highest_block;
     let maybe_download_block = opts
@@ -186,9 +186,8 @@ async fn main() -> Result<(), anyhow::Error> {
                 fs::create_dir_all(&chain_download_path)?;
             }
 
-            let mut storage =
-                create_storage(&chain_download_path, verifiable_chunked_hash_activation)
-                    .expect("should create storage");
+            let mut storage = create_storage(&chain_download_path, block_hash_v2_activation)
+                .expect("should create storage");
             info!("Downloading all blocks to genesis...");
             let (downloaded, read_from_disk) = retrieve_state::download_or_read_blocks(
                 &client,

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -130,7 +130,7 @@ pub fn normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, anyhow::Error> 
 
 pub fn create_storage(
     chain_download_path: impl AsRef<Path>,
-    verifiable_chunked_hash_activation: EraId,
+    block_hash_v2_activation: EraId,
 ) -> Result<Storage, anyhow::Error> {
     let chain_download_path = normalize_path(chain_download_path)?;
     let mut storage_config = StorageConfig::default();
@@ -143,7 +143,7 @@ pub fn create_storage(
         "test",
         Ratio::new(1, 3),
         None,
-        verifiable_chunked_hash_activation,
+        block_hash_v2_activation,
     )?)
 }
 


### PR DESCRIPTION
The `block_hash_v2_activation` setting will not be used for trie leaves, and continue to only affect block hashes.
