### PR TITLE
Update JSON-RPC responses for missing state

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.  The format
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
 * Requests for data from a peer are now de-prioritized over networking messages necessary for consensus and chain advancement.
+* JSON-RPC responses which fail to provide requested data will now also include an indication of that node's lowest contiguous block height, i.e. the block from which it holds all subsequent global state
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -626,6 +626,8 @@ async fn fast_sync(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, BlockHea
     fetch_block_headers_needed_for_era_supervisor_initialization(&most_recent_block_header, ctx)
         .await?;
 
+    ctx.effect_builder.update_contiguous_block_info().await;
+
     // Synchronize the trie store for the most recent block header.
     sync_trie_store(*most_recent_block_header.state_root_hash(), ctx).await?;
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -626,8 +626,6 @@ async fn fast_sync(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, BlockHea
     fetch_block_headers_needed_for_era_supervisor_initialization(&most_recent_block_header, ctx)
         .await?;
 
-    ctx.effect_builder.update_contiguous_block_info().await;
-
     // Synchronize the trie store for the most recent block header.
     sync_trie_store(*most_recent_block_header.state_root_hash(), ctx).await?;
 

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -294,6 +294,14 @@ where
                 }
                 .ignore()
             }
+            Event::RpcRequest(RpcRequest::GetLowestContiguousBlockHeight { responder }) => {
+                effect_builder
+                    .get_lowest_contiguous_block_height_from_storage()
+                    .event(move |height| Event::GetLowestContiguousBlockHeightResult {
+                        height,
+                        main_responder: responder,
+                    })
+            }
             Event::GetBlockResult {
                 maybe_id: _,
                 result,
@@ -329,6 +337,10 @@ where
                 peers,
                 main_responder,
             } => main_responder.respond(peers).ignore(),
+            Event::GetLowestContiguousBlockHeightResult {
+                height,
+                main_responder,
+            } => main_responder.respond(height).ignore(),
         }
     }
 }

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -55,6 +55,10 @@ pub(crate) enum Event {
         result: Result<BalanceResult, engine_state::Error>,
         main_responder: Responder<Result<BalanceResult, engine_state::Error>>,
     },
+    GetLowestContiguousBlockHeightResult {
+        height: u64,
+        main_responder: Responder<u64>,
+    },
 }
 
 impl Display for Event {
@@ -99,6 +103,11 @@ impl Display for Event {
                 write!(formatter, "get deploy result for {}: {:?}", hash, result)
             }
             Event::GetPeersResult { peers, .. } => write!(formatter, "get peers: {}", peers.len()),
+            Event::GetLowestContiguousBlockHeightResult { height, .. } => write!(
+                formatter,
+                "get lowest contiguous block height result: {}",
+                height
+            ),
         }
     }
 }

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -4,6 +4,7 @@
 
 pub mod account;
 pub mod chain;
+mod common;
 pub mod docs;
 pub mod info;
 pub mod state;
@@ -27,6 +28,7 @@ use casper_types::ProtocolVersion;
 
 use super::{ReactorEventT, RpcRequest};
 use crate::effect::EffectBuilder;
+pub use common::ErrorData;
 use docs::DocExample;
 
 /// The URL path.
@@ -49,6 +51,7 @@ enum ErrorCode {
     NoSuchAccount = -32009,
     FailedToGetDictionaryURef = -32010,
     FailedToGetTrie = -32011,
+    NoSuchStateRoot = -32012,
     // Same error code as warp_json INTERNAL_ERROR.
     InternalError = -32063,
 }
@@ -267,66 +270,4 @@ pub(super) trait RpcWithOptionalParamsExt: RpcWithOptionalParams {
         maybe_params: Option<Self::OptionalRequestParams>,
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>>;
-}
-
-mod common {
-    use std::convert::TryFrom;
-
-    use once_cell::sync::Lazy;
-
-    use casper_execution_engine::core::engine_state::{self, QueryResult};
-    use casper_types::bytesrepr::ToBytes;
-
-    use super::ErrorCode;
-    use crate::types::json_compatibility::StoredValue;
-
-    pub(super) static MERKLE_PROOF: Lazy<String> = Lazy::new(|| {
-        String::from(
-            "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e\
-        55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3\
-        f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a\
-        7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41d\
-        d035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce9450022\
-        6a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7\
-        725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60\
-        bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d0000030\
-        00000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467\
-        a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c\
-        1bcbcee522649d2b135fe510fe3")
-    });
-
-    // Extract the EE `(StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>)` from the result.
-    pub(super) fn extract_query_result(
-        query_result: Result<QueryResult, engine_state::Error>,
-    ) -> Result<(StoredValue, Vec<u8>), (ErrorCode, String)> {
-        let (value, proof) = match query_result {
-            Ok(QueryResult::Success { value, proofs }) => (value, proofs),
-            Ok(query_result) => {
-                let error_msg = format!("state query failed: {:?}", query_result);
-                return Err((ErrorCode::QueryFailed, error_msg));
-            }
-            Err(error) => {
-                let error_msg = format!("state query failed to execute: {:?}", error);
-                return Err((ErrorCode::QueryFailedToExecute, error_msg));
-            }
-        };
-
-        let value_compat = match StoredValue::try_from(*value) {
-            Ok(value_compat) => value_compat,
-            Err(error) => {
-                let error_msg = format!("failed to encode stored value: {:?}", error);
-                return Err((ErrorCode::QueryFailed, error_msg));
-            }
-        };
-
-        let proof_bytes = match proof.to_bytes() {
-            Ok(proof_bytes) => proof_bytes,
-            Err(error) => {
-                let error_msg = format!("failed to encode stored value: {:?}", error);
-                return Err((ErrorCode::QueryFailed, error_msg));
-            }
-        };
-
-        Ok((value_compat, proof_bytes))
-    }
 }

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -13,7 +13,6 @@ use hyper::Body;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use warp_json_rpc::Builder;
 
 use casper_hashing::Digest;
