### PR TITLE
Fetch blocks and deploys in a single fetch request.

### DIFF
--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -14,8 +14,8 @@ use casper_types::{EraId, ProtocolVersion};
 use crate::{
     components::{contract_runtime::BlockExecutionError, fetcher::FetcherError},
     types::{
-        Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy,
-        FinalizedApprovalsWithId,
+        Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata,
+        Deploy, FinalizedApprovalsWithId,
     },
 };
 
@@ -61,6 +61,9 @@ pub(crate) enum Error {
 
     #[error(transparent)]
     BlockWithMetadataFetcher(#[from] FetcherError<BlockWithMetadata>),
+
+    #[error(transparent)]
+    BlockAndDeploysFetcher(#[from] FetcherError<BlockAndDeploys>),
 
     #[error(transparent)]
     DeployWithMetadataFetcher(#[from] FetcherError<Deploy>),

--- a/node/src/components/chain_synchronizer/metrics.rs
+++ b/node/src/components/chain_synchronizer/metrics.rs
@@ -60,6 +60,9 @@ pub(super) struct Metrics {
     /// Time in seconds of fetching deploys during chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_deploys_duration_seconds: Histogram,
+    /// Time in seconds of fetching block with deploys during chain sync.
+    #[data_size(skip)]
+    pub(super) chain_sync_fetch_block_and_deploys_duration_seconds: Histogram,
     /// Integer representing a height of a block that we've successfully downloaded.
     #[data_size(skip)]
     pub(super) chain_sync_block_height_synced: IntGauge,
@@ -193,6 +196,12 @@ impl Metrics {
                 registry,
                 "chain_sync_fetch_deploys_duration_seconds",
                 "time in seconds of fetching deploys during chain sync",
+                buckets.clone(),
+            )?,
+            chain_sync_fetch_block_and_deploys_duration_seconds: utils::register_histogram_metric(
+                registry,
+                "chain_sync_fetch_block_and_deploys_duration_seconds",
+                "time in seconds of fetching block and all of its deploys",
                 buckets,
             )?,
             chain_sync_block_height_synced,
@@ -207,6 +216,11 @@ impl Metrics {
 
     pub(super) fn observe_fetch_deploys_duration_seconds(&self, start: Timestamp) {
         self.chain_sync_fetch_deploys_duration_seconds
+            .observe(start.elapsed().millis() as f64 / 1000.0);
+    }
+
+    pub(super) fn observe_fetch_block_and_deploys_duration_seconds(&self, start: Timestamp) {
+        self.chain_sync_fetch_block_and_deploys_duration_seconds
             .observe(start.elapsed().millis() as f64 / 1000.0);
     }
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -974,7 +974,10 @@ async fn sync_to_genesis(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, Bl
     // era 0.
     let mut trusted_key_block_info = get_trusted_key_block_info(ctx).await?;
 
-    let trusted_block = *fetch_and_store_block_by_hash(ctx.trusted_hash(), ctx).await?;
+    let BlockAndDeploys {
+        block: trusted_block,
+        deploys: _,
+    } = *fetch_and_store_block_with_deploys_by_hash(ctx.trusted_hash(), ctx).await?;
 
     fetch_to_genesis(&trusted_block, ctx).await?;
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -661,8 +661,9 @@ async fn fetch_and_store_block_with_deploys_by_hash(
     block_hash: BlockHash,
     ctx: &ChainSyncContext<'_>,
 ) -> Result<Box<BlockAndDeploys>, FetcherError<BlockAndDeploys>> {
+    let start = Timestamp::now();
     let fetched_block = fetch_retry_forever::<BlockAndDeploys>(ctx, block_hash).await?;
-    match fetched_block {
+    let res = match fetched_block {
         FetchedData::FromStorage {
             item: block_and_deploys,
             ..
@@ -676,7 +677,10 @@ async fn fetch_and_store_block_with_deploys_by_hash(
                 .await;
             Ok(block_and_deploys)
         }
-    }
+    };
+    ctx.metrics
+        .observe_fetch_block_and_deploys_duration_seconds(start);
+    res
 }
 
 /// A worker task that takes trie keys from a queue and downloads the trie.

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -22,9 +22,9 @@ use crate::{
     },
     protocol::Message,
     types::{
-        Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy,
-        DeployHash, DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedApprovalsWithId,
-        Item, NodeId,
+        Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata,
+        Deploy, DeployHash, DeployWithFinalizedApprovals, FinalizedApprovals,
+        FinalizedApprovalsWithId, Item, NodeId,
     },
     utils::Source,
     FetcherConfig, NodeRng,
@@ -312,6 +312,40 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
                         .expect("can only contain one result")
                         .map(DeployWithFinalizedApprovals::into_naive),
                 ),
+            })
+    }
+}
+
+impl ItemFetcher<BlockAndDeploys> for Fetcher<BlockAndDeploys> {
+    const SAFE_TO_RESPOND_TO_ALL: bool = false;
+
+    fn responders(
+        &mut self,
+    ) -> &mut HashMap<BlockHash, HashMap<NodeId, Vec<FetchResponder<BlockAndDeploys>>>> {
+        &mut self.responders
+    }
+
+    fn metrics(&mut self) -> &Metrics {
+        &self.metrics
+    }
+
+    fn peer_timeout(&self) -> Duration {
+        self.get_from_peer_timeout
+    }
+
+    /// Gets a `Deploy` from the storage component.
+    fn get_from_storage<REv: ReactorEventT<BlockAndDeploys>>(
+        &mut self,
+        effect_builder: EffectBuilder<REv>,
+        id: BlockHash,
+        peer: NodeId,
+    ) -> Effects<Event<BlockAndDeploys>> {
+        effect_builder
+            .get_block_and_deploys_from_storage(id)
+            .event(move |result| Event::GetFromStorageResult {
+                id,
+                peer,
+                maybe_item: Box::new(result),
             })
     }
 }

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -399,6 +399,7 @@ impl reactor::Reactor for Reactor {
                 | NetResponse::Block(_)
                 | NetResponse::GossipedAddress(_)
                 | NetResponse::BlockAndMetadataByHeight(_)
+                | NetResponse::BlockAndDeploys(_)
                 | NetResponse::BlockHeaderByHash(_)
                 | NetResponse::BlockHeaderAndFinalitySignaturesByHeight(_)) => {
                     fatal!(effect_builder, "unexpected net response: {:?}", other).ignore()

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -88,9 +88,9 @@ use crate::{
     protocol::Message,
     reactor::ReactorEvent,
     types::{
-        AvailableBlockRange, Block, BlockBody, BlockHash, BlockHeader, BlockHeaderWithMetadata,
-        BlockSignatures, BlockWithMetadata, Deploy, DeployHash, DeployMetadata,
-        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedApprovalsWithId,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockBody, BlockHash, BlockHeader,
+        BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata, Deploy, DeployHash,
+        DeployMetadata, DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedApprovalsWithId,
         HashingAlgorithmVersion, Item, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
         NodeId, TimeDiff,
     },
@@ -782,6 +782,20 @@ impl StorageInner {
                     opt_item,
                 )?)
             }
+            NetRequest::BlockAndDeploys(ref serialized_id) => {
+                let item_id = decode_item_id::<BlockAndDeploys>(serialized_id)?;
+                let opt_item = self
+                    .read_block_and_deploys_by_hash(item_id)
+                    .map_err(FatalStorageError::from)?;
+
+                Ok(self.update_pool_and_send(
+                    effect_builder,
+                    incoming.sender,
+                    serialized_id,
+                    item_id,
+                    opt_item,
+                )?)
+            }
         }
     }
 
@@ -1174,6 +1188,15 @@ impl StorageInner {
             } => responder
                 .respond(self.store_finalized_approvals(deploy_hash, finalized_approvals)?)
                 .ignore(),
+            StorageRequest::PutBlockAndDeploys { block, responder } => responder
+                .respond(self.put_block_and_deploys(&*block)?)
+                .ignore(),
+            StorageRequest::GetBlockAndDeploys {
+                block_hash,
+                responder,
+            } => responder
+                .respond(self.read_block_and_deploys_by_hash(block_hash)?)
+                .ignore(),
         })
     }
 
