### PR TITLE
Unambiguous hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "hex",
  "hex-buffer-serde 0.3.0",
  "itertools",
+ "once_cell",
  "proptest",
  "proptest-attr-macro",
  "rand 0.8.4",

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -17,6 +17,7 @@ datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"
 itertools = "0.10.1"
+once_cell = "1"
 schemars = { version = "=0.8.5", features = ["preserve_order"] }
 serde = "1.0.130"
 thiserror = "1.0.29"

--- a/hashing/src/indexed_merkle_proof.rs
+++ b/hashing/src/indexed_merkle_proof.rs
@@ -153,7 +153,7 @@ impl IndexedMerkleProof {
         };
 
         // The Merkle root is the hash of the count with the raw root.
-        Digest::hash_pair(count.to_le_bytes(), raw_root)
+        Digest::hash_merkle_root(*count, raw_root)
     }
 
     pub(crate) fn merkle_proof(&self) -> &[Digest] {
@@ -366,7 +366,7 @@ mod tests {
         }
 
         let raw_root = compute_raw_root_from_proof(index, count, proof);
-        Digest::hash_pair(count.to_le_bytes(), raw_root)
+        Digest::hash_merkle_root(count, raw_root)
     }
 
     /// Construct an `IndexedMerkleProof` with a proof of zero digests.

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -114,9 +114,19 @@ impl Digest {
         Digest(result)
     }
 
-    /// Hashes a Merkle root and leaf count.
+    /// Hashes a raw Merkle root and leaf count to firm the final Merkle hash.
     ///
