### PR TITLE
Remove panicking code from initializer

### DIFF
--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -40,7 +40,6 @@ pub(crate) enum Event {
     Chainspec(chainspec_loader::Event),
 
     /// Storage event.
-
     #[from]
     Storage(#[serde(skip_serializing)] storage::Event),
 

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -306,7 +306,8 @@ impl reactor::Reactor for Reactor {
                 Effects::new()
             }
             Event::ContractRuntimeAnnouncement => {
-                // We don't dispatch ContractRuntimeAnnouncement as it shouldn't actually arrive to the initializer
+                // We don't dispatch ContractRuntimeAnnouncement as it shouldn't actually arrive to
+                // the initializer
                 Effects::new()
             }
         }


### PR DESCRIPTION
This PR removes a code that could cause panic in the initializer reactor. Appropriate messages are written to the log instead.