### PR TITLE
Add deploy gossiper to joiner

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
+* Nodes will now also gossip deploys onwards while joining.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -693,6 +693,11 @@ impl reactor::Reactor for Reactor {
             JoinerEvent::DeployAcceptorAnnouncement(
                 DeployAcceptorAnnouncement::AcceptedNewDeploy { deploy, source },
             ) => {
+                if let Err(error) = deploy.deploy_info() {
+                    error!(%error, "invalid deploy");
+                    return Effects::new();
+                };
+
                 let event = event_stream_server::Event::DeployAccepted(*deploy.id());
                 let mut effects =
                     self.dispatch_event(effect_builder, rng, JoinerEvent::EventStreamServer(event));

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -912,10 +912,11 @@ impl reactor::Reactor for Reactor {
                 debug!(%incoming, "ignoring incoming consensus message");
                 Effects::new()
             }
-            JoinerEvent::DeployGossiperIncoming(incoming) => {
-                debug!(%incoming, "ignoring incoming deploy gossiper message");
-                Effects::new()
-            }
+            JoinerEvent::DeployGossiperIncoming(incoming) => reactor::wrap_effects(
+                JoinerEvent::DeployGossiper,
+                self.deploy_gossiper
+                    .handle_event(effect_builder, rng, incoming.into()),
+            ),
             JoinerEvent::AddressGossiperIncoming(incoming) => reactor::wrap_effects(
                 JoinerEvent::AddressGossiper,
                 self.address_gossiper
@@ -972,7 +973,10 @@ impl reactor::Reactor for Reactor {
             }
             JoinerEvent::DeployGossiperAnnouncement(GossiperAnnouncement::FinishedGossiping(
                 _gossiped_deploy_id,
-            )) => Effects::new(),
+            )) => {
+                // We never process any deploys onwards, so we can ignore successful gossip outcome
+                Effects::new()
+            }
         }
     }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -702,6 +702,16 @@ impl reactor::Reactor for Reactor {
                 let mut effects =
                     self.dispatch_event(effect_builder, rng, JoinerEvent::EventStreamServer(event));
 
+                let event = gossiper::Event::ItemReceived {
+                    item_id: *deploy.id(),
+                    source: source.clone(),
+                };
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    JoinerEvent::DeployGossiper(event),
+                ));
+
                 let event = fetcher::Event::GotRemotely {
                     verifiable_chunked_hash_activation: None,
                     item: deploy,


### PR DESCRIPTION
Adds a deploy gossiper to the joiner reactor. Closes #2667.

We have been observing high failure rates and slow consensus on artificial networks with a large ratio of joiners to validators (e.g. 20:5). see below for an explanation of what happened.

This PR adds a deploy gossiper to joining nodes.