@@ -1183,6 +1206,34 @@ impl StorageInner {
         let outcome = txn.put_value(self.deploy_db, deploy.id(), &deploy, false)?;
         txn.commit()?;
         Ok(outcome)
+    }
+
+    /// Puts deploys into storage.
+    pub fn put_deploys<'a, I: IntoIterator<Item = &'a Deploy> + 'a>(
+        &self,
+        deploys: I,
+    ) -> Result<bool, FatalStorageError> {
+        let mut txn = self.env.begin_rw_txn()?;
+        let mut outcome = true;
+        for deploy in deploys {
+            outcome = outcome && txn.put_value(self.deploy_db, deploy.id(), &deploy, false)?;
+        }
+        txn.commit()?;
+        Ok(outcome)
+    }
+
+    /// Puts block and its deploys into storage.
+    pub fn put_block_and_deploys(
+        &self,
+        block_and_deploys: &BlockAndDeploys,
+    ) -> Result<bool, FatalStorageError> {
+        let BlockAndDeploys { block, deploys } = block_and_deploys;
+
+        let write_block_result = self.write_block(block)?;
+
+        let write_deploys_result = self.put_deploys(deploys)?;
+
+        Ok(write_block_result && write_deploys_result)
     }
 
     /// Retrieves a block by hash.
