### PR TITLE
CI: Setup prior to building client contracts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -135,6 +135,7 @@ steps:
 - name: build-client-contracts
   image: casperlabs/node-build-u1804
   commands:
+    - make setup
     - make build-client-contracts
   when:
     branch:


### PR DESCRIPTION
Adds:
- run `make setup` prior to building to ensure toolchain is present.