### PR TITLE
Clean-up process names used in the chain sync operation

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 * Introduce fast-syncing to join the network, avoiding the need to execute every block to catch up.
 * Add `max_parallel_deploy_fetches` and `max_parallel_trie_fetches` config options to the `[node]` section to control how many requests are made in parallel while syncing.
 * Add `retry_interval` to `[node]` config section to control the delay between retry attempts while syncing.
-* Add `archival_sync` to `[node]` config section, along with archival syncing capabilities.
+* Add `sync_to_genesis` to `[node]` config section, along with syncing to genesis capabilities.
 * Add new event to the main SSE server stream across all endpoints `<IP:PORT>/events/*` which emits a shutdown event when the node shuts down.
 * Add `SIGUSR2` signal handling to dump the queue in JSON format (see "Changed" section for `SIGUSR1`).
 * A diagnostic console can now be enabled via the `[console]` section in the configuration file. See the `README.md` for details.

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -23,9 +23,9 @@ pub(super) struct Config {
     max_parallel_trie_fetches: u32,
     /// The duration for which to pause between retry attempts while synchronising.
     retry_interval: Duration,
-    /// Whether to run in archival-sync mode. Archival-sync mode captures all data (blocks, deploys
+    /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
-    archival_sync: bool,
+    sync_to_genesis: bool,
     /// The maximum number of consecutive times we'll allow the network component to return an
     /// empty set of fully-connected peers before we give up.
     max_retries_while_not_connected: u64,
@@ -46,7 +46,7 @@ impl Config {
             max_parallel_deploy_fetches: node_config.max_parallel_deploy_fetches,
             max_parallel_trie_fetches: node_config.max_parallel_trie_fetches,
             retry_interval: Duration::from_millis(node_config.retry_interval.millis()),
-            archival_sync: node_config.archival_sync,
+            sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
         }
     }
@@ -124,8 +124,8 @@ impl Config {
         self.retry_interval
     }
 