@@ -1288,6 +1339,29 @@ impl StorageInner {
     pub fn read_block_by_height(&self, height: u64) -> Result<Option<Block>, FatalStorageError> {
         let indices = self.indices.read()?;
         self.get_block_by_height(&mut self.env.begin_ro_txn()?, &indices, height)
+    }
+
+    /// Retrieves single block and all of its deploys.
+    /// If any of the deploys can't be found, returns `Ok(None)`.
+    pub fn read_block_and_deploys_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Option<BlockAndDeploys>, FatalStorageError> {
+        let block = self.read_block(&hash)?;
+        match block {
+            None => Ok(None),
+            Some(block) => {
+                let deploy_hashes = block
+                    .deploy_hashes()
+                    .iter()
+                    .chain(block.transfer_hashes().iter());
+                let deploys_count = block.deploy_hashes().len() + block.transfer_hashes().len();
+                match self.read_deploys(deploys_count, deploy_hashes)? {
+                    None => Ok(None),
+                    Some(deploys) => Ok(Some(BlockAndDeploys { block, deploys })),
+                }
+            }
+        }
     }
 
     /// Retrieves single block by height by looking it up in the index and returning it.
@@ -1714,6 +1788,23 @@ impl StorageInner {
     ) -> Result<Option<Deploy>, FatalStorageError> {
         let mut txn = self.env.begin_ro_txn()?;
         Ok(txn.get_value(self.deploy_db, &deploy_hash)?)
+    }
+
+    /// Directly returns all deploys or None if any is missing.
+    pub fn read_deploys<'a, I: Iterator<Item = &'a DeployHash> + 'a>(
+        &self,
+        deploys_count: usize,
+        deploy_hashes: I,
+    ) -> Result<Option<Vec<Deploy>>, FatalStorageError> {
+        let mut txn = self.env.begin_ro_txn()?;
+        let mut result = Vec::with_capacity(deploys_count);
+        for deploy_hash in deploy_hashes {
+            match txn.get_value(self.deploy_db, deploy_hash)? {
+                Some(deploy) => result.push(deploy),
+                None => return Ok(None),
+            }
+        }
+        Ok(Some(result))
     }
 
     /// Stores a set of finalized approvals.

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -68,6 +68,8 @@ pub(crate) enum NetRequest {
     GossipedAddress(Vec<u8>),
     /// Request for a block by its height in the linear chain.
     BlockAndMetadataByHeight(Vec<u8>),
+    /// Request for a block and its deploys by hash.
+    BlockAndDeploys(Vec<u8>),
     /// Request for a block header by its hash.
     BlockHeaderByHash(Vec<u8>),
     /// Request for a block header and its finality signatures by its height in the linear chain.
@@ -88,6 +90,7 @@ impl Display for NetRequest {
             NetRequest::BlockHeaderAndFinalitySignaturesByHeight(_) => {
                 f.write_str("request for block header and finality signatures by height")
             }
+            NetRequest::BlockAndDeploys(_) => f.write_str("request for a block and its deploys"),
         }
     }
 }
