### PR TITLE
Update obsolete URLs in Readme - PR for #337

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The Casper MainNet is live.
 
 ## Specification
 
-- [Platform Specification](https://docs.casperlabs.io/en/latest/implementation/index.html)
+- [Platform Specification](https://docs.casperlabs.io/design/)
 - [Highway Consensus Proofs](https://github.com/CasperLabs/highway/releases/latest)
 
 ## Get Started with Smart Contracts
-- [Writing Smart Contracts](https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html)
+- [Writing Smart Contracts](https://docs.casperlabs.io/dapp-dev-guide/)
 - [Rust Smart Contract SDK](https://crates.io/crates/cargo-casper)
 - [Rust Smart Contract API Docs](https://docs.rs/casper-contract/latest/casper_contract/contract_api/index.html)
 - [AssemblyScript Smart Contract API](https://www.npmjs.com/package/casper-contract)


### PR DESCRIPTION
Please consider the following when creating a PR:

This is a PR for updates to the Readme file where obsolete/broken URLs/links under the below sections were replaced with recent/relevant updated links;

**Reason for change/update:**  After redirecting the documentation from https://casper.network/docs to https://docs.casperlabs.io/, the following sections of the README file needs updating to updated/relevant links;

**Update 1:** 
Hyperlink in Platform Specification from https://docs.casperlabs.io/en/latest/implementation/index.html to https://docs.casperlabs.io/design/

**Update 2:** 

Hyperlink of "Writing Smart Contracts" in the 'Getting started with smart contracts' section of the [README.md](https://github.com/casper-network/casper-node#get-started-with-smart-contracts) needs fixing.  
Currently, the underlying link/URL is - https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html. It needs to be updated to https://docs.casperlabs.io/dapp-dev-guide/
 
Link to the GitHub issue relating to this PR;
https://github.com/casper-network/docs/issues/337


