### PR TITLE
Don't assert on the number of leftover events when switching from `joiner` to `participating` in `MultiStageTestReactor`

### DIFF
--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -428,15 +428,13 @@ impl Reactor for MultiStageTestReactor {
                         warn!("when transitioning from joiner to participating, left {} effects unhandled", dropped_events_count)
                     }
 
-                    assert_eq!(
-                        joiner_event_queue_handle
-                            .event_queues_counts()
-                            .values()
-                            .sum::<usize>(),
-                        0,
-                        "before transitioning from joiner to participating, \
-                         there should be no unprocessed events"
-                    );
+                    let joiner_event_queue_length = joiner_event_queue_handle
+                        .event_queues_counts()
+                        .values()
+                        .sum::<usize>();
+                    if joiner_event_queue_length != 0 {
+                        warn!("before transitioning from joiner to participating, there should be no unprocessed events, left {} unprocessed events", joiner_event_queue_length)
+                    }
 
                     // `into_participating_config` is just waiting for networking sockets to shut
                     // down and will not stall on disabled event processing, so


### PR DESCRIPTION
This PR removes the assert on the number of leftover events to be handled by the joiner reactor. The assert is replaced with a warning, as the leftover events do not prevent the node from functioning correctly.

The assert could have triggered spuriously, because at the time of asserting there could still be other components putting the events into the queue.

Neither assert nor warning would be needed if we switch to a single reactor model in the future.

The idea to dump the remaining events into the logs was dropped, because it would require substantial effort and hacky code to get access to the internal data of the queues from within the non-async `dispatch_event()` function.