### PR TITLE
Query for Contract Package by Contract Package Hash

### DIFF
--- a/execution_engine_testing/tests/src/test/regression/gh_1931.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1931.rs
@@ -1,0 +1,34 @@
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_types::{RuntimeArgs, StoredValue};
+
+const CONTRACT_NAME: &str = "do_nothing_stored.wasm";
+const CONTRACT_PACKAGE_NAMED_KEY: &str = "do_nothing_package_hash";
+
+#[test]
+fn should_query_contract_package() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
+
+    let install_request =
+        ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, CONTRACT_NAME, RuntimeArgs::new())
+            .build();
+
+    builder.exec(install_request).expect_success().commit();
+
+    let contract_package_hash = builder
+        .get_expected_account(*DEFAULT_ACCOUNT_ADDR)
+        .named_keys()
+        .clone()
+        .get(CONTRACT_PACKAGE_NAMED_KEY)
+        .expect("failed to get contract package named key.")
+        .clone();
+
+    let contract_package = builder
+        .query(None, contract_package_hash, &[])
+        .expect("failed to find contract package");
+
+    assert!(matches!(contract_package, StoredValue::ContractPackage(_)));
+}

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -34,6 +34,7 @@ mod ee_966;
 mod gh_1470;
 mod gh_1688;
 mod gh_1902;
+mod gh_1931;
 mod gh_2280;
 mod gov_116;
 mod gov_74;


### PR DESCRIPTION
This PR introduces a regression test that asserts that Contract Packages may be queried by hash.

# Querying by Contract Package Hash Example
Step 1: Query for the mint contract on mainnet:

```
casper-client query-global-state --key hash-7cc1b1db4e08bbfe7bacf8e1ad828a5d9bcccbb33e55d322808c3a88da53213a --state-root-hash 420cb59ea5b400e82871e15d6041ac7a2039340caf3a4b7a754b02059128d6d3 -n http://3.142.224.108:7777

{
  "id": -7086977302587134255,
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.4.4",
    "block_header": null,
    "merkle_proof": "[5112 hex chars]",
    "stored_value": {
      "Contract": {
        "contract_package_hash": "contract-package-wasm4475016098705466254edd18d267a9dad43e341d4dafadb507d0fe3cf2d4a74b",
        "contract_wasm_hash": "contract-wasm-41c6f5bad412de7e16af7943b0c751f0dc9152a337c8b024313057dd8d707f99",
        "entry_points": [
        ...
```

Then we can query for the contract package, just replace the `contract-package-wasm` prefix with `hash-`
```
casper-client query-global-state --key  hash-4475016098705466254edd18d267a9dad43e341d4dafadb507d0fe3cf2d4a74b --state-root-hash 420cb59ea5b400e82871e15d6041ac7a2039340caf3a4b7a754b02059128d6d3 -n http://3.142.224.108:7777
{
  "id": 413736053229266654,
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.4.4",
    "block_header": null,
    "merkle_proof": "[4292 hex chars]",
    "stored_value": {
      "ContractPackage": {
        "access_key": "uref-145838cb97d0476295b411c2f384110f64c73a7952c63a8ae9fd47494ecc80a1-007",
        "disabled_versions": [],
        "groups": [],
        "versions": [
          {
            "contract_hash": "contract-7cc1b1db4e08bbfe7bacf8e1ad828a5d9bcccbb33e55d322808c3a88da53213a",
            "contract_version": 1,
            "protocol_version_major": 1
          }
        ]
      }
    }
  }
}
```