-    /// TODO: Document this function and its role in pre-image attacks.
+    /// To avoid pre-image attacks, the final hash that is based upon the number of leaves in the
+    /// merkle tree and the root hash is prepended with a padding to ensure it is longer than the
+    /// actual chunk size.
+    ///
+    /// Without this feature, an attacker could construct an item that is only a few bytes long but
+    /// hashes to the same value as a much longer, chunked item by hashing `(len || root hash of
+    /// longer items Merkle tree root)`.
+    ///
+    /// This function computes the correct final hash by ensuring the hasher used has been
+    /// initialized with padding before. For efficiency reasons it uses a memoized hasher state
+    /// computed on first run and cloned afterwards.
     fn hash_merkle_root(leaf_count: u64, root: Digest) -> Digest {
         static PAIR_PREFIX_HASHER: OnceCell<VarBlake2b> = OnceCell::new();
 

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -545,7 +545,7 @@ mod tests {
 
         assert_eq!(
             hash_lower_hex,
-            "9ba070a55c7f72600d7f3fee2c0a6e52ec89237d97a8677eb0612132fb34df60"
+            "775cec8133b97b0e8d4e97659025d5bac4ed7c8927d1bd99cf62114df57f3e74"
         );
     }
 
@@ -565,7 +565,7 @@ mod tests {
 
         assert_eq!(
             hash_lower_hex,
-            "8768e1ca1b86ed3d722fb1b7d7a0228349c7d448058d0ce1e314f99dbd1c8573"
+            "4bd50b08a8366b28c35bc831b95d147123bad01c29ffbf854b659c4b3ea4086c"
         );
     }
 
@@ -583,7 +583,7 @@ mod tests {
 
         assert_eq!(
             hash_lower_hex,
-            "aae1660ca492ed9af6b2ead22f88b390aeb2ec0719654824d084aa6c6553ceeb"
+            "fd1214a627473ffc6d6cc97e7012e6344d74abbf987b48cde5d0642049a0db98"
         );
     }
 
@@ -653,7 +653,9 @@ mod tests {
             235, 32, 69, 169, 236, 40, 170, 81, 224, 212, 32, 17, 190, 67, 244, 169, 31, 95,
         ];
 
-        let short_data_hash = Digest::hash(maybe_colliding_short_data);
+        // Use `blake2b_hash` to work around the issue of the chunk size being shorter than the
+        // digest length.
+        let short_data_hash = Digest::blake2b_hash(maybe_colliding_short_data);
 
         // Ensure there is no collision. You can verify this test is correct by temporarily changing
         // the `Digest::hash_merkle_tree` function to use the unpadded `hash_pair` function, instead

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -176,11 +176,11 @@ impl Digest {
         I::IntoIter: ExactSizeIterator,
     {
         let leaves = leaves.into_iter();
-        let leaf_count_bytes = (leaves.len() as u64).to_le_bytes();
+        let leaf_count = leaves.len() as u64;
 
         leaves.tree_fold1(Digest::hash_pair).map_or_else(
             || Digest::SENTINEL_MERKLE_TREE,
-            |raw_root| Digest::hash_pair(leaf_count_bytes, raw_root),
+            |raw_root| Digest::hash_merkle_root(leaf_count, raw_root),
         )
     }
 

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -627,15 +627,15 @@ mod tests {
         //
         // The resulting tree will look like this:
         //
-        // 1..9  a..j
+        // 1..0  a..j
         // │     │
         // └─────── R
         //
-        // The merkle root is thus: R = h( h(1..9) || h(a..j) )
+        // The merkle root is thus: R = h( h(1..0) || h(a..j) )
         //
-        // h(1..9) = 807f1ba73147c3a96c2d63b38dd5a5f514f66290a1436bb9821e9f2a72eff263
+        // h(1..0) = 807f1ba73147c3a96c2d63b38dd5a5f514f66290a1436bb9821e9f2a72eff263
         // h(a..j) = 499e1cdb476523fedafc9d9db31125e2744f271578ea95b16ab4bd1905f05fea
-        // R=h(h(1..9)||h(a..j)) = 1319394a98d0cb194f960e3748baeb2045a9ec28aa51e0d42011be43f4a91f5f
+        // R=h(h(1..0)||h(a..j)) = 1319394a98d0cb194f960e3748baeb2045a9ec28aa51e0d42011be43f4a91f5f
         // h(2u64le || R) = c31f0bb6ef569354d1a26c3a51f1ad4b6d87cef7f73a290ab6be8db6a9c7d4ee
         //
         // The final step is to hash h(2u64le || R), which is the length as little endian

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -117,12 +117,12 @@ impl Digest {
     /// Hashes a raw Merkle root and leaf count to firm the final Merkle hash.
     ///
     /// To avoid pre-image attacks, the final hash that is based upon the number of leaves in the
-    /// merkle tree and the root hash is prepended with a padding to ensure it is longer than the
+    /// Merkle tree and the root hash is prepended with a padding to ensure it is longer than the
     /// actual chunk size.
     ///
     /// Without this feature, an attacker could construct an item that is only a few bytes long but
     /// hashes to the same value as a much longer, chunked item by hashing `(len || root hash of
-    /// longer items Merkle tree root)`.
+    /// longer item's Merkle tree root)`.
     ///
     /// This function computes the correct final hash by ensuring the hasher used has been
     /// initialized with padding before. For efficiency reasons it uses a memoized hasher state

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -656,7 +656,7 @@ mod tests {
                 .map(Digest::blake2b_hash),
         );
 
-        // The concatenation of `2u64` in little endian + the merkle root hash `R`. Note that this
+        // The concatenation of `2u64` in little endian + the Merkle root hash `R`. Note that this
         // is a valid hashable object on its own.
         let maybe_colliding_short_data = [
             2, 0, 0, 0, 0, 0, 0, 0, 19, 25, 57, 74, 152, 208, 203, 25, 79, 150, 14, 55, 72, 186,


### PR DESCRIPTION
Updates the hashing function for chunk based hashing to pad the final hash of `(length, root)` with a full chunk of zeros to avoid preimage attacks. More details can be found in the documentation of the newly added function and test.

Please review this carefully and double check that no other calls of `hash_pair` need to be updated/changed, as these can also be found in the node for reasons unrelated to Merkle tree hashing.

As this is security relevant crypto code, I would strongly suggest at least 4 positive reviews be made before merging this. Please also doublecheck that block hashing is unaffected.

No changelog update has been made, as this affects mostly the unreleased `hashing` crate.

Closes #2603 