### PR TITLE
Exhaustive Pattern Matching in Deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,9 @@ cmake-build-debug/
 
 # OS X
 .DS_Store
+
+# notes
+notes
+
+# swp files
+.*.sw*

--- a/execution_engine/src/core/engine_state/executable_deploy_item.rs
+++ b/execution_engine/src/core/engine_state/executable_deploy_item.rs
@@ -47,7 +47,7 @@ const TAG_LENGTH: usize = 1;
 
 #[repr(u8)]
 #[derive(Debug, FromPrimitive, ToPrimitive)]
-pub enum ExecutableDeployItemTag {
+enum ExecutableDeployItemTag {
     ModuleBytes = 0,
     StoredContractByHash = 1,
     StoredContractByName = 2,

--- a/node/src/types/chainspec/activation_point.rs
+++ b/node/src/types/chainspec/activation_point.rs
@@ -54,7 +54,8 @@ impl ActivationPoint {
     }
 
     fn tag_byte(&self) -> u8 {
-        self.to_u8()
+        self.tag()
+            .to_u8()
             .expect("ActivationPointTag should be representable as a u8")
     }
 

--- a/types/src/cl_type.rs
+++ b/types/src/cl_type.rs
@@ -8,6 +8,9 @@ use alloc::{
     vec::Vec,
 };
 use core::mem;
+use num::{FromPrimitive, ToPrimitive};
+use num_derive::{FromPrimitive, ToPrimitive};
+use std::convert::TryFrom;
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
@@ -21,29 +24,47 @@ use crate::{
     Key, URef, U128, U256, U512,
 };
 
-const CL_TYPE_TAG_BOOL: u8 = 0;
-const CL_TYPE_TAG_I32: u8 = 1;
-const CL_TYPE_TAG_I64: u8 = 2;
-const CL_TYPE_TAG_U8: u8 = 3;
-const CL_TYPE_TAG_U32: u8 = 4;
-const CL_TYPE_TAG_U64: u8 = 5;
-const CL_TYPE_TAG_U128: u8 = 6;
-const CL_TYPE_TAG_U256: u8 = 7;
-const CL_TYPE_TAG_U512: u8 = 8;
-const CL_TYPE_TAG_UNIT: u8 = 9;
-const CL_TYPE_TAG_STRING: u8 = 10;
-const CL_TYPE_TAG_KEY: u8 = 11;
-const CL_TYPE_TAG_UREF: u8 = 12;
-const CL_TYPE_TAG_OPTION: u8 = 13;
-const CL_TYPE_TAG_LIST: u8 = 14;
-const CL_TYPE_TAG_BYTE_ARRAY: u8 = 15;
-const CL_TYPE_TAG_RESULT: u8 = 16;
-const CL_TYPE_TAG_MAP: u8 = 17;
-const CL_TYPE_TAG_TUPLE1: u8 = 18;
-const CL_TYPE_TAG_TUPLE2: u8 = 19;
-const CL_TYPE_TAG_TUPLE3: u8 = 20;
-const CL_TYPE_TAG_ANY: u8 = 21;
-const CL_TYPE_TAG_PUBLIC_KEY: u8 = 22;
+#[derive(FromPrimitive, ToPrimitive, Debug)]
+#[repr(u8)]
+enum CLTypeTag {
+    Bool = 0,
+    I32 = 1,
+    I64 = 2,
+    U8 = 3,
+    U32 = 4,
+    U64 = 5,
+    U128 = 6,
+    U256 = 7,
+    U512 = 8,
+    Unit = 9,
+    String = 10,
+    Key = 11,
+    URef = 12,
+    Option = 13,
+    List = 14,
+    ByteArray = 15,
+    Result = 16,
+    Map = 17,
+    Tuple1 = 18,
+    Tuple2 = 19,
+    Tuple3 = 20,
+    Any = 21,
+    PublicKey = 22,
+}
+
+impl Into<u8> for CLTypeTag {
+    fn into(self) -> u8 {
+        self.to_u8().expect("CLTypeTag must be represented as a u8")
+    }
+}
+
+impl TryFrom<u8> for CLTypeTag {
+    type Error = bytesrepr::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        FromPrimitive::from_u8(value).ok_or(bytesrepr::Error::Formatting)
+    }
+}
 
 /// Casper types, i.e. types which can be stored and manipulated by smart contracts.
 ///
@@ -114,6 +135,40 @@ pub enum CLType {
 }
 
 impl CLType {
+    fn tag_byte(&self) -> u8 {
+        self.tag()
+            .to_u8()
+            .expect("CLType should be represented as a u8")
+    }
+
+    fn tag(&self) -> CLTypeTag {
+        match self {
+            CLType::Bool => CLTypeTag::Bool,
+            CLType::I32 => CLTypeTag::I32,
+            CLType::I64 => CLTypeTag::I64,
+            CLType::U8 => CLTypeTag::U8,
+            CLType::U32 => CLTypeTag::U32,
+            CLType::U64 => CLTypeTag::U64,
+            CLType::U128 => CLTypeTag::U128,
+            CLType::U256 => CLTypeTag::U256,
+            CLType::U512 => CLTypeTag::U512,
+            CLType::Unit => CLTypeTag::Unit,
+            CLType::String => CLTypeTag::String,
+            CLType::Key => CLTypeTag::Key,
+            CLType::URef => CLTypeTag::URef,
+            CLType::PublicKey => CLTypeTag::PublicKey,
+            CLType::Option(_) => CLTypeTag::Option,
+            CLType::List(_) => CLTypeTag::List,
+            CLType::ByteArray(_) => CLTypeTag::ByteArray,
+            CLType::Result { ok: _, err: _ } => CLTypeTag::Result,
+            CLType::Map { key: _, value: _ } => CLTypeTag::Map,
+            CLType::Tuple1(_) => CLTypeTag::Tuple1,
+            CLType::Tuple2(_) => CLTypeTag::Tuple2,
+            CLType::Tuple3(_) => CLTypeTag::Tuple3,
+            CLType::Any => CLTypeTag::Any,
+        }
+    }
+
     /// The `len()` of the `Vec<u8>` resulting from `self.to_bytes()`.
     pub fn serialized_length(&self) -> usize {
         mem::size_of::<u8>()
@@ -156,53 +211,43 @@ pub fn named_key_type() -> CLType {
 
 impl CLType {
     pub(crate) fn append_bytes(&self, stream: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        stream.push(self.tag_byte());
         match self {
-            CLType::Bool => stream.push(CL_TYPE_TAG_BOOL),
-            CLType::I32 => stream.push(CL_TYPE_TAG_I32),
-            CLType::I64 => stream.push(CL_TYPE_TAG_I64),
-            CLType::U8 => stream.push(CL_TYPE_TAG_U8),
-            CLType::U32 => stream.push(CL_TYPE_TAG_U32),
-            CLType::U64 => stream.push(CL_TYPE_TAG_U64),
-            CLType::U128 => stream.push(CL_TYPE_TAG_U128),
-            CLType::U256 => stream.push(CL_TYPE_TAG_U256),
-            CLType::U512 => stream.push(CL_TYPE_TAG_U512),
-            CLType::Unit => stream.push(CL_TYPE_TAG_UNIT),
-            CLType::String => stream.push(CL_TYPE_TAG_STRING),
-            CLType::Key => stream.push(CL_TYPE_TAG_KEY),
-            CLType::URef => stream.push(CL_TYPE_TAG_UREF),
-            CLType::PublicKey => stream.push(CL_TYPE_TAG_PUBLIC_KEY),
+            CLType::Bool => {}
+            CLType::I32 => {}
+            CLType::I64 => {}
+            CLType::U8 => {}
+            CLType::U32 => {}
+            CLType::U64 => {}
+            CLType::U128 => {}
+            CLType::U256 => {}
+            CLType::U512 => {}
+            CLType::Unit => {}
+            CLType::String => {}
+            CLType::Key => {}
+            CLType::URef => {}
+            CLType::PublicKey => {}
             CLType::Option(cl_type) => {
-                stream.push(CL_TYPE_TAG_OPTION);
                 cl_type.append_bytes(stream)?;
             }
             CLType::List(cl_type) => {
-                stream.push(CL_TYPE_TAG_LIST);
                 cl_type.append_bytes(stream)?;
             }
             CLType::ByteArray(len) => {
-                stream.push(CL_TYPE_TAG_BYTE_ARRAY);
                 stream.append(&mut len.to_bytes()?);
             }
             CLType::Result { ok, err } => {
-                stream.push(CL_TYPE_TAG_RESULT);
                 ok.append_bytes(stream)?;
                 err.append_bytes(stream)?;
             }
             CLType::Map { key, value } => {
-                stream.push(CL_TYPE_TAG_MAP);
                 key.append_bytes(stream)?;
                 value.append_bytes(stream)?;
             }
-            CLType::Tuple1(cl_type_array) => {
-                serialize_cl_tuple_type(CL_TYPE_TAG_TUPLE1, cl_type_array, stream)?
-            }
-            CLType::Tuple2(cl_type_array) => {
-                serialize_cl_tuple_type(CL_TYPE_TAG_TUPLE2, cl_type_array, stream)?
-            }
-            CLType::Tuple3(cl_type_array) => {
-                serialize_cl_tuple_type(CL_TYPE_TAG_TUPLE3, cl_type_array, stream)?
-            }
-            CLType::Any => stream.push(CL_TYPE_TAG_ANY),
+            CLType::Tuple1(cl_type_array) => serialize_cl_tuple_types(cl_type_array, stream)?,
+            CLType::Tuple2(cl_type_array) => serialize_cl_tuple_types(cl_type_array, stream)?,
+            CLType::Tuple3(cl_type_array) => serialize_cl_tuple_types(cl_type_array, stream)?,
+            CLType::Any => {}
         }
         Ok(())
     }
@@ -212,37 +257,37 @@ impl CLType {
 impl FromBytes for CLType {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (tag, remainder) = u8::from_bytes(bytes)?;
-        match tag {
-            CL_TYPE_TAG_BOOL => Ok((CLType::Bool, remainder)),
-            CL_TYPE_TAG_I32 => Ok((CLType::I32, remainder)),
-            CL_TYPE_TAG_I64 => Ok((CLType::I64, remainder)),
-            CL_TYPE_TAG_U8 => Ok((CLType::U8, remainder)),
-            CL_TYPE_TAG_U32 => Ok((CLType::U32, remainder)),
-            CL_TYPE_TAG_U64 => Ok((CLType::U64, remainder)),
-            CL_TYPE_TAG_U128 => Ok((CLType::U128, remainder)),
-            CL_TYPE_TAG_U256 => Ok((CLType::U256, remainder)),
-            CL_TYPE_TAG_U512 => Ok((CLType::U512, remainder)),
-            CL_TYPE_TAG_UNIT => Ok((CLType::Unit, remainder)),
-            CL_TYPE_TAG_STRING => Ok((CLType::String, remainder)),
-            CL_TYPE_TAG_KEY => Ok((CLType::Key, remainder)),
-            CL_TYPE_TAG_UREF => Ok((CLType::URef, remainder)),
-            CL_TYPE_TAG_PUBLIC_KEY => Ok((CLType::PublicKey, remainder)),
-            CL_TYPE_TAG_OPTION => {
+        match CLTypeTag::try_from(tag)? {
+            CLTypeTag::Bool => Ok((CLType::Bool, remainder)),
+            CLTypeTag::I32 => Ok((CLType::I32, remainder)),
+            CLTypeTag::I64 => Ok((CLType::I64, remainder)),
+            CLTypeTag::U8 => Ok((CLType::U8, remainder)),
+            CLTypeTag::U32 => Ok((CLType::U32, remainder)),
+            CLTypeTag::U64 => Ok((CLType::U64, remainder)),
+            CLTypeTag::U128 => Ok((CLType::U128, remainder)),
+            CLTypeTag::U256 => Ok((CLType::U256, remainder)),
+            CLTypeTag::U512 => Ok((CLType::U512, remainder)),
+            CLTypeTag::Unit => Ok((CLType::Unit, remainder)),
+            CLTypeTag::String => Ok((CLType::String, remainder)),
+            CLTypeTag::Key => Ok((CLType::Key, remainder)),
+            CLTypeTag::URef => Ok((CLType::URef, remainder)),
+            CLTypeTag::PublicKey => Ok((CLType::PublicKey, remainder)),
+            CLTypeTag::Option => {
                 let (inner_type, remainder) = CLType::from_bytes(remainder)?;
                 let cl_type = CLType::Option(Box::new(inner_type));
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_LIST => {
+            CLTypeTag::List => {
                 let (inner_type, remainder) = CLType::from_bytes(remainder)?;
                 let cl_type = CLType::List(Box::new(inner_type));
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_BYTE_ARRAY => {
+            CLTypeTag::ByteArray => {
                 let (len, remainder) = u32::from_bytes(remainder)?;
                 let cl_type = CLType::ByteArray(len);
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_RESULT => {
+            CLTypeTag::Result => {
                 let (ok_type, remainder) = CLType::from_bytes(remainder)?;
                 let (err_type, remainder) = CLType::from_bytes(remainder)?;
                 let cl_type = CLType::Result {
@@ -251,7 +296,7 @@ impl FromBytes for CLType {
                 };
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_MAP => {
+            CLTypeTag::Map => {
                 let (key_type, remainder) = CLType::from_bytes(remainder)?;
                 let (value_type, remainder) = CLType::from_bytes(remainder)?;
                 let cl_type = CLType::Map {
@@ -260,14 +305,14 @@ impl FromBytes for CLType {
                 };
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_TUPLE1 => {
+            CLTypeTag::Tuple1 => {
                 let (mut inner_types, remainder) = parse_cl_tuple_types(1, remainder)?;
                 // NOTE: Assumed safe as `parse_cl_tuple_types` is expected to have exactly 1
                 // element
                 let cl_type = CLType::Tuple1([inner_types.pop_front().unwrap()]);
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_TUPLE2 => {
+            CLTypeTag::Tuple2 => {
                 let (mut inner_types, remainder) = parse_cl_tuple_types(2, remainder)?;
                 // NOTE: Assumed safe as `parse_cl_tuple_types` is expected to have exactly 2
                 // elements
@@ -277,7 +322,7 @@ impl FromBytes for CLType {
                 ]);
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_TUPLE3 => {
+            CLTypeTag::Tuple3 => {
                 let (mut inner_types, remainder) = parse_cl_tuple_types(3, remainder)?;
                 // NOTE: Assumed safe as `parse_cl_tuple_types` is expected to have exactly 3
                 // elements
@@ -288,18 +333,15 @@ impl FromBytes for CLType {
                 ]);
                 Ok((cl_type, remainder))
             }
-            CL_TYPE_TAG_ANY => Ok((CLType::Any, remainder)),
-            _ => Err(bytesrepr::Error::Formatting),
+            CLTypeTag::Any => Ok((CLType::Any, remainder)),
         }
     }
 }
 
-fn serialize_cl_tuple_type<'a, T: IntoIterator<Item = &'a Box<CLType>>>(
-    tag: u8,
+fn serialize_cl_tuple_types<'a, T: IntoIterator<Item = &'a Box<CLType>>>(
     cl_type_array: T,
     stream: &mut Vec<u8>,
 ) -> Result<(), bytesrepr::Error> {
-    stream.push(tag);
     for cl_type in cl_type_array {
         cl_type.append_bytes(stream)?;
     }

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -780,8 +780,7 @@ impl ContractPackage {
         let contract_version_key = self
             .versions
             .iter()
-            .filter_map(|(k, v)| if *v == contract_hash { Some(*k) } else { None })
-            .next()
+            .find_map(|(k, v)| if *v == contract_hash { Some(*k) } else { None })
             .ok_or(Error::ContractNotFound)?;
 
         if !self.disabled_versions.contains(&contract_version_key) {

--- a/types/src/crypto.rs
+++ b/types/src/crypto.rs
@@ -11,10 +11,7 @@ use blake2::{
 use crate::key::BLAKE2B_DIGEST_LENGTH;
 #[cfg(any(feature = "gens", test))]
 pub use asymmetric_key::gens;
-pub use asymmetric_key::{
-    AsymmetricType, PublicKey, SecretKey, Signature, ED25519_TAG, SECP256K1_TAG, SYSTEM_ACCOUNT,
-    SYSTEM_TAG,
-};
+pub use asymmetric_key::{AsymmetricType, KeyTag, PublicKey, SecretKey, Signature};
 pub use error::Error;
 
 #[doc(hidden)]

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -7,6 +7,8 @@ use alloc::{
 };
 use core::{convert::TryFrom, fmt::Debug};
 
+use num::{FromPrimitive, ToPrimitive};
+use num_derive::{FromPrimitive, ToPrimitive};
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 
@@ -20,6 +22,7 @@ use crate::{
 pub use type_mismatch::TypeMismatch;
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 enum Tag {
     CLValue = 0,
@@ -32,6 +35,14 @@ enum Tag {
     EraInfo = 7,
     Bid = 8,
     Withdraw = 9,
+}
+
+impl TryFrom<u8> for Tag {
+    type Error = bytesrepr::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        FromPrimitive::from_u8(value).ok_or(bytesrepr::Error::Formatting)
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -164,6 +175,12 @@ impl StoredValue {
             StoredValue::Bid(_) => Tag::Bid,
             StoredValue::Withdraw(_) => Tag::Withdraw,
         }
+    }
+
+    fn tag_byte(&self) -> u8 {
+        self.tag()
+            .to_u8()
+            .expect("StoredValueTag should be represented as a u8")
     }
 }
 
@@ -307,25 +324,19 @@ impl TryFrom<StoredValue> for EraInfo {
 impl ToBytes for StoredValue {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        let (tag, mut serialized_data) = match self {
-            StoredValue::CLValue(cl_value) => (Tag::CLValue, cl_value.to_bytes()?),
-            StoredValue::Account(account) => (Tag::Account, account.to_bytes()?),
-            StoredValue::ContractWasm(contract_wasm) => {
-                (Tag::ContractWasm, contract_wasm.to_bytes()?)
-            }
-            StoredValue::Contract(contract_header) => (Tag::Contract, contract_header.to_bytes()?),
-            StoredValue::ContractPackage(contract_package) => {
-                (Tag::ContractPackage, contract_package.to_bytes()?)
-            }
-            StoredValue::Transfer(transfer) => (Tag::Transfer, transfer.to_bytes()?),
-            StoredValue::DeployInfo(deploy_info) => (Tag::DeployInfo, deploy_info.to_bytes()?),
-            StoredValue::EraInfo(era_info) => (Tag::EraInfo, era_info.to_bytes()?),
-            StoredValue::Bid(bid) => (Tag::Bid, bid.to_bytes()?),
-            StoredValue::Withdraw(unbonding_purses) => {
-                (Tag::Withdraw, unbonding_purses.to_bytes()?)
-            }
+        result.push(self.tag_byte());
+        let mut serialized_data = match self {
+            StoredValue::CLValue(cl_value) => cl_value.to_bytes()?,
+            StoredValue::Account(account) => account.to_bytes()?,
+            StoredValue::ContractWasm(contract_wasm) => contract_wasm.to_bytes()?,
+            StoredValue::Contract(contract_header) => contract_header.to_bytes()?,
+            StoredValue::ContractPackage(contract_package) => contract_package.to_bytes()?,
+            StoredValue::Transfer(transfer) => transfer.to_bytes()?,
+            StoredValue::DeployInfo(deploy_info) => deploy_info.to_bytes()?,
+            StoredValue::EraInfo(era_info) => era_info.to_bytes()?,
+            StoredValue::Bid(bid) => bid.to_bytes()?,
+            StoredValue::Withdraw(unbonding_purses) => unbonding_purses.to_bytes()?,
         };
-        result.push(tag as u8);
         result.append(&mut serialized_data);
         Ok(result)
     }
@@ -349,7 +360,7 @@ impl ToBytes for StoredValue {
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        writer.push(self.tag() as u8);
+        writer.push(self.tag_byte());
         match self {
             StoredValue::CLValue(cl_value) => cl_value.write_bytes(writer)?,
             StoredValue::Account(account) => account.write_bytes(writer)?,
@@ -371,37 +382,36 @@ impl ToBytes for StoredValue {
 impl FromBytes for StoredValue {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (tag, remainder): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
-        match tag {
-            tag if tag == Tag::CLValue as u8 => CLValue::from_bytes(remainder)
+        match TryFrom::try_from(tag)? {
+            Tag::CLValue => CLValue::from_bytes(remainder)
                 .map(|(cl_value, remainder)| (StoredValue::CLValue(cl_value), remainder)),
-            tag if tag == Tag::Account as u8 => Account::from_bytes(remainder)
+            Tag::Account => Account::from_bytes(remainder)
                 .map(|(account, remainder)| (StoredValue::Account(account), remainder)),
-            tag if tag == Tag::ContractWasm as u8 => {
+            Tag::ContractWasm => {
                 ContractWasm::from_bytes(remainder).map(|(contract_wasm, remainder)| {
                     (StoredValue::ContractWasm(contract_wasm), remainder)
                 })
             }
-            tag if tag == Tag::ContractPackage as u8 => {
+            Tag::ContractPackage => {
                 ContractPackage::from_bytes(remainder).map(|(contract_package, remainder)| {
                     (StoredValue::ContractPackage(contract_package), remainder)
                 })
             }
-            tag if tag == Tag::Contract as u8 => Contract::from_bytes(remainder)
+            Tag::Contract => Contract::from_bytes(remainder)
                 .map(|(contract, remainder)| (StoredValue::Contract(contract), remainder)),
-            tag if tag == Tag::Transfer as u8 => Transfer::from_bytes(remainder)
+            Tag::Transfer => Transfer::from_bytes(remainder)
                 .map(|(transfer, remainder)| (StoredValue::Transfer(transfer), remainder)),
-            tag if tag == Tag::DeployInfo as u8 => DeployInfo::from_bytes(remainder)
+            Tag::DeployInfo => DeployInfo::from_bytes(remainder)
                 .map(|(deploy_info, remainder)| (StoredValue::DeployInfo(deploy_info), remainder)),
-            tag if tag == Tag::EraInfo as u8 => EraInfo::from_bytes(remainder)
+            Tag::EraInfo => EraInfo::from_bytes(remainder)
                 .map(|(deploy_info, remainder)| (StoredValue::EraInfo(deploy_info), remainder)),
-            tag if tag == Tag::Bid as u8 => Bid::from_bytes(remainder)
+            Tag::Bid => Bid::from_bytes(remainder)
                 .map(|(bid, remainder)| (StoredValue::Bid(Box::new(bid)), remainder)),
-            tag if tag == Tag::Withdraw as u8 => {
+            Tag::Withdraw => {
                 Vec::<UnbondingPurse>::from_bytes(remainder).map(|(unbonding_purses, remainder)| {
                     (StoredValue::Withdraw(unbonding_purses), remainder)
                 })
             }
-            _ => Err(bytesrepr::Error::Formatting),
         }
     }
 }


### PR DESCRIPTION
## Description
Improves ToBytes/FromBytes implementations so they are less likely to have bugs in them. In particular, use `enum`s and `FromPrimitive` to make sure we match on all cases of the `*Tag` constructor. This doesn't exactly fix everything, as implementors still need to add a `*Tag` variant, but I believe that seeing its lack in the `ToBytes` implementation will cause that. I had an idea like:

```rust
enum T<A, B, C> {
  A(A),
  B(B),
  C(C),
}
```

but I don't know how to make it `repr(u8)` _only_ when `A = B = C = ()`. Beyond that, there's the worse problem of not being able to specify the explicit numbers corresponding to each variant in this declaration. That may be fixed by the implicit derivation of `FromPrimitive`, haven't checked.

## Risks
Any faulty modification of the serialization layer could lead to serious bugs in the Casper Network, its users' code, or in any of our tooling.

## Issue
https://github.com/casper-network/casper-node/issues/2329