### PR TITLE
Port ScratchTrie to release-1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ notes
 
 # sw* files in vim
 .*.sw*
+
+# disk use reports
+**/disk_use_report.csv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,12 +363,14 @@ dependencies = [
  "casper-execution-engine",
  "casper-hashing",
  "casper-types",
+ "filesize",
  "lmdb",
  "log",
  "num-rational 0.4.0",
  "num-traits",
  "once_cell",
  "rand 0.8.4",
+ "tempfile",
  "version-sync",
 ]
 
@@ -1666,6 +1668,15 @@ dependencies = [
  "bitvec",
  "rand_core 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "filesize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -125,6 +125,11 @@ impl EngineState<ScratchGlobalState> {
 }
 
 impl EngineState<LmdbGlobalState> {
+    /// Gets underlyng LmdbGlobalState
+    pub fn get_state(&self) -> &LmdbGlobalState {
+        &self.state
+    }
+
     /// Flushes the LMDB environment to disk when manual sync is enabled in the config.toml.
     pub fn flush_environment(&self) -> Result<(), lmdb::Error> {
         if self.state.environment.is_manual_sync_enabled() {

--- a/execution_engine/src/storage/global_state/in_memory.rs
+++ b/execution_engine/src/storage/global_state/in_memory.rs
@@ -256,9 +256,9 @@ impl StateProvider for InMemoryGlobalState {
             || Ok(None),
             |bytes| {
                 if bytes.len() <= ChunkWithProof::CHUNK_SIZE_BYTES {
-                    Ok(Some(TrieOrChunk::Trie(bytes.to_owned().into())))
+                    Ok(Some(TrieOrChunk::Trie(bytes)))
                 } else {
-                    let chunk_with_proof = ChunkWithProof::new(bytes, trie_index)?;
+                    let chunk_with_proof = ChunkWithProof::new(&bytes, trie_index)?;
                     Ok(Some(TrieOrChunk::ChunkWithProof(chunk_with_proof)))
                 }
             },
@@ -274,8 +274,7 @@ impl StateProvider for InMemoryGlobalState {
     ) -> Result<Option<Bytes>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let ret: Option<Bytes> =
-            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?
-                .map(|slice| slice.to_owned().into());
+            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?;
         txn.commit()?;
         Ok(ret)
     }

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -23,7 +23,7 @@ use crate::{
             TrieOrChunkId,
         },
         trie_store::{
-            lmdb::LmdbTrieStore,
+            lmdb::{LmdbTrieStore, ScratchTrieStore},
             operations::{
                 descendant_trie_keys, keys_with_prefix, missing_trie_keys, put_trie, read,
                 read_with_proof, ReadResult,
@@ -102,14 +102,33 @@ impl LmdbGlobalState {
         prestate_hash: Digest,
         stored_values: HashMap<Key, StoredValue>,
     ) -> Result<Digest, error::Error> {
-        put_stored_values::<LmdbEnvironment, LmdbTrieStore, error::Error>(
-            &self.environment,
-            &self.trie_store,
+        let scratch_trie = self.get_scratch_store();
+        let new_state_root = put_stored_values::<_, _, error::Error>(
+            &scratch_trie,
+            &scratch_trie,
             correlation_id,
             prestate_hash,
             stored_values,
-        )
-        .map_err(Into::into)
+        )?;
+        scratch_trie.write_root_to_db(new_state_root)?;
+        Ok(new_state_root)
+    }
+
+    /// Gets a scratch trie store.
+    fn get_scratch_store(&self) -> ScratchTrieStore {
+        ScratchTrieStore::new(Arc::clone(&self.trie_store), Arc::clone(&self.environment))
+    }
+
+    /// Get a reference to the lmdb global state's environment.
+    #[must_use]
+    pub fn environment(&self) -> &LmdbEnvironment {
+        &self.environment
+    }
+
+    /// Get a reference to the lmdb global state's trie store.
+    #[must_use]
+    pub fn trie_store(&self) -> &LmdbTrieStore {
+        &self.trie_store
     }
 }
 
@@ -245,9 +264,9 @@ impl StateProvider for LmdbGlobalState {
             || Ok(None),
             |bytes| {
                 if bytes.len() <= ChunkWithProof::CHUNK_SIZE_BYTES {
-                    Ok(Some(TrieOrChunk::Trie(bytes.to_owned().into())))
+                    Ok(Some(TrieOrChunk::Trie(bytes)))
                 } else {
-                    let chunk_with_proof = ChunkWithProof::new(bytes, trie_index)?;
+                    let chunk_with_proof = ChunkWithProof::new(&bytes, trie_index)?;
                     Ok(Some(TrieOrChunk::ChunkWithProof(chunk_with_proof)))
                 }
             },
@@ -264,8 +283,7 @@ impl StateProvider for LmdbGlobalState {
     ) -> Result<Option<Bytes>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let ret: Option<Bytes> =
-            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?
-                .map(|slice| slice.to_owned().into());
+            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?;
         txn.commit()?;
         Ok(ret)
     }

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -73,6 +73,9 @@ pub enum CommitError {
     /// Transform error.
     #[error(transparent)]
     TransformError(transform::Error),
+    /// Trie not found while attempting to validate cache write.
+    #[error("Trie not found in cache {0}")]
+    TrieNotFoundInCache(Digest),
 }
 
 /// Provides `commit` method.

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -52,6 +52,8 @@ impl Cache {
         self.cached_values.get(key).map(|(_dirty, value)| value)
     }
 
+    /// Consumes self and returns only written values as values that were only read must be filtered
+    /// out to prevent unecessary writes.
     fn into_dirty_writes(self) -> HashMap<Key, StoredValue> {
         self.cached_values
             .into_iter()
@@ -298,9 +300,9 @@ impl StateProvider for ScratchGlobalState {
             || Ok(None),
             |bytes| {
                 if bytes.len() <= ChunkWithProof::CHUNK_SIZE_BYTES {
-                    Ok(Some(TrieOrChunk::Trie(bytes.to_owned().into())))
+                    Ok(Some(TrieOrChunk::Trie(bytes)))
                 } else {
-                    let chunk_with_proof = ChunkWithProof::new(bytes, trie_index)?;
+                    let chunk_with_proof = ChunkWithProof::new(&bytes, trie_index)?;
                     Ok(Some(TrieOrChunk::ChunkWithProof(chunk_with_proof)))
                 }
             },
@@ -317,8 +319,7 @@ impl StateProvider for ScratchGlobalState {
     ) -> Result<Option<Bytes>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let ret: Option<Bytes> =
-            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?
-                .map(|slice| slice.to_owned().into());
+            Store::<Digest, Trie<Digest, StoredValue>>::get_raw(&*self.trie_store, &txn, trie_key)?;
         txn.commit()?;
         Ok(ret)
     }

--- a/execution_engine/src/storage/store/mod.rs
+++ b/execution_engine/src/storage/store/mod.rs
@@ -2,7 +2,7 @@ mod store_ext;
 #[cfg(test)]
 pub(crate) mod tests;
 
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use casper_types::bytesrepr::{self, Bytes, FromBytes, ToBytes};
 
 pub use self::store_ext::StoreExt;
 use crate::storage::transaction_source::{Readable, Writable};
@@ -40,7 +40,7 @@ pub trait Store<K, V> {
 
     /// Returns an optional value (may exist or not) as read through a transaction, or an error
     /// of the associated `Self::Error` variety.
-    fn get_raw<'a, T>(&self, txn: &'a T, key: &K) -> Result<Option<&'a [u8]>, Self::Error>
+    fn get_raw<T>(&self, txn: &T, key: &K) -> Result<Option<Bytes>, Self::Error>
     where
         T: Readable<Handle = Self::Handle>,
         K: AsRef<[u8]>,

--- a/execution_engine/src/storage/transaction_source/in_memory.rs
+++ b/execution_engine/src/storage/transaction_source/in_memory.rs
@@ -48,12 +48,12 @@ impl Transaction for InMemoryReadTransaction {
 }
 
 impl Readable for InMemoryReadTransaction {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         let sub_view = match self.view.get(&handle) {
             Some(view) => view,
             None => return Ok(None),
         };
-        Ok(sub_view.get(&Bytes::from(key)).map(Bytes::as_slice))
+        Ok(sub_view.get(&Bytes::from(key)).cloned())
     }
 }
 
@@ -95,12 +95,12 @@ impl<'a> Transaction for InMemoryReadWriteTransaction<'a> {
 }
 
 impl<'a> Readable for InMemoryReadWriteTransaction<'a> {
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error> {
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         let sub_view = match self.view.get(&handle) {
             Some(view) => view,
             None => return Ok(None),
         };
-        Ok(sub_view.get(&Bytes::from(key)).map(Bytes::as_slice))
+        Ok(sub_view.get(&Bytes::from(key)).cloned())
     }
 }
 

--- a/execution_engine/src/storage/transaction_source/mod.rs
+++ b/execution_engine/src/storage/transaction_source/mod.rs
@@ -1,3 +1,5 @@
+use casper_types::bytesrepr::Bytes;
+
 /// In-memory implementation of transaction source.
 pub mod in_memory;
 /// LMDB implementation of transaction source.
@@ -26,7 +28,7 @@ pub trait Transaction: Sized {
 /// A transaction with the capability to read from a given [`Handle`](Transaction::Handle).
 pub trait Readable: Transaction {
     /// Returns the value from the corresponding key from a given [`Transaction::Handle`].
-    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<&[u8]>, Self::Error>;
+    fn read(&self, handle: Self::Handle, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
 }
 
 /// A transaction with the capability to write to a given [`Handle`](Transaction::Handle).

--- a/execution_engine/src/storage/trie/tests.rs
+++ b/execution_engine/src/storage/trie/tests.rs
@@ -49,6 +49,7 @@ mod pointer_block {
 mod proptests {
     use proptest::prelude::*;
 
+    use casper_hashing::Digest;
     use casper_types::{bytesrepr, gens::key_arb, Key, StoredValue};
 
     use crate::storage::trie::{gens::*, PointerBlock, Trie};
@@ -157,6 +158,30 @@ mod proptests {
              let json_str = serde_json::to_string(&key)?;
              let deserialized_key = serde_json::from_str(&json_str)?;
              assert_eq!(key, deserialized_key)
+        }
+
+        #[test]
+        fn iter_descendants_trie_leaf(trie_leaf in trie_leaf_arb()) {
+            assert!(trie_leaf.iter_descendants().next().is_none());
+        }
+
+        #[test]
+        fn iter_descendants_trie_extension(trie_extension in trie_extension_arb()) {
+            let children = if let Trie::Extension { pointer, .. } = trie_extension {
+                vec![*pointer.hash()]
+            } else {
+                unreachable!()
+            };
+            assert_eq!(children, trie_extension.iter_descendants().collect::<Vec<Digest>>());
+        }
+
+        #[test]
+        fn iter_descendants_trie_node(trie_node in trie_node_arb()) {
+            let children: Vec<Digest> = trie_node.as_pointer_block().unwrap()
+                    .as_indexed_pointers()
+                    .map(|(_index, ptr)| *ptr.hash())
+                    .collect();
+            assert_eq!(children, trie_node.iter_descendants().collect::<Vec<Digest>>());
         }
     }
 }

--- a/execution_engine/src/storage/trie_store/lmdb.rs
+++ b/execution_engine/src/storage/trie_store/lmdb.rs
@@ -103,15 +103,21 @@
 //!
 //! tmp_dir.close().unwrap();
 //! ```
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
-use lmdb::{Database, DatabaseFlags};
+use casper_types::{bytesrepr, Key, StoredValue};
+use lmdb::{Database, DatabaseFlags, Transaction};
 
 use casper_hashing::Digest;
 
 use crate::storage::{
     error,
+    global_state::CommitError,
     store::Store,
-    transaction_source::lmdb::LmdbEnvironment,
+    transaction_source::{lmdb::LmdbEnvironment, Readable, TransactionSource, Writable},
     trie::Trie,
     trie_store::{self, TrieStore},
 };
@@ -148,6 +154,11 @@ impl LmdbTrieStore {
             .map(|name| format!("{}-{}", trie_store::NAME, name))
             .unwrap_or_else(|| String::from(trie_store::NAME))
     }
+
+    /// Get a handle to the underlying database.
+    pub fn get_db(&self) -> Database {
+        self.db
+    }
 }
 
 impl<K, V> Store<Digest, Trie<K, V>> for LmdbTrieStore {
@@ -161,3 +172,135 @@ impl<K, V> Store<Digest, Trie<K, V>> for LmdbTrieStore {
 }
 
 impl<K, V> TrieStore<K, V> for LmdbTrieStore {}
+
+/// Cache used by the scratch trie.  The keys represent the hash of the trie being cached.  The
+/// values represent:  1) A boolean, where `false` means the trie was _not_ written and `true` means
+/// it was 2) A deserialized trie
+pub(crate) type Cache = Arc<Mutex<HashMap<Digest, (bool, Trie<Key, StoredValue>)>>>;
+
+/// Cached version of the trie store.
+#[derive(Clone)]
+pub(crate) struct ScratchTrieStore {
+    pub(crate) cache: Cache,
+    pub(crate) store: Arc<LmdbTrieStore>,
+    pub(crate) env: Arc<LmdbEnvironment>,
+}
+
+impl ScratchTrieStore {
+    /// Creates a new ScratchTrieStore.
+    pub fn new(store: Arc<LmdbTrieStore>, env: Arc<LmdbEnvironment>) -> Self {
+        Self {
+            store,
+            env,
+            cache: Default::default(),
+        }
+    }
+
+    /// Writes only tries which are both under the given `state_root` and dirty to the underlying db
+    /// while maintaining the invariant that children must be written before parent nodes.
+    pub fn write_root_to_db(self, state_root: Digest) -> Result<(), error::Error> {
+        let env = self.env;
+        let store = self.store;
+        let cache = &mut *self.cache.lock().map_err(|_| error::Error::Poison)?;
+
+        let (is_root_dirty, root_trie) = cache
+            .get(&state_root)
+            .ok_or(CommitError::TrieNotFoundInCache(state_root))?;
+
+        // Early exit if there is no work to do.
+        if !is_root_dirty {
+            return Ok(());
+        }
+
+        let mut txn = env.create_read_write_txn()?;
+        let mut tries_to_visit = vec![(state_root, root_trie, root_trie.iter_descendants())];
+
+        while let Some((digest, current_trie, mut descendants_iterator)) = tries_to_visit.pop() {
+            if let Some(descendant) = descendants_iterator.next() {
+                tries_to_visit.push((digest, current_trie, descendants_iterator));
+                // Only if a node is marked as dirty in the cache do we want to visit it's
+                // descendants
+                if let Some((true, child_trie)) = cache.get(&descendant) {
+                    tries_to_visit.push((descendant, child_trie, child_trie.iter_descendants()));
+                }
+            } else {
+                // We can write this node since it has no children, or they were already written.
+                store.put(&mut txn, &digest, current_trie)?;
+            }
+        }
+
+        txn.commit()?;
+        Ok(())
+    }
+}
+
+impl Store<Digest, Trie<Key, StoredValue>> for ScratchTrieStore {
+    type Error = error::Error;
+
+    type Handle = ScratchTrieStore;
+
+    fn handle(&self) -> Self::Handle {
+        self.clone()
+    }
+
+    /// Puts a `value` into the store at `key` within a transaction, potentially returning an
+    /// error of type `Self::Error` if that fails.
+    fn put<T>(
+        &self,
+        _txn: &mut T,
+        digest: &Digest,
+        trie: &Trie<Key, StoredValue>,
+    ) -> Result<(), Self::Error>
+    where
+        T: Writable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        self.cache
+            .lock()
+            .map_err(|_| error::Error::Poison)?
+            .insert(*digest, (true, trie.clone()));
+        Ok(())
+    }
+
+    /// Returns an optional value (may exist or not) as read through a transaction, or an error
+    /// of the associated `Self::Error` variety.
+    fn get<T>(
+        &self,
+        txn: &T,
+        digest: &Digest,
+    ) -> Result<Option<Trie<Key, StoredValue>>, Self::Error>
+    where
+        T: Readable<Handle = Self::Handle>,
+        Self::Error: From<T::Error>,
+    {
+        let maybe_trie = {
+            self.cache
+                .lock()
+                .map_err(|_| error::Error::Poison)?
+                .get(digest)
+                .cloned()
+        };
+        match maybe_trie {
+            Some((_, cached)) => Ok(Some(cached)),
+            None => {
+                let raw = self.get_raw(txn, digest)?;
+                match raw {
+                    Some(bytes) => {
+                        let value: Trie<Key, StoredValue> = bytesrepr::deserialize(bytes.into())?;
+                        {
+                            let store =
+                                &mut *self.cache.lock().map_err(|_| error::Error::Poison)?;
+                            if !store.contains_key(digest) {
+                                store.insert(*digest, (false, value.clone()));
+                            }
+                        }
+                        Ok(Some(value))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
+    }
+}
+
+impl TrieStore<Key, StoredValue> for ScratchTrieStore {}

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -14,12 +14,14 @@ license = "Apache-2.0"
 casper-execution-engine = { version = "1.5.0", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
+filesize = "0.2.0"
 lmdb = "0.8.0"
 log = "0.4.14"
 num-rational = "0.4.0"
 num-traits = "0.2.14"
 once_cell = "1.8.0"
 rand = "0.8.4"
+tempfile = "3"
 
 [dev-dependencies]
 version-sync = "0.9.3"

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -1,0 +1,402 @@
+use std::{collections::HashSet, convert::TryFrom, io::Write, time::Instant};
+
+use lmdb::{Cursor, Transaction};
+use tempfile::TempDir;
+
+use casper_execution_engine::{
+    core::{
+        engine_state::{
+            self, genesis::GenesisValidator, run_genesis_request::RunGenesisRequest,
+            ChainspecRegistry, EngineState, ExecConfig, ExecuteRequest, GenesisAccount, RewardItem,
+        },
+        execution,
+    },
+    shared::newtypes::CorrelationId,
+    storage::{
+        global_state::{CommitProvider, StateProvider},
+        trie::{Pointer, Trie, TrieOrChunk, TrieOrChunkId},
+    },
+};
+use casper_hashing::Digest;
+use casper_types::{
+    account::AccountHash, bytesrepr, runtime_args, system::auction, Key, Motes, ProtocolVersion,
+    PublicKey, RuntimeArgs, SecretKey, StoredValue, U512,
+};
+
+use rand::Rng;
+
+use crate::{
+    transfer, DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, StepRequestBuilder,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
+    DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROPOSER_PUBLIC_KEY, DEFAULT_PROTOCOL_VERSION,
+    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
+    DEFAULT_WASM_CONFIG, SYSTEM_ADDR,
+};
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_TARGET: &str = "target";
+const ARG_ID: &str = "id";
+
+const DELEGATION_RATE: u8 = 1;
+const ID_NONE: Option<u64> = None;
+
+/// Initial balance for delegators in our test.
+pub const DELEGATOR_INITIAL_BALANCE: u64 = 500 * 1_000_000_000u64;
+
+const VALIDATOR_BID_AMOUNT: u64 = 100;
+
+/// Amount of time to step foward between runs of the auction in our tests.
+pub const TIMESTAMP_INCREMENT_MILLIS: u64 = 30_000;
+
+const TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE: u64 = 1_000_000 * 1_000_000_000;
+
+/// Run a block with transfers and optionally run step.
+#[allow(clippy::too_many_arguments)]
+pub fn run_blocks_with_transfers_and_step(
+    transfer_count: usize,
+    purse_count: usize,
+    use_scratch: bool,
+    run_auction: bool,
+    block_count: usize,
+    delegator_count: usize,
+    validator_count: usize,
+    mut report_writer: impl Write,
+) {
+    let data_dir = TempDir::new().expect("should create temp dir");
+    let mut builder = LmdbWasmTestBuilder::new(data_dir.as_ref());
+    let delegator_keys = generate_public_keys(delegator_count);
+    let validator_keys = generate_public_keys(validator_count);
+    let mut necessary_tries = HashSet::new();
+
+    run_genesis_and_create_initial_accounts(
+        &mut builder,
+        &validator_keys,
+        delegator_keys
+            .iter()
+            .map(|pk| pk.to_account_hash())
+            .collect::<Vec<_>>(),
+        U512::from(TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE),
+    );
+    let contract_hash = builder.get_auction_contract_hash();
+    let mut next_validator_iter = validator_keys.iter().cycle();
+
+    for delegator_public_key in delegator_keys {
+        let delegation_amount = U512::from(2000 * 1_000_000_000u64);
+        let delegator_account_hash = delegator_public_key.to_account_hash();
+        let next_validator_key = next_validator_iter
+            .next()
+            .expect("should produce values forever");
+        let delegate = create_delegate_request(
+            delegator_public_key,
+            next_validator_key.clone(),
+            delegation_amount,
+            delegator_account_hash,
+            contract_hash,
+        );
+        builder.exec(delegate);
+        builder.expect_success();
+        builder.commit();
+        builder.clear_results();
+    }
+
+    let purse_amount = U512::from(1_000_000_000u64);
+
+    let purses = transfer::create_test_purses(
+        &mut builder,
+        *DEFAULT_ACCOUNT_ADDR,
+        purse_count as u64,
+        purse_amount,
+    );
+
+    let exec_requests = transfer::create_multiple_native_transfers_to_purses(
+        *DEFAULT_ACCOUNT_ADDR,
+        transfer_count,
+        &purses,
+    );
+
+    let mut total_transfers = 0;
+    {
+        let engine_state = builder.get_engine_state();
+        let lmdb_env = engine_state.get_state().environment().env();
+        let db = engine_state.get_state().trie_store().get_db();
+
+        let txn = lmdb_env.begin_ro_txn().unwrap();
+        let mut cursor = txn.open_ro_cursor(db).unwrap();
+
+        let existing_keys = cursor
+            .iter()
+            .map(|(key, _)| Digest::try_from(&*key).expect("should be a digest"));
+        necessary_tries.extend(existing_keys);
+    }
+    writeln!(
+        report_writer,
+        "height,db-size,transfers,time_ms,necessary_tries,total_tries"
+    )
+    .unwrap();
+    // simulating a block boundary here.
+    for current_block in 0..block_count {
+        let start = Instant::now();
+        total_transfers += exec_requests.len();
+
+        transfer::transfer_to_account_multiple_native_transfers(
+            &mut builder,
+            &exec_requests,
+            use_scratch,
+        );
+        let transfer_root = builder.get_post_state_hash();
+        let maybe_auction_root = if run_auction {
+            if use_scratch {
+                step_and_run_auction(&mut builder, &validator_keys);
+            } else {
+                builder.advance_era(
+                    validator_keys
+                        .iter()
+                        .cloned()
+                        .map(|id| RewardItem::new(id, 1)),
+                );
+                builder.commit();
+            }
+            Some(builder.get_post_state_hash())
+        } else {
+            None
+        };
+        let exec_time = start.elapsed();
+        find_necessary_tries(
+            builder.get_engine_state(),
+            &mut necessary_tries,
+            transfer_root,
+        );
+
+        if let Some(auction_root) = maybe_auction_root {
+            find_necessary_tries(
+                builder.get_engine_state(),
+                &mut necessary_tries,
+                auction_root,
+            );
+        }
+
+        let total_tries = {
+            let engine_state = builder.get_engine_state();
+            let lmdb_env = engine_state.get_state().environment().env();
+            let db = engine_state.get_state().trie_store().get_db();
+            let txn = lmdb_env.begin_ro_txn().unwrap();
+            let mut cursor = txn.open_ro_cursor(db).unwrap();
+            cursor.iter().count()
+        };
+
+        if use_scratch {
+            // This assertion is only valid with the scratch trie.
+            assert_eq!(
+                necessary_tries.len(),
+                total_tries,
+                "should not create unnecessary tries"
+            );
+        }
+
+        writeln!(
+            report_writer,
+            "{},{},{},{},{},{}",
+            current_block,
+            builder.lmdb_on_disk_size().unwrap(),
+            total_transfers,
+            exec_time.as_millis() as usize,
+            necessary_tries.len(),
+            total_tries,
+        )
+        .unwrap();
+        report_writer.flush().unwrap();
+    }
+}
+
+// find all necessary tries - hoist to FN
+fn find_necessary_tries<S>(
+    engine_state: &EngineState<S>,
+    necessary_tries: &mut HashSet<Digest>,
+    state_root: Digest,
+) where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+    engine_state::Error: From<S::Error>,
+{
+    let mut queue = Vec::new();
+    queue.push(state_root);
+
+    while let Some(root) = queue.pop() {
+        if necessary_tries.contains(&root) {
+            continue;
+        }
+        necessary_tries.insert(root);
+
+        let trie_or_chunk: TrieOrChunk = engine_state
+            .get_trie(CorrelationId::new(), TrieOrChunkId(0, root))
+            .unwrap()
+            .expect("trie should exist");
+
+        let trie_bytes = match trie_or_chunk {
+            TrieOrChunk::Trie(trie) => trie,
+            TrieOrChunk::ChunkWithProof(_) => continue,
+        };
+
+        if let Some(0) = trie_bytes.get(0) {
+            continue;
+        }
+
+        let trie: Trie<Key, StoredValue> =
+            bytesrepr::deserialize(trie_bytes.inner_bytes().to_owned())
+                .expect("unable to deserialize");
+
+        match trie {
+            Trie::Leaf { .. } => continue,
+            Trie::Node { pointer_block } => queue.extend(pointer_block.as_indexed_pointers().map(
+                |(_idx, ptr)| match ptr {
+                    Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => digest,
+                },
+            )),
+            Trie::Extension { affix: _, pointer } => match pointer {
+                Pointer::LeafPointer(digest) | Pointer::NodePointer(digest) => queue.push(digest),
+            },
+        }
+    }
+}
+
+/// Runs genesis, creates system, validator and delegator accounts, and funds the system account and
+/// delegator accounts.
+pub fn run_genesis_and_create_initial_accounts(
+    builder: &mut LmdbWasmTestBuilder,
+    validator_keys: &[PublicKey],
+    delegator_accounts: Vec<AccountHash>,
+    delegator_initial_balance: U512,
+) {
+    let mut genesis_accounts = vec![
+        GenesisAccount::account(
+            DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
+            Motes::new(U512::from(u128::MAX)),
+            None,
+        ),
+        GenesisAccount::account(
+            DEFAULT_PROPOSER_PUBLIC_KEY.clone(),
+            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+            None,
+        ),
+    ];
+    for validator in validator_keys {
+        genesis_accounts.push(GenesisAccount::account(
+            validator.clone(),
+            Motes::new(U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE)),
+            Some(GenesisValidator::new(
+                Motes::new(U512::from(VALIDATOR_BID_AMOUNT)),
+                DELEGATION_RATE,
+            )),
+        ))
+    }
+    let run_genesis_request =
+        create_run_genesis_request(validator_keys.len() as u32 + 2, genesis_accounts);
+    builder.run_genesis(&run_genesis_request);
+
+    // Setup the system account with enough cspr
+    let transfer = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+                ARG_TARGET => *SYSTEM_ADDR,
+                ARG_AMOUNT => U512::from(10_000 * 1_000_000_000u64),
+                ARG_ID => ID_NONE,
+        },
+    )
+    .build();
+    builder.exec(transfer);
+    builder.expect_success().commit();
+
+    for (_i, delegator_account) in delegator_accounts.iter().enumerate() {
+        let transfer = ExecuteRequestBuilder::transfer(
+            *DEFAULT_ACCOUNT_ADDR,
+            runtime_args! {
+                    ARG_TARGET => *delegator_account,
+                    ARG_AMOUNT => delegator_initial_balance,
+                    ARG_ID => ID_NONE,
+            },
+        )
+        .build();
+        builder.exec(transfer);
+        builder.expect_success().commit();
+    }
+}
+
+fn create_run_genesis_request(
+    validator_slots: u32,
+    genesis_accounts: Vec<GenesisAccount>,
+) -> RunGenesisRequest {
+    let exec_config = {
+        ExecConfig::new(
+            genesis_accounts,
+            *DEFAULT_WASM_CONFIG,
+            *DEFAULT_SYSTEM_CONFIG,
+            validator_slots,
+            DEFAULT_AUCTION_DELAY,
+            DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+            DEFAULT_ROUND_SEIGNIORAGE_RATE,
+            DEFAULT_UNBONDING_DELAY,
+            DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+        )
+    };
+    RunGenesisRequest::new(
+        *DEFAULT_GENESIS_CONFIG_HASH,
+        *DEFAULT_PROTOCOL_VERSION,
+        exec_config,
+        ChainspecRegistry::new_with_genesis(&[], &[]),
+    )
+}
+
+/// Creates a delegation request.
+pub fn create_delegate_request(
+    delegator_public_key: PublicKey,
+    next_validator_key: PublicKey,
+    delegation_amount: U512,
+    delegator_account_hash: AccountHash,
+    contract_hash: casper_types::ContractHash,
+) -> ExecuteRequest {
+    let entry_point = auction::METHOD_DELEGATE;
+    let args = runtime_args! {
+        auction::ARG_DELEGATOR => delegator_public_key,
+        auction::ARG_VALIDATOR => next_validator_key,
+        auction::ARG_AMOUNT => delegation_amount,
+    };
+    let mut rng = rand::thread_rng();
+    let deploy_hash = rng.gen();
+    let deploy = DeployItemBuilder::new()
+        .with_address(delegator_account_hash)
+        .with_stored_session_hash(contract_hash, entry_point, args)
+        .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(100_000_000), })
+        .with_authorization_keys(&[delegator_account_hash])
+        .with_deploy_hash(deploy_hash)
+        .build();
+    ExecuteRequestBuilder::new().push_deploy(deploy).build()
+}
+
+/// Generate `key_count` public keys.
+pub fn generate_public_keys(key_count: usize) -> Vec<PublicKey> {
+    let mut ret = Vec::with_capacity(key_count);
+    for _ in 0..key_count {
+        let bytes: [u8; SecretKey::ED25519_LENGTH] = rand::random();
+        let secret_key = SecretKey::ed25519_from_bytes(&bytes).unwrap();
+        let public_key = PublicKey::from(&secret_key);
+        ret.push(public_key);
+    }
+    ret
+}
+
+/// Build a step request and run the auction.
+pub fn step_and_run_auction(builder: &mut LmdbWasmTestBuilder, validator_keys: &[PublicKey]) {
+    let mut step_request_builder = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0);
+    for validator in validator_keys {
+        step_request_builder =
+            step_request_builder.with_reward_item(RewardItem::new(validator.clone(), 1));
+    }
+    let step_request = step_request_builder
+        .with_next_era_id(builder.get_era().successor())
+        .build();
+    builder.step_with_scratch(step_request);
+    builder.write_scratch_to_lmdb();
+}

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -146,17 +146,8 @@ pub fn run_blocks_with_transfers_and_step(
         );
         let transfer_root = builder.get_post_state_hash();
         let maybe_auction_root = if run_auction {
-            if use_scratch {
-                step_and_run_auction(&mut builder, &validator_keys);
-            } else {
-                builder.advance_era(
-                    validator_keys
-                        .iter()
-                        .cloned()
-                        .map(|id| RewardItem::new(id, 1)),
-                );
-                builder.commit();
-            }
+            step_and_run_auction(&mut builder, &validator_keys);
+            builder.commit();
             Some(builder.get_post_state_hash())
         } else {
             None

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -8,9 +8,13 @@
 )]
 #![warn(missing_docs)]
 mod additive_map_diff;
+/// Utility methods for running the auction in a test or bench context.
+pub mod auction;
 mod deploy_item_builder;
 mod execute_request_builder;
 mod step_request_builder;
+/// Utilities for running transfers in a test or bench context.
+pub mod transfer;
 mod upgrade_request_builder;
 pub mod utils;
 mod wasm_test_builder;

--- a/execution_engine_testing/test_support/src/transfer.rs
+++ b/execution_engine_testing/test_support/src/transfer.rs
@@ -1,0 +1,287 @@
+use casper_execution_engine::core::engine_state::ExecuteRequest;
+use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U512};
+
+use crate::{
+    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+};
+
+const CONTRACT_CREATE_ACCOUNTS: &str = "create_accounts.wasm";
+const CONTRACT_CREATE_PURSES: &str = "create_purses.wasm";
+const CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT: &str = "transfer_to_existing_account.wasm";
+const CONTRACT_TRANSFER_TO_PURSE: &str = "transfer_to_purse.wasm";
+
+/// Size of batch used in multiple execs benchmark, and multiple deploys per exec cases.
+pub const TRANSFER_BATCH_SIZE: u64 = 3;
+
+/// Test target address.
+pub const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_ID: &str = "id";
+const ARG_ACCOUNTS: &str = "accounts";
+const ARG_SEED_AMOUNT: &str = "seed_amount";
+const ARG_TOTAL_PURSES: &str = "total_purses";
+const ARG_TARGET: &str = "target";
+const ARG_TARGET_PURSE: &str = "target_purse";
+
+/// Test value for number of deploys to generate for a block.
+pub const BLOCK_TRANSFER_COUNT: usize = 2500;
+
+/// Converts an integer into an array of type [u8; 32] by converting integer
+/// into its big endian representation and embedding it at the end of the
+/// range.
+fn make_deploy_hash(i: u64) -> [u8; 32] {
+    let mut result = [128; 32];
+    result[32 - 8..].copy_from_slice(&i.to_be_bytes());
+    result
+}
+
+/// Create initial accounts and run genesis.
+pub fn create_initial_accounts_and_run_genesis(
+    builder: &mut LmdbWasmTestBuilder,
+    accounts: Vec<AccountHash>,
+    amount: U512,
+) {
+    let exec_request = create_accounts_request(accounts, amount);
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(exec_request)
+        .expect_success()
+        .commit();
+}
+
+/// Creates a request that will call the create_accounts.wasm and create test accounts using the
+/// default account for the initial transfer.
+pub fn create_accounts_request(source_accounts: Vec<AccountHash>, amount: U512) -> ExecuteRequest {
+    ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_CREATE_ACCOUNTS,
+        runtime_args! { ARG_ACCOUNTS => source_accounts, ARG_SEED_AMOUNT => amount },
+    )
+    .build()
+}
+
+/// Create a number of test purses with an initial balance.
+pub fn create_test_purses(
+    builder: &mut LmdbWasmTestBuilder,
+    source: AccountHash,
+    total_purses: u64,
+    purse_amount: U512,
+) -> Vec<URef> {
+    let exec_request = ExecuteRequestBuilder::standard(
+        source,
+        CONTRACT_CREATE_PURSES,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(total_purses) * purse_amount,
+            ARG_TOTAL_PURSES => total_purses,
+            ARG_SEED_AMOUNT => purse_amount
+        },
+    )
+    .build();
+
+    builder.exec(exec_request).expect_success().commit();
+
+    // Return creates purses for given account by filtering named keys
+    let query_result = builder
+        .query(None, Key::Account(source), &[])
+        .expect("should query target");
+    let account = query_result
+        .as_account()
+        .unwrap_or_else(|| panic!("result should be account but received {:?}", query_result));
+
+    (0..total_purses)
+        .map(|index| {
+            let purse_lookup_key = format!("purse:{}", index);
+            let purse_uref = account
+                .named_keys()
+                .get(&purse_lookup_key)
+                .and_then(Key::as_uref)
+                .unwrap_or_else(|| panic!("should get named key {} as uref", purse_lookup_key));
+            *purse_uref
+        })
+        .collect()
+}
+
+/// Uses multiple exec requests with a single deploy to transfer tokens. Executes all transfers in
+/// batch determined by value of TRANSFER_BATCH_SIZE.
+pub fn transfer_to_account_multiple_execs(
+    builder: &mut LmdbWasmTestBuilder,
+    account: AccountHash,
+    should_commit: bool,
+) {
+    let amount = U512::one();
+
+    for _ in 0..TRANSFER_BATCH_SIZE {
+        let exec_request = ExecuteRequestBuilder::standard(
+            *DEFAULT_ACCOUNT_ADDR,
+            CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
+            runtime_args! {
+                ARG_TARGET => account,
+                ARG_AMOUNT => amount,
+            },
+        )
+        .build();
+
+        let builder = builder.exec(exec_request).expect_success();
+        if should_commit {
+            builder.commit();
+        }
+    }
+}
+
+/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
+pub fn transfer_to_account_multiple_deploys(
+    builder: &mut LmdbWasmTestBuilder,
+    account: AccountHash,
+    should_commit: bool,
+) {
+    let mut exec_builder = ExecuteRequestBuilder::new();
+
+    for i in 0..TRANSFER_BATCH_SIZE {
+        let deploy = DeployItemBuilder::default()
+            .with_address(*DEFAULT_ACCOUNT_ADDR)
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT })
+            .with_session_code(
+                CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
+                runtime_args! {
+                    ARG_TARGET => account,
+                    ARG_AMOUNT => U512::one(),
+                },
+            )
+            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
+            .build();
+        exec_builder = exec_builder.push_deploy(deploy);
+    }
+
+    let exec_request = exec_builder.build();
+
+    let builder = builder.exec(exec_request).expect_success();
+    if should_commit {
+        builder.commit();
+    }
+}
+
+/// Uses multiple exec requests with a single deploy to transfer tokens from purse to purse.
+/// Executes all transfers in batch determined by value of TRANSFER_BATCH_SIZE.
+pub fn transfer_to_purse_multiple_execs(
+    builder: &mut LmdbWasmTestBuilder,
+    purse: URef,
+    should_commit: bool,
+) {
+    let amount = U512::one();
+
+    for _ in 0..TRANSFER_BATCH_SIZE {
+        let exec_request = ExecuteRequestBuilder::standard(
+            TARGET_ADDR,
+            CONTRACT_TRANSFER_TO_PURSE,
+            runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => amount },
+        )
+        .build();
+
+        let builder = builder.exec(exec_request).expect_success();
+        if should_commit {
+            builder.commit();
+        }
+    }
+}
+
+/// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
+pub fn transfer_to_purse_multiple_deploys(
+    builder: &mut LmdbWasmTestBuilder,
+    purse: URef,
+    should_commit: bool,
+) {
+    let mut exec_builder = ExecuteRequestBuilder::new();
+
+    for i in 0..TRANSFER_BATCH_SIZE {
+        let deploy = DeployItemBuilder::default()
+            .with_address(TARGET_ADDR)
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT, })
+            .with_session_code(
+                CONTRACT_TRANSFER_TO_PURSE,
+                runtime_args! { ARG_TARGET_PURSE => purse, ARG_AMOUNT => U512::one() },
+            )
+            .with_authorization_keys(&[TARGET_ADDR])
+            .with_deploy_hash(make_deploy_hash(i)) // deploy_hash
+            .build();
+        exec_builder = exec_builder.push_deploy(deploy);
+    }
+
+    let exec_request = exec_builder.build();
+
+    let builder = builder.exec(exec_request).expect_success();
+    if should_commit {
+        builder.commit();
+    }
+}
+
+/// This test simulates flushing at the end of a block.
+pub fn transfer_to_account_multiple_native_transfers(
+    builder: &mut LmdbWasmTestBuilder,
+    execute_requests: &[ExecuteRequest],
+    use_scratch: bool,
+) {
+    for exec_request in execute_requests {
+        let request = ExecuteRequest::new(
+            exec_request.parent_state_hash,
+            exec_request.block_time,
+            exec_request.deploys.clone(),
+            exec_request.protocol_version,
+            exec_request.proposer.clone(),
+        );
+        if use_scratch {
+            builder.scratch_exec_and_commit(request).expect_success();
+        } else {
+            builder.exec(request).expect_success();
+            builder.commit();
+        }
+    }
+    if use_scratch {
+        builder.write_scratch_to_lmdb();
+    }
+    // flush to disk only after entire block (simulates manual_sync_enabled=true config entry)
+    builder.flush_environment();
+
+    // WasmTestBuilder holds on to all execution results. This needs to be cleared to reduce
+    // overhead in this test - it will likely OOM without.
+    builder.clear_results();
+}
+
+/// Generate many native transfers from target_account.
+pub fn create_multiple_native_transfers_to_purses(
+    source_account: AccountHash,
+    transfer_count: usize,
+    purses: &[URef],
+) -> Vec<ExecuteRequest> {
+    let mut purse_index = 0usize;
+    let mut exec_requests = Vec::with_capacity(transfer_count);
+    for _ in 0..transfer_count {
+        let account = {
+            let account = purses[purse_index];
+            if purse_index == purses.len() - 1 {
+                purse_index = 0;
+            } else {
+                purse_index += 1;
+            }
+            account
+        };
+        let mut exec_builder = ExecuteRequestBuilder::new();
+        let runtime_args = runtime_args! {
+            ARG_TARGET => account,
+            ARG_AMOUNT => U512::one(),
+            ARG_ID => <Option<u64>>::None
+        };
+        let native_transfer = DeployItemBuilder::new()
+            .with_address(source_account)
+            .with_empty_payment_bytes(runtime_args! {})
+            .with_transfer_args(runtime_args)
+            .with_authorization_keys(&[source_account])
+            .build();
+        exec_builder = exec_builder.push_deploy(native_transfer);
+        let exec_request = exec_builder.build();
+        exec_requests.push(exec_request);
+    }
+    exec_requests
+}

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -9,6 +9,7 @@ use std::{
     sync::Arc,
 };
 