@@ -162,17 +161,10 @@ impl RpcWithOptionalParamsExt for GetBlock {
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
             let json_block = match get_block_with_metadata(maybe_block_id, effect_builder).await {
-                Ok(Some(BlockWithMetadata {
+                Ok(BlockWithMetadata {
                     block,
                     finality_signatures,
-                })) => JsonBlock::new(block, Some(finality_signatures)),
-                Ok(None) => {
-                    let error = warp_json_rpc::Error::custom(
-                        ErrorCode::NoSuchBlock as i64,
-                        "block not known",
-                    );
-                    return Ok(response_builder.error(error)?);
-                }
+                }) => JsonBlock::new(block, Some(finality_signatures)),
                 Err(error) => return Ok(response_builder.error(error)?),
             };
 
@@ -254,15 +246,8 @@ impl RpcWithOptionalParamsExt for GetBlockTransfers {
         async move {
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block_hash = match get_block(maybe_block_id, effect_builder).await {
-                Ok(Some(block)) => *block.hash(),
-                Ok(None) => {
-                    return Ok(response_builder.success(Self::ResponseResult::new(
-                        api_version,
-                        None,
-                        None,
-                    ))?)
-                }
+            let block_hash = match common::get_block(maybe_block_id, effect_builder).await {
+                Ok(block) => *block.hash(),
                 Err(error) => return Ok(response_builder.error(error)?),
             };
 
@@ -334,15 +319,15 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
         async move {
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let maybe_block = match get_block(maybe_block_id, effect_builder).await {
-                Ok(maybe_block) => maybe_block,
+            let block = match common::get_block(maybe_block_id, effect_builder).await {
+                Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
 
             // Return the result.
             let result = Self::ResponseResult {
                 api_version,
-                state_root_hash: maybe_block.map(|block| *block.state_root_hash()),
+                state_root_hash: Some(*block.state_root_hash()),
             };
             Ok(response_builder.success(result)?)
         }
@@ -400,19 +385,9 @@ impl RpcWithOptionalParamsExt for GetEraInfoBySwitchBlock {
         async move {
             // TODO: decide if/how to handle era id
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let maybe_block = match get_block(maybe_block_id, effect_builder).await {
-                Ok(maybe_block) => maybe_block,
+            let block = match common::get_block(maybe_block_id, effect_builder).await {
+                Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
-            };
-
-            let block = match maybe_block {
-                Some(block) => block,
-                None => {
-                    return Ok(response_builder.success(Self::ResponseResult {
-                        api_version,
-                        era_summary: None,
-                    })?)
-                }
             };
 
             if !block.header().is_switch_block() {
@@ -422,70 +397,40 @@ impl RpcWithOptionalParamsExt for GetEraInfoBySwitchBlock {
                 })?);
             }
 
-            let era_id = block.header().era_id();
             let state_root_hash = block.state_root_hash().to_owned();
+            let era_id = block.header().era_id();
             let base_key = Key::EraInfo(era_id);
             let path = Vec::new();
-            let query_result = effect_builder
-                .make_request(
-                    |responder| RpcRequest::QueryGlobalState {
-                        state_root_hash,
-                        base_key,
-                        path,
-                        responder,
-                    },
-                    QueueKind::Api,
-                )
-                .await;
 
-            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
-                Ok(tuple) => tuple,
-                Err((error_code, error_msg)) => {
-                    info!("{}", error_msg);
-                    return Ok(response_builder
-                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
+            let query_result =
+                common::run_query_and_encode(effect_builder, state_root_hash, base_key, path).await;
+
+            match query_result {
+                Ok((stored_value, merkle_proof)) => {
+                    let result = Self::ResponseResult {
+                        api_version,
+                        era_summary: Some(EraSummary {
+                            block_hash: *block.hash(),
+                            era_id,
+                            stored_value,
+                            state_root_hash,
+                            merkle_proof,
+                        }),
+                    };
+                    Ok(response_builder.success(result)?)
                 }
-            };
-
-            let block_hash = block.hash().to_owned();
-
-            let result = Self::ResponseResult {
-                api_version,
-                era_summary: Some(EraSummary {
-                    block_hash,
-                    era_id,
-                    stored_value,
-                    state_root_hash,
-                    merkle_proof: base16::encode_lower(&proof_bytes),
-                }),
-            };
-
-            Ok(response_builder.success(result)?)
+                Err(error) => Ok(response_builder.error(error)?),
+            }
         }
         .boxed()
     }
 }
 
-async fn get_block<REv: ReactorEventT>(
+pub(super) async fn get_block_with_metadata<REv: ReactorEventT>(
     maybe_id: Option<BlockIdentifier>,
     effect_builder: EffectBuilder<REv>,
-) -> Result<Option<Block>, warp_json_rpc::Error> {
-    match get_block_with_metadata(maybe_id, effect_builder).await {
-        Ok(Some(BlockWithMetadata { block, .. })) => Ok(Some(block)),
-        Ok(None) => Err(warp_json_rpc::Error::custom(
-            ErrorCode::NoSuchBlock as i64,
-            "block not known",
-        )),
-        Err(error) => Err(error),
-    }
-}
-
-async fn get_block_with_metadata<REv: ReactorEventT>(
-    maybe_id: Option<BlockIdentifier>,
-    effect_builder: EffectBuilder<REv>,
-) -> Result<Option<BlockWithMetadata>, warp_json_rpc::Error> {
+) -> Result<BlockWithMetadata, warp_json_rpc::Error> {
     // Get the block from storage or the latest from the linear chain.
-    let getting_specific_block = maybe_id.is_some();
     let maybe_result = effect_builder
         .make_request(
             |responder| RpcRequest::GetBlock {
@@ -496,13 +441,28 @@ async fn get_block_with_metadata<REv: ReactorEventT>(
         )
         .await;
 
-    if maybe_result.is_none() && getting_specific_block {
-        info!("failed to get {:?} from storage", maybe_id.unwrap());
-        return Err(warp_json_rpc::Error::custom(
-            ErrorCode::NoSuchBlock as i64,
-            "block not known",
-        ));
+    if let Some(block_with_metadata) = maybe_result {
+        return Ok(block_with_metadata);
     }
 
-    Ok(maybe_result)
+    let error = match maybe_id {
+        Some(BlockIdentifier::Hash(block_hash)) => common::missing_block_or_state_root_error(
+            effect_builder,
+            ErrorCode::NoSuchBlock,
+            format!("block {:?} not stored on this node", block_hash.inner()),
+        ),
+        Some(BlockIdentifier::Height(block_height)) => common::missing_block_or_state_root_error(
+            effect_builder,
+            ErrorCode::NoSuchBlock,
+            format!("block at height {} not stored on this node", block_height),
+        ),
+        None => common::missing_block_or_state_root_error(
+            effect_builder,
+            ErrorCode::InternalError,
+            "failed to get highest block".to_string(),
+        ),
+    }
+    .await;
+
+    Err(error)
 }

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -114,7 +114,7 @@ pub enum ParseBlockIdentifierError {
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockParams {
-    /// The block hash.
+    /// The block identifier.
     pub block_identifier: BlockIdentifier,
 }
 

--- a/node/src/components/rpc_server/rpcs/common.rs
+++ b/node/src/components/rpc_server/rpcs/common.rs
@@ -1,0 +1,118 @@
+use std::convert::TryFrom;
+
+use once_cell::sync::Lazy;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use casper_hashing::Digest;
+use casper_types::{bytesrepr::ToBytes, Key};
+
+use super::{
+    chain::{self, BlockIdentifier},
+    state, ErrorCode, ReactorEventT, RpcRequest,
+};
+use crate::{
+    effect::EffectBuilder,
+    reactor::QueueKind,
+    types::{json_compatibility::StoredValue, Block},
+};
+
+pub(super) static MERKLE_PROOF: Lazy<String> = Lazy::new(|| {
+    String::from(
+        "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e\
+        55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3\
+        f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a\
+        7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41d\
+        d035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce9450022\
+        6a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7\
+        725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60\
+        bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d0000030\
+        00000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467\
+        a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c\
+        1bcbcee522649d2b135fe510fe3")
+});
+
+/// Runs a global state query and returns a tuple of the JSON-compatible stored value and merkle
+/// proof of the value.
+///
+/// The proof is bytesrepr-encoded, and then hex-encoded.
+///
+/// On error, a `warp_json_rpc::Error` is returned suitable for sending as a JSON-RPC response.
+pub(super) async fn run_query_and_encode<REv: ReactorEventT>(
+    effect_builder: EffectBuilder<REv>,
+    state_root_hash: Digest,
+    base_key: Key,
+    path: Vec<String>,
+) -> Result<(StoredValue, String), warp_json_rpc::Error> {
+    let (value, proofs) = state::run_query(effect_builder, state_root_hash, base_key, path).await?;
+
+    let value_compat = match StoredValue::try_from(value) {
+        Ok(value_compat) => value_compat,
+        Err(error) => {
+            warn!(?error, "failed to encode stored value");
+            return Err(warp_json_rpc::Error::custom(
+                ErrorCode::InternalError as i64,
+                format!("failed to encode stored value: {}", error),
+            ));
+        }
+    };
+
+    let encoded_proofs = match proofs.to_bytes() {
+        Ok(bytes) => base16::encode_lower(&bytes),
+        Err(error) => {
+            warn!(?error, ?proofs, "failed to encode proof");
+            return Err(warp_json_rpc::Error::custom(
+                ErrorCode::InternalError as i64,
+                format!("failed to encode proof: {}", error),
+            ));
+        }
+    };
+
+    Ok((value_compat, encoded_proofs))
+}
+
+/// An enum to be used as the `data` field of a JSON-RPC error response.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorData {
+    /// The lowest block height from which this node has contiguous blocks to the tip of the chain.
+    LowestContiguousBlockHeight(u64),
+}
+
+impl ErrorData {
+    pub(super) fn lowest_contiguous_block_height(height: u64) -> Self {
+        ErrorData::LowestContiguousBlockHeight(height)
+    }
+}
+
+/// Returns a `warp_json_rpc::Error` which includes the lowest contiguous block height as the
+/// additional `data` field.
+pub(super) async fn missing_block_or_state_root_error<REv: ReactorEventT>(
+    effect_builder: EffectBuilder<REv>,
+    error_code: ErrorCode,
+    error_message: String,
+) -> warp_json_rpc::Error {
+    let lowest_contiguous_block_height = effect_builder
+        .make_request(
+            |responder| RpcRequest::GetLowestContiguousBlockHeight { responder },
+            QueueKind::Api,
+        )
+        .await;
+
+    info!(lowest_contiguous_block_height, "{}", error_message);
+
+    warp_json_rpc::Error::custom(error_code as i64, error_message).with_data(
+        ErrorData::lowest_contiguous_block_height(lowest_contiguous_block_height),
+    )
+}
+
+pub(super) async fn get_block<REv: ReactorEventT>(
+    maybe_id: Option<BlockIdentifier>,
+    effect_builder: EffectBuilder<REv>,
+) -> Result<Block, warp_json_rpc::Error> {
+    chain::get_block_with_metadata(maybe_id, effect_builder)
+        .await
+        .map(|block_with_metadata| block_with_metadata.block)
+}

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -14,7 +14,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 use warp_json_rpc::Builder;
 
-use casper_execution_engine::core::engine_state::{BalanceResult, GetBidsResult, QueryResult};
+use casper_execution_engine::{
+    core::engine_state::{BalanceResult, GetBidsResult, QueryResult},
+    storage::trie::merkle_proof::TrieMerkleProof,
+};
 use casper_hashing::Digest;
 use casper_types::{
     bytesrepr::{Bytes, ToBytes},
@@ -22,10 +25,6 @@ use casper_types::{
     U512,
 };
 
-use super::{
-    docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
-    Error, ErrorCode, ReactorEventT, RpcRequest, RpcWithParams, RpcWithParamsExt,
-};
 use crate::{
     components::rpc_server::rpcs::RpcWithOptionalParams,
     effect::EffectBuilder,
@@ -33,11 +32,13 @@ use crate::{
     rpcs::{
         chain::BlockIdentifier,
         common::{self, MERKLE_PROOF},
-        RpcWithOptionalParamsExt,
+        docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
+        Error, ErrorCode, ReactorEventT, RpcRequest, RpcWithOptionalParamsExt, RpcWithParams,
+        RpcWithParamsExt,
     },
     types::{
         json_compatibility::{Account as JsonAccount, AuctionState, StoredValue},
-        Block, BlockHash, BlockWithMetadata, JsonBlockHeader,
+        Block, BlockHash, JsonBlockHeader,
     },
 };
 
@@ -190,34 +191,25 @@ impl RpcWithParamsExt for GetItem {
             };
 
             // Run the query.
-            let query_result = effect_builder
-                .make_request(
-                    |responder| RpcRequest::QueryGlobalState {
-                        state_root_hash: params.state_root_hash,
-                        base_key,
-                        path: params.path,
-                        responder,
-                    },
-                    QueueKind::Api,
-                )
-                .await;
+            let query_result = common::run_query_and_encode(
+                effect_builder,
+                params.state_root_hash,
+                base_key,
+                params.path,
+            )
+            .await;
 
-            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
-                Ok(tuple) => tuple,
-                Err((error_code, error_msg)) => {
-                    info!("{}", error_msg);
-                    return Ok(response_builder
-                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
+            match query_result {
+                Ok((stored_value, merkle_proof)) => {
+                    let result = Self::ResponseResult {
+                        api_version,
+                        stored_value,
+                        merkle_proof,
+                    };
+                    Ok(response_builder.success(result)?)
                 }
-            };
-
-            let result = Self::ResponseResult {
-                api_version,
-                stored_value,
-                merkle_proof: base16::encode_lower(&proof_bytes),
-            };
-
-            Ok(response_builder.success(result)?)
+                Err(error) => Ok(response_builder.error(error)?),
+            }
         }
         .boxed()
     }
@@ -391,33 +383,10 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
-            let maybe_id = maybe_params.map(|params| params.block_identifier);
-            let block: Block = {
-                let maybe_block = effect_builder
-                    .make_request(
-                        |responder| RpcRequest::GetBlock {
-                            maybe_id,
-                            responder,
-                        },
-                        QueueKind::Api,
-                    )
-                    .await;
-
-                match maybe_block {
-                    None => {
-                        let error_msg = if maybe_id.is_none() {
-                            "get-auction-info failed to get last added block".to_string()
-                        } else {
-                            "get-auction-info failed to get specified block".to_string()
-                        };
-                        info!("{}", error_msg);
-                        return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                            ErrorCode::NoSuchBlock as i64,
-                            error_msg,
-                        ))?);
-                    }
-                    Some(BlockWithMetadata { block, .. }) => block,
-                }
+            let maybe_block_id = maybe_params.map(|params| params.block_identifier);
+            let block = match common::get_block(maybe_block_id, effect_builder).await {
+                Ok(block) => block,
+                Err(error) => return Ok(response_builder.error(error)?),
             };
 
             let protocol_version = api_version;
@@ -438,21 +407,28 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
                 .await;
 
             let bids = match get_bids_result {
-                Ok(get_bids_result) => match get_bids_result {
-                    GetBidsResult::RootNotFound => {
-                        error!(block_hash=?block.hash(), ?state_root_hash, "failed to get bids");
-                        return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                            ErrorCode::InternalError as i64,
-                            format!("get-auction-info failed to get bids at block={:?}", block.hash()),
-                        ))?);
-                    }
-                    GetBidsResult::Success { bids } => bids,
-                },
-                Err(err) => {
-                    error!(block_hash=?block.hash(), ?state_root_hash, ?err, "failed to get bids");
+                Ok(GetBidsResult::Success { bids }) => bids,
+                Ok(GetBidsResult::RootNotFound) => {
+                    error!(
+                        block_hash=?block.hash(),
+                        ?state_root_hash,
+                        "root not found while trying to get bids"
+                    );
                     return Ok(response_builder.error(warp_json_rpc::Error::custom(
                         ErrorCode::InternalError as i64,
-                        format!("get-auction-info failed to get bids at block={:?}", block.hash()),
+                        format!("failed to get bids at block {:?}", block.hash().inner()),
+                    ))?);
+                }
+                Err(error) => {
+                    error!(
+                        block_hash=?block.hash(),
+                        ?state_root_hash,
+                        ?error,
+                        "failed to get bids"
+                    );
+                    return Ok(response_builder.error(warp_json_rpc::Error::custom(
+                        ErrorCode::InternalError as i64,
+                        format!("error getting bids at block {:?}", block.hash().inner()),
                     ))?);
                 }
             };
@@ -474,7 +450,7 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
                     error!(block_hash=?block.hash(), ?state_root_hash, ?err, "failed to get era validators");
                     return Ok(response_builder.error(warp_json_rpc::Error::custom(
                         ErrorCode::InternalError as i64,
-                        format!("get-auction-info failed to get validators at block={:?}", block.hash()),
+                        format!("failed to get validators at block {:?}", block.hash().inner()),
                     ))?);
                 }
             };
@@ -544,67 +520,31 @@ impl RpcWithParamsExt for GetAccountInfo {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            let maybe_block_id = params.block_identifier;
+            let block = match common::get_block(maybe_block_id, effect_builder).await {
+                Ok(block) => block,
+                Err(error) => return Ok(response_builder.error(error)?),
+            };
+
+            let state_root_hash = *block.header().state_root_hash();
             let base_key = {
                 let account_hash = params.public_key.to_account_hash();
                 Key::Account(account_hash)
             };
-
-            let block: Block = {
-                let maybe_id = params.block_identifier;
-                let maybe_block = effect_builder
-                    .make_request(
-                        |responder| RpcRequest::GetBlock {
-                            maybe_id,
-                            responder,
-                        },
-                        QueueKind::Api,
-                    )
+            let query_result =
+                common::run_query_and_encode(effect_builder, state_root_hash, base_key, vec![])
                     .await;
 
-                match maybe_block {
-                    None => {
-                        let error_msg = if maybe_id.is_none() {
-                            "get-account-info failed to get last added block".to_string()
-                        } else {
-                            "get-account-info failed to get specified block".to_string()
-                        };
-                        info!("{}", error_msg);
-                        return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                            ErrorCode::NoSuchBlock as i64,
-                            error_msg,
-                        ))?);
-                    }
-                    Some(BlockWithMetadata { block, .. }) => block,
-                }
-            };
-
-            let state_root_hash = *block.header().state_root_hash();
-
-            let query_result = effect_builder
-                .make_request(
-                    |responder| RpcRequest::QueryGlobalState {
-                        state_root_hash,
-                        base_key,
-                        path: vec![],
-                        responder,
-                    },
-                    QueueKind::Api,
-                )
-                .await;
-
-            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
+            let (stored_value, merkle_proof) = match query_result {
                 Ok(tuple) => tuple,
-                Err((error_code, error_msg)) => {
-                    info!("{}", error_msg);
-                    return Ok(response_builder
-                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
-                }
+                Err(error) => return Ok(response_builder.error(error)?),
             };
 
             let account = if let StoredValue::Account(account) = stored_value {
                 account
             } else {
-                let error_msg = "get-account-info failed to get specified account".to_string();
+                let error_msg = "failed to get specified account".to_string();
+                info!(?stored_value, "{}", error_msg);
                 return Ok(response_builder.error(warp_json_rpc::Error::custom(
                     ErrorCode::NoSuchAccount as i64,
                     error_msg,
@@ -614,7 +554,7 @@ impl RpcWithParamsExt for GetAccountInfo {
             let result = Self::ResponseResult {
                 api_version,
                 account,
-                merkle_proof: base16::encode_lower(&proof_bytes),
+                merkle_proof,
             };
 
             Ok(response_builder.success(result)?)
@@ -790,40 +730,20 @@ impl RpcWithParamsExt for GetDictionaryItem {
                     };
 
                     let empty_path = Vec::new();
-
-                    let query_result = effect_builder
-                        .make_request(
-                            |responder| RpcRequest::QueryGlobalState {
-                                state_root_hash: params.state_root_hash,
-                                base_key,
-                                path: empty_path,
-                                responder,
-                            },
-                            QueueKind::Api,
-                        )
-                        .await;
-
-                    let value = match query_result {
-                        Ok(QueryResult::Success { value, .. }) => value,
-                        Ok(query_result) => {
-                            let error_msg = format!("state query failed: {:?}", query_result);
-                            return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                                ErrorCode::QueryFailed as i64,
-                                error_msg,
-                            ))?);
-                        }
-                        Err(error) => {
-                            let error_msg = format!("state query failed to execute: {:?}", error);
-                            return Ok(response_builder.error(warp_json_rpc::Error::custom(
-                                ErrorCode::QueryFailedToExecute as i64,
-                                error_msg,
-                            ))?);
-                        }
+                    let value = match run_query(
+                        effect_builder,
+                        params.state_root_hash,
+                        base_key,
+                        empty_path,
+                    )
+                    .await
+                    {
+                        Ok((value, _proofs)) => value,
+                        Err(error) => return Ok(response_builder.error(error)?),
                     };
-
                     params
                         .dictionary_identifier
-                        .get_dictionary_address(Some(*value))
+                        .get_dictionary_address(Some(value))
                 }
                 DictionaryIdentifier::URef { .. } | DictionaryIdentifier::Dictionary(_) => {
                     params.dictionary_identifier.get_dictionary_address(None)
@@ -840,35 +760,26 @@ impl RpcWithParamsExt for GetDictionaryItem {
                 }
             };
 
-            let query_result = effect_builder
-                .make_request(
-                    |responder| RpcRequest::QueryGlobalState {
-                        state_root_hash: params.state_root_hash,
-                        base_key: dictionary_query_key,
-                        path: vec![],
-                        responder,
-                    },
-                    QueueKind::Api,
-                )
-                .await;
+            let query_result = common::run_query_and_encode(
+                effect_builder,
+                params.state_root_hash,
+                dictionary_query_key,
+                vec![],
+            )
+            .await;
 
-            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
-                Ok(tuple) => tuple,
-                Err((error_code, error_msg)) => {
-                    info!("{}", error_msg);
-                    return Ok(response_builder
-                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
+            match query_result {
+                Ok((stored_value, merkle_proof)) => {
+                    let result = Self::ResponseResult {
+                        api_version,
+                        dictionary_key: dictionary_query_key.to_formatted_string(),
+                        stored_value,
+                        merkle_proof,
+                    };
+                    Ok(response_builder.success(result)?)
                 }
-            };
-
-            let result = Self::ResponseResult {
-                api_version,
-                dictionary_key: dictionary_query_key.to_formatted_string(),
-                stored_value,
-                merkle_proof: base16::encode_lower(&proof_bytes),
-            };
-
-            Ok(response_builder.success(result)?)
+                Err(error) => Ok(response_builder.error(error)?),
+            }
         }
         .boxed()
     }
@@ -978,35 +889,26 @@ impl RpcWithParamsExt for QueryGlobalState {
                 }
             };
 
-            let query_result = effect_builder
-                .make_request(
-                    |responder| RpcRequest::QueryGlobalState {
-                        state_root_hash,
-                        base_key,
-                        path: params.path,
-                        responder,
-                    },
-                    QueueKind::Api,
-                )
-                .await;
+            let query_result = common::run_query_and_encode(
+                effect_builder,
+                state_root_hash,
+                base_key,
+                params.path,
+            )
+            .await;
 
-            let (stored_value, proof_bytes) = match common::extract_query_result(query_result) {
-                Ok(tuple) => tuple,
-                Err((error_code, error_msg)) => {
-                    info!("{}", error_msg);
-                    return Ok(response_builder
-                        .error(warp_json_rpc::Error::custom(error_code as i64, error_msg))?);
+            match query_result {
+                Ok((stored_value, merkle_proof)) => {
+                    let result = Self::ResponseResult {
+                        api_version,
+                        block_header: maybe_block_header,
+                        stored_value,
+                        merkle_proof,
+                    };
+                    Ok(response_builder.success(result)?)
                 }
-            };
-
-            let result = Self::ResponseResult {
-                api_version,
-                block_header: maybe_block_header,
-                stored_value,
-                merkle_proof: base16::encode_lower(&proof_bytes),
-            };
-
-            Ok(response_builder.success(result)?)
+                Err(error) => Ok(response_builder.error(error)?),
+            }
         }
         .boxed()
     }
@@ -1086,5 +988,61 @@ impl RpcWithParamsExt for GetTrie {
             Ok(response)
         }
         .boxed()
+    }
+}
+
+type QuerySuccess = (
+    DomainStoredValue,
+    Vec<TrieMerkleProof<Key, DomainStoredValue>>,
+);
+
+/// Runs a global state query and returns a tuple of the domain stored value and merkle proof of the
+/// value.
+///
+/// On error, a `warp_json_rpc::Error` is returned suitable for sending as a JSON-RPC response.
+pub(super) async fn run_query<REv: ReactorEventT>(
+    effect_builder: EffectBuilder<REv>,
+    state_root_hash: Digest,
+    base_key: Key,
+    path: Vec<String>,
+) -> Result<QuerySuccess, warp_json_rpc::Error> {
+    let query_result = effect_builder
+        .make_request(
+            |responder| RpcRequest::QueryGlobalState {
+                state_root_hash,
+                base_key,
+                path,
+                responder,
+            },
+            QueueKind::Api,
+        )
+        .await;
+
+    match query_result {
+        Ok(QueryResult::Success { value, proofs }) => Ok((*value, proofs)),
+        Ok(QueryResult::RootNotFound) => {
+            info!("query failed: root not found");
+            let error = common::missing_block_or_state_root_error(
+                effect_builder,
+                ErrorCode::NoSuchStateRoot,
+                format!("failed to get state root at {:?}", state_root_hash),
+            )
+            .await;
+            Err(error)
+        }
+        Ok(query_result) => {
+            info!(?query_result, "query failed");
+            Err(warp_json_rpc::Error::custom(
+                ErrorCode::QueryFailed as i64,
+                format!("state query failed: {:?}", query_result),
+            ))
+        }
+        Err(error) => {
+            info!(?error, "query failed to execute");
+            Err(warp_json_rpc::Error::custom(
+                ErrorCode::QueryFailedToExecute as i64,
+                format!("state query failed to execute: {:?}", error),
+            ))
+        }
     }
 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -35,9 +35,9 @@
 //! The storage component itself is panic free and in general reports three classes of errors:
 //! Corruption, temporary resource exhaustion and potential bugs.
 
+mod disjoint_sequences;
 mod lmdb_ext;
 mod object_pool;
-
 #[cfg(test)]
 mod tests;
 
@@ -97,6 +97,7 @@ use crate::{
     utils::{display_error, WithDir},
     NodeRng,
 };
+use disjoint_sequences::DisjointSequences;
 use lmdb_ext::{LmdbExtError, TransactionExt, WriteTransactionExt};
 use object_pool::ObjectPool;
 
@@ -358,6 +359,9 @@ pub struct Storage {
     state_store_db: Database,
     /// A map of block height to block ID.
     block_height_index: BTreeMap<u64, BlockHash>,
+    /// A set of disjoint sequences of block heights of blocks which are fully stored (not just the
+    /// headers).
+    disjoint_block_height_sequences: DisjointSequences,
     /// A map of era ID to switch block ID.
     switch_block_era_id_index: BTreeMap<EraId, BlockHash>,
     /// A map of deploy hashes to hashes of blocks containing them.
@@ -527,6 +531,7 @@ impl Storage {
 
         let mut deleted_block_hashes = HashSet::new();
         let mut deleted_block_body_hashes_v1 = HashSet::new();
+        let mut full_block_heights = Vec::with_capacity(1_000_000);
         // Note: `iter_start` has an undocumented panic if called on an empty database. We rely on
         //       the iterator being at the start when created.
         for (_, raw_val) in cursor.iter() {
@@ -579,11 +584,15 @@ impl Storage {
                     block_header.hash(verifiable_chunked_hash_activation),
                     &block_body,
                 )?;
+
+                full_block_heights.push(block_header.height());
             }
         }
         info!("block store reindexing complete");
         drop(cursor);
         block_txn.commit()?;
+
+        let disjoint_block_height_sequences = DisjointSequences::from(full_block_heights);
 
         let deleted_block_hashes_raw = deleted_block_hashes.iter().map(BlockHash::as_ref).collect();
 
@@ -614,6 +623,7 @@ impl Storage {
             transfer_db,
             state_store_db,
             block_height_index,
+            disjoint_block_height_sequences,
             switch_block_era_id_index,
             deploy_hash_index,
             enable_mem_deduplication: config.enable_mem_deduplication,
@@ -1094,6 +1104,12 @@ impl Storage {
                 txn.commit()?;
                 responder.respond(true).ignore()
             }
+            StorageRequest::GetLowestContiguousBlockHeight { responder } => {
+                let result = self
+                    .disjoint_block_height_sequences
+                    .highest_sequence_low_value();
+                responder.respond(result).ignore()
+            }
         })
     }
 
