### PR TITLE
Change nctl to allow nodes time to stop before killing them

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -574,7 +574,7 @@ type: docker
 name: nightly-tests-cron
 
 steps:
-- name: nctl-nighly-script
+- name: nctl-nightly-script
   image: casperlabs/node-build-u1804
   environment:
     AWS_ACCESS_KEY_ID:
@@ -602,7 +602,7 @@ steps:
     - failure
     - success
   depends_on:
-  - nctl-nighly-script
+  - nctl-nightly-script
 
 trigger:
   cron: [ nightly-tests-cron, feat-fast-sync ]

--- a/utils/nctl/sh/assets/setup_supervisord.sh
+++ b/utils/nctl/sh/assets/setup_supervisord.sh
@@ -41,18 +41,19 @@ do
     PATH_NODE_BIN=$(get_path_to_node_bin "$NODE_ID")
     PATH_NODE_CONFIG=$(get_path_to_node_config "$NODE_ID")
     PATH_NODE_LOGS=$(get_path_to_node_logs "$NODE_ID")
-    
+
     cat >> "$PATH_SUPERVISOR_CONFIG" <<- EOM
 
 [program:casper-net-$NET_ID-node-$NODE_ID]
 autostart=false
 autorestart=false
-command=$PATH_NODE_BIN/casper-node-launcher 
+command=$PATH_NODE_BIN/casper-node-launcher
 environment=CASPER_BIN_DIR="$PATH_NODE_BIN",CASPER_CONFIG_DIR="$PATH_NODE_CONFIG"
 numprocs=1
 numprocs_start=0
 startsecs=0
-stopwaitsecs=0
+stopsignal=TERM
+stopwaitsecs=5
 stopasgroup=true
 stderr_logfile=$PATH_NODE_LOGS/stderr.log ;
 stderr_logfile_backups=5 ;

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -47,13 +47,12 @@ function main() {
     do_await_deploy_inclusion
     # 11. Run Health Checks
     # ... restarts=15: due to node being stopped and started
-    # ... crashes=5: expected in an emergency restart scenario?
     # ... errors=ignore: ticket sre issue 77
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='ignore' \
             equivocators=0 \
             doppels=0 \
-            crashes=5 \
+            crashes=0 \
             restarts=10 \
             ejections=0
 

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
@@ -69,12 +69,11 @@ function main() {
 
     # 7. Run Closing Health Checks
     # ... restarts=10: due to nodes being stopped and started
-    # ... crashes=5: expected in an emergency restart scenario?
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors=0 \
             equivocators=0 \
             doppels=0 \
-            crashes=5 \
+            crashes=0 \
             restarts=10 \
             ejections=0
 


### PR DESCRIPTION
This PR adjusts the supervisord config file to allow nodes time to handle a SIGTERM gracefully before a SIGKILL is sent.

Part of #1665.