### PR TITLE
(release-1.4.5-rocksdb) - Port ScratchGlobalState and ScratchTrie

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -12,8 +12,7 @@ use crate::{
         runtime::stack,
     },
     shared::wasm_prep,
-    storage,
-    storage::global_state::CommitError,
+    storage::{self, error::db::DbError, global_state::CommitError},
 };
 
 /// Engine state errors.
@@ -109,6 +108,12 @@ impl From<execution::Error> for Error {
 impl From<bytesrepr::Error> for Error {
     fn from(error: bytesrepr::Error) -> Self {
         Error::Bytesrepr(format!("{}", error))
+    }
+}
+
+impl From<lmdb::Error> for Error {
+    fn from(error: lmdb::Error) -> Self {
+        Error::Storage(storage::error::Error::Db(DbError::Lmdb(error)))
     }
 }
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -128,18 +128,35 @@ impl EngineState<DbGlobalState> {
         state_root: Digest,
         limit_rate: bool,
     ) -> Result<bool, storage::error::db::Error> {
-        if !self
+        let state_root_bytes = &state_root.value();
+
+        let root_migration_state = self
             .state
             .rocksdb_store
             .rocksdb
-            .is_state_root_migrated(&state_root.value())?
-        {
+            .get_root_migration_state(state_root_bytes)?;
+
+        if !root_migration_state.is_complete() {
+            // was there a previous migration that had been interrupted?
+            let force = root_migration_state.is_incomplete();
+
+            // mark that we're starting the migration
             self.state
-                .migrate_state_root_to_rocksdb(state_root, limit_rate)?;
-            Ok(true)
-        } else {
-            Ok(false)
+                .rocksdb_store
+                .rocksdb
+                .mark_state_root_migration_incomplete(state_root_bytes)?;
+
+            // perform migration
+            self.state
+                .migrate_state_root_to_rocksdb(state_root, limit_rate, force)?;
+
+            self.state
+                .rocksdb_store
+                .rocksdb
+                .mark_state_root_migration_completed(state_root_bytes)?;
+            return Ok(true);
         }
+        Ok(false)
     }
 
     /// Flushes the LMDB environment to disk when manual sync is enabled in the config.toml.

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -240,6 +240,7 @@ where
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn is_valid_uref(&mut self, uref_ptr: u32, uref_size: u32) -> Result<bool, Trap> {
         let bytes = self.bytes_from_mem(uref_ptr, uref_size as usize)?;
         let uref: URef = bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?;

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -31,7 +31,7 @@ use crate::{
     shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::{
         in_memory::{InMemoryGlobalState, InMemoryGlobalStateView},
-        StateProvider,
+        CommitProvider, StateProvider,
     },
 };
 

--- a/execution_engine/src/storage/error/db.rs
+++ b/execution_engine/src/storage/error/db.rs
@@ -8,7 +8,7 @@ use casper_types::bytesrepr;
 
 use crate::storage::{error::in_memory, global_state::CommitError};
 
-/// Error num representing possible errors from database internals.
+/// Error enum representing possible errors from database internals.
 #[derive(Debug, Clone, Error, PartialEq)]
 pub enum DbError {
     /// LMDB error returned from underlying `lmdb` crate.
@@ -27,13 +27,13 @@ pub enum Error {
     #[error(transparent)]
     Db(#[from] DbError),
 
-    /// Error when we cannot create a column family.
+    /// Error when we cannot open a column family.
     #[error("unable to open column family {0}")]
     UnableToOpenColumnFamily(String),
 
-    /// Could not get data under a trie key in lmdb while migrating to rockdb.
+    /// Could not get data under a trie key in lmdb while migrating to rocksdb.
     #[error("corrupt state root {state_root} could not find value under trie key {trie_key}")]
-    CorruptLmdbStateRootDuringMigrationToRocksdb {
+    CorruptLmdbStateRootDuringMigrationToRocksDb {
         /// Trie key that couldn't be found.
         trie_key: Digest,
         /// State root being migrated.

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -3,8 +3,9 @@
 /// In-memory implementation of global state.
 pub mod in_memory;
 
-/// Lmdb implementation of global state.
+/// Db implementation of global state.
 pub mod db;
+
 /// Implementation of global state with cache.
 pub mod scratch;
 
@@ -72,6 +73,9 @@ pub enum CommitError {
     /// Transform error.
     #[error(transparent)]
     TransformError(transform::Error),
+    /// Trie not found while attempting to validate cache write.
+    #[error("Trie not found in cache {0}")]
+    TrieNotFoundDuringCacheValidate(Digest),
 }
 
 /// Provides `commit` method.

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -25,26 +25,33 @@ use super::db::{DbGlobalState, DbGlobalStateView};
 type SharedCache = Arc<RwLock<Cache>>;
 
 struct Cache {
-    stored_values: HashMap<Key, StoredValue>,
+    cached_values: HashMap<Key, (bool, StoredValue)>,
 }
 
 impl Cache {
     fn new() -> Self {
         Cache {
-            stored_values: HashMap::new(),
+            cached_values: HashMap::new(),
         }
     }
 
-    fn insert(&mut self, key: Key, value: StoredValue) {
-        self.stored_values.insert(key, value);
+    fn insert_write(&mut self, key: Key, value: StoredValue) {
+        self.cached_values.insert(key, (true, value));
+    }
+
+    fn insert_read(&mut self, key: Key, value: StoredValue) {
+        self.cached_values.entry(key).or_insert((false, value));
     }
 
     fn get(&self, key: &Key) -> Option<&StoredValue> {
-        self.stored_values.get(key)
+        self.cached_values.get(key).map(|(_dirty, value)| value)
     }
 
-    fn into_inner(self) -> HashMap<Key, StoredValue> {
-        self.stored_values
+    fn into_dirty_writes(self) -> HashMap<Key, StoredValue> {
+        self.cached_values
+            .into_iter()
+            .filter_map(|(key, (dirty, value))| if dirty { Some((key, value)) } else { None })
+            .collect()
     }
 }
 
@@ -77,7 +84,7 @@ impl ScratchGlobalState {
     /// Consume self and return inner cache.
     pub fn into_inner(self) -> HashMap<Key, StoredValue> {
         let cache = mem::replace(&mut *self.cache.write().unwrap(), Cache::new());
-        cache.into_inner()
+        cache.into_dirty_writes()
     }
 }
 
@@ -97,7 +104,7 @@ impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
             self.cache
                 .write()
                 .map_err(|_| error::Error::Poison)?
-                .insert(*key, value.clone());
+                .insert_read(*key, value.clone());
         }
         Ok(ret)
     }
@@ -177,7 +184,7 @@ impl CommitProvider for ScratchGlobalState {
                 },
             };
 
-            self.cache.write().unwrap().insert(key, value);
+            self.cache.write().unwrap().insert_write(key, value);
         }
         Ok(state_hash)
     }

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -1,0 +1,504 @@
+use std::{
+    collections::HashMap,
+    mem,
+    sync::{Arc, RwLock},
+};
+
+use tracing::error;
+
+use casper_hashing::Digest;
+use casper_types::{Key, StoredValue};
+
+use crate::{
+    shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
+    storage::{
+        error,
+        global_state::{CommitError, CommitProvider, StateProvider, StateReader},
+        transaction_source::{Transaction, TransactionSource},
+        trie::{merkle_proof::TrieMerkleProof, Trie},
+        trie_store::operations::{read, ReadResult},
+    },
+};
+
+use super::db::{DbGlobalState, DbGlobalStateView};
+
+type SharedCache = Arc<RwLock<Cache>>;
+
+struct Cache {
+    stored_values: HashMap<Key, StoredValue>,
+}
+
+impl Cache {
+    fn new() -> Self {
+        Cache {
+            stored_values: HashMap::new(),
+        }
+    }
+
+    fn insert(&mut self, key: Key, value: StoredValue) {
+        self.stored_values.insert(key, value);
+    }
+
+    fn get(&self, key: &Key) -> Option<&StoredValue> {
+        self.stored_values.get(key)
+    }
+
+    fn into_inner(self) -> HashMap<Key, StoredValue> {
+        self.stored_values
+    }
+}
+
+/// Global state implemented against rocksdb as a backing data store.
+pub struct ScratchGlobalState {
+    /// Underlying cached stored values.
+    cache: SharedCache,
+    /// Underlying uncached global state which is delegated to for reads.
+    store: DbGlobalState,
+}
+
+/// Represents a "view" of global state at a particular root hash.
+pub struct ScratchGlobalStateView {
+    /// Underlying cached stored values.
+    cache: SharedCache,
+    /// Underlying uncached global state view which is delegated to for reads.
+    view: DbGlobalStateView,
+}
+
+impl ScratchGlobalState {
+    /// Creates a state from an existing environment, store, and root_hash.
+    /// Intended to be used for testing.
+    pub fn new(store: DbGlobalState) -> Self {
+        ScratchGlobalState {
+            cache: Arc::new(RwLock::new(Cache::new())),
+            store,
+        }
+    }
+
+    /// Consume self and return inner cache.
+    pub fn into_inner(self) -> HashMap<Key, StoredValue> {
+        let cache = mem::replace(&mut *self.cache.write().unwrap(), Cache::new());
+        cache.into_inner()
+    }
+}
+
+impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
+    type Error = error::Error;
+
+    fn read(
+        &self,
+        correlation_id: CorrelationId,
+        key: &Key,
+    ) -> Result<Option<StoredValue>, Self::Error> {
+        if let Some(value) = self.cache.read().unwrap().get(key) {
+            return Ok(Some(value.clone()));
+        }
+        let ret = self.view.read(correlation_id, key)?;
+        if let Some(value) = ret.as_ref() {
+            self.cache
+                .write()
+                .map_err(|_| error::Error::Poison)?
+                .insert(*key, value.clone());
+        }
+        Ok(ret)
+    }
+
+    fn read_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        key: &Key,
+    ) -> Result<Option<TrieMerkleProof<Key, StoredValue>>, Self::Error> {
+        self.view.read_with_proof(correlation_id, key)
+    }
+
+    fn keys_with_prefix(
+        &self,
+        correlation_id: CorrelationId,
+        prefix: &[u8],
+    ) -> Result<Vec<Key>, Self::Error> {
+        self.view.keys_with_prefix(correlation_id, prefix)
+    }
+}
+
+impl CommitProvider for ScratchGlobalState {
+    /// State hash returned is the one provided, as we do not write to lmdb with this kind of global
+    /// state. Note that the state hash is NOT used, and simply passed back to the caller.
+    fn commit(
+        &self,
+        correlation_id: CorrelationId,
+        state_hash: Digest,
+        effects: AdditiveMap<Key, Transform>,
+    ) -> Result<Digest, Self::Error> {
+        for (key, transform) in effects.into_iter() {
+            let cached_value = self.cache.read().unwrap().get(&key).cloned();
+            let value = match (cached_value, transform) {
+                (None, Transform::Write(new_value)) => new_value,
+                (None, transform) => {
+                    // It might be the case that for `Add*` operations we don't have the previous
+                    // value in cache yet.
+                    let txn = self.store.rocksdb_store.create_read_txn()?;
+                    let updated_value = match read::<Key, StoredValue, _, _, Self::Error>(
+                        correlation_id,
+                        &txn,
+                        &self.store.rocksdb_store,
+                        &state_hash,
+                        &key,
+                    )? {
+                        ReadResult::Found(current_value) => {
+                            match transform.apply(current_value.clone()) {
+                                Ok(updated_value) => updated_value,
+                                Err(err) => {
+                                    error!(?key, ?err, "Key found, but could not apply transform");
+                                    return Err(CommitError::TransformError(err).into());
+                                }
+                            }
+                        }
+                        ReadResult::NotFound => {
+                            error!(
+                                ?key,
+                                ?transform,
+                                "Key not found while attempting to apply transform"
+                            );
+                            return Err(CommitError::KeyNotFound(key).into());
+                        }
+                        ReadResult::RootNotFound => {
+                            error!(root_hash=?state_hash, "root not found");
+                            return Err(CommitError::ReadRootNotFound(state_hash).into());
+                        }
+                    };
+                    txn.commit()?;
+                    updated_value
+                }
+                (Some(current_value), transform) => match transform.apply(current_value.clone()) {
+                    Ok(updated_value) => updated_value,
+                    Err(err) => {
+                        error!(?key, ?err, "Key found, but could not apply transform");
+                        return Err(CommitError::TransformError(err).into());
+                    }
+                },
+            };
+
+            self.cache.write().unwrap().insert(key, value);
+        }
+        Ok(state_hash)
+    }
+}
+
+impl StateProvider for ScratchGlobalState {
+    type Error = error::Error;
+
+    type Reader = ScratchGlobalStateView;
+
+    fn checkout(&self, state_hash: Digest) -> Result<Option<Self::Reader>, Self::Error> {
+        let maybe_view = self.store.checkout(state_hash)?;
+        let maybe_state = maybe_view.map(|view| ScratchGlobalStateView {
+            cache: Arc::clone(&self.cache),
+            view,
+        });
+        Ok(maybe_state)
+    }
+
+    fn empty_root(&self) -> Digest {
+        self.store.empty_root_hash
+    }
+
+    fn get_trie(
+        &self,
+        correlation_id: CorrelationId,
+        trie_key: &Digest,
+    ) -> Result<Option<Trie<Key, StoredValue>>, Self::Error> {
+        self.store.get_trie(correlation_id, trie_key)
+    }
+
+    fn put_trie(
+        &self,
+        correlation_id: CorrelationId,
+        trie: &Trie<Key, StoredValue>,
+    ) -> Result<Digest, Self::Error> {
+        self.store.put_trie(correlation_id, trie)
+    }
+
+    /// Finds all of the keys of missing descendant `Trie<K,V>` values
+    fn missing_trie_keys(
+        &self,
+        correlation_id: CorrelationId,
+        trie_keys: Vec<Digest>,
+    ) -> Result<Vec<Digest>, Self::Error> {
+        self.store.missing_trie_keys(correlation_id, trie_keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lmdb::DatabaseFlags;
+    use tempfile::tempdir;
+
+    use casper_hashing::Digest;
+    use casper_types::{account::AccountHash, CLValue};
+
+    use super::*;
+    use crate::{
+        rocksdb_defaults,
+        storage::{
+            global_state::{db::DbGlobalState, CommitProvider},
+            transaction_source::db::LmdbEnvironment,
+            trie_store::db::LmdbTrieStore,
+            DEFAULT_TEST_MAX_DB_SIZE, DEFAULT_TEST_MAX_READERS,
+        },
+    };
+
+    #[derive(Debug, Clone)]
+    struct TestPair {
+        key: Key,
+        value: StoredValue,
+    }
+
+    fn create_test_pairs() -> [TestPair; 2] {
+        [
+            TestPair {
+                key: Key::Account(AccountHash::new([1_u8; 32])),
+                value: StoredValue::CLValue(CLValue::from_t(1_i32).unwrap()),
+            },
+            TestPair {
+                key: Key::Account(AccountHash::new([2_u8; 32])),
+                value: StoredValue::CLValue(CLValue::from_t(2_i32).unwrap()),
+            },
+        ]
+    }
+
+    fn create_test_pairs_updated() -> [TestPair; 3] {
+        [
+            TestPair {
+                key: Key::Account(AccountHash::new([1u8; 32])),
+                value: StoredValue::CLValue(CLValue::from_t("one".to_string()).unwrap()),
+            },
+            TestPair {
+                key: Key::Account(AccountHash::new([2u8; 32])),
+                value: StoredValue::CLValue(CLValue::from_t("two".to_string()).unwrap()),
+            },
+            TestPair {
+                key: Key::Account(AccountHash::new([3u8; 32])),
+                value: StoredValue::CLValue(CLValue::from_t(3_i32).unwrap()),
+            },
+        ]
+    }
+
+    fn create_test_transforms() -> AdditiveMap<Key, Transform> {
+        let mut transforms = AdditiveMap::new();
+        transforms.insert(
+            Key::Account(AccountHash::new([3u8; 32])),
+            Transform::Write(StoredValue::CLValue(CLValue::from_t("one").unwrap())),
+        );
+        transforms.insert(
+            Key::Account(AccountHash::new([3u8; 32])),
+            Transform::AddInt32(1),
+        );
+        transforms.insert(
+            Key::Account(AccountHash::new([3u8; 32])),
+            Transform::AddInt32(2),
+        );
+        transforms
+    }
+
+    struct TestState {
+        state: DbGlobalState,
+        root_hash: Digest,
+    }
+
+    fn create_test_state() -> TestState {
+        let correlation_id = CorrelationId::new();
+        let temp_dir = tempdir().unwrap();
+        let environment = Arc::new(
+            LmdbEnvironment::new(
+                temp_dir.path(),
+                DEFAULT_TEST_MAX_DB_SIZE,
+                DEFAULT_TEST_MAX_READERS,
+                true,
+            )
+            .unwrap(),
+        );
+        let trie_store =
+            Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
+
+        let engine_state = DbGlobalState::empty(
+            environment,
+            trie_store,
+            tempdir().unwrap(),
+            rocksdb_defaults(),
+        )
+        .unwrap();
+        let mut current_root = engine_state.empty_root_hash;
+        for TestPair { key, value } in create_test_pairs() {
+            let mut stored_values = HashMap::new();
+            stored_values.insert(key, value);
+            current_root = engine_state
+                .put_stored_values(correlation_id, current_root, stored_values)
+                .unwrap();
+        }
+        TestState {
+            state: engine_state,
+            root_hash: current_root,
+        }
+    }
+
+    #[test]
+    fn commit_updates_state() {
+        let correlation_id = CorrelationId::new();
+        let test_pairs_updated = create_test_pairs_updated();
+
+        let TestState { state, root_hash } = create_test_state();
+
+        let state = Arc::new(state);
+
+        let scratch = state.create_scratch();
+
+        let effects: AdditiveMap<Key, Transform> = {
+            let mut tmp = AdditiveMap::new();
+            for TestPair { key, value } in &test_pairs_updated {
+                tmp.insert(*key, Transform::Write(value.to_owned()));
+            }
+            tmp
+        };
+
+        let scratch_root_hash = scratch
+            .commit(correlation_id, root_hash, effects.clone())
+            .unwrap();
+
+        assert_eq!(
+            scratch_root_hash, root_hash,
+            "ScratchGlobalState should not modify the state root, as it does no hashing"
+        );
+
+        let lmdb_hash = state.commit(correlation_id, root_hash, effects).unwrap();
+        let updated_checkout = state.checkout(lmdb_hash).unwrap().unwrap();
+
+        let all_keys = updated_checkout
+            .keys_with_prefix(correlation_id, &[])
+            .unwrap();
+
+        let stored_values = scratch.into_inner();
+        assert_eq!(all_keys.len(), stored_values.len());
+
+        for key in all_keys {
+            assert!(stored_values.get(&key).is_some());
+            assert_eq!(
+                stored_values.get(&key),
+                updated_checkout
+                    .read(correlation_id, &key)
+                    .unwrap()
+                    .as_ref()
+            );
+        }
+
+        for TestPair { key, value } in test_pairs_updated.iter().cloned() {
+            assert_eq!(
+                Some(value),
+                updated_checkout.read(correlation_id, &key).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn commit_updates_state_with_add() {
+        let correlation_id = CorrelationId::new();
+        let test_pairs_updated = create_test_pairs_updated();
+
+        // create two lmdb instances, with a scratch instance on the first
+        let TestState { state, root_hash } = create_test_state();
+        let TestState {
+            state: state2,
+            root_hash: state_2_root_hash,
+        } = create_test_state();
+
+        let scratch = state.create_scratch();
+
+        let effects: AdditiveMap<Key, Transform> = {
+            let mut tmp = AdditiveMap::new();
+            for TestPair { key, value } in &test_pairs_updated {
+                tmp.insert(*key, Transform::Write(value.to_owned()));
+            }
+            tmp
+        };
+
+        // Commit effects to both databases.
+        scratch
+            .commit(correlation_id, root_hash, effects.clone())
+            .unwrap();
+        let updated_hash = state2
+            .commit(correlation_id, state_2_root_hash, effects)
+            .unwrap();
+
+        // Create add transforms as well
+        let add_effects = create_test_transforms();
+        scratch
+            .commit(correlation_id, root_hash, add_effects.clone())
+            .unwrap();
+        let updated_hash = state2
+            .commit(correlation_id, updated_hash, add_effects)
+            .unwrap();
+
+        let scratch_checkout = scratch.checkout(root_hash).unwrap().unwrap();
+        let updated_checkout = state2.checkout(updated_hash).unwrap().unwrap();
+        let all_keys = updated_checkout
+            .keys_with_prefix(correlation_id, &[])
+            .unwrap();
+
+        // Check that cache matches the contents of the second instance of lmdb
+        for key in all_keys {
+            assert_eq!(
+                scratch_checkout
+                    .read(correlation_id, &key)
+                    .unwrap()
+                    .as_ref(),
+                updated_checkout
+                    .read(correlation_id, &key)
+                    .unwrap()
+                    .as_ref()
+            );
+        }
+    }
+
+    #[test]
+    fn commit_updates_state_and_original_state_stays_intact() {
+        let correlation_id = CorrelationId::new();
+        let test_pairs_updated = create_test_pairs_updated();
+
+        let TestState {
+            state, root_hash, ..
+        } = create_test_state();
+
+        let scratch = state.create_scratch();
+
+        let effects: AdditiveMap<Key, Transform> = {
+            let mut tmp = AdditiveMap::new();
+            for TestPair { key, value } in &test_pairs_updated {
+                tmp.insert(*key, Transform::Write(value.to_owned()));
+            }
+            tmp
+        };
+
+        let updated_hash = scratch.commit(correlation_id, root_hash, effects).unwrap();
+
+        let updated_checkout = scratch.checkout(updated_hash).unwrap().unwrap();
+        for TestPair { key, value } in test_pairs_updated.iter().cloned() {
+            assert_eq!(
+                Some(value),
+                updated_checkout.read(correlation_id, &key).unwrap(),
+                "ScratchGlobalState should not yet be written to the underlying lmdb state"
+            );
+        }
+
+        let original_checkout = state.checkout(root_hash).unwrap().unwrap();
+        for TestPair { key, value } in create_test_pairs().iter().cloned() {
+            assert_eq!(
+                Some(value),
+                original_checkout.read(correlation_id, &key).unwrap()
+            );
+        }
+        assert_eq!(
+            None,
+            original_checkout
+                .read(correlation_id, &test_pairs_updated[2].key)
+                .unwrap()
+        );
+    }
+}

--- a/execution_engine/src/storage/transaction_source/db.rs
+++ b/execution_engine/src/storage/transaction_source/db.rs
@@ -3,19 +3,24 @@ use std::{
     sync::Arc,
 };
 
-use casper_types::bytesrepr::Bytes;
 use lmdb::{
     self, Database, Environment, EnvironmentFlags, RoTransaction, RwTransaction, WriteFlags,
 };
-use rocksdb::{BoundColumnFamily, DBWithThreadMode, MultiThreaded, Options};
+use rocksdb::{
+    BoundColumnFamily, DBIteratorWithThreadMode, DBWithThreadMode, IteratorMode, MultiThreaded,
+    Options,
+};
 
 use crate::storage::{
     error,
     transaction_source::{
-        Readable, Transaction, TransactionSource, Writable, ROCKS_DB_TRIE_V1_COLUMN_FAMILY,
+        Readable, Transaction, TransactionSource, Writable,
+        ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY, ROCKS_DB_TRIE_V1_COLUMN_FAMILY,
     },
+    trie_store::db::{ScratchCache, ScratchTrieStore},
     MAX_DBS,
 };
+use casper_types::bytesrepr::Bytes;
 
 /// Filename for the LMDB database created by the EE.
 const EE_LMDB_FILENAME: &str = "data.lmdb";
@@ -25,13 +30,67 @@ pub struct RocksDb {
     db: Arc<DBWithThreadMode<MultiThreaded>>,
 }
 
+/// Represents the state of a migration of a state root from lmdb to rocksdb.
+pub enum RootMigration {
+    /// Has the migration been left incomplete
+    NotMigrated,
+    /// Has the migration been not yet been started or completed
+    Incomplete,
+    /// Has the migration been completed
+    Complete,
+}
+
+impl RootMigration {
+    /// Has the migration been left incomplete
+    pub fn is_incomplete(&self) -> bool {
+        matches!(self, RootMigration::Incomplete)
+    }
+    /// Has the migration been not yet been started or completed
+    pub fn is_not_migrated(&self) -> bool {
+        matches!(self, RootMigration::NotMigrated)
+    }
+    /// Has the migration been completed
+    pub fn is_complete(&self) -> bool {
+        matches!(self, RootMigration::Complete)
+    }
+}
+
 impl RocksDb {
     /// Check if a state root has been marked as migrated from lmdb to rocksdb.
-    pub(crate) fn is_state_root_migrated(&self, state_root: &[u8]) -> Result<bool, error::Error> {
-        let cf = self.trie_column_family()?;
-        Ok(self.db.get_cf(&cf, state_root)?.is_some())
+    pub(crate) fn get_root_migration_state(
+        &self,
+        state_root: &[u8],
+    ) -> Result<RootMigration, error::Error> {
+        let lmdb_migration_column = self.lmdb_tries_migrated_column()?;
+        let migration_state = self.db.get_cf(&lmdb_migration_column, state_root)?;
+        Ok(match migration_state {
+            Some(state) if state.is_empty() => RootMigration::Complete,
+            Some(state) if state.get(0) == Some(&1u8) => RootMigration::Incomplete,
+            _ => RootMigration::NotMigrated,
+        })
     }
 
+    /// Marks a state root as started migration from lmdb to rocksdb.
+    pub(crate) fn mark_state_root_migration_incomplete(
+        &self,
+        state_root: &[u8],
+    ) -> Result<(), error::Error> {
+        let lmdb_migration_column = self.lmdb_tries_migrated_column()?;
+        self.db.put_cf(&lmdb_migration_column, state_root, &[1u8])?;
+        Ok(())
+    }
+
+    /// Marks a state root as fully migrated from lmdb to rocksdb.
+    pub(crate) fn mark_state_root_migration_completed(
+        &self,
+        state_root: &[u8],
+    ) -> Result<(), error::Error> {
+        let lmdb_migration_column = self.lmdb_tries_migrated_column()?;
+        self.db.put_cf(&lmdb_migration_column, state_root, &[])?;
+        Ok(())
+    }
+
+    /// Trie V1 column family.
     fn trie_column_family(&self) -> Result<Arc<BoundColumnFamily<'_>>, error::Error> {
         self.db
             .cf_handle(ROCKS_DB_TRIE_V1_COLUMN_FAMILY)
@@ -39,15 +98,65 @@ impl RocksDb {
                 error::Error::UnableToOpenColumnFamily(ROCKS_DB_TRIE_V1_COLUMN_FAMILY.to_string())
             })
     }
+
+    /// Column family tracking state roots migrated from lmdb (supports safely resuming if the node
+    /// were to be stopped during a migration).
+    fn lmdb_tries_migrated_column(&self) -> Result<Arc<BoundColumnFamily<'_>>, error::Error> {
+        self.db
+            .cf_handle(ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY)
+            .ok_or_else(|| {
+                error::Error::UnableToOpenColumnFamily(
+                    ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY.to_string(),
+                )
+            })
+    }
+
+    /// Trie store iterator.
+    pub fn trie_store_iterator<'a: 'b, 'b>(
+        &'a self,
+    ) -> Result<DBIteratorWithThreadMode<'b, DBWithThreadMode<MultiThreaded>>, error::Error> {
+        let cf_handle = self.trie_column_family()?;
+        Ok(self.db.iterator_cf(&cf_handle, IteratorMode::Start))
+    }
 }
 
 impl Transaction for RocksDb {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     fn commit(self) -> Result<(), Self::Error> {
-        // NO OP as rockdb doesn't use transactions.
+        // NO OP as rocksdb doesn't use transactions.
+        Ok(())
+    }
+}
+
+impl Transaction for ScratchCache {
+    type Error = error::Error;
+    type Handle = ScratchCache;
+    fn commit(self) -> Result<(), Self::Error> {
+        // NO OP as scratch doesn't use transactions.
+        Ok(())
+    }
+}
+
+impl Readable for ScratchCache {
+    fn read(&self, _handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        let cf = self.rocksdb_store.rocksdb.trie_column_family()?;
+        Ok(self.rocksdb_store.rocksdb.db.get_cf(&cf, key)?.map(|some| {
+            let value = some.as_ref();
+            Bytes::from(value)
+        }))
+    }
+}
+
+impl Writable for ScratchCache {
+    fn write(
+        &mut self,
+        _handle: Self::Handle,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Self::Error> {
+        let cf = self.rocksdb_store.rocksdb.trie_column_family()?;
+        let _result = self.rocksdb_store.rocksdb.db.put_cf(&cf, key, value)?;
         Ok(())
     }
 }
@@ -83,7 +192,7 @@ pub struct RocksDbStore {
 }
 
 impl RocksDbStore {
-    /// Create a new environment for alternative db.
+    /// Create a new environment for RocksDB.
     pub fn new(
         path: impl AsRef<Path>,
         rocksdb_opts: Options,
@@ -91,7 +200,10 @@ impl RocksDbStore {
         let db = Arc::new(DBWithThreadMode::<MultiThreaded>::open_cf(
             &rocksdb_opts,
             path.as_ref(),
-            vec![ROCKS_DB_TRIE_V1_COLUMN_FAMILY],
+            vec![
+                ROCKS_DB_TRIE_V1_COLUMN_FAMILY,
+                ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY,
+            ],
         )?);
 
         let rocksdb = RocksDb { db };
@@ -103,26 +215,39 @@ impl RocksDbStore {
     }
 
     /// Return the path to the backing rocksdb files.
-    pub fn path(&self) -> PathBuf {
+    pub(crate) fn path(&self) -> PathBuf {
         self.path.clone()
+    }
+
+    /// Gets a scratch trie store.
+    pub fn get_scratch_store(&self) -> ScratchTrieStore {
+        ScratchTrieStore::new(self.clone())
     }
 }
 
 // TODO: remove this abstraction entirely when we've moved from lmdb to rocksdb for global state.
+impl<'a> TransactionSource<'a> for ScratchTrieStore {
+    type Error = error::Error;
+    type Handle = ScratchCache;
+    type ReadTransaction = ScratchCache;
+    type ReadWriteTransaction = ScratchCache;
+    fn create_read_txn(&'a self) -> Result<Self::ReadTransaction, Self::Error> {
+        Ok(self.store.clone())
+    }
+
+    fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error> {
+        Ok(self.store.clone())
+    }
+}
 
 impl<'a> TransactionSource<'a> for RocksDbStore {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     type ReadTransaction = RocksDb;
-
     type ReadWriteTransaction = RocksDb;
-
     fn create_read_txn(&'a self) -> Result<Self::ReadTransaction, Self::Error> {
         Ok(self.rocksdb.clone())
     }
-
     fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error> {
         Ok(self.rocksdb.clone())
     }
@@ -234,17 +359,12 @@ impl LmdbEnvironment {
 
 impl<'a> TransactionSource<'a> for LmdbEnvironment {
     type Error = lmdb::Error;
-
     type Handle = Database;
-
     type ReadTransaction = RoTransaction<'a>;
-
     type ReadWriteTransaction = RwTransaction<'a>;
-
     fn create_read_txn(&'a self) -> Result<RoTransaction<'a>, Self::Error> {
         self.env.begin_ro_txn()
     }
-
     fn create_read_write_txn(&'a self) -> Result<RwTransaction<'a>, Self::Error> {
         self.env.begin_rw_txn()
     }

--- a/execution_engine/src/storage/transaction_source/mod.rs
+++ b/execution_engine/src/storage/transaction_source/mod.rs
@@ -22,6 +22,9 @@ const ROCKS_DB_WINDOW_BITS: i32 = -14;
 /// Column family name for the v1 trie data store.
 const ROCKS_DB_TRIE_V1_COLUMN_FAMILY: &str = "trie_v1_column";
 
+/// Column family name for tracking progress of data migration.
+const ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY: &str = "lmdb_migrated_state_roots_column";
+
 /// A transaction which can be committed or aborted.
 pub trait Transaction: Sized {
     /// An error which can occur while reading or writing during a transaction,

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -412,6 +412,21 @@ impl<K, V> Trie<K, V> {
             None
         }
     }
+
+    /// Get children of this node.
+    pub fn children(&self) -> Option<Vec<Digest>> {
+        match self {
+            // A leaf has no child to extract
+            Trie::Leaf { .. } => None,
+            Trie::Node { pointer_block } => Some(
+                pointer_block
+                    .as_indexed_pointers()
+                    .map(|(_index, ptr)| *ptr.hash())
+                    .collect(),
+            ),
+            Trie::Extension { affix: _, pointer } => Some(vec![*pointer.hash()]),
+        }
+    }
 }
 
 impl<K, V> ToBytes for Trie<K, V>

--- a/execution_engine/src/storage/trie_store/db.rs
+++ b/execution_engine/src/storage/trie_store/db.rs
@@ -1,13 +1,23 @@
 //! An LMDB-backed trie store.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use casper_types::{bytesrepr, Key, StoredValue};
 use lmdb::{Database, DatabaseFlags};
 
 use casper_hashing::Digest;
 
 use crate::storage::{
     error,
+    global_state::CommitError,
     store::Store,
-    transaction_source::db::{LmdbEnvironment, RocksDb, RocksDbStore},
+    transaction_source::{
+        db::{LmdbEnvironment, RocksDb, RocksDbStore},
+        Readable, TransactionSource, Writable,
+    },
     trie::Trie,
     trie_store::{self, TrieStore},
 };
@@ -48,9 +58,7 @@ impl LmdbTrieStore {
 
 impl<K, V> Store<Digest, Trie<K, V>> for LmdbTrieStore {
     type Error = error::Error;
-
     type Handle = Database;
-
     fn handle(&self) -> Self::Handle {
         self.db
     }
@@ -60,12 +68,140 @@ impl<K, V> TrieStore<K, V> for LmdbTrieStore {}
 
 impl<K, V> Store<Digest, Trie<K, V>> for RocksDbStore {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     fn handle(&self) -> Self::Handle {
         self.rocksdb.clone()
     }
 }
 
 impl<K, V> TrieStore<K, V> for RocksDbStore {}
+
+pub(crate) type Cache = Arc<Mutex<HashMap<Digest, (bool, Trie<Key, StoredValue>)>>>;
+/// In-memory cached trie store, backed by rocksdb.
+#[derive(Clone)]
+pub struct ScratchCache {
+    pub(crate) cache: Cache,
+    pub(crate) rocksdb_store: RocksDbStore,
+}
+
+/// Cached version of the trie store.
+#[derive(Clone)]
+pub struct ScratchTrieStore {
+    pub(crate) store: ScratchCache,
+}
+
+impl ScratchTrieStore {
+    /// Creates a new ScratchTrieStore.
+    pub fn new(rocksdb_store: RocksDbStore) -> Self {
+        Self {
+            store: ScratchCache {
+                rocksdb_store,
+                cache: Default::default(),
+            },
+        }
+    }
+
+    /// Writes all dirty (modified) cached tries to rocksdb.
+    pub fn write_all_tries_to_rocksdb(self, new_state_root: Digest) -> Result<(), error::Error> {
+        let rocksdb_store = self.store.rocksdb_store;
+        let cache = &mut *self.store.cache.lock().map_err(|_| error::Error::Poison)?;
+
+        let mut txn = rocksdb_store.create_read_write_txn()?;
+        let mut missing_trie_keys = vec![new_state_root];
+        let mut validated_tries = HashMap::new();
+
+        while let Some(next_trie_key) = missing_trie_keys.pop() {
+            if cache.is_empty() {
+                return Err(error::Error::CommitError(
+                    CommitError::TrieNotFoundDuringCacheValidate(next_trie_key),
+                ));
+            }
+            match cache.remove(&next_trie_key) {
+                Some((false, _)) => continue,
+                None => {
+                    let handle = rocksdb_store.rocksdb.clone();
+                    txn.read(handle, next_trie_key.as_ref())?
+                        .ok_or(error::Error::CommitError(
+                            CommitError::TrieNotFoundDuringCacheValidate(next_trie_key),
+                        ))?;
+                }
+                Some((true, trie)) => {
+                    if let Some(children) = trie.children() {
+                        missing_trie_keys.extend(children);
+                    }
+                    validated_tries.insert(next_trie_key, trie);
+                }
+            }
+        }
+
+        // after validating that all the needed tries are present, write everything
+        for (digest, trie) in validated_tries.iter() {
+            rocksdb_store.put(&mut txn, digest, trie)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Store<Digest, Trie<Key, StoredValue>> for ScratchTrieStore {
+    type Error = error::Error;
+
+    type Handle = ScratchCache;
+
+    fn handle(&self) -> Self::Handle {
+        self.store.clone()
+    }
+
+    /// Puts a `value` into the store at `key` within a transaction, potentially returning an
+    /// error of type `Self::Error` if that fails.
+    fn put<T>(
+        &self,
+        _txn: &mut T,
+        digest: &Digest,
+        trie: &Trie<Key, StoredValue>,
+    ) -> Result<(), Self::Error>
+    where
+        T: Writable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        self.store
+            .cache
+            .lock()
+            .map_err(|_| error::Error::Poison)?
+            .insert(*digest, (true, trie.clone()));
+        Ok(())
+    }
+
+    /// Returns an optional value (may exist or not) as read through a transaction, or an error
+    /// of the associated `Self::Error` variety.
+    fn get<T>(
+        &self,
+        txn: &T,
+        digest: &Digest,
+    ) -> Result<Option<Trie<Key, StoredValue>>, Self::Error>
+    where
+        T: Readable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        let maybe_trie = {
+            self.store
+                .cache
+                .lock()
+                .map_err(|_| error::Error::Poison)?
+                .get(digest)
+                .cloned()
+        };
+        match maybe_trie {
+            Some((_, cached)) => Ok(Some(cached)),
+            None => {
+                let raw = self.get_raw(txn, digest)?;
+                match raw {
+                    Some(bytes) => Ok(Some(bytesrepr::deserialize(bytes.into())?)),
+                    None => Ok(None),
+                }
+            }
+        }
+    }
+}
+
+impl TrieStore<Key, StoredValue> for ScratchTrieStore {}

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
-    sync::Arc,
-    time::Instant,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use itertools::Itertools;
 use tracing::{debug, trace};
@@ -10,14 +6,14 @@ use tracing::{debug, trace};
 use casper_execution_engine::{
     core::engine_state::{
         self, step::EvictItem, DeployItem, EngineState, ExecuteRequest,
-        ExecutionResult as EngineExecutionResult, ExecutionResults, GetEraValidatorsRequest,
-        RewardItem, StepError, StepRequest, StepSuccess,
+        ExecutionResult as EngineExecutionResult, GetEraValidatorsRequest, RewardItem, StepError,
+        StepRequest, StepSuccess,
     },
     shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::db::DbGlobalState,
 };
 use casper_hashing::Digest;
-use casper_types::{EraId, ExecutionResult, Key, ProtocolVersion, PublicKey, U512};
+use casper_types::{DeployHash, EraId, ExecutionResult, Key, ProtocolVersion, PublicKey, U512};
 
 use crate::{
     components::{
@@ -27,10 +23,15 @@ use crate::{
             BlockAndExecutionEffects, ExecutionPreState, Metrics,
         },
     },
-    types::{Block, Deploy, DeployHash, DeployHeader, FinalizedBlock},
+    types::{Block, Deploy, DeployHeader, FinalizedBlock},
+};
+use casper_execution_engine::{
+    core::{engine_state::execution_result::ExecutionResults, execution},
+    storage::global_state::{CommitProvider, StateProvider},
 };
 
 /// Executes a finalized block.
+#[allow(clippy::too_many_arguments)]
 pub fn execute_finalized_block(
     engine_state: &EngineState<DbGlobalState>,
     metrics: Option<Arc<Metrics>>,
@@ -53,11 +54,15 @@ pub fn execute_finalized_block(
         next_block_height: _,
     } = execution_pre_state;
     let mut state_root_hash = pre_state_root_hash;
-    let mut execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)> =
-        HashMap::new();
+    let mut execution_results: Vec<(_, DeployHeader, ExecutionResult)> =
+        Vec::with_capacity(deploys.len() + transfers.len());
     // Run any deploys that must be executed
     let block_time = finalized_block.timestamp().millis();
     let start = Instant::now();
+
+    // Create a new EngineState that reads from LMDB but only caches changes in memory.
+    let scratch_state = engine_state.get_scratch_engine_state();
+
     for deploy in deploys.into_iter().chain(transfers) {
         let deploy_hash = *deploy.id();
         let deploy_header = deploy.header().clone();
@@ -74,23 +79,20 @@ pub fn execute_finalized_block(
         // mapping between deploy_hash and execution result, and this outer logic is
         // enriching it with the deploy hash. If we were passing multiple deploys per exec
         // the relation between the deploy and the execution results would be lost.
-        let result = execute(engine_state, metrics.clone(), execute_request)?;
+        let result = execute(&scratch_state, metrics.clone(), execute_request)?;
 
         trace!(?deploy_hash, ?result, "deploy execution result");
         // As for now a given state is expected to exist.
         let (state_hash, execution_result) = commit_execution_effects(
-            engine_state,
+            &scratch_state,
             metrics.clone(),
             state_root_hash,
-            deploy_hash,
+            deploy_hash.into(),
             result,
         )?;
-        execution_results.insert(deploy_hash, (deploy_header, execution_result));
+        execution_results.push((deploy_hash, deploy_header, execution_result));
         state_root_hash = state_hash;
     }
-
-    // Flush once, after all deploys have been executed.
-    engine_state.flush_environment()?;
 
     if let Some(metrics) = metrics.as_ref() {
         metrics.exec_block.observe(start.elapsed().as_secs_f64());
@@ -131,6 +133,14 @@ pub fn execute_finalized_block(
             None
         };
 
+    // Finally, the new state-root-hash from the cumulative changes to global state is returned when
+    // they are written to LMDB.
+    state_root_hash =
+        engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
+
+    // Flush once, after all deploys have been executed.
+    engine_state.flush_environment()?;
+
     // Update the metric.
     let block_height = finalized_block.height();
     if let Some(metrics) = metrics.as_ref() {
@@ -159,21 +169,31 @@ pub fn execute_finalized_block(
         protocol_version,
     )?;
 
+    // Temporarily patch this into what the older API expected.
+    let patched_execution_results = execution_results
+        .into_iter()
+        .map(|(hash, header, result)| (hash, (header, result)))
+        .collect();
+
     Ok(BlockAndExecutionEffects {
         block,
-        execution_results,
+        execution_results: patched_execution_results,
         maybe_step_effect_and_upcoming_era_validators,
     })
 }
 
 /// Commits the execution effects.
-fn commit_execution_effects(
-    engine_state: &EngineState<DbGlobalState>,
+fn commit_execution_effects<S>(
+    engine_state: &EngineState<S>,
     metrics: Option<Arc<Metrics>>,
     state_root_hash: Digest,
     deploy_hash: DeployHash,
     execution_results: ExecutionResults,
-) -> Result<(Digest, ExecutionResult), BlockExecutionError> {
+) -> Result<(Digest, ExecutionResult), BlockExecutionError>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
     let ee_execution_result = execution_results
         .into_iter()
         .exactly_one()
@@ -210,12 +230,16 @@ fn commit_execution_effects(
     Ok((new_state_root, json_execution_result))
 }
 
-fn commit_transforms(
-    engine_state: &EngineState<DbGlobalState>,
+fn commit_transforms<S>(
+    engine_state: &EngineState<S>,
     metrics: Option<Arc<Metrics>>,
     state_root_hash: Digest,
     effects: AdditiveMap<Key, Transform>,
-) -> Result<Digest, engine_state::Error> {
+) -> Result<Digest, engine_state::Error>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
     trace!(?state_root_hash, ?effects, "commit");
     let correlation_id = CorrelationId::new();
     let start = Instant::now();
@@ -227,11 +251,15 @@ fn commit_transforms(
     result.map(Digest::from)
 }
 
-fn execute(
-    engine_state: &EngineState<DbGlobalState>,
+fn execute<S>(
+    engine_state: &EngineState<S>,
     metrics: Option<Arc<Metrics>>,
     execute_request: ExecuteRequest,
-) -> Result<VecDeque<EngineExecutionResult>, engine_state::Error> {
+) -> Result<ExecutionResults, engine_state::Error>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
     trace!(?execute_request, "execute");
     let correlation_id = CorrelationId::new();
     let start = Instant::now();

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -106,7 +106,7 @@ pub fn execute_finalized_block(
                 post_state_hash,
                 execution_journal: step_execution_journal,
             } = commit_step(
-                engine_state,
+                &scratch_state,
                 metrics.clone(),
                 protocol_version,
                 state_root_hash,
@@ -271,15 +271,19 @@ where
     result
 }
 
-fn commit_step(
-    engine_state: &EngineState<DbGlobalState>,
+fn commit_step<S>(
+    engine_state: &EngineState<S>,
     maybe_metrics: Option<Arc<Metrics>>,
     protocol_version: ProtocolVersion,
     pre_state_root_hash: Digest,
     era_report: &EraReport<PublicKey>,
     era_end_timestamp_millis: u64,
     next_era_id: EraId,
-) -> Result<StepSuccess, StepError> {
+) -> Result<StepSuccess, StepError>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
     // Extract the rewards and the inactive validators if this is a switch block
     let EraReport {
         equivocators,

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -493,10 +493,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },
@@ -597,10 +594,7 @@ impl DeployAcceptor {
                     })
             }
             ExecutableDeployItemIdentifier::Package(
-                ref
-                contract_package_identifier
-                @
-                ContractPackageIdentifier::Hash {
+                ref contract_package_identifier @ ContractPackageIdentifier::Hash {
                     contract_package_hash,
                     ..
                 },

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -171,7 +171,7 @@ where
                 writer,
                 " {}{:<6}{}",
                 color.prefix(),
-                meta.level().to_string(),
+                meta.level(),
                 color.suffix()
             )?;
         } else {

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -280,6 +280,12 @@ impl DeployHash {
     }
 }
 
+impl From<DeployHash> for casper_types::DeployHash {
+    fn from(deploy_hash: DeployHash) -> casper_types::DeployHash {
+        casper_types::DeployHash::new(deploy_hash.inner().value())
+    }
+}
+
 impl From<DeployHash> for Digest {
     fn from(deploy_hash: DeployHash) -> Self {
         deploy_hash.0

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -329,6 +329,7 @@ pub(crate) enum Source<I> {
 }
 
 impl<I> Source<I> {
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_client(&self) -> bool {
         matches!(self, Source::Client)
     }

--- a/smart_contracts/contracts/test/regression-20220204/src/main.rs
+++ b/smart_contracts/contracts/test/regression-20220204/src/main.rs
@@ -150,8 +150,7 @@ pub extern "C" fn nontrivial_arg_as_contract() {
     let non_trivial_arg: NonTrivialArg = runtime::get_named_arg(ARG_PURSE);
     let source_purse: URef = non_trivial_arg
         .into_values()
-        .map(Key::into_uref)
-        .flatten()
+        .flat_map(Key::into_uref)
         .next()
         .unwrap();
 

--- a/types/src/block_time.rs
+++ b/types/src/block_time.rs
@@ -17,6 +17,7 @@ impl BlockTime {
 
     /// Saturating integer subtraction. Computes `self - other`, saturating at `0` instead of
     /// overflowing.
+    #[must_use]
     pub fn saturating_sub(self, other: BlockTime) -> Self {
         BlockTime(self.0.saturating_sub(other.0))
     }

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -56,6 +56,7 @@ impl EraId {
     }
 
     /// Returns a successor to current era.
+    #[must_use]
     #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
     pub fn successor(self) -> EraId {
         EraId::from(self.0 + 1)
@@ -72,16 +73,19 @@ impl EraId {
     }
 
     /// Returns the current era minus `x`, or `0` if that would be less than `0`.
+    #[must_use]
     pub fn saturating_sub(&self, x: u64) -> EraId {
         EraId::from(self.0.saturating_sub(x))
     }
 
     /// Returns the current era plus `x`, or [`EraId::MAX`] if overflow would occur.
+    #[must_use]
     pub fn saturating_add(self, rhs: EraId) -> EraId {
         EraId(self.0.saturating_add(rhs.0))
     }
 
     /// Returns the current era times `x`, or [`EraId::MAX`] if overflow would occur.
+    #[must_use]
     pub fn saturating_mul(&self, x: u64) -> EraId {
         EraId::from(self.0.saturating_mul(x))
     }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -229,6 +229,7 @@ impl Key {
     /// If `self` is of type [`Key::URef`], returns `self` with the
     /// [`AccessRights`](crate::AccessRights) stripped from the wrapped [`URef`], otherwise
     /// returns `self` unmodified.
+    #[must_use]
     pub fn normalize(self) -> Key {
         match self {
             Key::URef(uref) => Key::URef(uref.remove_access_rights()),

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -113,44 +113,52 @@ impl URef {
     }
 
     /// Returns a new [`URef`] with the same address and updated access rights.
+    #[must_use]
     pub fn with_access_rights(self, access_rights: AccessRights) -> Self {
         URef(self.0, access_rights)
     }
 
     /// Removes the access rights from this [`URef`].
+    #[must_use]
     pub fn remove_access_rights(self) -> Self {
         URef(self.0, AccessRights::NONE)
     }
 
     /// Returns `true` if the access rights are `Some` and
     /// [`is_readable`](AccessRights::is_readable) is `true` for them.
+    #[must_use]
     pub fn is_readable(self) -> bool {
         self.1.is_readable()
     }
 
     /// Returns a new [`URef`] with the same address and [`AccessRights::READ`] permission.
+    #[must_use]
     pub fn into_read(self) -> URef {
         URef(self.0, AccessRights::READ)
     }
 
     /// Returns a new [`URef`] with the same address and [`AccessRights::WRITE`] permission.
+    #[must_use]
     pub fn into_write(self) -> URef {
         URef(self.0, AccessRights::WRITE)
     }
 
     /// Returns a new [`URef`] with the same address and [`AccessRights::ADD`] permission.
+    #[must_use]
     pub fn into_add(self) -> URef {
         URef(self.0, AccessRights::ADD)
     }
 
     /// Returns a new [`URef`] with the same address and [`AccessRights::READ_ADD_WRITE`]
     /// permission.
+    #[must_use]
     pub fn into_read_add_write(self) -> URef {
         URef(self.0, AccessRights::READ_ADD_WRITE)
     }
 
     /// Returns a new [`URef`] with the same address and [`AccessRights::READ_WRITE`]
     /// permission.
+    #[must_use]
     pub fn into_read_write(self) -> URef {
         URef(self.0, AccessRights::READ_WRITE)
     }


### PR DESCRIPTION
This PR ports ScratchGlobalState over the existing port of rocksdb to 1.4.5. The goal here is to ascertain growth rates with ScratchGlobalState enabled.

* It also includes migration resumption safety, and ScratchTrie.