### PR TITLE
Do not limit validators due to unrelated joiner traffic.

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.  The format
 * Remove `verify_accounts` option from `config.toml`, meaning deploys received from clients always undergo account balance checks to assess suitability for execution or not.
 * Remove a temporary chainspec setting `max_stored_value_size` to limit the size of individual values stored in global state.
 
+### Fixed
+* Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.
+
 ### Security
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -3,16 +3,17 @@
 //! Resource limiters restrict the usable amount of a resource through slowing down the request rate
 //! by making each user request an allowance first.
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use casper_types::PublicKey;
 use prometheus::Counter;
-use tokio::{
-    sync::{mpsc, oneshot},
-    time::Instant,
-};
-use tracing::{debug, info, warn};
+use tokio::sync::Mutex;
+use tracing::{debug, trace};
 
 use crate::types::NodeId;
 
@@ -79,13 +80,63 @@ impl LimiterHandle for UnlimitedHandle {
     }
 }
 
-/// A limiter dividing resources into multiple classes based on their validator status.
+/// A limiter dividing resources into two classes based on their validator status.
 ///
 /// Imposes a limit on non-validator resources while not limiting active validator resources at all.
 #[derive(Debug)]
 pub(super) struct ClassBasedLimiter {
-    /// Sender for commands to the limiter.
-    sender: mpsc::UnboundedSender<ClassBasedCommand>,
+    /// Shared data across all handles.
+    data: Arc<ClassBasedLimiterData>,
+}
+
+/// The limiter's state.
+#[derive(Debug)]
+struct ClassBasedLimiterData {
+    /// Number of resource units to allow for non-validators per second.
+    resources_per_second: u32,
+    /// Set of active and upcoming validators.
+    validator_sets: RwLock<ValidatorSets>,
+    /// Information about available resources.
+    resources: Mutex<ResourceData>,
+    /// Total time spent waiting.
+    wait_time_sec: Counter,
+}
+
+/// Resource data.
+#[derive(Debug)]
+struct ResourceData {
+    /// How many resource units are buffered.
+    ///
+    /// May go negative in the case of a deficit.
+    available: i64,
+    /// Last time resource data was refilled.
+    last_refill: Instant,
+}
+
+impl ClassBasedLimiterData {
+    /// Creates a new set of class based limiter data.
+    ///
+    /// Initial resources will be initialized 0, with the last refill set to the current time.
+    fn new(resources_per_second: u32, wait_time_sec: Counter) -> Self {
+        ClassBasedLimiterData {
+            resources_per_second,
+            validator_sets: Default::default(),
+            resources: Mutex::new(ResourceData {
+                available: 0,
+                last_refill: Instant::now(),
+            }),
+            wait_time_sec,
+        }
+    }
+}
+
+/// Sets of validators used to classify traffic.
+#[derive(Debug, Default)]
+struct ValidatorSets {
+    /// The new set of validators active in the current era.
+    active_validators: HashSet<PublicKey>,
+    /// The new set of validators in future eras.
+    upcoming_validators: HashSet<PublicKey>,
 }
 
 /// Peer class for the `ClassBasedLimiter`.
@@ -98,35 +149,13 @@ enum PeerClass {
     Bulk,
 }
 
-/// Command sent to the `ClassBasedLimiter`.
-enum ClassBasedCommand {
-    /// Updates the set of active/upcoming validators.
-    UpdateValidators {
-        /// The new set of validators active in the current era.
-        active_validators: HashSet<PublicKey>,
-        /// The new set of validators in future eras.
-        upcoming_validators: HashSet<PublicKey>,
-    },
-    /// Requests a certain amount of a resource.
-    RequestResource {
-        /// Amount of resource requested.
-        amount: u32,
-        /// Id of the requesting sender.
-        id: Arc<ConsumerId>,
-        /// Response channel.
-        responder: oneshot::Sender<()>,
-    },
-    /// Shuts down the worker task
-    Shutdown,
-}
-
 /// Handle for `ClassBasedLimiter`.
 #[derive(Debug)]
 struct ClassBasedHandle {
     /// Sender for commands.
-    sender: mpsc::UnboundedSender<ClassBasedCommand>,
+    data: Arc<ClassBasedLimiterData>,
     /// Consumer ID for the sender holding this handle.
-    consumer_id: Arc<ConsumerId>,
+    consumer_id: ConsumerId,
 }
 
 /// An identity for a consumer.
