### PR TITLE
NCTL: show node status and chain-height before exiting

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -110,7 +110,7 @@ function _step_04()
 {
     local NODE_ID=${1:-'5'}
     local ACCOUNT_ID=${2:-'7'}
-    local AMOUNT=${3:-'1'}
+    local AMOUNT=${3:-'500000000000'}
 
     log_step_upgrades 4 "Delegating $AMOUNT from account-$ACCOUNT_ID to validator-$NODE_ID"
 
@@ -297,7 +297,7 @@ function _step_12()
 {
     local NODE_ID=${1:-'5'}
     local ACCOUNT_ID=${2:-'7'}
-    local AMOUNT=${3:-'1'}
+    local AMOUNT=${3:-'500000000000'}
 
     log_step_upgrades 12 "Undelegating $AMOUNT to account-$ACCOUNT_ID from validator-$NODE_ID"
 

--- a/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_3.accounts.toml
+++ b/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_3.accounts.toml
@@ -46,7 +46,7 @@ balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
 bonded_amount = "1"
-delegation_rate = 5
+delegation_rate = 100
 
 # VALIDATOR 6.
 [[accounts]]

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -110,6 +110,8 @@ function check_network_sync() {
         WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
         if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
             log "ERROR: Failed to confirm network sync"
+            nctl-status
+            nctl-view-chain-height
             exit 1
         fi
         sleep 1


### PR DESCRIPTION
CHANGES:
- output node status and chain-height when sync check times out.
- sync delegation amount to new minimum