### PR TITLE
Correct documentation about USR1 dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,44 +177,6 @@ asssigned an ID of `ev=123`, the first round of subsequent events will show `a=1
 
 Some additional debug functionality is available, mainly allowed for inspections of the internal event queue.
 
-### Event queue dump
-
-The event queue can be dumped by sending a `SIGUSR1` or `SIGUSR2` to the running node process, e.g. if the node's process ID was `$NODE_PID`:
-
-```console
-kill -USR1 $NODE_PID
-```
-
-`USR1` will cause a debug/text representation to be dumped, `USR2` a JSON formatted version, which is likely much larger.
-
-Both variants will create a dump file in the working directory of the node. A tool like [jq](https://stedolan.github.io/jq/) can then be used to format and display the JSON representation:
-
-```console
-$ jq < queue_dump.json
-{
-  "NetworkIncoming": [],
-  "Network": [],
-  "Regular": [
-    "AddressGossiper"
-  ],
-  "Api": []
-}
-```
-
-### jq Examples
-
-Dump the type of events:
-
-```console
-jq 'map_values( map(keys[0] | {"type": ., weight: 1})| group_by(.type) | map ([.[0].type,(.|length)]) | map({(.[0]): .[1]}) )' queue_dump.json
-```
-
-Count number of events in each queue:
-
-```console
-jq 'map_values(map(keys[0]))' queue_dump.json
-```
-
 ### Diagnostics port
 
 If the configuration option `diagnostics_port.enabled` is set to `true`, a unix socket named `debug.socket` by default can be found next to the configuration while the node is running.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
-* `SIGUSR1` now only dumps the queue in the debug text format.
+* `SIGUSR1`/`SIGUSR2` queue dumps have been removed in favor of the diagnostics port.
 * Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
 * Nodes no longer connect to nodes that do not speak the same protocol version by default.
 * Chain automatically creates a switch block immediately after genesis or an upgrade.


### PR DESCRIPTION
They have been removed in favor of the diagnostics port.

Closes #2613.
