### PR TITLE
Implement `Payload::incoming_resource_estimate` for `Message`

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.  The format
 * Added `max_parallel_deploy_fetches` and `max_parallel_trie_fetches` config options to the `[node]` section to control how many requests are made in parallel while syncing.
 * Added `archival_sync` to `[node]` config section, along with archival syncing capabilities
 * Introducing fast-syncing to join the network, avoiding the need to execute every block to catch up.
+* In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -89,7 +89,7 @@ pub(crate) use self::{
     error::Error,
     event::Event,
     gossiped_address::GossipedAddress,
-    message::{FromIncoming, Message, MessageKind, Payload, PayloadWeights},
+    message::{EstimatorWeights, FromIncoming, Message, MessageKind, Payload},
 };
 use crate::{
     components::{consensus, Component},

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::TimeDiff;
 
-use super::PayloadWeights;
+use super::EstimatorWeights;
 
 /// Default binding address.
 ///
@@ -82,7 +82,7 @@ pub struct Config {
     /// Maximum of requests answered from non-validating peers. Unlimited if 0.
     pub max_incoming_message_rate_non_validators: u32,
     /// Weight distribution for the payload impact estimator.
-    pub estimator_weights: PayloadWeights,
+    pub estimator_weights: EstimatorWeights,
     /// Whether or not to reject incompatible versions during handshake.
     pub reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -300,8 +300,22 @@ pub(crate) trait FromIncoming<I, P> {
 pub struct PayloadWeights {
     /// Weight to attach to consensus traffic.
     pub consensus: u32,
+    /// Weight to attach to gossiper traffic.
+    pub gossip: u32,
+    /// Weight to attach to finality signatures traffic.
+    pub finality_signatures: u32,
     /// Weight to attach to deploy requests.
     pub deploy_requests: u32,
+    /// Weight to attach to deploy responses.
+    pub deploy_responses: u32,
+    /// Weight to attach to block requests.
+    pub block_requests: u32,
+    /// Weight to attach to block responses.
+    pub block_responses: u32,
+    /// Weight to attach to trie requests.
+    pub trie_requests: u32,
+    /// Weight to attach to trie responses.
+    pub trie_responses: u32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -283,9 +283,7 @@ pub(crate) trait Payload:
     fn classify(&self) -> MessageKind;
 
     /// The penalty for resource usage of a message to be applied when processed as incoming.
-    fn incoming_resource_estimate(&self, _weights: &PayloadWeights) -> u32 {
-        0
-    }
+    fn incoming_resource_estimate(&self, _weights: &PayloadWeights) -> u32;
 }
 
 /// Network message conversion support.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -55,7 +55,7 @@ impl<P: Payload> Message<P> {
 
     /// Returns the incoming resource estimate of the payload.
     #[inline]
-    pub(super) fn payload_incoming_resource_estimate(&self, weights: &PayloadWeights) -> u32 {
+    pub(super) fn payload_incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
         match self {
             Message::Handshake { .. } => 0,
             Message::Payload(payload) => payload.incoming_resource_estimate(weights),
@@ -283,7 +283,7 @@ pub(crate) trait Payload:
     fn classify(&self) -> MessageKind;
 
     /// The penalty for resource usage of a message to be applied when processed as incoming.
-    fn incoming_resource_estimate(&self, _weights: &PayloadWeights) -> u32;
+    fn incoming_resource_estimate(&self, _weights: &EstimatorWeights) -> u32;
 }
 
 /// Network message conversion support.
@@ -297,7 +297,7 @@ pub(crate) trait FromIncoming<I, P> {
 ///
 /// The default implementation sets all weights to zero.
 #[derive(DataSize, Debug, Default, Clone, Deserialize, Serialize)]
-pub struct PayloadWeights {
+pub struct EstimatorWeights {
     /// Weight to attach to consensus traffic.
     pub consensus: u32,
     /// Weight to attach to gossiper traffic.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -41,7 +41,7 @@ use super::{
     event::{IncomingConnection, OutgoingConnection},
     framed,
     limiter::LimiterHandle,
-    message::{ConsensusKeyPair, PayloadWeights},
+    message::{ConsensusKeyPair, EstimatorWeights},
     Event, FramedTransport, Message, Metrics, Payload, Transport,
 };
 use crate::{
@@ -180,7 +180,7 @@ where
     /// Timeout for handshake completion.
     pub(super) handshake_timeout: TimeDiff,
     /// Weights to estimate payloads with.
-    pub(super) payload_weights: PayloadWeights,
+    pub(super) payload_weights: EstimatorWeights,
     /// Whether or not to reject incompatible versions during handshake.
     pub(super) reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -147,6 +147,10 @@ impl Payload for Message {
             Message::AddressGossiper(_) => MessageKind::AddressGossip,
         }
     }
+
+    fn incoming_resource_estimate(&self, _weights: &super::PayloadWeights) -> u32 {
+        0
+    }
 }
 
 /// Test reactor.

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -148,7 +148,7 @@ impl Payload for Message {
         }
     }
 
-    fn incoming_resource_estimate(&self, _weights: &super::PayloadWeights) -> u32 {
+    fn incoming_resource_estimate(&self, _weights: &super::EstimatorWeights) -> u32 {
         0
     }
 }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -15,7 +15,7 @@ use crate::{
         consensus,
         fetcher::FetchedOrNotFound,
         gossiper,
-        small_network::{FromIncoming, GossipedAddress, MessageKind, Payload, PayloadWeights},
+        small_network::{EstimatorWeights, FromIncoming, GossipedAddress, MessageKind, Payload},
     },
     effect::incoming::{
         ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming, NetRequest,
@@ -80,7 +80,7 @@ impl Payload for Message {
     }
 
     #[inline]
-    fn incoming_resource_estimate(&self, weights: &PayloadWeights) -> u32 {
+    fn incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
         match self {
             Message::Consensus(_) => weights.consensus,
             Message::DeployGossiper(_) => weights.gossip,

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -80,30 +80,30 @@ impl Payload for Message {
     }
 
     #[inline]
-    fn incoming_resource_estimate(&self, _weights: &PayloadWeights) -> u32 {
+    fn incoming_resource_estimate(&self, weights: &PayloadWeights) -> u32 {
         match self {
-            Message::Consensus(_) => 0,
-            Message::DeployGossiper(_) => 0,
-            Message::AddressGossiper(_) => 0,
+            Message::Consensus(_) => weights.consensus,
+            Message::DeployGossiper(_) => weights.gossip,
+            Message::AddressGossiper(_) => weights.gossip,
             Message::GetRequest { tag, .. } => match tag {
-                Tag::Deploy => 1,
-                Tag::Block => 1,
-                Tag::GossipedAddress => 0,
-                Tag::BlockAndMetadataByHeight => 1,
-                Tag::BlockHeaderByHash => 1,
-                Tag::BlockHeaderAndFinalitySignaturesByHeight => 1,
-                Tag::Trie => 1,
+                Tag::Deploy => weights.deploy_requests,
+                Tag::Block => weights.block_requests,
+                Tag::GossipedAddress => weights.gossip,
+                Tag::BlockAndMetadataByHeight => weights.block_requests,
+                Tag::BlockHeaderByHash => weights.block_requests,
+                Tag::BlockHeaderAndFinalitySignaturesByHeight => weights.block_requests,
+                Tag::Trie => weights.trie_requests,
             },
             Message::GetResponse { tag, .. } => match tag {
-                Tag::Deploy => 1,
-                Tag::Block => 0,
-                Tag::GossipedAddress => 0,
-                Tag::BlockAndMetadataByHeight => 0,
-                Tag::BlockHeaderByHash => 0,
-                Tag::BlockHeaderAndFinalitySignaturesByHeight => 0,
-                Tag::Trie => 0,
+                Tag::Deploy => weights.deploy_responses,
+                Tag::Block => weights.block_responses,
+                Tag::GossipedAddress => weights.gossip,
+                Tag::BlockAndMetadataByHeight => weights.block_responses,
+                Tag::BlockHeaderByHash => weights.block_responses,
+                Tag::BlockHeaderAndFinalitySignaturesByHeight => weights.block_responses,
+                Tag::Trie => weights.trie_responses,
             },
-            Message::FinalitySignature(_) => 0,
+            Message::FinalitySignature(_) => weights.finality_signatures,
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -197,6 +197,7 @@ block_responses = 0
 trie_requests = 1
 trie_responses = 0
 
+
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server
 # ==================================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -151,12 +151,6 @@ max_outgoing_byte_rate_non_validators = 0
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 
-# Weights for impact estimation of incoming messages, used in combination with
-# `max_incoming_message_rate_non_validators`.
-#
-# Any weight set to 0 means that the category of traffic is exempt from throttling.
-estimator_weights = { consensus=0, deploy_requests=1 }
-
 # Reject incompatible node versions
 #
 # Causes the node to immediately disconnect from versions on a different protocol version than
@@ -187,6 +181,21 @@ tarpit_duration = '10min'
 # set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
 # legacy nodes running this software.
 tarpit_chance = 0.2
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -150,12 +150,6 @@ max_outgoing_byte_rate_non_validators = 6553600
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 3000
 
-# Weights for impact estimation of incoming messages, used in combination with
-# `max_incoming_message_rate_non_validators`.
-#
-# Any weight set to 0 means that the category of traffic is exempt from throttling.
-estimator_weights = { consensus=0, deploy_requests=1 }
-
 # Reject incompatible node versions
 #
 # Causes the node to immediately disconnect from versions on a different protocol version than
@@ -186,6 +180,21 @@ tarpit_duration = '10min'
 # set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
 # legacy nodes running this software.
 tarpit_chance = 0.2
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
 
 
 # ==================================================

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -151,12 +151,6 @@ max_outgoing_byte_rate_non_validators = 0
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 
-# Weights for impact estimation of incoming messages, used in combination with
-# `max_incoming_message_rate_non_validators`.
-#
-# Any weight set to 0 means that the category of traffic is exempt from throttling.
-estimator_weights = { consensus=0, deploy_requests=1 }
-
 # Reject incompatible node versions
 #
 # Causes the node to immediately disconnect from versions on a different protocol version than
@@ -187,6 +181,22 @@ tarpit_duration = '10min'
 # set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
 # legacy nodes running this software.
 tarpit_chance = 0.2
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -154,12 +154,6 @@ max_outgoing_byte_rate_non_validators = 0
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 
-# Weights for impact estimation of incoming messages, used in combination with
-# `max_incoming_message_rate_non_validators`.
-#
-# Any weight set to 0 means that the category of traffic is exempt from throttling.
-estimator_weights = { consensus=0, deploy_requests=1 }
-
 # Reject incompatible node versions
 #
 # Causes the node to immediately disconnect from versions on a different protocol version than
@@ -190,6 +184,22 @@ tarpit_duration = '10min'
 # set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
 # legacy nodes running this software.
 tarpit_chance = 0.2
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -151,12 +151,6 @@ max_outgoing_byte_rate_non_validators = 0
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 
-# Weights for impact estimation of incoming messages, used in combination with
-# `max_incoming_message_rate_non_validators`.
-#
-# Any weight set to 0 means that the category of traffic is exempt from throttling.
-estimator_weights = { consensus=0, deploy_requests=1 }
-
 # Reject incompatible node versions
 #
 # Causes the node to immediately disconnect from versions on a different protocol version than
@@ -187,6 +181,22 @@ tarpit_duration = '10min'
 # set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
 # legacy nodes running this software.
 tarpit_chance = 0.2
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server


### PR DESCRIPTION
This PR removes the default implementation of the `incoming_resource_estimate` method in `Payload` trait and provides a dedicated one.

It sets the estimate to `1` for `GetRequest::Deploy`, `GetResponse::Deploy` and all request with tags that are used in the fast sync process:
* `Block`
* `BlockAndMetadataByHeight`
* `BlockHeaderByHash`
* `BlockHeaderAndFinalitySignaturesByHeight`
* `Trie`

Closes https://github.com/casper-network/casper-node/issues/2644