### PR TITLE
Store children before parent tries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +493,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "assert-json-diff",
+ "async-recursion",
  "async-trait",
  "backtrace",
  "base16",

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1722,34 +1722,16 @@ where
         Ok(self.state.get_trie_full(correlation_id, &trie_key)?)
     }
 
-    /// Puts a trie and finds missing descendant trie keys.
-    pub fn put_trie_and_find_missing_descendant_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_bytes: &[u8],
-    ) -> Result<Vec<Digest>, Error>
+    /// Puts a trie.
+    // TODO: Offer to verify the trie has all of its descendents present?
+    // TODO: Do we want to return the calculated inserted trie key?
+    pub fn put_trie(&self, correlation_id: CorrelationId, trie_bytes: &[u8]) -> Result<(), Error>
     where
         Error: From<S::Error>,
     {
-        let inserted_trie_key = self.state.put_trie(correlation_id, trie_bytes)?;
-        let missing_descendant_trie_keys = self
-            .state
-            .missing_trie_keys(correlation_id, vec![inserted_trie_key])?;
-        Ok(missing_descendant_trie_keys)
-    }
+        let _inserted_trie_key = self.state.put_trie(correlation_id, trie_bytes)?;
 
-    /// Performs a lookup for a list of missing root hashes.
-    pub fn missing_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_keys: Vec<Digest>,
-    ) -> Result<Vec<Digest>, Error>
-    where
-        Error: From<S::Error>,
-    {
-        self.state
-            .missing_trie_keys(correlation_id, trie_keys)
-            .map_err(Error::from)
+        Ok(())
     }
 
     /// Obtains validator weights for given era.

--- a/execution_engine/src/storage/global_state/in_memory.rs
+++ b/execution_engine/src/storage/global_state/in_memory.rs
@@ -22,8 +22,7 @@ use crate::{
         trie_store::{
             in_memory::InMemoryTrieStore,
             operations::{
-                self, keys_with_prefix, missing_trie_keys, put_trie, read, read_with_proof,
-                ReadResult, WriteResult,
+                self, keys_with_prefix, put_trie, read, read_with_proof, ReadResult, WriteResult,
             },
         },
     },
@@ -291,25 +290,6 @@ impl StateProvider for InMemoryGlobalState {
         >(correlation_id, &mut txn, &self.trie_store, trie)?;
         txn.commit()?;
         Ok(trie_hash)
-    }
-
-    /// Finds all of the keys of missing descendant `Trie<Key,StoredValue>` values.
-    fn missing_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_keys: Vec<Digest>,
-    ) -> Result<Vec<Digest>, Self::Error> {
-        let txn = self.environment.create_read_txn()?;
-        let missing_descendants =
-            missing_trie_keys::<
-                Key,
-                StoredValue,
-                InMemoryReadTransaction,
-                InMemoryTrieStore,
-                Self::Error,
-            >(correlation_id, &txn, self.trie_store.deref(), trie_keys)?;
-        txn.commit()?;
-        Ok(missing_descendants)
     }
 }
 

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -19,9 +19,7 @@ use crate::{
         },
         trie_store::{
             lmdb::LmdbTrieStore,
-            operations::{
-                keys_with_prefix, missing_trie_keys, put_trie, read, read_with_proof, ReadResult,
-            },
+            operations::{keys_with_prefix, put_trie, read, read_with_proof, ReadResult},
         },
     },
 };
@@ -273,24 +271,6 @@ impl StateProvider for LmdbGlobalState {
         >(correlation_id, &mut txn, &self.trie_store, trie)?;
         txn.commit()?;
         Ok(trie_hash)
-    }
-
-    /// Finds all of the keys of missing descendant `Trie<K,V>` values.
-    fn missing_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_keys: Vec<Digest>,
-    ) -> Result<Vec<Digest>, Self::Error> {
-        let txn = self.environment.create_read_txn()?;
-        let missing_descendants =
-            missing_trie_keys::<Key, StoredValue, lmdb::RoTransaction, LmdbTrieStore, Self::Error>(
-                correlation_id,
-                &txn,
-                self.trie_store.deref(),
-                trie_keys,
-            )?;
-        txn.commit()?;
-        Ok(missing_descendants)
     }
 }
 

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -117,13 +117,6 @@ pub trait StateProvider {
 
     /// Insert a trie node into the trie
     fn put_trie(&self, correlation_id: CorrelationId, trie: &[u8]) -> Result<Digest, Self::Error>;
-
-    /// Finds all of the missing or corrupt keys of which are descendants of `trie_key`.
-    fn missing_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_keys: Vec<Digest>,
-    ) -> Result<Vec<Digest>, Self::Error>;
 }
 
 /// Write multiple key/stored value pairs to the store in a single rw transaction.

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -20,9 +20,7 @@ use crate::{
         trie::{merkle_proof::TrieMerkleProof, Trie, TrieOrChunk, TrieOrChunkId},
         trie_store::{
             lmdb::LmdbTrieStore,
-            operations::{
-                keys_with_prefix, missing_trie_keys, put_trie, read, read_with_proof, ReadResult,
-            },
+            operations::{keys_with_prefix, put_trie, read, read_with_proof, ReadResult},
         },
     },
 };
