### PR TITLE
Don't discard deploys without announcing expiry.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -357,11 +357,6 @@ impl BlockProposerReady {
         hash: DeployOrTransferHash,
         deploy_info: DeployInfo,
     ) {
-        if deploy_info.header.expired(current_instant) {
-            trace!(%hash, "expired deploy rejected from the buffer");
-            return;
-        }
-
         if hash.is_transfer() {
             // only add the transfer if it isn't contained in a finalized block
             if self
@@ -377,6 +372,7 @@ impl BlockProposerReady {
             self.sets
                 .pending_transfers
                 .insert(*hash.deploy_hash(), (deploy_info, current_instant));
+            info!(%hash, "added transfer to the buffer");
         } else {
             // only add the deploy if it isn't contained in a finalized block
             if self.sets.finalized_deploys.contains_key(hash.deploy_hash()) {
@@ -388,9 +384,8 @@ impl BlockProposerReady {
             self.sets
                 .pending_deploys
                 .insert(*hash.deploy_hash(), (deploy_info, current_instant));
+            info!(%hash, "added deploy to the buffer");
         }
-
-        info!(%hash, "added deploy to the buffer");
     }
 
     /// Handles finalization of a block.

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -21,7 +21,7 @@ use std::{
 use datasize::DataSize;
 use futures::join;
 use prometheus::{self, Registry};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use casper_types::PublicKey;
 


### PR DESCRIPTION
Don't silently drop deploys in `BlockProposer::add_deploy`.
Expired deploys are filtered by the deploy acceptor anyway, and are periodically purged, causing an announcement and event.

Also update the log message in `add_deploy` so it distinguishes between transfers and other deploys, like the other log messages.

Closes #2629.
