### PR TITLE
(feat-rocksdb) Implement scratch trie store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ notes
 
 # sw* files in vim
 .*.sw*
+
+# reports
+**/disk_use_report*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.4",
  "rocksdb",
+ "tempfile",
  "version-sync",
  "walkdir",
 ]

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -127,6 +127,11 @@ impl EngineState<ScratchGlobalState> {
 }
 
 impl EngineState<DbGlobalState> {
+    /// get state
+    pub fn get_state(&self) -> &DbGlobalState {
+        &self.state
+    }
+
     /// Migrate the given state roots from lmdb to rocksdb data store.
     /// Returns Ok(true) if the migration was needed.
     pub fn migrate_state_root_to_rocksdb_if_needed(

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -73,6 +73,9 @@ pub enum CommitError {
     /// Transform error.
     #[error(transparent)]
     TransformError(transform::Error),
+    /// Trie not found while attempting to validate cache write.
+    #[error("Trie not found in cache {0}")]
+    TrieNotFoundDuringCacheValidate(Digest),
 }
 
 /// Provides `commit` method.

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -25,26 +25,33 @@ use super::db::{DbGlobalState, DbGlobalStateView};
 type SharedCache = Arc<RwLock<Cache>>;
 
 struct Cache {
-    stored_values: HashMap<Key, StoredValue>,
+    cached_values: HashMap<Key, (bool, StoredValue)>,
 }
 
 impl Cache {
     fn new() -> Self {
         Cache {
-            stored_values: HashMap::new(),
+            cached_values: HashMap::new(),
         }
     }
 
-    fn insert(&mut self, key: Key, value: StoredValue) {
-        self.stored_values.insert(key, value);
+    fn insert_write(&mut self, key: Key, value: StoredValue) {
+        self.cached_values.insert(key, (true, value));
+    }
+
+    fn insert_read(&mut self, key: Key, value: StoredValue) {
+        self.cached_values.entry(key).or_insert((false, value));
     }
 
     fn get(&self, key: &Key) -> Option<&StoredValue> {
-        self.stored_values.get(key)
+        self.cached_values.get(key).map(|(_dirty, value)| value)
     }
 
-    fn into_inner(self) -> HashMap<Key, StoredValue> {
-        self.stored_values
+    fn into_dirty_writes(self) -> HashMap<Key, StoredValue> {
+        self.cached_values
+            .into_iter()
+            .filter_map(|(key, (dirty, value))| if dirty { Some((key, value)) } else { None })
+            .collect()
     }
 }
 
@@ -77,7 +84,7 @@ impl ScratchGlobalState {
     /// Consume self and return inner cache.
     pub fn into_inner(self) -> HashMap<Key, StoredValue> {
         let cache = mem::replace(&mut *self.cache.write().unwrap(), Cache::new());
-        cache.into_inner()
+        cache.into_dirty_writes()
     }
 }
 
@@ -97,7 +104,7 @@ impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
             self.cache
                 .write()
                 .map_err(|_| error::Error::Poison)?
-                .insert(*key, value.clone());
+                .insert_read(*key, value.clone());
         }
         Ok(ret)
     }
@@ -177,7 +184,7 @@ impl CommitProvider for ScratchGlobalState {
                 },
             };
 
-            self.cache.write().unwrap().insert(key, value);
+            self.cache.write().unwrap().insert_write(key, value);
         }
         Ok(state_hash)
     }

--- a/execution_engine/src/storage/store/mod.rs
+++ b/execution_engine/src/storage/store/mod.rs
@@ -52,14 +52,14 @@ pub trait Store<K, V> {
 
     /// Puts a `value` into the store at `key` within a transaction, potentially returning an
     /// error of type `Self::Error` if that fails.
-    fn put<T>(&self, txn: &mut T, key: &K, value: &V) -> Result<(), Self::Error>
+    fn put<T>(&self, txn: &mut T, digest: &K, trie: &V) -> Result<(), Self::Error>
     where
         T: Writable<Handle = Self::Handle>,
         K: AsRef<[u8]>,
         V: ToBytes,
         Self::Error: From<T::Error>,
     {
-        self.put_raw(txn, key, &value.to_bytes()?)
+        self.put_raw(txn, digest, &trie.to_bytes()?)
     }
 
     /// Puts a raw `value` into the store at `key` within a transaction, potentially returning an

--- a/execution_engine/src/storage/transaction_source/db.rs
+++ b/execution_engine/src/storage/transaction_source/db.rs
@@ -6,7 +6,10 @@ use std::{
 use lmdb::{
     self, Database, Environment, EnvironmentFlags, RoTransaction, RwTransaction, WriteFlags,
 };
-use rocksdb::{BoundColumnFamily, DBWithThreadMode, MultiThreaded, Options};
+use rocksdb::{
+    BoundColumnFamily, DBIteratorWithThreadMode, DBWithThreadMode, IteratorMode, MultiThreaded,
+    Options,
+};
 
 use casper_types::bytesrepr::Bytes;
 
@@ -16,6 +19,7 @@ use crate::storage::{
         Readable, Transaction, TransactionSource, Writable,
         ROCKS_DB_LMDB_MIGRATED_STATE_ROOTS_COLUMN_FAMILY, ROCKS_DB_TRIE_V1_COLUMN_FAMILY,
     },
+    trie_store::db::{ScratchCache, ScratchTrieStore},
     MAX_DBS,
 };
 
@@ -108,15 +112,53 @@ impl RocksDb {
                 )
             })
     }
