### PR TITLE
Measure time throttled in networking

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
+* Add metrics `accumulated_outgoing_limiter_delay` and `accumulated_incoming_limiter_delay` to report how much time was spent throttling other peers.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -143,7 +143,7 @@ impl ClassBasedLimiter {
     /// Creates a new class based limiter.
     ///
     /// Starts the background worker task as well. Any time the limiter caused a delay,
-    /// `wait_time_sec` will be increment.
+    /// `wait_time_sec` will be incremented.
     pub(super) fn new(resources_per_second: u32, wait_time_sec: Counter) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
 
@@ -471,11 +471,18 @@ mod tests {
         assert!(diff <= Duration::from_secs(6));
 
         // Ensure metrics recorded the correct number of seconds.
-        println!("wait_metric is {}", wait_metric.get());
-        assert!(wait_metric.get() <= 6.0);
+        assert!(
+            wait_metric.get() <= 6.0,
+            "wait metric is too large: {}",
+            wait_metric.get()
+        );
 
         // Note: The limiting will not apply to all data, so it should be slightly below 5 seconds.
-        assert!(wait_metric.get() >= 4.5);
+        assert!(
+            wait_metric.get() >= 4.5,
+            "wait metric is too small: {}",
+            wait_metric.get()
+        );
     }
 
     #[tokio::test]
@@ -513,7 +520,10 @@ mod tests {
         }
 
         // There should have been no time spent waiting.
-        println!("wait_metric is {}", wait_metric.get());
-        assert!(wait_metric.get() < SHORT_TIME.as_secs_f64());
+        assert!(
+            wait_metric.get() < SHORT_TIME.as_secs_f64(),
+            "wait_metric is too large: {}",
+            wait_metric.get()
+        );
     }
 }

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use casper_types::PublicKey;
+use prometheus::Counter;
 use tokio::{
     sync::{mpsc, oneshot},
     time::Instant,
@@ -141,14 +142,16 @@ struct ConsumerId {
 impl ClassBasedLimiter {
     /// Creates a new class based limiter.
     ///
-    /// Starts the background worker task as well.
-    pub(super) fn new(resources_per_second: u32) -> Self {
+    /// Starts the background worker task as well. Any time the limiter caused a delay,
+    /// `wait_time_sec` will be increment.
+    pub(super) fn new(resources_per_second: u32, wait_time_sec: Counter) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
 
         tokio::spawn(worker(
             receiver,
             resources_per_second,
             ((resources_per_second as f64) * STORED_BUFFER_SECS.as_secs_f64()) as u32,
+            wait_time_sec,
         ));
 
         ClassBasedLimiter { sender }
@@ -234,6 +237,7 @@ async fn worker(
     mut receiver: mpsc::UnboundedReceiver<ClassBasedCommand>,
     resources_per_second: u32,
     max_stored_resource: u32,
+    wait_time_sec: Counter,
 ) {
     let mut active_validators = HashSet::new();
     let mut upcoming_validators = HashSet::new();
@@ -311,6 +315,7 @@ async fn worker(
                                 );
 
                                 tokio::time::sleep(estimated_time_remaining).await;
+                                wait_time_sec.inc_by(estimated_time_remaining.as_secs_f64());
                             }
                         }
 
@@ -336,6 +341,7 @@ async fn worker(
 mod tests {
     use std::{collections::HashSet, time::Duration};
 
+    use prometheus::Counter;
     use tokio::time::Instant;
 
     use super::{ClassBasedLimiter, Limiter, NodeId, PublicKey, Unlimited};
@@ -343,6 +349,12 @@ mod tests {
 
     /// Something that happens almost immediately, with some allowance for test jitter.
     const SHORT_TIME: Duration = Duration::from_millis(250);
+
+    /// Creates a new counter for testing.
+    fn new_wait_time_sec() -> Counter {
+        Counter::new("test_time_waiting", "wait time counter used in tests")
+            .expect("could not create new counter")
+    }
 
     #[tokio::test]
     async fn unlimited_limiter_is_unlimited() {
@@ -366,7 +378,7 @@ mod tests {
         let mut rng = crate::new_rng();
 
         let validator_id = PublicKey::random(&mut rng);
-        let limiter = ClassBasedLimiter::new(1_000);
+        let limiter = ClassBasedLimiter::new(1_000, new_wait_time_sec());
 
         let mut active_validators = HashSet::new();
         active_validators.insert(validator_id.clone());
@@ -388,7 +400,7 @@ mod tests {
         let mut rng = crate::new_rng();
 
         let validator_id = PublicKey::random(&mut rng);
-        let limiter = ClassBasedLimiter::new(1_000);
+        let limiter = ClassBasedLimiter::new(1_000, new_wait_time_sec());
 
         // We insert one unrelated active validator to avoid triggering the automatic disabling of
         // the limiter in case there are no active validators.
@@ -425,7 +437,8 @@ mod tests {
         let mut rng = crate::new_rng();
 
         let validator_id = PublicKey::random(&mut rng);
-        let limiter = ClassBasedLimiter::new(1_000);
+        let wait_metric = new_wait_time_sec();
+        let limiter = ClassBasedLimiter::new(1_000, wait_metric.clone());
 
         let start = Instant::now();
 
@@ -456,6 +469,13 @@ mod tests {
         let diff = end - start;
         assert!(diff >= Duration::from_secs(5));
         assert!(diff <= Duration::from_secs(6));
+
+        // Ensure metrics recorded the correct number of seconds.
+        println!("wait_metric is {}", wait_metric.get());
+        assert!(wait_metric.get() <= 6.0);
+
+        // Note: The limiting will not apply to all data, so it should be slightly below 5 seconds.
+        assert!(wait_metric.get() >= 4.5);
     }
 
     #[tokio::test]
@@ -465,7 +485,8 @@ mod tests {
         let mut rng = crate::new_rng();
 
         let validator_id = PublicKey::random(&mut rng);
-        let limiter = ClassBasedLimiter::new(1_000);
+        let wait_metric = new_wait_time_sec();
+        let limiter = ClassBasedLimiter::new(1_000, wait_metric.clone());
 
         limiter.update_validators(HashSet::new(), HashSet::new());
 
@@ -478,7 +499,7 @@ mod tests {
         for handle in handles {
             let start = Instant::now();
 
-            // Send 9_0001 bytes, we expect this to take roughly 15 seconds.
+            // Send 9_0001 bytes, should now finish instantly.
             handle.request_allowance(1000).await;
             handle.request_allowance(1000).await;
             handle.request_allowance(1000).await;
@@ -490,5 +511,9 @@ mod tests {
             let diff = end - start;
             assert!(diff <= SHORT_TIME);
         }
+
+        // There should have been no time spent waiting.
+        println!("wait_metric is {}", wait_metric.get());
+        assert!(wait_metric.get() < SHORT_TIME.as_secs_f64());
     }
 }

--- a/node/src/components/small_network/metrics.rs
+++ b/node/src/components/small_network/metrics.rs
@@ -194,7 +194,10 @@ impl Metrics {
             "accumulated_outgoing_limiter_delay",
             "seconds spent delaying outgoing traffic to non-validators due to limiter, in seconds",
         )?;
-        let accumulated_incoming_limiter_delay = Counter::new("accumulated_incoming_limiter_delay","seconds spent delaying incoming traffic from non-validators due to limiter, in seconds.")?;
+        let accumulated_incoming_limiter_delay = Counter::new(
+            "accumulated_incoming_limiter_delay",
+            "seconds spent delaying incoming traffic from non-validators due to limiter, in seconds."
+        )?;
 
         registry.register(Box::new(broadcast_requests.clone()))?;
         registry.register(Box::new(direct_message_requests.clone()))?;

--- a/node/src/components/small_network/metrics.rs
+++ b/node/src/components/small_network/metrics.rs
@@ -1,6 +1,6 @@
 use std::sync::Weak;
 
-use prometheus::{IntCounter, IntGauge, Registry};
+use prometheus::{Counter, IntCounter, IntGauge, Registry};
 use tracing::debug;
 
 use super::{outgoing::OutgoingMetrics, MessageKind};
@@ -68,6 +68,11 @@ pub(super) struct Metrics {
     pub(super) out_state_blocked: IntGauge,
     /// Number of outgoing connections in loopback state.
     pub(super) out_state_loopback: IntGauge,
+
+    /// Total time spent delaying outgoing traffic to non-validators due to limiter, in seconds.
+    pub(super) accumulated_outgoing_limiter_delay: Counter,
+    /// Total time spent delaying incoming traffic from non-validators due to limiter, in seconds.
+    pub(super) accumulated_incoming_limiter_delay: Counter,
 
     /// Registry instance.
     registry: Registry,
@@ -185,6 +190,12 @@ impl Metrics {
             "number of connections in the loopback state",
         )?;
 
+        let accumulated_outgoing_limiter_delay = Counter::new(
+            "accumulated_outgoing_limiter_delay",
+            "seconds spent delaying outgoing traffic to non-validators due to limiter, in seconds",
+        )?;
+        let accumulated_incoming_limiter_delay = Counter::new("accumulated_incoming_limiter_delay","seconds spent delaying incoming traffic from non-validators due to limiter, in seconds.")?;
+
         registry.register(Box::new(broadcast_requests.clone()))?;
         registry.register(Box::new(direct_message_requests.clone()))?;
         registry.register(Box::new(open_connections.clone()))?;
@@ -217,6 +228,9 @@ impl Metrics {
         registry.register(Box::new(out_state_blocked.clone()))?;
         registry.register(Box::new(out_state_loopback.clone()))?;
 
+        registry.register(Box::new(accumulated_outgoing_limiter_delay.clone()))?;
+        registry.register(Box::new(accumulated_incoming_limiter_delay.clone()))?;
+
         Ok(Metrics {
             broadcast_requests,
             direct_message_requests,
@@ -246,6 +260,8 @@ impl Metrics {
             out_state_connected,
             out_state_blocked,
             out_state_loopback,
+            accumulated_outgoing_limiter_delay,
+            accumulated_incoming_limiter_delay,
             registry: registry.clone(),
         })
     }
@@ -340,5 +356,8 @@ impl Drop for Metrics {
         unregister_metric!(self.registry, self.out_state_connected);
         unregister_metric!(self.registry, self.out_state_blocked);
         unregister_metric!(self.registry, self.out_state_loopback);
+
+        unregister_metric!(self.registry, self.accumulated_outgoing_limiter_delay);
+        unregister_metric!(self.registry, self.accumulated_incoming_limiter_delay);
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -149,11 +149,11 @@ handshake_timeout = '20sec'
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3
 
-# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0
 
-# The maximum allowed impact of requests from non-validating peers per second answered.
+# The maximum allowed total impact of requests from non-validating peers per second answered.
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -149,11 +149,11 @@ handshake_timeout = '20sec'
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3
 
-# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 6553600
 
-# The maximum allowed impact of requests from non-validating peers per second answered.
+# The maximum allowed total impact of requests from non-validating peers per second answered.
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 3000
 

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -149,11 +149,11 @@ handshake_timeout = '20sec'
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3
 
-# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0
 
-# The maximum allowed impact of requests from non-validating peers per second answered.
+# The maximum allowed total impact of requests from non-validating peers per second answered.
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -152,11 +152,11 @@ handshake_timeout = '20sec'
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3
 
-# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0
 
-# The maximum allowed impact of requests from non-validating peers per second answered.
+# The maximum allowed total impact of requests from non-validating peers per second answered.
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -149,11 +149,11 @@ handshake_timeout = '20sec'
 # connections will be rejected. A value of `0` means unlimited.
 max_incoming_peer_connections = 3
 
-# The maximum amount of upstream bandwidth in bytes per second allocated to non-validating peers.
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0
 
-# The maximum allowed impact of requests from non-validating peers per second answered.
+# The maximum allowed total impact of requests from non-validating peers per second answered.
 # A value of `0` means unlimited.
 max_incoming_message_rate_non_validators = 0
 


### PR DESCRIPTION
Adds a new metric that tracks how much accumulated time was taken throttling overzealous peers.

Closes #2914