### PR TITLE
Check block availability when responding to RPC requests

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -473,8 +473,11 @@ impl ItemFetcher<BlockHeader> for Fetcher<BlockHeader> {
         id: BlockHash,
         peer: NodeId,
     ) -> Effects<Event<BlockHeader>> {
+        // Requests from fetcher are not restricted by the block availability index.
+        let only_from_highest_contiguous_range = false;
+
         effect_builder
-            .get_block_header_from_storage(id)
+            .get_block_header_from_storage(id, only_from_highest_contiguous_range)
             .event(move |maybe_block_header| Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -188,9 +188,10 @@ where
                 .ignore(),
             Event::RpcRequest(RpcRequest::GetBlock {
                 maybe_id: Some(BlockIdentifier::Hash(hash)),
+                only_from_highest_contiguous_range,
                 responder,
             }) => effect_builder
-                .get_block_with_metadata_from_storage(hash)
+                .get_block_with_metadata_from_storage(hash, only_from_highest_contiguous_range)
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Hash(hash)),
                     result: Box::new(result),
@@ -198,9 +199,13 @@ where
                 }),
             Event::RpcRequest(RpcRequest::GetBlock {
                 maybe_id: Some(BlockIdentifier::Height(height)),
+                only_from_highest_contiguous_range,
                 responder,
             }) => effect_builder
-                .get_block_at_height_with_metadata_from_storage(height)
+                .get_block_at_height_with_metadata_from_storage(
+                    height,
+                    only_from_highest_contiguous_range,
+                )
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Height(height)),
                     result: Box::new(result),