@@ -327,24 +325,6 @@ impl StateProvider for ScratchGlobalState {
         >(correlation_id, &mut txn, &self.trie_store, trie)?;
         txn.commit()?;
         Ok(trie_hash)
-    }
-
-    /// Finds all of the keys of missing descendant `Trie<K,V>` values
-    fn missing_trie_keys(
-        &self,
-        correlation_id: CorrelationId,
-        trie_keys: Vec<Digest>,
-    ) -> Result<Vec<Digest>, Self::Error> {
-        let txn = self.environment.create_read_txn()?;
-        let missing_descendants =
-            missing_trie_keys::<Key, StoredValue, lmdb::RoTransaction, LmdbTrieStore, Self::Error>(
-                correlation_id,
-                &txn,
-                self.trie_store.deref(),
-                trie_keys,
-            )?;
-        txn.commit()?;
-        Ok(missing_descendants)
     }
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -97,6 +97,7 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 warp = { version = "0.3.0", features = ["compression"] }
 warp-json-rpc = "0.3.0"
 wheelbuf = "0.2.0"
+async-recursion = "1.0.0"
 
 [build-dependencies]
 vergen = "3"

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -143,6 +143,16 @@ pub(crate) enum Error {
         #[serde(skip_serializing)]
         FetchTrieError,
     ),
