### PR TITLE
Don't attempt to redundantly execute downloaded blocks.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1171,6 +1171,14 @@ async fn execute_finalized_block<REv>(
 ) where
     REv: From<StorageRequest> + From<ControlAnnouncement> + From<ContractRuntimeRequest>,
 {
+    // if the block exists in storage, it either has been executed before, or we fast synced to a
+    // higher block - skip execution
+    if effect_builder
+        .check_block_header_existence(finalized_block.height())
+        .await
+    {
+        return;
+    }
     // Get all deploys in order they appear in the finalized block.
     let deploys =
         match get_deploys_or_transfers(effect_builder, finalized_block.deploy_hashes().to_owned())

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1174,7 +1174,7 @@ async fn execute_finalized_block<REv>(
     // if the block exists in storage, it either has been executed before, or we fast synced to a
     // higher block - skip execution
     if effect_builder
-        .check_block_header_existence(finalized_block.height())
+        .block_header_exists(finalized_block.height())
         .await
     {
         return;

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -862,6 +862,12 @@ impl Storage {
             } => responder
                 .respond(self.get_single_block_header(&mut self.env.begin_ro_txn()?, &block_hash)?)
                 .ignore(),
+            StorageRequest::CheckBlockHeaderExistence {
+                block_height,
+                responder,
+            } => responder
+                .respond(self.block_header_exists(block_height))
+                .ignore(),
             StorageRequest::GetBlockTransfers {
                 block_hash,
                 responder,
@@ -1401,6 +1407,13 @@ impl Storage {
             });
         };
         Ok(Some(block_header))
+    }
+
+    /// Checks whether a block at the given height exists in the block height index (and, since the
+    /// index is initialized on startup based on the actual contents of storage, if it exists in
+    /// storage).
+    fn block_header_exists(&self, block_height: u64) -> bool {
+        self.block_height_index.contains_key(&block_height)
     }
 
     /// Retrieves a single Merklized block body in a separate transaction from storage.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -868,6 +868,21 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Checks if a block header exists in storage
+    pub(crate) async fn check_block_header_existence(self, block_height: u64) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::CheckBlockHeaderExistence {
+                block_height,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Gets the requested signatures for a given block hash.
     pub(crate) async fn get_signatures_from_storage(
         self,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -869,7 +869,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Checks if a block header exists in storage
-    pub(crate) async fn check_block_header_existence(self, block_height: u64) -> bool
+    pub(crate) async fn block_header_exists(self, block_height: u64) -> bool
     where
         REv: From<StorageRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -283,7 +283,7 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
-    /// Checks if a header at the given height exists in storage.
+    /// Checks if a block header at the given height exists in storage.
     CheckBlockHeaderExistence {
         /// Height of the block to check.
         block_height: u64,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -283,6 +283,13 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
+    /// Checks if a header at the given height exists in storage.
+    CheckBlockHeaderExistence {
+        /// Height of the block to check.
+        block_height: u64,
+        /// Responder to call with the result.
+        responder: Responder<bool>,
+    },
     /// Retrieve block header with sufficient finality signatures by height.
     GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
         /// Height of block to get header of.
@@ -410,6 +417,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetBlockHeader { block_hash, .. } => {
                 write!(formatter, "get {}", block_hash)
+            }
+            StorageRequest::CheckBlockHeaderExistence { block_height, .. } => {
+                write!(formatter, "check existence {}", block_height)
             }
             StorageRequest::GetBlockTransfers { block_hash, .. } => {
                 write!(formatter, "get transfers for {}", block_hash)


### PR DESCRIPTION
This skips block execution if storage reports that the block already exists.

Closes #2507 
