### PR TITLE
GH-2260: Explicit overflow safety when casting

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Changed
 
 * (Perf) Changed contract runtime to allow caching GlobalState changes during execution of a single block.
+* Fixed some integer casts.
 
 
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -11,7 +11,7 @@ mod standard_payment_internal;
 use std::{
     cmp,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     iter::{FromIterator, IntoIterator},
 };
 
@@ -1186,8 +1186,11 @@ where
             return Err(Error::Interpreter(error.into()).into());
         }
 
-        // For all practical purposes following cast is assumed to be safe
-        let bytes_size = key_bytes.len() as u32;
+        // For all practical purposes following conversion is assumed to be safe
+        let bytes_size: u32 = key_bytes
+            .len()
+            .try_into()
+            .expect("Keys should not serialize to many bytes");
         let size_bytes = bytes_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(bytes_written_ptr, &size_bytes) {
             return Err(Error::Interpreter(error.into()).into());
@@ -1303,7 +1306,10 @@ where
             return Ok(Err(ApiError::HostBufferFull));
         }
         let call_stack = self.stack.call_stack_elements();
-        let call_stack_len = call_stack.len() as u32;
+        let call_stack_len: u32 = match call_stack.len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+        };
         let call_stack_len_bytes = call_stack_len.to_le_bytes();
 
         if let Err(error) = self.memory.set(call_stack_len_ptr, &call_stack_len_bytes) {
@@ -1316,7 +1322,12 @@ where
 
         let call_stack_cl_value = CLValue::from_t(call_stack.clone()).map_err(Error::CLValue)?;
 
-        let call_stack_cl_value_bytes_len = call_stack_cl_value.inner_bytes().len() as u32;
+        let call_stack_cl_value_bytes_len: u32 =
+            match call_stack_cl_value.inner_bytes().len().try_into() {
+                Ok(value) => value,
+                Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+            };
+
         if let Err(error) = self.write_host_buffer(call_stack_cl_value) {
             return Ok(Err(error));
         }
@@ -2377,7 +2388,10 @@ where
         result_size_ptr: u32,
         result: CLValue,
     ) -> Result<Result<(), ApiError>, Error> {
-        let result_size = result.inner_bytes().len() as u32; // considered to be safe
+        let result_size: u32 = match result.inner_bytes().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+        };
 
         // leave the host buffer set to `None` if there's nothing to write there
         if result_size != 0 {
@@ -2404,7 +2418,11 @@ where
             return Ok(Err(ApiError::HostBufferFull));
         }
 
-        let total_keys = self.context.named_keys().len() as u32;
+        let total_keys: u32 = match self.context.named_keys().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+        };
+
         let total_keys_bytes = total_keys.to_le_bytes();
         if let Err(error) = self.memory.set(total_keys_ptr, &total_keys_bytes) {
             return Err(Error::Interpreter(error.into()).into());
@@ -2418,7 +2436,11 @@ where
         let named_keys =
             CLValue::from_t(self.context.named_keys().clone()).map_err(Error::CLValue)?;
 
-        let length = named_keys.inner_bytes().len() as u32;
+        let length: u32 = match named_keys.inner_bytes().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::BufferTooSmall)),
+        };
+
         if let Err(error) = self.write_host_buffer(named_keys) {
             return Ok(Err(error));
         }
@@ -2609,7 +2631,10 @@ where
             }
 
             // Following cast is assumed to be safe
-            let bytes_size = key_bytes.len() as u32;
+            let bytes_size: u32 = key_bytes
+                .len()
+                .try_into()
+                .expect("Serialized value should fit within the limit");
             let size_bytes = bytes_size.to_le_bytes(); // Wasm is little-endian
             if let Err(error) = self.memory.set(bytes_written_ptr, &size_bytes) {
                 return Err(Error::Interpreter(error.into()));
@@ -2770,7 +2795,11 @@ where
             None => return Ok(Err(ApiError::ValueNotFound)),
         };
 
-        let value_size = cl_value.inner_bytes().len() as u32;
+        let value_size: u32 = match cl_value.inner_bytes().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::BufferTooSmall)),
+        };
+
         if let Err(error) = self.write_host_buffer(cl_value) {
             return Ok(Err(error));
         }
@@ -3299,7 +3328,11 @@ where
             return Err(Error::Interpreter(error.into()));
         }
 
