### PR TITLE
CI: sync PR 2858 to dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -171,13 +171,6 @@ kind: pipeline
 type: docker
 name: package
 
-environment:
-  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
-  CACHEPOT_BUCKET: 'drone-sccache'
-  CACHEPOT_S3_KEY_PREFIX: ci
-  CACHEPOT_REGION: 'us-east-2'
-  CARGO_INCREMENTAL: '0'
-
 __buildenv: &buildenv
   image: casperlabs/node-build-u1804
   volumes:
@@ -189,11 +182,6 @@ __buildenv: &buildenv
     path: "/drone"
   - name: nctl-temp-dir
     path: "/tmp/nctl_upgrade_stage"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: cachepot_aws_ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: cachepot_aws_sk
 
 __buildenv_upload: &buildenv_upload
   image: casperlabs/node-build-u1804
@@ -320,13 +308,6 @@ kind: pipeline
 type: docker
 name: release-by-tag
 
-environment:
-  RUSTC_WRAPPER: '/root/.cargo/bin/cachepot'
-  CACHEPOT_BUCKET: 'drone-sccache'
-  CACHEPOT_S3_KEY_PREFIX: ci
-  CACHEPOT_REGION: 'us-east-2'
-  CARGO_INCREMENTAL: '0'
-
 __buildenv: &buildenv
   image: casperlabs/node-build-u1804
   volumes:
@@ -338,11 +319,6 @@ __buildenv: &buildenv
     path: "/drone"
   - name: nctl-temp-dir
     path: "/tmp/nctl_upgrade_stage"
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: cachepot_aws_ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: cachepot_aws_sk
 
 __buildenv_upload: &buildenv_upload
   image: casperlabs/node-build-u1804


### PR DESCRIPTION
### Description:
Ports changes from https://github.com/casper-network/casper-node/pull/2858 -> `dev`

### Changes:
- Removes the use of cachepot in package and tag pipelines

### Ticket:
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/384

### Related: 
- https://github.com/casper-network/casper-node/pull/2854
- https://github.com/casper-network/casper-node/pull/2858
