### PR TITLE
Add `query_balance` endpoint

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file.  The format
 * Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
+* Add a new identifier `BalanceIdentifier` which is a new parameter to identify URefs for balance related queries.
+* Extended `GlobalStateIdentifier` to include `BlockHeight`.
+* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a give `BalanceIdentifier`
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -28,9 +28,9 @@ All notable changes to this project will be documented in this file.  The format
 * Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
-* Add a new identifier `BalanceIdentifier` which is a new parameter to identify URefs for balance related queries.
+* Add a new identifier `PurseIdentifier` which is a new parameter to identify URefs for balance related queries.
 * Extended `GlobalStateIdentifier` to include `BlockHeight`.
-* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a give `BalanceIdentifier`
+* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a give `PurseIdentifier`
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
 * Add a new identifier `PurseIdentifier` which is a new parameter to identify URefs for balance related queries.
 * Extended `GlobalStateIdentifier` to include `BlockHeight`.
-* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a give `PurseIdentifier`
+* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a given `PurseIdentifier`
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -78,6 +78,7 @@ pub(super) async fn run<REv: ReactorEventT>(
     let rpc_get_dictionary_item =
         rpcs::state::GetDictionaryItem::create_filter(effect_builder, api_version);
     let rpc_get_chainspec = rpcs::info::GetChainspec::create_filter(effect_builder, api_version);
+    let rpc_query_balance = rpcs::state::QueryBalance::create_filter(effect_builder, api_version);
 
     // Catch requests where the method is not one we handle.
     let unknown_method = warp::path(RPC_API_PATH)
@@ -112,6 +113,7 @@ pub(super) async fn run<REv: ReactorEventT>(
         .or(rpc_get_trie)
         .or(rpc_get_chainspec)
         .or(rpc_query_global_state)
+        .or(rpc_query_balance)
         .or(unknown_method)
         .or(parse_failure)
         .with(

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -23,12 +23,13 @@ use super::{
     chain::{GetBlock, GetBlockTransfers, GetEraInfoBySwitchBlock, GetStateRootHash},
     info::{GetChainspec, GetDeploy, GetPeers, GetStatus, GetValidatorChanges},
     state::{
-        GetAccountInfo, GetAuctionInfo, GetBalance, GetDictionaryItem, GetItem, QueryGlobalState,
+        GetAccountInfo, GetAuctionInfo, GetBalance, GetDictionaryItem, GetItem, QueryBalance,
+        QueryGlobalState,
     },
     Error, ReactorEventT, RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
     RpcWithoutParamsExt,
 };
-use crate::{effect::EffectBuilder, rpcs::state::QueryBalance};
+use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
     ProtocolVersion::from_parts(1, 4, 5);

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -28,7 +28,7 @@ use super::{
     Error, ReactorEventT, RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
     RpcWithoutParamsExt,
 };
-use crate::effect::EffectBuilder;
+use crate::{effect::EffectBuilder, rpcs::state::QueryBalance};
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
     ProtocolVersion::from_parts(1, 4, 5);
@@ -75,6 +75,9 @@ pub(crate) static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
     schema.push_with_params::<GetDictionaryItem>("returns an item from a Dictionary");
     schema.push_with_params::<QueryGlobalState>(
         "a query to global state using either a Block hash or state root hash",
+    );
+    schema.push_with_params::<QueryBalance>(
+        "query for a balance using a balance identifier and a state identifier",
     );
     schema.push_without_params::<GetPeers>("returns a list of peers connected to the node");
     schema.push_without_params::<GetStatus>("returns the current status of the node");

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -78,7 +78,7 @@ pub(crate) static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
         "a query to global state using either a Block hash or state root hash",
     );
     schema.push_with_params::<QueryBalance>(
-        "query for a balance using a balance identifier and a state identifier",
+        "query for a balance using a purse identifier and a state identifier",
     );
     schema.push_without_params::<GetPeers>("returns a list of peers connected to the node");
     schema.push_without_params::<GetStatus>("returns the current status of the node");

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -125,7 +125,7 @@ static QUERY_BALANCE_PARAMS: Lazy<QueryBalanceParams> = Lazy::new(|| QueryBalanc
     state_identifier: Some(GlobalStateIdentifier::BlockHash(
         *Block::doc_example().hash(),
     )),
-    balance_identifier: PurseIdentifier::MainPurseUnderAccountHash(AccountHash::new([9u8; 32])),
+    purse_identifier: PurseIdentifier::MainPurseUnderAccountHash(AccountHash::new([9u8; 32])),
 });
 static QUERY_BALANCE_RESULT: Lazy<QueryBalanceResult> = Lazy::new(|| QueryBalanceResult {
     api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
@@ -947,7 +947,7 @@ pub struct QueryBalanceParams {
     /// The state identifier used for the query.
     pub state_identifier: Option<GlobalStateIdentifier>,
     /// The identifier to obtain the purse corresponding to balance query.
-    pub balance_identifier: PurseIdentifier,
+    pub purse_identifier: PurseIdentifier,
 }
 
 impl DocExample for QueryBalanceParams {
@@ -1014,7 +1014,7 @@ impl RpcWithParamsExt for QueryBalance {
                 }
             };
 
-            let purse_uref = match params.balance_identifier {
+            let purse_uref = match params.purse_identifier {
                 PurseIdentifier::MainPurseUnderPublicKey(account_public_key) => {
                     match get_account(
                         effect_builder,

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -944,7 +944,8 @@ pub enum PurseIdentifier {
 /// Params for "query_balance" RPC request.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct QueryBalanceParams {
-    /// The state identifier used for the query.
+    /// The state identifier used for the query, if none is passed
+    /// the tip of the chain will be used.
     pub state_identifier: Option<GlobalStateIdentifier>,
     /// The identifier to obtain the purse corresponding to balance query.
     pub purse_identifier: PurseIdentifier,

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -19,8 +19,8 @@ use casper_execution_engine::{
     storage::trie::merkle_proof::TrieMerkleProof,
 };
 use casper_hashing::Digest;
-use casper_types::account::AccountHash;
 use casper_types::{
+    account::AccountHash,
     bytesrepr::{Bytes, ToBytes},
     CLValue, Key, ProtocolVersion, PublicKey, SecretKey, StoredValue as DomainStoredValue, URef,
     U512,
@@ -120,6 +120,14 @@ static GET_TRIE_PARAMS: Lazy<GetTrieParams> = Lazy::new(|| GetTrieParams {
 static GET_TRIE_RESULT: Lazy<GetTrieResult> = Lazy::new(|| GetTrieResult {
     api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
     maybe_trie_bytes: None,
+});
+static QUERY_BALANCE_PARAMS: Lazy<QueryBalanceParams> = Lazy::new(|| QueryBalanceParams {
+    state_identifier: GlobalStateIdentifier::BlockHash(*Block::doc_example().hash()),
+    balance_identifier: BalanceIdentifier::MainPurseUnderAccountHash(AccountHash::new([9u8; 32])),
+});
+static QUERY_BALANCE_RESULT: Lazy<QueryBalanceResult> = Lazy::new(|| QueryBalanceResult {
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
+    balance_value: U512::from(123_456),
 });
 
 /// Params for "state_get_item" RPC request.
@@ -927,18 +935,22 @@ pub enum BalanceIdentifier {
     PurseUref(URef),
 }
 
+/// Params for "query_balance" RPC request.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct QueryBalanceParams {
+    /// The state identifier used for the query.
     pub state_identifier: GlobalStateIdentifier,
+    /// The identifier to obtain the purse corresponding to balance query.
     pub balance_identifier: BalanceIdentifier,
 }
 
 impl DocExample for QueryBalanceParams {
     fn doc_example() -> &'static Self {
-        todo!()
+        &*QUERY_BALANCE_PARAMS
     }
 }
 
+/// Result for "query_balance" RPC response.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct QueryBalanceResult {
     /// The RPC API version.
@@ -950,10 +962,11 @@ pub struct QueryBalanceResult {
 
 impl DocExample for QueryBalanceResult {
     fn doc_example() -> &'static Self {
-        todo!()
+        &*QUERY_BALANCE_RESULT
     }
 }
 
+/// "query_balance" RPC.
 pub struct QueryBalance {}
 
 impl RpcWithParams for QueryBalance {

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -1050,7 +1050,7 @@ impl RpcWithParamsExt for QueryBalance {
 
             let balance_value = match balance_result {
                 Ok(BalanceResult::Success { motes, .. }) => motes,
-                Ok(balance_result) => {
+                Ok(BalanceResult::RootNotFound) => {
                     let error_msg = format!("query-balance failed: {:?}", balance_result);
                     info!("{}", error_msg);
                     return Ok(response_builder.error(warp_json_rpc::Error::custom(

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1115,6 +1115,20 @@ impl StorageInner {
             StorageRequest::GetFinalizedBlocks { ttl, responder } => {
                 responder.respond(self.get_finalized_blocks(ttl)?).ignore()
             }
+            StorageRequest::GetBlockHeaderByHeight {
+                block_height,
+                only_from_available_block_range,
+                responder,
+            } => {
+                let indices = self.indices.read()?;
+                let result = self.get_block_header_by_height_restricted(
+                    &mut self.env.begin_ro_txn()?,
+                    &indices,
+                    block_height,
+                    only_from_available_block_range,
+                )?;
+                responder.respond(result).ignore()
+            }
             StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
                 block_height,
                 responder,
@@ -1422,6 +1436,21 @@ impl StorageInner {
 
         self.validate_block_header_hash(&block_header, block_hash)?;
         Ok(Some(block_header))
+    }
+
+    fn get_block_header_by_height_restricted<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        indices: &Indices,
+        block_height: u64,
+        only_from_available_block_range: bool,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let block_hash = match indices.block_height_index.get(&block_height) {
+            None => return Ok(None),
+            Some(block_hash) => block_hash,
+        };
+
+        self.get_single_block_header_restricted(tx, block_hash, only_from_available_block_range)
     }
 
     /// Retrieves a single block header in a given transaction from storage.

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -2053,7 +2053,7 @@ fn should_restrict_returned_blocks() {
 #[test]
 fn should_get_block_header_by_height() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&harness, EraId::from(5));
+    let mut storage = storage_fixture(&harness, EraId::from(u64::MAX));
 
     let (block, _) = Block::random_v1(&mut harness.rng);
     let expected_header = block.header().clone();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -903,6 +903,25 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    pub(crate) async fn get_block_header_at_height_from_storage(
+        self,
+        block_height: u64,
+        only_from_available_block_range: bool,
+    ) -> Option<BlockHeader>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockHeaderByHeight {
+                block_height,
+                only_from_available_block_range,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Checks if a block header exists in storage
     pub(crate) async fn block_header_exists(self, block_height: u64) -> bool
     where

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -290,6 +290,16 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
+    GetBlockHeaderByHeight {
+        /// Height of block to get header of.
+        block_height: u64,
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
+        only_from_available_block_range: bool,
+        /// Responder to call with the result.  Returns `None` is the block header doesn't exist in
+        /// local storage.
+        responder: Responder<Option<BlockHeader>>,
+    },
     /// Checks if a block header at the given height exists in storage.
     CheckBlockHeaderExistence {
         /// Height of the block to check.
@@ -459,6 +469,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetBlockHeader { block_hash, .. } => {
                 write!(formatter, "get {}", block_hash)
+            }
+            StorageRequest::GetBlockHeaderByHeight { block_height, .. } => {
+                write!(formatter, "get header for height {}", block_height)
             }
             StorageRequest::CheckBlockHeaderExistence { block_height, .. } => {
                 write!(formatter, "check existence {}", block_height)

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -389,6 +389,7 @@ pub fn assert_schema(schema_path: String, actual_schema: RootSchema) {
     let expected_schema = fs::read_to_string(&schema_path).unwrap();
     let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
     let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
+    println!("{}", actual_schema);
     let mut temp_file = tempfile::Builder::new()
         .suffix(".json")
         .tempfile_in(env!("OUT_DIR"))

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -389,7 +389,6 @@ pub fn assert_schema(schema_path: String, actual_schema: RootSchema) {
     let expected_schema = fs::read_to_string(&schema_path).unwrap();
     let expected_schema: Value = serde_json::from_str(&expected_schema).unwrap();
     let actual_schema = serde_json::to_string_pretty(&actual_schema).unwrap();
-    println!("{}", actual_schema);
     let mut temp_file = tempfile::Builder::new()
         .suffix(".json")
         .tempfile_in(env!("OUT_DIR"))

--- a/node/src/types/json_compatibility/account.rs
+++ b/node/src/types/json_compatibility/account.rs
@@ -64,6 +64,12 @@ pub struct Account {
     action_thresholds: ActionThresholds,
 }
 
+impl Account {
+    pub(crate) fn main_purse(&self) -> URef {
+        self.main_purse
+    }
+}
+
 impl From<&ExecutionEngineAccount> for Account {
     fn from(ee_account: &ExecutionEngineAccount) -> Self {
         Account {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -152,6 +152,50 @@
             ],
             "type": "object"
           },
+          "BalanceIdentifier": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Query for the main_purse balance corresponding to this `PublicKey`.",
+                "properties": {
+                  "main_purse_under_public_key": {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                },
+                "required": [
+                  "main_purse_under_public_key"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Query for the main_purse balance corresponding to this `AccountHash`.",
+                "properties": {
+                  "main_purse_under_account_hash": {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                },
+                "required": [
+                  "main_purse_under_account_hash"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Query for purse balance underneath this `URef`.",
+                "properties": {
+                  "purse_uref": {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                },
+                "required": [
+                  "purse_uref"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "Identifier for the main purse of a given account."
+          },
           "Bid": {
             "additionalProperties": false,
             "description": "An entry in the validator map.",
@@ -1383,6 +1427,21 @@
                 },
                 "required": [
                   "BlockHash"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Query using a block height.",
+                "properties": {
+                  "BlockHeight": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "BlockHeight"
                 ],
                 "type": "object"
               },
@@ -3443,6 +3502,75 @@
             }
           },
           "summary": "a query to global state using either a Block hash or state root hash"
+        },
+        {
+          "examples": [
+            {
+              "name": "query_balance_example",
+              "params": [
+                {
+                  "name": "balance_identifier",
+                  "value": {
+                    "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
+                  }
+                },
+                {
+                  "name": "state_identifier",
+                  "value": {
+                    "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+                  }
+                }
+              ],
+              "result": {
+                "name": "query_balance_example_result",
+                "value": {
+                  "api_version": "1.4.5",
+                  "balance_value": "123456"
+                }
+              }
+            }
+          ],
+          "name": "query_balance",
+          "params": [
+            {
+              "name": "state_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/GlobalStateIdentifier",
+                "description": "The state identifier used for the query."
+              }
+            },
+            {
+              "name": "balance_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/BalanceIdentifier",
+                "description": "The identifier to obtain the purse corresponding to balance query."
+              }
+            }
+          ],
+          "result": {
+            "name": "query_balance_result",
+            "schema": {
+              "description": "Result for \"query_balance\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
+                },
+                "balance_value": {
+                  "$ref": "#/components/schemas/U512",
+                  "description": "The balance value."
+                }
+              },
+              "required": [
+                "api_version",
+                "balance_value"
+              ],
+              "type": "object"
+            }
+          },
+          "summary": "query for a balance using a balance identifier and a state identifier"
         },
         {
           "examples": [

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -152,50 +152,6 @@
             ],
             "type": "object"
           },
-          "BalanceIdentifier": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Query for the main_purse balance corresponding to this `PublicKey`.",
-                "properties": {
-                  "main_purse_under_public_key": {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                },
-                "required": [
-                  "main_purse_under_public_key"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Query for the main_purse balance corresponding to this `AccountHash`.",
-                "properties": {
-                  "main_purse_under_account_hash": {
-                    "$ref": "#/components/schemas/AccountHash"
-                  }
-                },
-                "required": [
-                  "main_purse_under_account_hash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Query for purse balance underneath this `URef`.",
-                "properties": {
-                  "purse_uref": {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                },
-                "required": [
-                  "purse_uref"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Identifier for the main purse of a given account."
-          },
           "Bid": {
             "additionalProperties": false,
             "description": "An entry in the validator map.",
@@ -2097,6 +2053,50 @@
             "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
             "type": "string"
           },
+          "PurseIdentifier": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "The main purse of the account identified by this public key.",
+                "properties": {
+                  "main_purse_under_public_key": {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                },
+                "required": [
+                  "main_purse_under_public_key"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The main purse of the account identified by this account hash.",
+                "properties": {
+                  "main_purse_under_account_hash": {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                },
+                "required": [
+                  "main_purse_under_account_hash"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The purse identified by this URef.",
+                "properties": {
+                  "purse_uref": {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                },
+                "required": [
+                  "purse_uref"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "Identifier of a purse."
+          },
           "Reward": {
             "additionalProperties": false,
             "properties": {
@@ -3525,7 +3525,7 @@
                 "name": "query_balance_example_result",
                 "value": {
                   "api_version": "1.4.5",
-                  "balance_value": "123456"
+                  "balance": "123456"
                 }
               }
             }
@@ -3533,19 +3533,26 @@
           "name": "query_balance",
           "params": [
             {
-              "name": "state_identifier",
-              "required": true,
-              "schema": {
-                "$ref": "#/components/schemas/GlobalStateIdentifier",
-                "description": "The state identifier used for the query."
-              }
-            },
-            {
               "name": "balance_identifier",
               "required": true,
               "schema": {
-                "$ref": "#/components/schemas/BalanceIdentifier",
+                "$ref": "#/components/schemas/PurseIdentifier",
                 "description": "The identifier to obtain the purse corresponding to balance query."
+              }
+            },
+            {
+              "name": "state_identifier",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/GlobalStateIdentifier"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The state identifier used for the query."
               }
             }
           ],
@@ -3558,14 +3565,14 @@
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "balance_value": {
+                "balance": {
                   "$ref": "#/components/schemas/U512",
-                  "description": "The balance value."
+                  "description": "The balance represented in motes."
                 }
               },
               "required": [
                 "api_version",
-                "balance_value"
+                "balance"
               ],
               "type": "object"
             }

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3509,7 +3509,7 @@
               "name": "query_balance_example",
               "params": [
                 {
-                  "name": "balance_identifier",
+                  "name": "purse_identifier",
                   "value": {
                     "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
                   }
@@ -3533,7 +3533,7 @@
           "name": "query_balance",
           "params": [
             {
-              "name": "balance_identifier",
+              "name": "purse_identifier",
               "required": true,
               "schema": {
                 "$ref": "#/components/schemas/PurseIdentifier",

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3552,7 +3552,7 @@
                     "type": "null"
                   }
                 ],
-                "description": "The state identifier used for the query."
+                "description": "The state identifier used for the query, if none is passed the tip of the chain will be used."
               }
             }
           ],
@@ -3577,7 +3577,7 @@
               "type": "object"
             }
           },
-          "summary": "query for a balance using a balance identifier and a state identifier"
+          "summary": "query for a balance using a purse identifier and a state identifier"
         },
         {
           "examples": [


### PR DESCRIPTION
CHANGELOG:

* Add a new identifier `PurseIdentifier` which is a new parameter to identify URefs for balance related queries.
* Extended `GlobalStateIdentifier` to include `BlockHeight`.
* Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a give `PurseIdentifier`

```
{
  "id": -3634587318258248453,
  "jsonrpc": "2.0",
  "method": "query_balance",
  "params": {
    "purse_identifier": {
      "main_purse_under_public_key": "01cb56f4b34bbeed2f25487524866deb80861da4c7ebadf0ce36c3aea9a93d652e"
    },
    "state_identifier": null
  }
}
{
  "id": -3634587318258248453,
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "balance": "1000000000000000000000000000000000"
  }
}
```





Closes #2451 
