### PR TITLE
CI: initial rework of CI pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -70,6 +70,10 @@ steps:
     - push
     status:
     - failure
+    branch:
+    - dev
+    - "release-*"
+    - "feat-*"
 
 volumes:
 - name: rustup

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,178 +1,238 @@
 ---
-# Quick checks to make before spending time on test and package.clone:
-# on failure -> failed-pre-checks pipeline
-# on success --> cargo-test (parallel) ---> [ test-package-success | test-package-failure ]
-#            \-> package  (parallel) ----/
-kind: pipeline
-type: docker
-name: pre-checks
-
-# Steps perform as fast serially, due to file thrashing.
-steps:
-
-    # TODO: re-enable once we figure out publishing
-    # - name: markdown-link-check
-    #   image: casperlabs/node-build-u1804
-    #   commands:
-    #     - "./ci/markdown_link_check.sh"
-
-  - name: cargo-fmt
-    image: casperlabs/node-build-u1804
-    commands:
-      - make setup-rs
-      - make check-format
-
-  - name: cargo-clippy
-    image: casperlabs/node-build-u1804
-    commands:
-      - make setup-rs
-      - make lint
-
-  - name: cargo-doc
-    image: casperlabs/node-build-u1804
-    commands:
-      - make setup-rs
-      - make doc
-
-  - name: audit
-    image: casperlabs/node-build-u1804
-    commands:
-      - make setup-audit
-      - cargo generate-lockfile
-      - make audit
-
-trigger:
-  branch:
-    - master
-    - trying
-    - staging
-    - dev
-    - "release-*"
-    - "feat-*"
-  event:
-    exclude:
-      - tag
-
----
-# Failure state from pre-checks pipeline
-kind: pipeline
-type: docker
-name: failed-pre-checks
-
-clone:
-  disable: true
-
-steps:
-  - name: notify
-    image: plugins/slack
-    settings:
-      webhook:
-        from_secret: slack_webhook
-      template:
-        - |
-          casper-node build status: *{{ uppercasefirst build.status }}*
-          Author: {{ build.author }}
-          Drone Build: <{{ build.link }}|#{{ build.number }}>
-          Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
-trigger:
-  status:
-    - failure
-  branch:
-    - master
-    - trying
-    - staging
-    - dev
-    - "release-*"
-    - "feat-*"
-  event:
-    exclude:
-      - tag
-
-depends_on:
-  - pre-checks
-
----
-# Testing pipeline, runs in parallel with package pipeline
 kind: pipeline
 type: docker
 name: cargo-test
 
-steps:
-- name: updater-dry-run
-  image: casperlabs/node-build-u1804
-  commands:
-  - cargo run --package=casper-updater -- --root-dir=. --dry-run
+environment:
+  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
+  CACHEPOT_BUCKET: 'drone-sccache'
+  CACHEPOT_S3_KEY_PREFIX: ci
+  CACHEPOT_REGION: 'us-east-2'
+  CARGO_INCREMENTAL: '0'
 
-- name: cargo-test
+__buildenv: &buildenv
   image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: cachepot_aws_ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: cachepot_aws_sk
+
+steps:
+- name: setup
+  <<: *buildenv
   commands:
   - make setup
+
+# The below is duplicated for pull and push 
+# due to environment bug with caching. 
+- name: cargo-test-pr
+  <<: *buildenv
+  environment:
+    SCCACHE_S3_PUBLIC: true
+  commands:
   - make test CARGO_FLAGS=--release
   - make test-contracts CARGO_FLAGS=--release
-
-depends_on:
-  - pre-checks
-
-trigger:
-  branch:
-    - master
-    - trying
-    - staging
-    - dev
-    - "release-*"
-    - "feat-*"
-  event:
-    exclude:
-      - tag
-
----
-# Packaging pipeline, runs in parallel with cargo-test pipeline
-kind: pipeline
-type: docker
-name: package
-
-steps:
-- name: build-client-contracts
-  image: casperlabs/node-build-u1804
-  commands:
-    - make setup
-    - make build-client-contracts
+  - cachepot --show-stats
   when:
-    branch:
-    - master
-    - dev
-    - "release-*"
-    - "feat-*"
+    event:
+    - pull_request
+
+- name: cargo-test-push
+  <<: *buildenv
+  commands:
+  - make test CARGO_FLAGS=--release
+  - make test-contracts CARGO_FLAGS=--release
+  - cachepot --show-stats
+  when:
     event:
     - push
 
