### PR TITLE
Low priority networking queue

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.  The format
 * Chain automatically creates a switch block immediately after genesis or an upgrade.
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
+* Requests for data from a peer are now de-prioritized over networking message necessary for consensus and chain advancement.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.  The format
 * Chain automatically creates a switch block immediately after genesis or an upgrade.
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
-* Requests for data from a peer are now de-prioritized over networking message necessary for consensus and chain advancement.
+* Requests for data from a peer are now de-prioritized over networking messages necessary for consensus and chain advancement.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -53,6 +53,15 @@ impl<P: Payload> Message<P> {
         }
     }
 
+    /// Determines whether or not a message is low priority.
+    #[inline]
+    pub(super) fn is_low_priority(&self, from_validator: bool) -> bool {
+        match self {
+            Message::Handshake { .. } => false,
+            Message::Payload(payload) => payload.is_low_priority(from_validator),
+        }
+    }
+
     /// Returns the incoming resource estimate of the payload.
     #[inline]
     pub(super) fn payload_incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
@@ -284,6 +293,13 @@ pub(crate) trait Payload:
 
     /// The penalty for resource usage of a message to be applied when processed as incoming.
     fn incoming_resource_estimate(&self, _weights: &EstimatorWeights) -> u32;
+
+    /// Determines if the payload should be considered low priority.
+    ///
+    /// If `from_validator` is true, the message was received from an active validator.
+    fn is_low_priority(&self, from_validator: bool) -> bool {
+        !from_validator
+    }
 }
 
 /// Network message conversion support.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -55,10 +55,10 @@ impl<P: Payload> Message<P> {
 
     /// Determines whether or not a message is low priority.
     #[inline]
-    pub(super) fn is_low_priority(&self, from_validator: bool) -> bool {
+    pub(super) fn is_low_priority(&self) -> bool {
         match self {
             Message::Handshake { .. } => false,
-            Message::Payload(payload) => payload.is_low_priority(from_validator),
+            Message::Payload(payload) => payload.is_low_priority(),
         }
     }
 
@@ -295,10 +295,8 @@ pub(crate) trait Payload:
     fn incoming_resource_estimate(&self, _weights: &EstimatorWeights) -> u32;
 
     /// Determines if the payload should be considered low priority.
-    ///
-    /// If `from_validator` is true, the message was received from an active validator.
-    fn is_low_priority(&self, from_validator: bool) -> bool {
-        !from_validator
+    fn is_low_priority(&self) -> bool {
+        false
     }
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -504,7 +504,7 @@ where
                         )
                         .await;
 
-                    let queue_kind = if msg.is_low_priority(false) {
+                    let queue_kind = if msg.is_low_priority() {
                         QueueKind::NetworkLowPriority
                     } else {
                         QueueKind::NetworkIncoming

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -503,6 +503,13 @@ where
                             msg.payload_incoming_resource_estimate(&context.payload_weights),
                         )
                         .await;
+
+                    let queue_kind = if msg.is_low_priority(false) {
+                        QueueKind::NetworkLowPriority
+                    } else {
+                        QueueKind::NetworkIncoming
+                    };
+
                     context
                         .event_queue
                         .schedule(
@@ -511,7 +518,7 @@ where
                                 msg: Box::new(msg),
                                 span: span.clone(),
                             },
-                            QueueKind::NetworkIncoming,
+                            queue_kind,
                         )
                         .await;
                 }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -79,6 +79,17 @@ impl Payload for Message {
         }
     }
 
+    fn is_low_priority(&self) -> bool {
+        match self {
+            Message::Consensus(_) => false,
+            Message::DeployGossiper(_) => false,
+            Message::AddressGossiper(_) => false,
+            Message::GetRequest { .. } => true,
+            Message::GetResponse { .. } => false,
+            Message::FinalitySignature(_) => false,
+        }
+    }
+
     #[inline]
     fn incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
         match self {

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -80,11 +80,14 @@ impl Payload for Message {
     }
 
     fn is_low_priority(&self) -> bool {
+        // We only deprioritize requested trie nodes, as they are the most commonly requested item
+        // during fast sync.
         match self {
             Message::Consensus(_) => false,
             Message::DeployGossiper(_) => false,
             Message::AddressGossiper(_) => false,
-            Message::GetRequest { .. } => true,
+            Message::GetRequest { tag, .. } if *tag == Tag::Trie => true,
+            Message::GetRequest { .. } => false,
             Message::GetResponse { .. } => false,
             Message::FinalitySignature(_) => false,
         }

--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -20,6 +20,8 @@ pub enum QueueKind {
     ///
     /// Their load may vary and grouping them together in one queue aides DoS protection.
     NetworkIncoming,
+    /// Network events that are low priority.
+    NetworkLowPriority,
     /// Network events that were initiated by the local node, such as outgoing messages.
     Network,
     /// Events of unspecified priority.
@@ -38,6 +40,7 @@ impl Display for QueueKind {
         let str_value = match self {
             QueueKind::Control => "Control",
             QueueKind::NetworkIncoming => "NetworkIncoming",
+            QueueKind::NetworkLowPriority => "NetworkLowPriority",
             QueueKind::Network => "Network",
             QueueKind::Regular => "Regular",
             QueueKind::Api => "Api",
@@ -62,6 +65,7 @@ impl QueueKind {
             // Note: Control events should be very rare, but we do want to process them right away.
             QueueKind::Control => 32,
             QueueKind::NetworkIncoming => 4,
+            QueueKind::NetworkLowPriority => 1,
             QueueKind::Network => 4,
             QueueKind::Regular => 8,
             QueueKind::Api => 16,
@@ -80,6 +84,7 @@ impl QueueKind {
         match self {
             QueueKind::Control => "control",
             QueueKind::NetworkIncoming => "network_incoming",
+            QueueKind::NetworkLowPriority => "network_low_priority",
             QueueKind::Network => "network",
             QueueKind::Regular => "regular",
             QueueKind::Api => "api",


### PR DESCRIPTION
Adds a special low-priority incoming network message queue. Any incoming request for data will be put into this queue, preventing these kinds of message from stopping things like consensus message to reach the respective component or interfere with internal node operation (an incoming consensus message will essentially bypass almost all `GetRequests` this way).

This should keep consensus nodes live even when under pressure by joining nodes.