### PR TITLE
NCTL: removing references to gas-price

### DIFF
--- a/utils/nctl/sh/contracts-auction/do_bid.sh
+++ b/utils/nctl/sh/contracts-auction/do_bid.sh
@@ -18,7 +18,6 @@ function main()
     local QUIET=${4:-"FALSE"}
 
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -27,7 +26,6 @@ function main()
     local BIDDER_SECRET_KEY
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -50,7 +48,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-auction/do_bid_activate.sh
+++ b/utils/nctl/sh/contracts-auction/do_bid_activate.sh
@@ -14,7 +14,6 @@ function main()
     local QUIET=${2:-"FALSE"}
 
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -23,7 +22,6 @@ function main()
     local VALIDATOR_SECRET_KEY
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -45,7 +43,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-auction/do_bid_withdraw.sh
+++ b/utils/nctl/sh/contracts-auction/do_bid_withdraw.sh
@@ -15,7 +15,6 @@ function main()
     local AMOUNT=${2}
     local QUIET=${3:-"FALSE"}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -25,7 +24,6 @@ function main()
     local BIDDER_MAIN_PURSE_UREF
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -50,7 +48,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-auction/do_delegate.sh
+++ b/utils/nctl/sh/contracts-auction/do_delegate.sh
@@ -10,7 +10,6 @@ source "$NCTL"/sh/utils/main.sh
 #   Delegator ordinal identifier.
 #   Validator ordinal identifier.
 #   Amount to delegate.
-#   Gas price.
 #   Gas payment.
 #######################################
 function main()