-- name: build-wasm-package-push-to-s3
-  image: casperlabs/s3cmd-build:latest
+- name: notify
+  image: plugins/slack
+  settings:
+    webhook:
+      from_secret: slack_webhook
+    template:
+    - |
+      Cargo-Test Pipeline Status: *{{ uppercasefirst build.status }}*
+      Drone Build: <{{ build.link }}|#{{ build.number }}>
+      Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
+  when:
+    event:
+    - push
+    status:
+    - failure
+
+volumes:
+- name: rustup
+  temp: {}
+- name: cargo
+  temp: {}
+- name: drone
+  temp: {}
+
+trigger:
+  branch:
+  - trying
+  - staging
+  - dev
+  - "release-*"
+  - "feat-*"
+  event:
+    include:
+    - pull_request
+    - push
+    exclude:
+    - tag
+    - cron
+
+---
+kind: pipeline
+type: docker
+name: nctl-testing
+
+environment:
+  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
+  CACHEPOT_BUCKET: 'drone-sccache'
+  CACHEPOT_S3_KEY_PREFIX: ci
+  CACHEPOT_REGION: 'us-east-2'
+  CARGO_INCREMENTAL: '0'
+
+__buildenv: &buildenv
+  image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: cachepot_aws_ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: cachepot_aws_sk
+
+steps:
+- name: setup
+  <<: *buildenv
   commands:
-    - "./build_wasm_package.sh"
+  - make setup
+
+- name: nctl-compile
+  <<: *buildenv
+  commands:
+  - bash -i ./ci/nctl_compile.sh
+
+- name: nctl-upgrade-test
+  <<: *buildenv
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: put-drone-aws-ak
     AWS_SECRET_ACCESS_KEY:
       from_secret: put-drone-aws-sk
-  when:
-    branch:
-    - master
-    - dev
-    - "release-*"
-    - "feat-*"
-    event:
+  commands:
+  - bash -i ./ci/nctl_upgrade.sh
+
+volumes:
+- name: rustup
+  temp: {}
+- name: cargo
+  temp: {}
+- name: drone
+  temp: {}
+
+trigger:
+  branch:
+  - trying
+  - staging
+  event:
+    include:
     - push
+    exclude:
+    - pull_request
+    - tag
+    - cron
+
+---
+kind: pipeline
+type: docker
+name: package
+
+environment:
+  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
+  CACHEPOT_BUCKET: 'drone-sccache'
+  CACHEPOT_S3_KEY_PREFIX: ci
+  CACHEPOT_REGION: 'us-east-2'
+  CARGO_INCREMENTAL: '0'
+
+__buildenv: &buildenv
+  image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  - name: nctl-temp-dir
+    path: "/tmp/nctl_upgrade_stage"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: cachepot_aws_ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: cachepot_aws_sk
+
+__buildenv_upload: &buildenv_upload
+  image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  - name: nctl-temp-dir
+    path: "/tmp/nctl_upgrade_stage"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
+
+steps:
+- name: setup
+  <<: *buildenv
+  commands:
+  - make setup
+
+- name: build-client-contracts
+  <<: *buildenv
+  commands:
+  - make build-client-contracts
+
+- name: stest-wasm-package-push-to-s3
+  image: casperlabs/s3cmd-build:latest
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
+  commands:
+  - "./build_wasm_package.sh"
 
 - name: build-upgrade-package
-  image: casperlabs/node-build-u1804
+  <<: *buildenv
   commands:
-    - "./ci/build_update_package.sh"
-
-- name: dry-run-publish
-  image: casperlabs/node-build-u1804
-  commands:
-    - "cd types && cargo publish --dry-run"
+  - "./ci/build_update_package.sh"
 
 - name: upload-to-s3-genesis
   image: plugins/s3
@@ -186,44 +246,17 @@ steps:
     source: "target/upgrade_build/**/*"
     strip_prefix: 'target/upgrade_build/'
     target: "/drone/${DRONE_COMMIT}/"
-  when:
-    branch:
-      - master
-      - dev
-      - "release-*"
-      - "feat-*"
-    event:
-      - push
 
-- name: nctl-upgrade-assets-stage-rc
-  image: casperlabs/node-build-u1804
+- name: nctl-s3-build
+  <<: *buildenv_upload
   commands:
