### PR TITLE
Fix too many bids being removed when generating a global state update

### DIFF
--- a/utils/global-state-update-gen/src/auction_utils.rs
+++ b/utils/global-state-update-gen/src/auction_utils.rs
@@ -64,10 +64,8 @@ pub fn find_large_bids(
     builder: &mut LmdbWasmTestBuilder,
     new_snapshot: &SeigniorageRecipientsSnapshot,
 ) -> BTreeSet<PublicKey> {
-    let min_bid = new_snapshot
-        .values()
-        .next()
-        .unwrap()
+    let seigniorage_recipients = new_snapshot.values().next().unwrap();
+    let min_bid = seigniorage_recipients
         .values()
         .map(SeigniorageRecipient::stake)
         .min()
@@ -75,7 +73,9 @@ pub fn find_large_bids(
     builder
         .get_bids()
         .into_iter()
-        .filter(|(_pkey, bid)| bid.staked_amount() >= min_bid)
+        .filter(|(pkey, bid)| {
+            bid.staked_amount() >= min_bid && !seigniorage_recipients.contains_key(pkey)
+        })
         .map(|(pkey, _bid)| pkey)
         .collect()
 }


### PR DESCRIPTION
Closes #2736 .

The root cause of the issue was this:
- The global state update was changing the validators by removing set A and adding set C.
- Nodes from set A and B gathered some rewards from previous eras and their stakes were quite high. Nodes from set C were added with small stakes.
- `global-state-update-gen` looks for bids made before the upgrade that are higher than the minimum stake among the new validators and removes them. This is to prevent other nodes from replacing the newly appointed validators right after the first era.
- In this case, since the nodes from set C had low stakes, this found bids from sets A and B and removed them. So nodes from set B were still validators, but were no longer bidding for being ones.
- After one era has passed, since nodes B weren't bidding, they were removed from the validator set, leaving only set C.

This PR changes the logic so that bids from nodes that keep being validators after the upgrade won't be removed.