@@ -19,7 +18,6 @@ function main()
     local DELEGATOR_ID=${2}
     local VALIDATOR_ID=${3}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -29,7 +27,6 @@ function main()
     local VALIDATOR_ACCOUNT_KEY
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -51,7 +48,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-auction/do_delegate_withdraw.sh
+++ b/utils/nctl/sh/contracts-auction/do_delegate_withdraw.sh
@@ -14,7 +14,6 @@ function main()
     local DELEGATOR_ID=${2}
     local VALIDATOR_ID=${3}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -25,7 +24,6 @@ function main()
     local VALIDATOR_ACCOUNT_KEY
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -49,7 +47,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-erc20/do_approve.sh
+++ b/utils/nctl/sh/contracts-erc20/do_approve.sh
@@ -12,7 +12,6 @@ function main()
 {
     local AMOUNT=${1}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -22,7 +21,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -49,7 +47,6 @@ function main()
         DEPLOY_HASH=$(
             $PATH_TO_CLIENT put-deploy \
                 --chain-name "$CHAIN_NAME" \
-                --gas-price "$GAS_PRICE" \
                 --node-address "$NODE_ADDRESS" \
                 --payment-amount "$GAS_PAYMENT" \
                 --secret-key "$CONTRACT_OWNER_SECRET_KEY" \

--- a/utils/nctl/sh/contracts-erc20/do_fund_users.sh
+++ b/utils/nctl/sh/contracts-erc20/do_fund_users.sh
@@ -12,7 +12,6 @@ function main()
 {
     local AMOUNT=${1}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -22,7 +21,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -49,7 +47,6 @@ function main()
         DEPLOY_HASH=$(
             $PATH_TO_CLIENT put-deploy \
                 --chain-name "$CHAIN_NAME" \
-                --gas-price "$GAS_PRICE" \
                 --node-address "$NODE_ADDRESS" \
                 --payment-amount "$GAS_PAYMENT" \
                 --secret-key "$CONTRACT_OWNER_SECRET_KEY" \

--- a/utils/nctl/sh/contracts-erc20/do_install.sh
+++ b/utils/nctl/sh/contracts-erc20/do_install.sh
@@ -16,7 +16,6 @@ function main()
     local TOKEN_SYMBOL=${2}
     local TOKEN_SUPPLY=${3}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -25,7 +24,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=10000000000000
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -44,7 +42,6 @@ function main()
     log "... chain = $CHAIN_NAME"
     log "... dispatch node = $NODE_ADDRESS"
     log "... gas payment = $GAS_PAYMENT"
-    log "... gas price = $GAS_PRICE"
     log "contract constructor args:"
     log "... token name = $TOKEN_NAME"
     log "... token symbol = $TOKEN_SYMBOL"
@@ -56,7 +53,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-erc20/do_transfer.sh
+++ b/utils/nctl/sh/contracts-erc20/do_transfer.sh
@@ -13,7 +13,6 @@ function main()
     local AMOUNT=${1}
     local CHAIN_NAME
     local DEPLOY_HASH
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -26,7 +25,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -60,7 +58,6 @@ function main()
         DEPLOY_HASH=$(
             $PATH_TO_CLIENT put-deploy \
                 --chain-name "$CHAIN_NAME" \
-                --gas-price "$GAS_PRICE" \
                 --node-address "$NODE_ADDRESS" \
                 --payment-amount "$GAS_PAYMENT" \
                 --secret-key "$CONTRACT_OWNER_SECRET_KEY" \

--- a/utils/nctl/sh/contracts-hello-world/do_install.sh
+++ b/utils/nctl/sh/contracts-hello-world/do_install.sh
@@ -9,7 +9,6 @@ source "$NCTL"/sh/contracts-kv/utils.sh
 function main()
 {
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -19,7 +18,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=10000000000000
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -38,7 +36,6 @@ function main()
     log "... chain = $CHAIN_NAME"
     log "... dispatch node = $NODE_ADDRESS"
     log "... gas payment = $GAS_PAYMENT"
-    log "... gas price = $GAS_PRICE"
     log "contract constructor args:"
     log "... message = $CONTRACT_ARG_MESSAGE"
     log "contract installation details:"
@@ -48,7 +45,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-kv/do_install.sh
+++ b/utils/nctl/sh/contracts-kv/do_install.sh
@@ -9,7 +9,6 @@ source "$NCTL"/sh/contracts-kv/utils.sh
 function main()
 {
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -18,7 +17,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=10000000000000
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -37,7 +35,6 @@ function main()
     log "... chain = $CHAIN_NAME"
     log "... dispatch node = $NODE_ADDRESS"
     log "... gas payment = $GAS_PAYMENT"
-    log "... gas price = $GAS_PRICE"
     log "contract constructor args:"
     log "... N/A"
     log "contract installation details:"
@@ -47,7 +44,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "1day" \

--- a/utils/nctl/sh/contracts-kv/set_key.sh
+++ b/utils/nctl/sh/contracts-kv/set_key.sh
@@ -16,7 +16,6 @@ function main()
     local KEY_TYPE=${2}
     local KEY_VALUE=${3}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -26,7 +25,6 @@ function main()
 
     # Set standard deploy parameters.
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
@@ -44,7 +42,6 @@ function main()
     DEPLOY_HASH=$(
         $PATH_TO_CLIENT put-deploy \
             --chain-name "$CHAIN_NAME" \
-            --gas-price "$GAS_PRICE" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --secret-key "$CONTRACT_OWNER_SECRET_KEY" \

--- a/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
+++ b/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
@@ -22,7 +22,6 @@ function main()
     local VERBOSE=${6}
 
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -33,7 +32,6 @@ function main()
     local DISPATCH_NODE_ADDRESS
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     PATH_TO_CLIENT=$(get_path_to_client)
 
@@ -66,7 +64,6 @@ function main()
         DEPLOY_HASH=$(
             $PATH_TO_CLIENT transfer \
                 --chain-name "$CHAIN_NAME" \
-                --gas-price "$GAS_PRICE" \
                 --node-address "$DISPATCH_NODE_ADDRESS" \
                 --payment-amount "$GAS_PAYMENT" \
                 --ttl "1day" \

--- a/utils/nctl/sh/contracts-transfers/do_dispatch_wasm.sh
+++ b/utils/nctl/sh/contracts-transfers/do_dispatch_wasm.sh
@@ -22,7 +22,6 @@ function main()
     local VERBOSE=${6}
     
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
@@ -33,7 +32,6 @@ function main()
     local DISPATCH_NODE_ADDRESS
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     PATH_TO_CLIENT=$(get_path_to_client)
     PATH_TO_CONTRACT=$(get_path_to_contract "transfers/transfer_to_account_u512.wasm")
@@ -70,7 +68,6 @@ function main()
         DEPLOY_HASH=$(
             $PATH_TO_CLIENT put-deploy \
                 --chain-name "$CHAIN_NAME" \
-                --gas-price "$GAS_PRICE" \
                 --node-address "$DISPATCH_NODE_ADDRESS" \
                 --payment-amount "$GAS_PAYMENT" \
                 --ttl "1day" \

--- a/utils/nctl/sh/contracts-transfers/do_prepare_wasm_batch.sh
+++ b/utils/nctl/sh/contracts-transfers/do_prepare_wasm_batch.sh
@@ -15,7 +15,6 @@ function main()
     local BATCH_COUNT=${2}
     local BATCH_SIZE=${3}
     local CHAIN_NAME
-    local GAS_PRICE
     local GAS_PAYMENT
     local PATH_TO_CLIENT
     local CP1_SECRET_KEY
@@ -26,7 +25,6 @@ function main()
     local PATH_TO_OUTPUT_SIGNED
 
     CHAIN_NAME=$(get_chain_name)
-    GAS_PRICE=${GAS_PRICE:-$NCTL_DEFAULT_GAS_PRICE}
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     PATH_TO_CLIENT=$(get_path_to_client)
     PATH_TO_CONTRACT=$(get_path_to_contract "transfers/transfer_to_account_u512.wasm")
@@ -59,7 +57,6 @@ function main()
                 $PATH_TO_CLIENT make-deploy \
                     --output "$PATH_TO_OUTPUT_UNSIGNED" \
                     --chain-name "$CHAIN_NAME" \
-                    --gas-price "$GAS_PRICE" \
                     --payment-amount "$GAS_PAYMENT" \
                     --ttl "1day" \
                     --secret-key "$CP1_SECRET_KEY" \

--- a/utils/nctl/sh/utils/constants.sh
+++ b/utils/nctl/sh/utils/constants.sh
@@ -49,9 +49,6 @@ export NCTL_DEFAULT_ERA_ACTIVATION_OFFSET=2
 # Default motes to pay for consumed gas.
 export NCTL_DEFAULT_GAS_PAYMENT=100000000000   # (1e11)
 
-# Default gas price multiplier.
-export NCTL_DEFAULT_GAS_PRICE=10
-
 # Default amount used when making transfers.
 export NCTL_DEFAULT_TRANSFER_AMOUNT=2500000000   # (1e9)
 


### PR DESCRIPTION
CHANGES:
- removes all references to `gas-price`
    - needed to sync with changes from: https://github.com/casper-ecosystem/casper-client-rs/pull/16
    
Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/376

CC: @thamps-casp might effect your setup as well