-    - "./ci/nctl_upgrade_stage.sh"
-  volumes:
-  - name: nctl-temp-dir
-    path: /tmp/nctl_upgrade_stage
+  - "aws s3 rm s3://nctl.casperlabs.io/${DRONE_BRANCH} --recursive"
+  - "./ci/nctl_upgrade_stage.sh"
   when:
     branch:
-      - "release-*"
-    event:
-      - push
+    - "release-*"
 
-- name: nctl-bucket-pr-clear
-  image: casperlabs/node-build-u1804
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
-  commands:
-    - "aws s3 rm s3://nctl.casperlabs.io/${DRONE_BRANCH} --recursive"
-  when:
-    branch:
-      - "release-*"
-    event:
-      - push
-
-- name: nctl-bucket-upload-rc
+- name: nctl-bucket-upload
   image: plugins/s3-sync:latest
   settings:
     bucket: 'nctl.casperlabs.io'
@@ -239,170 +272,7 @@ steps:
     path: /tmp/nctl_upgrade_stage
   when:
     branch:
-      - "release-*"
-    event:
-      - push
-
-- name: nctl-upgrade-test
-  image: casperlabs/node-build-u1804
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
-  commands:
-    - "python3 -m pip install supervisor toml"
-    - "apt update && apt install lsof -y"
-    - "bash -i ./ci/nctl_upgrade.sh"
-  when:
-    branch:
-      - trying
-      - staging
-
-depends_on:
-  - pre-checks
-
-trigger:
-  branch:
-    - master
-    - trying
-    - staging
-    - dev
     - "release-*"
-    - "feat-*"
-  event:
-    exclude:
-      - tag
-
-volumes:
-- name: nctl-temp-dir
-  temp: {}
-
----
-# Run on success of cargo-test and package pipelines.
-kind: pipeline
-type: docker
-name: test-package-success
-
-steps:
-  # Retrieving packages built and put in s3 from package pipeline.
-- name: get-and-del-drone-s3-cache
-  image: casperlabs/s3cmd-build:latest
-  commands:
-    - s3cmd sync "s3://$AWS_BUCKET/drone_temp/${DRONE_BUILD_NUMBER}_${DRONE_REPO_OWNER}_${DRONE_REPO_NAME}/debian/" "./target/debian/"
-    - s3cmd del --recursive "s3://$AWS_BUCKET/drone_temp/${DRONE_BUILD_NUMBER}_${DRONE_REPO_OWNER}_${DRONE_REPO_NAME}/"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
-    AWS_DEFAULT_REGION: "us-east-2"
-    AWS_BUCKET:
-      from_secret: put-drone-s3-bucket
-  when:
-    branch:
-      - master
-      - dev
-      - "release-*"
-      - "feat-*"
-    event:
-      - push
-
-- name: publish-repo-test
-  image: casperlabs/aptly:latest
-  failure: ignore
-  environment:
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: APTLY_SECRET_KEY
-    AWS_ACCESS_KEY_ID:
-      from_secret: APTLY_KEY_ID
-  settings:
-    repo_name:
-      from_secret: APTLY_REPO_NAME
-    region:
-      from_secret: APTLY_REGION
-    gpg_key:
-      from_secret: APTLY_GPG_KEY
-    gpg_pass:
-      from_secret: APTLY_GPG_PASS
-    distribution_id:
-      from_secret: APTLY_DISTRIBUTION_ID
-    acl: 'public-read'
-    prefix: 'releases'
-    deb_path: './target/debian'
-    deb_name: '*.deb'
-  when:
-    branch:
-      - master
-      - dev
-      - "release-*"
-      - "feat-*"
-    event:
-      - push
-
-depends_on:
-  - cargo-test
-  - package
-
-trigger:
-  branch:
-    - master
-    - trying
-    - staging
-    - dev
-    - "release-*"
-    - "feat-*"
-  event:
-    exclude:
-      - tag
-
----
-# Runs on failure of cargo-test or package pipelines.
-kind: pipeline
-type: docker
-name: test-package-failure
-
-clone:
-  disable: true
-
-steps:
-- name: del-s3-cache
-  image: casperlabs/s3cmd-build:latest
-  commands:
-    - s3cmd del --recursive "s3://$AWS_BUCKET/drone_temp/${DRONE_BUILD_NUMBER}_${DRONE_REPO_OWNER}_${DRONE_REPO_NAME}/"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
-    AWS_DEFAULT_REGION: "us-east-2"
-    AWS_BUCKET:
-      from_secret: put-drone-s3-bucket
-  when:
-    branch:
-      - master
-      - dev
-      - "release-*"
-      - "feat-*"
-    event:
-      - push
-
-# Build failed so remove the update_package candidate
-#- name: del-upgrade_package-s3
-#  image: casperlabs/s3cmd-build:latest
-#  commands:
-#    - ./ci/upgrade_package_s3_storage.sh del
-#  environment:
-#    CL_VAULT_TOKEN:
-#      from_secret: vault_token
-#    CL_VAULT_HOST:
-#      from_secret: vault_host
-#  when:
-#    branch:
-#      - master
-#      - "release-*"
-#    event:
-#      - push
 
 - name: notify
   image: plugins/slack