-        let bytes_written = sliced_buf.len() as u32;
+        // Never panics because we check that `serialized_value.len()` fits in `u32`.
+        let bytes_written: u32 = sliced_buf
+            .len()
+            .try_into()
+            .expect("Size of buffer should fit within limit");
         let bytes_written_data = bytes_written.to_le_bytes();
 
         if let Err(error) = self.memory.set(bytes_written_ptr, &bytes_written_data) {
@@ -3325,11 +3358,11 @@ where
         let name_bytes = self.bytes_from_mem(name_ptr, name_size)?;
         let name = String::from_utf8_lossy(&name_bytes);
 
-        let arg_size = match self.context.args().get(&name) {
+        let arg_size: u32 = match self.context.args().get(&name) {
             Some(arg) if arg.inner_bytes().len() > u32::max_value() as usize => {
                 return Ok(Err(ApiError::OutOfMemory));
             }
-            Some(arg) => arg.inner_bytes().len() as u32,
+            Some(arg) => arg.inner_bytes().len().try_into().unwrap(),
             None => return Ok(Err(ApiError::MissingArgument)),
         };
 
@@ -3608,7 +3641,11 @@ where
             None => return Ok(Err(ApiError::ValueNotFound)),
         };
 
-        let value_size = cl_value.inner_bytes().len() as u32;
+        let value_size: u32 = match cl_value.inner_bytes().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::BufferTooSmall)),
+        };
+
         if let Err(error) = self.write_host_buffer(cl_value) {
             return Ok(Err(error));
         }
@@ -3691,7 +3728,10 @@ where
         let authorization_keys =
             Vec::from_iter(self.context.authorization_keys().clone().into_iter());
 
-        let total_keys = authorization_keys.len() as u32;
+        let total_keys: u32 = match authorization_keys.len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+        };
         let total_keys_bytes = total_keys.to_le_bytes();
         if let Err(error) = self.memory.set(len_ptr, &total_keys_bytes) {
             return Err(Error::Interpreter(error.into()).into());
@@ -3704,7 +3744,10 @@ where
 
         let authorization_keys = CLValue::from_t(authorization_keys).map_err(Error::CLValue)?;
 
-        let length = authorization_keys.inner_bytes().len() as u32;
+        let length: u32 = match authorization_keys.inner_bytes().len().try_into() {
+            Ok(value) => value,
+            Err(_) => return Ok(Err(ApiError::OutOfMemory)),
+        };
         if let Err(error) = self.write_host_buffer(authorization_keys) {
             return Ok(Err(error));
         }

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1186,7 +1186,7 @@ where
             return Err(Error::Interpreter(error.into()).into());
         }
 
-        // For all practical purposes following conversion is assumed to be safe
+        // SAFETY: For all practical purposes following conversion is assumed to be safe
         let bytes_size: u32 = key_bytes
             .len()
             .try_into()
@@ -2630,7 +2630,7 @@ where
                 return Err(Error::Interpreter(error.into()));
             }
 
-            // Following cast is assumed to be safe
+            // SAFETY: For all practical purposes following conversion is assumed to be safe
             let bytes_size: u32 = key_bytes
                 .len()
                 .try_into()
@@ -3362,7 +3362,13 @@ where
             Some(arg) if arg.inner_bytes().len() > u32::max_value() as usize => {
                 return Ok(Err(ApiError::OutOfMemory));
             }
