### PR TITLE
Migrate information from dev book

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -108,7 +108,7 @@ pub(crate) trait Component<REv> {
     /// Processes an event, outputting zero or more effects.
     ///
     /// This function must not ever perform any blocking or CPU intensive work, as it is expected
-    /// to return very quickly.
+    /// to return very quickly -- it will usually be called from an `async` function context.
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -28,7 +28,7 @@
 //! # Component events and reactor events
 //!
 //! It is easy to confuse the components own associated event ([`Component::Event`]) and the
-//! so-called "reactor event", often written `REv` (see [`effects`](crate::effects) for details on
+//! so-called "reactor event", often written `REv` (see [`effects`](crate::effect) for details on
 //! the distinctions).
 //!
 //! A component's own event defines what sort of events it produces purely for internal use, and
@@ -42,7 +42,7 @@
 //! reactor provides a set of capabilities** by requiring `From`-implementations on the `REv`, e.g.
 //! by restricting the `impl Component<REv>` by `where REv: From<Baz>`. The concrete requirement
 //! will usually be dictated by a restriction on a method on an
-//! [`EffectBuilder`](crate::events::EffectBuilder).
+//! [`EffectBuilder`](crate::effect::EffectBuilder).
 
 pub(crate) mod block_proposer;
 pub(crate) mod block_validator;

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -19,8 +19,8 @@
 //! # Error and halting states
 //!
 //! Components in general are expected to be able to handle every input (that is every
-//! [`Component::Event`]) in every state. Unexpected inputs should usually be logged and discard, if
-//! possible, and the component is expected to recover from error states by itself.
+//! [`Component::Event`]) in every state. Unexpected inputs should usually be logged and discarded,
+//! if possible, and the component is expected to recover from error states by itself.
 //!
 //! When a recovery is not possible, the [`fatal!`](crate::fatal!) macro should be used to produce
 //! an effect that will shut down the system.

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -43,7 +43,7 @@
 //! by restricting the `impl Component<REv>` by `where REv: From<Baz>`. The concrete requirement
 //! will usually be dictated by a restriction on a method on an
 //! [`EffectBuilder`](crate::events::EffectBuilder).
-//!
+
 pub(crate) mod block_proposer;
 pub(crate) mod block_validator;
 pub(crate) mod chain_synchronizer;

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -151,7 +151,7 @@ impl Display for BlockProposerDeploySets {
 /// Returns keys of the drained elements.
 ///
 /// To be replaced with `HashMap::drain_filter` when stabilized.
-/// [https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.drain_filter]
+/// <https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.drain_filter>
 fn hashmap_drain_filter_in_place<K, V, F>(hash_map: &mut HashMap<K, V>, pred: F) -> Vec<K>
 where
     K: Eq + Hash + Copy,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -58,7 +58,7 @@ pub(crate) use sse_server::SseData;
 
 /// This is used to define the number of events to buffer in the tokio broadcast channel to help
 /// slower clients to try to avoid missing events (See
-/// https://docs.rs/tokio/1.4.0/tokio/sync/broadcast/index.html#lagging for further details).  The
+/// <https://docs.rs/tokio/1.4.0/tokio/sync/broadcast/index.html#lagging> for further details).  The
 /// resulting broadcast channel size is `ADDITIONAL_PERCENT_FOR_BROADCAST_CHANNEL_SIZE` percent
 /// greater than `config.event_stream_buffer_length`.
 ///

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -16,9 +16,9 @@
 //!
 //! * (unbound) events: These events are not associated with a particular reactor or component and
 //!   represent information or requests by themselves. An example is the
-//!   [`BlocklistAnnouncement`](`crate::effect::BlocklistAnnouncement`), it can be emitted through
-//!   an effect by different components and contains the ID of a peer that should be shunned. It is
-//!   not associated with a particular reactor or component though.
+//!   [`BlocklistAnnouncement`](`crate::effect::announcements::BlocklistAnnouncement`), it can be
+//!   emitted through an effect by different components and contains the ID of a peer that should be
+//!   shunned. It is not associated with a particular reactor or component though.
 //!
 //!   While the node is running, these unbound events cannot exist on their own, instead they are
 //!   typically converted into a concrete reactor event by the effect builder as soon as they are
@@ -35,8 +35,7 @@
 //!   Component events are also created from the return values of effects: While effects do not
 //!   return events themselves when called, their return values are turned first into component
 //!   events through the [`event`](crate::effect::EffectExt) method. In a second step, inside the
-//!   reactors routing code, [`wrap_effect`](crate::reactor::wrap_effect) will then convert from
-//!   component to reactor event.
+//!   reactors routing code, `wrap_effect` will then convert from component to reactor event.
 //!
 //! # Using effects
 //!

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -2,29 +2,30 @@
 //!
 //! Any long running instance of the node application uses an event-dispatch pattern: Events are
 //! generated and stored on an event queue, then processed one-by-one. This process happens inside
-//! the reactor*, which also exclusively holds the state of the application besides pending events:
+//! the reactor, which also exclusively holds the state of the application besides pending events:
 //!
-//! 1. The reactor pops an event off the event queue (called a [`Scheduler`](type.Scheduler.html)).
-//! 2. The event is dispatched by the reactor. Since the reactor holds mutable state, it can grant
-//!    any component that processes an event mutable, exclusive access to its state.
-//! 3. Once the (synchronous) event processing has completed, the component returns an effect.
-//! 4. The reactor spawns a task that executes these effects and eventually schedules another event.
+//! 1. The reactor pops a reactor event off the event queue (called a
+//!    [`Scheduler`](type.Scheduler.html)).
+//! 2. The event is dispatched by the reactor via [`Reactor::dispatch_event`]. Since the reactor
+//!    holds mutable state, it can grant any component that processes an event mutable, exclusive
+//!    access to its state.
+//! 3. Once the [(synchronous)](`crate::component::Component::handle_even`) event processing has
+//!    completed, the component returns an [`effect`](crate::effect).
+//! 4. The reactor spawns a task that executes these effects and possibly schedules more events.
 //! 5. go to 1.
 //!
-//! For instructions on how to create effects, see the [`effect`](super::effect) module.
+//! For descriptions of events and instructions on how to create effects, see the
+//! [`effect`](super::effect) module.
 //!
 //! # Reactors
 //!
 //! There is no single reactor, but rather a reactor for each application type, since it defines
 //! which components are used and how they are wired up. The reactor defines the state by being a
-//! `struct` of components, their initialization through the
-//! [`Reactor::new()`](trait.Reactor.html#tymethod.new) and a method
-//! [`Reactor::dispatch_event()`](trait.Reactor.html#tymethod.dispatch_event) to dispatch events to
-//! components.
+//! `struct` of components, their initialization through [`Reactor::new`] and event dispatching to
+//! components via [`Reactor::dispatch_event`].
 //!
-//! With all these set up, a reactor can be executed using a [`Runner`](struct.Runner.html), either
-//! in a step-wise manner using [`crank`](struct.Runner.html#method.crank) or indefinitely using
-//! [`run`](struct.Runner.html#method.crank).
+//! With all these set up, a reactor can be executed using a [`Runner`], either in a step-wise
+//! manner using [`Runner::crank`] or indefinitely using [`Runner::run`].
 
 mod event_queue_metrics;
 pub(crate) mod initializer;

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -11,6 +11,8 @@
 //! 4. The reactor spawns a task that executes these effects and eventually schedules another event.
 //! 5. go to 1.
 //!
+//! For instructions on how to create effects, see the [`effect`](super::effect) module.
+//!
 //! # Reactors
 //!
 //! There is no single reactor, but rather a reactor for each application type, since it defines

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -9,7 +9,7 @@
 //!    any component that processes an event mutable, exclusive access to its state.
 //! 3. Once the (synchronous) event processing has completed, the component returns an effect.
 //! 4. The reactor spawns a task that executes these effects and eventually schedules another event.
-//! 5. meanwhile go to 1.
+//! 5. go to 1.
 //!
 //! # Reactors
 //!

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -9,7 +9,7 @@
 //! 2. The event is dispatched by the reactor via [`Reactor::dispatch_event`]. Since the reactor
 //!    holds mutable state, it can grant any component that processes an event mutable, exclusive
 //!    access to its state.
-//! 3. Once the [(synchronous)](`crate::component::Component::handle_even`) event processing has
+//! 3. Once the [(synchronous)](`crate::components::Component::handle_event`) event processing has
 //!    completed, the component returns an [`effect`](crate::effect).
 //! 4. The reactor spawns a task that executes these effects and possibly schedules more events.
 //! 5. go to 1.


### PR DESCRIPTION
This PR should migrate most of the usable information from #2732.

Closes #2790.