### PR TITLE
Avoid re-syncing locally available data

### DIFF
--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -8,6 +8,8 @@ use std::{
     mem,
 };
 
+use tracing::error;
+
 use casper_hashing::Digest;
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
@@ -252,16 +254,45 @@ where
         if !visited.insert(trie_key) {
             continue;
         }
-        let maybe_retrieved_trie: Option<Trie<K, V>> = store.get(txn, &trie_key)?;
-        match maybe_retrieved_trie {
-            // If we can't find the trie_key; it is missing and we'll return it
+        let maybe_retrieved_trie_bytes = store.get_raw(txn, &trie_key)?;
+        // Optimization: Don't look for descendants of leaves.
+        match maybe_retrieved_trie_bytes.and_then(|bytes| bytes.get(0)) {
+            // if this is a leaf don't parse (ie, the first byte is 0), just continue
+            Some(&Trie::<K, V>::LEAF_TAG) => continue,
+            // Either no entry under trie key or data is empty.  If data is empty then the trie is
+            // corrupted. Either way treat as missing.
             None => {
                 missing_descendants.push(trie_key);
+                continue;
             }
-            // If we could retrieve the node and it is a leaf, the search can move on
-            Some(Trie::Leaf { .. }) => (),
+            _ => (),
+        }
+
+        // Parse the trie, handling errors gracefully.
+        let retrieved_trie: Trie<K, V> = match maybe_retrieved_trie_bytes
+            .map(bytesrepr::deserialize_from_slice)
+            .transpose()
+        {
+            Ok(Some(retrieved_trie)) => retrieved_trie,
+            Ok(None) => {
+                missing_descendants.push(trie_key);
+                continue;
+            }
+            // Couldn't parse; treat as missing and continue
+            Err(err) => {
+                error!(?err, "unable to parse trie");
+                missing_descendants.push(trie_key);
+                continue;
+            }
+        };
+
+        match retrieved_trie {
+            // Should be unreachable due to checking the first byte as a shortcut above.
+            Trie::Leaf { .. } => {
+                error!("did not expect to see a trie leaf in `missing_trie_keys` after shortcut");
+            }
             // If we hit a pointer block, queue up all of the nodes it points to
-            Some(Trie::Node { pointer_block }) => {
+            Trie::Node { pointer_block } => {
                 for (_, pointer) in pointer_block.as_indexed_pointers() {
                     match pointer {
                         Pointer::LeafPointer(descendant_leaf_trie_key) => {
@@ -274,7 +305,7 @@ where
                 }
             }
             // If we hit an extension block, add its pointer to the queue
-            Some(Trie::Extension { pointer, .. }) => trie_keys_to_visit.push(pointer.into_hash()),
+            Trie::Extension { pointer, .. } => trie_keys_to_visit.push(pointer.into_hash()),
         }
     }
     Ok(missing_descendants)

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -915,6 +915,9 @@ async fn fetch_to_genesis(trusted_block: &Block, ctx: &ChainSyncContext<'_>) -> 
                 .await;
             if let Some(lowest_available_block) = maybe_lowest_available_block {
                 if lowest_available_block.height() == 0 {
+                    ctx.effect_builder
+                        .update_lowest_available_block_height_in_storage(0)
+                        .await;
                     break;
                 }
                 walkback_block = *fetch_and_store_block_by_hash(

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -622,10 +622,14 @@ async fn sync_trie_store(state_root_hash: Digest, ctx: &ChainSyncContext<'_>) ->
 ///
 /// Performs the following:
 ///
-///  1. Fetches the most recent block header.
-///  2. Fetches deploys for replay detection and historical switch block info.
-///  3. The historical switch block info is needed by the [`EraSupervisor`].
-///  4. Fetches global state for the current block header.
+///  1. Fetches block headers back towards genesis until we get to a switch block.
+///  2. Starting at the trusted block, fetches block headers by iterating forwards towards tip until
+///     getting to one from the current era or failing to get a higher one from any peer.
+///  3. Starting at that most recent block, iterates backwards towards genesis, fetching
+///     `deploy_max_ttl`'s worth of blocks (for deploy replay protection).
+///  4. Starting at the most recent block, again iterates backwards, fetching enough block headers
+///     to allow consensus to be initialized.
+///  5. Fetches the tries under the most recent block's state root hash (parallelized tasks).
 ///
 /// Returns the most recent block header along with the last trusted key block information for
 /// validation.
@@ -823,10 +827,17 @@ async fn sync_deploys_and_transfers_and_state(
 ///
 /// Performs the following:
 ///
-///  1. Fetches blocks all the way back to genesis.
-///  2. Fetches global state for each block starting from genesis onwards.
-///  3. Fetches all deploys and finality signatures.
-///  4. Stops after fetching a block with the current version and its global state.
+///  1. Fetches block headers back towards genesis until we get to a switch block.
+///  2. Fetches the full trusted block.
+///  3. Starting at the trusted block and iterating one block at a time all the way back to genesis:
+///    a. Fetches the deploys for that block (parallelized tasks).
+///    b. Fetches the tries under that block's state root hash (parallelized tasks).
+///    c. Fetches the next block.
+///  4. Starting at the trusted block and iterating forwards towards tip until we get to a block at
+///     the same protocol version as we're currently running:
+///    a. Fetches the block.
+///    b. Fetches the deploys for that block (parallelized tasks).
+///    c. Fetches the tries under that block's state root hash (parallelized tasks).
 ///
 /// Returns the block header with our current version and the last trusted key block information for
 /// validation.
@@ -843,10 +854,6 @@ async fn sync_to_genesis(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, Bl
 
     // Sync forward until we are at the current version.
     let most_recent_block = fetch_forward(trusted_block, &mut trusted_key_block_info, ctx).await?;
-
-    ctx.effect_builder
-        .update_lowest_available_block_height_in_storage(0)
-        .await;
 
     Ok((trusted_key_block_info, most_recent_block.take_header()))
 }
@@ -890,6 +897,9 @@ async fn fetch_to_genesis(trusted_block: &Block, ctx: &ChainSyncContext<'_>) -> 
     let mut walkback_block = trusted_block.clone();
     loop {
         sync_deploys_and_transfers_and_state(&walkback_block, ctx).await?;
+        ctx.effect_builder
+            .update_lowest_available_block_height_in_storage(walkback_block.height())
+            .await;
         if walkback_block.height() == 0 {
             break;
         } else {
@@ -909,7 +919,6 @@ pub(super) async fn run_chain_sync_task(
 ) -> Result<BlockHeader, Error> {
     let _metric = ScopeTimer::new(&metrics.chain_sync_total_duration_seconds);
 
-    // Fetch the trusted header
     let trusted_block_header = fetch_and_store_initial_trusted_block_header(
         effect_builder,
         &config,
@@ -937,6 +946,8 @@ pub(super) async fn run_chain_sync_task(
         fast_sync(&chain_sync_context).await?
     };
 
+    // Iterate forwards, fetching each full block and deploys but executing each block to generate
+    // global state. Stop once we get to a block in the current era.
     let most_recent_block_header = execute_blocks(
         &most_recent_block_header,
         &trusted_key_block_info,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1192,6 +1192,12 @@ impl Storage {
             StorageRequest::GetAvailableBlockRange { responder } => {
                 responder.respond(self.get_available_block_range()).ignore()
             }
+            StorageRequest::GetLowestAvailableBlock { responder } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_lowest_block =
+                    self.get_block_by_height(&mut txn, self.lowest_available_block_height)?;
+                responder.respond(maybe_lowest_block).ignore()
+            }
             StorageRequest::StoreFinalizedApprovals {
                 ref deploy_hash,
                 ref finalized_approvals,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1263,6 +1263,18 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets the lowest block from the available range in storage.
+    pub(crate) async fn get_lowest_available_block_from_storage(self) -> Option<Block>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetLowestAvailableBlock { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Fetches an item from a fetcher.
     pub(crate) async fn fetch<T>(self, id: T::Id, peer: NodeId) -> FetchResult<T>
     where

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -431,6 +431,11 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.
         responder: Responder<AvailableBlockRange>,
     },
+    /// Get the lowest block of the available range.
+    GetLowestAvailableBlock {
+        /// Responder to call with the block if it exists.
+        responder: Responder<Option<Block>>,
+    },
     /// Store a set of finalized approvals for a specific deploy.
     StoreFinalizedApprovals {
         /// The deploy hash to store the finalized approvals for.
@@ -538,6 +543,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetAvailableBlockRange { .. } => {
                 write!(formatter, "get available block range",)
+            }
+            StorageRequest::GetLowestAvailableBlock { .. } => {
+                write!(formatter, "get lowest available block",)
             }
             StorageRequest::StoreFinalizedApprovals { deploy_hash, .. } => {
                 write!(formatter, "finalized approvals for deploy {}", deploy_hash)

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -1056,7 +1056,7 @@ impl Reactor {
                 {
                     Ok(FetchedOrNotFound::Fetched(deploy)) => Box::new(deploy),
                     Ok(FetchedOrNotFound::NotFound(deploy_hash)) => {
-                        error!(
+                        warn!(
                             "peer did not have deploy with hash {}: {}",
                             sender, deploy_hash
                         );

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -20,7 +20,7 @@ use derive_more::From;
 use prometheus::Registry;
 use reactor::ReactorEvent;
 use serde::Serialize;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 #[cfg(test)]
 use crate::testing::network::NetworkedReactor;
@@ -1173,7 +1173,7 @@ impl reactor::Reactor for Reactor {
                         {
                             Ok(FetchedOrNotFound::Fetched(deploy)) => Box::new(deploy),
                             Ok(FetchedOrNotFound::NotFound(deploy_hash)) => {
-                                error!(
+                                warn!(
                                     "peer did not have deploy with hash {}: {}",
                                     sender, deploy_hash
                                 );

--- a/node/src/types/available_block_range.rs
+++ b/node/src/types/available_block_range.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
-/// An unbroken, inclusive range of blocks.
+/// An error returned by attempting to construct an [`AvailableBlockRange`] where the low value
+/// exceeds the high.
 #[derive(
     Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug, Error,
 )]

--- a/node/src/types/available_block_range.rs
+++ b/node/src/types/available_block_range.rs
@@ -45,6 +45,16 @@ impl AvailableBlockRange {
     pub fn contains(&self, height: u64) -> bool {
         height >= self.low && height <= self.high
     }
+
+    /// Returns the low value.
+    pub fn low(&self) -> u64 {
+        self.low
+    }
+
+    /// Returns the high value.
+    pub fn high(&self) -> u64 {
+        self.high
+    }
 }
 
 impl Default for AvailableBlockRange {


### PR DESCRIPTION
This PR modifies the sync-to-genesis process to skip fetching blocks, deploys and global state which are already stored locally.  This allows for rapid re-joining in the case of a node which had previously synced to genesis, and then stopped running.

The determination is made by retrieving the available block range from storage.  All blocks (and corresponding deploys and global state) included in that range can safely be assumed to be held locally, as they were either retrieved previously during chain synchronization or executed locally.

The PR also includes an optimization of the `missing_trie_keys` function, ported from #2810.  It appears there is a slight overall benefit to sync times with this included, but it could use further benchmarking.

Finally, there are two error level log messages which have been downgraded to warnings as they appeared during testing when two peers were joining concurrently.

Closes #2842.