@@ -1165,6 +1181,7 @@ impl Storage {
             block.body(),
         )?;
         txn.commit()?;
+        self.disjoint_block_height_sequences.insert(block.height());
         Ok(true)
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -44,7 +44,7 @@ mod tests;
 #[cfg(test)]
 use std::collections::BTreeSet;
 use std::{
-    collections::{btree_map::Entry, hash_map, BTreeMap, HashMap, HashSet},
+    collections::{btree_map, hash_map, BTreeMap, HashMap, HashSet},
     convert::TryFrom,
     fmt::{self, Display, Formatter},
     fs, io, mem,
@@ -1821,10 +1821,10 @@ fn insert_to_block_header_indices(
 
     if block_header.is_switch_block() {
         match switch_block_era_id_index.entry(block_header.era_id()) {
-            Entry::Vacant(entry) => {
+            btree_map::Entry::Vacant(entry) => {
                 let _ = entry.insert(block_hash);
             }
-            Entry::Occupied(entry) => {
+            btree_map::Entry::Occupied(entry) => {
                 if *entry.get() != block_hash {
                     return Err(FatalStorageError::DuplicateEraIdIndex {
                         era_id: block_header.era_id(),

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1108,7 +1108,7 @@ impl Storage {
                     self.verifiable_chunked_hash_activation,
                 )?;
 
-                if self.has_corresponsing_body(&mut txn, &block_header)? {
+                if self.has_corresponding_body(&mut txn, &block_header)? {
                     self.disjoint_block_height_sequences
                         .insert(block_header.height());
                 } else {
@@ -1135,7 +1135,7 @@ impl Storage {
     }
 
     /// Returns `true` if there is a block body for the given block header available in storage.
-    fn has_corresponsing_body<Tx: Transaction>(
+    fn has_corresponding_body<Tx: Transaction>(
         &self,
         txn: &mut Tx,
         block_header: &BlockHeader,
@@ -1152,10 +1152,11 @@ impl Storage {
         self.disjoint_block_height_sequences
             .insert(block_header.height());
 
-        if let Some(block_bodies_to_add) = self.missing_block_bodies.get(block_header.body_hash()) {
+        if let Some(block_bodies_to_add) =
+            self.missing_block_bodies.remove(block_header.body_hash())
+        {
             self.disjoint_block_height_sequences
                 .extend(block_bodies_to_add);
-            self.missing_block_bodies.remove(block_header.body_hash());
         }
     }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -137,11 +137,11 @@ impl DisjointSequences {
     }
 
     /// Inserts multiple values produced by the given interator.
-    pub(super) fn extend<T>(&mut self, iter: T)
+    pub(super) fn extend<'a, T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = u64>,
+        T: IntoIterator<Item = &'a u64>,
     {
-        iter.into_iter().for_each(|height| self.insert(height))
+        iter.into_iter().for_each(|height| self.insert(*height))
     }
 
     /// Returns the `low` value from the highest sequence, or `u64::MAX` if there are no sequences.
@@ -233,11 +233,11 @@ mod tests {
         expected.extend(to_be_inserted.clone());
 
         let mut disjoint_sequences = DisjointSequences::default();
-        disjoint_sequences.extend(to_be_inserted);
+        disjoint_sequences.extend(to_be_inserted.iter());
         assert_matches(&disjoint_sequences, &expected);
 
         // Extending with empty set should not modify the sequences.
-        disjoint_sequences.extend(Vec::<u64>::new());
+        disjoint_sequences.extend(Vec::<u64>::new().iter());
         assert_matches(&disjoint_sequences, &expected);
     }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -21,7 +21,7 @@ enum InsertOutcome {
 
 /// Represents a continuous sequence of `u64`s.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, DataSize, Ord, PartialOrd)]
-pub(crate) struct Sequence {
+pub(super) struct Sequence {
     /// The upper bound (inclusive) of the sequence.
     high: u64,
     /// The lower bound (inclusive) of the sequence.
@@ -142,11 +142,11 @@ impl DisjointSequences {
     }
 
     /// Inserts multiple values produced by the given interator.
-    pub(super) fn extend<'a, T>(&mut self, iter: T)
+    pub(super) fn extend<T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = &'a u64>,
+        T: IntoIterator<Item = u64>,
     {
-        iter.into_iter().for_each(|height| self.insert(*height))
+        iter.into_iter().for_each(|height| self.insert(height))
     }
 
     /// Returns the `low` value from the highest sequence, or `u64::MAX` if there are no sequences.
@@ -243,11 +243,11 @@ mod tests {
         expected.extend(to_be_inserted.clone());
 
         let mut disjoint_sequences = DisjointSequences::default();
-        disjoint_sequences.extend(to_be_inserted.iter());
+        disjoint_sequences.extend(to_be_inserted);
         assert_matches(&disjoint_sequences, &expected);
 
         // Extending with empty set should not modify the sequences.
-        disjoint_sequences.extend(Vec::<u64>::new().iter());
+        disjoint_sequences.extend(Vec::<u64>::new());
         assert_matches(&disjoint_sequences, &expected);
     }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -20,8 +20,8 @@ enum InsertOutcome {
 }
 
 /// Represents a continuous sequence of `u64`s.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, DataSize)]
-struct Sequence {
+#[derive(Copy, Clone, Debug, Eq, PartialEq, DataSize, Ord, PartialOrd)]
+pub(crate) struct Sequence {
     /// The upper bound (inclusive) of the sequence.
     high: u64,
     /// The lower bound (inclusive) of the sequence.
@@ -35,6 +35,11 @@ impl Sequence {
             high: value,
             low: value,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_bounds(low: u64, high: u64) -> Self {
+        Sequence { high, low }
     }
 
     /// Tries to insert `value` into the sequence.
@@ -150,6 +155,11 @@ impl DisjointSequences {
             .first()
             .map(|sequence| sequence.low)
             .unwrap_or(u64::MAX)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sequences(&self) -> &Vec<Sequence> {
+        &self.sequences
     }
 }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -150,11 +150,8 @@ impl DisjointSequences {
     }
 
     /// Returns the `low` value from the highest sequence, or `u64::MAX` if there are no sequences.
-    pub(super) fn highest_sequence_low_value(&self) -> u64 {
-        self.sequences
-            .first()
-            .map(|sequence| sequence.low)
-            .unwrap_or(u64::MAX)
+    pub(super) fn highest_sequence_low_value(&self) -> Option<u64> {
+        self.sequences.first().map(|sequence| sequence.low)
     }
 
     #[cfg(test)]
@@ -294,24 +291,24 @@ mod tests {
     #[test]
     fn should_get_highest_sequence_low_value() {
         let mut disjoint_sequences = DisjointSequences::default();
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), u64::MAX);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), None);
 
         disjoint_sequences.insert(10);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
 
         disjoint_sequences.insert(11);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
 
         disjoint_sequences.insert(5);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
 
         disjoint_sequences.insert(6);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
 
         disjoint_sequences.insert(13);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 13);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(13));
 
         disjoint_sequences.insert(14);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 13);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(13));
     }
 }

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -1,0 +1,281 @@
+use std::fmt::{self, Display, Formatter};
+
+use datasize::DataSize;
+use itertools::Itertools;
+
+/// The outcome of an attempt to insert a value into a `Sequence`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum InsertOutcome {
+    /// The value was greater than `Sequence::high + 1` and wasn't inserted.
+    TooHigh,
+    /// The value was inserted at the high end, and is now `Sequence::high`.
+    ExtendedHigh,
+    /// The value was a duplicate; inserted and didn't affect the high or low values.
+    AlreadyInSequence,
+    /// The value was inserted at the low end, and is now `Sequence::low`.
+    ExtendedLow,
+    /// The value was less than `Sequence::low - 1` and wasn't inserted.
+    TooLow,
+}
+
+/// Represents a continuous sequence of `u64`s.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, DataSize)]
+struct Sequence {
+    /// The upper bound (inclusive) of the sequence.
+    high: u64,
+    /// The lower bound (inclusive) of the sequence.
+    low: u64,
+}
+
+impl Sequence {
+    /// Constructs a new sequence containing only `value`.
+    fn new(value: u64) -> Self {
+        Sequence {
+            high: value,
+            low: value,
+        }
+    }
+
+    /// Tries to insert `value` into the sequence.
+    ///
+    /// Returns an outcome which indicates where the value was inserted if at all.
+    fn try_insert(&mut self, value: u64) -> InsertOutcome {
+        if value == self.high + 1 {
+            self.high = value;
+            InsertOutcome::ExtendedHigh
+        } else if value >= self.low && value <= self.high {
+            InsertOutcome::AlreadyInSequence
+        } else if value + 1 == self.low {
+            self.low = value;
+            InsertOutcome::ExtendedLow
+        } else if value > self.high {
+            InsertOutcome::TooHigh
+        } else {
+            InsertOutcome::TooLow
+        }
+    }
+}
+
+/// Represents a collection of disjoint sequences of `u64`s.
+///
+/// The collection is kept ordered from high to low, and each entry represents a discrete portion of
+/// the space from [0, u64::MAX] with a gap of at least 1 between each.
+///
+/// The collection is ordered this way to optimize insertion for the normal use case: adding
+/// monotonically increasing values representing the latest block height.
+///
+/// As values are inserted, if two separate sequences become contiguous, they are merged into a
+/// single sequence.
+///
+/// For example, if `sequences` contains `[9,9], [7,3]` and `8` is inserted, then `sequences` will
+/// be reduced to `[9,3]`.
+#[derive(Default, Debug, DataSize)]
+pub(super) struct DisjointSequences {
+    sequences: Vec<Sequence>,
+}
+
+impl DisjointSequences {
+    /// Inserts `value` into the appropriate sequence and merges sequences if required.
+    ///
+    /// Note, this method is efficient where `value` is one greater than the current highest value.
+    /// However, it's not advisable to use this method in a loop to rebuild a `DisjointSequences`
+    /// from a large collection of randomly-ordered values.  In that case, it is very much more
+    /// efficient to use `DisjointSequences::from(mut input: Vec<u64>)`.
+    pub(super) fn insert(&mut self, value: u64) {
+        let mut iter_mut = self.sequences.iter_mut().enumerate().peekable();
+
+        // The index at which to add a new `Sequence` containing only `value`.
+        let mut maybe_insertion_index = Some(0);
+        // The index of a `Sequence` to be removed due to the insertion of `value` causing two
+        // consecutive sequences to become contiguous.
+        let mut maybe_removal_index = None;
+        while let Some((index, sequence)) = iter_mut.next() {
+            match sequence.try_insert(value) {
+                InsertOutcome::ExtendedHigh | InsertOutcome::AlreadyInSequence => {
+                    // We should exit the loop, and we don't need to add a new sequence; we only
+                    // need to check for merges of sequences when we get `ExtendedLow` since we're
+                    // iterating the sequences from high to low.
+                    maybe_insertion_index = None;
+                    break;
+                }
+                InsertOutcome::TooHigh => {
+                    // We should exit the loop and we need to add a new sequence at this index.
+                    maybe_insertion_index = Some(index);
+                    break;
+                }
+                InsertOutcome::TooLow => {
+                    // We need to add a new sequence immediately after this one if this is the last
+                    // sequence.  Continue iterating in case this is not the last sequence.
+                    maybe_insertion_index = Some(index + 1);
+                }
+                InsertOutcome::ExtendedLow => {
+                    // We should exit the loop, and we don't need to add a new sequence.
+                    maybe_insertion_index = None;
+                    // If the next sequence is now contiguous with this one, update this one's low
+                    // value and set the next sequence to be removed.
+                    if let Some((next_index, next_sequence)) = iter_mut.peek() {
+                        if next_sequence.high + 1 == sequence.low {
+                            sequence.low = next_sequence.low;
+                            maybe_removal_index = Some(*next_index);
+                        }
+                    }
+                    break;
+                }
+            };
+        }
+
+        if let Some(index_to_insert) = maybe_insertion_index {
+            let _ = self.sequences.insert(index_to_insert, Sequence::new(value));
+        }
+
+        if let Some(index_to_remove) = maybe_removal_index {
+            let _ = self.sequences.remove(index_to_remove);
+        }
+    }
+
+    /// Returns the `low` value from the highest sequence, or `u64::MAX` if there are no sequences.
+    pub(super) fn highest_sequence_low_value(&self) -> u64 {
+        self.sequences
+            .first()
+            .map(|sequence| sequence.low)
+            .unwrap_or(u64::MAX)
+    }
+}
+
+/// This impl is provided to allow for efficient re-building of a `DisjointSequences` from a large,
+/// randomly-ordered set of values.
+impl From<Vec<u64>> for DisjointSequences {
+    fn from(mut input: Vec<u64>) -> Self {
+        input.sort_unstable();
+
+        let sequences = input
+            .drain(..)
+            .peekable()
+            .batching(|iter| match iter.next() {
+                None => None,
+                Some(low) => {
+                    let mut sequence = Sequence::new(low);
+                    while let Some(i) = iter.peek() {
+                        if *i == sequence.high + 1 {
+                            sequence.high = iter.next().unwrap();
+                        }
+                    }
+                    Some(sequence)
+                }
+            })
+            .collect();
+
+        DisjointSequences { sequences }
+    }
+}
+
+impl Display for DisjointSequences {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let mut iter = self.sequences.iter().peekable();
+        while let Some(sequence) = iter.next() {
+            write!(formatter, "[{}, {}]", sequence.high, sequence.low)?;
+            if iter.peek().is_some() {
+                write!(formatter, ", ")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use rand::{seq::SliceRandom, Rng};
+
+    use super::*;
+
+    fn assert_matches(actual: &DisjointSequences, expected: &BTreeSet<u64>) {
+        let mut actual_set = BTreeSet::new();
+        for sequence in &actual.sequences {
+            for i in sequence.low..=sequence.high {
+                assert!(actual_set.insert(i));
+            }
+        }
+        assert_eq!(&actual_set, expected)
+    }
+
+    #[test]
+    fn should_insert_all_u8s_including_duplicates() {
+        let mut rng = crate::new_rng();
+
+        let mut disjoint_sequences = DisjointSequences::default();
+        let mut expected = BTreeSet::new();
+
+        while disjoint_sequences.sequences != vec![Sequence { high: 255, low: 0 }] {
+            let value = rng.gen::<u8>() as u64;
+            disjoint_sequences.insert(value);
+            expected.insert(value);
+            assert_matches(&disjoint_sequences, &expected);
+        }
+    }
+
+    #[test]
+    fn should_insert_with_no_duplicates() {
+        const MAX: u64 = 1000;
+
+        let mut rng = crate::new_rng();
+
+        let mut values = (0..=MAX).collect::<Vec<u64>>();
+        values.shuffle(&mut rng);
+
+        let mut disjoint_sequences = DisjointSequences::default();
+        let mut expected = BTreeSet::new();
+
+        for value in values {
+            disjoint_sequences.insert(value);
+            expected.insert(value);
+            assert_matches(&disjoint_sequences, &expected);
+        }
+
+        assert_eq!(
+            disjoint_sequences.sequences,
+            vec![Sequence { high: MAX, low: 0 }]
+        );
+    }
+
+    #[test]
+    fn should_construct_from_random_set() {
+        const MAX: u64 = 2_000_000;
+
+        let mut rng = crate::new_rng();
+
+        let mut values = (0..=MAX).collect::<Vec<u64>>();
+        values.shuffle(&mut rng);
+
+        let disjoint_sequences = DisjointSequences::from(values);
+        assert_eq!(
+            disjoint_sequences.sequences,
+            vec![Sequence { high: MAX, low: 0 }]
+        );
+    }
+
+    #[test]
+    fn should_get_highest_sequence_low_value() {
+        let mut disjoint_sequences = DisjointSequences::default();
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), u64::MAX);
+
+        disjoint_sequences.insert(10);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+
+        disjoint_sequences.insert(11);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+
+        disjoint_sequences.insert(5);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+
+        disjoint_sequences.insert(6);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 10);
+
+        disjoint_sequences.insert(13);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 13);
+
+        disjoint_sequences.insert(14);
+        assert_eq!(disjoint_sequences.highest_sequence_low_value(), 13);
+    }
+}

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the storage component.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
     convert::TryFrom,
     fs::{self, File},
     thread,
@@ -17,9 +17,9 @@ use casper_hashing::Digest;
 use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, SecretKey, U512};
 
 use super::{
-    construct_block_body_to_block_header_reverse_lookup, garbage_collect_block_body_v2_db,
-    move_storage_files_to_network_subdir, should_move_storage_files_to_network_subdir, Config,
-    Storage,
+    construct_block_body_to_block_header_reverse_lookup, disjoint_sequences::Sequence,
+    garbage_collect_block_body_v2_db, move_storage_files_to_network_subdir,
+    should_move_storage_files_to_network_subdir, Config, Storage,
 };
 use crate::{
     components::{
@@ -28,7 +28,6 @@ use crate::{
     },
     crypto::AsymmetricKeyExt,
     effect::{requests::StorageRequest, Multiple},
-    storage::disjoint_sequences::Sequence,
     testing::{ComponentHarness, TestRng, UnitTestEvent},
     types::{
         Block, BlockHash, BlockHeader, BlockPayload, BlockSignatures, Deploy, DeployHash,
@@ -46,10 +45,10 @@ impl Storage {
 
     fn add_missing_block_body(&mut self, block_header: &BlockHeader) {
         match self.missing_block_bodies.entry(*block_header.body_hash()) {
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
+            Entry::Occupied(mut entry) => {
                 entry.get_mut().push(block_header.height());
             }
-            std::collections::hash_map::Entry::Vacant(entry) => {
+            Entry::Vacant(entry) => {
                 entry.insert(vec![block_header.height()]);
             }
         }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1706,11 +1706,13 @@ fn update_disjoint_height_sequences() {
     );
 
     // Write full block with the same block body as the two missing ones.
-    // All 5 blocks should now be considered available.
+    // All 5 blocks should now be considered available and missing bodies
+    // map should be empty.
     let mut block_5 = block_3.clone();
     block_5.set_height(5, verifiable_chunked_hash_activation);
     storage.update_disjoint_height_sequences(block_5.header());
 
+    assert_eq!(HashMap::new(), storage.missing_block_bodies);
     assert_eq!(
         storage.disjoint_sequences(),
         &vec![Sequence::new_with_bounds(1, 5)]

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the storage component.
 
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::TryFrom,
     fs::{self, File},
     thread,
@@ -44,14 +44,10 @@ impl Storage {
     }
 
     fn add_missing_block_body(&mut self, block_header: &BlockHeader) {
-        match self.missing_block_bodies.entry(*block_header.body_hash()) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().push(block_header.height());
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(vec![block_header.height()]);
-            }
-        }
+        self.missing_block_bodies
+            .entry(*block_header.body_hash())
+            .or_default()
+            .push(block_header.height());
     }
 }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -929,18 +929,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Recalculate the information about the contiguous blocks.
-    pub(crate) async fn update_contiguous_block_info(self)
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::UpdateContiguousBlockInfo { responder },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Gets the requested block's transfers from storage.
     pub(crate) async fn get_block_transfers_from_storage(
         self,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -929,6 +929,18 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Recalculate the information about the contiguous blocks.
+    pub(crate) async fn update_contiguous_block_info(self)
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::UpdateContiguousBlockInfo { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Gets the requested block's transfers from storage.
     pub(crate) async fn get_block_transfers_from_storage(
         self,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1018,6 +1018,19 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
+    /// Requests the lowest height from which we have an unbroken chain of stored blocks (not just
+    /// headers) ending in the highest stored block.
+    pub(crate) async fn get_lowest_contiguous_block_height_from_storage(self) -> u64
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetLowestContiguousBlockHeight { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Get a trie or chunk by its ID.
     pub(crate) async fn get_trie(
         self,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -403,6 +403,12 @@ pub(crate) enum StorageRequest {
         /// stored.
         responder: Responder<bool>,
     },
+    /// Retrieve the lowest height from which we have an unbroken chain of stored blocks (not just
+    /// headers) ending in the highest stored block.
+    GetLowestContiguousBlockHeight {
+        /// Responder to call with the result.
+        responder: Responder<u64>,
+    },
 }
 
 impl Display for StorageRequest {
@@ -491,6 +497,9 @@ impl Display for StorageRequest {
                     "get block and sufficient finality signatures by height: {}",
                     block_height
                 )
+            }
+            StorageRequest::GetLowestContiguousBlockHeight { .. } => {
+                write!(formatter, "get lowest contiguous block height",)
             }
         }
     }
@@ -666,6 +675,11 @@ pub(crate) enum RpcRequest {
         /// Responder to call with the result.
         responder: Responder<StatusFeed>,
     },
+    /// Return the lowest contiguous block height.
+    GetLowestContiguousBlockHeight {
+        /// Responder to call with the result.
+        responder: Responder<u64>,
+    },
 }
 
 impl Display for RpcRequest {
@@ -715,6 +729,9 @@ impl Display for RpcRequest {
             RpcRequest::GetDeploy { hash, .. } => write!(formatter, "get {}", hash),
             RpcRequest::GetPeers { .. } => write!(formatter, "get peers"),
             RpcRequest::GetStatus { .. } => write!(formatter, "get status"),
+            RpcRequest::GetLowestContiguousBlockHeight { .. } => {
+                write!(formatter, "get lowest contiguous block height")
+            }
         }
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -409,8 +409,6 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.
         responder: Responder<u64>,
     },
-    /// Recalculate the information about the contiguous blocks.
-    UpdateContiguousBlockInfo { responder: Responder<()> },
 }
 
 impl Display for StorageRequest {
@@ -502,9 +500,6 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetLowestContiguousBlockHeight { .. } => {
                 write!(formatter, "get lowest contiguous block height",)
-            }
-            StorageRequest::UpdateContiguousBlockInfo { .. } => {
-                write!(formatter, "update info about contiguous blocks",)
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -409,6 +409,8 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.
         responder: Responder<u64>,
     },
+    /// Recalculate the information about the contiguous blocks.
+    UpdateContiguousBlockInfo { responder: Responder<()> },
 }
 
 impl Display for StorageRequest {
@@ -500,6 +502,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetLowestContiguousBlockHeight { .. } => {
                 write!(formatter, "get lowest contiguous block height",)
+            }
+            StorageRequest::UpdateContiguousBlockInfo { .. } => {
+                write!(formatter, "update info about contiguous blocks",)
             }
         }
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1310,7 +1310,7 @@ pub struct Block {
 }
 
 /// The hashing algorithm used for the header and the body of a block
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, DataSize, Hash)]
 pub enum HashingAlgorithmVersion {
     /// Version 1
     V1,

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3723,7 +3723,7 @@
               "required": false,
               "schema": {
                 "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block hash."
+                "description": "The block identifier."
               }
             }
           ],


### PR DESCRIPTION
This PR adds info to RPC responses indicating the lowest contiguous block height for that node in the case where it is unable to provide data to the requester.  This can be used by the requester to decide whether to repeat the request on a different node (with a more complete global state store) or not.

Closes #2632 