@@ -410,45 +280,93 @@ steps:
     webhook:
       from_secret: slack_webhook
     template:
-      - |
-        casper-node build status: *{{ uppercasefirst build.status }}*
-        Author: {{ build.author }}
-        Drone Build: <{{ build.link }}|#{{ build.number }}>
-        Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
+    - |
+      Package Pipeline Status: *{{ uppercasefirst build.status }}*
+      Drone Build: <{{ build.link }}|#{{ build.number }}>
+      Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
+  when:
+    status:
+    - failure
+
+volumes:
+- name: rustup
+  temp: {}
+- name: cargo
+  temp: {}
+- name: drone
+  temp: {}
+- name: nctl-temp-dir
+  temp: {}
 
 trigger:
-  status:
-    - failure
   branch:
-    - master
-    - trying
-    - staging
-    - dev
-    - "release-*"
-    - "feat-*"
+  - dev
+  - "release-*"
+  - "feat-*"
   event:
+    include:
+    - push
     exclude:
-      - tag
+    - pull_request
+    - tag
+    - cron
 
-depends_on:
-  - cargo-test
-  - package
-
-# TAGGING PIPELINES
-# release-by-tag
-#      | (failure)
-# failed-tag
 ---
-# act on release - when the tag is created
 kind: pipeline
 type: docker
 name: release-by-tag
 
-steps:
-- name: build-upgrade-package
+environment:
+  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
+  CACHEPOT_BUCKET: 'drone-sccache'
+  CACHEPOT_S3_KEY_PREFIX: ci
+  CACHEPOT_REGION: 'us-east-2'
+  CARGO_INCREMENTAL: '0'
+
+__buildenv: &buildenv
   image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  - name: nctl-temp-dir
+    path: "/tmp/nctl_upgrade_stage"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: cachepot_aws_ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: cachepot_aws_sk
+
+__buildenv_upload: &buildenv_upload
+  image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  - name: nctl-temp-dir
+    path: "/tmp/nctl_upgrade_stage"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
+
+steps:
+- name: setup
+  <<: *buildenv
   commands:
-    - "./ci/build_update_package.sh"
+  - make setup
+
+- name: build-upgrade-package
+  <<: *buildenv
+  commands:
+  - "./ci/build_update_package.sh"
 
 - name: publish-github-pre-release
   image: plugins/github-release
@@ -462,17 +380,6 @@ steps:
     - "./target/upgrade_build/*.gz"
     prerelease:
     - true
-  when:
-    ref:
-    - refs/tags/v*
-
-- name: publish-crate
-  image: casperlabs/node-build-u1804
-  commands:
-    - "./ci/publish_to_crates_io.sh"
-  environment:
-    CARGO_TOKEN:
-      from_secret: crates_io_token
 
 - name: as-contract-publish
   image: plugins/npm
@@ -490,23 +397,11 @@ steps:
     access:
     - "public"
 
-- name: nctl-upgrade-assets-stage
-  image: casperlabs/node-build-u1804
+- name: nctl-s3-build
+  <<: *buildenv_upload
   commands:
-    - "./ci/nctl_upgrade_stage.sh"
-  volumes:
-  - name: nctl-temp-dir
-    path: /tmp/nctl_upgrade_stage
-
-- name: nctl-bucket-tag-clear
-  image: casperlabs/node-build-u1804
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
-  commands:
-    - "aws s3 rm s3://nctl.casperlabs.io/${DRONE_TAG} --recursive"
+  - "aws s3 rm s3://nctl.casperlabs.io/${DRONE_TAG} --recursive"
+  - "./ci/nctl_upgrade_stage.sh"
 
 - name: nctl-bucket-upload
   image: plugins/s3-sync:latest
