### PR TITLE
Fix clippy warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,15 +179,15 @@ setup-audit:
 
 .PHONY: setup-rs
 setup-rs: smart_contracts/rust-toolchain
-	$(RUSTUP) update --no-self-update
-	$(RUSTUP) toolchain install --no-self-update stable $(PINNED_NIGHTLY)
+	$(RUSTUP) update
+	$(RUSTUP) toolchain install stable $(PINNED_NIGHTLY)
 	$(RUSTUP) target add --toolchain stable wasm32-unknown-unknown
 	$(RUSTUP) target add --toolchain $(PINNED_NIGHTLY) wasm32-unknown-unknown
 
 .PHONY: setup-nightly-rs
 setup-nightly-rs:
-	$(RUSTUP) update --no-self-update
-	$(RUSTUP) toolchain install --no-self-update nightly
+	$(RUSTUP) update
+	$(RUSTUP) toolchain install nightly
 	$(RUSTUP) target add --toolchain nightly wasm32-unknown-unknown
 
 .PHONY: setup-as

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -206,7 +206,7 @@ where
         let module = {
             let full_module_path = meta
                 .module_path()
-                .or_else(|| field_visitor.module.as_deref())
+                .or(field_visitor.module.as_deref())
                 .unwrap_or_default();
             if self.abbreviate_modules {
                 // Use a smallvec for going up to six levels deep.
@@ -229,7 +229,7 @@ where
 
         let file = if !self.abbreviate_modules {
             meta.file()
-                .or_else(|| field_visitor.file.as_deref())
+                .or(field_visitor.file.as_deref())
                 .unwrap_or_default()
                 .rsplit_once('/')
                 .map(|parts| parts.1)


### PR DESCRIPTION
This fixes clippy warnings generated by the new 1.59 stable version of Rust.