### PR TITLE
Enable CORS to allow any route in JSON-RPC, REST and SSE servers

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -36,9 +36,10 @@ All notable changes to this project will be documented in this file.  The format
 * Connection handshake timeouts can now be configured via the `handshake_timeout` variable (they were hardcoded at 20 seconds before).
 * `Key::SystemContractRegistry` is now readable and can be queried via the RPC.
 * Requests for data from a peer are now de-prioritized over networking messages necessary for consensus and chain advancement.
-* JSON-RPC responses which fail to provide requested data will now also include an indication of that node's highest contiguous block height range, i.e. the block heights for which it holds all global state
+* JSON-RPC responses which fail to provide requested data will now also include an indication of that node's highest contiguous block height range, i.e. the block heights for which it holds all global state.
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 * Switch blocks immediately after genesis or an upgrade are now signed.
+* Added CORS behavior to allow any route on the JSON-RPC, REST and SSE servers.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/rest_server/http_server.rs
+++ b/node/src/components/rest_server/http_server.rs
@@ -35,7 +35,8 @@ pub(super) async fn run<REv: ReactorEventT>(
             .or(rest_metrics)
             .or(rest_open_rpc)
             .or(rest_validator_changes)
-            .or(rest_chainspec_filter),
+            .or(rest_chainspec_filter)
+            .with(warp::cors().allow_any_origin()),
     );
 
     // Start the server, passing a oneshot receiver to allow the server to be shut down gracefully.

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -119,7 +119,8 @@ pub(super) async fn run<REv: ReactorEventT>(
     // https://github.com/seanmonstar/warp/pull/513 moves forward.
     let service_routes_gzip = warp::header::exact("accept-encoding", "gzip")
         .and(service_routes.clone())
-        .with(warp::compression::gzip());
+        .with(warp::compression::gzip())
+        .with(warp::cors().allow_any_origin());
 
     // TODO - we can't catch cases where we should return `warp_json_rpc::Error::INVALID_REQUEST`
     //        (i.e. where the request is JSON, but not valid JSON-RPC).  This will require an


### PR DESCRIPTION
This PR adds CORS behavior to the three servers, allowing any route.

Closes #2792.