### PR TITLE
Replace msgpack as the main network encoding format

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.  The format
 * Switch blocks immediately after genesis or an upgrade are now signed.
 * Added CORS behavior to allow any route on the JSON-RPC, REST and SSE servers.
 * Storage operations are now executed in parallel, the degree of parallelism can be controlled through the `storage.max_sync_tasks` setting.
+* The network message format has been replaced with a more efficient encoding while keeping the initial handshake intact.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -23,6 +23,7 @@
 //! Nodes gossip their public listening addresses periodically, and will try to establish and
 //! maintain an outgoing connection to any new address learned.
 
+mod bincode_format;
 mod chain_info;
 mod config;
 mod counting_format;

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -554,7 +554,11 @@ where
             | ConnectionError::TlsHandshake(_)
             | ConnectionError::HandshakeSend(_)
             | ConnectionError::HandshakeRecv(_)
-            | ConnectionError::IncompatibleVersion(_)
+            | ConnectionError::IncompatibleVersion(_) => false,
+
+            // These errors are potential bugs on our side.
+            ConnectionError::HandshakeSenderCrashed(_)
+            | ConnectionError::FailedToReuniteHandshakeSinkAndStream
             | ConnectionError::CouldNotEncodeOurHandshake(_) => false,
 
             // These could be candidates for blocking, but for now we decided not to.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -73,13 +73,13 @@ use tokio_util::codec::LengthDelimitedCodec;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
 use self::{
+    bincode_format::BincodeFormat,
     chain_info::ChainInfo,
     counting_format::{ConnectionId, CountingFormat, Role},
     error::{ConnectionError, Result},
     event::{IncomingConnection, OutgoingConnection},
     limiter::Limiter,
     message::ConsensusKeyPair,
-    message_pack_format::MessagePackFormat,
     metrics::Metrics,
     outgoing::{DialOutcome, DialRequest, OutgoingConfig, OutgoingManager},
     symmetry::ConnectionSymmetry,
@@ -1051,7 +1051,7 @@ pub(crate) type FullTransport<P> = tokio_serde::Framed<
     FramedTransport,
     Message<P>,
     Arc<Message<P>>,
-    CountingFormat<MessagePackFormat>,
+    CountingFormat<BincodeFormat>,
 >;
 
 pub(crate) type FramedTransport = tokio_util::codec::Framed<Transport, LengthDelimitedCodec>;
@@ -1071,7 +1071,7 @@ where
 {
     tokio_serde::Framed::new(
         framed,
-        CountingFormat::new(metrics, connection_id, role, MessagePackFormat),
+        CountingFormat::new(metrics, connection_id, role, BincodeFormat::default()),
     )
 }
 

--- a/node/src/components/small_network/bincode_format.rs
+++ b/node/src/components/small_network/bincode_format.rs
@@ -18,6 +18,7 @@ use tokio_serde::{Deserializer, Serializer};
 use super::Message;
 
 /// bincode encoder/decoder for messages.
+#[allow(clippy::type_complexity)]
 pub struct BincodeFormat(
     // Note: This scary looking type is because `bincode` encodes its options at the type level.
     //       The exact shape is determined by `BincodeFormat::default()`.

--- a/node/src/components/small_network/bincode_format.rs
+++ b/node/src/components/small_network/bincode_format.rs
@@ -20,8 +20,8 @@ use super::Message;
 /// bincode encoder/decoder for messages.
 #[allow(clippy::type_complexity)]
 pub struct BincodeFormat(
-    // Note: This scary looking type is because `bincode` encodes its options at the type level.
-    //       The exact shape is determined by `BincodeFormat::default()`.
+    // Note: `bincode` encodes its options at the type level. The exact shape is determined by
+    // `BincodeFormat::default()`.
     WithOtherTrailing<
         WithOtherIntEncoding<
             WithOtherEndian<

--- a/node/src/components/small_network/bincode_format.rs
+++ b/node/src/components/small_network/bincode_format.rs
@@ -1,0 +1,81 @@
+//! Bincode wire format encoder.
+//!
+//! An encoder for `Bincode` messages with our specific settings pinned.
+
+use std::{fmt::Debug, io, pin::Pin, sync::Arc};
+
+use bincode::{
+    config::{
+        RejectTrailing, VarintEncoding, WithOtherEndian, WithOtherIntEncoding, WithOtherLimit,
+        WithOtherTrailing,
+    },
+    Options,
+};
+use bytes::{Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
+use tokio_serde::{Deserializer, Serializer};
+
+use super::Message;
+
+/// bincode encoder/decoder for messages.
+pub struct BincodeFormat(
+    // Note: This scary looking type is because `bincode` encodes its options at the type level.
+    //       The exact shape is determined by `BincodeFormat::default()`.
+    WithOtherTrailing<
+        WithOtherIntEncoding<
+            WithOtherEndian<
+                WithOtherLimit<bincode::DefaultOptions, bincode::config::Infinite>,
+                bincode::config::LittleEndian,
+            >,
+            VarintEncoding,
+        >,
+        RejectTrailing,
+    >,
+);
+
+impl Debug for BincodeFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("BincodeFormat")
+    }
+}
+
+impl Default for BincodeFormat {
+    fn default() -> Self {
+        let opts = bincode::options()
+            .with_no_limit() // We rely on framed tokio transports to impose limits.
+            .with_little_endian() // Default at the time of this writing, we are merely pinning it.
+            .with_varint_encoding() // Same as above.
+            .reject_trailing_bytes(); // There is no reason for us not to reject trailing bytes.
+        BincodeFormat(opts)
+    }
+}
+
+impl<P> Serializer<Arc<Message<P>>> for BincodeFormat
+where
+    Message<P>: Serialize,
+{
+    type Error = io::Error;
+
+    #[inline]
+    fn serialize(self: Pin<&mut Self>, item: &Arc<Message<P>>) -> Result<Bytes, Self::Error> {
+        let msg = &**item;
+        self.0
+            .serialize(msg)
+            .map(Into::into)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}
+
+impl<P> Deserializer<Message<P>> for BincodeFormat
+where
+    for<'de> Message<P>: Deserialize<'de>,
+{
+    type Error = io::Error;
+
+    #[inline]
+    fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Message<P>, Self::Error> {
+        self.0
+            .deserialize(src)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -145,9 +145,23 @@ pub enum ConnectionError {
     /// Peer reported an incompatible version.
     #[error("peer is running incompatible version: {0}")]
     IncompatibleVersion(ProtocolVersion),
-    /// Peer sent a non-handshake message as its first message.
+    /// Peer sent no or a non-handshake message as its first message.
     #[error("peer did not send handshake")]
     DidNotSendHandshake,
+    /// Failed to encode our handshake.
+    #[error("could not encode our handshake")]
+    CouldNotEncodeOurHandshake(
+        #[serde(skip_serializing)]
+        #[source]
+        io::Error,
+    ),
+    /// Could not deserialize the message that is supposed to contain the remotes handshake.
+    #[error("could not decode remote handshake message")]
+    InvalidRemoteHandshakeMessage(
+        #[serde(skip_serializing)]
+        #[source]
+        io::Error,
+    ),
     /// The peer sent a consensus certificate, but it was invalid.
     #[error("invalid consensus certificate")]
     InvalidConsensusCertificate(

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -155,6 +155,15 @@ pub enum ConnectionError {
         #[source]
         io::Error,
     ),
+    /// A background sender for our handshake panicked or crashed.
+    ///
+    /// This is usually a bug.
+    #[error("handshake sender crashed")]
+    HandshakeSenderCrashed(
+        #[serde(skip_serializing)]
+        #[source]
+        tokio::task::JoinError,
+    ),
     /// Could not deserialize the message that is supposed to contain the remotes handshake.
     #[error("could not decode remote handshake message")]
     InvalidRemoteHandshakeMessage(
@@ -169,6 +178,11 @@ pub enum ConnectionError {
         #[source]
         crypto::Error,
     ),
+    /// Failed to reunited handshake sink/stream.
+    ///
+    /// This is usually a bug.
+    #[error("handshake sink/stream could not be reunited")]
+    FailedToReuniteHandshakeSinkAndStream,
 }
 
 /// IO operation that can time out or close.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -145,7 +145,7 @@ pub enum ConnectionError {
     /// Peer reported an incompatible version.
     #[error("peer is running incompatible version: {0}")]
     IncompatibleVersion(ProtocolVersion),
-    /// Peer sent no or a non-handshake message as its first message.
+    /// Peer did not send any message, or a non-handshake as its first message.
     #[error("peer did not send handshake")]
     DidNotSendHandshake,
     /// Failed to encode our handshake.
@@ -178,7 +178,7 @@ pub enum ConnectionError {
         #[source]
         crypto::Error,
     ),
-    /// Failed to reunited handshake sink/stream.
+    /// Failed to reunite handshake sink/stream.
     ///
     /// This is usually a bug.
     #[error("handshake sink/stream could not be reunited")]

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use static_assertions::const_assert;
 use tracing::Span;
 
-use super::{error::ConnectionError, FramedTransport, GossipedAddress, Message, NodeId};
+use super::{error::ConnectionError, FullTransport, GossipedAddress, Message, NodeId};
 use crate::{
     effect::{
         announcements::{BlocklistAnnouncement, ContractRuntimeAnnouncement},
@@ -181,7 +181,7 @@ pub(crate) enum IncomingConnection<P> {
         peer_consensus_public_key: Option<PublicKey>,
         /// Stream of incoming messages. for incoming connections.
         #[serde(skip_serializing)]
-        stream: SplitStream<FramedTransport<P>>,
+        stream: SplitStream<FullTransport<P>>,
     },
 }
 
@@ -251,7 +251,7 @@ pub(crate) enum OutgoingConnection<P> {
         peer_consensus_public_key: Option<PublicKey>,
         /// Sink for outgoing messages.
         #[serde(skip_serializing)]
-        sink: SplitSink<FramedTransport<P>, Arc<Message<P>>>,
+        sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
     },
 }
 

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -343,12 +343,14 @@ pub struct EstimatorWeights {
 // We use a variety of weird names in these tests.
 #[allow(non_camel_case_types)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, pin::Pin};
 
+    use bytes::BytesMut;
     use casper_types::ProtocolVersion;
     use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use tokio_serde::{Deserializer, Serializer};
 
-    use crate::protocol;
+    use crate::{components::small_network::message_pack_format::MessagePackFormat, protocol};
 
     use super::*;
 
@@ -432,16 +434,22 @@ mod tests {
 
     /// Serialize a message using the standard serialization method for handshakes.
     fn serialize_message<M: Serialize>(msg: &M) -> Vec<u8> {
-        // The actual serialization/deserialization code can be found at
-        // https://github.com/carllerche/tokio-serde/blob/f3c3d69ce049437973468118c9d01b46e0b1ade5/src/lib.rs#L426-L450
+        let mut serializer = MessagePackFormat;
 
-        rmp_serde::to_vec(&msg).expect("handshake serialization failed")
+        Pin::new(&mut serializer)
+            .serialize(&msg)
+            .expect("handshake serialization failed")
+            .into_iter()
+            .collect()
     }
 
     /// Deserialize a message using the standard deserialization method for handshakes.
     fn deserialize_message<M: DeserializeOwned>(serialized: &[u8]) -> M {
-        rmp_serde::from_read(std::io::Cursor::new(&serialized))
-            .expect("handshake deserialization failed")
+        let mut deserializer = MessagePackFormat;
+
+        Pin::new(&mut deserializer)
+            .deserialize(&BytesMut::from(serialized))
+            .expect("message deserialization failed")
     }
 
     /// Given a message `from` of type `F`, serializes it, then deserializes it as `T`.

--- a/node/src/components/small_network/message_pack_format.rs
+++ b/node/src/components/small_network/message_pack_format.rs
@@ -3,49 +3,44 @@
 //! This module is used to pin the correct version of message pack used throughout the codebase to
 //! our network decoder via `Cargo.toml`; using `tokio_serde::MessagePack` would instead tie it
 //! to the dependency specified in `tokio_serde`'s `Cargo.toml`.
-//!
-//! The encoder is also specialized to `Message<P>` instead of a generic payload for simplicity.
 
 use std::{
     io::{self, Cursor},
     pin::Pin,
-    sync::Arc,
 };
 
 use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_serde::{Deserializer, Serializer};
 
-use super::Message;
-
 /// msgpack encoder/decoder for messages.
 #[derive(Debug)]
 pub struct MessagePackFormat;
 
-impl<P> Serializer<Arc<Message<P>>> for MessagePackFormat
+impl<M> Serializer<M> for MessagePackFormat
 where
-    Message<P>: Serialize,
+    M: Serialize,
 {
     // Note: We cast to `io::Error` because of the `Codec::Error: Into<Transport::Error>`
     // requirement.
     type Error = io::Error;
 
     #[inline]
-    fn serialize(self: Pin<&mut Self>, item: &Arc<Message<P>>) -> Result<Bytes, Self::Error> {
+    fn serialize(self: Pin<&mut Self>, item: &M) -> Result<Bytes, Self::Error> {
         rmp_serde::to_vec(item)
             .map(Into::into)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
 }
 
-impl<P> Deserializer<Message<P>> for MessagePackFormat
+impl<M> Deserializer<M> for MessagePackFormat
 where
-    for<'de> Message<P>: Deserialize<'de>,
+    for<'de> M: Deserialize<'de>,
 {
     type Error = io::Error;
 
     #[inline]
-    fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Message<P>, Self::Error> {
+    fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<M, Self::Error> {
         rmp_serde::from_read(Cursor::new(src))
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }


### PR DESCRIPTION
Closes #2881 

This changes the underlying network protocol to use msgpack only for the initial handshake for backwards compatibility. Actual network messages are instead encoded using fixed-settings `bincode` for now.

The tests have been improved, now using the actual encoder instead of a "replication". Furthermore a potential, rare race condition in the handshake has been removed by making the sending of the handshake a background task.

## Benchmarks

I've benchmarked this quickly using casper-test: https://github.com/casper-network/casper-test/blob/06db5ed0127b9e915201b683196515df55abb96a/src/bin/benchmark_network_traffic_gossiping.rs

`release-1.5.0` results (run twice):

```
Total bytes gossiped across the network: 79420
Total bytes gossiped across the network: 81964
```

With the changes in this PR:

```
Total bytes gossiped across the network: 42838
```

That's roughly a 45% reduction in traffic.

## Important

**Note**: If this merges, the resulting node will be **entirely incompatible with all previous versions of 1.5.0 currently used in testnets**. The underlying network protocol has changed in a manner invisible to the nodes, they will just report encoding errors when talking to older nodes.