-            Some(arg) => arg.inner_bytes().len().try_into().unwrap(),
+            Some(arg) => {
+                // SAFETY: Safe to unwrap as wee asserted length above
+                arg.inner_bytes()
+                    .len()
+                    .try_into()
+                    .expect("Should fit within the range")
+            }
             None => return Ok(Err(ApiError::MissingArgument)),
         };
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -3363,7 +3363,7 @@ where
                 return Ok(Err(ApiError::OutOfMemory));
             }
             Some(arg) => {
-                // SAFETY: Safe to unwrap as wee asserted length above
+                // SAFETY: Safe to unwrap as we asserted length above
                 arg.inner_bytes()
                     .len()
                     .try_into()

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -5,6 +5,7 @@ use casper_types::{
     bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, Gas, RuntimeArgs,
     SecretKey,
 };
+use core::convert::TryInto;
 use itertools::Itertools;
 
 use super::*;
@@ -600,7 +601,7 @@ fn test_proposer_with(
     config.block_max_transfer_count = max_transfer_count;
     config.block_gas_limit = block_gas_limit;
     if let Some(max_block_size) = max_block_size {
-        config.max_block_size = max_block_size as u32;
+        config.max_block_size = max_block_size.try_into().unwrap();
     }
 
     for _ in 0..deploy_count {

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -1,12 +1,12 @@
-use std::time::Duration;
+use std::{convert::TryInto, time::Duration};
+
+use itertools::Itertools;
 
 use casper_execution_engine::core::engine_state::executable_deploy_item::ExecutableDeployItem;
 use casper_types::{
     bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, Gas, RuntimeArgs,
     SecretKey,
 };
-use core::convert::TryInto;
-use itertools::Itertools;
 
 use super::*;
 use crate::{

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Changed
 * Disable checksummed-hex encoding, but leave checksummed-hex decoding in place.
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
+* Fixed some integer casts.
 
 
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Added
+* Added new `bytesrepr::Error::NotRepresentable` error variant that represents values that are not representable by the serialization format.
+
 ### Changed
 * Disable checksummed-hex encoding, but leave checksummed-hex decoding in place.
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.

--- a/types/src/account/associated_keys.rs
+++ b/types/src/account/associated_keys.rs
@@ -5,6 +5,8 @@ use alloc::{
     vec::Vec,
 };
 
+use core::convert::TryInto;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -132,7 +134,12 @@ impl ToBytes for AssociatedKeys {
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        writer.extend_from_slice(&(self.0.len() as u32).to_le_bytes());
+        let length_32: u32 = self
+            .0
+            .len()
+            .try_into()
+            .map_err(|_| Error::NotRepresentable)?;
+        writer.extend_from_slice(&length_32.to_le_bytes());
         for (key, weight) in self.0.iter() {
             key.write_bytes(writer)?;
             weight.write_bytes(writer)?;

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -338,6 +338,12 @@ pub enum ApiError {
     /// assert_eq!(ApiError::from(38), ApiError::MissingSystemContractHash);
     /// ```
     MissingSystemContractHash,
+    /// Attempt to serialize a value that does not have a serialized representation.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(39), ApiError::NonRepresentableSerialization);
+    /// ```
+    NonRepresentableSerialization,
     /// Error specific to Auction contract. See
     /// [casper_types::system::auction::Error](crate::system::auction::Error).
     /// ```
@@ -392,6 +398,7 @@ impl From<bytesrepr::Error> for ApiError {
             bytesrepr::Error::Formatting => ApiError::Formatting,
             bytesrepr::Error::LeftOverBytes => ApiError::LeftOverBytes,
             bytesrepr::Error::OutOfMemory => ApiError::OutOfMemory,
+            bytesrepr::Error::NotRepresentable => ApiError::NonRepresentableSerialization,
         }
     }
 }
@@ -525,6 +532,7 @@ impl From<ApiError> for u32 {
             ApiError::DictionaryItemKeyExceedsLength => 36,
             ApiError::InvalidDictionaryItemKey => 37,
             ApiError::MissingSystemContractHash => 38,
+            ApiError::NonRepresentableSerialization => 39,
             ApiError::AuctionError(value) => AUCTION_ERROR_OFFSET + u32::from(value),
             ApiError::ContractHeader(value) => HEADER_ERROR_OFFSET + u32::from(value),
             ApiError::Mint(value) => MINT_ERROR_OFFSET + u32::from(value),
@@ -575,6 +583,7 @@ impl From<u32> for ApiError {
             36 => ApiError::DictionaryItemKeyExceedsLength,
             37 => ApiError::InvalidDictionaryItemKey,
             38 => ApiError::MissingSystemContractHash,
+            39 => ApiError::NonRepresentableSerialization,
             USER_ERROR_MIN..=USER_ERROR_MAX => ApiError::User(value as u16),
             HP_ERROR_MIN..=HP_ERROR_MAX => ApiError::HandlePayment(value as u8),
             MINT_ERROR_MIN..=MINT_ERROR_MAX => ApiError::Mint(value as u8),
@@ -630,6 +639,9 @@ impl Debug for ApiError {
             }
             ApiError::InvalidDictionaryItemKey => write!(f, "ApiError::InvalidDictionaryItemKey")?,
             ApiError::MissingSystemContractHash => write!(f, "ApiError::MissingContractHash")?,
+            ApiError::NonRepresentableSerialization => {
+                write!(f, "ApiError::NonRepresentableSerialization")?
+            }
             ApiError::AuctionError(value) => write!(
                 f,
                 "ApiError::AuctionError({:?})",
@@ -837,6 +849,7 @@ mod tests {
         round_trip(Err(ApiError::HostBufferEmpty));
         round_trip(Err(ApiError::HostBufferFull));
         round_trip(Err(ApiError::AllocLayout));
+        round_trip(Err(ApiError::NonRepresentableSerialization));
         round_trip(Err(ApiError::ContractHeader(0)));
         round_trip(Err(ApiError::ContractHeader(u8::MAX)));
         round_trip(Err(ApiError::Mint(0)));

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -12,6 +12,7 @@ use alloc::{
 #[cfg(debug_assertions)]
 use core::any;
 use core::{
+    convert::TryInto,
     fmt::{self, Display, Formatter},
     mem,
     ptr::NonNull,
@@ -116,6 +117,8 @@ pub enum Error {
     LeftOverBytes,
     /// Out of memory error.
     OutOfMemory,
+    /// No serialized representation is available for a value.
+    NotRepresentable,
 }
 
 impl Display for Error {
@@ -127,6 +130,9 @@ impl Display for Error {
             Error::Formatting => formatter.write_str("Deserialization error: formatting"),
             Error::LeftOverBytes => formatter.write_str("Deserialization error: left-over bytes"),
             Error::OutOfMemory => formatter.write_str("Serialization error: out of memory"),
+            Error::NotRepresentable => {
+                formatter.write_str("Serialization error: value is not representable.")
+            }
         }
     }
 }
@@ -389,7 +395,8 @@ impl<T: ToBytes> ToBytes for Vec<T> {
         ensure_efficient_serialization::<T>();
 
         let mut result = try_vec_with_capacity(self.serialized_length())?;
-        result.append(&mut (self.len() as u32).to_bytes()?);
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        result.append(&mut length_32.to_bytes()?);
 
         for item in self.iter() {
             result.append(&mut item.to_bytes()?);
@@ -402,7 +409,8 @@ impl<T: ToBytes> ToBytes for Vec<T> {
         ensure_efficient_serialization::<T>();
 
         let mut result = allocate_buffer(&self)?;
-        result.append(&mut (self.len() as u32).to_bytes()?);
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        result.append(&mut length_32.to_bytes()?);
 
         for item in self {
             result.append(&mut item.into_bytes()?);
@@ -416,7 +424,8 @@ impl<T: ToBytes> ToBytes for Vec<T> {
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
-        writer.extend_from_slice(&(self.len() as u32).to_le_bytes());
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        writer.extend_from_slice(&length_32.to_le_bytes());
         for item in self.iter() {
             item.write_bytes(writer)?;
         }
@@ -473,7 +482,8 @@ impl<T: ToBytes> ToBytes for VecDeque<T> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let (slice1, slice2) = self.as_slices();
         let mut result = allocate_buffer(self)?;
-        result.append(&mut (self.len() as u32).to_bytes()?);
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        result.append(&mut length_32.to_bytes()?);
         for item in slice1.iter().chain(slice2.iter()) {
             result.append(&mut item.to_bytes()?);
         }
@@ -548,7 +558,7 @@ impl<V: ToBytes> ToBytes for BTreeSet<V> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut result = allocate_buffer(self)?;
 
-        let num_keys = self.len() as u32;
+        let num_keys: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
         result.append(&mut num_keys.to_bytes()?);
 
         for value in self.iter() {
@@ -563,7 +573,8 @@ impl<V: ToBytes> ToBytes for BTreeSet<V> {
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
-        writer.extend_from_slice(&(self.len() as u32).to_le_bytes());
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        writer.extend_from_slice(&length_32.to_le_bytes());
         for value in self.iter() {
             value.write_bytes(writer)?;
         }
@@ -592,7 +603,7 @@ where
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut result = allocate_buffer(self)?;
 
-        let num_keys = self.len() as u32;
+        let num_keys: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
         result.append(&mut num_keys.to_bytes()?);
 
         for (key, value) in self.iter() {
@@ -612,7 +623,8 @@ where
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
-        writer.extend_from_slice(&(self.len() as u32).to_le_bytes());
+        let length_32: u32 = self.len().try_into().map_err(|_| Error::NotRepresentable)?;
+        writer.extend_from_slice(&length_32.to_le_bytes());
         for (key, value) in self.iter() {
             key.write_bytes(writer)?;
             value.write_bytes(writer)?;
@@ -1220,7 +1232,10 @@ where
 fn u8_slice_to_bytes(bytes: &[u8]) -> Result<Vec<u8>, Error> {
     let serialized_length = u8_slice_serialized_length(bytes);
     let mut vec = try_vec_with_capacity(serialized_length)?;
-    let length_prefix = bytes.len() as u32;
+    let length_prefix: u32 = bytes
+        .len()
+        .try_into()
+        .map_err(|_| Error::NotRepresentable)?;
     let length_prefix_bytes = length_prefix.to_le_bytes();
     vec.extend_from_slice(&length_prefix_bytes);
     vec.extend_from_slice(bytes);
@@ -1228,7 +1243,11 @@ fn u8_slice_to_bytes(bytes: &[u8]) -> Result<Vec<u8>, Error> {
 }
 
 fn write_u8_slice(bytes: &[u8], writer: &mut Vec<u8>) -> Result<(), Error> {
-    writer.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    let length_32: u32 = bytes
+        .len()
+        .try_into()
+        .map_err(|_| Error::NotRepresentable)?;
+    writer.extend_from_slice(&length_32.to_le_bytes());
     writer.extend_from_slice(bytes);
     Ok(())
 }


### PR DESCRIPTION
Closes #2260
Closes #2270 

This commit adds explicit conversion from `usize` to `u32` whenever possible and handles the failure appropriately for each host function.