+use filesize::PathExt;
 use lmdb::DatabaseFlags;
 use log::LevelFilter;
 
@@ -106,6 +107,8 @@ pub struct WasmTestBuilder<S> {
     scratch_engine_state: Option<EngineState<ScratchGlobalState>>,
     /// System contract registry
     system_contract_registry: Option<SystemContractRegistry>,
+    /// Global state dir, for implementations that define one.
+    global_state_dir: Option<PathBuf>,
 }
 
 impl<S> WasmTestBuilder<S> {
@@ -134,6 +137,7 @@ impl Default for InMemoryWasmTestBuilder {
             genesis_transforms: None,
             scratch_engine_state: None,
             system_contract_registry: None,
+            global_state_dir: None,
         }
     }
 }
@@ -153,6 +157,7 @@ impl<S> Clone for WasmTestBuilder<S> {
             genesis_transforms: self.genesis_transforms.clone(),
             scratch_engine_state: None,
             system_contract_registry: self.system_contract_registry.clone(),
+            global_state_dir: self.global_state_dir.clone(),
         }
     }
 }
@@ -213,6 +218,7 @@ impl LmdbWasmTestBuilder {
             genesis_transforms: None,
             scratch_engine_state: None,
             system_contract_registry: None,
+            global_state_dir: Some(global_state_dir),
         }
     }
 