@@ -107,6 +110,7 @@ impl NetRequest {
             NetRequest::BlockAndMetadataByHeight(ref id) => id,
             NetRequest::BlockHeaderByHash(ref id) => id,
             NetRequest::BlockHeaderAndFinalitySignaturesByHeight(ref id) => id,
+            NetRequest::BlockAndDeploys(ref id) => id,
         };
         let mut unique_id = Vec::with_capacity(id.len() + 1);
         unique_id.push(self.tag() as u8);
@@ -127,6 +131,7 @@ impl NetRequest {
             NetRequest::BlockHeaderAndFinalitySignaturesByHeight(_) => {
                 Tag::BlockHeaderAndFinalitySignaturesByHeight
             }
+            NetRequest::BlockAndDeploys(_) => Tag::BlockAndDeploysByHash,
         }
     }
 }
@@ -160,6 +165,8 @@ pub(crate) enum NetResponse {
     BlockHeaderByHash(Arc<[u8]>),
     /// Response of a block header and its finality signatures by its height in the linear chain.
     BlockHeaderAndFinalitySignaturesByHeight(Arc<[u8]>),
+    /// Response for a block and its deploys.
+    BlockAndDeploys(Arc<[u8]>),
 }
 
 // `NetResponse` uses `Arcs`, so we count all data as 0.
@@ -187,6 +194,7 @@ impl Display for NetResponse {
             NetResponse::BlockHeaderAndFinalitySignaturesByHeight(_) => {
                 f.write_str("response, block header and finality signatures by height")
             }
+            NetResponse::BlockAndDeploys(_) => f.write_str("response, block and deploys"),
         }
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -48,10 +48,11 @@ use crate::{
     effect::Responder,
     rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
-        AvailableBlockRange, Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockPayload,
-        BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
-        DeployHash, DeployMetadata, DeployWithFinalizedApprovals, FinalizedApprovals,
-        FinalizedBlock, Item, NodeId, StatusFeed, TimeDiff,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
+        BlockHeaderWithMetadata, BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec,
+        ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash, DeployMetadata,
+        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedBlock, Item, NodeId, StatusFeed,
+        TimeDiff,
     },
     utils::{DisplayIter, Source},
 };
@@ -247,6 +248,14 @@ pub(crate) enum StorageRequest {
         /// attempt or false if it was previously stored.
         responder: Responder<bool>,
     },
