### PR TITLE
Add the highest available block height to the RPC error response

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.  The format
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
 * Requests for data from a peer are now de-prioritized over networking messages necessary for consensus and chain advancement.
-* JSON-RPC responses which fail to provide requested data will now also include an indication of that node's lowest contiguous block height, i.e. the block from which it holds all subsequent global state
+* JSON-RPC responses which fail to provide requested data will now also include an indication of that node's highest contiguous block height range, i.e. the block heights for which it holds all global state
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 
 ### Deprecated

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -294,13 +294,16 @@ where
                 }
                 .ignore()
             }
-            Event::RpcRequest(RpcRequest::GetLowestContiguousBlockHeight { responder }) => {
+            Event::RpcRequest(RpcRequest::GetHighestContiguousBlockHeightRange { responder }) => {
                 effect_builder
-                    .get_lowest_contiguous_block_height_from_storage()
-                    .event(move |height| Event::GetLowestContiguousBlockHeightResult {
-                        height,
-                        main_responder: responder,
-                    })
+                    .get_highest_contiguous_block_range_from_storage()
+                    .event(
+                        move |(low, high)| Event::GetHighestContiguousBlockHeightRange {
+                            low,
+                            high,
+                            main_responder: responder,
+                        },
+                    )
             }
             Event::GetBlockResult {
                 maybe_id: _,
@@ -337,10 +340,11 @@ where
                 peers,
                 main_responder,
             } => main_responder.respond(peers).ignore(),
-            Event::GetLowestContiguousBlockHeightResult {
-                height,
+            Event::GetHighestContiguousBlockHeightRange {
+                low,
+                high,
                 main_responder,
-            } => main_responder.respond(height).ignore(),
+            } => main_responder.respond((low, high)).ignore(),
         }
     }
 }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -295,15 +295,16 @@ where
                 .ignore()
             }
             Event::RpcRequest(RpcRequest::GetHighestContiguousBlockHeightRange { responder }) => {
-                effect_builder
-                    .get_highest_contiguous_block_range_from_storage()
-                    .event(
-                        move |(low, high)| Event::GetHighestContiguousBlockHeightRange {
-                            low,
-                            high,
-                            main_responder: responder,
-                        },
-                    )
+                async move {
+                    responder
+                        .respond(
+                            effect_builder
+                                .get_highest_contiguous_block_range_from_storage()
+                                .await,
+                        )
+                        .await
+                }
+                .ignore()
             }
             Event::GetBlockResult {
                 maybe_id: _,
@@ -340,11 +341,6 @@ where
                 peers,
                 main_responder,
             } => main_responder.respond(peers).ignore(),
-            Event::GetHighestContiguousBlockHeightRange {
-                low,
-                high,
-                main_responder,
-            } => main_responder.respond((low, high)).ignore(),
         }
     }
 }

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -55,9 +55,10 @@ pub(crate) enum Event {
         result: Result<BalanceResult, engine_state::Error>,
         main_responder: Responder<Result<BalanceResult, engine_state::Error>>,
     },
-    GetLowestContiguousBlockHeightResult {
-        height: u64,
-        main_responder: Responder<u64>,
+    GetHighestContiguousBlockHeightRange {
+        low: u64,
+        high: u64,
+        main_responder: Responder<(u64, u64)>,
     },
 }
 
@@ -103,10 +104,10 @@ impl Display for Event {
                 write!(formatter, "get deploy result for {}: {:?}", hash, result)
             }
             Event::GetPeersResult { peers, .. } => write!(formatter, "get peers: {}", peers.len()),
-            Event::GetLowestContiguousBlockHeightResult { height, .. } => write!(
+            Event::GetHighestContiguousBlockHeightRange { low, high, .. } => write!(
                 formatter,
-                "get lowest contiguous block height result: {}",
-                height
+                "get highest contiguous block height range result: ({}, {})",
+                low, high
             ),
         }
     }

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -55,11 +55,6 @@ pub(crate) enum Event {
         result: Result<BalanceResult, engine_state::Error>,
         main_responder: Responder<Result<BalanceResult, engine_state::Error>>,
     },