@@ -275,6 +281,7 @@ impl LmdbWasmTestBuilder {
             genesis_transforms: None,
             scratch_engine_state: None,
             system_contract_registry: None,
+            global_state_dir: Some(global_state_dir.as_ref().to_path_buf()),
         }
     }
 
@@ -293,8 +300,18 @@ impl LmdbWasmTestBuilder {
         path
     }
 
+    /// Returns the file size on disk of the backing lmdb file behind DbGlobalState.
+    pub fn lmdb_on_disk_size(&self) -> Option<u64> {
+        if let Some(path) = self.global_state_dir.as_ref() {
+            let mut path = path.clone();
+            path.push("data.lmdb");
+            return path.as_path().size_on_disk().ok();
+        }
+        None
+    }
+
     /// Execute and commit transforms from an ExecuteRequest into a scratch global state.
-    /// You MUST call scratch_flush to flush these changes to LmdbGlobalState.
+    /// You MUST call write_scratch_to_lmdb to flush these changes to LmdbGlobalState.
     pub fn scratch_exec_and_commit(&mut self, mut exec_request: ExecuteRequest) -> &mut Self {
         if self.scratch_engine_state.is_none() {
             self.scratch_engine_state = Some(self.engine_state.get_scratch_engine_state());
@@ -338,12 +355,29 @@ impl LmdbWasmTestBuilder {
     pub fn write_scratch_to_lmdb(&mut self) -> &mut Self {
         let prestate_hash = self.post_state_hash.expect("Should have genesis hash");
         if let Some(scratch) = self.scratch_engine_state.take() {
-            self.post_state_hash = Some(
-                self.engine_state
-                    .write_scratch_to_lmdb(prestate_hash, scratch.into_inner())
-                    .unwrap(),
-            );
+            let new_state_root = self
+                .engine_state
+                .write_scratch_to_lmdb(prestate_hash, scratch.into_inner())
+                .unwrap();
+            self.post_state_hash = Some(new_state_root);
         }
+        self
+    }
+
+    /// run step against scratch global state.
+    pub fn step_with_scratch(&mut self, step_request: StepRequest) -> &mut Self {
+        if self.scratch_engine_state.is_none() {
+            self.scratch_engine_state = Some(self.engine_state.get_scratch_engine_state());
+        }
+
+        let cached_state = self
+            .scratch_engine_state
+            .as_ref()
+            .expect("scratch state should exist");
+
+        cached_state
+            .commit_step(CorrelationId::new(), step_request)
+            .expect("unable to run step request against scratch global state");
         self
     }
 }

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -52,6 +52,10 @@ name = "auction_bench"
 harness = false
 
 [[bin]]
+name = "disk_use"
+path = "bin/disk_use.rs"
+
+[[bin]]
 name = "state-initializer"
 path = "src/profiling/state_initializer.rs"
 test = false

--- a/execution_engine_testing/tests/bin/README.md
+++ b/execution_engine_testing/tests/bin/README.md
@@ -1,0 +1,15 @@
+# `disk_use` binary
+
+A binary that will construct global state and profile the disk use of various operations. It's recommended to run this tool in `--release` mode.
+
+The outcome is a report, `disk_use_report.csv`. This contains time-series data with the following columns, with one line per block:
+
+- `height` - height of the simulated chain.
+- `db-size` - size on disk of the backing trie database. 
+- `transfers` - total number of transfers run.
+- `time_ms` - time in milliseconds for a given block to run.
+- `necessary_tries` - calculated value for the number of tries we expect to find in the trie database.
+- `total_tries` - found total number of tries in the backing trie database.
+
+This report can be used to get a relatively quick view into disk and time cost of running transfers and auction processes.
+

--- a/execution_engine_testing/tests/bin/disk_use.rs
+++ b/execution_engine_testing/tests/bin/disk_use.rs
@@ -1,0 +1,24 @@
+use std::{fs::File, io::BufWriter};
+
+use casper_engine_test_support::auction::run_blocks_with_transfers_and_step;
+
+fn main() {
+    let purse_count = 100;
+    let total_transfer_count = 100;
+    let transfers_per_block = 1;
+    let block_count = total_transfer_count / transfers_per_block;
+    let delegator_count = 20_000;
+    let validator_count = 100;
+
+    let report_writer = BufWriter::new(File::create("disk_use_report.csv").unwrap());
+    run_blocks_with_transfers_and_step(
+        transfers_per_block,
+        purse_count,
+        true,
+        true,
+        block_count,
+        delegator_count,
+        validator_count,
+        report_writer,
+    );
+}

--- a/execution_engine_testing/tests/src/test/bulk_update_with_scratch_trie.rs
+++ b/execution_engine_testing/tests/src/test/bulk_update_with_scratch_trie.rs
@@ -1,0 +1,26 @@
+use std::{fs::File, io::BufWriter};
+
+use casper_engine_test_support::auction::run_blocks_with_transfers_and_step;
+
+#[ignore]
+#[test]
+fn should_run_transfers_and_auction_producing_expected_number_of_tries_only() {
+    let purse_count = 100;
+    let total_transfer_count = 10;
+    let transfers_per_block = 1;
+    let block_count = total_transfer_count / transfers_per_block;
+    let delegator_count = 100;
+    let validator_count = 10;
+
+    let report_writer = BufWriter::new(File::create("disk_use_report.csv").unwrap());
+    run_blocks_with_transfers_and_step(
+        transfers_per_block,
+        purse_count,
+        true,
+        true,
+        block_count,
+        delegator_count,
+        validator_count,
+        report_writer,
+    );
+}

--- a/execution_engine_testing/tests/src/test/mod.rs
+++ b/execution_engine_testing/tests/src/test/mod.rs
@@ -1,3 +1,4 @@
+mod bulk_update_with_scratch_trie;
 mod chainspec_registry;
 mod check_transfer_success;
 mod contract_api;


### PR DESCRIPTION
This PR ports the ScratchTrie from the dev branch (backed by lmdb only) to `release-1.5.0`.