### PR TITLE
GH-2443: Get auction info backwards compatibility

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -953,8 +953,12 @@ where
         let correlation_id = CorrelationId::new();
         let state_hash = self.get_post_state_hash();
         let request = GetEraValidatorsRequest::new(state_hash, *DEFAULT_PROTOCOL_VERSION);
+        let system_contract_registry = self
+            .system_contract_registry
+            .clone()
+            .expect("System contract registry not found. Please run genesis first.");
         self.engine_state
-            .get_era_validators(correlation_id, request)
+            .get_era_validators(correlation_id, &system_contract_registry, request)
             .expect("get era validators should not error")
     }
 

--- a/node/src/components/contract_runtime/error.rs
+++ b/node/src/components/contract_runtime/error.rs
@@ -1,7 +1,7 @@
 //! Errors that the contract runtime component may raise.
 
 use casper_execution_engine::{
-    core::engine_state::{Error as EngineStateError, StepError},
+    core::engine_state::{self, Error as EngineStateError, StepError},
     storage::error::lmdb::Error as StorageLmdbError,
 };
 
@@ -20,6 +20,9 @@ pub(crate) enum ConfigError {
     /// Error initializing metrics.
     #[error("failed to initialize metrics for contract runtime: {0}")]
     Prometheus(#[from] prometheus::Error),
+    /// Error initializing execution engine.
+    #[error("failed to initialize execution engine: {0}")]
+    EngineState(#[from] engine_state::Error),
 }
 
 /// An error raised by a contract runtime variant.

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -7,7 +7,7 @@ use casper_execution_engine::{
     core::engine_state::{
         self, step::EvictItem, DeployItem, EngineState, ExecuteRequest,
         ExecutionResult as EngineExecutionResult, GetEraValidatorsRequest, RewardItem, StepError,
-        StepRequest, StepSuccess,
+        StepRequest, StepSuccess, SystemContractRegistry,
     },
     shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::lmdb::LmdbGlobalState,
@@ -31,8 +31,10 @@ use casper_execution_engine::{
 };
 
 /// Executes a finalized block.
+#[allow(clippy::too_many_arguments)]
 pub fn execute_finalized_block(
     engine_state: &EngineState<LmdbGlobalState>,
+    system_contract_registry: &SystemContractRegistry,
     metrics: Option<Arc<Metrics>>,
     protocol_version: ProtocolVersion,
     execution_pre_state: ExecutionPreState,
@@ -116,6 +118,7 @@ pub fn execute_finalized_block(
             state_root_hash = post_state_hash;
             let upcoming_era_validators = engine_state.get_era_validators(
                 CorrelationId::new(),
+                system_contract_registry,
                 GetEraValidatorsRequest::new(state_root_hash, protocol_version),
             )?;
             Some(StepEffectAndUpcomingEraValidators {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -509,7 +509,7 @@ impl reactor::Reactor for Reactor {
             registry,
         )?;
 
-        contract_runtime.set_initial_state(chainspec_loader.initial_execution_pre_state());
+        contract_runtime.set_initial_state(chainspec_loader.initial_execution_pre_state())?;
         let linear_chain = linear_chain::LinearChainComponent::new(
             registry,
             *protocol_version,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -711,7 +711,7 @@ impl reactor::Reactor for Reactor {
             }
             _ => chainspec_loader.initial_execution_pre_state(),
         };
-        contract_runtime.set_initial_state(execution_pre_state);
+        contract_runtime.set_initial_state(execution_pre_state)?;
 
         let block_validator = BlockValidator::new(Arc::clone(chainspec_loader.chainspec()));
         let linear_chain = linear_chain::LinearChainComponent::new(

--- a/utils/dry-run-deploys/src/main.rs
+++ b/utils/dry-run-deploys/src/main.rs
@@ -76,6 +76,10 @@ async fn main() -> Result<(), anyhow::Error> {
     )?;
 
     let mut execution_pre_state = ExecutionPreState::from(&previous_block_header);
+    let system_contract_registry = engine_state
+        .get_system_contract_registry(Default::default(), *previous_block_header.state_root_hash())
+        .expect("should have system contract registry");
+
     let mut execute_count = 0;
 
     let highest_height_in_chain = storage.read_highest_block()?;
@@ -127,6 +131,7 @@ async fn main() -> Result<(), anyhow::Error> {
         let start = Instant::now();
         let block_and_execution_effects = execute_finalized_block(
             &engine_state,
+            &system_contract_registry,
             None,
             protocol_version,
             execution_pre_state,


### PR DESCRIPTION
Closes #2443

This PR fixes a problem of the get-auction-state query for pre #1814 (introduction of `Key::SystemContractRegistry`) blocks by passing down an instance of `SystemContractRegistry` initialized from a highest block's state root hash at component initialization time. This avoids querying the registry from a specified state which may not exist for older blocks.