### PR TITLE
Fix macos clippy issue

### DIFF
--- a/node/src/components/console.rs
+++ b/node/src/components/console.rs
@@ -80,7 +80,7 @@ impl Console {
         }
 
         let socket_path = cfg.with_dir(config.socket_path.clone());
-        let listener = setup_listener(&socket_path, config.socket_umask.into())?;
+        let listener = setup_listener(&socket_path, config.socket_umask)?;
         let server = tasks::server(
             EffectBuilder::new(event_queue),
             socket_path,
@@ -96,7 +96,10 @@ impl Console {
 ///
 /// If the socket already exists, an attempt to delete it is made. Errors during deletion are
 /// ignored, but may cause the subsequent socket opening to fail.
-fn setup_listener<P: AsRef<Path>>(path: P, socket_umask: umask::Mode) -> io::Result<UnixListener> {
+fn setup_listener<P: AsRef<Path>, M: Into<umask::Mode>>(
+    path: P,
+    socket_umask: M,
+) -> io::Result<UnixListener> {
     let socket_path = path.as_ref();
 
     // This would be racy, but no one is racing us for the socket, so we'll just do a naive
@@ -118,7 +121,7 @@ fn setup_listener<P: AsRef<Path>>(path: P, socket_umask: umask::Mode) -> io::Res
 
     // This is not thread-safe, as it will set the umask for the entire process, but we assume that
     // initalization happens "sufficiently single-threaded".
-    let umask_guard = umask::temp_umask(socket_umask);
+    let umask_guard = umask::temp_umask(socket_umask.into());
     let listener = UnixListener::bind(socket_path)?;
     drop(umask_guard);
 


### PR DESCRIPTION
On macOS `umask::Mode` is u16 and clippy complains about unnecessary `.into()`.