+
+    /// A received trie matched the correct hash, but failed to serialize into a valid trie.
+    #[error("corrupt trie {hash}: {error}")]
+    CorruptTrie {
+        /// The hash of the corrupt trie.
+        hash: Digest,
+        #[serde(skip_serializing)]
+        /// Decoding error description.
+        error: String,
+    },
 }
 
 #[derive(Error, Debug)]

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -149,7 +149,6 @@ pub(crate) enum Error {
     CorruptTrie {
         /// The hash of the corrupt trie.
         hash: Digest,
-        #[serde(skip_serializing)]
         /// Decoding error description.
         error: String,
     },

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -574,7 +574,7 @@ async fn sync_trie_store(state_root_hash: Digest, ctx: Arc<ChainSyncContext>) ->
 /// Downloads a given trie and all of its descendants, then stores them into the trie store.
 ///
 /// Ensures that all descendant nodes are downloaded using post-order tree traversal, i.e. child
-/// nodes are recursively downloaded and store first before the parent node is stored.
+/// nodes are recursively downloaded and stored first before the parent node is stored.
 ///
 /// This function does not check for missing descendants for existing tries, the invariant of there
 /// being no trie nodes with missing descendants is assumed.
@@ -589,7 +589,7 @@ async fn recursive_trie_download(hash: Digest, ctx: Arc<ChainSyncContext>) -> Re
             Ok(())
         }
         TrieAlreadyPresentOrDownloaded::Downloaded(trie_bytes) => {
-            let mut descendent_handles: FuturesUnordered<_> =
+            let mut descendant_handles: FuturesUnordered<_> =
                 NetTrie::descendants_from_bytes(&trie_bytes)
                     .map_err(|err| Error::CorruptTrie {
                         hash,
@@ -603,7 +603,7 @@ async fn recursive_trie_download(hash: Digest, ctx: Arc<ChainSyncContext>) -> Re
                     })
                     .collect();
 
-            while let Some(result) = descendent_handles.next().await {
+            while let Some(result) = descendant_handles.next().await {
                 // Exit early if any of the descendant downloads failed.
                 result.map_err(Error::Join)??;
             }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -641,7 +641,7 @@ async fn recursive_trie_download(hash: Digest, ctx: Arc<ChainSyncContext>) -> Re
             Ok(())
         }
         TrieAlreadyPresentOrDownloaded::Downloaded(trie_bytes) => {
-            let descendent_handles: FuturesUnordered<_> =
+            let mut descendent_handles: FuturesUnordered<_> =
                 NetTrie::descendants_from_bytes(&trie_bytes)
                     .map_err(|err| Error::CorruptTrie {
                         hash,

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -10,7 +10,7 @@ use futures::{
 use prometheus::IntGauge;
 use quanta::Instant;
 use tokio::sync::Semaphore;
-use tracing::{error, info, trace, warn};
+use tracing::{info, trace, warn};
 
 use casper_execution_engine::storage::trie::{Trie, TrieOrChunk, TrieOrChunkId};
 use casper_hashing::Digest;
@@ -609,17 +609,7 @@ async fn recursive_trie_download(hash: Digest, ctx: Arc<ChainSyncContext>) -> Re
             }
 
             // At this point, we know all descendants are stored, so we store the parent node.
-            let descendants = ctx
-                .effect_builder
-                .put_trie_and_find_missing_descendant_trie_keys(trie_bytes)
-                .await?;
-
-            // Warn if we got an unexpected missing descendent.
-            if !descendants.is_empty() {
-                error!(trie_hash=%hash, "stored trie had missing descendants, even though they were all downloaded. this is a bug or the trie store is corrupted");
-
-                // Note: As an alternative, we can try to recover and download the missing items.
-            }
+            ctx.effect_builder.put_trie(trie_bytes).await?;
 
             Ok(())
         }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -411,10 +411,7 @@ impl ContractRuntime {
                 async move {
                     let correlation_id = CorrelationId::new();
                     let start = Instant::now();
-                    let result = engine_state.put_trie_and_find_missing_descendant_trie_keys(
-                        correlation_id,
-                        &*trie_bytes,
-                    );
+                    let result = engine_state.put_trie(correlation_id, &*trie_bytes);
                     // PERF: this *could* be called only periodically.
                     if let Err(lmdb_error) = engine_state.flush_environment() {
                         fatal!(
@@ -653,9 +650,10 @@ impl ContractRuntime {
     ) -> Result<Vec<Digest>, engine_state::Error> {
         let correlation_id = CorrelationId::new();
         let start = Instant::now();
-        let result = self
-            .engine_state
-            .missing_trie_keys(correlation_id, trie_keys);
+        // let result = self
+        //     .engine_state
+        //     .missing_trie_keys(correlation_id, trie_keys);
+        let result = todo!();
         self.metrics
             .missing_trie_keys
             .observe(start.elapsed().as_secs_f64());

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -523,25 +523,6 @@ impl ContractRuntime {
                 }
                 .ignore()
             }
-            ContractRuntimeRequest::FindMissingDescendantTrieKeys {
-                trie_key,
-                responder,
-            } => {
-                trace!(?trie_key, "find missing descendant trie keys");
-                let engine_state = Arc::clone(&self.engine_state);
-                let metrics = Arc::clone(&self.metrics);
-                async move {
-                    let correlation_id = CorrelationId::new();
-                    let start = Instant::now();
-                    let result = engine_state.missing_trie_keys(correlation_id, vec![trie_key]);
-                    metrics
-                        .missing_trie_keys
-                        .observe(start.elapsed().as_secs_f64());
-                    trace!(?result, "find missing descendant trie keys");
-                    responder.respond(result).await
-                }
-                .ignore()
-            }
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1084,24 +1084,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Asynchronously returns any missing descendant trie keys given an ancestor.
-    pub(crate) async fn find_missing_descendant_trie_keys(
-        self,
-        trie_key: Digest,
-    ) -> Result<Vec<Digest>, engine_state::Error>
-    where
-        REv: From<ContractRuntimeRequest>,
-    {
-        self.make_request(
-            |responder| ContractRuntimeRequest::FindMissingDescendantTrieKeys {
-                trie_key,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Puts the given deploy into the deploy store.
     pub(crate) async fn put_deploy_to_storage(self, deploy: Box<Deploy>) -> bool
     where

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1067,10 +1067,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts a trie into the trie store and asynchronously returns any missing descendant trie keys.
-    pub(crate) async fn put_trie_and_find_missing_descendant_trie_keys(
-        self,
-        trie_bytes: Bytes,
-    ) -> Result<Vec<Digest>, engine_state::Error>
+    pub(crate) async fn put_trie(self, trie_bytes: Bytes) -> Result<(), engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -929,13 +929,6 @@ pub(crate) enum ContractRuntimeRequest {
         /// trie.
         responder: Responder<Result<Vec<Digest>, engine_state::Error>>,
     },
-    /// Find the missing descendants for a trie key
-    FindMissingDescendantTrieKeys {
-        /// The trie key to find the missing descendants for.
-        trie_key: Digest,
-        /// The responder to call with the result.
-        responder: Responder<Result<Vec<Digest>, engine_state::Error>>,
-    },
     /// Execute a provided protoblock
     ExecuteBlock {
         /// The protocol version of the block to execute.
@@ -1017,9 +1010,6 @@ impl Display for ContractRuntimeRequest {
                 finalized_block, ..
             } => {
                 write!(formatter, "Execute finalized block: {}", finalized_block)
-            }
-            ContractRuntimeRequest::FindMissingDescendantTrieKeys { trie_key, .. } => {
-                write!(formatter, "Find missing descendant trie keys: {}", trie_key)
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -925,9 +925,8 @@ pub(crate) enum ContractRuntimeRequest {
     PutTrie {
         /// The hash of the value to get from the `TrieStore`
         trie_bytes: Bytes,
-        /// Responder to call with the result. Contains the missing descendants of the inserted
-        /// trie.
-        responder: Responder<Result<Vec<Digest>, engine_state::Error>>,
+        /// Responder to call with the result.
+        responder: Responder<Result<(), engine_state::Error>>,
     },
     /// Execute a provided protoblock
     ExecuteBlock {

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -463,10 +463,7 @@ pub async fn download_trie_channels(
                 }) => {
                     let mut missing_trie_descendants = tokio::task::block_in_place(|| {
                         engine_state
-                            .put_trie_and_find_missing_descendant_trie_keys(
-                                CorrelationId::new(),
-                                &trie_bytes,
-                            )
+                            .put_trie(CorrelationId::new(), &trie_bytes)
                             .unwrap()
                     });
 
@@ -899,11 +896,8 @@ async fn fetch_and_store_trie(
             }
 
             // similar to how the contract-runtime does related operations, spawn in a blocking task
-            tokio::task::spawn_blocking(move || {
-                engine_state
-                    .put_trie_and_find_missing_descendant_trie_keys(CorrelationId::new(), &bytes)
-            })
-            .await??
+            tokio::task::spawn_blocking(move || engine_state.put_trie(CorrelationId::new(), &bytes))
+                .await??
         }
         Ok(GetTrieResult {
             maybe_trie_bytes: None,


### PR DESCRIPTION
Changes the fast-sync code to store tries in post-order when downloading, thus obviating the need to find missing descendants. Requires that the trie store has stored only complete tries. This is meant as an experimental improvement for fast sync performance.

This commits eliminates the work queue in favor of recursive solution. It is not "true" recursion, as tasks are spawned instead of awaiting, thus hopefully eliminating potential stack overflows should the trie grow arbitrarily deep (small demo: https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=1661dae87acc9e4c9913551f91c24ead). Performance should be at least ballpark-comparable (https://casperlabs-team.slack.com/archives/CGPDWN4MQ/p1649866751247089).

This code has seen very little testing yet; it may very well crash or lock on first try.

## Open questions

The actual type (called `NetTrie` in the code) for the `Trie` nodes received over the network was unclear. A small bit of refactoring has made the ancestor-determining functions available on `Trie` itself using only raw bytes, but for this to work, the type must be known. I was not sure if there are one or two types sent serialized across the wire, see the comment for details.

## Missing features

* A self-healing function should be added, to be either run when accidentally discovering missing tries, and/or at start-up or through manual intervention, to fill potential holes in the store.
* The `utils/retrieve-state` program has not been updated, it will probably corrupt the store when run.
* It could be beneficial to use a lock to enforce only one root state hash to be downloaded at the same time, as they are guaranteed to be cycle free. Otherwise, parallel processes could end up downloading the same trie nodes twice. This is not a current concern, as far as I know though.

Closes #2860.