### PR TITLE
NCTL: Small tweaks for fast-sync

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -55,8 +55,8 @@ function start_run_teardown() {
 
     # Start nctl network
     nctl-start
-    echo "Sleeping 90 to allow network startup"
-    sleep 90
+    echo "Sleeping 10s to allow network startup"
+    sleep 10
 
     # Run passed in test
     pushd "$SCENARIOS_DIR"

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -233,6 +233,7 @@ function setup_asset_chainspec()
     local ACTIVATION_POINT=${3}
     local PATH_TO_CHAINSPEC_TEMPLATE=${4}
     local IS_GENESIS=${5}
+    local CHUNKED_HASH_ACTIVATION=${6}
     local PATH_TO_CHAINSPEC
     local SCRIPT
 
@@ -257,6 +258,7 @@ function setup_asset_chainspec()
             "cfg=toml.load('$PATH_TO_CHAINSPEC');"
             "cfg['protocol']['activation_point']=$ACTIVATION_POINT;"
             "cfg['protocol']['version']='$PROTOCOL_VERSION';"
+            "cfg['protocol']['verifiable_chunked_hash_activation']=$CHUNKED_HASH_ACTIVATION;"
             "cfg['network']['name']='$(get_chain_name)';"
             "cfg['core']['validator_slots']=$COUNT_NODES;"
             "toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));"

--- a/utils/nctl/sh/assets/upgrade_from_stage.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage.sh
@@ -74,9 +74,13 @@ function _main()
     local STAGE_ID=${1}
     local ACTIVATION_POINT=${2}
     local VERBOSE=${3}
+    local CHUNKED_HASH_ACTIVATION
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
     local COUNT_NODES
+
+    #Set `verifiable_chunked_hash_activation` equal to upgrade activation point
+    CHUNKED_HASH_ACTIVATION="$ACTIVATION_POINT"
 
     PATH_TO_STAGE="$NCTL/stages/stage-$STAGE_ID"
     COUNT_NODES=$(get_count_of_nodes)
@@ -98,7 +102,8 @@ function _main()
                               "$(get_protocol_version_for_chainspec "$PROTOCOL_VERSION")" \
                               "$ACTIVATION_POINT" \
                               "$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml" \
-                              false
+                              false \
+                              "$CHUNKED_HASH_ACTIVATION"
         setup_asset_node_configs "$COUNT_NODES" \
                                  "$PROTOCOL_VERSION" \
                                  "$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml" \

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -157,6 +157,7 @@ function _step_07()
 {
     local NODE_ID
     local TRUSTED_HASH
+    local SLEEP_COUNT
 
     log_step_upgrades 7 "joining passive nodes"
 
@@ -186,14 +187,19 @@ function _step_07()
     done
 
     log "... ... awaiting new nodes to start"
-    #sleep 60
+
     while [ "$(get_count_of_up_nodes)" != '10' ]; do
         sleep 1.0
-        local sleep_count
-        sleep_count=$((sleep_count + 1))
+        SLEEP_COUNT=$((SLEEP_COUNT + 1))
         log "NODE_COUNT_UP: $(get_count_of_up_nodes)"
-        log "Sleep time: $sleep_count seconds"
+        log "Sleep time: $SLEEP_COUNT seconds"
+
+        if [ "$SLEEP_COUNT" -ge "60" ]; then
+            log "Timeout reached of 1 minute! Exiting ..."
+            exit 1
+        fi
     done
+
     await_n_eras 1
     await_n_blocks 1
 }

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -17,7 +17,7 @@ max_parallel_deploy_fetches = 20
 max_parallel_trie_fetches = 20
 
 # Whether to synchronize all data back to genesis when joining.
-#archival_sync = true
+archival_sync = true
 
 # =================================
 # Configuration options for logging
@@ -373,16 +373,6 @@ verify_accounts = true
 #
 # If unset, defaults to true.
 #enable_manual_sync = true
-
-
-# ========================================================
-# Configuration options for synchronizing the linear chain
-# ========================================================
-[linear_chain_sync]
-
-# The amount of time that the node will try to sync without making progress before shutting down.
-sync_timeout = '1hr'
-
 
 # ====================================================================
 # Configuration options for selecting deploys to propose in new blocks


### PR DESCRIPTION
### Changes
`ci/nightly-test.sh`
- Reduce setup time in nightly wrapper. This was an old value left around.

`utils/nctl/sh/assets/setup_shared.sh` & `utils/nctl/sh/assets/upgrade_from_stage.sh`
- Updates to handle `verifiable_chunked_hash_activation`.
    - Set to activation point in upgrade tests

`utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh`
- Timeout check after a minute if not in sync. Currently waits forever.

`utils/nctl/sh/scenarios/configs/gov96.config.toml`
- Updated so the test would start without error.