### PR TITLE
Merge `dev` to `feat-fast-sync` 26.01.2022

### DIFF
--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -726,7 +726,7 @@ where
                 // bits are verified from within API call.
                 false
             }
-            Key::SystemContractRegistry => false,
+            Key::SystemContractRegistry => true,
         }
     }
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.  The format
 * `SIGUSR1` now only dumps the queue in the debug text format.
 * Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
-
+* `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
 
 
 ## 1.4.3 - 2021-12-06


### PR DESCRIPTION
This PR integrates the recent changes from the `dev` (as of 26.01.2022 10:00am CEST) branch into the `feat-fast-sync` branch.