### PR TITLE
npm audit in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
       - make setup-rs
       - make doc
 
-  - name: cargo-audit
+  - name: audit
     image: casperlabs/node-build-u1804
     commands:
       - make setup-audit

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ cmake-build-debug/
 
 # vscode
 .vscode/
+.dccache
 
 # NCTL transient assets
 /utils/nctl/assets

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,17 @@ lint: lint-contracts-rs
 	$(CARGO) clippy --all-targets --all-features -- -D warnings -A renamed_and_removed_lints
 	cd smart_contracts/contract && $(CARGO) clippy --all-targets -- -D warnings -A renamed_and_removed_lints
 
-.PHONY: audit
-audit:
+.PHONY: audit-rs
+audit-rs:
 	$(CARGO) audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
+
+.PHONY: audit-as
+audit-as:
+	@# Runs a vulnerability scan that fails if there are prod vulnerabilities with a moderate level or above.
+	cd smart_contracts/contract_as && $(NPM) audit --production --audit-level=moderate
+
+.PHONY: audit
+audit: audit-rs audit-as
 
 .PHONY: doc
 doc:


### PR DESCRIPTION
This PR introduces the npm audit step for production-related libraries in CI.
If any vulnerabilities with severity >= moderate are left, the step will fail. 
