### PR TITLE
Make the `joiner` reactor handle the `NetRequestIncoming` and `TrieRequestIncoming` events

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -6,8 +6,6 @@ mod metrics;
 mod operations;
 mod types;
 
-use derive_more::From;
-use once_cell::sync::Lazy;
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Display, Formatter},
@@ -17,7 +15,9 @@ use std::{
 };
 
 use datasize::DataSize;
+use derive_more::From;
 use lmdb::DatabaseFlags;
+use once_cell::sync::Lazy;
 use prometheus::Registry;
 use serde::Serialize;
 use thiserror::Error;

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -226,6 +226,7 @@ where
 }
 
 impl ContractRuntime {
+    /// Handles an incoming request to get a trie.
     fn handle_trie_request<REv>(
         &self,
         effect_builder: EffectBuilder<REv>,
@@ -254,6 +255,7 @@ impl ContractRuntime {
         }
     }
 
+    /// Handles a contract runtime request.
     fn handle_contract_runtime_request<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -709,7 +709,6 @@ impl ContractRuntime {
     /// Reads the trie (or chunk of a trie) under the given key and index.
     pub(crate) fn get_trie(
         &self,
-        // trie_or_chunk_id: TrieOrChunkId,
         serialized_id: &[u8],
     ) -> Option<(TrieOrChunkId, Option<TrieOrChunk>)> {
         trace!(?serialized_id, "get_trie");

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -153,18 +153,11 @@ type ExecQueue = Arc<Mutex<BTreeMap<u64, (FinalizedBlock, Vec<Deploy>, Vec<Deplo
 
 #[derive(Debug, From, Serialize)]
 pub(crate) enum Event {
-    // TODO: Consider boxing the internals of `ContractRuntimeRequest` to make the variant smaller
     #[from]
-    ContractRuntimeRequest(Box<ContractRuntimeRequest>),
+    ContractRuntimeRequest(ContractRuntimeRequest),
 
     #[from]
     TrieRequestIncoming(TrieRequestIncoming),
-}
-
-impl From<ContractRuntimeRequest> for Event {
-    fn from(request: ContractRuntimeRequest) -> Self {
-        Event::ContractRuntimeRequest(Box::new(request))
-    }
 }
 
 impl Display for Event {
@@ -216,7 +209,7 @@ where
     ) -> Effects<Self::Event> {
         match event {
             Event::ContractRuntimeRequest(request) => {
-                self.handle_contract_runtime_request(effect_builder, rng, *request)
+                self.handle_contract_runtime_request(effect_builder, rng, request)
             }
             Event::TrieRequestIncoming(request) => {
                 self.handle_trie_request(effect_builder, request)

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -72,7 +72,7 @@ pub fn execute_finalized_block(
             block_time,
             vec![DeployItem::from(deploy)],
             protocol_version,
-            finalized_block.proposer().clone(),
+            *finalized_block.proposer(),
         );
 
         // TODO: this is currently working coincidentally because we are passing only one

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -88,7 +88,7 @@ impl ReactorEvent for Event {
             Event::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             Event::ControlAnnouncement(_) => "ControlAnnouncement",
             Event::StorageRequest(_) => "StorageRequest",
-            Event::ContractRuntime(_) => "StorageRequest",
+            Event::ContractRuntime(_) => "ContractRuntime",
         }
     }
 }
@@ -135,7 +135,7 @@ impl Display for Event {
             Event::Chainspec(event) => write!(formatter, "chainspec: {}", event),
             Event::Storage(event) => write!(formatter, "storage: {}", event),
             Event::ContractRuntimeRequest(event) => {
-                write!(formatter, "contract runtime: {:?}", event)
+                write!(formatter, "contract runtime request: {:?}", event)
             }
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
             Event::StorageRequest(req) => write!(formatter, "storage request: {}", req),

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -63,7 +63,13 @@ pub(crate) enum Event {
 
     /// Contract runtime request.
     #[from]
-    ContractRuntimeRequest(ContractRuntimeRequest),
+    ContractRuntimeRequest(Box<ContractRuntimeRequest>),
+}
+
+impl From<ContractRuntimeRequest> for Event {
+    fn from(request: ContractRuntimeRequest) -> Self {
+        Event::ContractRuntimeRequest(Box::new(request))
+    }
 }
 
 impl ReactorEvent for Event {

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -63,13 +63,7 @@ pub(crate) enum Event {
 
     /// Contract runtime request.
     #[from]
-    ContractRuntimeRequest(Box<ContractRuntimeRequest>),
-}
-
-impl From<ContractRuntimeRequest> for Event {
-    fn from(request: ContractRuntimeRequest) -> Self {
-        Event::ContractRuntimeRequest(Box::new(request))
-    }
+    ContractRuntimeRequest(ContractRuntimeRequest),
 }
 
 impl ReactorEvent for Event {

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -60,10 +60,6 @@ pub(crate) enum Event {
     /// Storage request.
     #[from]
     StorageRequest(StorageRequest),
-
-    /// Contract runtime request.
-    #[from]
-    ContractRuntimeRequest(ContractRuntimeRequest),
 }
 
 impl ReactorEvent for Event {
@@ -79,11 +75,16 @@ impl ReactorEvent for Event {
         match self {
             Event::Chainspec(_) => "Chainspec",
             Event::Storage(_) => "Storage",
-            Event::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             Event::ControlAnnouncement(_) => "ControlAnnouncement",
             Event::StorageRequest(_) => "StorageRequest",
             Event::ContractRuntime(_) => "ContractRuntime",
         }
+    }
+}
+
+impl From<ContractRuntimeRequest> for Event {
+    fn from(request: ContractRuntimeRequest) -> Self {
+        Event::ContractRuntime(contract_runtime::Event::ContractRuntimeRequest(request))
     }
 }
 
@@ -128,9 +129,6 @@ impl Display for Event {
         match self {
             Event::Chainspec(event) => write!(formatter, "chainspec: {}", event),
             Event::Storage(event) => write!(formatter, "storage: {}", event),
-            Event::ContractRuntimeRequest(event) => {
-                write!(formatter, "contract runtime request: {:?}", event)
-            }
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
             Event::StorageRequest(req) => write!(formatter, "storage request: {}", req),
             Event::ContractRuntime(event) => write!(formatter, "contract runtime event: {}", event),
@@ -315,11 +313,6 @@ impl reactor::Reactor for Reactor {
                 Event::ContractRuntime,
                 self.contract_runtime
                     .handle_event(effect_builder, rng, event),
-            ),
-            Event::ContractRuntimeRequest(event) => reactor::wrap_effects(
-                Event::ContractRuntime,
-                self.contract_runtime
-                    .handle_event(effect_builder, rng, event.into()),
             ),
             Event::StorageRequest(req) => reactor::wrap_effects(
                 Event::Storage,

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -60,6 +60,10 @@ pub(crate) enum Event {
     /// Storage request.
     #[from]
     StorageRequest(StorageRequest),
+
+    /// Contract runtime request.
+    #[from]
+    ContractRuntimeRequest(ContractRuntimeRequest),
 }
 
 impl ReactorEvent for Event {
@@ -75,16 +79,11 @@ impl ReactorEvent for Event {
         match self {
             Event::Chainspec(_) => "Chainspec",
             Event::Storage(_) => "Storage",
+            Event::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             Event::ControlAnnouncement(_) => "ControlAnnouncement",
             Event::StorageRequest(_) => "StorageRequest",
             Event::ContractRuntime(_) => "ContractRuntime",
         }
-    }
-}
-
-impl From<ContractRuntimeRequest> for Event {
-    fn from(request: ContractRuntimeRequest) -> Self {
-        Event::ContractRuntime(contract_runtime::Event::ContractRuntimeRequest(request))
     }
 }
 
@@ -129,6 +128,9 @@ impl Display for Event {
         match self {
             Event::Chainspec(event) => write!(formatter, "chainspec: {}", event),
             Event::Storage(event) => write!(formatter, "storage: {}", event),
+            Event::ContractRuntimeRequest(event) => {
+                write!(formatter, "contract runtime request: {:?}", event)
+            }
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
             Event::StorageRequest(req) => write!(formatter, "storage request: {}", req),
             Event::ContractRuntime(event) => write!(formatter, "contract runtime event: {}", event),
@@ -313,6 +315,11 @@ impl reactor::Reactor for Reactor {
                 Event::ContractRuntime,
                 self.contract_runtime
                     .handle_event(effect_builder, rng, event),
+            ),
+            Event::ContractRuntimeRequest(event) => reactor::wrap_effects(
+                Event::ContractRuntime,
+                self.contract_runtime
+                    .handle_event(effect_builder, rng, event.into()),
             ),
             Event::StorageRequest(req) => reactor::wrap_effects(
                 Event::Storage,

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -50,7 +50,8 @@ pub(crate) enum Event {
     Storage(storage::Event),
 
     /// Contract runtime event.
-    ContractRuntime(#[serde(skip_serializing)] Box<ContractRuntimeRequest>),
+    #[from]
+    ContractRuntime(contract_runtime::Event),
 
     /// Control announcement.
     #[from]
@@ -59,12 +60,10 @@ pub(crate) enum Event {
     /// Storage request.
     #[from]
     StorageRequest(StorageRequest),
-}
 
-impl From<ContractRuntimeRequest> for Event {
-    fn from(contract_runtime_request: ContractRuntimeRequest) -> Self {
-        Event::ContractRuntime(Box::new(contract_runtime_request))
-    }
+    /// Contract runtime request.
+    #[from]
+    ContractRuntimeRequest(ContractRuntimeRequest),
 }
 
 impl ReactorEvent for Event {
@@ -80,9 +79,10 @@ impl ReactorEvent for Event {
         match self {
             Event::Chainspec(_) => "Chainspec",
             Event::Storage(_) => "Storage",
-            Event::ContractRuntime(_) => "ContractRuntime",
+            Event::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             Event::ControlAnnouncement(_) => "ControlAnnouncement",
             Event::StorageRequest(_) => "StorageRequest",
+            Event::ContractRuntime(_) => "StorageRequest",
         }
     }
 }
@@ -128,9 +128,12 @@ impl Display for Event {
         match self {
             Event::Chainspec(event) => write!(formatter, "chainspec: {}", event),
             Event::Storage(event) => write!(formatter, "storage: {}", event),
-            Event::ContractRuntime(event) => write!(formatter, "contract runtime: {:?}", event),
+            Event::ContractRuntimeRequest(event) => {
+                write!(formatter, "contract runtime: {:?}", event)
+            }
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
             Event::StorageRequest(req) => write!(formatter, "storage request: {}", req),
+            Event::ContractRuntime(event) => write!(formatter, "contract runtime event: {}", event),
         }
     }
 }
@@ -309,9 +312,14 @@ impl reactor::Reactor for Reactor {
                 self.storage.handle_event(effect_builder, rng, event),
             ),
             Event::ContractRuntime(event) => reactor::wrap_effects(
-                Event::from,
+                Event::ContractRuntime,
                 self.contract_runtime
-                    .handle_event(effect_builder, rng, *event),
+                    .handle_event(effect_builder, rng, event),
+            ),
+            Event::ContractRuntimeRequest(event) => reactor::wrap_effects(
+                Event::ContractRuntime,
+                self.contract_runtime
+                    .handle_event(effect_builder, rng, event.into()),
             ),
             Event::StorageRequest(req) => reactor::wrap_effects(
                 Event::Storage,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -866,10 +866,11 @@ impl reactor::Reactor for Reactor {
                 self.address_gossiper
                     .handle_event(effect_builder, rng, incoming.into()),
             ),
-            JoinerEvent::NetRequestIncoming(incoming) => {
-                debug!(%incoming, "net request ignored");
-                Effects::new()
-            }
+            JoinerEvent::NetRequestIncoming(incoming) => reactor::wrap_effects(
+                JoinerEvent::Storage,
+                self.storage
+                    .handle_event(effect_builder, rng, incoming.into()),
+            ),
             JoinerEvent::NetResponseIncoming(NetResponseIncoming { sender, message }) => {
                 self.handle_get_response(effect_builder, rng, sender, message)
             }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -917,12 +917,6 @@ impl reactor::Reactor for Reactor {
                 req.answer(Err(Cow::Borrowed("node is joining, no running consensus")))
                     .ignore()
             }
-            #[allow(unused)]
-            JoinerEvent::ContractRuntimeRequest(req) => reactor::wrap_effects(
-                JoinerEvent::ContractRuntime,
-                self.contract_runtime
-                    .handle_event(effect_builder, rng, req.into()),
-            ),
         }
     }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -917,6 +917,7 @@ impl reactor::Reactor for Reactor {
                 req.answer(Err(Cow::Borrowed("node is joining, no running consensus")))
                     .ignore()
             }
+            #[allow(unused)]
             JoinerEvent::ContractRuntimeRequest(req) => reactor::wrap_effects(
                 JoinerEvent::ContractRuntime,
                 self.contract_runtime

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -202,10 +202,6 @@ pub(crate) enum JoinerEvent {
     #[from]
     BeginAddressGossipRequest(BeginGossipRequest<GossipedAddress>),
 
-    /// Contract runtime request.
-    #[from]
-    ContractRuntimeRequest(ContractRuntimeRequest),
-
     // Announcements
     /// A control announcement.
     #[from]
@@ -333,8 +329,13 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::TrieRequestIncoming(_) => "TrieRequestIncoming",
             JoinerEvent::TrieResponseIncoming(_) => "TrieResponseIncoming",
             JoinerEvent::FinalitySignatureIncoming(_) => "FinalitySignatureIncoming",
-            JoinerEvent::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
         }
+    }
+}
+
+impl From<ContractRuntimeRequest> for JoinerEvent {
+    fn from(request: ContractRuntimeRequest) -> Self {
+        JoinerEvent::ContractRuntime(contract_runtime::Event::ContractRuntimeRequest(request))
     }
 }
 
@@ -450,9 +451,6 @@ impl Display for JoinerEvent {
             JoinerEvent::TrieRequestIncoming(inner) => write!(f, "incoming: {}", inner),
             JoinerEvent::TrieResponseIncoming(inner) => write!(f, "incoming: {}", inner),
             JoinerEvent::FinalitySignatureIncoming(inner) => write!(f, "incoming: {}", inner),
-            JoinerEvent::ContractRuntimeRequest(req) => {
-                write!(f, "contract runtime request: {}", req)
-            }
             JoinerEvent::DumpConsensusStateRequest(req) => {
                 write!(f, "consensus dump request: {}", req)
             }
@@ -754,11 +752,6 @@ impl reactor::Reactor for Reactor {
                 JoinerEvent::ContractRuntime,
                 self.contract_runtime
                     .handle_event(effect_builder, rng, event),
-            ),
-            JoinerEvent::ContractRuntimeRequest(req) => reactor::wrap_effects(
-                JoinerEvent::ContractRuntime,
-                self.contract_runtime
-                    .handle_event(effect_builder, rng, req.into()),
             ),
             JoinerEvent::ContractRuntimeAnnouncement(_) => Effects::new(),
             JoinerEvent::AddressGossiper(event) => reactor::wrap_effects(

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -333,7 +333,7 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::TrieRequestIncoming(_) => "TrieRequestIncoming",
             JoinerEvent::TrieResponseIncoming(_) => "TrieResponseIncoming",
             JoinerEvent::FinalitySignatureIncoming(_) => "FinalitySignatureIncoming",
-            JoinerEvent::ContractRuntimeRequest(_) => todo!(),
+            JoinerEvent::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
         }
     }
 }
@@ -450,10 +450,12 @@ impl Display for JoinerEvent {
             JoinerEvent::TrieRequestIncoming(inner) => write!(f, "incoming: {}", inner),
             JoinerEvent::TrieResponseIncoming(inner) => write!(f, "incoming: {}", inner),
             JoinerEvent::FinalitySignatureIncoming(inner) => write!(f, "incoming: {}", inner),
+            JoinerEvent::ContractRuntimeRequest(req) => {
+                write!(f, "contract runtime request: {}", req)
+            }
             JoinerEvent::DumpConsensusStateRequest(req) => {
                 write!(f, "consensus dump request: {}", req)
             }
-            JoinerEvent::ContractRuntimeRequest(_) => todo!(),
         }
     }
 }
@@ -915,7 +917,11 @@ impl reactor::Reactor for Reactor {
                 req.answer(Err(Cow::Borrowed("node is joining, no running consensus")))
                     .ignore()
             }
-            JoinerEvent::ContractRuntimeRequest(_) => todo!(),
+            JoinerEvent::ContractRuntimeRequest(req) => reactor::wrap_effects(
+                JoinerEvent::ContractRuntime,
+                self.contract_runtime
+                    .handle_event(effect_builder, rng, req.into()),
+            ),
         }
     }
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1186,7 +1186,6 @@ impl reactor::Reactor for Reactor {
 
                 self.dispatch_event(effect_builder, rng, event)
             }
-            // self.handle_get_request(effect_builder, sender, Tag::Trie, serialized_id),
             ParticipatingEvent::TrieRequestIncoming(req) => reactor::wrap_effects(
                 ParticipatingEvent::ContractRuntime,
                 self.contract_runtime

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -133,9 +133,6 @@ pub(crate) enum ParticipatingEvent {
     ContractRuntime(contract_runtime::Event),
 
     // Requests
-    /// Contract runtime request.
-    #[from]
-    ContractRuntimeRequest(ContractRuntimeRequest),
     /// Network request.
     #[from]
     NetworkRequest(#[serde(skip_serializing)] NetworkRequest<NodeId, Message>),
@@ -255,7 +252,6 @@ impl ReactorEvent for ParticipatingEvent {
             ParticipatingEvent::AddressGossiper(_) => "AddressGossiper",
             ParticipatingEvent::BlockValidator(_) => "BlockValidator",
             ParticipatingEvent::LinearChain(_) => "LinearChain",
-            ParticipatingEvent::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             ParticipatingEvent::Console(_) => "Console",
             ParticipatingEvent::NetworkRequest(_) => "NetworkRequest",
             ParticipatingEvent::NetworkInfoRequest(_) => "NetworkInfoRequest",
@@ -289,6 +285,14 @@ impl ReactorEvent for ParticipatingEvent {
             ParticipatingEvent::FinalitySignatureIncoming(_) => "FinalitySignatureIncoming",
             ParticipatingEvent::ContractRuntime(_) => "ContractRuntime",
         }
+    }
+}
+
+impl From<ContractRuntimeRequest> for ParticipatingEvent {
+    fn from(request: ContractRuntimeRequest) -> Self {
+        ParticipatingEvent::ContractRuntime(contract_runtime::Event::ContractRuntimeRequest(
+            request,
+        ))
     }
 }
 
@@ -345,9 +349,6 @@ impl Display for ParticipatingEvent {
             ParticipatingEvent::DeployFetcher(event) => write!(f, "deploy fetcher: {}", event),
             ParticipatingEvent::DeployGossiper(event) => write!(f, "deploy gossiper: {}", event),
             ParticipatingEvent::AddressGossiper(event) => write!(f, "address gossiper: {}", event),
-            ParticipatingEvent::ContractRuntimeRequest(event) => {
-                write!(f, "contract runtime request: {:?}", event)
-            }
             ParticipatingEvent::LinearChain(event) => write!(f, "linear-chain event {}", event),
             ParticipatingEvent::BlockValidator(event) => write!(f, "block validator: {}", event),
             ParticipatingEvent::Console(event) => write!(f, "console: {}", event),
@@ -782,11 +783,6 @@ impl reactor::Reactor for Reactor {
                 ParticipatingEvent::AddressGossiper,
                 self.address_gossiper
                     .handle_event(effect_builder, rng, event),
-            ),
-            ParticipatingEvent::ContractRuntimeRequest(req) => reactor::wrap_effects(
-                ParticipatingEvent::ContractRuntime,
-                self.contract_runtime
-                    .handle_event(effect_builder, rng, req.into()),
             ),
             ParticipatingEvent::BlockValidator(event) => reactor::wrap_effects(
                 ParticipatingEvent::BlockValidator,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -255,7 +255,7 @@ impl ReactorEvent for ParticipatingEvent {
             ParticipatingEvent::AddressGossiper(_) => "AddressGossiper",
             ParticipatingEvent::BlockValidator(_) => "BlockValidator",
             ParticipatingEvent::LinearChain(_) => "LinearChain",
-            ParticipatingEvent::ContractRuntimeRequest(_) => "ContractRuntime",
+            ParticipatingEvent::ContractRuntimeRequest(_) => "ContractRuntimeRequest",
             ParticipatingEvent::Console(_) => "Console",
             ParticipatingEvent::NetworkRequest(_) => "NetworkRequest",
             ParticipatingEvent::NetworkInfoRequest(_) => "NetworkInfoRequest",
@@ -346,7 +346,7 @@ impl Display for ParticipatingEvent {
             ParticipatingEvent::DeployGossiper(event) => write!(f, "deploy gossiper: {}", event),
             ParticipatingEvent::AddressGossiper(event) => write!(f, "address gossiper: {}", event),
             ParticipatingEvent::ContractRuntimeRequest(event) => {
-                write!(f, "contract runtime: {:?}", event)
+                write!(f, "contract runtime request: {:?}", event)
             }
             ParticipatingEvent::LinearChain(event) => write!(f, "linear-chain event {}", event),
             ParticipatingEvent::BlockValidator(event) => write!(f, "block validator: {}", event),

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -20,7 +20,7 @@ use derive_more::From;
 use prometheus::Registry;
 use reactor::ReactorEvent;
 use serde::Serialize;
-use tracing::{debug, error, warn};
+use tracing::error;
 
 #[cfg(test)]
 use crate::testing::network::NetworkedReactor;
@@ -56,7 +56,7 @@ use crate::{
         console::DumpConsensusStateRequest,
         incoming::{
             ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming,
-            NetRequestIncoming, NetResponse, NetResponseIncoming, TrieRequest, TrieRequestIncoming,
+            NetRequestIncoming, NetResponse, NetResponseIncoming, TrieRequestIncoming,
             TrieResponseIncoming,
         },
         requests::{
@@ -69,7 +69,7 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle, ReactorExit},
-    types::{Deploy, DeployHash, ExitCode, Item, NodeId, Tag},
+    types::{Deploy, DeployHash, ExitCode, NodeId},
     utils::{Source, WithDir},
     NodeRng,
 };

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -441,7 +441,7 @@ async fn dont_upgrade_without_switch_block() {
             .await;
         let mut exec_request_received = false;
         runner.reactor_mut().inner_mut().set_filter(move |event| {
-            if let ParticipatingEvent::ContractRuntime(request) = &event {
+            if let ParticipatingEvent::ContractRuntimeRequest(request) = &event {
                 if let ContractRuntimeRequest::EnqueueBlockForExecution {
                     finalized_block, ..
                 } = request.as_ref()

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -18,7 +18,6 @@ use casper_types::{
 
 use crate::{
     components::{chainspec_loader::NextUpgrade, gossiper, small_network, storage},
-    contract_runtime,
     crypto::AsymmetricKeyExt,
     effect::{
         requests::{ContractRuntimeRequest, NetworkRequest},
@@ -442,12 +441,10 @@ async fn dont_upgrade_without_switch_block() {
             .await;
         let mut exec_request_received = false;
         runner.reactor_mut().inner_mut().set_filter(move |event| {
-            if let ParticipatingEvent::ContractRuntime(
-                contract_runtime::Event::ContractRuntimeRequest(
-                    ContractRuntimeRequest::EnqueueBlockForExecution {
-                        finalized_block, ..
-                    },
-                ),
+            if let ParticipatingEvent::ContractRuntimeRequest(
+                ContractRuntimeRequest::EnqueueBlockForExecution {
+                    finalized_block, ..
+                },
             ) = &event
             {
                 if finalized_block.era_report().is_some()

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -18,6 +18,7 @@ use casper_types::{
 
 use crate::{
     components::{chainspec_loader::NextUpgrade, gossiper, small_network, storage},
+    contract_runtime,
     crypto::AsymmetricKeyExt,
     effect::{
         requests::{ContractRuntimeRequest, NetworkRequest},
@@ -441,10 +442,12 @@ async fn dont_upgrade_without_switch_block() {
             .await;
         let mut exec_request_received = false;
         runner.reactor_mut().inner_mut().set_filter(move |event| {
-            if let ParticipatingEvent::ContractRuntimeRequest(
-                ContractRuntimeRequest::EnqueueBlockForExecution {
-                    finalized_block, ..
-                },
+            if let ParticipatingEvent::ContractRuntime(
+                contract_runtime::Event::ContractRuntimeRequest(
+                    ContractRuntimeRequest::EnqueueBlockForExecution {
+                        finalized_block, ..
+                    },
+                ),
             ) = &event
             {
                 if finalized_block.era_report().is_some()


### PR DESCRIPTION
This PR makes the joiner reactor be able to respond properly to `NetRequestIncoming` and `TrieRequestIncoming` events instead of ignoring them.

Routines that handle these requests are moved from the `participating` reactor into the `contract_runtime` component and the wiring is updated accordingly in all three reactors.

Closes https://github.com/casper-network/casper-node/issues/2568