### PR TITLE
NCTL: always use casper-client-rs repo for casper-client

### DIFF
--- a/utils/nctl/sh/assets/setup_from_stage.sh
+++ b/utils/nctl/sh/assets/setup_from_stage.sh
@@ -57,7 +57,7 @@ function _main()
     setup_asset_directories "$COUNT_NODES" "$COUNT_USERS" "$PROTOCOL_VERSION_FS"
     setup_asset_binaries "$PROTOCOL_VERSION_FS" \
                          "$COUNT_NODES" \
-                         "$PATH_TO_STAGED_ASSETS/casper-client" \
+                         "$NCTL_CASPER_CLIENT_HOME/target/$NCTL_COMPILE_TARGET/casper-client" \
                          "$PATH_TO_STAGED_ASSETS/casper-node" \
                          "$PATH_TO_STAGED_ASSETS/casper-node-launcher" \
                          "$PATH_TO_STAGED_ASSETS"

--- a/utils/nctl/sh/staging/set_remote.sh
+++ b/utils/nctl/sh/staging/set_remote.sh
@@ -18,7 +18,6 @@ _BASE_URL="http://nctl.casperlabs.io.s3-website.us-east-2.amazonaws.com"
 # Set of remote files.
 _REMOTE_FILES=(
     "add_bid.wasm"
-    "casper-client"
     "casper-node"
     "chainspec.toml.in"
     "config.toml"
@@ -52,7 +51,6 @@ function _main()
             curl -O "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
         fi
     done
-    chmod +x ./casper-client
     chmod +x ./casper-node
     if [ "${#PROTOCOL_VERSION}" = '3' ]; then
         RC_VERSION=$(./casper-node --version | awk '{ print $2 }' |  awk -F'-' '{ print $1 }')


### PR DESCRIPTION
Changes:
- removes pulling of casper-client from nctl bucket
- switches to always use casper-client-rs