### PR TITLE
added advance_eras method on WasmTestBuilder and used in distribute.r…

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1171,4 +1171,23 @@ where
         self.transforms = Vec::new();
         self
     }
+
+    /// Advances eras by num_eras
+    pub fn advance_eras_by(&mut self, num_eras: u64) {
+        for _ in 0..=num_eras {
+            let step_request = StepRequestBuilder::new()
+                .with_parent_state_hash(self.get_post_state_hash())
+                .with_protocol_version(ProtocolVersion::V1_0_0)
+                .with_next_era_id(self.get_era().successor())
+                .with_run_auction(true)
+                .build();
+            self.step(step_request)
+                .expect("must execute third step request post upgrade");
+        }
+    }
+
+    /// Advances eras by configured amount
+    pub fn advance_eras_by_configured_amount(&mut self) {
+        self.advance_eras_by(DEFAULT_AUCTION_DELAY);
+    }
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -4043,15 +4043,7 @@ fn should_not_restake_after_full_unbond() {
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
 
     // advance past the initial auction delay due to special condition of post-genesis behavior.
-    for _ in 0..4 {
-        let step_request = StepRequestBuilder::new()
-            .with_parent_state_hash(builder.get_post_state_hash())
-            .with_protocol_version(ProtocolVersion::V1_0_0)
-            .with_next_era_id(builder.get_era() + 1)
-            .build();
-
-        builder.step(step_request).expect("should step");
-    }
+    builder.advance_eras_by(4);
 
     let validator_1_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,


### PR DESCRIPTION
  #2690

Added utility methods 
* advance_eras_by
* advance_eras_by_configured_amount

to WasmTestBuilder. Refactored the test "should_not_restake_after_full_unbond" in distribute.rs to make use of the utility method advance_eras_by.