### PR TITLE
Decrease queued message count on connection drop

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -55,6 +55,9 @@ All notable changes to this project will be documented in this file.  The format
 * Remove `verify_accounts` option from `config.toml`, meaning deploys received from clients always undergo account balance checks to assess suitability for execution or not.
 * Remove a temporary chainspec setting `max_stored_value_size` to limit the size of individual values stored in global state.
 
+### Fixed
+* Dropped connections no longer cause the outstanding messages metric to become incorrect.
+
 ### Security
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -604,6 +604,13 @@ pub(super) async fn message_sender<P>(
                 err = display_error(err),
                 "message send failed, closing outgoing connection"
             );
+
+            // To ensure, metrics are up to date, we close the queue and drain it.
+            queue.close();
+            while queue.recv().await.is_some() {
+                counter.dec();
+            }
+
             break;
         };
     }


### PR DESCRIPTION
This fixes an issue where losing a connection with queued messages caused the metric not to be updated correctly. We seal the queue and drain it to fix this issue.

Closes #2913 