@@ -523,6 +418,14 @@ steps:
   - name: nctl-temp-dir
     path: /tmp/nctl_upgrade_stage
 
+- name: publish-crates
+  <<: *buildenv
+  environment:
+    CARGO_TOKEN:
+      from_secret: crates_io_token
+  commands:
+  - "./ci/publish_to_crates_io.sh"
+
 - name: update-default-branch
   image: casperlabs/node-build-u1804
   environment:
@@ -531,7 +434,28 @@ steps:
   commands:
     - "./ci/change_default_branch.py"
 
+- name: notify
+  image: plugins/slack
+  settings:
+    webhook:
+      from_secret: slack_webhook
+    template:
+    - |
+      Casper-Node Release Status: *{{ uppercasefirst build.status }}*
+      Drone Build: <{{ build.link }}|#{{ build.number }}>
+      Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
+  when:
+    status:
+    - failure
+    - success
+
 volumes:
+- name: rustup
+  temp: {}
+- name: cargo
+  temp: {}
+- name: drone
+  temp: {}
 - name: nctl-temp-dir
   temp: {}
 
@@ -542,49 +466,50 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: failed-tag
+name: nightly-testing
 
-clone:
-  disable: true
+environment:
+  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
+  CACHEPOT_BUCKET: 'drone-sccache'
+  CACHEPOT_S3_KEY_PREFIX: ci
+  CACHEPOT_REGION: 'us-east-2'
+  CARGO_INCREMENTAL: '0'
 
-steps:
-- name: notify
-  image: plugins/slack
-  settings:
-    webhook:
-      from_secret: slack_webhook
-    template:
-    - |
-      casper-node build status: *{{ uppercasefirst build.status }}*
-      Author: {{ build.author }}
-      Drone Build: <{{ build.link }}|#{{ build.number }}>
-      Commit Link: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 10 }}>
-trigger:
-  status:
-  - failure
-  ref:
-    - refs/tags/v*
-
-depends_on:
-- release-by-tag
-
----
-kind: pipeline
-type: docker
-name: nightly-tests-cron
-
-steps:
-- name: nctl-nighly-script
+__buildenv: &buildenv
   image: casperlabs/node-build-u1804
+  volumes:
+  - name: rustup
+    path: "/root/.rustup"
+  - name: cargo
+    path: "/root/.cargo"
+  - name: drone
+    path: "/drone"
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: cachepot_aws_ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: cachepot_aws_sk
+
+steps:
+- name: setup
+  <<: *buildenv
+  commands:
+  - make setup
+
+- name: nctl-compile
+  <<: *buildenv
+  commands:
+  - bash -i ./ci/nctl_compile.sh
+
+- name: nctl-nightly-tests
+  <<: *buildenv
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: put-drone-aws-ak
     AWS_SECRET_ACCESS_KEY:
       from_secret: put-drone-aws-sk
   commands:
-  - "python3 -m pip install supervisor toml"
-  - "apt update && apt install lsof -y"
-  - "bash -i ci/nightly-test.sh"
+  - bash -i ./ci/nightly-test.sh
 
 - name: notify
   image: plugins/slack
@@ -601,8 +526,14 @@ steps:
     status:
     - failure
     - success
-  depends_on:
-  - nctl-nighly-script
+
+volumes:
+- name: rustup
+  temp: {}
+- name: cargo
+  temp: {}
+- name: drone
+  temp: {}
 
 trigger:
   cron: [ nightly-tests-cron ]

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,70 @@
+---
+name: lints
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - dev
+      - trying
+      - staging
+      - 'release-**'
+      - 'feat-**'
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches:
+      - dev
+      - 'release-**'
+      - 'feat-**'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  lints:
+    name: lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #tag v2.4.0
+        with:
+          persist-credentials: false
+
+      - name: Get nightly toolchain from smart_contracts dir
+        id: nightly-toolchain
+        run: echo "::set-output name=version::$(cat smart_contracts/rust-toolchain)"
+
+      - name: Install Toolchain - Stable
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+
+      - name: Install Toolchain - Nightly
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ steps.nightly-toolchain.outputs.version }}
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: fmt
+        run: make check-format
+
+      - name: clippy
+        run: make lint
+
+      - name: doc
+        run: make doc
+
+      - name: lockfile
+        run: cargo generate-lockfile
+
+      - name: audit
+        run: make audit

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+NCTL_CLIENT_BRANCH="${DRONE_BRANCH:='dev'}"
+
+# Activate Environment
+pushd "$ROOT_DIR"
+source $(pwd)/utils/nctl/activate
+
+# Clone the client and launcher repos if required.
+if [ ! -d "$NCTL_CASPER_CLIENT_HOME" ]; then
+    echo "Checking out $NCTL_CLIENT_BRANCH of casper-client-rs..."
+    git clone -b "$NCTL_CLIENT_BRANCH" https://github.com/casper-ecosystem/casper-client-rs "$NCTL_CASPER_CLIENT_HOME"
+fi
+if [ ! -d "$NCTL_CASPER_NODE_LAUNCHER_HOME" ]; then
+    git clone https://github.com/casper-network/casper-node-launcher "$NCTL_CASPER_NODE_LAUNCHER_HOME"
+fi
+
+popd
+
+# NCTL Build
+nctl-compile
+cachepot --show-stats

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -8,6 +8,16 @@ NCTL_CLIENT_BRANCH="${DRONE_BRANCH:='dev'}"
 pushd "$ROOT_DIR"
 source $(pwd)/utils/nctl/activate
 