@@ -142,19 +171,14 @@ struct ConsumerId {
 impl ClassBasedLimiter {
     /// Creates a new class based limiter.
     ///
-    /// Starts the background worker task as well. Any time the limiter caused a delay,
-    /// `wait_time_sec` will be incremented.
+    /// Starts the background worker task as well.
     pub(super) fn new(resources_per_second: u32, wait_time_sec: Counter) -> Self {
-        let (sender, receiver) = mpsc::unbounded_channel();
-
-        tokio::spawn(worker(
-            receiver,
-            resources_per_second,
-            ((resources_per_second as f64) * STORED_BUFFER_SECS.as_secs_f64()) as u32,
-            wait_time_sec,
-        ));
-
-        ClassBasedLimiter { sender }
+        ClassBasedLimiter {
+            data: Arc::new(ClassBasedLimiterData::new(
+                resources_per_second,
+                wait_time_sec,
+            )),
+        }
     }
 }
 
@@ -165,11 +189,11 @@ impl Limiter for ClassBasedLimiter {
         validator_id: Option<PublicKey>,
     ) -> Box<dyn LimiterHandle> {
         Box::new(ClassBasedHandle {
-            sender: self.sender.clone(),
-            consumer_id: Arc::new(ConsumerId {
+            data: self.data.clone(),
+            consumer_id: ConsumerId {
                 peer_id,
                 validator_id,
-            }),
+            },
         })
     }
 
@@ -178,15 +202,19 @@ impl Limiter for ClassBasedLimiter {
         active_validators: HashSet<PublicKey>,
         upcoming_validators: HashSet<PublicKey>,
     ) {
-        if self
-            .sender
-            .send(ClassBasedCommand::UpdateValidators {
-                active_validators,
-                upcoming_validators,
-            })
-            .is_err()
-        {
-            debug!("could not update validator data set of limiter, channel closed");
+        match self.data.validator_sets.write() {
+            Ok(mut validators) => {
+                debug!(
+                    ?active_validators,
+                    ?upcoming_validators,
+                    "updating resources classes"
+                );
+                validators.active_validators = active_validators;
+                validators.upcoming_validators = upcoming_validators;
+            }
+            Err(_) => {
+                debug!("could not update validator data set of limiter, lock poisoned");
+            }
         }
     }
 }
@@ -194,149 +222,91 @@ impl Limiter for ClassBasedLimiter {
 #[async_trait]
 impl LimiterHandle for ClassBasedHandle {
     async fn request_allowance(&self, amount: u32) {
-        let (responder, waiter) = oneshot::channel();
-
-        // Send a request to the limiter and await a response. If we do not receive one due to
-        // errors, simply ignore it and do not restrict resources.
-        //
-        // While ignoring it is suboptimal, it is likely that we can continue operation normally in
-        // many circumstances, thus the message is downgraded from what would be a `warn!` to
-        // `debug!`.
-        if self
-            .sender
-            .send(ClassBasedCommand::RequestResource {
-                amount,
-                id: self.consumer_id.clone(),
-                responder,
-            })
-            .is_err()
-        {
-            debug!("worker was shutdown, sending is unlimited");
-        } else if waiter.await.is_err() {
-            debug!("failed to await resource allowance, unlimited");
-        }
-    }
-}
-
-impl Drop for ClassBasedLimiter {
-    fn drop(&mut self) {
-        if self.sender.send(ClassBasedCommand::Shutdown).is_err() {
-            warn!("error sending shutdown command to class based limiter");
-        }
-    }
-}
-
-/// Background worker for the limiter.
-///
-/// Will permit any amount of current/future validator resource requests, while restricting
-/// non-validators to `resources_per_second`, although with unlimited one-time burst. The latter
-/// guarantees that any size request can be satisfied (e.g. a message larger than the burst limit).
-///
-/// Stores up to `max_stored_resources` during idle times to smooth this process.
-async fn worker(
-    mut receiver: mpsc::UnboundedReceiver<ClassBasedCommand>,
-    resources_per_second: u32,
-    max_stored_resource: u32,
-    wait_time_sec: Counter,
-) {
-    let mut active_validators = HashSet::new();
-    let mut upcoming_validators = HashSet::new();
-
-    let mut resources_available: i64 = 0;
-    let mut last_refill: Instant = Instant::now();
-
-    // Whether or not we emitted a warning that the limiter is currently implicitly disabled.
-    let mut logged_uninitialized = false;
-
-    while let Some(msg) = receiver.recv().await {
-        match msg {
-            ClassBasedCommand::UpdateValidators {
-                active_validators: new_active_validators,
-                upcoming_validators: new_upcoming_validators,
-            } => {
-                active_validators = new_active_validators;
-                upcoming_validators = new_upcoming_validators;
-                debug!(
-                    ?active_validators,
-                    ?upcoming_validators,
-                    "resource classes updated"
-                );
-            }
-            ClassBasedCommand::RequestResource {
-                amount,
-                id,
-                responder,
-            } => {
-                if active_validators.is_empty() && upcoming_validators.is_empty() {
+        // As a first step, determine the peer class by checking if our id is in the validator set.
+        let peer_class = match self.data.validator_sets.read() {
+            Ok(validators) => {
+                if validators.active_validators.is_empty()
+                    && validators.upcoming_validators.is_empty()
+                {
                     // It is likely that we have not been initialized, thus no node is getting the
                     // reserved resources. In this case, do not limit at all.
-                    if !logged_uninitialized {
-                        logged_uninitialized = true;
-                        info!("empty set of validators, not limiting resources at all");
-                    }
-                    continue;
+                    trace!("empty set of validators, not limiting resources at all");
+
+                    return;
                 }
 
-                let peer_class = if let Some(ref validator_id) = id.validator_id {
-                    if active_validators.contains(validator_id) {
+                if let Some(ref validator_id) = self.consumer_id.validator_id {
+                    if validators.active_validators.contains(validator_id) {
                         PeerClass::ActiveValidator
-                    } else if upcoming_validators.contains(validator_id) {
+                    } else if validators.upcoming_validators.contains(validator_id) {
                         PeerClass::UpcomingValidator
                     } else {
                         PeerClass::Bulk
                     }
                 } else {
                     PeerClass::Bulk
-                };
-
-                match peer_class {
-                    PeerClass::ActiveValidator | PeerClass::UpcomingValidator => {
-                        // No limit imposed on validators.
-                    }
-                    PeerClass::Bulk => {
-                        while resources_available < 0 {
-                            // Determine time delta since last refill.
-                            let now = Instant::now();
-                            let elapsed = now - last_refill;
-                            last_refill = now;
-
-                            // Add appropriate amount of resources, capped at `max_stored_bytes`.
-                            resources_available +=
-                                ((elapsed.as_nanos() * resources_per_second as u128)
-                                    / 1_000_000_000) as i64;
-                            resources_available =
-                                resources_available.min(max_stored_resource as i64);
-
-                            // If we do not have enough resources available, sleep until we do.
-                            if resources_available < 0 {
-                                let estimated_time_remaining = Duration::from_millis(
-                                    (-resources_available) as u64 * 1000
-                                        / resources_per_second as u64,
-                                );
-
-                                tokio::time::sleep(estimated_time_remaining).await;
-                                wait_time_sec.inc_by(estimated_time_remaining.as_secs_f64());
-                            }
-                        }
-
-                        // Subtract requested amount.
-                        resources_available -= amount as i64;
-                    }
-                }
-
-                if responder.send(()).is_err() {
-                    debug!("resource requester disappeared before we could answer.")
                 }
             }
-            ClassBasedCommand::Shutdown => {
-                // Shutdown the channel, processing only the remaining messages.
-                receiver.close();
+            Err(_) => {
+                debug!("limiter lock poisoned, not limiting");
+                return;
+            }
+        };
+
+        match peer_class {
+            PeerClass::ActiveValidator | PeerClass::UpcomingValidator => {
+                // No limit imposed on validators.
+                return;
+            }
+            PeerClass::Bulk => {
+                let max_stored_resource = ((self.data.resources_per_second as f64)
+                    * STORED_BUFFER_SECS.as_secs_f64())
+                    as u32;
+
+                // We are a low-priority sender. Obtain a lock on the resources and wait an
+                // appropriate amount of time to fill them up.
+                {
+                    let mut resources = self.data.resources.lock().await;
+
+                    while resources.available < 0 {
+                        // Determine time delta since last refill.
+                        let now = Instant::now();
+                        let elapsed = now - resources.last_refill;
+                        resources.last_refill = now;
+
+                        // Add appropriate amount of resources, capped at `max_stored_bytes`. We
+                        // are still maintaining the lock here to avoid issues with other
+                        // low-priority requestors.
+                        resources.available += ((elapsed.as_nanos()
+                            * self.data.resources_per_second as u128)
+                            / 1_000_000_000) as i64;
+                        resources.available = resources.available.min(max_stored_resource as i64);
+
+                        // If we do not have enough resources available, sleep until we do.
+                        if resources.available < 0 {
+                            let estimated_time_remaining = Duration::from_millis(
+                                (-resources.available) as u64 * 1000
+                                    / self.data.resources_per_second as u64,
+                            );
+
+                            // Note: This sleep call is the reason we are using a tokio mutex
+                            //       instead of a regular `std` one, as we are holding it across the
+                            //       await point here.
+                            tokio::time::sleep(estimated_time_remaining).await;
+                            self.data
+                                .wait_time_sec
+                                .inc_by(estimated_time_remaining.as_secs_f64());
+                        }
+                    }
+
+                    // Subtract the amount. If available resources go negative as a result, it
+                    // is the next senders problem.
+                    resources.available -= amount as i64;
+                }
             }
         }
     }
-    debug!("class based worker exiting");
 }
-
 #[cfg(test)]
 mod tests {
     use std::{collections::HashSet, time::Duration};

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -152,7 +152,7 @@ enum PeerClass {
 /// Handle for `ClassBasedLimiter`.
 #[derive(Debug)]
 struct ClassBasedHandle {
-    /// Data share between handles and limiter.
+    /// Data shared between handles and limiter.
     data: Arc<ClassBasedLimiterData>,
     /// Consumer ID for the sender holding this handle.
     consumer_id: ConsumerId,
@@ -497,7 +497,7 @@ mod tests {
         );
     }
 
-    /// Regression test for #2929 (fill in issue once created)
+    /// Regression test for #2929.
     #[tokio::test]
     async fn throttling_of_non_validators_does_not_affect_validators() {
         init_logging();

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -116,7 +116,7 @@ struct ResourceData {
 impl ClassBasedLimiterData {
     /// Creates a new set of class based limiter data.
     ///
-    /// Initial resources will be initialized 0, with the last refill set to the current time.
+    /// Initial resources will be initialized to 0, with the last refill set to the current time.
     fn new(resources_per_second: u32, wait_time_sec: Counter) -> Self {
         ClassBasedLimiterData {
             resources_per_second,
@@ -152,7 +152,7 @@ enum PeerClass {
 /// Handle for `ClassBasedLimiter`.
 #[derive(Debug)]
 struct ClassBasedHandle {
-    /// Sender for commands.
+    /// Data share between handles and limiter.
     data: Arc<ClassBasedLimiterData>,
     /// Consumer ID for the sender holding this handle.
     consumer_id: ConsumerId,
@@ -497,7 +497,7 @@ mod tests {
         );
     }
 
-    /// Regression test for #??? (fill in issue once created)
+    /// Regression test for #2929 (fill in issue once created)
     #[tokio::test]
     async fn throttling_of_non_validators_does_not_affect_validators() {
         init_logging();


### PR DESCRIPTION
Fixes an issue where we would unintentionally throttle validators due to joiner traffic. Historically, this was possible because there was a single worker, processing all resource requests in order. If a large number (or one large) resource request from unprivileged handles was causing `tokio::time::sleep` to be called, no other requests would be serviced in the meantime, even though they are supposed to bypass the system entirely.

The new implementation does away with the channel and solves the issue by determining the privileged status first for all requests in parallel, fast tracking the validators and only descending into serialized, potentially sleeping code after.

This required a substantial rewrite of the inner workings, but the interface has remained the same and the original tests are unchanged. A regression test has been added for the issue and been manually verified (failed on the old code).