-    pub(super) fn archival_sync(&self) -> bool {
-        self.archival_sync
+    pub(super) fn sync_to_genesis(&self) -> bool {
+        self.sync_to_genesis
     }
 
     pub(super) fn max_retries_while_not_connected(&self) -> u64 {

--- a/node/src/components/chain_synchronizer/metrics.rs
+++ b/node/src/components/chain_synchronizer/metrics.rs
@@ -20,10 +20,10 @@ pub(super) struct Metrics {
     /// Time in seconds to get the trusted key block.
     #[data_size(skip)]
     pub(super) chain_sync_get_trusted_key_block_info_duration_seconds: IntGauge,
-    /// Time in seconds to fetch to genesis during archival sync.
+    /// Time in seconds to fetch to genesis during sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_to_genesis_duration_seconds: IntGauge,
-    /// Time in seconds to fetch forward during archival sync.
+    /// Time in seconds to fetch forward during sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_forward_duration_seconds: IntGauge,
     /// Total time in seconds of performing the fast sync.

--- a/node/src/components/chain_synchronizer/metrics.rs
+++ b/node/src/components/chain_synchronizer/metrics.rs
@@ -14,18 +14,18 @@ pub(super) struct Metrics {
     /// Time in seconds of handling the upgrade.
     #[data_size(skip)]
     pub(super) chain_sync_upgrade_duration_seconds: IntGauge,
-    /// Total time in seconds of performing the archival sync.
+    /// Total time in seconds of performing the sync to genesis..
     #[data_size(skip)]
-    pub(super) chain_sync_archival_sync_total_duration_seconds: IntGauge,
+    pub(super) chain_sync_to_genesis_total_duration_seconds: IntGauge,
     /// Time in seconds to get the trusted key block.
     #[data_size(skip)]
     pub(super) chain_sync_get_trusted_key_block_info_duration_seconds: IntGauge,
-    /// Time in seconds to sync to genesis during archival sync.
+    /// Time in seconds to fetch to genesis during archival sync.
     #[data_size(skip)]
-    pub(super) chain_sync_sync_to_genesis_duration_seconds: IntGauge,
-    /// Time in seconds to sync forward during archival sync.
+    pub(super) chain_sync_fetch_to_genesis_duration_seconds: IntGauge,
+    /// Time in seconds to fetch forward during archival sync.
     #[data_size(skip)]
-    pub(super) chain_sync_sync_forward_duration_seconds: IntGauge,
+    pub(super) chain_sync_fetch_forward_duration_seconds: IntGauge,
     /// Total time in seconds of performing the fast sync.
     #[data_size(skip)]
     pub(super) chain_sync_fast_sync_total_duration_seconds: IntGauge,
@@ -68,21 +68,21 @@ impl Metrics {
             "chain_sync_upgrade_duration_seconds",
             "time in seconds of handling the upgrade",
         )?;
-        let chain_sync_archival_sync_total_duration_seconds = IntGauge::new(
-            "chain_sync_archival_sync_total_duration_seconds",
-            "total time in seconds of performing the archival sync",
+        let chain_sync_to_genesis_total_duration_seconds = IntGauge::new(
+            "chain_sync_to_genesis_total_duration_seconds",
+            "total time in seconds of performing the sync to genesis",
         )?;
         let chain_sync_get_trusted_key_block_info_duration_seconds = IntGauge::new(
             "chain_sync_get_trusted_key_block_info_duration_seconds",
             "time in seconds to get the trusted key block",
         )?;
-        let chain_sync_sync_to_genesis_duration_seconds = IntGauge::new(
-            "chain_sync_sync_to_genesis_duration_seconds",
-            "time in seconds to sync to genesis during archival sync",
+        let chain_sync_fetch_to_genesis_duration_seconds = IntGauge::new(
+            "chain_sync_fetch_to_genesis_duration_seconds",
+            "time in seconds to fetch to genesis during sync to genesis",
         )?;
-        let chain_sync_sync_forward_duration_seconds = IntGauge::new(
-            "chain_sync_sync_forward_duration_seconds",
-            "time in seconds to sync forward during archival sync",
+        let chain_sync_fetch_forward_duration_seconds = IntGauge::new(
+            "chain_sync_fetch_forward_duration_seconds",
+            "time in seconds to fetch forward during sync to genesis",
         )?;
         let chain_sync_fast_sync_total_duration_seconds = IntGauge::new(
             "chain_sync_fast_sync_total_duration_seconds",
@@ -120,15 +120,15 @@ impl Metrics {
         ))?;
         registry.register(Box::new(chain_sync_upgrade_duration_seconds.clone()))?;
         registry.register(Box::new(
-            chain_sync_archival_sync_total_duration_seconds.clone(),
+            chain_sync_to_genesis_total_duration_seconds.clone(),
         ))?;
         registry.register(Box::new(
             chain_sync_get_trusted_key_block_info_duration_seconds.clone(),
         ))?;
         registry.register(Box::new(
-            chain_sync_sync_to_genesis_duration_seconds.clone(),
+            chain_sync_fetch_to_genesis_duration_seconds.clone(),
         ))?;
-        registry.register(Box::new(chain_sync_sync_forward_duration_seconds.clone()))?;
+        registry.register(Box::new(chain_sync_fetch_forward_duration_seconds.clone()))?;
         registry.register(Box::new(
             chain_sync_fast_sync_total_duration_seconds.clone(),
         ))?;
@@ -150,10 +150,10 @@ impl Metrics {
             chain_sync_total_duration_seconds,
             chain_sync_emergency_restart_duration_seconds,
             chain_sync_upgrade_duration_seconds,
-            chain_sync_archival_sync_total_duration_seconds,
+            chain_sync_to_genesis_total_duration_seconds,
             chain_sync_get_trusted_key_block_info_duration_seconds,
-            chain_sync_sync_to_genesis_duration_seconds,
-            chain_sync_sync_forward_duration_seconds,
+            chain_sync_fetch_to_genesis_duration_seconds,
+            chain_sync_fetch_forward_duration_seconds,
             chain_sync_fast_sync_total_duration_seconds,
             chain_sync_fetch_block_headers_duration_seconds,
             chain_sync_replay_protection_duration_seconds,

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -764,7 +764,7 @@ async fn sync_deploys_and_transfers_and_state(
 /// Returns the block header with our current version and the last trusted key block information for
 /// validation.
 async fn sync_to_genesis(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, BlockHeader), Error> {
-    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_archival_sync_total_duration_seconds);
+    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_to_genesis_total_duration_seconds);
 
     // Get the trusted block info. This will fail if we are trying to join with a trusted hash in
     // era 0.
@@ -785,7 +785,7 @@ async fn fetch_forward(
     trusted_key_block_info: &mut KeyBlockInfo,
     ctx: &ChainSyncContext<'_>,
 ) -> Result<Block, Error> {
-    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_sync_forward_duration_seconds);
+    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fetch_forward_duration_seconds);
 
     let mut most_recent_block = trusted_block;
     while most_recent_block.header().protocol_version() < ctx.config.protocol_version() {
@@ -814,7 +814,7 @@ async fn fetch_forward(
 }
 
 async fn fetch_to_genesis(trusted_block: &Block, ctx: &ChainSyncContext<'_>) -> Result<(), Error> {
-    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_sync_to_genesis_duration_seconds);
+    let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fetch_to_genesis_duration_seconds);
 
     let mut walkback_block = trusted_block.clone();
     loop {

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -172,7 +172,7 @@ impl TestChain {
         first_node: bool,
         secret_key: Arc<SecretKey>,
         trusted_hash: Option<BlockHash>,
-        archival_sync: bool,
+        sync_to_genesis: bool,
         rng: &mut NodeRng,
     ) -> NodeId {
         // Set the network configuration.
@@ -188,7 +188,7 @@ impl TestChain {
             ..Default::default()
         };
 
-        participating_config.node.archival_sync = archival_sync;
+        participating_config.node.sync_to_genesis = sync_to_genesis;
 
         // Additionally set up storage in a temporary directory.
         let (storage_config, temp_dir) = storage::Config::default_for_tests();
@@ -458,7 +458,7 @@ async fn test_joiner_at_genesis() {
 
 /// Test a node joining to a single node network
 #[tokio::test]
-async fn test_archival_sync() {
+async fn test_sync_to_genesis() {
     testing::init_logging();
 
     const INITIAL_NETWORK_SIZE: usize = 1;

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -26,7 +26,7 @@ pub struct NodeConfig {
     /// The duration for which to pause between retry attempts while synchronising during joining.
     pub retry_interval: TimeDiff,
 
-    /// Whether to run in sync_to_genesis mode which captures all data (blocks, deploys
+    /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
 }

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -26,9 +26,9 @@ pub struct NodeConfig {
     /// The duration for which to pause between retry attempts while synchronising during joining.
     pub retry_interval: TimeDiff,
 
-    /// Whether to run in archival-sync mode. Archival-sync mode captures all data (blocks, deploys
+    /// Whether to run in sync_to_genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
-    pub archival_sync: bool,
+    pub sync_to_genesis: bool,
 }
 
 impl Default for NodeConfig {
@@ -38,7 +38,7 @@ impl Default for NodeConfig {
             max_parallel_deploy_fetches: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES,
             max_parallel_trie_fetches: DEFAULT_MAX_PARALLEL_TRIE_FETCHES,
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
-            archival_sync: false,
+            sync_to_genesis: false,
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -16,7 +16,7 @@ max_parallel_trie_fetches = 20
 retry_interval = '100ms'
 
 # Whether to synchronize all data back to genesis when joining.
-archival_sync = true
+sync_to_genesis = true
 
 
 # =================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -16,7 +16,8 @@ max_parallel_trie_fetches = 20
 retry_interval = '100ms'
 
 # Whether to synchronize all data back to genesis when joining.
-archival_sync = true
+sync_to_genesis = true
+
 
 # =================================
 # Configuration options for logging

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -16,7 +16,7 @@ max_parallel_trie_fetches = 20
 retry_interval = '100ms'
 
 # Whether to synchronize all data back to genesis when joining.
-archival_sync = true
+sync_to_genesis = true
 
 
 # =================================

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -20,7 +20,7 @@ max_parallel_trie_fetches = 20
 retry_interval = '100ms'
 
 # Whether to synchronize all data back to genesis when joining.
-archival_sync = true
+sync_to_genesis = true
 
 # =================================
 # Configuration options for logging

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -16,7 +16,7 @@ max_parallel_trie_fetches = 20
 retry_interval = '100ms'
 
 # Whether to synchronize all data back to genesis when joining.
-archival_sync = true
+sync_to_genesis = true
 
 
 # =================================


### PR DESCRIPTION
This PR renames some sub-processes of the chain sync operation:
* `archival_sync` => `sync_to_genesis`
* `fast_sync_to_most_recent` => `fast_sync`
* `non_archival_sync` => `fast_sync`

Closes #2709