+# TODO: Remove this after feat-fast-sync merges to dev
+#
+# Hack for picking between dev and feat-fast-sync branch for client
+# ... casper-mainnet feature flag is removed in feat-fast-sync
+if ( cat "$NCTL"/sh/assets/compile_client.sh | grep -q casper-mainnet ); then
+    NCTL_CLIENT_BRANCH='dev'
+else
+    NCTL_CLIENT_BRANCH='feat-fast-sync'
+fi
+
 # Clone the client and launcher repos if required.
 if [ ! -d "$NCTL_CASPER_CLIENT_HOME" ]; then
     echo "Checking out $NCTL_CLIENT_BRANCH of casper-client-rs..."

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -2,7 +2,6 @@
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
-NCTL_CLIENT_BRANCH="${DRONE_BRANCH:='dev'}"
 
 # Activate Environment
 pushd "$ROOT_DIR"

--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -7,16 +7,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 pushd "$ROOT_DIR"
 source $(pwd)/utils/nctl/activate
 
-# Clone the client and launcher repos if required.
-if [ ! -d "$NCTL_CASPER_CLIENT_HOME" ]; then
-    git clone https://github.com/casper-ecosystem/casper-client-rs "$NCTL_CASPER_CLIENT_HOME"
-fi
-if [ ! -d "$NCTL_CASPER_NODE_LAUNCHER_HOME" ]; then
-    git clone https://github.com/casper-network/casper-node-launcher "$NCTL_CASPER_NODE_LAUNCHER_HOME"
-fi
-
-# NCTL Build
-nctl-compile
+# Call compile wrapper for client, launcher, and nctl-compile
+bash -i "$ROOT_DIR/ci/nctl_compile.sh"
 
 function main() {
     local TEST_ID=${1}

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -11,16 +11,8 @@ SCENARIOS_CONFIGS_DIR="$SCENARIOS_DIR/configs"
 pushd "$DRONE_ROOT_DIR"
 source "$(pwd)"/utils/nctl/activate
 
-# Clone the client and launcher repos if required.
-if [ ! -d "$NCTL_CASPER_CLIENT_HOME" ]; then
-    git clone https://github.com/casper-ecosystem/casper-client-rs "$NCTL_CASPER_CLIENT_HOME"
-fi
-if [ ! -d "$NCTL_CASPER_NODE_LAUNCHER_HOME" ]; then
-    git clone https://github.com/casper-network/casper-node-launcher "$NCTL_CASPER_NODE_LAUNCHER_HOME"
-fi
-
-# Build, Setup, and Start NCTL
-nctl-compile
+# Call compile wrapper for client, launcher, and nctl-compile
+bash -i "$DRONE_ROOT_DIR/ci/nctl_compile.sh"
 
 function start_run_teardown() {
     local RUN_CMD=$1


### PR DESCRIPTION
Changes:

- Moves previous Drone "pre-checks" pipeline to GHA.
    - Runs in parallel with Drone.
- Removed misc. steps from pipelines that are no longer used or necessary for CI.
- Combines NCTL compiling to a single wrapper for maintenance.
- Brings in the use of [cachepot](https://github.com/paritytech/cachepot) which is paritys fork of `sccache`

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/294

Reviewer Notes:
- The diff of `.drone.yml` might be tough to look at