+    /// Store given block and its deploys.
+    PutBlockAndDeploys {
+        /// Block to be stored.
+        block: Box<BlockAndDeploys>,
+        /// Responder to call with the result.  Returns true if the block was stored on this
+        /// attempt or false if it was previously stored.
+        responder: Responder<bool>,
+    },
     /// Retrieve block with given hash.
     GetBlock {
         /// Hash of block to be retrieved.
@@ -254,6 +263,14 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.  Returns `None` is the block doesn't exist in local
         /// storage.
         responder: Responder<Option<Block>>,
+    },
+    /// Retrieve block and deploys with given hash.
+    GetBlockAndDeploys {
+        /// Hash of block to be retrieved.
+        block_hash: BlockHash,
+        /// Responder to call with the result.  Returns `None` is the block doesn't exist in local
+        /// storage.
+        responder: Responder<Option<BlockAndDeploys>>,
     },
     /// Retrieve highest block.
     GetHighestBlock {
@@ -451,7 +468,16 @@ impl Display for StorageRequest {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             StorageRequest::PutBlock { block, .. } => write!(formatter, "put {}", block),
+            StorageRequest::PutBlockAndDeploys {
+                block: block_deploys,
+                ..
+            } => {
+                write!(formatter, "put block and deploys {}", block_deploys)
+            }
             StorageRequest::GetBlock { block_hash, .. } => write!(formatter, "get {}", block_hash),
+            StorageRequest::GetBlockAndDeploys { block_hash, .. } => {
+                write!(formatter, "get block and deploys {}", block_hash)
+            }
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
             StorageRequest::GetHighestBlockHeader { .. } => {
                 write!(formatter, "get highest block header")

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -74,6 +74,7 @@ impl Payload for Message {
                     Tag::BlockHeaderByHash => MessageKind::BlockTransfer,
                     Tag::BlockHeaderAndFinalitySignaturesByHeight => MessageKind::BlockTransfer,
                     Tag::TrieOrChunk => MessageKind::TrieTransfer,
+                    Tag::BlockAndDeploysByHash => MessageKind::BlockTransfer,
                 }
             }
             Message::FinalitySignature(_) => MessageKind::Consensus,
@@ -109,6 +110,7 @@ impl Payload for Message {
                 Tag::BlockHeaderByHash => weights.block_requests,
                 Tag::BlockHeaderAndFinalitySignaturesByHeight => weights.block_requests,
                 Tag::TrieOrChunk => weights.trie_requests,
+                Tag::BlockAndDeploysByHash => weights.block_requests,
             },
             Message::GetResponse { tag, .. } => match tag {
                 Tag::Deploy => weights.deploy_responses,
@@ -119,6 +121,7 @@ impl Payload for Message {
                 Tag::BlockHeaderByHash => weights.block_responses,
                 Tag::BlockHeaderAndFinalitySignaturesByHeight => weights.block_responses,
                 Tag::TrieOrChunk => weights.trie_responses,
+                Tag::BlockAndDeploysByHash => weights.block_requests,
             },
             Message::FinalitySignature(_) => weights.finality_signatures,
         }
@@ -259,6 +262,11 @@ where
                     message: TrieRequest(serialized_id),
                 }
                 .into(),
+                Tag::BlockAndDeploysByHash => NetRequestIncoming {
+                    sender,
+                    message: NetRequest::BlockAndDeploys(serialized_id),
+                }
+                .into(),
             },
             Message::GetResponse {
                 tag,
@@ -302,6 +310,11 @@ where
                 Tag::TrieOrChunk => TrieResponseIncoming {
                     sender,
                     message: TrieResponse(serialized_item.to_vec()),
+                }
+                .into(),
+                Tag::BlockAndDeploysByHash => NetResponseIncoming {
+                    sender,
+                    message: NetResponse::BlockAndDeploys(serialized_item),
                 }
                 .into(),
             },

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -69,8 +69,8 @@ use crate::{
         EventQueueHandle, Finalize, ReactorExit,
     },
     types::{
-        Block, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy, DeployHash,
-        ExitCode, FinalizedApprovalsWithId, NodeId, NodeState,
+        Block, BlockAndDeploys, BlockHeader, BlockHeaderWithMetadata, BlockWithMetadata, Deploy,
+        DeployHash, ExitCode, FinalizedApprovalsWithId, NodeId, NodeState,
     },
     utils::{Source, WithDir},
     NodeRng,