@@ -208,6 +213,7 @@ where
                 }),
             Event::RpcRequest(RpcRequest::GetBlock {
                 maybe_id: None,
+                only_from_highest_contiguous_range: _, // Requesting for higest block cannot be restricted by block availability index
                 responder,
             }) => effect_builder
                 .get_highest_block_with_metadata_from_storage()

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -213,7 +213,7 @@ where
                 }),
             Event::RpcRequest(RpcRequest::GetBlock {
                 maybe_id: None,
-                only_from_highest_contiguous_range: _, // Requesting for higest block cannot be restricted by block availability index
+                only_from_highest_contiguous_range: _, /* Requesting for higest block cannot be restricted by block availability index */
                 responder,
             }) => effect_builder
                 .get_highest_block_with_metadata_from_storage()

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -158,9 +158,18 @@ impl RpcWithOptionalParamsExt for GetBlock {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
+
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let json_block = match get_block_with_metadata(maybe_block_id, effect_builder).await {
+            let json_block = match get_block_with_metadata(
+                maybe_block_id,
+                only_from_highest_contiguous_range,
+                effect_builder,
+            )
+            .await
+            {
                 Ok(BlockWithMetadata {
                     block,
                     finality_signatures,
@@ -244,9 +253,18 @@ impl RpcWithOptionalParamsExt for GetBlockTransfers {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
+
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block_hash = match common::get_block(maybe_block_id, effect_builder).await {
+            let block_hash = match common::get_block(
+                maybe_block_id,
+                only_from_highest_contiguous_range,
+                effect_builder,
+            )
+            .await
+            {
                 Ok(block) => *block.hash(),
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -317,9 +335,18 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
+
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block = match common::get_block(maybe_block_id, effect_builder).await {
+            let block = match common::get_block(
+                maybe_block_id,
+                only_from_highest_contiguous_range,
+                effect_builder,
+            )
+            .await
+            {
                 Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -383,9 +410,18 @@ impl RpcWithOptionalParamsExt for GetEraInfoBySwitchBlock {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
+
             // TODO: decide if/how to handle era id
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block = match common::get_block(maybe_block_id, effect_builder).await {
+            let block = match common::get_block(
+                maybe_block_id,
+                only_from_highest_contiguous_range,
+                effect_builder,
+            )
+            .await
+            {
                 Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -428,6 +464,7 @@ impl RpcWithOptionalParamsExt for GetEraInfoBySwitchBlock {
 
 pub(super) async fn get_block_with_metadata<REv: ReactorEventT>(
     maybe_id: Option<BlockIdentifier>,
+    only_from_highest_contiguous_range: bool,
     effect_builder: EffectBuilder<REv>,
 ) -> Result<BlockWithMetadata, warp_json_rpc::Error> {
     // Get the block from storage or the latest from the linear chain.
@@ -435,6 +472,7 @@ pub(super) async fn get_block_with_metadata<REv: ReactorEventT>(
         .make_request(
             |responder| RpcRequest::GetBlock {
                 maybe_id,
+                only_from_highest_contiguous_range,
                 responder,
             },
             QueueKind::Api,

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -483,6 +483,9 @@ pub(super) async fn get_block_with_metadata<REv: ReactorEventT>(
         return Ok(block_with_metadata);
     }
 
+    // TODO: Potential optimization: We might want to make the `GetBlock` actually return the
+    // highest disjoint sequence of block heights, so we don't need to request it again inside the
+    // `missing_block_or_state_root_error` function.
     let error = match maybe_id {
         Some(BlockIdentifier::Hash(block_hash)) => common::missing_block_or_state_root_error(
             effect_builder,

--- a/node/src/components/rpc_server/rpcs/common.rs
+++ b/node/src/components/rpc_server/rpcs/common.rs
@@ -112,9 +112,10 @@ pub(super) async fn missing_block_or_state_root_error<REv: ReactorEventT>(
 
 pub(super) async fn get_block<REv: ReactorEventT>(
     maybe_id: Option<BlockIdentifier>,
+    only_from_highest_contiguous_range: bool,
     effect_builder: EffectBuilder<REv>,
 ) -> Result<Block, warp_json_rpc::Error> {
-    chain::get_block_with_metadata(maybe_id, effect_builder)
+    chain::get_block_with_metadata(maybe_id, only_from_highest_contiguous_range, effect_builder)
         .await
         .map(|block_with_metadata| block_with_metadata.block)
 }

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -383,8 +383,11 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+                        // This RPC request is restricted by the block availability index.
+                        let only_from_highest_contiguous_range = true;
+
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block = match common::get_block(maybe_block_id, effect_builder).await {
+            let block = match common::get_block(maybe_block_id, only_from_highest_contiguous_range,effect_builder).await {
                 Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -520,8 +523,17 @@ impl RpcWithParamsExt for GetAccountInfo {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
+
             let maybe_block_id = params.block_identifier;
-            let block = match common::get_block(maybe_block_id, effect_builder).await {
+            let block = match common::get_block(
+                maybe_block_id,
+                only_from_highest_contiguous_range,
+                effect_builder,
+            )
+            .await
+            {
                 Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -383,11 +383,11 @@ impl RpcWithOptionalParamsExt for GetAuctionInfo {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
-                        // This RPC request is restricted by the block availability index.
-                        let only_from_highest_contiguous_range = true;
+            // This RPC request is restricted by the block availability index.
+            let only_from_highest_contiguous_range = true;
 
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let block = match common::get_block(maybe_block_id, only_from_highest_contiguous_range,effect_builder).await {
+            let block = match common::get_block(maybe_block_id, only_from_highest_contiguous_range, effect_builder).await {
                 Ok(block) => block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -866,8 +866,14 @@ impl RpcWithParamsExt for QueryGlobalState {
         async move {
             let (state_root_hash, maybe_block_header) = match params.state_identifier {
                 GlobalStateIdentifier::BlockHash(block_hash) => {
+                    // This RPC request is restricted by the block availability index.
+                    let only_from_highest_contiguous_range = true;
+
                     match effect_builder
-                        .get_block_header_from_storage(block_hash)
+                        .get_block_header_from_storage(
+                            block_hash,
+                            only_from_highest_contiguous_range,
+                        )
                         .await
                     {
                         Some(header) => {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1167,7 +1167,7 @@ impl Storage {
         if only_from_highest_contiguous_range {
             let highest_sequence = self.disjoint_block_height_sequences.highest_sequence();
             if let Some(highest_sequence) = highest_sequence {
-                return highest_sequence.0 >= block_height && highest_sequence.1 <= block_height;
+                return block_height >= highest_sequence.0 && block_height <= highest_sequence.1;
             } else {
                 return false;
             }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1157,7 +1157,7 @@ impl Storage {
         })
     }
 
-    /// Returns `true` is the storage should attempt to return a block. Depending on the
+    /// Returns `true` if the storage should attempt to return a block. Depending on the
     /// `only_from_highest_contiguous_range` flag it should be unconditional or restricted by the
     /// highest disjoined block sequence.
     fn should_return_block(

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -23,9 +23,9 @@ enum InsertOutcome {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, DataSize, Ord, PartialOrd)]
 pub(super) struct Sequence {
     /// The upper bound (inclusive) of the sequence.
-    high: u64,
+    pub(super) high: u64,
     /// The lower bound (inclusive) of the sequence.
-    low: u64,
+    pub(super) low: u64,
 }
 
 impl Sequence {
@@ -59,6 +59,11 @@ impl Sequence {
         } else {
             InsertOutcome::TooLow
         }
+    }
+
+    /// Returns `true` if a sequence contains the value.
+    pub(super) fn contains(&self, value: u64) -> bool {
+        value >= self.low && value <= self.high
     }
 }
 
@@ -150,10 +155,8 @@ impl DisjointSequences {
     }
 
     /// Returns the highest sequence, or `None` if there are no sequences.
-    pub(super) fn highest_sequence(&self) -> Option<(u64, u64)> {
-        self.sequences
-            .first()
-            .map(|sequence| (sequence.low, sequence.high))
+    pub(super) fn highest_sequence(&self) -> Option<&Sequence> {
+        self.sequences.first()
     }
 
     #[cfg(test)]
@@ -218,6 +221,22 @@ mod tests {
             }
         }
         assert_eq!(&actual_set, expected)
+    }
+
+    #[test]
+    fn check_contains() {
+        // Single item sequence
+        let seq = Sequence::new_with_bounds(1, 1);
+        assert!(!seq.contains(0));
+        assert!(seq.contains(1));
+        assert!(!seq.contains(2));
+
+        // Mutliple item sequence
+        let seq = Sequence::new_with_bounds(1, 2);
+        assert!(!seq.contains(0));
+        assert!(seq.contains(1));
+        assert!(seq.contains(2));
+        assert!(!seq.contains(3));
     }
 
     #[test]
@@ -296,12 +315,21 @@ mod tests {
         assert_eq!(disjoint_sequences.highest_sequence(), None);
 
         disjoint_sequences.extend([1]);
-        assert_eq!(disjoint_sequences.highest_sequence(), Some((1, 1)));
+        assert_eq!(
+            disjoint_sequences.highest_sequence(),
+            Some(&Sequence { low: 1, high: 1 })
+        );
 
         disjoint_sequences.extend([5, 6]);
-        assert_eq!(disjoint_sequences.highest_sequence(), Some((5, 6)));
+        assert_eq!(
+            disjoint_sequences.highest_sequence(),
+            Some(&Sequence { low: 5, high: 6 })
+        );
 
         disjoint_sequences.extend([8, 9]);
-        assert_eq!(disjoint_sequences.highest_sequence(), Some((8, 9)));
+        assert_eq!(
+            disjoint_sequences.highest_sequence(),
+            Some(&Sequence { low: 8, high: 9 })
+        );
     }
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1742,7 +1742,7 @@ fn should_restrict_returned_blocks() {
     assert!(storage.should_return_block(6, false));
 
     // With restriction, the node should attemt to return only the blocks that are
-    // on the highest disjoint sequence, i.e blocsk 4 and 5 only.
+    // on the highest disjoint sequence, i.e blocks 4 and 5 only.
     assert!(!storage.should_return_block(0, true));
     assert!(!storage.should_return_block(1, true));
     assert!(!storage.should_return_block(2, true));

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -853,6 +853,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn get_block_header_from_storage(
         self,
         block_hash: BlockHash,
+        only_from_highest_contiguous_range: bool,
     ) -> Option<BlockHeader>
     where
         REv: From<StorageRequest>,
@@ -860,6 +861,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| StorageRequest::GetBlockHeader {
                 block_hash,
+                only_from_highest_contiguous_range,
                 responder,
             },
             QueueKind::Regular,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1176,6 +1176,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn get_block_at_height_with_metadata_from_storage(
         self,
         block_height: u64,
+        only_from_highest_contiguous_range: bool,
     ) -> Option<BlockWithMetadata>
     where
         REv: From<StorageRequest>,
@@ -1183,6 +1184,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHeight {
                 block_height,
+                only_from_highest_contiguous_range,
                 responder,
             },
             QueueKind::Regular,
@@ -1230,6 +1232,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn get_block_with_metadata_from_storage(
         self,
         block_hash: BlockHash,
+        only_from_highest_contiguous_range: bool,
     ) -> Option<BlockWithMetadata>
     where
         REv: From<StorageRequest>,
@@ -1237,6 +1240,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHash {
                 block_hash,
+                only_from_highest_contiguous_range,
                 responder,
             },
             QueueKind::Regular,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -365,6 +365,8 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHash {
         /// The hash of the block.
         block_hash: BlockHash,
+        /// TODO[RC]
+        only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
     },
@@ -372,6 +374,8 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHeight {
         /// The height of the block.
         block_height: BlockHeight,
+        /// TODO[RC]
+        only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
     },
@@ -611,6 +615,8 @@ pub(crate) enum RpcRequest {
     GetBlock {
         /// The identifier (can either be a hash or the height) of the block to be retrieved.
         maybe_id: Option<BlockIdentifier>,
+        /// TODO[RC]
+        only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.
         responder: Responder<Option<BlockWithMetadata>>,
     },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -281,7 +281,8 @@ pub(crate) enum StorageRequest {
     GetBlockHeader {
         /// Hash of block to get header of.
         block_hash: BlockHash,
-        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
         only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.  Returns `None` is the block header doesn't exist in
         /// local storage.
@@ -367,7 +368,8 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHash {
         /// The hash of the block.
         block_hash: BlockHash,
-        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
         only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
@@ -376,7 +378,8 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHeight {
         /// The height of the block.
         block_height: BlockHeight,
-        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
         only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
@@ -617,7 +620,8 @@ pub(crate) enum RpcRequest {
     GetBlock {
         /// The identifier (can either be a hash or the height) of the block to be retrieved.
         maybe_id: Option<BlockIdentifier>,
-        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
         only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.
         responder: Responder<Option<BlockWithMetadata>>,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -281,7 +281,7 @@ pub(crate) enum StorageRequest {
     GetBlockHeader {
         /// Hash of block to get header of.
         block_hash: BlockHash,
-        /// TODO[RC]
+        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
         only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.  Returns `None` is the block header doesn't exist in
         /// local storage.
@@ -367,7 +367,7 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHash {
         /// The hash of the block.
         block_hash: BlockHash,
-        /// TODO[RC]
+        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
         only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
@@ -376,7 +376,7 @@ pub(crate) enum StorageRequest {
     GetBlockAndMetadataByHeight {
         /// The height of the block.
         block_height: BlockHeight,
-        /// TODO[RC]
+        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
         only_from_highest_contiguous_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
@@ -617,7 +617,7 @@ pub(crate) enum RpcRequest {
     GetBlock {
         /// The identifier (can either be a hash or the height) of the block to be retrieved.
         maybe_id: Option<BlockIdentifier>,
-        /// TODO[RC]
+        /// Flag indicating whether storage should check the block availability before trying to retrieve it.
         only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.
         responder: Responder<Option<BlockWithMetadata>>,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -281,6 +281,8 @@ pub(crate) enum StorageRequest {
     GetBlockHeader {
         /// Hash of block to get header of.
         block_hash: BlockHash,
+        /// TODO[RC]
+        only_from_highest_contiguous_range: bool,
         /// Responder to call with the result.  Returns `None` is the block header doesn't exist in
         /// local storage.
         responder: Responder<Option<BlockHeader>>,


### PR DESCRIPTION
This PR changes the behavior of the RPC server in a way that it'll not provide success responses when asked for a data from blocks that are not a part of the highest contiguous block range known to the node.

The following endpoints are affected:
* `chain_get_block`
* `chain_get_block_transfers`
* `chain_get_state_root_hash`
* `chain_get_era_info_by_switch_block`
* `state_get_auction_info`
* `state_get_account_info`
* `query_global_state` - only when queried by using `GlobalStateIdentifier::BlockHash`

Closes https://github.com/casper-network/casper-node/issues/2781