-    GetHighestContiguousBlockHeightRange {
-        low: u64,
-        high: u64,
-        main_responder: Responder<(u64, u64)>,
-    },
 }
 
 impl Display for Event {
@@ -104,11 +99,6 @@ impl Display for Event {
                 write!(formatter, "get deploy result for {}: {:?}", hash, result)
             }
             Event::GetPeersResult { peers, .. } => write!(formatter, "get peers: {}", peers.len()),
-            Event::GetHighestContiguousBlockHeightRange { low, high, .. } => write!(
-                formatter,
-                "get highest contiguous block height range result: ({}, {})",
-                low, high
-            ),
         }
     }
 }

--- a/node/src/components/rpc_server/rpcs/common.rs
+++ b/node/src/components/rpc_server/rpcs/common.rs
@@ -77,7 +77,7 @@ pub(super) async fn run_query_and_encode<REv: ReactorEventT>(
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorData {
-    /// The highest contiguous height range of fully available blocks.
+    /// The highest contiguous height range (inclusive) of fully available blocks.
     HighestContiguousBlockHeightRange((u64, u64)),
 }
 

--- a/node/src/components/rpc_server/rpcs/common.rs
+++ b/node/src/components/rpc_server/rpcs/common.rs
@@ -101,7 +101,10 @@ pub(super) async fn missing_block_or_state_root_error<REv: ReactorEventT>(
         )
         .await;
 
-    info!(low, high, "{}", error_message);
+    info!(
+        low,
+        high, "got request for non-existent data, will respond with msg: {}", error_message
+    );
 
     warp_json_rpc::Error::custom(error_code as i64, error_message)
         .with_data(ErrorData::highest_contiguous_block_height_range(low, high))

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1127,13 +1127,13 @@ impl Storage {
                 txn.commit()?;
                 responder.respond(true).ignore()
             }
-            StorageRequest::GetLowestContiguousBlockHeight { responder } => {
+            StorageRequest::GetHighestContiguousBlockHeightRange { responder } => {
                 let result = self
                     .disjoint_block_height_sequences
-                    .highest_sequence_low_value()
+                    .highest_sequence()
                     .unwrap_or_else(|| {
                         error!("storage disjoint sequences of block heights should not be empty");
-                        u64::MAX
+                        (u64::MAX, u64::MAX)
                     });
                 responder.respond(result).ignore()
             }

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -149,9 +149,11 @@ impl DisjointSequences {
         iter.into_iter().for_each(|height| self.insert(height))
     }
 
-    /// Returns the `low` value from the highest sequence, or `u64::MAX` if there are no sequences.
-    pub(super) fn highest_sequence_low_value(&self) -> Option<u64> {
-        self.sequences.first().map(|sequence| sequence.low)
+    /// Returns the highest sequence, or `None` if there are no sequences.
+    pub(super) fn highest_sequence(&self) -> Option<(u64, u64)> {
+        self.sequences
+            .first()
+            .map(|sequence| (sequence.low, sequence.high))
     }
 
     #[cfg(test)]
@@ -289,26 +291,17 @@ mod tests {
     }
 
     #[test]
-    fn should_get_highest_sequence_low_value() {
+    fn should_get_highest_sequence() {
         let mut disjoint_sequences = DisjointSequences::default();
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), None);
+        assert_eq!(disjoint_sequences.highest_sequence(), None);
 
-        disjoint_sequences.insert(10);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
+        disjoint_sequences.extend([1]);
+        assert_eq!(disjoint_sequences.highest_sequence(), Some((1, 1)));
 
-        disjoint_sequences.insert(11);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
+        disjoint_sequences.extend([5, 6]);
+        assert_eq!(disjoint_sequences.highest_sequence(), Some((5, 6)));
 
-        disjoint_sequences.insert(5);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
-
-        disjoint_sequences.insert(6);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(10));
-
-        disjoint_sequences.insert(13);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(13));
-
-        disjoint_sequences.insert(14);
-        assert_eq!(disjoint_sequences.highest_sequence_low_value(), Some(13));
+        disjoint_sequences.extend([8, 9]);
+        assert_eq!(disjoint_sequences.highest_sequence(), Some((8, 9)));
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1019,14 +1019,14 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Requests the lowest height from which we have an unbroken chain of stored blocks (not just
-    /// headers) ending in the highest stored block.
-    pub(crate) async fn get_lowest_contiguous_block_height_from_storage(self) -> u64
+    /// Requests the highest contiguous height range of fully available blocks (not just block
+    /// headers).
+    pub(crate) async fn get_highest_contiguous_block_range_from_storage(self) -> (u64, u64)
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::GetLowestContiguousBlockHeight { responder },
+            |responder| StorageRequest::GetHighestContiguousBlockHeightRange { responder },
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -730,7 +730,7 @@ impl Display for RpcRequest {
             RpcRequest::GetPeers { .. } => write!(formatter, "get peers"),
             RpcRequest::GetStatus { .. } => write!(formatter, "get status"),
             RpcRequest::GetHighestContiguousBlockHeightRange { .. } => {
-                write!(formatter, "get lowest contiguous block height")
+                write!(formatter, "get highest contiguous block height range")
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -403,11 +403,11 @@ pub(crate) enum StorageRequest {
         /// stored.
         responder: Responder<bool>,
     },
-    /// Retrieve the lowest height from which we have an unbroken chain of stored blocks (not just
-    /// headers) ending in the highest stored block.
-    GetLowestContiguousBlockHeight {
+    /// Retrieve the highest contiguous height range of fully available blocks (not just block
+    /// headers). Returns (u64::MAX, u64::MAX) when there are no sequences.
+    GetHighestContiguousBlockHeightRange {
         /// Responder to call with the result.
-        responder: Responder<u64>,
+        responder: Responder<(u64, u64)>,
     },
 }
 
@@ -498,8 +498,8 @@ impl Display for StorageRequest {
                     block_height
                 )
             }
-            StorageRequest::GetLowestContiguousBlockHeight { .. } => {
-                write!(formatter, "get lowest contiguous block height",)
+            StorageRequest::GetHighestContiguousBlockHeightRange { .. } => {
+                write!(formatter, "get highest contiguous block height range",)
             }
         }
     }
@@ -675,10 +675,10 @@ pub(crate) enum RpcRequest {
         /// Responder to call with the result.
         responder: Responder<StatusFeed>,
     },
-    /// Return the lowest contiguous block height.
-    GetLowestContiguousBlockHeight {
+    /// Return the highest contiguous height range of fully available blocks.
+    GetHighestContiguousBlockHeightRange {
         /// Responder to call with the result.
-        responder: Responder<u64>,
+        responder: Responder<(u64, u64)>,
     },
 }
 
@@ -729,7 +729,7 @@ impl Display for RpcRequest {
             RpcRequest::GetDeploy { hash, .. } => write!(formatter, "get {}", hash),
             RpcRequest::GetPeers { .. } => write!(formatter, "get peers"),
             RpcRequest::GetStatus { .. } => write!(formatter, "get status"),
-            RpcRequest::GetLowestContiguousBlockHeight { .. } => {
+            RpcRequest::GetHighestContiguousBlockHeightRange { .. } => {
                 write!(formatter, "get lowest contiguous block height")
             }
         }


### PR DESCRIPTION
This PR changes the response to the block query. In case of requesting a block that is missing from the node, the response will now contain the highest contiguous height range of fully available blocks, for example:

```json
{
	"jsonrpc": "2.0",
	"id": "1",
	"error": {
		"code": -32001,
		"message": "block at height 200 not stored on this node",
		"data": {
			"highest_contiguous_block_height_range": [3, 93]
		}
	}
}
```

Closes https://github.com/casper-network/casper-node/issues/2780