@@ -133,6 +133,9 @@ pub(crate) enum JoinerEvent {
     #[from]
     BlockByHeightFetcher(#[serde(skip_serializing)] fetcher::Event<BlockWithMetadata>),
 
+    #[from]
+    BlockAndDeploysFetcher(#[serde(skip_serializing)] fetcher::Event<BlockAndDeploys>),
+
     /// Deploy fetcher event.
     #[from]
     DeployFetcher(#[serde(skip_serializing)] fetcher::Event<Deploy>),
@@ -192,6 +195,9 @@ pub(crate) enum JoinerEvent {
     /// Linear chain block by height fetcher request.
     #[from]
     BlockByHeightFetcherRequest(#[serde(skip_serializing)] FetcherRequest<BlockWithMetadata>),
+
+    #[from]
+    BlockAndDeploysFetcherRequest(#[serde(skip_serializing)] FetcherRequest<BlockAndDeploys>),
 
     /// Deploy fetcher request.
     #[from]
@@ -339,6 +345,8 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::BlockHeaderByHeightFetcherRequest(_) => {
                 "BlockHeaderByHeightFetcherRequest"
             }
+            JoinerEvent::BlockAndDeploysFetcher(_) => "BlockAndDeploysFetcher",
+            JoinerEvent::BlockAndDeploysFetcherRequest(_) => "BlockAndDeploysFetcherRequest",
             JoinerEvent::BlocklistAnnouncement(_) => "BlocklistAnnouncement",
             JoinerEvent::StorageRequest(_) => "StorageRequest",
             JoinerEvent::BeginAddressGossipRequest(_) => "BeginAddressGossipRequest",
@@ -489,6 +497,12 @@ impl Display for JoinerEvent {
             JoinerEvent::DeployGossiperAnnouncement(ann) => {
                 write!(f, "deploy gossiper announcement: {}", ann)
             }
+            JoinerEvent::BlockAndDeploysFetcher(event) => {
+                write!(f, "block and deploys fetcher: {}", event)
+            }
+            JoinerEvent::BlockAndDeploysFetcherRequest(req) => {
+                write!(f, "block and deploys fetcher request: {}", req)
+            }
         }
     }
 }
@@ -510,6 +524,7 @@ pub(crate) struct Reactor {
     block_by_hash_fetcher: Fetcher<Block>,
     block_by_height_fetcher: Fetcher<BlockWithMetadata>,
     block_header_and_finality_signatures_by_height_fetcher: Fetcher<BlockHeaderWithMetadata>,
+    block_and_deploys_fetcher: Fetcher<BlockAndDeploys>,
     trie_or_chunk_fetcher: Fetcher<TrieOrChunk>,
     diagnostics_port: DiagnosticsPort,
     block_header_by_hash_fetcher: Fetcher<BlockHeader>,
@@ -638,6 +653,7 @@ impl reactor::Reactor for Reactor {
         let block_header_and_finality_signatures_by_height_fetcher =
             fetcher_builder.build("block_header_by_height")?;
         let block_header_by_hash_fetcher = fetcher_builder.build("block_header")?;
+        let block_and_deploys_fetcher = fetcher_builder.build("block_and_deploys")?;
 
         let trie_or_chunk_fetcher = fetcher_builder.build("trie_or_chunk")?;
 
@@ -672,6 +688,7 @@ impl reactor::Reactor for Reactor {
                 block_by_height_fetcher,
                 block_header_by_hash_fetcher,
                 block_header_and_finality_signatures_by_height_fetcher,
+                block_and_deploys_fetcher,
                 trie_or_chunk_fetcher,
                 deploy_acceptor,
                 event_queue_metrics,
@@ -823,6 +840,16 @@ impl reactor::Reactor for Reactor {
                 JoinerEvent::TrieOrChunkFetcher,
                 self.trie_or_chunk_fetcher
                     .handle_event(effect_builder, rng, event),
+            ),
+            JoinerEvent::BlockAndDeploysFetcher(event) => reactor::wrap_effects(
+                JoinerEvent::BlockAndDeploysFetcher,
+                self.block_and_deploys_fetcher
+                    .handle_event(effect_builder, rng, event),
+            ),
+            JoinerEvent::BlockAndDeploysFetcherRequest(fetcher_req) => self.dispatch_event(
+                effect_builder,
+                rng,
+                JoinerEvent::BlockAndDeploysFetcher(fetcher_req.into()),
             ),
             JoinerEvent::ContractRuntime(event) => reactor::wrap_effects(
                 JoinerEvent::ContractRuntime,
@@ -1126,6 +1153,16 @@ impl Reactor {
             }
             NetResponse::BlockHeaderAndFinalitySignaturesByHeight(ref serialized_item) => {
                 reactor::handle_fetch_response::<Self, BlockHeaderWithMetadata>(
+                    self,
+                    effect_builder,
+                    rng,
+                    sender,
+                    serialized_item,
+                    verifiable_chunked_hash_activation,
+                )
+            }
+            NetResponse::BlockAndDeploys(ref serialized_item) => {
+                reactor::handle_fetch_response::<Self, BlockAndDeploys>(
                     self,
                     effect_builder,
                     rng,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1234,6 +1234,14 @@ impl reactor::Reactor for Reactor {
                         );
                         return Effects::new();
                     }
+                    NetResponse::BlockAndDeploys(_) => {
+                        error!(
+                            "cannot handle get response for \
+                            block-and-deploys from {}",
+                            sender
+                        );
+                        return Effects::new();
+                    }
                 };
 
                 self.dispatch_event(effect_builder, rng, event)

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -24,8 +24,9 @@ use rand_chacha::ChaCha20Rng;
 pub use available_block_range::{AvailableBlockRange, AvailableBlockRangeError};
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},
-    Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature, FinalizedBlock,
-    HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
+    Block, BlockAndDeploys, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature,
+    FinalizedBlock, HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart,
+    MerkleLinkedListNode,
 };
 pub(crate) use block::{BlockHeaderWithMetadata, BlockPayload, BlockWithMetadata};
 pub use chainspec::Chainspec;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1835,6 +1835,60 @@ impl Item for BlockWithMetadata {
     }
 }
 
+#[derive(DataSize, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Wrapper around block and its deploys.
+pub struct BlockAndDeploys {
+    /// Block part.
+    pub block: Block,
+    /// Deploys.
+    pub deploys: Vec<Deploy>,
+}
+
+impl Display for BlockAndDeploys {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "block {} and deploys", self.block.hash())
+    }
+}
+
+impl Item for BlockAndDeploys {
+    type Id = BlockHash;
+
+    type ValidationError = BlockValidationError;
+
+    const TAG: Tag = Tag::BlockAndDeploysByHash;
+
+    // false b/c we're not validating finality signatures.
+    const ID_IS_COMPLETE_ITEM: bool = false;
+
+    fn validate(
+        &self,
+        verifiable_chunked_hash_activation: EraId,
+    ) -> Result<(), Self::ValidationError> {
+        let _ = self.block.verify(verifiable_chunked_hash_activation)?;
+        // Validate that we've got all of the deploys we should have gotten.
+        if !self
+            .block
+            .deploy_hashes()
+            .iter()
+            .chain(self.block.transfer_hashes().iter())
+            .all(|deploy_hash| {
+                self.deploys
+                    .iter()
+                    .any(|deploy| (*deploy).id() == deploy_hash)
+            })
+        {
+            // todo: error
+            panic!("return proper error here")
+        }
+
+        Ok(())
+    }
+
+    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+        *self.block.hash()
+    }
+}
+
 pub(crate) mod json_compatibility {
     use super::*;
 

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -48,6 +48,8 @@ pub enum Tag {
     BlockHeaderAndFinalitySignaturesByHeight,
     /// A trie or chunk from the global Merkle tree in the execution engine.
     TrieOrChunk,
+    /// A full block and its deploys.
+    BlockAndDeploysByHash,
 }
 
 /// A trait which allows an implementing type to be used by the gossiper and fetcher components, and


### PR DESCRIPTION
Previously, each fast sync's _sync to Genesis_ round would consist of three, sequential steps:

1. fetch block's deploys
2. fetch block's trie
3. fetch block's parent (and use it as a base block in the next loop)

On top of that, each of the deploys and trie nodes would be requested independently, from a different peer. That adds a lot of latency to the process and slows it down considerably. Especially when the size of data we fetch, like a deploy or a trie node, is small - that makes us pay the cost of latency many times.

In this PR, we change the algorithm to the following:
1. fetch whole block and its deploys
2. fetch block's trie

Now, we make a single request to fetch the block and all of its deploys, hopefully speeding up the process.

**Why is this a safe thing to do?**
Our limit for a network message is ~23MB while a single block, with all of its deploys, can be ~12MB maximum.

 In this PR we're also adding a new histogram metric `chain_sync_fetch_block_and_deploys_duration_seconds` measuring time that it takes to download a block and all of its deploys.