### PR TITLE
Add Accept-Encoding header to avoid request failure

### DIFF
--- a/utils/nctl/sh/utils/queries.sh
+++ b/utils/nctl/sh/utils/queries.sh
@@ -133,7 +133,8 @@ function get_node_status()
 
     NODE_ADDRESS_CURL=$(get_node_address_rpc_for_curl "$NODE_ID")
     NODE_API_RESPONSE=$(
-        curl -s --header 'Content-Type: application/json' \
+        curl -s --header 'Accept-Encoding: gzip' \
+            --header 'Content-Type: application/json' \
             --request POST "$NODE_ADDRESS_CURL" \
             --data-raw '{
                 "id": 1,

--- a/utils/nctl/sh/views/view_node_status.sh
+++ b/utils/nctl/sh/views/view_node_status.sh
@@ -17,13 +17,13 @@ function main()
             if [ "$(get_node_is_up "$NODE_ID")" = true ]; then
                 echo "------------------------------------------------------------------------------------------------------------------------------------"
                 do_render "$NODE_ID"
-            fi        
+            fi
         done
         echo "------------------------------------------------------------------------------------------------------------------------------------"
     else
         if [ "$(get_node_is_up "$NODE_ID")" = true ]; then
             do_render "$NODE_ID"
-        fi        
+        fi
     fi
 }
 
@@ -38,10 +38,11 @@ function do_render()
     local NODE_ID=${1}
     local NODE_ADDRESS_CURL
     local NODE_API_RESPONSE
-    
+
     NODE_ADDRESS_CURL=$(get_node_address_rpc_for_curl "$NODE_ID")
     NODE_API_RESPONSE=$(
-        curl -s --header 'Content-Type: application/json' \
+        curl -s --header 'Accept-Encoding: gzip' \
+            --header 'Content-Type: application/json' \
             --request POST "$NODE_ADDRESS_CURL" \
             --data-raw '{
                 "id": 1,


### PR DESCRIPTION
Add Accept-Encoding header to avoid request failure: `Invalid request header "accept-encoding"`

- Without `Accept-Encoding` header option
```bash
curl --location --request POST 'http://65.108.1.10:7777/rpc
' \
--header 'Content-Type: application/json' \
--data-raw '{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "info_get_status",
    "params": []
}'
```

Got error: `Invalid request header "accept-encoding"`

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/7955133/157085281-993e8ab1-445f-42e4-b66b-6e05251a99ca.png">

- With `Accept-Encoding: gzip` header option
```bash
curl --location --request POST 'http://65.108.1.10:7777/rpc' \
--header 'Content-Type: application/json' \
--header 'Accept-Encoding: gzip' \
--data-raw '{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "info_get_status",
    "params": []
}'
```

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/7955133/157086366-5e9d90d2-9893-473b-b346-30d5dc4c8690.png">