+
+    /// Trie store iterator.
+    pub fn trie_store_iterator<'a: 'b, 'b>(
+        &'a self,
+    ) -> Result<DBIteratorWithThreadMode<'b, DBWithThreadMode<MultiThreaded>>, error::Error> {
+        let cf_handle = self.trie_column_family()?;
+        Ok(self.db.iterator_cf(&cf_handle, IteratorMode::Start))
+    }
 }
 
 impl Transaction for RocksDb {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     fn commit(self) -> Result<(), Self::Error> {
         // NO OP as rocksdb doesn't use transactions.
+        Ok(())
+    }
+}
+
+impl Transaction for ScratchCache {
+    type Error = error::Error;
+    type Handle = ScratchCache;
+    fn commit(self) -> Result<(), Self::Error> {
+        // NO OP as scratch doesn't use transactions.
+        Ok(())
+    }
+}
+
+impl Readable for ScratchCache {
+    fn read(&self, _handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        let cf = self.rocksdb_store.rocksdb.trie_column_family()?;
+        Ok(self.rocksdb_store.rocksdb.db.get_cf(&cf, key)?.map(|some| {
+            let value = some.as_ref();
+            Bytes::from(value)
+        }))
+    }
+}
+
+impl Writable for ScratchCache {
+    fn write(
+        &mut self,
+        _handle: Self::Handle,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Self::Error> {
+        let cf = self.rocksdb_store.rocksdb.trie_column_family()?;
+        let _result = self.rocksdb_store.rocksdb.db.put_cf(&cf, key, value)?;
         Ok(())
     }
 }
@@ -146,8 +188,9 @@ impl Writable for RocksDb {
 
 /// Environment for rocksdb.
 #[derive(Clone)]
-pub(crate) struct RocksDbStore {
-    pub(crate) rocksdb: RocksDb,
+pub struct RocksDbStore {
+    /// RocksDb handle.
+    pub rocksdb: RocksDb,
     pub(crate) path: PathBuf,
 }
 
@@ -178,23 +221,36 @@ impl RocksDbStore {
     pub(crate) fn path(&self) -> PathBuf {
         self.path.clone()
     }
+
+    /// Gets a scratch trie store.
+    pub fn get_scratch_store(&self) -> ScratchTrieStore {
+        ScratchTrieStore::new(self.clone())
+    }
 }
 
 // TODO: remove this abstraction entirely when we've moved from lmdb to rocksdb for global state.
+impl<'a> TransactionSource<'a> for ScratchTrieStore {
+    type Error = error::Error;
+    type Handle = ScratchCache;
+    type ReadTransaction = ScratchCache;
+    type ReadWriteTransaction = ScratchCache;
+    fn create_read_txn(&'a self) -> Result<Self::ReadTransaction, Self::Error> {
+        Ok(self.store.clone())
+    }
+
+    fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error> {
+        Ok(self.store.clone())
+    }
+}
 
 impl<'a> TransactionSource<'a> for RocksDbStore {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     type ReadTransaction = RocksDb;
-
     type ReadWriteTransaction = RocksDb;
-
     fn create_read_txn(&'a self) -> Result<Self::ReadTransaction, Self::Error> {
         Ok(self.rocksdb.clone())
     }
-
     fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error> {
         Ok(self.rocksdb.clone())
     }
@@ -306,17 +362,12 @@ impl LmdbEnvironment {
 
 impl<'a> TransactionSource<'a> for LmdbEnvironment {
     type Error = lmdb::Error;
-
     type Handle = Database;
-
     type ReadTransaction = RoTransaction<'a>;
-
     type ReadWriteTransaction = RwTransaction<'a>;
-
     fn create_read_txn(&'a self) -> Result<RoTransaction<'a>, Self::Error> {
         self.env.begin_ro_txn()
     }
-
     fn create_read_write_txn(&'a self) -> Result<RwTransaction<'a>, Self::Error> {
         self.env.begin_rw_txn()
     }

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -543,6 +543,21 @@ impl<K, V> Trie<K, V> {
             None
         }
     }
+
+    /// Get children of this node.
+    pub fn children(&self) -> Option<Vec<Digest>> {
+        match self {
+            // A leaf has no child to extract
+            Trie::Leaf { .. } => None,
+            Trie::Node { pointer_block } => Some(
+                pointer_block
+                    .as_indexed_pointers()
+                    .map(|(_index, ptr)| *ptr.hash())
+                    .collect(),
+            ),
+            Trie::Extension { affix: _, pointer } => Some(vec![*pointer.hash()]),
+        }
+    }
 }
 
 /// Hash bytes into chunks if necessary.

--- a/execution_engine/src/storage/trie_store/db.rs
+++ b/execution_engine/src/storage/trie_store/db.rs
@@ -1,13 +1,23 @@
 //! An LMDB-backed trie store.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use casper_types::{bytesrepr, Key, StoredValue};
 use lmdb::{Database, DatabaseFlags};
 
 use casper_hashing::Digest;
 
 use crate::storage::{
     error,
+    global_state::CommitError,
     store::Store,
-    transaction_source::db::{LmdbEnvironment, RocksDb, RocksDbStore},
+    transaction_source::{
+        db::{LmdbEnvironment, RocksDb, RocksDbStore},
+        Readable, TransactionSource, Writable,
+    },
     trie::Trie,
     trie_store::{self, TrieStore},
 };
@@ -48,9 +58,7 @@ impl LmdbTrieStore {
 
 impl<K, V> Store<Digest, Trie<K, V>> for LmdbTrieStore {
     type Error = error::Error;
-
     type Handle = Database;
-
     fn handle(&self) -> Self::Handle {
         self.db
     }
@@ -60,12 +68,151 @@ impl<K, V> TrieStore<K, V> for LmdbTrieStore {}
 
 impl<K, V> Store<Digest, Trie<K, V>> for RocksDbStore {
     type Error = error::Error;
-
     type Handle = RocksDb;
-
     fn handle(&self) -> Self::Handle {
         self.rocksdb.clone()
     }
 }
 
 impl<K, V> TrieStore<K, V> for RocksDbStore {}
+
+pub(crate) type Cache = Arc<Mutex<HashMap<Digest, (bool, Trie<Key, StoredValue>)>>>;
+/// In-memory cached trie store, backed by rocksdb.
+#[derive(Clone)]
+pub struct ScratchCache {
+    pub(crate) cache: Cache,
+    pub(crate) rocksdb_store: RocksDbStore,
+}
+
+/// Cached version of the trie store.
+#[derive(Clone)]
+pub struct ScratchTrieStore {
+    pub(crate) store: ScratchCache,
+}
+
+impl ScratchTrieStore {
+    /// Creates a new ScratchTrieStore.
+    pub fn new(rocksdb_store: RocksDbStore) -> Self {
+        Self {
+            store: ScratchCache {
+                rocksdb_store,
+                cache: Default::default(),
+            },
+        }
+    }
+
+    /// Writes all dirty (modified) cached tries to rocksdb.
+    pub fn write_all_tries_to_rocksdb(self, new_state_root: Digest) -> Result<(), error::Error> {
+        let rocksdb_store = self.store.rocksdb_store;
+        let cache = &mut *self.store.cache.lock().map_err(|_| error::Error::Poison)?;
+
+        let mut txn = rocksdb_store.create_read_write_txn()?;
+        let mut missing_trie_keys = vec![new_state_root];
+        let mut validated_tries = HashMap::new();
+
+        while let Some(next_trie_key) = missing_trie_keys.pop() {
+            if cache.is_empty() {
+                return Err(error::Error::CommitError(
+                    CommitError::TrieNotFoundDuringCacheValidate(next_trie_key),
+                ));
+            }
+            match cache.remove(&next_trie_key) {
+                Some((false, _)) => continue,
+                None => {
+                    let handle = rocksdb_store.rocksdb.clone();
+                    txn.read(handle, next_trie_key.as_ref())?
+                        .ok_or(error::Error::CommitError(
+                            CommitError::TrieNotFoundDuringCacheValidate(next_trie_key),
+                        ))?;
+                }
+                Some((true, trie)) => {
+                    if let Some(children) = trie.children() {
+                        missing_trie_keys.extend(children);
+                    }
+                    validated_tries.insert(next_trie_key, trie);
+                }
+            }
+        }
+
+        // after validating that all the needed tries are present, write everything
+        for (digest, trie) in validated_tries.iter() {
+            rocksdb_store.put(&mut txn, digest, trie)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Store<Digest, Trie<Key, StoredValue>> for ScratchTrieStore {
+    type Error = error::Error;
+
+    type Handle = ScratchCache;
+
+    fn handle(&self) -> Self::Handle {
+        self.store.clone()
+    }
+
+    /// Puts a `value` into the store at `key` within a transaction, potentially returning an
+    /// error of type `Self::Error` if that fails.
+    fn put<T>(
+        &self,
+        _txn: &mut T,
+        digest: &Digest,
+        trie: &Trie<Key, StoredValue>,
+    ) -> Result<(), Self::Error>
+    where
+        T: Writable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        self.store
+            .cache
+            .lock()
+            .map_err(|_| error::Error::Poison)?
+            .insert(*digest, (true, trie.clone()));
+        Ok(())
+    }
+
+    /// Returns an optional value (may exist or not) as read through a transaction, or an error
+    /// of the associated `Self::Error` variety.
+    fn get<T>(
+        &self,
+        txn: &T,
+        digest: &Digest,
+    ) -> Result<Option<Trie<Key, StoredValue>>, Self::Error>
+    where
+        T: Readable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        let maybe_trie = {
+            self.store
+                .cache
+                .lock()
+                .map_err(|_| error::Error::Poison)?
+                .get(digest)
+                .cloned()
+        };
+        match maybe_trie {
+            Some((_, cached)) => Ok(Some(cached)),
+            None => {
+                let raw = self.get_raw(txn, digest)?;
+                match raw {
+                    Some(bytes) => {
+                        let value: Trie<Key, StoredValue> =
+                            bytesrepr::deserialize_from_slice(bytes)?;
+                        {
+                            let store =
+                                &mut *self.store.cache.lock().map_err(|_| error::Error::Poison)?;
+                            if !store.contains_key(digest) {
+                                store.insert(*digest, (false, value.clone()));
+                            }
+                        }
+                        Ok(Some(value))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
+    }
+}
+
+impl TrieStore<Key, StoredValue> for ScratchTrieStore {}

--- a/execution_engine/src/storage/trie_store/db.rs
+++ b/execution_engine/src/storage/trie_store/db.rs
@@ -134,7 +134,7 @@ impl ScratchTrieStore {
             }
         }
 
-        // after validating that all the needed tries are present, write everything
+        // after validating that all the needed tries are present write everything
         for (digest, trie) in validated_tries.iter() {
             rocksdb_store.put(&mut txn, digest, trie)?;
         }

--- a/execution_engine/src/storage/trie_store/db.rs
+++ b/execution_engine/src/storage/trie_store/db.rs
@@ -107,10 +107,10 @@ impl ScratchTrieStore {
         let cache = &mut *self.store.cache.lock().map_err(|_| error::Error::Poison)?;
 
         let mut txn = rocksdb_store.create_read_write_txn()?;
-        let mut missing_trie_keys = vec![new_state_root];
+        let mut new_trie_keys = vec![new_state_root];
         let mut validated_tries = HashMap::new();
 
-        while let Some(next_trie_key) = missing_trie_keys.pop() {
+        while let Some(next_trie_key) = new_trie_keys.pop() {
             if cache.is_empty() {
                 return Err(error::Error::CommitError(
                     CommitError::TrieNotFoundDuringCacheValidate(next_trie_key),
@@ -127,7 +127,7 @@ impl ScratchTrieStore {
                 }
                 Some((true, trie)) => {
                     if let Some(children) = trie.children() {
-                        missing_trie_keys.extend(children);
+                        new_trie_keys.extend(children);
                     }
                     validated_tries.insert(next_trie_key, trie);
                 }

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.8.0"
 rand = "0.8.4"
 rocksdb = { version = "0.18", default-features = false, features = ["zstd"]}
 walkdir = "2"
+tempfile = "3"
 
 [dev-dependencies]
 version-sync = "0.9.3"

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use rand::Rng;
 
 use casper_execution_engine::core::engine_state::{

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -8,13 +8,12 @@ use std::{
 
 use tempfile::TempDir;
 
-use casper_execution_engine::core::engine_state::{
-    genesis::GenesisValidator, run_genesis_request::RunGenesisRequest, ChainspecRegistry,
-    ExecConfig, ExecuteRequest, GenesisAccount, RewardItem,
-};
 use casper_execution_engine::{
     core::{
-        engine_state::{self, EngineState},
+        engine_state::{
+            self, genesis::GenesisValidator, run_genesis_request::RunGenesisRequest,
+            ChainspecRegistry, EngineState, ExecConfig, ExecuteRequest, GenesisAccount, RewardItem,
+        },
         execution,
     },
     shared::newtypes::CorrelationId,
@@ -25,10 +24,9 @@ use casper_execution_engine::{
 };
 use casper_hashing::Digest;
 use casper_types::{
-    account::AccountHash, runtime_args, system::auction, Motes, ProtocolVersion, PublicKey,
-    RuntimeArgs, SecretKey,
+    account::AccountHash, bytesrepr, runtime_args, system::auction, Key, Motes, ProtocolVersion,
+    PublicKey, RuntimeArgs, SecretKey, StoredValue, U512,
 };
-use casper_types::{bytesrepr, Key, StoredValue, U512};
 
 use rand::Rng;
 

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -1,16 +1,39 @@
-use rand::Rng;
+use std::{
+    collections::HashSet,
+    convert::TryFrom,
+    fs::File,
+    io::{BufWriter, Write},
+    time::Instant,
+};
+
+use tempfile::TempDir;
 
 use casper_execution_engine::core::engine_state::{
     genesis::GenesisValidator, run_genesis_request::RunGenesisRequest, ChainspecRegistry,
     ExecConfig, ExecuteRequest, GenesisAccount, RewardItem,
 };
+use casper_execution_engine::{
+    core::{
+        engine_state::{self, EngineState},
+        execution,
+    },
+    shared::newtypes::CorrelationId,
+    storage::{
+        global_state::{CommitProvider, StateProvider},
+        trie::{Pointer, Trie, TrieOrChunk, TrieOrChunkId},
+    },
+};
+use casper_hashing::Digest;
 use casper_types::{
     account::AccountHash, runtime_args, system::auction, Motes, ProtocolVersion, PublicKey,
-    RuntimeArgs, SecretKey, U512,
+    RuntimeArgs, SecretKey,
 };
+use casper_types::{bytesrepr, Key, StoredValue, U512};
+
+use rand::Rng;
 
 use crate::{
-    DbWasmTestBuilder, DeployItemBuilder, ExecuteRequestBuilder, StepRequestBuilder,
+    transfer, DbWasmTestBuilder, DeployItemBuilder, ExecuteRequestBuilder, StepRequestBuilder,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
     DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
     DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROPOSER_PUBLIC_KEY, DEFAULT_PROTOCOL_VERSION,
@@ -32,6 +55,207 @@ const VALIDATOR_BID_AMOUNT: u64 = 100;
 
 /// Amount of time to step foward between runs of the auction in our tests.
 pub const TIMESTAMP_INCREMENT_MILLIS: u64 = 30_000;
+
+const TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE: u64 = 1_000_000 * 1_000_000_000;
+
+/// Run a block with transfers and step.
+#[allow(clippy::too_many_arguments)]
+pub fn run_block_with_transfers_and_step(
+    transfer_count: usize,
+    purse_count: usize,
+    use_scratch: bool,
+    run_auction: bool,
+    block_count: usize,
+    delegator_count: usize,
+    validator_count: usize,
+    mut report_writer: BufWriter<File>,
+) {
+    let data_dir = TempDir::new().expect("should create temp dir");
+    let mut builder = DbWasmTestBuilder::new(data_dir.as_ref());
+    let delegator_keys = generate_public_keys(delegator_count);
+    let validator_keys = generate_public_keys(validator_count);
+    let mut necessary_tries = HashSet::new();
+
+    println!("creating genesis accounts");
+    run_genesis_and_create_initial_accounts(
+        &mut builder,
+        &validator_keys,
+        delegator_keys
+            .iter()
+            .map(|pk| pk.to_account_hash())
+            .collect::<Vec<_>>(),
+        U512::from(TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE),
+    );
+    let contract_hash = builder.get_auction_contract_hash();
+    let mut next_validator_iter = validator_keys.iter().cycle();
+
+    println!("creating delegators");
+    for delegator_public_key in delegator_keys {
+        let delegation_amount = U512::from(2000 * 1_000_000_000u64);
+        let delegator_account_hash = delegator_public_key.to_account_hash();
+        let next_validator_key = next_validator_iter
+            .next()
+            .expect("should produce values forever");
+        let delegate = create_delegate_request(
+            delegator_public_key,
+            next_validator_key.clone(),
+            delegation_amount,
+            delegator_account_hash,
+            contract_hash,
+        );
+        builder.exec(delegate);
+        builder.expect_success();
+        builder.commit();
+        builder.clear_results();
+    }
+
+    let purse_amount = U512::from(1_000_000_000);
+
+    println!("creating test purses");
+    let purses = transfer::create_test_purses(
+        &mut builder,
+        *DEFAULT_ACCOUNT_ADDR,
+        purse_count as u64,
+        purse_amount,
+    );
+
+    let exec_requests = transfer::create_multiple_native_transfers_to_purses(
+        *DEFAULT_ACCOUNT_ADDR,
+        transfer_count,
+        &purses,
+    );
+
+    println!("getting all keys up to this point");
+    let mut total_transfers = 0;
+    {
+        let engine_state = builder.get_engine_state();
+        let rocksdb = engine_state.get_state().rocksdb_state();
+
+        let existing_keys = rocksdb
+            .rocksdb
+            .trie_store_iterator()
+            .expect("unable to get iterator")
+            .map(|(key, _)| Digest::try_from(&*key).expect("should be a digest"));
+        necessary_tries.extend(existing_keys);
+    }
+
+    println!("found {} keys so far", necessary_tries.len());
+
+    writeln!(
+        report_writer,
+        "height,rocksdb-size,transfers,time_ms,necessary_tries,total_tries"
+    )
+    .unwrap();
+    // simulating a block boundary here.
+    for current_block in 0..block_count {
+        println!("executing height {current_block}");
+        let start = Instant::now();
+        total_transfers += exec_requests.len();
+        transfer::transfer_to_account_multiple_native_transfers(
+            &mut builder,
+            &exec_requests,
+            use_scratch,
+        );
+        let transfer_root = builder.get_post_state_hash();
+        let maybe_auction_root = if run_auction {
+            step_and_run_auction(&mut builder, &validator_keys);
+            Some(builder.get_post_state_hash())
+        } else {
+            None
+        };
+        let exec_time = start.elapsed();
+        find_necessary_tries(
+            builder.get_engine_state(),
+            &mut necessary_tries,
+            transfer_root,
+        );
+
+        if let Some(auction_root) = maybe_auction_root {
+            find_necessary_tries(
+                builder.get_engine_state(),
+                &mut necessary_tries,
+                auction_root,
+            );
+        }
+
+        let engine_state = builder.get_engine_state();
+        let rocksdb = engine_state.get_state().rocksdb_state();
+        let trie_store_iter = rocksdb
+            .rocksdb
+            .trie_store_iterator()
+            .expect("unable to get iterator");
+        let total_tries = trie_store_iter.count();
+
+        assert_eq!(
+            necessary_tries.len(),
+            total_tries,
+            "should not create unnecessary tries"
+        );
+        writeln!(
+            report_writer,
+            "{},{},{},{},{},{}",
+            current_block,
+            builder.rocksdb_on_disk_size().unwrap(),
+            total_transfers,
+            exec_time.as_millis() as usize,
+            necessary_tries.len(),
+            total_tries,
+        )
+        .unwrap();
+        report_writer.flush().unwrap();
+    }
+}
+
+// find all necessary tries - hoist to FN
+fn find_necessary_tries<S>(
+    engine_state: &EngineState<S>,
+    necessary_tries: &mut HashSet<Digest>,
+    state_root: Digest,
+) where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+    engine_state::Error: From<S::Error>,
+{
+    let mut queue = Vec::new();
+    queue.push(state_root);
+
+    while let Some(root) = queue.pop() {
+        if necessary_tries.contains(&root) {
+            continue;
+        }
+        necessary_tries.insert(root);
+
+        let trie_or_chunk: TrieOrChunk = engine_state
+            .get_trie(CorrelationId::new(), TrieOrChunkId(0, root))
+            .unwrap()
+            .expect("trie should exist");
+
+        let trie_bytes = match trie_or_chunk {
+            TrieOrChunk::Trie(trie) => trie,
+            TrieOrChunk::ChunkWithProof(_) => continue,
+        };
+
+        if let Some(0) = trie_bytes.get(0) {
+            continue;
+        }
+
+        let trie: Trie<Key, StoredValue> =
+            bytesrepr::deserialize(trie_bytes.inner_bytes().to_owned())
+                .expect("unable to deserialize");
+
+        match trie {
+            Trie::Leaf { .. } => continue,
+            Trie::Node { pointer_block } => queue.extend(pointer_block.as_indexed_pointers().map(
+                |(_idx, ptr)| match ptr {
+                    Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => digest,
+                },
+            )),
+            Trie::Extension { affix: _, pointer } => match pointer {
+                Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => queue.push(digest),
+            },
+        }
+    }
+}
 
 /// Runs genesis, creates system, validator and delegator accounts, and funds the system account and
 /// delegator accounts.

--- a/execution_engine_testing/test_support/src/transfer.rs
+++ b/execution_engine_testing/test_support/src/transfer.rs
@@ -72,7 +72,11 @@ pub fn create_test_purses(
     let exec_request = ExecuteRequestBuilder::standard(
         source,
         CONTRACT_CREATE_PURSES,
-        runtime_args! { ARG_TOTAL_PURSES => total_purses, ARG_SEED_AMOUNT => purse_amount },
+        runtime_args! {
+            ARG_AMOUNT => U512::from(total_purses) * purse_amount,
+            ARG_TOTAL_PURSES => total_purses,
+            ARG_SEED_AMOUNT => purse_amount
+        },
     )
     .build();
 

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -395,6 +395,23 @@ impl DbWasmTestBuilder {
         }
         self
     }
+
+    /// run step against scratch global state.
+    pub fn step_with_scratch(&mut self, step_request: StepRequest) -> &mut Self {
+        if self.scratch_engine_state.is_none() {
+            self.scratch_engine_state = Some(self.engine_state.get_scratch_engine_state());
+        }
+
+        let cached_state = self
+            .scratch_engine_state
+            .as_ref()
+            .expect("scratch state should exist");
+
+        cached_state
+            .commit_step(CorrelationId::new(), step_request)
+            .expect("unable to run step request against scratch global state");
+        self
+    }
 }
 
 impl<S> WasmTestBuilder<S>

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -7,7 +7,7 @@ fn main() {
     let total_transfer_count = 100;
     let transfers_per_block = 1;
     let block_count = total_transfer_count / transfers_per_block;
-    let delegator_count = 20_000;
+    let delegator_count = 20_0;
     let validator_count = 100;
 
     let report_writer = BufWriter::new(File::create("disk_use_report.csv").unwrap());

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -1,224 +1,6 @@
-use std::{
-    collections::HashSet,
-    convert::TryFrom,
-    fs::File,
-    io::{BufWriter, Write},
-    time::Instant,
-};
+use std::{fs::File, io::BufWriter};
 
-use tempfile::TempDir;
-
-use casper_engine_test_support::{
-    auction::{self},
-    transfer, DbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-};
-use casper_execution_engine::{
-    core::{
-        engine_state::{self, EngineState},
-        execution,
-    },
-    shared::newtypes::CorrelationId,
-    storage::{
-        global_state::{CommitProvider, StateProvider},
-        trie::{Pointer, Trie, TrieOrChunk, TrieOrChunkId},
-    },
-};
-use casper_hashing::Digest;
-use casper_types::{bytesrepr, Key, StoredValue, U512};
-
-const TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE: u64 = 1_000_000 * 1_000_000_000;
-
-// Generate multiple purses as well as transfer requests between them with the specified count.
-pub fn multiple_native_transfers(
-    transfer_count: usize,
-    purse_count: usize,
-    use_scratch: bool,
-    run_auction: bool,
-    block_count: usize,
-    delegator_count: usize,
-    mut report_writer: BufWriter<File>,
-) {
-    let data_dir = TempDir::new().expect("should create temp dir");
-    let mut builder = DbWasmTestBuilder::new(data_dir.as_ref());
-    let delegator_keys = auction::generate_public_keys(delegator_count);
-    let validator_keys = auction::generate_public_keys(100);
-    let mut necessary_tries = HashSet::new();
-
-    println!("creating genesis accounts");
-    auction::run_genesis_and_create_initial_accounts(
-        &mut builder,
-        &validator_keys,
-        delegator_keys
-            .iter()
-            .map(|pk| pk.to_account_hash())
-            .collect::<Vec<_>>(),
-        U512::from(TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE),
-    );
-    let contract_hash = builder.get_auction_contract_hash();
-    let mut next_validator_iter = validator_keys.iter().cycle();
-
-    println!("creating delegators");
-    for delegator_public_key in delegator_keys {
-        let delegation_amount = U512::from(2000 * 1_000_000_000u64);
-        let delegator_account_hash = delegator_public_key.to_account_hash();
-        let next_validator_key = next_validator_iter
-            .next()
-            .expect("should produce values forever");
-        let delegate = auction::create_delegate_request(
-            delegator_public_key,
-            next_validator_key.clone(),
-            delegation_amount,
-            delegator_account_hash,
-            contract_hash,
-        );
-        builder.exec(delegate);
-        builder.expect_success();
-        builder.commit();
-        builder.clear_results();
-    }
-
-    let purse_amount = U512::from(1_000_000_000);
-
-    println!("creating test purses");
-    let purses = transfer::create_test_purses(
-        &mut builder,
-        *DEFAULT_ACCOUNT_ADDR,
-        purse_count as u64,
-        purse_amount,
-    );
-
-    let exec_requests = transfer::create_multiple_native_transfers_to_purses(
-        *DEFAULT_ACCOUNT_ADDR,
-        transfer_count,
-        &purses,
-    );
-
-    println!("getting all keys up to this point");
-    let mut total_transfers = 0;
-    {
-        let engine_state = builder.get_engine_state();
-        let rocksdb = engine_state.get_state().rocksdb_state();
-
-        let existing_keys = rocksdb
-            .rocksdb
-            .trie_store_iterator()
-            .expect("unable to get iterator")
-            .map(|(key, _)| Digest::try_from(&*key).expect("should be a digest"));
-        necessary_tries.extend(existing_keys);
-    }
-
-    println!("found {} keys so far", necessary_tries.len());
-
-    writeln!(
-        report_writer,
-        "height,rocksdb-size,transfers,time_ms,necessary_tries,total_tries"
-    )
-    .unwrap();
-    // simulating a block boundary here.
-    for current_block in 0..block_count {
-        println!("executing height {current_block}");
-        let start = Instant::now();
-        total_transfers += exec_requests.len();
-        transfer::transfer_to_account_multiple_native_transfers(
-            &mut builder,
-            &exec_requests,
-            use_scratch,
-        );
-        let transfer_root = builder.get_post_state_hash();
-        let maybe_auction_root = if run_auction {
-            auction::step_and_run_auction(&mut builder, &validator_keys);
-            Some(builder.get_post_state_hash())
-        } else {
-            None
-        };
-        let exec_time = start.elapsed();
-        find_necessary_tries(
-            builder.get_engine_state(),
-            &mut necessary_tries,
-            transfer_root,
-        );
-
-        if let Some(auction_root) = maybe_auction_root {
-            find_necessary_tries(
-                builder.get_engine_state(),
-                &mut necessary_tries,
-                auction_root,
-            );
-        }
-
-        let engine_state = builder.get_engine_state();
-        let rocksdb = engine_state.get_state().rocksdb_state();
-        let trie_store_iter = rocksdb
-            .rocksdb
-            .trie_store_iterator()
-            .expect("unable to get iterator");
-        let total_tries = trie_store_iter.count();
-
-        writeln!(
-            report_writer,
-            "{},{},{},{},{},{}",
-            current_block,
-            builder.rocksdb_on_disk_size().unwrap(),
-            total_transfers,
-            exec_time.as_millis() as usize,
-            necessary_tries.len(),
-            total_tries,
-        )
-        .unwrap();
-        report_writer.flush().unwrap();
-    }
-}
-
-// find all necessary tries - hoist to FN
-fn find_necessary_tries<S>(
-    engine_state: &EngineState<S>,
-    necessary_tries: &mut HashSet<Digest>,
-    state_root: Digest,
-) where
-    S: StateProvider + CommitProvider,
-    S::Error: Into<execution::Error>,
-    engine_state::Error: From<S::Error>,
-{
-    let mut queue = Vec::new();
-    queue.push(state_root);
-
-    while let Some(root) = queue.pop() {
-        if necessary_tries.contains(&root) {
-            continue;
-        }
-        necessary_tries.insert(root);
-
-        let trie_or_chunk: TrieOrChunk = engine_state
-            .get_trie(CorrelationId::new(), TrieOrChunkId(0, root))
-            .unwrap()
-            .expect("trie should exist");
-
-        let trie_bytes = match trie_or_chunk {
-            TrieOrChunk::Trie(trie) => trie,
-            TrieOrChunk::ChunkWithProof(_) => continue,
-        };
-
-        if let Some(0) = trie_bytes.get(0) {
-            continue;
-        }
-
-        let trie: Trie<Key, StoredValue> =
-            bytesrepr::deserialize(trie_bytes.inner_bytes().to_owned())
-                .expect("unable to deserialize");
-
-        match trie {
-            Trie::Leaf { .. } => continue,
-            Trie::Node { pointer_block } => queue.extend(pointer_block.as_indexed_pointers().map(
-                |(_idx, ptr)| match ptr {
-                    Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => digest,
-                },
-            )),
-            Trie::Extension { affix: _, pointer } => match pointer {
-                Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => queue.push(digest),
-            },
-        }
-    }
-}
+use casper_engine_test_support::auction::run_block_with_transfers_and_step;
 
 fn main() {
     let purse_count = 100;
@@ -226,15 +8,17 @@ fn main() {
     let transfers_per_block = 1;
     let block_count = total_transfer_count / transfers_per_block;
     let delegator_count = 20_000;
+    let validator_count = 100;
 
     let report_writer = BufWriter::new(File::create("disk_use_report.csv").unwrap());
-    multiple_native_transfers(
+    run_block_with_transfers_and_step(
         transfers_per_block,
         purse_count,
         true,
         true,
         block_count,
         delegator_count,
+        validator_count,
         report_writer,
     );
 }

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -7,7 +7,7 @@ fn main() {
     let total_transfer_count = 100;
     let transfers_per_block = 1;
     let block_count = total_transfer_count / transfers_per_block;
-    let delegator_count = 20_0;
+    let delegator_count = 20_000;
     let validator_count = 100;
 
     let report_writer = BufWriter::new(File::create("disk_use_report.csv").unwrap());

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -104,10 +104,10 @@ pub fn execute_finalized_block(
     let maybe_step_effect_and_upcoming_era_validators =
         if let Some(era_report) = finalized_block.era_report() {
             let StepSuccess {
-                post_state_hash,
+                post_state_hash: _, // ignore the post-state-hash returned from scratch
                 execution_journal: step_execution_journal,
             } = commit_step(
-                engine_state,
+                &scratch_state, // engine_state
                 metrics.clone(),
                 protocol_version,
                 state_root_hash,
@@ -115,7 +115,9 @@ pub fn execute_finalized_block(
                 finalized_block.timestamp().millis(),
                 finalized_block.era_id().successor(),
             )?;
-            state_root_hash = post_state_hash;
+
+            state_root_hash =
+                engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
 
             // In this flow we execute using a recent state root hash where the system contract
             // registry is guaranteed to exist.
@@ -131,13 +133,12 @@ pub fn execute_finalized_block(
                 upcoming_era_validators,
             })
         } else {
+            // Finally, the new state-root-hash from the cumulative changes to global state is
+            // returned when they are written to LMDB.
+            state_root_hash =
+                engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
             None
         };
-
-    // Finally, the new state-root-hash from the cumulative changes to global state is returned when
-    // they are written to LMDB.
-    state_root_hash =
-        engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
 
     // Flush once, after all deploys have been executed.
     engine_state.flush_environment()?;
@@ -267,15 +268,19 @@ where
     result
 }
 
-fn commit_step(
-    engine_state: &EngineState<DbGlobalState>,
+fn commit_step<S>(
+    engine_state: &EngineState<S>,
     maybe_metrics: Option<Arc<Metrics>>,
     protocol_version: ProtocolVersion,
     pre_state_root_hash: Digest,
     era_report: &EraReport<PublicKey>,
     era_end_timestamp_millis: u64,
     next_era_id: EraId,
-) -> Result<StepSuccess, StepError> {
+) -> Result<StepSuccess, StepError>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
     // Extract the rewards and the inactive validators if this is a switch block
     let EraReport {
         equivocators,


### PR DESCRIPTION
Implements a scratch trie store. This change implements a cache to eliminate interstitial roots from being written to the database. In my tests, this means that the commit_step runs in ~3 seconds consistently, where before we'd see spikes as big as 60s. This also substantially reduced write amplification due to interstitial tries being no longer written to disk. This is effectively "bulk update" of the trie.

![image](https://user-images.githubusercontent.com/1497784/163594898-c486eadf-7db0-4550-b941-5ab3a14fc05a.png)
