### PR TITLE
Remove Node ID Generic Parameter from Consensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ cmake-build-debug/
 
 # OS X
 .DS_Store
+
+# sw* files in vim
+.*.sw*

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -262,7 +262,7 @@ where
                                 // For every request, increase the number of in-flight...
                                 in_flight.inc(&dt_hash.into());
                                 // ...then request it.
-                                fetch_deploy(effect_builder, dt_hash, sender.clone())
+                                fetch_deploy(effect_builder, dt_hash, sender)
                             },
                         ));
                         let block_timestamp = entry.key().timestamp();

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -19,20 +19,18 @@ use crate::{
 
 use super::*;
 
-type NodeId = &'static str;
-
 #[derive(Debug, From)]
 enum ReactorEvent {
     #[from]
-    BlockValidator(Event<NodeId>),
+    BlockValidator(Event),
     #[from]
-    Fetcher(FetcherRequest<NodeId, Deploy>),
+    Fetcher(FetcherRequest<Deploy>),
     #[from]
     Storage(StorageRequest),
 }
 
-impl From<BlockValidationRequest<NodeId>> for ReactorEvent {
-    fn from(req: BlockValidationRequest<NodeId>) -> ReactorEvent {
+impl From<BlockValidationRequest> for ReactorEvent {
+    fn from(req: BlockValidationRequest) -> ReactorEvent {
         ReactorEvent::BlockValidator(req.into())
     }
 }
@@ -48,7 +46,7 @@ impl MockReactor {
         }
     }
 
-    async fn expect_block_validator_event(&self) -> Event<NodeId> {
+    async fn expect_block_validator_event(&self) -> Event {
         let ((_ancestor, reactor_event), _) = self.scheduler.pop().await;
         if let ReactorEvent::BlockValidator(event) = reactor_event {
             event
@@ -163,7 +161,7 @@ async fn validate_block(
     let reactor = MockReactor::new();
     let effect_builder = EffectBuilder::new(EventQueueHandle::without_shutdown(reactor.scheduler));
     let chainspec = Arc::new(Chainspec::from_resources("local"));
-    let mut block_validator = BlockValidator::<NodeId>::new(chainspec);
+    let mut block_validator = BlockValidator::new(chainspec);
 
     // Pass the block to the component. This future will eventually resolve to the result, i.e.
     // whether the block is valid or not.

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -165,8 +165,9 @@ async fn validate_block(
 
     // Pass the block to the component. This future will eventually resolve to the result, i.e.
     // whether the block is valid or not.
+    let bob_node_id = NodeId::random(rng);
     let validation_result =
-        tokio::spawn(effect_builder.validate_block("Bob", proposed_block.clone()));
+        tokio::spawn(effect_builder.validate_block(bob_node_id, proposed_block.clone()));
     let event = reactor.expect_block_validator_event().await;
     let effects = block_validator.handle_event(effect_builder, rng, event);
 

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -14,7 +14,7 @@ use casper_types::bytesrepr::ToBytes;
 
 use crate::{
     components::consensus::{traits::Context, ActionId, TimerId},
-    types::{TimeDiff, Timestamp},
+    types::{NodeId, TimeDiff, Timestamp},
     NodeRng,
 };
 
@@ -188,15 +188,15 @@ pub(crate) struct FinalizedBlock<C: Context> {
     pub(crate) proposer: C::ValidatorId,
 }
 
-pub(crate) type ProtocolOutcomes<I, C> = Vec<ProtocolOutcome<I, C>>;
+pub(crate) type ProtocolOutcomes<C> = Vec<ProtocolOutcome<C>>;
 
 // TODO: get rid of anyhow::Error; use variant and derive Clone and PartialEq. This is for testing.
 #[derive(Debug)]
-pub(crate) enum ProtocolOutcome<I, C: Context> {
+pub(crate) enum ProtocolOutcome<C: Context> {
     CreatedGossipMessage(Vec<u8>),
-    CreatedTargetedMessage(Vec<u8>, I),
+    CreatedTargetedMessage(Vec<u8>, NodeId),
     CreatedMessageToRandomPeer(Vec<u8>),
-    InvalidIncomingMessage(Vec<u8>, I, Error),
+    InvalidIncomingMessage(Vec<u8>, NodeId, Error),
     ScheduleTimer(Timestamp, TimerId),
     QueueAction(ActionId),
     /// Request deploys for a new block, providing the necessary context.
@@ -210,13 +210,13 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     /// that it has the expected structure, or that deploys that are mentioned by hash actually
     /// exist, and then call `ConsensusProtocol::resolve_validity`.
     ValidateConsensusValue {
-        sender: I,
+        sender: NodeId,
         proposed_block: ProposedBlock<C>,
     },
     /// New direct evidence was added against the given validator.
     NewEvidence(C::ValidatorId),
     /// Send evidence about the validator from an earlier era to the peer.
-    SendEvidence(I, C::ValidatorId),
+    SendEvidence(NodeId, C::ValidatorId),
     /// We've detected an equivocation our own node has made.
     WeAreFaulty,
     /// We've received a unit from a doppelganger.
@@ -227,11 +227,11 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     /// No progress has been made recently.
     StandstillAlert,
     /// We want to disconnect from a sender of invalid data.
-    Disconnect(I),
+    Disconnect(NodeId),
 }
 
 /// An API for a single instance of the consensus.
-pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
+pub(crate) trait ConsensusProtocol<C: Context>: Send {
     /// Upcasts consensus protocol into `dyn Any`.
     ///
     /// Typically called on a boxed trait object for downcasting afterwards.
@@ -241,26 +241,22 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn handle_message(
         &mut self,
         rng: &mut NodeRng,
-        sender: I,
+        sender: NodeId,
         msg: Vec<u8>,
         now: Timestamp,
-    ) -> ProtocolOutcomes<I, C>;
+    ) -> ProtocolOutcomes<C>;
 
     /// Current instance of consensus protocol is latest era.
-    fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<I, C>;
+    fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<C>;
 
     /// Triggers consensus' timer.
-    fn handle_timer(&mut self, timestamp: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<I, C>;
+    fn handle_timer(&mut self, timestamp: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<C>;
 
     /// Triggers a queued action.
-    fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<I, C>;
+    fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<C>;
 
     /// Proposes a new value for consensus.
-    fn propose(
-        &mut self,
-        proposed_block: ProposedBlock<C>,
-        now: Timestamp,
-    ) -> ProtocolOutcomes<I, C>;
+    fn propose(&mut self, proposed_block: ProposedBlock<C>, now: Timestamp) -> ProtocolOutcomes<C>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
     /// `ProtocolOutcome::ValidateConsensusvalue`.
@@ -269,7 +265,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
         proposed_block: ProposedBlock<C>,
         valid: bool,
         now: Timestamp,
-    ) -> ProtocolOutcomes<I, C>;
+    ) -> ProtocolOutcomes<C>;
 
     /// Turns this instance into an active validator, that participates in the consensus protocol.
     fn activate_validator(
@@ -278,7 +274,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
         secret: C::ValidatorSecret,
         timestamp: Timestamp,
         unit_hash_file: Option<PathBuf>,
-    ) -> ProtocolOutcomes<I, C>;
+    ) -> ProtocolOutcomes<C>;
 
     /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self);
@@ -293,7 +289,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn mark_faulty(&mut self, vid: &C::ValidatorId);
 
     /// Sends evidence for a faulty of validator `vid` to the `sender` of the request.
-    fn request_evidence(&self, sender: I, vid: &C::ValidatorId) -> ProtocolOutcomes<I, C>;
+    fn request_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C>;
 
     /// Sets the pause status: While paused we don't create consensus messages other than pings.
     fn set_paused(&mut self, paused: bool);

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -692,7 +692,7 @@ impl EraSupervisor {
                 self.iter_past(era_id, self.bonded_eras())
                     .flat_map(|e_id| {
                         self.delegate_to_era(effect_builder, rng, e_id, |consensus, _| {
-                            consensus.request_evidence(sender.clone(), &pub_key)
+                            consensus.request_evidence(sender, &pub_key)
                         })
                     })
                     .collect()
@@ -1097,11 +1097,7 @@ impl EraSupervisor {
                 let mut effects = Effects::new();
                 for pub_key in missing_evidence {
                     let msg = ConsensusMessage::EvidenceRequest { era_id, pub_key };
-                    effects.extend(
-                        effect_builder
-                            .send_message(sender.clone(), msg.into())
-                            .ignore(),
-                    );
+                    effects.extend(effect_builder.send_message(sender, msg.into()).ignore());
                 }
                 effects.extend(
                     async move {
@@ -1145,7 +1141,7 @@ impl EraSupervisor {
                 .iter_past_other(era_id, self.bonded_eras())
                 .flat_map(|e_id| {
                     self.delegate_to_era(effect_builder, rng, e_id, |consensus, _| {
-                        consensus.request_evidence(sender.clone(), &pub_key)
+                        consensus.request_evidence(sender, &pub_key)
                     })
                 })
                 .collect(),
@@ -1442,14 +1438,14 @@ where
         if block_header.era_id() < proposed_block_era_id {
             return Event::ResolveValidity(ResolveValidity {
                 era_id: proposed_block_era_id,
-                sender: sender.clone(),
+                sender,
                 proposed_block: proposed_block.clone(),
                 valid: false,
             });
         }
     }
 
-    let sender_for_validate_block: NodeId = sender.clone();
+    let sender_for_validate_block: NodeId = sender;
     let valid = effect_builder
         .validate_block(sender_for_validate_block, proposed_block.clone())
         .await;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -39,7 +39,6 @@ use crate::{
             ProtocolOutcome,
         },
         metrics::Metrics,
-        traits::NodeIdT,
         validator_change::ValidatorChanges,
         ActionId, Config, ConsensusMessage, Event, NewBlockPayload, ReactorEventT, ResolveValidity,
         TimerId, ValidatorChange,
@@ -52,7 +51,7 @@ use crate::{
     fatal,
     types::{
         ActivationPoint, BlockHash, BlockHeader, Deploy, DeployHash, DeployOrTransferHash,
-        FinalitySignature, FinalizedBlock, TimeDiff, Timestamp,
+        FinalitySignature, FinalizedBlock, NodeId, TimeDiff, Timestamp,
     },
     utils::WithDir,
     NodeRng,
@@ -62,7 +61,7 @@ use crate::{
 /// fault tolerance threshold.
 const FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS: u64 = 60 * 1000;
 
-type ConsensusConstructor<I> = dyn Fn(
+type ConsensusConstructor = dyn Fn(
         Digest,                    // the era's unique instance ID
         BTreeMap<PublicKey, U512>, // validator weights
         &HashSet<PublicKey>,       /* faulty validators that are banned in
@@ -70,30 +69,30 @@ type ConsensusConstructor<I> = dyn Fn(
         &HashSet<PublicKey>, // inactive validators that can't be leaders
         &ProtocolConfig,     // the network's chainspec
         &Config,             // The consensus part of the node config.
-        Option<&dyn ConsensusProtocol<I, ClContext>>, // previous era's consensus instance
+        Option<&dyn ConsensusProtocol<ClContext>>, // previous era's consensus instance
         Timestamp,           // start time for this era
         u64,                 // random seed
         Timestamp,           // now timestamp
     ) -> (
-        Box<dyn ConsensusProtocol<I, ClContext>>,
-        Vec<ProtocolOutcome<I, ClContext>>,
+        Box<dyn ConsensusProtocol<ClContext>>,
+        Vec<ProtocolOutcome<ClContext>>,
     ) + Send;
 
 #[derive(DataSize)]
-pub struct EraSupervisor<I> {
+pub struct EraSupervisor {
     /// A map of consensus protocol instances.
     /// A value is a trait so that we can run different consensus protocols per era.
     ///
     /// This map always contains exactly `2 * bonded_eras + 1` entries, with the last one being the
     /// current one.
-    open_eras: HashMap<EraId, Era<I>>,
+    open_eras: HashMap<EraId, Era>,
     secret_signing_key: Arc<SecretKey>,
     public_signing_key: PublicKey,
     current_era: EraId,
     protocol_config: ProtocolConfig,
     config: Config,
     #[data_size(skip)] // Negligible for most closures, zero for functions.
-    new_consensus: Box<ConsensusConstructor<I>>,
+    new_consensus: Box<ConsensusConstructor>,
     /// The height of the next block to be finalized.
     /// We keep that in order to be able to signal to the Block Proposer how many blocks have been
     /// finalized when we request a new block. This way the Block Proposer can know whether it's up
@@ -117,20 +116,17 @@ pub struct EraSupervisor<I> {
     era_where_we_joined: EraId,
 }
 
-impl<I> Debug for EraSupervisor<I> {
+impl Debug for EraSupervisor {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let ae: Vec<_> = self.open_eras.keys().collect();
         write!(formatter, "EraSupervisor {{ open_eras: {:?}, .. }}", ae)
     }
 }
 
-impl<I> EraSupervisor<I>
-where
-    I: NodeIdT,
-{
+impl EraSupervisor {
     /// Creates a new `EraSupervisor`, starting in the indicated current era.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new<REv: ReactorEventT<I>>(
+    pub(crate) fn new<REv: ReactorEventT>(
         current_era: EraId,
         storage_dir: &Path,
         config: WithDir<Config>,
@@ -139,8 +135,8 @@ where
         maybe_latest_block_header: Option<&BlockHeader>,
         next_upgrade_activation_point: Option<ActivationPoint>,
         registry: &Registry,
-        new_consensus: Box<ConsensusConstructor<I>>,
-    ) -> Result<(Self, Effects<Event<I>>), Error> {
+        new_consensus: Box<ConsensusConstructor>,
+    ) -> Result<(Self, Effects<Event>), Error> {
         if current_era < protocol_config.last_activation_point {
             panic!(
                 "Current era ({:?}) is before the last activation point ({:?}) - no eras would \
@@ -282,7 +278,7 @@ where
         seed: u64,
         start_time: Timestamp,
         start_height: u64,
-    ) -> Vec<ProtocolOutcome<I, ClContext>> {
+    ) -> Vec<ProtocolOutcome<ClContext>> {
         if self.open_eras.contains_key(&era_id) {
             panic!("{} already exists", era_id);
         }
@@ -449,7 +445,7 @@ where
 
     /// Returns whether the validator with the given public key is bonded in that era.
     fn is_validator_in(&self, pub_key: &PublicKey, era_id: EraId) -> bool {
-        let has_validator = |era: &Era<I>| era.validators().contains_key(pub_key);
+        let has_validator = |era: &Era| era.validators().contains_key(pub_key);
         self.open_eras.get(&era_id).map_or(false, has_validator)
     }
 
@@ -481,14 +477,14 @@ where
         }
     }
 
-    pub(super) fn handle_initialize_eras<REv: ReactorEventT<I>>(
+    pub(super) fn handle_initialize_eras<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         key_blocks: HashMap<EraId, BlockHeader>,
         booking_blocks: HashMap<EraId, BlockHash>,
         activation_era_validators: BTreeMap<PublicKey, U512>,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let mut effects = Effects::new();
         let now = Timestamp::now();
 
@@ -618,18 +614,18 @@ where
     }
 
     /// Applies `f` to the consensus protocol of the specified era.
-    fn delegate_to_era<REv: ReactorEventT<I>, F>(
+    fn delegate_to_era<REv: ReactorEventT, F>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         era_id: EraId,
         f: F,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
         F: FnOnce(
-            &mut dyn ConsensusProtocol<I, ClContext>,
+            &mut dyn ConsensusProtocol<ClContext>,
             &mut NodeRng,
-        ) -> Vec<ProtocolOutcome<I, ClContext>>,
+        ) -> Vec<ProtocolOutcome<ClContext>>,
     {
         match self.open_eras.get_mut(&era_id) {
             None => {
@@ -647,38 +643,38 @@ where
         }
     }
 
-    pub(super) fn handle_timer<REv: ReactorEventT<I>>(
+    pub(super) fn handle_timer<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         era_id: EraId,
         timestamp: Timestamp,
         timer_id: TimerId,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         self.delegate_to_era(effect_builder, rng, era_id, move |consensus, _| {
             consensus.handle_timer(timestamp, timer_id)
         })
     }
 
-    pub(super) fn handle_action<REv: ReactorEventT<I>>(
+    pub(super) fn handle_action<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         era_id: EraId,
         action_id: ActionId,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         self.delegate_to_era(effect_builder, rng, era_id, move |consensus, _| {
             consensus.handle_action(action_id, Timestamp::now())
         })
     }
 
-    pub(super) fn handle_message<REv: ReactorEventT<I>>(
+    pub(super) fn handle_message<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
-        sender: I,
+        sender: NodeId,
         msg: ConsensusMessage,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         match msg {
             ConsensusMessage::Protocol { era_id, payload } => {
                 // If the era is already unbonded, only accept new evidence, because still-bonded
@@ -704,12 +700,12 @@ where
         }
     }
 
-    pub(super) fn handle_new_block_payload<REv: ReactorEventT<I>>(
+    pub(super) fn handle_new_block_payload<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         new_block_payload: NewBlockPayload,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let NewBlockPayload {
             era_id,
             block_payload,
@@ -725,11 +721,11 @@ where
         })
     }
 
-    pub(super) fn handle_block_added<REv: ReactorEventT<I>>(
+    pub(super) fn handle_block_added<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         block_header: BlockHeader,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let our_pk = self.public_signing_key.clone();
         let our_sk = self.secret_signing_key.clone();
         let era_id = block_header.era_id();
@@ -785,13 +781,13 @@ where
         effects
     }
 
-    pub(super) fn handle_deactivate_era<REv: ReactorEventT<I>>(
+    pub(super) fn handle_deactivate_era<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         era_id: EraId,
         old_faulty_num: usize,
         delay: Duration,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let era = if let Some(era) = self.open_eras.get_mut(&era_id) {
             era
         } else {
@@ -819,13 +815,13 @@ where
     }
 
     /// Creates a new era.
-    pub(super) fn handle_create_new_era<REv: ReactorEventT<I>>(
+    pub(super) fn handle_create_new_era<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         switch_block_header: BlockHeader,
         booking_block_hash: BlockHash,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let (era_report, next_era_validators_weights) = match (
             switch_block_header.era_end(),
             switch_block_header.next_era_validator_weights(),
@@ -845,10 +841,8 @@ where
         let new_faulty = era_report.equivocators.clone();
         let era_id = switch_block_header.era_id().successor();
         info!(era = era_id.value(), "era created");
-        let seed = EraSupervisor::<I>::era_seed(
-            booking_block_hash,
-            switch_block_header.accumulated_seed(),
-        );
+        let seed =
+            EraSupervisor::era_seed(booking_block_hash, switch_block_header.accumulated_seed());
         trace!(%seed, "the seed for {}: {}", era_id, seed);
         let faulty = self
             .iter_past_other(era_id, self.banning_period())
@@ -875,12 +869,12 @@ where
         self.handle_consensus_outcomes(effect_builder, rng, era_id, outcomes)
     }
 
-    pub(super) fn resolve_validity<REv: ReactorEventT<I>>(
+    pub(super) fn resolve_validity<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
-        resolve_validity: ResolveValidity<I>,
-    ) -> Effects<Event<I>> {
+        resolve_validity: ResolveValidity,
+    ) -> Effects<Event> {
         let ResolveValidity {
             era_id,
             sender,
@@ -911,15 +905,15 @@ where
         effects
     }
 
-    fn handle_consensus_outcomes<REv: ReactorEventT<I>, T>(
+    fn handle_consensus_outcomes<REv: ReactorEventT, T>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         era_id: EraId,
         outcomes: T,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
-        T: IntoIterator<Item = ProtocolOutcome<I, ClContext>>,
+        T: IntoIterator<Item = ProtocolOutcome<ClContext>>,
     {
         outcomes
             .into_iter()
@@ -935,23 +929,23 @@ where
     }
 
     /// Returns the era with the specified ID. Panics if it does not exist.
-    fn era(&self, era_id: EraId) -> &Era<I> {
+    fn era(&self, era_id: EraId) -> &Era {
         &self.open_eras[&era_id]
     }
 
     /// Returns the era with the specified ID mutably. Panics if it does not exist.
-    fn era_mut(&mut self, era_id: EraId) -> &mut Era<I> {
+    fn era_mut(&mut self, era_id: EraId) -> &mut Era {
         self.open_eras.get_mut(&era_id).unwrap()
     }
 
     #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
-    fn handle_consensus_outcome<REv: ReactorEventT<I>>(
+    fn handle_consensus_outcome<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         era_id: EraId,
-        consensus_result: ProtocolOutcome<I, ClContext>,
-    ) -> Effects<Event<I>> {
+        consensus_result: ProtocolOutcome<ClContext>,
+    ) -> Effects<Event> {
         match consensus_result {
             ProtocolOutcome::InvalidIncomingMessage(_, sender, error) => {
                 warn!(
@@ -1179,7 +1173,7 @@ where
     pub(super) fn got_upgrade_activation_point(
         &mut self,
         activation_point: ActivationPoint,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         debug!("got {}", activation_point);
         self.next_upgrade_activation_point = Some(activation_point);
         Effects::new()
@@ -1188,7 +1182,7 @@ where
     pub(super) fn status(
         &self,
         responder: Responder<Option<(PublicKey, Option<TimeDiff>)>>,
-    ) -> Effects<Event<I>> {
+    ) -> Effects<Event> {
         let public_key = self.public_signing_key.clone();
         let round_length = self
             .open_eras
@@ -1197,11 +1191,11 @@ where
         responder.respond(Some((public_key, round_length))).ignore()
     }
 
-    fn disconnect<REv: ReactorEventT<I>>(
+    fn disconnect<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        sender: I,
-    ) -> Effects<Event<I>> {
+        sender: NodeId,
+    ) -> Effects<Event> {
         effect_builder
             .announce_disconnect_from_peer(sender)
             .ignore()
@@ -1220,16 +1214,13 @@ where
     }
 
     /// Get a reference to the era supervisor's open eras.
-    pub(crate) fn open_eras(&self) -> &HashMap<EraId, Era<I>> {
+    pub(crate) fn open_eras(&self) -> &HashMap<EraId, Era> {
         &self.open_eras
     }
 }
 
 #[cfg(test)]
-impl<I> EraSupervisor<I>
-where
-    I: NodeIdT,
-{
+impl EraSupervisor {
     /// Returns the list of validators who equivocated in this era.
     pub(crate) fn validators_with_evidence(&self, era_id: EraId) -> Vec<&PublicKey> {
         self.open_eras[&era_id].consensus.validators_with_evidence()
@@ -1424,15 +1415,14 @@ pub(crate) fn oldest_bonded_era(protocol_config: &ProtocolConfig, current_era: E
 /// previous eras. This is done by repeatedly querying storage for deploy metadata. When metadata is
 /// found storage is queried again to get the era id for the included deploy. That era id must *not*
 /// be less than the current era, otherwise the deploy is a replay attack.
-async fn check_deploys_for_replay_in_previous_eras_and_validate_block<REv, I>(
+async fn check_deploys_for_replay_in_previous_eras_and_validate_block<REv>(
     effect_builder: EffectBuilder<REv>,
     proposed_block_era_id: EraId,
-    sender: I,
+    sender: NodeId,
     proposed_block: ProposedBlock<ClContext>,
-) -> Event<I>
+) -> Event
 where
-    REv: From<BlockValidationRequest<I>> + From<StorageRequest>,
-    I: Clone + Send + 'static,
+    REv: From<BlockValidationRequest> + From<StorageRequest>,
 {
     for deploy_hash in proposed_block.value().deploys_and_transfers_iter() {
         let block_header = match effect_builder
@@ -1459,7 +1449,7 @@ where
         }
     }
 
-    let sender_for_validate_block: I = sender.clone();
+    let sender_for_validate_block: NodeId = sender.clone();
     let valid = effect_builder
         .validate_block(sender_for_validate_block, proposed_block.clone())
         .await;

--- a/node/src/components/consensus/era_supervisor/debug.rs
+++ b/node/src/components/consensus/era_supervisor/debug.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 use crate::{
     components::consensus::{highway_core::State, ClContext, HighwayProtocol},
-    types::{NodeId, Timestamp},
+    types::Timestamp,
 };
 
 use super::Era;
@@ -53,13 +53,13 @@ impl<'a> Display for EraDump<'a> {
 
 impl<'a> EraDump<'a> {
     /// Creates a new `EraDump` from a given era.
-    pub(crate) fn dump_era<I>(era: &'a Era<I>, era_id: EraId) -> Result<Self, Cow<'static, str>> {
+    pub(crate) fn dump_era(era: &'a Era, era_id: EraId) -> Result<Self, Cow<'static, str>> {
         let highway = era
             .consensus
             .as_any()
-            .downcast_ref::<HighwayProtocol<NodeId, ClContext>>()
+            .downcast_ref::<HighwayProtocol<ClContext>>()
             .ok_or(Cow::Borrowed(
-                "could not downcast `ConsensusProtocol` into `HighwayProtocol<NodeId, ClContext>`",
+                "could not downcast `ConsensusProtocol` into `HighwayProtocol<ClContext>`",
             ))?;
 
         Ok(EraDump {

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -46,9 +46,9 @@ impl ValidationState {
     }
 }
 
-pub struct Era<I> {
+pub struct Era {
     /// The consensus protocol instance.
-    pub(crate) consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
+    pub(crate) consensus: Box<dyn ConsensusProtocol<ClContext>>,
     /// The scheduled starting time of this era.
     pub(crate) start_time: Timestamp,
     /// The height of this era's first block.
@@ -69,9 +69,9 @@ pub struct Era<I> {
     pub(crate) validators: BTreeMap<PublicKey, U512>,
 }
 
-impl<I> Era<I> {
+impl Era {
     pub(crate) fn new(
-        consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
+        consensus: Box<dyn ConsensusProtocol<ClContext>>,
         start_time: Timestamp,
         start_height: u64,
         new_faulty: Vec<PublicKey>,
@@ -167,10 +167,7 @@ impl<I> Era<I> {
     }
 }
 
-impl<I> DataSize for Era<I>
-where
-    I: DataSize + 'static,
-{
+impl DataSize for Era {
     const IS_DYNAMIC: bool = true;
 
     const STATIC_HEAP_SIZE: usize = 0;
@@ -196,7 +193,7 @@ where
         let consensus_heap_size = {
             let any_ref = consensus.as_any();
 
-            if let Some(highway) = any_ref.downcast_ref::<HighwayProtocol<I, ClContext>>() {
+            if let Some(highway) = any_ref.downcast_ref::<HighwayProtocol<ClContext>>() {
                 if *CASPER_ENABLE_DETAILED_CONSENSUS_METRICS {
                     let detailed = (*highway).estimate_detailed_heap_size();
                     match serde_json::to_string(&detailed) {
@@ -210,7 +207,7 @@ where
             } else {
                 warn!(
                     "could not downcast consensus protocol to \
-                    HighwayProtocol<I, ClContext> to determine heap allocation size"
+                    HighwayProtocol<ClContext> to determine heap allocation size"
                 );
                 0
             }

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -13,9 +13,9 @@ use crate::{
     components::consensus::{
         consensus_protocol::{ProposedBlock, ProtocolOutcome, ProtocolOutcomes},
         protocols::highway::{HighwayMessage, ACTION_ID_VERTEX},
-        traits::{Context, NodeIdT},
+        traits::Context,
     },
-    types::Timestamp,
+    types::{NodeId, Timestamp},
 };
 
 use super::{
@@ -29,17 +29,17 @@ mod tests;
 /// Incoming pre-validated vertices that we haven't added to the protocol state yet, and the
 /// timestamp when we received them.
 #[derive(DataSize, Debug)]
-pub(crate) struct PendingVertices<I, C>(HashMap<PreValidatedVertex<C>, HashMap<I, Timestamp>>)
+pub(crate) struct PendingVertices<C>(HashMap<PreValidatedVertex<C>, HashMap<NodeId, Timestamp>>)
 where
     C: Context;
 
-impl<I, C: Context> Default for PendingVertices<I, C> {
+impl<C: Context> Default for PendingVertices<C> {
     fn default() -> Self {
         PendingVertices(Default::default())
     }
 }
 
-impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
+impl<C: Context> PendingVertices<C> {
     /// Removes expired vertices.
     fn remove_expired(&mut self, oldest: Timestamp) -> Vec<C::Hash> {
         let mut removed = vec![];
@@ -58,7 +58,7 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     }
 
     /// Adds a vertex, or updates its timestamp.
-    fn add(&mut self, sender: I, pvv: PreValidatedVertex<C>, time_received: Timestamp) {
+    fn add(&mut self, sender: NodeId, pvv: PreValidatedVertex<C>, time_received: Timestamp) {
         self.0
             .entry(pvv)
             .or_default()
@@ -68,18 +68,18 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     }
 
     /// Adds a holder to the vertex that satisfies `dep`.
-    fn add_holder(&mut self, dep: &Dependency<C>, sender: I, time_received: Timestamp) {
+    fn add_holder(&mut self, dep: &Dependency<C>, sender: NodeId, time_received: Timestamp) {
         if let Some((_, holders)) = self.0.iter_mut().find(|(pvv, _)| pvv.inner().id() == *dep) {
             holders.entry(sender).or_insert(time_received);
         }
     }
 
     /// Adds a vertex, or updates its timestamp.
-    fn push(&mut self, pv: PendingVertex<I, C>) {
+    fn push(&mut self, pv: PendingVertex<C>) {
         self.add(pv.sender, pv.pvv, pv.time_received)
     }
 
-    fn pop(&mut self) -> Option<PendingVertex<I, C>> {
+    fn pop(&mut self) -> Option<PendingVertex<C>> {
         let pvv = self.0.keys().next()?.clone();
         let (sender, timestamp, is_empty) = {
             let time_by_sender = self.0.get_mut(&pvv)?;
@@ -113,8 +113,8 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     }
 }
 
-impl<I: NodeIdT, C: Context> Iterator for PendingVertices<I, C> {
-    type Item = PendingVertex<I, C>;
+impl<C: Context> Iterator for PendingVertices<C> {
+    type Item = PendingVertex<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.pop()
@@ -123,21 +123,25 @@ impl<I: NodeIdT, C: Context> Iterator for PendingVertices<I, C> {
 
 /// An incoming pre-validated vertex that we haven't added to the protocol state yet.
 #[derive(DataSize, Debug)]
-pub(crate) struct PendingVertex<I, C>
+pub(crate) struct PendingVertex<C>
 where
     C: Context,
 {
     /// The peer who sent it to us.
-    sender: I,
+    sender: NodeId,
     /// The pre-validated vertex.
     pvv: PreValidatedVertex<C>,
     /// The time when we received it.
     time_received: Timestamp,
 }
 
-impl<I, C: Context> PendingVertex<I, C> {
+impl<C: Context> PendingVertex<C> {
     /// Returns a new pending vertex with the current timestamp.
-    pub(crate) fn new(sender: I, pvv: PreValidatedVertex<C>, time_received: Timestamp) -> Self {
+    pub(crate) fn new(
+        sender: NodeId,
+        pvv: PreValidatedVertex<C>,
+        time_received: Timestamp,
+    ) -> Self {
         Self {
             sender,
             pvv,
@@ -146,7 +150,7 @@ impl<I, C: Context> PendingVertex<I, C> {
     }
 
     /// Returns the peer from which we received this vertex.
-    pub(crate) fn sender(&self) -> &I {
+    pub(crate) fn sender(&self) -> &NodeId {
         &self.sender
     }
 
@@ -161,25 +165,25 @@ impl<I, C: Context> PendingVertex<I, C> {
     }
 }
 
-impl<I, C: Context> From<PendingVertex<I, C>> for PreValidatedVertex<C> {
-    fn from(vertex: PendingVertex<I, C>) -> Self {
+impl<C: Context> From<PendingVertex<C>> for PreValidatedVertex<C> {
+    fn from(vertex: PendingVertex<C>) -> Self {
         vertex.pvv
     }
 }
 
 #[derive(DataSize, Debug)]
-pub(crate) struct Synchronizer<I, C>
+pub(crate) struct Synchronizer<C>
 where
     C: Context,
 {
     /// Incoming vertices we can't add yet because they are still missing a dependency.
-    vertices_awaiting_deps: BTreeMap<Dependency<C>, PendingVertices<I, C>>,
+    vertices_awaiting_deps: BTreeMap<Dependency<C>, PendingVertices<C>>,
     /// The vertices that are scheduled to be processed at a later time.  The keys of this
     /// `BTreeMap` are timestamps when the corresponding vector of vertices will be added.
-    vertices_to_be_added_later: BTreeMap<Timestamp, PendingVertices<I, C>>,
+    vertices_to_be_added_later: BTreeMap<Timestamp, PendingVertices<C>>,
     /// Vertices that might be ready to add to the protocol state: We are not currently waiting for
     /// a requested dependency.
-    vertices_no_deps: PendingVertices<I, C>,
+    vertices_no_deps: PendingVertices<C>,
     /// Instance ID of an era for which this synchronizer is constructed.
     instance_id: C::InstanceId,
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
@@ -187,12 +191,12 @@ where
     oldest_seen_panorama: ValidatorMap<Option<u64>>,
     /// Keeps track of the requests we've sent so far and the recipients.
     /// Used to decide whether we should ask more nodes for a particular dependency.
-    requests_sent: BTreeMap<Dependency<C>, HashSet<I>>,
+    requests_sent: BTreeMap<Dependency<C>, HashSet<NodeId>>,
     /// Boolean flag indicating whether we're synchronizing current era.
     pub(crate) current_era: bool,
 }
 
-impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
+impl<C: Context + 'static> Synchronizer<C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
     pub(crate) fn new(validator_len: usize, instance_id: C::InstanceId) -> Self {
         Synchronizer {
@@ -270,7 +274,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         &mut self,
         future_timestamp: Timestamp,
         now: Timestamp,
-        sender: I,
+        sender: NodeId,
         pvv: PreValidatedVertex<C>,
     ) {
         self.vertices_to_be_added_later
@@ -286,7 +290,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     pub(crate) fn add_past_due_stored_vertices(
         &mut self,
         timestamp: Timestamp,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         let mut results = vec![];
         let past_due_timestamps: Vec<Timestamp> = self
             .vertices_to_be_added_later
@@ -306,10 +310,10 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Schedules a vertex to be added to the protocol state.
     pub(crate) fn schedule_add_vertex(
         &mut self,
-        sender: I,
+        sender: NodeId,
         pvv: PreValidatedVertex<C>,
         now: Timestamp,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         self.update_last_seen(&pvv);
         let pv = PendingVertex::new(sender, pvv, now);
         self.schedule_add_vertices(iter::once(pv))
@@ -325,7 +329,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     /// Moves all vertices whose known missing dependency is now satisfied into the
     /// `vertices_to_be_added` queue.
-    pub(crate) fn remove_satisfied_deps(&mut self, highway: &Highway<C>) -> ProtocolOutcomes<I, C> {
+    pub(crate) fn remove_satisfied_deps(&mut self, highway: &Highway<C>) -> ProtocolOutcomes<C> {
         let satisfied_deps = self
             .vertices_awaiting_deps
             .keys()
@@ -349,9 +353,9 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     pub(crate) fn pop_vertex_to_add(
         &mut self,
         highway: &Highway<C>,
-        pending_values: &HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, I)>>,
+        pending_values: &HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, NodeId)>>,
         max_requests_for_vertex: usize,
-    ) -> (Option<PendingVertex<I, C>>, ProtocolOutcomes<I, C>) {
+    ) -> (Option<PendingVertex<C>>, ProtocolOutcomes<C>) {
         let mut outcomes = Vec::new();
         // Get the next vertex to be added; skip the ones that are already in the protocol state,
         // and the ones that are still missing dependencies.
@@ -447,7 +451,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     fn find_transitive_dependency(
         &mut self,
         mut missing_dependency: Dependency<C>,
-        sender: &I,
+        sender: &NodeId,
         time_received: Timestamp,
     ) -> Dependency<C> {
         // If `missing_dependency` is already downloaded and waiting for its dependency to be
@@ -466,7 +470,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     }
 
     /// Adds a vertex with a known missing dependency to the queue.
-    fn add_missing_dependency(&mut self, dep: Dependency<C>, pv: PendingVertex<I, C>) {
+    fn add_missing_dependency(&mut self, dep: Dependency<C>, pv: PendingVertex<C>) {
         self.vertices_awaiting_deps.entry(dep).or_default().push(pv)
     }
 
@@ -485,7 +489,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and
     /// returns the set of their senders. If the specified dependencies are known to be invalid,
     /// those senders must be faulty.
-    pub(crate) fn invalid_vertices(&mut self, mut vertices: Vec<Dependency<C>>) -> HashSet<I> {
+    pub(crate) fn invalid_vertices(&mut self, mut vertices: Vec<Dependency<C>>) -> HashSet<NodeId> {
         let mut senders = HashSet::new();
         while !vertices.is_empty() {
             let (new_vertices, new_senders) = self.do_drop_dependent_vertices(vertices);
@@ -504,9 +508,9 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     }
 
     /// Schedules vertices to be added to the protocol state.
-    fn schedule_add_vertices<T>(&mut self, pending_vertices: T) -> ProtocolOutcomes<I, C>
+    fn schedule_add_vertices<T>(&mut self, pending_vertices: T) -> ProtocolOutcomes<C>
     where
-        T: IntoIterator<Item = PendingVertex<I, C>>,
+        T: IntoIterator<Item = PendingVertex<C>>,
     {
         let was_empty = self.vertices_no_deps.is_empty();
         for pv in pending_vertices {
@@ -524,7 +528,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     fn do_drop_dependent_vertices(
         &mut self,
         vertices: Vec<Dependency<C>>,
-    ) -> (Vec<Dependency<C>>, HashSet<I>) {
+    ) -> (Vec<Dependency<C>>, HashSet<NodeId>) {
         // collect the vertices that depend on the ones we got in the argument and their senders
         vertices
             .into_iter()
@@ -540,7 +544,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     /// Removes all expired entries from a `BTreeMap` of `Vec`s.
     fn remove_expired<T: Ord + Clone>(
-        map: &mut BTreeMap<T, PendingVertices<I, C>>,
+        map: &mut BTreeMap<T, PendingVertices<C>>,
         oldest: Timestamp,
     ) -> Vec<C::Hash> {
         let mut expired = vec![];

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -83,7 +83,7 @@ impl<C: Context> PendingVertices<C> {
         let pvv = self.0.keys().next()?.clone();
         let (sender, timestamp, is_empty) = {
             let time_by_sender = self.0.get_mut(&pvv)?;
-            let sender = time_by_sender.keys().next()?.clone();
+            let sender = *time_by_sender.keys().next()?;
             let timestamp = time_by_sender.remove(&sender)?;
             (sender, timestamp, time_by_sender.is_empty())
         };
@@ -366,7 +366,7 @@ impl<C: Context + 'static> Synchronizer<C> {
                 Some(pv) => pv,
             };
             if let Some(dep) = highway.missing_dependency(pv.pvv()) {
-                let sender = pv.sender().clone();
+                let sender = *pv.sender();
                 let time_received = pv.time_received;
                 // Find the first dependency that `pv` needs that we haven't synchronized yet
                 // and request it from the sender of `pv`. Since it relies on it, it should have
@@ -426,7 +426,7 @@ impl<C: Context + 'static> Synchronizer<C> {
                     .requests_sent
                     .entry(transitive_dependency.clone())
                     .or_default();
-                if entry.len() >= max_requests_for_vertex || !entry.insert(sender.clone()) {
+                if entry.len() >= max_requests_for_vertex || !entry.insert(sender) {
                     continue;
                 }
                 // Otherwise request the missing dependency from the sender.
@@ -463,7 +463,7 @@ impl<C: Context + 'static> Synchronizer<C> {
             .iter_mut()
             .find(|(_, pvs)| pvs.contains_dependency(&missing_dependency))
         {
-            pvs.add_holder(&missing_dependency, sender.clone(), time_received);
+            pvs.add_holder(&missing_dependency, *sender, time_received);
             missing_dependency = next_missing.clone();
         }
         missing_dependency

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -43,7 +43,7 @@ fn purge_vertices() {
     // Returns the PreValidatedVertex with the specified hash.
     let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
 
-    let peer0 = NodeId(0);
+    let peer0 = NodeId::from([0; 64]);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
@@ -144,8 +144,8 @@ fn do_not_download_synchronized_dependencies() {
     // Returns the PreValidatedVertex with the specified hash.
     let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
 
-    let peer0 = NodeId(0);
-    let peer1 = NodeId(1);
+    let peer0 = NodeId::from([0; 64]);
+    let peer1 = NodeId::from([1; 64]);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
@@ -248,8 +248,8 @@ fn transitive_proposal_dependency() {
     // Returns the PreValidatedVertex with the specified hash.
     let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
 
-    let peer0 = NodeId(0);
-    let peer1 = NodeId(1);
+    let peer0 = NodeId::from([0; 64]);
+    let peer1 = NodeId::from([1; 64]);
 
     // Create a synchronizer with a 0x200 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -1,21 +1,20 @@
 use std::collections::BTreeSet;
 
-use derive_more::Display;
 use itertools::Itertools;
 
-use crate::components::consensus::{
-    highway_core::{
-        highway::{tests::test_validators, ValidVertex},
-        highway_testing::TEST_INSTANCE_ID,
-        state::{tests::*, State},
+use crate::{
+    components::consensus::{
+        highway_core::{
+            highway::{tests::test_validators, ValidVertex},
+            highway_testing::TEST_INSTANCE_ID,
+            state::{tests::*, State},
+        },
+        BlockContext,
     },
-    BlockContext,
+    types::NodeId,
 };
 
 use super::*;
-
-#[derive(DataSize, Debug, Ord, PartialOrd, Copy, Clone, Display, Hash, Eq, PartialEq)]
-pub(crate) struct NodeId(pub u8);
 
 #[test]
 fn purge_vertices() {
@@ -48,7 +47,7 @@ fn purge_vertices() {
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
+    let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.
@@ -150,7 +149,7 @@ fn do_not_download_synchronized_dependencies() {
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
+    let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
 
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
     let now = 0x20.into();
@@ -254,7 +253,7 @@ fn transitive_proposal_dependency() {
 
     // Create a synchronizer with a 0x200 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
+    let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
 
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
     let now = 0x100.into();
@@ -363,7 +362,7 @@ fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {
 }
 
 fn assert_targeted_message(
-    outcome: &ProtocolOutcome<NodeId, TestContext>,
+    outcome: &ProtocolOutcome<TestContext>,
     peer: &NodeId,
     expected: Dependency<TestContext>,
 ) {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -327,7 +327,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
 
         // If the vertex is invalid, drop all vertices that depend on this one, and disconnect from
         // the faulty senders.
-        let sender = pending_vertex.sender().clone();
+        let sender = *pending_vertex.sender();
         let vv = match self.highway.validate_vertex(pending_vertex.into()) {
             Ok(vv) => vv,
             Err((pvv, err)) => {
@@ -355,7 +355,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
                     .pending_values
                     .entry(proposed_block.clone())
                     .or_default()
-                    .insert((vv, sender.clone()))
+                    .insert((vv, sender))
                 {
                     outcomes.push(ProtocolOutcome::ValidateConsensusValue {
                         sender,
@@ -891,7 +891,7 @@ where
                     .map(create_message)
                     .flat_map(|msgs| {
                         msgs.into_iter().map(|msg| {
-                            ProtocolOutcome::CreatedTargetedMessage(msg.serialize(), sender.clone())
+                            ProtocolOutcome::CreatedTargetedMessage(msg.serialize(), sender)
                         })
                     })
                     .collect()

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -38,10 +38,10 @@ use crate::{
             synchronizer::Synchronizer,
             validators::{ValidatorIndex, Validators},
         },
-        traits::{ConsensusValueT, Context, NodeIdT},
+        traits::{ConsensusValueT, Context},
         ActionId, TimerId,
     },
-    types::{TimeDiff, Timestamp},
+    types::{NodeId, TimeDiff, Timestamp},
     NodeRng,
 };
 
@@ -70,18 +70,17 @@ const TIMER_ID_REQUEST_STATE: TimerId = TimerId(6);
 pub(crate) const ACTION_ID_VERTEX: ActionId = ActionId(0);
 
 #[derive(DataSize, Debug)]
-pub(crate) struct HighwayProtocol<I, C>
+pub(crate) struct HighwayProtocol<C>
 where
-    I: DataSize,
     C: Context,
 {
     /// Incoming blocks we can't add yet because we are waiting for validation.
-    pending_values: HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, I)>>,
+    pending_values: HashMap<ProposedBlock<C>, HashSet<(ValidVertex<C>, NodeId)>>,
     finality_detector: FinalityDetector<C>,
     highway: Highway<C>,
     /// A tracker for whether we are keeping up with the current round exponent or not.
     round_success_meter: RoundSuccessMeter<C>,
-    synchronizer: Synchronizer<I, C>,
+    synchronizer: Synchronizer<C>,
     pvv_cache: HashMap<Dependency<C>, PreValidatedVertex<C>>,
     evidence_only: bool,
     /// The panorama snapshot. This is updated periodically, and if it does not change for too
@@ -90,7 +89,7 @@ where
     config: config::Config,
 }
 
-impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
+impl<C: Context + 'static> HighwayProtocol<C> {
     /// Creates a new boxed `HighwayProtocol` instance.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub(crate) fn new_boxed(
@@ -100,11 +99,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         inactive: &HashSet<C::ValidatorId>,
         protocol_config: &ProtocolConfig,
         config: &Config,
-        prev_cp: Option<&dyn ConsensusProtocol<I, C>>,
+        prev_cp: Option<&dyn ConsensusProtocol<C>>,
         era_start_time: Timestamp,
         seed: u64,
         now: Timestamp,
-    ) -> (Box<dyn ConsensusProtocol<I, C>>, ProtocolOutcomes<I, C>) {
+    ) -> (Box<dyn ConsensusProtocol<C>>, ProtocolOutcomes<C>) {
         let validators_count = validator_stakes.len();
         let sum_stakes: U512 = validator_stakes.iter().map(|(_, stake)| *stake).sum();
         assert!(
@@ -143,7 +142,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         let ftt = (ftt as u64).into();
 
         let round_success_meter = prev_cp
-            .and_then(|cp| cp.as_any().downcast_ref::<HighwayProtocol<I, C>>())
+            .and_then(|cp| cp.as_any().downcast_ref::<HighwayProtocol<C>>())
             .map(|highway_proto| highway_proto.next_era_round_succ_meter(era_start_time.max(now)))
             .unwrap_or_else(|| {
                 RoundSuccessMeter::new(
@@ -210,7 +209,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         now: Timestamp,
         era_start_time: Timestamp,
         config: &config::Config,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         let mut outcomes = vec![ProtocolOutcome::ScheduleTimer(
             now + config.pending_vertex_timeout,
             TIMER_ID_PURGE_VERTICES,
@@ -236,7 +235,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         outcomes
     }
 
-    fn process_av_effects<E>(&mut self, av_effects: E, now: Timestamp) -> ProtocolOutcomes<I, C>
+    fn process_av_effects<E>(&mut self, av_effects: E, now: Timestamp) -> ProtocolOutcomes<C>
     where
         E: IntoIterator<Item = AvEffect<C>>,
     {
@@ -246,7 +245,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             .collect()
     }
 
-    fn process_av_effect(&mut self, effect: AvEffect<C>, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn process_av_effect(&mut self, effect: AvEffect<C>, now: Timestamp) -> ProtocolOutcomes<C> {
         match effect {
             AvEffect::NewVertex(vv) => {
                 self.log_unit_size(vv.inner(), "sending new unit");
@@ -269,7 +268,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         }
     }
 
-    fn process_new_vertex(&mut self, vv: ValidVertex<C>) -> ProtocolOutcomes<I, C> {
+    fn process_new_vertex(&mut self, vv: ValidVertex<C>) -> ProtocolOutcomes<C> {
         let mut outcomes = Vec::new();
         if let Vertex::Evidence(ev) = vv.inner() {
             let v_id = self
@@ -286,7 +285,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         outcomes
     }
 
-    fn detect_finality(&mut self) -> ProtocolOutcomes<I, C> {
+    fn detect_finality(&mut self) -> ProtocolOutcomes<C> {
         let faulty_weight = match self.finality_detector.run(&self.highway) {
             Ok(iter) => return iter.map(ProtocolOutcome::FinalizedBlock).collect(),
             Err(FttExceeded(weight)) => weight.0,
@@ -303,7 +302,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     /// Adds the given vertices to the protocol state, if possible, or requests missing
     /// dependencies or validation. Recursively schedules events to add everything that is
     /// unblocked now.
-    fn add_vertex(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn add_vertex(&mut self, now: Timestamp) -> ProtocolOutcomes<C> {
         let (maybe_pending_vertex, mut outcomes) = self.synchronizer.pop_vertex_to_add(
             &self.highway,
             &self.pending_values,
@@ -400,7 +399,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         self.highway.set_round_exp(new_round_exp);
     }
 
-    fn add_valid_vertex(&mut self, vv: ValidVertex<C>, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn add_valid_vertex(&mut self, vv: ValidVertex<C>, now: Timestamp) -> ProtocolOutcomes<C> {
         if self.evidence_only && !vv.inner().is_evidence() {
             error!(vertex = ?vv.inner(), "unexpected vertex in evidence-only mode");
             return vec![];
@@ -475,7 +474,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 
     /// Request the latest state from a random peer.
-    fn handle_request_state_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn handle_request_state_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<C> {
         if self.evidence_only || self.finalized_switch_block() {
             return vec![]; // Era has ended. No further progress is expected.
         }
@@ -495,7 +494,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 
     /// Returns a `StandstillAlert` if no progress was made; otherwise schedules the next check.
-    fn handle_standstill_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn handle_standstill_alert_timer(&mut self, now: Timestamp) -> ProtocolOutcomes<C> {
         if self.evidence_only || self.finalized_switch_block() {
             // Era has ended and no further progress is expected, or shutdown on standstill is
             // turned off.
@@ -611,7 +610,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 
     /// Creates a message to send our panorama to a random peer.
-    fn latest_state_request(&self) -> ProtocolOutcomes<I, C> {
+    fn latest_state_request(&self) -> ProtocolOutcomes<C> {
         let request: HighwayMessage<C> = HighwayMessage::LatestStateRequest(
             IndexPanorama::from_panorama(self.highway.state().panorama(), self.highway.state()),
         );
@@ -722,18 +721,17 @@ impl<C: Context> HighwayMessage<C> {
     }
 }
 
-impl<I, C> ConsensusProtocol<I, C> for HighwayProtocol<I, C>
+impl<C> ConsensusProtocol<C> for HighwayProtocol<C>
 where
-    I: NodeIdT,
     C: Context + 'static,
 {
     fn handle_message(
         &mut self,
         rng: &mut NodeRng,
-        sender: I,
+        sender: NodeId,
         msg: Vec<u8>,
         now: Timestamp,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         match bincode::deserialize(msg.as_slice()) {
             Err(err) => vec![ProtocolOutcome::InvalidIncomingMessage(
                 msg,
@@ -901,7 +899,7 @@ where
         }
     }
 
-    fn handle_timer(&mut self, now: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<I, C> {
+    fn handle_timer(&mut self, now: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<C> {
         match timer_id {
             TIMER_ID_ACTIVE_VALIDATOR => {
                 let effects = self.highway.handle_timer(now);
@@ -941,7 +939,7 @@ where
         }
     }
 
-    fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<C> {
         // Request latest protocol state of the current era.
         let mut outcomes = self.latest_state_request();
         // If configured, schedule periodic latest state requests.
@@ -954,18 +952,14 @@ where
         outcomes
     }
 
-    fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<I, C> {
+    fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<C> {
         match action_id {
             ACTION_ID_VERTEX => self.add_vertex(now),
             _ => unreachable!("unexpected action ID"),
         }
     }
 
-    fn propose(
-        &mut self,
-        proposed_block: ProposedBlock<C>,
-        now: Timestamp,
-    ) -> ProtocolOutcomes<I, C> {
+    fn propose(&mut self, proposed_block: ProposedBlock<C>, now: Timestamp) -> ProtocolOutcomes<C> {
         let (value, block_context) = proposed_block.destructure();
         let effects = self.highway.propose(value, block_context);
         self.process_av_effects(effects, now)
@@ -976,7 +970,7 @@ where
         proposed_block: ProposedBlock<C>,
         valid: bool,
         now: Timestamp,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         if valid {
             let mut outcomes = self
                 .pending_values
@@ -1016,7 +1010,7 @@ where
         secret: C::ValidatorSecret,
         now: Timestamp,
         unit_hash_file: Option<PathBuf>,
-    ) -> ProtocolOutcomes<I, C> {
+    ) -> ProtocolOutcomes<C> {
         let ftt = self.finality_detector.fault_tolerance_threshold();
         let av_effects = self
             .highway
@@ -1045,7 +1039,7 @@ where
         self.highway.mark_faulty(vid);
     }
 
-    fn request_evidence(&self, sender: I, vid: &C::ValidatorId) -> ProtocolOutcomes<I, C> {
+    fn request_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
         self.highway
             .validators()
             .get_index(vid)

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -18,12 +18,14 @@ use crate::{
             config::Config as HighwayConfig, HighwayMessage, ACTION_ID_VERTEX,
             TIMER_ID_STANDSTILL_ALERT,
         },
-        tests::utils::{new_test_chainspec, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_PUBLIC_KEY},
+        tests::utils::{
+            new_test_chainspec, ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_PUBLIC_KEY,
+        },
         traits::Context,
         HighwayProtocol,
     },
     testing::TestRng,
-    types::{BlockPayload, NodeId, TimeDiff, Timestamp},
+    types::{BlockPayload, TimeDiff, Timestamp},
 };
 
 /// Returns a new `State` with `ClContext` parameters suitable for tests.
@@ -108,7 +110,7 @@ fn test_highway_protocol_handle_message_parse_error() {
 
     let mut rng = TestRng::new();
     let now = Timestamp::zero();
-    let sender = NodeId::random(&mut rng);
+    let sender = *ALICE_NODE_ID;
     let msg = vec![];
     let mut effects: Vec<ProtocolOutcome<ClContext>> =
         highway_protocol.handle_message(&mut rng, sender.to_owned(), msg.to_owned(), now);
@@ -156,7 +158,7 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
         SignedWireUnit::new(wunit.into_hashed(), &alice_keypair),
     ));
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
-    let sender = NodeId::random(&mut rng);
+    let sender = *ALICE_NODE_ID;
     let msg = bincode::serialize(&highway_message).unwrap();
     let mut outcomes =
         highway_protocol.handle_message(&mut rng, sender.to_owned(), msg.to_owned(), now);
@@ -211,7 +213,7 @@ fn send_a_valid_wire_unit() {
     ));
 
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
-    let sender = NodeId::random(&mut rng);
+    let sender = *ALICE_NODE_ID;
     let msg = bincode::serialize(&highway_message).unwrap();
 
     let mut outcomes = highway_protocol.handle_message(&mut rng, sender, msg, now);
@@ -279,7 +281,7 @@ fn detect_doppelganger() {
     // Activate ALICE as validator.
     let _ = highway_protocol.activate_validator(ALICE_PUBLIC_KEY.clone(), alice_keypair, now, None);
     assert!(highway_protocol.is_active());
-    let sender = NodeId::random(&mut rng);
+    let sender = *ALICE_NODE_ID;
     let msg = bincode::serialize(&highway_message).unwrap();
     // "Send" a message created by ALICE to an instance of Highway where she's an active validator.
     // An incoming unit, created by the same validator, should be properly detected as a

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -6,9 +6,10 @@ use once_cell::sync::Lazy;
 use casper_types::{system::auction::DelegationRate, Motes, PublicKey, SecretKey, U512};
 
 use crate::{
+    tls::{KeyFingerprint, Sha512},
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        ActivationPoint, Chainspec, Timestamp,
+        ActivationPoint, Chainspec, NodeId, Timestamp,
     },
     utils::Loadable,
 };
@@ -16,6 +17,12 @@ use crate::{
 pub static ALICE_SECRET_KEY: Lazy<Arc<SecretKey>> =
     Lazy::new(|| Arc::new(SecretKey::ed25519_from_bytes([0; SecretKey::ED25519_LENGTH]).unwrap()));
 pub static ALICE_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&**ALICE_SECRET_KEY));
+pub static ALICE_NODE_ID: Lazy<NodeId> = Lazy::new(|| {
+    NodeId::from(KeyFingerprint::from(Sha512::new(match *ALICE_PUBLIC_KEY {
+        PublicKey::Ed25519(pub_key) => pub_key,
+        _ => panic!("ALICE_PUBLIC_KEY is Ed25519"),
+    })))
+});
 
 pub static BOB_PRIVATE_KEY: Lazy<SecretKey> =
     Lazy::new(|| SecretKey::ed25519_from_bytes([1; SecretKey::ED25519_LENGTH]).unwrap());

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -6,9 +6,6 @@ use std::{
 use datasize::DataSize;
 use serde::{de::DeserializeOwned, Serialize};
 
-pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
-impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
-
 /// A validator identifier.
 pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display {}
 impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -25,7 +25,7 @@ pub enum ValidatorChange {
 pub(super) struct ValidatorChanges(pub(super) Vec<(PublicKey, ValidatorChange)>);
 
 impl ValidatorChanges {
-    pub(super) fn new<I>(era0: &Era<I>, era1: &Era<I>) -> Self {
+    pub(super) fn new(era0: &Era, era1: &Era) -> Self {
         let era0_metadata = EraMetadata::from(era0);
         let era1_metadata = EraMetadata::from(era1);
         Self::new_from_metadata(era0_metadata, era1_metadata)
@@ -95,8 +95,8 @@ struct EraMetadata<'a> {
     cannot_propose: &'a HashSet<PublicKey>,
 }
 
-impl<'a, I> From<&'a Era<I>> for EraMetadata<'a> {
-    fn from(era: &'a Era<I>) -> Self {
+impl<'a> From<&'a Era> for EraMetadata<'a> {
+    fn from(era: &'a Era) -> Self {
         let seen_as_faulty = era
             .consensus
             .validators_with_evidence()

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -492,7 +492,10 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                ref
+                contract_package_identifier
+                @
+                ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },
@@ -593,7 +596,10 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                ref
+                contract_package_identifier
+                @
+                ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -600,7 +600,7 @@ impl DeployAcceptor {
             ) => {
                 let query_key = Key::from(contract_package_hash);
                 let path = vec![];
-                let maybe_contract_version = contract_package_identifier.version();
+                let maybe_package_version = contract_package_identifier.version();
                 effect_builder
                     .get_contract_package_for_validation(prestate_hash, query_key, path)
                     .event(

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -492,10 +492,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },
@@ -596,10 +593,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -33,8 +33,7 @@ use crate::{
         EffectBuilder, EffectExt, Effects, Responder,
     },
     types::{
-        chainspec::DeployConfig, Block, Chainspec, Deploy, DeployConfigurationFailure, NodeId,
-        Timestamp,
+        chainspec::DeployConfig, Block, Chainspec, Deploy, DeployConfigurationFailure, Timestamp,
     },
     utils::Source,
     NodeRng,
@@ -125,7 +124,7 @@ pub(crate) enum DeployParameterFailure {
 /// A helper trait constraining `DeployAcceptor` compatible reactor events.
 pub(crate) trait ReactorEventT:
     From<Event>
-    + From<DeployAcceptorAnnouncement<NodeId>>
+    + From<DeployAcceptorAnnouncement>
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
     + Send
@@ -134,7 +133,7 @@ pub(crate) trait ReactorEventT:
 
 impl<REv> ReactorEventT for REv where
     REv: From<Event>
-        + From<DeployAcceptorAnnouncement<NodeId>>
+        + From<DeployAcceptorAnnouncement>
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
         + Send
@@ -180,7 +179,7 @@ impl DeployAcceptor {
         &mut self,
         effect_builder: EffectBuilder<REv>,
         deploy: Box<Deploy>,
-        source: Source<NodeId>,
+        source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Effects<Event> {
         let verification_start_timestamp = Timestamp::now();
@@ -492,12 +491,15 @@ impl DeployAcceptor {
                         verification_start_timestamp,
                     })
             }
-            ExecutableDeployItemIdentifier::Package(ContractPackageIdentifier::Hash {
-                contract_package_hash,
-                version: maybe_package_version,
-            }) => {
+            ExecutableDeployItemIdentifier::Package(
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                    contract_package_hash,
+                    ..
+                },
+            ) => {
                 let query_key = Key::from(contract_package_hash);
                 let path = vec![];
+                let maybe_package_version = contract_package_identifier.version();
                 effect_builder
                     .get_contract_package_for_validation(prestate_hash, query_key, path)
                     .event(
@@ -590,12 +592,15 @@ impl DeployAcceptor {
                         verification_start_timestamp,
                     })
             }
-            ExecutableDeployItemIdentifier::Package(ContractPackageIdentifier::Hash {
-                contract_package_hash,
-                version: maybe_package_version,
-            }) => {
+            ExecutableDeployItemIdentifier::Package(
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
+                    contract_package_hash,
+                    ..
+                },
+            ) => {
                 let query_key = Key::from(contract_package_hash);
                 let path = vec![];
+                let maybe_contract_version = contract_package_identifier.version();
                 effect_builder
                     .get_contract_package_for_validation(prestate_hash, query_key, path)
                     .event(

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -6,7 +6,7 @@ use super::Source;
 use crate::{
     components::deploy_acceptor::Error,
     effect::{announcements::RpcServerAnnouncement, Responder},
-    types::{Block, Deploy, NodeId, Timestamp},
+    types::{Block, Deploy, Timestamp},
 };
 
 use casper_hashing::Digest;
@@ -19,14 +19,14 @@ use casper_types::{
 #[derive(Debug, Serialize)]
 pub(crate) struct EventMetadata {
     pub(super) deploy: Box<Deploy>,
-    pub(super) source: Source<NodeId>,
+    pub(super) source: Source,
     pub(super) maybe_responder: Option<Responder<Result<(), Error>>>,
 }
 
 impl EventMetadata {
     pub(super) fn new(
         deploy: Box<Deploy>,
-        source: Source<NodeId>,
+        source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Self {
         EventMetadata {
@@ -43,7 +43,7 @@ pub(crate) enum Event {
     /// The initiating event to accept a new `Deploy`.
     Accept {
         deploy: Box<Deploy>,
-        source: Source<NodeId>,
+        source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
@@ -104,7 +104,7 @@ impl From<RpcServerAnnouncement> for Event {
         match announcement {
             RpcServerAnnouncement::DeployReceived { deploy, responder } => Event::Accept {
                 deploy,
-                source: Source::<NodeId>::Client,
+                source: Source::Client,
                 maybe_responder: responder,
             },
         }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -56,7 +56,7 @@ enum Event {
     #[from]
     ControlAnnouncement(ControlAnnouncement),
     #[from]
-    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement<NodeId>),
+    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     #[from]
     ContractRuntime(#[serde(skip_serializing)] ContractRuntimeRequest),
 }
@@ -154,7 +154,7 @@ enum TestScenario {
 }
 
 impl TestScenario {
-    fn source(&self, rng: &mut NodeRng) -> Source<NodeId> {
+    fn source(&self, rng: &mut NodeRng) -> Source {
         match self {
             TestScenario::FromPeerInvalidDeploy
             | TestScenario::FromPeerValidDeploy
@@ -628,7 +628,7 @@ fn put_deploy_to_storage(
 
 fn schedule_accept_deploy(
     deploy: Box<Deploy>,
-    source: Source<NodeId>,
+    source: Source,
     responder: Responder<Result<(), super::Error>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
@@ -648,7 +648,7 @@ fn schedule_accept_deploy(
 
 fn inject_balance_check_for_peer(
     deploy: Box<Deploy>,
-    source: Source<NodeId>,
+    source: Source,
     responder: Responder<Result<(), super::Error>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -32,11 +32,11 @@ use metrics::Metrics;
 /// A helper trait constraining `Fetcher` compatible reactor events.
 pub(crate) trait ReactorEventT<T>:
     From<Event<T>>
-    + From<NetworkRequest<NodeId, Message>>
+    + From<NetworkRequest<Message>>
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
     // Won't be needed when we implement "get block by height" feature in storage.
-    + From<LinearChainRequest<NodeId>>
+    + From<LinearChainRequest>
     + Send
     + 'static
 where
@@ -50,10 +50,10 @@ where
     T: Item + 'static,
     <T as Item>::Id: 'static,
     REv: From<Event<T>>
-        + From<NetworkRequest<NodeId, Message>>
+        + From<NetworkRequest<Message>>
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
-        + From<LinearChainRequest<NodeId>>
+        + From<LinearChainRequest>
         + Send
         + 'static,
 {
@@ -136,7 +136,7 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
     fn signal(
         &mut self,
         id: T::Id,
-        result: Option<FetchResult<T, NodeId>>,
+        result: Option<FetchResult<T>>,
         peer: NodeId,
     ) -> Effects<Event<T>> {
         let mut effects = Effects::new();

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -180,8 +180,6 @@ impl Reactor {
 }
 
 impl NetworkedReactor for Reactor {
-    type NodeId = NodeId;
-
     fn node_id(&self) -> NodeId {
         self.network.node_id()
     }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -39,8 +39,8 @@ use metrics::Metrics;
 /// work with.
 pub(crate) trait ReactorEventT<T>:
     From<Event<T>>
-    + From<NetworkRequest<NodeId, Message<T>>>
-    + From<NetworkRequest<NodeId, NodeMessage>>
+    + From<NetworkRequest<Message<T>>>
+    + From<NetworkRequest<NodeMessage>>
     + From<StorageRequest>
     + From<GossiperAnnouncement<T>>
     + Send
@@ -56,8 +56,8 @@ where
     T: Item + 'static,
     <T as Item>::Id: 'static,
     REv: From<Event<T>>
-        + From<NetworkRequest<NodeId, Message<T>>>
-        + From<NetworkRequest<NodeId, NodeMessage>>
+        + From<NetworkRequest<Message<T>>>
+        + From<NetworkRequest<NodeMessage>>
         + From<StorageRequest>
         + From<GossiperAnnouncement<T>>
         + Send
@@ -175,7 +175,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         &mut self,
         effect_builder: EffectBuilder<REv>,
         item_id: T::Id,
-        source: Source<NodeId>,
+        source: Source,
     ) -> Effects<Event<T>> {
         debug!(item=%item_id, %source, "received new gossip item");
         match self.table.new_complete_data(&item_id, source.node_id()) {

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -15,10 +15,7 @@ use crate::{
 #[derive(Debug, Serialize)]
 pub(crate) enum Event<T: Item> {
     /// A new item has been received to be gossiped.
-    ItemReceived {
-        item_id: T::Id,
-        source: Source<NodeId>,
-    },
+    ItemReceived { item_id: T::Id, source: Source },
     /// The network component gossiped to the included peers.
     GossipedTo {
         item_id: T::Id,

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -66,15 +66,15 @@ enum Event {
     #[from]
     DeployGossiper(super::Event<Deploy>),
     #[from]
-    NetworkRequest(NetworkRequest<NodeId, NodeMessage>),
+    NetworkRequest(NetworkRequest<NodeMessage>),
     #[from]
     ControlAnnouncement(ControlAnnouncement),
     #[from]
-    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<NodeId, NodeMessage>),
+    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<NodeMessage>),
     #[from]
     RpcServerAnnouncement(#[serde(skip_serializing)] RpcServerAnnouncement),
     #[from]
-    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement<NodeId>),
+    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     #[from]
     DeployGossiperAnnouncement(#[serde(skip_serializing)] GossiperAnnouncement<Deploy>),
     #[from]
@@ -103,8 +103,8 @@ impl From<StorageRequest> for Event {
     }
 }
 
-impl From<NetworkRequest<NodeId, Message<Deploy>>> for Event {
-    fn from(request: NetworkRequest<NodeId, Message<Deploy>>) -> Self {
+impl From<NetworkRequest<Message<Deploy>>> for Event {
+    fn from(request: NetworkRequest<Message<Deploy>>) -> Self {
         Event::NetworkRequest(request.map_payload(NodeMessage::from))
     }
 }
@@ -115,8 +115,8 @@ impl From<ConsensusRequest> for Event {
     }
 }
 
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(_request: LinearChainRequest<NodeId>) -> Self {
+impl From<LinearChainRequest> for Event {
+    fn from(_request: LinearChainRequest) -> Self {
         unimplemented!("not implemented for gossiper tests")
     }
 }
@@ -345,7 +345,7 @@ impl reactor::Reactor for Reactor {
             }) => {
                 let event = deploy_acceptor::Event::Accept {
                     deploy,
-                    source: Source::<NodeId>::Client,
+                    source: Source::Client,
                     maybe_responder: responder,
                 };
                 self.dispatch_event(effect_builder, rng, Event::DeployAcceptor(event))

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -386,8 +386,6 @@ impl reactor::Reactor for Reactor {
 }
 
 impl NetworkedReactor for Reactor {
-    type NodeId = NodeId;
-
     fn node_id(&self) -> NodeId {
         self.network.node_id()
     }

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -76,10 +76,10 @@
 //! }
 //!
 //! #[derive(Debug, From)]
-//! enum ShouterEvent<NodeId, Message> {
+//! enum ShouterEvent<Message> {
 //!     #[from]
 //!     // We received a new message via the network.
-//!     Net(NetworkAnnouncement<NodeId, Message>),
+//!     Net(NetworkAnnouncement<Message>),
 //!     // Ready to send another message.
 //!     #[from]
 //!     ReadyToSend,
@@ -87,8 +87,8 @@
 //!
 //! impl Shouter {
 //!     /// Creates a new shouter.
-//!     fn new<REv: Send, I: 'static, P: 'static>(effect_builder: EffectBuilder<REv>)
-//!             -> (Self, Effects<ShouterEvent<I, P>>) {
+//!     fn new<REv: Send, P: 'static>(effect_builder: EffectBuilder<REv>)
+//!             -> (Self, Effects<ShouterEvent<P>>) {
 //!         (Shouter {
 //!             whispers: Vec::new(),
 //!             shouts: Vec::new(),
@@ -100,9 +100,9 @@
 //! // Besides its own events, the shouter is capable of receiving network messages.
 //! impl<REv, R> Component<REv, R> for Shouter
 //! where
-//!     REv: From<NetworkRequest<NodeId, Message>> + Send,
+//!     REv: From<NetworkRequest<Message>> + Send,
 //! {
-//!     type Event = ShouterEvent<NodeId, Message>;
+//!     type Event = ShouterEvent<Message>;
 //!
 //!     fn handle_event(&mut self,
 //!         effect_builder: EffectBuilder<REv>,
@@ -148,13 +148,13 @@
 //! enum Event {
 //!    /// Asked to perform a network action.
 //!    #[from]
-//!    Request(NetworkRequest<NodeId, Message>),
+//!    Request(NetworkRequest<Message>),
 //!    /// Event for the shouter.
 //!    #[from]
-//!    Shouter(ShouterEvent<NodeId, Message>),
+//!    Shouter(ShouterEvent<Message>),
 //!    /// Notified of some network event.
 //!    #[from]
-//!    Announcement(NetworkAnnouncement<NodeId, Message>)
+//!    Announcement(NetworkAnnouncement<Message>)
 //! };
 //! #
 //! # impl Display for Event {
@@ -163,9 +163,8 @@
 //! #   }
 //! # }
 //! #
-//! # impl<I, P> Display for ShouterEvent<I, P>
-//! #     where I: Debug,
-//! #           P: Debug
+//! # impl<P> Display for ShouterEvent<P>
+//! #     where P: Debug,
 //! # {
 //! #   fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
 //! #       Debug::fmt(self, fmt)
@@ -311,10 +310,10 @@ type Network<P> = Arc<RwLock<HashMap<NodeId, mpsc::UnboundedSender<(NodeId, P)>>
 
 /// An in-memory network events.
 #[derive(Debug, Serialize)]
-pub(crate) struct Event<P>(NetworkRequest<NodeId, P>);
+pub(crate) struct Event<P>(NetworkRequest<P>);
 
-impl<P> From<NetworkRequest<NodeId, P>> for Event<P> {
-    fn from(req: NetworkRequest<NodeId, P>) -> Self {
+impl<P> From<NetworkRequest<P>> for Event<P> {
+    fn from(req: NetworkRequest<P>) -> Self {
         Event(req)
     }
 }
@@ -393,7 +392,7 @@ where
         rng: &mut TestRng,
     ) -> InMemoryNetwork<P>
     where
-        REv: From<NetworkAnnouncement<NodeId, P>> + Send,
+        REv: From<NetworkAnnouncement<P>> + Send,
     {
         ACTIVE_NETWORK.with(|active_network| {
             active_network
@@ -436,7 +435,7 @@ where
         rng: &mut TestRng,
     ) -> InMemoryNetwork<P>
     where
-        REv: From<NetworkAnnouncement<NodeId, P>> + Send,
+        REv: From<NetworkAnnouncement<P>> + Send,
     {
         InMemoryNetwork::new_with_data(event_queue, NodeId::random(rng), self.nodes.clone())
     }
@@ -461,7 +460,7 @@ where
     /// This function is an alias of `NetworkController::create_node_local`.
     pub(crate) fn new<REv>(event_queue: EventQueueHandle<REv>, rng: &mut NodeRng) -> Self
     where
-        REv: From<NetworkAnnouncement<NodeId, P>> + Send,
+        REv: From<NetworkAnnouncement<P>> + Send,
     {
         NetworkController::create_node(event_queue, rng)
     }
@@ -473,7 +472,7 @@ where
         nodes: Network<P>,
     ) -> Self
     where
-        REv: From<NetworkAnnouncement<NodeId, P>> + Send,
+        REv: From<NetworkAnnouncement<P>> + Send,
     {
         let (sender, receiver) = mpsc::unbounded_channel();
 
@@ -598,7 +597,7 @@ async fn receiver_task<REv, P>(
     event_queue: EventQueueHandle<REv>,
     mut receiver: mpsc::UnboundedReceiver<(NodeId, P)>,
 ) where
-    REv: From<NetworkAnnouncement<NodeId, P>>,
+    REv: From<NetworkAnnouncement<P>>,
     P: 'static + Send,
 {
     while let Some((sender, payload)) = receiver.recv().await {

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -211,8 +211,6 @@
 //! }
 //!
 //! impl NetworkedReactor for Reactor {
-//!     type NodeId = NodeId;
-//!
 //!     fn node_id(&self) -> NodeId {
 //!         self.net.node_id()
 //!     }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -6,7 +6,7 @@ mod signature_cache;
 mod state;
 
 use datasize::DataSize;
-use std::{convert::Infallible, fmt::Display, marker::PhantomData};
+use std::convert::Infallible;
 
 use itertools::Itertools;
 use prometheus::Registry;
@@ -36,14 +36,13 @@ pub(crate) use event::Event;
 use state::LinearChain;
 
 #[derive(DataSize, Debug)]
-pub(crate) struct LinearChainComponent<I> {
+pub(crate) struct LinearChainComponent {
     linear_chain_state: LinearChain,
     #[data_size(skip)]
     metrics: Metrics,
-    _marker: PhantomData<I>,
 }
 
-impl<I> LinearChainComponent<I> {
+impl LinearChainComponent {
     pub(crate) fn new(
         registry: &Registry,
         protocol_version: ProtocolVersion,
@@ -55,23 +54,21 @@ impl<I> LinearChainComponent<I> {
         Ok(LinearChainComponent {
             linear_chain_state,
             metrics,
-            _marker: PhantomData,
         })
     }
 }
 
-fn outcomes_to_effects<REv, I>(
+fn outcomes_to_effects<REv>(
     effect_builder: EffectBuilder<REv>,
     outcomes: Outcomes,
-) -> Effects<Event<I>>
+) -> Effects<Event>
 where
     REv: From<StorageRequest>
-        + From<NetworkRequest<I, Message>>
+        + From<NetworkRequest<Message>>
         + From<LinearChainAnnouncement>
         + From<ContractRuntimeRequest>
         + From<ChainspecLoaderRequest>
         + Send,
-    I: Display + Send + 'static,
 {
     outcomes
         .into_iter()
@@ -121,17 +118,16 @@ where
         .concat()
 }
 
-impl<I, REv> Component<REv> for LinearChainComponent<I>
+impl<REv> Component<REv> for LinearChainComponent
 where
     REv: From<StorageRequest>
-        + From<NetworkRequest<I, Message>>
+        + From<NetworkRequest<Message>>
         + From<LinearChainAnnouncement>
         + From<ContractRuntimeRequest>
         + From<ChainspecLoaderRequest>
         + Send,
-    I: Display + Send + 'static,
 {
-    type Event = Event<I>;
+    type Event = Event;
     type ConstructionError = Infallible;
 
     fn handle_event(

--- a/node/src/components/linear_chain/event.rs
+++ b/node/src/components/linear_chain/event.rs
@@ -12,10 +12,10 @@ use crate::{
 };
 
 #[derive(Debug, From)]
-pub(crate) enum Event<I> {
+pub(crate) enum Event {
     /// A linear chain request issued by another node in the network.
     #[from]
-    Request(LinearChainRequest<I>),
+    Request(LinearChainRequest),
     /// New linear chain block has been produced.
     NewLinearChainBlock {
         /// The block.
@@ -37,7 +37,7 @@ pub(crate) enum Event<I> {
     IsBonded(Option<Box<BlockSignatures>>, Box<FinalitySignature>, bool),
 }
 
-impl<I: Display> Display for Event<I> {
+impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::Request(req) => write!(f, "linear chain request: {}", req),

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -884,11 +884,10 @@ where
                 let mut effects = Effects::new();
                 if self.peers.is_empty() {
                     // First peer connected, start downloading.
-                    let cloned_peer_id = peer_id.clone();
                     effects.extend(
                         effect_builder
                             .immediately()
-                            .event(move |_| Event::Start(cloned_peer_id)),
+                            .event(move |_| Event::Start(peer_id)),
                     );
                 }
                 self.peers.push(peer_id);

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -32,7 +32,7 @@ mod peers;
 mod state;
 mod traits;
 
-use std::{cmp::Ordering, convert::Infallible, fmt::Display, mem};
+use std::{cmp::Ordering, convert::Infallible, mem};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -61,8 +61,8 @@ pub(crate) use state::State;
 pub(crate) use traits::ReactorEventT;
 
 #[derive(DataSize, Debug)]
-pub(crate) struct LinearChainSync<I> {
-    peers: PeersState<I>,
+pub(crate) struct LinearChainSync {
+    peers: PeersState,
     state: State,
     #[data_size(skip)]
     metrics: Metrics,
@@ -84,7 +84,7 @@ pub(crate) struct LinearChainSync<I> {
     initial_execution_pre_state: ExecutionPreState,
 }
 
-impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
+impl LinearChainSync {
     // TODO: fix this
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<REv, Err>(
@@ -98,9 +98,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         next_upgrade_activation_point: Option<ActivationPoint>,
         initial_execution_pre_state: ExecutionPreState,
         config: Config,
-    ) -> Result<(Self, Effects<Event<I>>), Err>
+    ) -> Result<(Self, Effects<Event>), Err>
     where
-        REv: From<Event<I>> + Send,
+        REv: From<Event> + Send,
         Err: From<prometheus::Error> + From<storage::Error>,
     {
         let timeout_event = effect_builder
@@ -267,10 +267,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         rng: &mut NodeRng,
         effect_builder: EffectBuilder<REv>,
         block: &Block,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
-        I: Send + 'static,
-        REv: ReactorEventT<I>,
+        REv: ReactorEventT,
     {
         self.peers.reset(rng);
         self.state.block_downloaded(block);
@@ -320,10 +319,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         rng: &mut NodeRng,
         effect_builder: EffectBuilder<REv>,
         block: &Block,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
-        I: Send + 'static,
-        REv: ReactorEventT<I>,
+        REv: ReactorEventT,
     {
         let height = block.height();
         let hash = block.hash();
@@ -466,10 +464,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
     fn fetch_next_block_deploys<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
-        I: Send + 'static,
-        REv: ReactorEventT<I>,
+        REv: ReactorEventT,
     {
         let peer = self.peers.random_unsafe();
 
@@ -515,10 +512,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         block: &Block,
-    ) -> Effects<Event<I>>
+    ) -> Effects<Event>
     where
-        I: Send + 'static,
-        REv: ReactorEventT<I>,
+        REv: ReactorEventT,
     {
         self.peers.reset(rng);
         let peer = self.peers.random_unsafe();
@@ -544,13 +540,9 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         }
     }
 
-    fn handle_upgrade_shutdown<REv>(
-        &mut self,
-        effect_builder: EffectBuilder<REv>,
-    ) -> Effects<Event<I>>
+    fn handle_upgrade_shutdown<REv>(&mut self, effect_builder: EffectBuilder<REv>) -> Effects<Event>
     where
-        I: Send + 'static,
-        REv: ReactorEventT<I>,
+        REv: ReactorEventT,
     {
         if self.state.is_done() || self.state.is_none() {
             error!(state=?self.state, "shutdown for upgrade initiated when in wrong state");
@@ -601,12 +593,11 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
     }
 }
 
-impl<I, REv> Component<REv> for LinearChainSync<I>
+impl<REv> Component<REv> for LinearChainSync
 where
-    I: Display + Clone + Send + PartialEq + 'static,
-    REv: ReactorEventT<I>,
+    REv: ReactorEventT,
 {
-    type Event = Event<I>;
+    type Event = Event;
     type ConstructionError = Infallible;
 
     fn handle_event(

--- a/node/src/components/linear_chain_sync/blocks.rs
+++ b/node/src/components/linear_chain_sync/blocks.rs
@@ -11,18 +11,18 @@ use crate::{
         EffectBuilder, EffectOptionExt, Effects,
     },
     fatal,
-    types::{Block, BlockByHeight, BlockHash, Deploy, FinalizedBlock},
+    types::{Block, BlockByHeight, BlockHash, Deploy, FinalizedBlock, NodeId},
 };
 
 use super::{event::BlockByHashResult, Event, ReactorEventT};
 
-pub(super) fn fetch_block_by_hash<I: Clone + Send + 'static, REv>(
+pub(super) fn fetch_block_by_hash<REv>(
     effect_builder: EffectBuilder<REv>,
-    peer: I,
+    peer: NodeId,
     block_hash: BlockHash,
-) -> Effects<Event<I>>
+) -> Effects<Event>
 where
-    REv: ReactorEventT<I>,
+    REv: ReactorEventT,
 {
     let cloned = peer.clone();
     effect_builder.fetch_block(block_hash, peer).map_or_else(
@@ -38,13 +38,13 @@ where
     )
 }
 
-pub(super) fn fetch_block_at_height<I: Send + Clone + 'static, REv>(
+pub(super) fn fetch_block_at_height<REv>(
     effect_builder: EffectBuilder<REv>,
-    peer: I,
+    peer: NodeId,
     block_height: u64,
-) -> Effects<Event<I>>
+) -> Effects<Event>
 where
-    REv: ReactorEventT<I>,
+    REv: ReactorEventT,
 {
     let cloned = peer.clone();
     effect_builder

--- a/node/src/components/linear_chain_sync/blocks.rs
+++ b/node/src/components/linear_chain_sync/blocks.rs
@@ -24,7 +24,6 @@ pub(super) fn fetch_block_by_hash<REv>(
 where
     REv: ReactorEventT,
 {
-    let cloned = peer.clone();
     effect_builder.fetch_block(block_hash, peer).map_or_else(
         move |fetch_result| match fetch_result {
             FetchResult::FromStorage(block) => {
@@ -34,7 +33,7 @@ where
                 Event::GetBlockHashResult(block_hash, BlockByHashResult::FromPeer(block, peer))
             }
         },
-        move || Event::GetBlockHashResult(block_hash, BlockByHashResult::Absent(cloned)),
+        move || Event::GetBlockHashResult(block_hash, BlockByHashResult::Absent(peer)),
     )
 }
 
@@ -46,9 +45,8 @@ pub(super) fn fetch_block_at_height<REv>(
 where
     REv: ReactorEventT,
 {
-    let cloned = peer.clone();
     effect_builder
-        .fetch_block_by_height(block_height, peer.clone())
+        .fetch_block_by_height(block_height, peer)
         .map_or_else(
             move |fetch_result| match fetch_result {
                 FetchResult::FromPeer(result, _) => match *result {
@@ -76,7 +74,7 @@ where
                     ),
                 },
             },
-            move || Event::GetBlockHeightResult(block_height, BlockByHeightResult::Absent(cloned)),
+            move || Event::GetBlockHeightResult(block_height, BlockByHeightResult::Absent(peer)),
         )
 }
 

--- a/node/src/components/linear_chain_sync/deploys.rs
+++ b/node/src/components/linear_chain_sync/deploys.rs
@@ -14,7 +14,7 @@ where
     REv: ReactorEventT,
 {
     effect_builder
-        .validate_block(peer.clone(), block.clone())
+        .validate_block(peer, block.clone())
         .event(move |valid| {
             if valid {
                 Event::GetDeploysResult(DeploysResult::Found(Box::new(block)))

--- a/node/src/components/linear_chain_sync/deploys.rs
+++ b/node/src/components/linear_chain_sync/deploys.rs
@@ -1,17 +1,17 @@
 use crate::{
     effect::{EffectBuilder, EffectExt, Effects},
-    types::Block,
+    types::{Block, NodeId},
 };
 
 use super::{event::DeploysResult, Event, ReactorEventT};
 
-pub(super) fn fetch_block_deploys<I: Clone + Send + 'static, REv>(
+pub(super) fn fetch_block_deploys<REv>(
     effect_builder: EffectBuilder<REv>,
-    peer: I,
+    peer: NodeId,
     block: Block,
-) -> Effects<Event<I>>
+) -> Effects<Event>
 where
-    REv: ReactorEventT<I>,
+    REv: ReactorEventT,
 {
     effect_builder
         .validate_block(peer.clone(), block.clone())

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -1,4 +1,4 @@
-use crate::types::{ActivationPoint, Block, BlockHash};
+use crate::types::{ActivationPoint, Block, BlockHash, NodeId};
 
 use std::fmt::{Debug, Display};
 
@@ -11,13 +11,13 @@ pub enum StopReason {
 }
 
 #[derive(Debug)]
-pub enum Event<I> {
-    Start(I),
-    GetBlockHashResult(BlockHash, BlockByHashResult<I>),
-    GetBlockHeightResult(u64, BlockByHeightResult<I>),
-    GetDeploysResult(DeploysResult<I>),
+pub enum Event {
+    Start(NodeId),
+    GetBlockHashResult(BlockHash, BlockByHashResult),
+    GetBlockHeightResult(u64, BlockByHeightResult),
+    GetDeploysResult(DeploysResult),
     StartDownloadingDeploys,
-    NewPeerConnected(I),
+    NewPeerConnected(NodeId),
     BlockHandled(Box<Block>),
     GotUpgradeActivationPoint(ActivationPoint),
     InitUpgradeShutdown,
@@ -27,29 +27,26 @@ pub enum Event<I> {
 }
 
 #[derive(Debug)]
-pub enum DeploysResult<I> {
+pub enum DeploysResult {
     Found(Box<Block>),
-    NotFound(Box<Block>, I),
+    NotFound(Box<Block>, NodeId),
 }
 
 #[derive(Debug)]
-pub enum BlockByHashResult<I> {
-    Absent(I),
+pub enum BlockByHashResult {
+    Absent(NodeId),
     FromStorage(Box<Block>),
-    FromPeer(Box<Block>, I),
+    FromPeer(Box<Block>, NodeId),
 }
 
 #[derive(Debug)]
-pub enum BlockByHeightResult<I> {
-    Absent(I),
+pub enum BlockByHeightResult {
+    Absent(NodeId),
     FromStorage(Box<Block>),
-    FromPeer(Box<Block>, I),
+    FromPeer(Box<Block>, NodeId),
 }
 
-impl<I> Display for Event<I>
-where
-    I: Debug + Display,
-{
+impl Display for Event {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Event::Start(init_peer) => write!(f, "Start syncing from peer {}.", init_peer),

--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -66,7 +66,7 @@ impl PeersState {
 
     /// Adds a new peer.
     pub(crate) fn push(&mut self, peer: NodeId) {
-        self.peers.push(peer.clone());
+        self.peers.push(peer);
         self.peers_to_try.push(peer);
     }
 
@@ -74,7 +74,7 @@ impl PeersState {
     /// Keeps the peer in the set of `succ_peers`.
     fn next_succ(&mut self) -> Option<NodeId> {
         let peer = self.succ_peers.pop_front()?;
-        self.succ_peers.push_back(peer.clone());
+        self.succ_peers.push_back(peer);
         Some(peer)
     }
 

--- a/node/src/components/linear_chain_sync/traits.rs
+++ b/node/src/components/linear_chain_sync/traits.rs
@@ -10,11 +10,11 @@ use crate::{
     types::{Block, BlockByHeight},
 };
 
-pub(crate) trait ReactorEventT<I>:
+pub(crate) trait ReactorEventT:
     From<StorageRequest>
-    + From<FetcherRequest<I, Block>>
-    + From<FetcherRequest<I, BlockByHeight>>
-    + From<BlockValidationRequest<I>>
+    + From<FetcherRequest<Block>>
+    + From<FetcherRequest<BlockByHeight>>
+    + From<BlockValidationRequest>
     + From<ContractRuntimeRequest>
     + From<StateStoreRequest>
     + From<ControlAnnouncement>
@@ -23,11 +23,11 @@ pub(crate) trait ReactorEventT<I>:
 {
 }
 
-impl<I, REv> ReactorEventT<I> for REv where
+impl<REv> ReactorEventT for REv where
     REv: From<StorageRequest>
-        + From<FetcherRequest<I, Block>>
-        + From<FetcherRequest<I, BlockByHeight>>
-        + From<BlockValidationRequest<I>>
+        + From<FetcherRequest<Block>>
+        + From<FetcherRequest<BlockByHeight>>
+        + From<BlockValidationRequest>
         + From<ContractRuntimeRequest>
         + From<StateStoreRequest>
         + From<ControlAnnouncement>

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -42,7 +42,7 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     reactor::Finalize,
-    types::{NodeId, StatusFeed},
+    types::StatusFeed,
     utils::{self, ListeningError},
     NodeRng,
 };
@@ -54,8 +54,8 @@ pub(crate) use event::Event;
 /// A helper trait capturing all of this components Request type dependencies.
 pub(crate) trait ReactorEventT:
     From<Event>
-    + From<RestRequest<NodeId>>
-    + From<NetworkInfoRequest<NodeId>>
+    + From<RestRequest>
+    + From<NetworkInfoRequest>
     + From<StorageRequest>
     + From<ChainspecLoaderRequest>
     + From<ConsensusRequest>
@@ -66,8 +66,8 @@ pub(crate) trait ReactorEventT:
 
 impl<REv> ReactorEventT for REv where
     REv: From<Event>
-        + From<RestRequest<NodeId>>
-        + From<NetworkInfoRequest<NodeId>>
+        + From<RestRequest>
+        + From<NetworkInfoRequest>
         + From<StorageRequest>
         + From<ChainspecLoaderRequest>
         + From<ConsensusRequest>

--- a/node/src/components/rest_server/event.rs
+++ b/node/src/components/rest_server/event.rs
@@ -6,10 +6,7 @@ use std::{
 use derive_more::From;
 use static_assertions::const_assert;
 
-use crate::{
-    effect::{requests::RestRequest, Responder},
-    types::NodeId,
-};
+use crate::effect::{requests::RestRequest, Responder};
 
 const _REST_EVENT_SIZE: usize = mem::size_of::<Event>();
 const_assert!(_REST_EVENT_SIZE < 89);
@@ -17,7 +14,7 @@ const_assert!(_REST_EVENT_SIZE < 89);
 #[derive(Debug, From)]
 pub(crate) enum Event {
     #[from]
-    RestRequest(RestRequest<NodeId>),
+    RestRequest(RestRequest),
     GetMetricsResult {
         text: Option<String>,
         main_responder: Responder<Option<String>>,

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -43,7 +43,7 @@ use crate::{
         },
         EffectBuilder, EffectExt, Effects, Responder,
     },
-    types::{NodeId, StatusFeed},
+    types::StatusFeed,
     utils::{self, ListeningError},
     NodeRng,
 };
@@ -53,14 +53,14 @@ pub(crate) use event::Event;
 /// A helper trait capturing all of this components Request type dependencies.
 pub(crate) trait ReactorEventT:
     From<Event>
-    + From<RpcRequest<NodeId>>
+    + From<RpcRequest>
     + From<RpcServerAnnouncement>
     + From<ChainspecLoaderRequest>
     + From<ContractRuntimeRequest>
     + From<ConsensusRequest>
-    + From<LinearChainRequest<NodeId>>
+    + From<LinearChainRequest>
     + From<MetricsRequest>
-    + From<NetworkInfoRequest<NodeId>>
+    + From<NetworkInfoRequest>
     + From<StorageRequest>
     + Send
 {
@@ -68,14 +68,14 @@ pub(crate) trait ReactorEventT:
 
 impl<REv> ReactorEventT for REv where
     REv: From<Event>
-        + From<RpcRequest<NodeId>>
+        + From<RpcRequest>
         + From<RpcServerAnnouncement>
         + From<ChainspecLoaderRequest>
         + From<ContractRuntimeRequest>
         + From<ConsensusRequest>
-        + From<LinearChainRequest<NodeId>>
+        + From<LinearChainRequest>
         + From<MetricsRequest>
-        + From<NetworkInfoRequest<NodeId>>
+        + From<NetworkInfoRequest>
         + From<StorageRequest>
         + Send
         + 'static

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, From)]
 pub(crate) enum Event {
     #[from]
-    RpcRequest(RpcRequest<NodeId>),
+    RpcRequest(RpcRequest),
     GetBlockResult {
         maybe_id: Option<BlockIdentifier>,
         result: Box<Option<(Block, BlockSignatures)>>,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -187,8 +187,7 @@ where
 impl<REv, P> SmallNetwork<REv, P>
 where
     P: Payload + 'static,
-    REv:
-        ReactorEvent + From<Event<P>> + From<NetworkAnnouncement<NodeId, P>> + From<StorageRequest>,
+    REv: ReactorEvent + From<Event<P>> + From<NetworkAnnouncement<P>> + From<StorageRequest>,
 {
     /// Creates a new small network component instance.
     #[allow(clippy::type_complexity)]
@@ -720,7 +719,7 @@ where
         span: Span,
     ) -> Effects<Event<P>>
     where
-        REv: From<NetworkAnnouncement<NodeId, P>>,
+        REv: From<NetworkAnnouncement<P>>,
     {
         span.in_scope(|| match msg {
             Message::Handshake { .. } => {
@@ -806,8 +805,7 @@ where
 
 impl<REv, P> Component<REv> for SmallNetwork<REv, P>
 where
-    REv:
-        ReactorEvent + From<Event<P>> + From<NetworkAnnouncement<NodeId, P>> + From<StorageRequest>,
+    REv: ReactorEvent + From<Event<P>> + From<NetworkAnnouncement<P>> + From<StorageRequest>,
     P: Payload,
 {
     type Event = Event<P>;

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -70,14 +70,14 @@ pub(crate) enum Event<P> {
     #[from]
     NetworkRequest {
         #[serde(skip_serializing)]
-        req: Box<NetworkRequest<NodeId, P>>,
+        req: Box<NetworkRequest<P>>,
     },
 
     /// Incoming network info request.
     #[from]
     NetworkInfoRequest {
         #[serde(skip_serializing)]
-        req: Box<NetworkInfoRequest<NodeId>>,
+        req: Box<NetworkInfoRequest>,
     },
 
     /// The node should gossip its own public listening address.
@@ -91,21 +91,21 @@ pub(crate) enum Event<P> {
 
     /// Blocklist announcement.
     #[from]
-    BlocklistAnnouncement(BlocklistAnnouncement<NodeId>),
+    BlocklistAnnouncement(BlocklistAnnouncement),
 
     /// Contract runtime announcement.
     #[from]
     ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
 }
 
-impl From<NetworkRequest<NodeId, ProtocolMessage>> for Event<ProtocolMessage> {
-    fn from(req: NetworkRequest<NodeId, ProtocolMessage>) -> Self {
+impl From<NetworkRequest<ProtocolMessage>> for Event<ProtocolMessage> {
+    fn from(req: NetworkRequest<ProtocolMessage>) -> Self {
         Self::NetworkRequest { req: Box::new(req) }
     }
 }
 
-impl From<NetworkInfoRequest<NodeId>> for Event<ProtocolMessage> {
-    fn from(req: NetworkInfoRequest<NodeId>) -> Self {
+impl From<NetworkInfoRequest> for Event<ProtocolMessage> {
+    fn from(req: NetworkInfoRequest) -> Self {
         Self::NetworkInfoRequest { req: Box::new(req) }
     }
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -50,11 +50,11 @@ enum Event {
     #[from]
     AddressGossiper(#[serde(skip_serializing)] gossiper::Event<GossipedAddress>),
     #[from]
-    NetworkRequest(#[serde(skip_serializing)] NetworkRequest<NodeId, Message>),
+    NetworkRequest(#[serde(skip_serializing)] NetworkRequest<Message>),
     #[from]
     ControlAnnouncement(ControlAnnouncement),
     #[from]
-    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<NodeId, Message>),
+    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<Message>),
     #[from]
     AddressGossiperAnnouncement(#[serde(skip_serializing)] GossiperAnnouncement<GossipedAddress>),
 }
@@ -69,22 +69,22 @@ impl ReactorEvent for Event {
     }
 }
 
-impl From<NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>> for Event {
-    fn from(request: NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>) -> Self {
+impl From<NetworkRequest<gossiper::Message<GossipedAddress>>> for Event {
+    fn from(request: NetworkRequest<gossiper::Message<GossipedAddress>>) -> Self {
         Event::NetworkRequest(request.map_payload(Message::from))
     }
 }
 
-impl From<NetworkRequest<NodeId, Message>> for SmallNetworkEvent<Message> {
-    fn from(request: NetworkRequest<NodeId, Message>) -> SmallNetworkEvent<Message> {
+impl From<NetworkRequest<Message>> for SmallNetworkEvent<Message> {
+    fn from(request: NetworkRequest<Message>) -> SmallNetworkEvent<Message> {
         SmallNetworkEvent::NetworkRequest {
             req: Box::new(request),
         }
     }
 }
 
-impl From<NetworkRequest<NodeId, protocol::Message>> for Event {
-    fn from(_request: NetworkRequest<NodeId, protocol::Message>) -> Self {
+impl From<NetworkRequest<protocol::Message>> for Event {
+    fn from(_request: NetworkRequest<protocol::Message>) -> Self {
         unreachable!()
     }
 }
@@ -202,7 +202,7 @@ impl Reactor for TestReactor {
             Event::NetworkAnnouncement(NetworkAnnouncement::GossipOurAddress(gossiped_address)) => {
                 let event = gossiper::Event::ItemReceived {
                     item_id: gossiped_address,
-                    source: Source::<NodeId>::Ourself,
+                    source: Source::Ourself,
                 };
                 self.dispatch_event(effect_builder, rng, Event::AddressGossiper(event))
             }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -230,8 +230,6 @@ impl Reactor for TestReactor {
 }
 
 impl NetworkedReactor for TestReactor {
-    type NodeId = NodeId;
-
     fn node_id(&self) -> NodeId {
         self.net.node_id()
     }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -112,7 +112,7 @@ use crate::{
     types::{
         Block, BlockByHeight, BlockHash, BlockHeader, BlockPayload, BlockSignatures, Chainspec,
         ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, TimeDiff, Timestamp,
+        FinalizedBlock, Item, NodeId, TimeDiff, Timestamp,
     },
     utils::{SharedFlag, Source},
 };
@@ -554,9 +554,9 @@ impl<REv> EffectBuilder<REv> {
     ///
     /// The message is queued in "fire-and-forget" fashion, there is no guarantee that the peer
     /// will receive it.
-    pub(crate) async fn send_message<I, P>(self, dest: I, payload: P)
+    pub(crate) async fn send_message<P>(self, dest: NodeId, payload: P)
     where
-        REv: From<NetworkRequest<I, P>>,
+        REv: From<NetworkRequest<P>>,
     {
         self.make_request(
             |responder| NetworkRequest::SendMessage {
@@ -572,9 +572,9 @@ impl<REv> EffectBuilder<REv> {
     /// Broadcasts a network message.
     ///
     /// Broadcasts a network message to all peers connected at the time the message is sent.
-    pub(crate) async fn broadcast_message<I, P>(self, payload: P)
+    pub(crate) async fn broadcast_message<P>(self, payload: P)
     where
-        REv: From<NetworkRequest<I, P>>,
+        REv: From<NetworkRequest<P>>,
     {
         self.make_request(
             |responder| NetworkRequest::Broadcast {
@@ -592,15 +592,14 @@ impl<REv> EffectBuilder<REv> {
     /// excluding the indicated ones, and sends each a copy of the message.
     ///
     /// Returns the IDs of the chosen nodes.
-    pub(crate) async fn gossip_message<I, P>(
+    pub(crate) async fn gossip_message<P>(
         self,
         payload: P,
         count: usize,
-        exclude: HashSet<I>,
-    ) -> HashSet<I>
+        exclude: HashSet<NodeId>,
+    ) -> HashSet<NodeId>
     where
-        REv: From<NetworkRequest<I, P>>,
-        I: Send + 'static,
+        REv: From<NetworkRequest<P>>,
         P: Send,
     {
         self.make_request(
@@ -616,10 +615,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets connected network peers.
-    pub(crate) async fn network_peers<I>(self) -> BTreeMap<I, String>
+    pub(crate) async fn network_peers(self) -> BTreeMap<NodeId, String>
     where
-        REv: From<NetworkInfoRequest<I>>,
-        I: Send + 'static,
+        REv: From<NetworkInfoRequest>,
     {
         self.make_request(
             |responder| NetworkInfoRequest::GetPeers { responder },
@@ -629,10 +627,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the current network peers in random order.
-    pub async fn get_fully_connected_peers<I>(self) -> Vec<I>
+    pub async fn get_fully_connected_peers(self) -> Vec<NodeId>
     where
-        REv: From<NetworkInfoRequest<I>>,
-        I: Send + 'static,
+        REv: From<NetworkInfoRequest>,
     {
         self.make_request(
             |responder| NetworkInfoRequest::GetFullyConnectedPeers { responder },
@@ -655,9 +652,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that a network message has been received.
-    pub(crate) async fn announce_message_received<I, P>(self, sender: I, payload: P)
+    pub(crate) async fn announce_message_received<P>(self, sender: NodeId, payload: P)
     where
-        REv: From<NetworkAnnouncement<I, P>>,
+        REv: From<NetworkAnnouncement<P>>,
     {
         self.event_queue
             .schedule(
@@ -668,9 +665,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that we should gossip our own public listening address.
-    pub(crate) async fn announce_gossip_our_address<I, P>(self, our_address: GossipedAddress)
+    pub(crate) async fn announce_gossip_our_address<P>(self, our_address: GossipedAddress)
     where
-        REv: From<NetworkAnnouncement<I, P>>,
+        REv: From<NetworkAnnouncement<P>>,
     {
         self.event_queue
             .schedule(
@@ -681,9 +678,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that a new peer has connected.
-    pub(crate) async fn announce_new_peer<I, P>(self, peer_id: I)
+    pub(crate) async fn announce_new_peer<P>(self, peer_id: NodeId)
     where
-        REv: From<NetworkAnnouncement<I, P>>,
+        REv: From<NetworkAnnouncement<P>>,
     {
         self.event_queue
             .schedule(
@@ -728,13 +725,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that a deploy not previously stored has now been accepted and stored.
-    pub(crate) fn announce_new_deploy_accepted<I>(
+    pub(crate) fn announce_new_deploy_accepted(
         self,
         deploy: Box<Deploy>,
-        source: Source<I>,
+        source: Source,
     ) -> impl Future<Output = ()>
     where
-        REv: From<DeployAcceptorAnnouncement<I>>,
+        REv: From<DeployAcceptorAnnouncement>,
     {
         self.event_queue.schedule(
             DeployAcceptorAnnouncement::AcceptedNewDeploy { deploy, source },
@@ -757,13 +754,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that an invalid deploy has been received.
-    pub(crate) fn announce_invalid_deploy<I>(
+    pub(crate) fn announce_invalid_deploy(
         self,
         deploy: Box<Deploy>,
-        source: Source<I>,
+        source: Source,
     ) -> impl Future<Output = ()>
     where
-        REv: From<DeployAcceptorAnnouncement<I>>,
+        REv: From<DeployAcceptorAnnouncement>,
     {
         self.event_queue.schedule(
             DeployAcceptorAnnouncement::InvalidDeploy { deploy, source },
@@ -1120,14 +1117,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the requested deploy using the `DeployFetcher`.
-    pub(crate) async fn fetch_deploy<I>(
+    pub(crate) async fn fetch_deploy(
         self,
         deploy_hash: DeployHash,
-        peer: I,
-    ) -> Option<FetchResult<Deploy, I>>
+        peer: NodeId,
+    ) -> Option<FetchResult<Deploy>>
     where
-        REv: From<FetcherRequest<I, Deploy>>,
-        I: Send + 'static,
+        REv: From<FetcherRequest<Deploy>>,
     {
         self.make_request(
             |responder| FetcherRequest::Fetch {
@@ -1141,14 +1137,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the requested block using the `BlockFetcher`
-    pub(crate) async fn fetch_block<I>(
+    pub(crate) async fn fetch_block(
         self,
         block_hash: BlockHash,
-        peer: I,
-    ) -> Option<FetchResult<Block, I>>
+        peer: NodeId,
+    ) -> Option<FetchResult<Block>>
     where
-        REv: From<FetcherRequest<I, Block>>,
-        I: Send + 'static,
+        REv: From<FetcherRequest<Block>>,
     {
         self.make_request(
             |responder| FetcherRequest::Fetch {
@@ -1162,14 +1157,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Requests a linear chain block at `block_height`.
-    pub(crate) async fn fetch_block_by_height<I>(
+    pub(crate) async fn fetch_block_by_height(
         self,
         block_height: u64,
-        peer: I,
-    ) -> Option<FetchResult<BlockByHeight, I>>
+        peer: NodeId,
+    ) -> Option<FetchResult<BlockByHeight>>
     where
-        REv: From<FetcherRequest<I, BlockByHeight>>,
-        I: Send + 'static,
+        REv: From<FetcherRequest<BlockByHeight>>,
     {
         self.make_request(
             |responder| FetcherRequest::Fetch {
@@ -1263,9 +1257,9 @@ impl<REv> EffectBuilder<REv> {
 
     /// Checks whether the deploys included in the block exist on the network and the block is
     /// valid.
-    pub(crate) async fn validate_block<I, T>(self, sender: I, block: T) -> bool
+    pub(crate) async fn validate_block<T>(self, sender: NodeId, block: T) -> bool
     where
-        REv: From<BlockValidationRequest<I>>,
+        REv: From<BlockValidationRequest>,
         T: Into<ValidatingBlock>,
     {
         self.make_request(
@@ -1329,9 +1323,9 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announce the intent to disconnect from a specific peer, which consensus thinks is faulty.
-    pub(crate) async fn announce_disconnect_from_peer<I>(self, peer: I)
+    pub(crate) async fn announce_disconnect_from_peer(self, peer: NodeId)
     where
-        REv: From<BlocklistAnnouncement<I>>,
+        REv: From<BlocklistAnnouncement>,
     {
         self.event_queue
             .schedule(

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -16,7 +16,8 @@ use crate::{
     },
     effect::Responder,
     types::{
-        Block, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock, Item, Timestamp,
+        Block, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock, Item, NodeId,
+        Timestamp,
     },
     utils::Source,
 };
@@ -58,11 +59,11 @@ impl Display for ControlAnnouncement {
 /// A networking layer announcement.
 #[derive(Debug, Serialize)]
 #[must_use]
-pub(crate) enum NetworkAnnouncement<I, P> {
+pub(crate) enum NetworkAnnouncement<P> {
     /// A payload message has been received from a peer.
     MessageReceived {
         /// The sender of the message
-        sender: I,
+        sender: NodeId,
         /// The message payload
         payload: P,
     },
@@ -73,12 +74,11 @@ pub(crate) enum NetworkAnnouncement<I, P> {
     /// IMPORTANT NOTE: This announcement is a work-around for some short-term functionality. Do
     ///                 not rely on or use this for anything without asking anyone that has written
     ///                 this section of the code first!
-    NewPeer(I),
+    NewPeer(NodeId),
 }
 
-impl<I, P> Display for NetworkAnnouncement<I, P>
+impl<P> Display for NetworkAnnouncement<P>
 where
-    I: Display,
     P: Display,
 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
@@ -119,13 +119,13 @@ impl Display for RpcServerAnnouncement {
 
 /// A `DeployAcceptor` announcement.
 #[derive(Debug, Serialize)]
-pub(crate) enum DeployAcceptorAnnouncement<I> {
+pub(crate) enum DeployAcceptorAnnouncement {
     /// A deploy which wasn't previously stored on this node has been accepted and stored.
     AcceptedNewDeploy {
         /// The new deploy.
         deploy: Box<Deploy>,
         /// The source (peer or client) of the deploy.
-        source: Source<I>,
+        source: Source,
     },
 
     /// An invalid deploy was received.
@@ -133,11 +133,11 @@ pub(crate) enum DeployAcceptorAnnouncement<I> {
         /// The invalid deploy.
         deploy: Box<Deploy>,
         /// The source (peer or client) of the deploy.
-        source: Source<I>,
+        source: Source,
     },
 }
 
-impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
+impl Display for DeployAcceptorAnnouncement {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             DeployAcceptorAnnouncement::AcceptedNewDeploy { deploy, source } => write!(
@@ -212,15 +212,12 @@ impl Display for ConsensusAnnouncement {
 
 /// A block-list related announcement.
 #[derive(Debug, Serialize)]
-pub(crate) enum BlocklistAnnouncement<I> {
+pub(crate) enum BlocklistAnnouncement {
     /// A given peer committed a blockable offense.
-    OffenseCommitted(Box<I>),
+    OffenseCommitted(Box<NodeId>),
 }
 
-impl<I> Display for BlocklistAnnouncement<I>
-where
-    I: Display,
-{
+impl Display for BlocklistAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             BlocklistAnnouncement::OffenseCommitted(peer) => {

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -349,8 +349,7 @@ pub(crate) mod tests {
     }
 
     impl NetworkedReactor for Reactor {
-        type NodeId = NodeId;
-        fn node_id(&self) -> Self::NodeId {
+        fn node_id(&self) -> NodeId {
             NodeId::from(&self.small_network_identity)
         }
     }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, participating, EventQueueHandle, ReactorExit},
-    types::{chainspec, NodeId},
+    types::chainspec,
     utils::WithDir,
     NodeRng,
 };
@@ -93,8 +93,8 @@ impl From<StorageRequest> for Event {
     }
 }
 
-impl From<NetworkRequest<NodeId, Message>> for Event {
-    fn from(_request: NetworkRequest<NodeId, Message>) -> Self {
+impl From<NetworkRequest<Message>> for Event {
+    fn from(_request: NetworkRequest<Message>) -> Self {
         unreachable!("no network traffic happens during initialization")
     }
 }
@@ -105,14 +105,14 @@ impl From<ChainspecLoaderAnnouncement> for Event {
     }
 }
 
-impl From<LinearChainRequest<NodeId>> for Event {
-    fn from(_req: LinearChainRequest<NodeId>) -> Self {
+impl From<LinearChainRequest> for Event {
+    fn from(_req: LinearChainRequest) -> Self {
         unreachable!("no linear chain events happen during initialization")
     }
 }
 
-impl From<NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>> for Event {
-    fn from(_request: NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>) -> Self {
+impl From<NetworkRequest<gossiper::Message<GossipedAddress>>> for Event {
+    fn from(_request: NetworkRequest<gossiper::Message<GossipedAddress>>) -> Self {
         unreachable!("no gossiper events happen during initialization")
     }
 }
@@ -123,8 +123,8 @@ impl From<ConsensusRequest> for Event {
     }
 }
 
-impl From<RestRequest<NodeId>> for Event {
-    fn from(_request: RestRequest<NodeId>) -> Self {
+impl From<RestRequest> for Event {
+    fn from(_request: RestRequest) -> Self {
         unreachable!("no rest requests happen during initialization")
     }
 }
@@ -328,7 +328,10 @@ impl reactor::Reactor for Reactor {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{testing::network::NetworkedReactor, types::Chainspec};
+    use crate::{
+        testing::network::NetworkedReactor,
+        types::{Chainspec, NodeId},
+    };
     use std::sync::Arc;
 
     impl Reactor {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -1000,8 +1000,7 @@ impl Reactor {
 
 #[cfg(test)]
 impl NetworkedReactor for Reactor {
-    type NodeId = crate::types::NodeId;
-    fn node_id(&self) -> Self::NodeId {
+    fn node_id(&self) -> crate::types::NodeId {
         self.small_network.node_id()
     }
 }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1247,8 +1247,7 @@ impl reactor::Reactor for Reactor {
 
 #[cfg(test)]
 impl NetworkedReactor for Reactor {
-    type NodeId = NodeId;
-    fn node_id(&self) -> Self::NodeId {
+    fn node_id(&self) -> NodeId {
         self.small_network.node_id()
     }
 }

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -103,7 +103,7 @@ pub(crate) enum ParticipatingEvent {
     ChainspecLoader(#[serde(skip_serializing)] chainspec_loader::Event),
     #[from]
     /// Consensus event.
-    Consensus(#[serde(skip_serializing)] consensus::Event<NodeId>),
+    Consensus(#[serde(skip_serializing)] consensus::Event),
     /// Deploy acceptor event.
     #[from]
     DeployAcceptor(#[serde(skip_serializing)] deploy_acceptor::Event),
@@ -118,10 +118,10 @@ pub(crate) enum ParticipatingEvent {
     AddressGossiper(gossiper::Event<GossipedAddress>),
     /// Block validator event.
     #[from]
-    BlockValidator(#[serde(skip_serializing)] block_validator::Event<NodeId>),
+    BlockValidator(#[serde(skip_serializing)] block_validator::Event),
     /// Linear chain event.
     #[from]
-    LinearChain(#[serde(skip_serializing)] linear_chain::Event<NodeId>),
+    LinearChain(#[serde(skip_serializing)] linear_chain::Event),
     /// Console event.
     #[from]
     Console(console::Event),
@@ -131,19 +131,19 @@ pub(crate) enum ParticipatingEvent {
     ContractRuntime(#[serde(skip_serializing)] Box<ContractRuntimeRequest>),
     /// Network request.
     #[from]
-    NetworkRequest(#[serde(skip_serializing)] NetworkRequest<NodeId, Message>),
+    NetworkRequest(#[serde(skip_serializing)] NetworkRequest<Message>),
     /// Network info request.
     #[from]
-    NetworkInfoRequest(#[serde(skip_serializing)] NetworkInfoRequest<NodeId>),
+    NetworkInfoRequest(#[serde(skip_serializing)] NetworkInfoRequest),
     /// Deploy fetcher request.
     #[from]
-    DeployFetcherRequest(#[serde(skip_serializing)] FetcherRequest<NodeId, Deploy>),
+    DeployFetcherRequest(#[serde(skip_serializing)] FetcherRequest<Deploy>),
     /// Block proposer request.
     #[from]
     BlockProposerRequest(#[serde(skip_serializing)] BlockProposerRequest),
     /// Block validator request.
     #[from]
-    BlockValidatorRequest(#[serde(skip_serializing)] BlockValidationRequest<NodeId>),
+    BlockValidatorRequest(#[serde(skip_serializing)] BlockValidationRequest),
     /// Metrics request.
     #[from]
     MetricsRequest(#[serde(skip_serializing)] MetricsRequest),
@@ -166,13 +166,13 @@ pub(crate) enum ParticipatingEvent {
     ControlAnnouncement(ControlAnnouncement),
     /// Network announcement.
     #[from]
-    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<NodeId, Message>),
+    NetworkAnnouncement(#[serde(skip_serializing)] NetworkAnnouncement<Message>),
     /// API server announcement.
     #[from]
     RpcServerAnnouncement(#[serde(skip_serializing)] RpcServerAnnouncement),
     /// DeployAcceptor announcement.
     #[from]
-    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement<NodeId>),
+    DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     /// Consensus announcement.
     #[from]
     ConsensusAnnouncement(#[serde(skip_serializing)] ConsensusAnnouncement),
@@ -193,7 +193,7 @@ pub(crate) enum ParticipatingEvent {
     ChainspecLoaderAnnouncement(#[serde(skip_serializing)] ChainspecLoaderAnnouncement),
     /// Blocklist announcement.
     #[from]
-    BlocklistAnnouncement(BlocklistAnnouncement<NodeId>),
+    BlocklistAnnouncement(BlocklistAnnouncement),
     /// Block proposer announcement.
     #[from]
     BlockProposerAnnouncement(#[serde(skip_serializing)] BlockProposerAnnouncement),
@@ -259,32 +259,32 @@ impl From<ContractRuntimeRequest> for ParticipatingEvent {
     }
 }
 
-impl From<RpcRequest<NodeId>> for ParticipatingEvent {
-    fn from(request: RpcRequest<NodeId>) -> Self {
+impl From<RpcRequest> for ParticipatingEvent {
+    fn from(request: RpcRequest) -> Self {
         ParticipatingEvent::RpcServer(rpc_server::Event::RpcRequest(request))
     }
 }
 
-impl From<RestRequest<NodeId>> for ParticipatingEvent {
-    fn from(request: RestRequest<NodeId>) -> Self {
+impl From<RestRequest> for ParticipatingEvent {
+    fn from(request: RestRequest) -> Self {
         ParticipatingEvent::RestServer(rest_server::Event::RestRequest(request))
     }
 }
 
-impl From<NetworkRequest<NodeId, consensus::ConsensusMessage>> for ParticipatingEvent {
-    fn from(request: NetworkRequest<NodeId, consensus::ConsensusMessage>) -> Self {
+impl From<NetworkRequest<consensus::ConsensusMessage>> for ParticipatingEvent {
+    fn from(request: NetworkRequest<consensus::ConsensusMessage>) -> Self {
         ParticipatingEvent::NetworkRequest(request.map_payload(Message::from))
     }
 }
 
-impl From<NetworkRequest<NodeId, gossiper::Message<Deploy>>> for ParticipatingEvent {
-    fn from(request: NetworkRequest<NodeId, gossiper::Message<Deploy>>) -> Self {
+impl From<NetworkRequest<gossiper::Message<Deploy>>> for ParticipatingEvent {
+    fn from(request: NetworkRequest<gossiper::Message<Deploy>>) -> Self {
         ParticipatingEvent::NetworkRequest(request.map_payload(Message::from))
     }
 }
 
-impl From<NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>> for ParticipatingEvent {
-    fn from(request: NetworkRequest<NodeId, gossiper::Message<GossipedAddress>>) -> Self {
+impl From<NetworkRequest<gossiper::Message<GossipedAddress>>> for ParticipatingEvent {
+    fn from(request: NetworkRequest<gossiper::Message<GossipedAddress>>) -> Self {
         ParticipatingEvent::NetworkRequest(request.map_payload(Message::from))
     }
 }
@@ -295,8 +295,8 @@ impl From<ConsensusRequest> for ParticipatingEvent {
     }
 }
 
-impl From<LinearChainRequest<NodeId>> for ParticipatingEvent {
-    fn from(request: LinearChainRequest<NodeId>) -> Self {
+impl From<LinearChainRequest> for ParticipatingEvent {
+    fn from(request: LinearChainRequest) -> Self {
         ParticipatingEvent::LinearChain(linear_chain::Event::Request(request))
     }
 }
@@ -423,14 +423,14 @@ pub(crate) struct Reactor {
     rest_server: RestServer,
     event_stream_server: EventStreamServer,
     chainspec_loader: ChainspecLoader,
-    consensus: EraSupervisor<NodeId>,
+    consensus: EraSupervisor,
     #[data_size(skip)]
     deploy_acceptor: DeployAcceptor,
     deploy_fetcher: Fetcher<Deploy>,
     deploy_gossiper: Gossiper<Deploy, ParticipatingEvent>,
     block_proposer: BlockProposer,
-    block_validator: BlockValidator<NodeId>,
-    linear_chain: LinearChainComponent<NodeId>,
+    block_validator: BlockValidator,
+    linear_chain: LinearChainComponent,
     console: Console,
 
     // Non-components.
@@ -444,7 +444,7 @@ pub(crate) struct Reactor {
 #[cfg(test)]
 impl Reactor {
     /// Inspect consensus.
-    pub(crate) fn consensus(&self) -> &EraSupervisor<NodeId> {
+    pub(crate) fn consensus(&self) -> &EraSupervisor {
         &self.consensus
     }
 
@@ -983,7 +983,7 @@ impl reactor::Reactor for Reactor {
             )) => {
                 let event = gossiper::Event::ItemReceived {
                     item_id: gossiped_address,
-                    source: Source::<NodeId>::Ourself,
+                    source: Source::Ourself,
                 };
                 self.dispatch_event(
                     effect_builder,
@@ -1001,7 +1001,7 @@ impl reactor::Reactor for Reactor {
             }) => {
                 let event = deploy_acceptor::Event::Accept {
                     deploy,
-                    source: Source::<NodeId>::Client,
+                    source: Source::Client,
                     maybe_responder: responder,
                 };
                 self.dispatch_event(

--- a/node/src/testing/condition_check_reactor.rs
+++ b/node/src/testing/condition_check_reactor.rs
@@ -7,6 +7,7 @@ use super::network::NetworkedReactor;
 use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{EventQueueHandle, Finalize, Reactor, ReactorExit},
+    types::NodeId,
     NodeRng,
 };
 
@@ -100,9 +101,7 @@ impl<R: Reactor + Finalize> Finalize for ConditionCheckReactor<R> {
 }
 
 impl<R: Reactor + NetworkedReactor> NetworkedReactor for ConditionCheckReactor<R> {
-    type NodeId = R::NodeId;
-
-    fn node_id(&self) -> Self::NodeId {
+    fn node_id(&self) -> NodeId {
         self.reactor.node_id()
     }
 }

--- a/node/src/testing/filter_reactor.rs
+++ b/node/src/testing/filter_reactor.rs
@@ -8,6 +8,7 @@ use super::network::NetworkedReactor;
 use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{EventQueueHandle, Finalize, Reactor, ReactorExit},
+    types::NodeId,
     NodeRng,
 };
 
@@ -77,9 +78,7 @@ impl<R: Reactor + Finalize> Finalize for FilterReactor<R> {
 }
 
 impl<R: Reactor + NetworkedReactor> NetworkedReactor for FilterReactor<R> {
-    type NodeId = R::NodeId;
-
-    fn node_id(&self) -> Self::NodeId {
+    fn node_id(&self) -> NodeId {
         self.reactor.node_id()
     }
 }

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -512,8 +512,7 @@ impl Reactor for MultiStageTestReactor {
 }
 
 impl NetworkedReactor for MultiStageTestReactor {
-    type NodeId = NodeId;
-    fn node_id(&self) -> Self::NodeId {
+    fn node_id(&self) -> NodeId {
         match self {
             MultiStageTestReactor::Deactivated => unreachable!(),
             MultiStageTestReactor::Initializer {

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -120,7 +120,7 @@ pub(crate) enum MultiStageTestReactor {
 }
 
 impl MultiStageTestReactor {
-    pub(crate) fn consensus(&self) -> Option<&EraSupervisor<NodeId>> {
+    pub(crate) fn consensus(&self) -> Option<&EraSupervisor> {
         match self {
             MultiStageTestReactor::Deactivated => unreachable!(),
             MultiStageTestReactor::Initializer { .. }

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -2,8 +2,7 @@
 
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fmt::{Debug, Display},
-    hash::Hash,
+    fmt::Debug,
     time::Duration,
 };
 
@@ -19,22 +18,19 @@ use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{Finalize, Reactor, Runner},
     testing::TestRng,
+    types::NodeId,
     NodeRng,
 };
 
 /// Type alias for set of nodes inside a network.
 ///
 /// Provided as a convenience for writing condition functions for `settle_on` and friends.
-pub(crate) type Nodes<R> =
-    HashMap<<R as NetworkedReactor>::NodeId, Runner<ConditionCheckReactor<R>>>;
+pub(crate) type Nodes<R> = HashMap<NodeId, Runner<ConditionCheckReactor<R>>>;
 
 /// A reactor with networking functionality.
 pub(crate) trait NetworkedReactor: Sized {
-    /// The node ID on the networking level.
-    type NodeId: Eq + Hash + Clone + Display + Debug;
-
     /// Returns the node ID assigned to this specific reactor instance.
-    fn node_id(&self) -> Self::NodeId;
+    fn node_id(&self) -> NodeId;
 }
 
 /// Time interval for which to poll an observed testing network when no events have occurred.
@@ -48,7 +44,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 #[derive(Debug, Default)]
 pub(crate) struct Network<R: Reactor + NetworkedReactor> {
     /// Current network.
-    nodes: HashMap<<R as NetworkedReactor>::NodeId, Runner<ConditionCheckReactor<R>>>,
+    nodes: HashMap<NodeId, Runner<ConditionCheckReactor<R>>>,
 }
 
 impl<R> Network<R>
@@ -68,12 +64,12 @@ where
     pub(crate) async fn add_node(
         &mut self,
         rng: &mut TestRng,
-    ) -> Result<(R::NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
+    ) -> Result<(NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
         self.add_node_with_config(Default::default(), rng).await
     }
 
     /// Adds `count` new nodes to the network, and returns their IDs.
-    pub(crate) async fn add_nodes(&mut self, rng: &mut TestRng, count: usize) -> Vec<R::NodeId> {
+    pub(crate) async fn add_nodes(&mut self, rng: &mut TestRng, count: usize) -> Vec<NodeId> {
         let mut node_ids = vec![];
         for _ in 0..count {
             let (node_id, _runner) = self.add_node(rng).await.unwrap();
@@ -105,12 +101,12 @@ where
         &mut self,
         cfg: R::Config,
         rng: &mut NodeRng,
-    ) -> Result<(R::NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
+    ) -> Result<(NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
         let runner: Runner<ConditionCheckReactor<R>> = Runner::new(cfg, rng).await?;
 
         let node_id = runner.reactor().node_id();
 
-        let node_ref = match self.nodes.entry(node_id.clone()) {
+        let node_ref = match self.nodes.entry(node_id) {
             Entry::Occupied(_) => {
                 // This happens in the event of the extremely unlikely hash collision, or if the
                 // node ID was set manually.
@@ -125,13 +121,13 @@ where
     /// Removes a node from the network.
     pub(crate) fn remove_node(
         &mut self,
-        node_id: &R::NodeId,
+        node_id: &NodeId,
     ) -> Option<Runner<ConditionCheckReactor<R>>> {
         self.nodes.remove(node_id)
     }
 
     /// Crank the specified runner once, returning the number of events processed.
-    pub(crate) async fn crank(&mut self, node_id: &R::NodeId, rng: &mut TestRng) -> usize {
+    pub(crate) async fn crank(&mut self, node_id: &NodeId, rng: &mut TestRng) -> usize {
         let runner = self.nodes.get_mut(node_id).expect("should find node");
 
         let node_id = runner.reactor().node_id();
@@ -152,7 +148,7 @@ where
     /// Returns `true` if `condition` has been met within the specified timeout.
     pub(crate) async fn crank_until<F>(
         &mut self,
-        node_id: &R::NodeId,
+        node_id: &NodeId,
         rng: &mut TestRng,
         condition: F,
         within: Duration,
@@ -170,7 +166,7 @@ where
             .unwrap()
     }
 
-    async fn crank_and_check_indefinitely(&mut self, node_id: &R::NodeId, rng: &mut TestRng) {
+    async fn crank_and_check_indefinitely(&mut self, node_id: &NodeId, rng: &mut TestRng) {
         loop {
             if self.crank(node_id, rng).await == 0 {
                 Instant::advance_time(POLL_INTERVAL.as_millis() as u64);
@@ -284,7 +280,7 @@ where
     }
 
     /// Returns the internal map of nodes.
-    pub(crate) fn nodes(&self) -> &HashMap<R::NodeId, Runner<ConditionCheckReactor<R>>> {
+    pub(crate) fn nodes(&self) -> &HashMap<NodeId, Runner<ConditionCheckReactor<R>>> {
         &self.nodes
     }
 
@@ -307,7 +303,7 @@ where
     /// an `EffectBuilder`.
     pub(crate) async fn process_injected_effect_on<F>(
         &mut self,
-        node_id: &R::NodeId,
+        node_id: &NodeId,
         create_effects: F,
     ) where
         F: FnOnce(EffectBuilder<R::Event>) -> Effects<R::Event>,
@@ -325,7 +321,6 @@ impl<R> Finalize for Network<R>
 where
     R: Finalize + NetworkedReactor + Reactor + Send + 'static,
     R::Event: Serialize + Send + Sync,
-    R::NodeId: Send,
     R::Error: From<prometheus::Error>,
 {
     fn finalize(self) -> BoxFuture<'static, ()> {

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -81,7 +81,7 @@ type SslResult<T> = Result<T, ErrorStack>;
 
 /// SHA512 hash.
 #[derive(Copy, Clone, DataSize, Deserialize, Serialize)]
-struct Sha512(#[serde(with = "big_array::BigArray")] [u8; Sha512::SIZE]);
+pub struct Sha512(#[serde(with = "big_array::BigArray")] [u8; Sha512::SIZE]);
 
 impl Sha512 {
     /// Size of digest in bytes.
@@ -91,7 +91,7 @@ impl Sha512 {
     const NID: Nid = Nid::SHA512;
 
     /// Create a new Sha512 by hashing a slice.
-    fn new<B: AsRef<[u8]>>(data: B) -> Self {
+    pub fn new<B: AsRef<[u8]>>(data: B) -> Self {
         let mut openssl_sha = sha::Sha512::new();
         openssl_sha.update(data.as_ref());
         Sha512(openssl_sha.finish())
@@ -163,6 +163,12 @@ impl Debug for KeyFingerprint {
 impl From<[u8; KeyFingerprint::LENGTH]> for KeyFingerprint {
     fn from(raw_bytes: [u8; KeyFingerprint::LENGTH]) -> Self {
         KeyFingerprint(Sha512(raw_bytes))
+    }
+}
+
+impl From<Sha512> for KeyFingerprint {
+    fn from(hash: Sha512) -> Self {
+        Self(hash)
     }
 }
 

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::BTreeMap,
-    hash::Hash,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
@@ -41,7 +40,7 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
     let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 54321);
     let mut peers = BTreeMap::new();
     peers.insert(*node_id, socket_addr.to_string());
-    let status_feed = StatusFeed::<NodeId> {
+    let status_feed = StatusFeed {
         last_added_block: Some(Block::doc_example().clone()),
         peers,
         chainspec_info: ChainspecInfo::doc_example().clone(),
@@ -87,12 +86,11 @@ impl ChainspecInfo {
 
 /// Data feed for client "info_get_status" endpoint.
 #[derive(Debug, Serialize)]
-#[serde(bound = "I: Eq + Hash + Ord + Serialize")]
-pub struct StatusFeed<I> {
+pub struct StatusFeed {
     /// The last block added to the chain.
     pub last_added_block: Option<Block>,
     /// The peer nodes which are connected to this node.
-    pub peers: BTreeMap<I, String>,
+    pub peers: BTreeMap<NodeId, String>,
     /// The chainspec info for this node.
     pub chainspec_info: ChainspecInfo,
     /// Our public signing key.
@@ -105,10 +103,10 @@ pub struct StatusFeed<I> {
     pub node_uptime: Duration,
 }
 
-impl<I> StatusFeed<I> {
+impl StatusFeed {
     pub(crate) fn new(
         last_added_block: Option<Block>,
-        peers: BTreeMap<I, String>,
+        peers: BTreeMap<NodeId, String>,
         chainspec_info: ChainspecInfo,
         consensus_status: Option<(PublicKey, Option<TimeDiff>)>,
         node_uptime: Duration,
@@ -182,7 +180,7 @@ pub struct GetStatusResult {
 }
 
 impl GetStatusResult {
-    pub(crate) fn new(status_feed: StatusFeed<NodeId>, api_version: ProtocolVersion) -> Self {
+    pub(crate) fn new(status_feed: StatusFeed, api_version: ProtocolVersion) -> Self {
         GetStatusResult {
             api_version,
             chainspec_name: status_feed.chainspec_info.name,

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -42,6 +42,8 @@ pub(crate) use external::RESOURCES_PATH;
 pub(crate) use external::{External, LoadError, Loadable};
 pub(crate) use round_robin::WeightedRoundRobin;
 
+use crate::types::NodeId;
+
 /// DNS resolution error.
 #[derive(Debug, Error)]
 #[error("could not resolve `{address}`: {kind}")]
@@ -320,24 +322,22 @@ impl<T> WithDir<T> {
 
 /// The source of a piece of data.
 #[derive(Clone, Debug, Serialize)]
-pub(crate) enum Source<I> {
+pub(crate) enum Source {
     /// A peer with the wrapped ID.
-    Peer(I),
+    Peer(NodeId),
     /// A client.
     Client,
     /// This node.
     Ourself,
 }
 
-impl<I> Source<I> {
+impl Source {
     pub(crate) fn is_client(&self) -> bool {
         matches!(self, Source::Client)
     }
-}
 
-impl<I: Clone> Source<I> {
     /// If `self` represents a peer, returns its ID, otherwise returns `None`.
-    pub(crate) fn node_id(&self) -> Option<I> {
+    pub(crate) fn node_id(&self) -> Option<NodeId> {
         match self {
             Source::Peer(node_id) => Some(node_id.clone()),
             Source::Client | Source::Ourself => None,
@@ -345,7 +345,7 @@ impl<I: Clone> Source<I> {
     }
 }
 
-impl<I: Display> Display for Source<I> {
+impl Display for Source {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Source::Peer(node_id) => Display::fmt(node_id, formatter),

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -339,7 +339,7 @@ impl Source {
     /// If `self` represents a peer, returns its ID, otherwise returns `None`.
     pub(crate) fn node_id(&self) -> Option<NodeId> {
         match self {
-            Source::Peer(node_id) => Some(node_id.clone()),
+            Source::Peer(node_id) => Some(*node_id),
             Source::Client | Source::Ourself => None,
         }
     }


### PR DESCRIPTION
I tried to remove it merely from the surrounding territory of the consensus protocol, but that did not work, so I think it makes sense to remove it from everywhere. Once we extract highway and our new consensus protocol as separate crates, we can parameterize them there so users aren't forced to depend on our type.