### PR TITLE
Remove misleading comment in Deploy acceptor

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -184,7 +184,6 @@ impl DeployAcceptor {
             self.max_associated_keys,
         );
         // checks chainspec values
-        // DOES NOT check cryptographic security
         if let Err(error) = acceptable_result {
             debug!(%deploy, %error, "deploy is incorrectly configured");
             return self.handle_invalid_deploy_result(


### PR DESCRIPTION
CHANGELOG:

- Removed misleading comment leading people to incorrectly infer that the deploy acceptor doesn't perform cryptographic checks.

Closes #2863 