### PR TITLE
Update OpenSSL version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,9 +2857,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.17.0+1.1.1m"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.  The format
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
 * Requests for data from a peer are now de-prioritized over networking messages necessary for consensus and chain advancement.
 * JSON-RPC responses which fail to provide requested data will now also include an indication of that node's lowest contiguous block height, i.e. the block from which it holds all subsequent global state
+* OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.


### PR DESCRIPTION
Updates the included OpenSSL source version to mitigate a recent potential DOS attack vector, see <https://www.openssl.org/news/secadv/20220315.txt> for details.

Note that this is only an issue when compiling with the vendored OpenSSL option.