### PR TITLE
NCTL: Follow-Up on ignored error detection

### DIFF
--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -48,9 +48,8 @@ function main() {
     # 11. Run Health Checks
     # ... restarts=15: due to node being stopped and started
     # ... crashes=5: expected in an emergency restart scenario?
-    # ... errors=ignore: ticket sre issue 77
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors='0' \
             equivocators=0 \
             doppels=0 \
             crashes=5 \

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -38,10 +38,9 @@ function main() {
     # 8. Walkback and verify transfers were included in blocks
     check_transfer_inclusion '1' '1000'
     # 10. Run Health Checks
-    # ... errors=ignore: ticket sre issue 71
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors='0' \
             equivocators=0 \
             doppels=0 \
             crashes=0 \

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -38,9 +38,8 @@ function main() {
     check_wasm_inclusion '1' '1000'
     # 9. Run Health Checks
     # ... restarts=1: due to node being stopped and started
-    # ... errors=ignore: ticket sre issue 79
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors=0 \
             equivocators=0 \
             doppels=0 \
             crashes=0 \

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -32,7 +32,8 @@ function main() {
     # 6. Look for one of the two nodes to report as faulty
     assert_equivication "5" "6"
     # 7. Run Health Checks
-    # ... errors=1: due to doppels being logged at ERROR level
+    # ... errors=ignore: can cause multiple errors non-deterministicly
+    #                    see: sre issue 347.
     # ... doppels=ignore: doppelganger purposely created in this test
     # ... equivocators=ignore: doppelganger can cause an equivocation
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -63,11 +63,10 @@ function main() {
     # 15. Assert that restarted validator is producing blocks.
     assert_node_proposed '5' '300'
     # 16. Run Health Checks
-    # ... errors=ignore: ticket sre issue 72
     # ... restarts=1: due to node being stopped and started
     # ... ejections=1: node is expected to be ejected in test
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors=0 \
             equivocators=0 \
             doppels=0 \
             crashes=0 \

--- a/utils/nctl/sh/scenarios/sync_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/sync_upgrade_test.sh
@@ -52,9 +52,8 @@ function main() {
     do_await_full_synchronization "$NEW_NODE_ID"
     # 12. Run Closing Health Checks
     # ... restarts=6: due to nodes being stopped and started
-    # ... errors=ignore: ticket sre issue 78
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors=0 \
             equivocators=0 \
             doppels=0 \
             crashes=0 \


### PR DESCRIPTION
Changes:
- switches ignored error check to allowable errors of the test.

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/343
