### PR TITLE
ZH-SRE-I340: Use dev branch for client with NCTL

### DIFF
--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -2,20 +2,11 @@
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+NCTL_CLIENT_BRANCH='dev'
 
 # Activate Environment
 pushd "$ROOT_DIR"
 source $(pwd)/utils/nctl/activate
-
-# TODO: Remove this after feat-fast-sync merges to dev
-#
-# Hack for picking between dev and feat-fast-sync branch for client
-# ... casper-mainnet feature flag is removed in feat-fast-sync
-if ( cat "$NCTL"/sh/assets/compile_client.sh | grep -q casper-mainnet ); then
-    NCTL_CLIENT_BRANCH='dev'
-else
-    NCTL_CLIENT_BRANCH='feat-fast-sync'
-fi
 
 # Clone the client and launcher repos if required.
 if [ ! -d "$NCTL_CASPER_CLIENT_HOME" ]; then


### PR DESCRIPTION
Changes:
- removes switching of client branches now that fast-sync is in dev.

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/340