### PR TITLE
Fix fetch forward

### DIFF
--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -949,6 +949,7 @@ async fn sync_to_genesis(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, Bl
     let mut trusted_key_block_info = get_trusted_key_block_info(ctx).await?;
 
     let trusted_block = *fetch_and_store_block_by_hash(ctx.trusted_hash(), ctx).await?;
+    sync_deploys_and_transfers_and_state(&trusted_block, ctx).await?;
 
     fetch_to_genesis(&trusted_block, ctx).await?;
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -16,7 +16,7 @@ use futures::{
 };
 use prometheus::IntGauge;
 use quanta::Instant;
-use tracing::{info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
 use casper_hashing::Digest;
@@ -33,9 +33,9 @@ use crate::{
     effect::{requests::FetcherRequest, EffectBuilder},
     reactor::joiner::JoinerEvent,
     types::{
-        Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata,
-        Deploy, DeployHash, FinalizedApprovals, FinalizedApprovalsWithId, FinalizedBlock, Item,
-        NodeId, TimeDiff, Timestamp,
+        AvailableBlockRange, Block, BlockHash, BlockHeader, BlockHeaderWithMetadata,
+        BlockSignatures, BlockWithMetadata, Deploy, DeployHash, FinalizedApprovals,
+        FinalizedApprovalsWithId, FinalizedBlock, Item, NodeId, TimeDiff, Timestamp,
     },
     utils::work_queue::WorkQueue,
 };
@@ -75,6 +75,8 @@ struct ChainSyncContext<'a> {
     bad_peer_list: RwLock<VecDeque<NodeId>>,
     /// Number of times peer lists have been filtered.
     filter_count: AtomicI64,
+    /// A range of blocks for which we already have all required data stored locally.
+    locally_available_block_range_on_start: AvailableBlockRange,
 }
 
 impl<'a> ChainSyncContext<'a> {
@@ -82,6 +84,7 @@ impl<'a> ChainSyncContext<'a> {
         effect_builder: &'a EffectBuilder<JoinerEvent>,
         config: &'a Config,
         metrics: &'a Metrics,
+        locally_available_block_range_on_start: AvailableBlockRange,
     ) -> Self {
         Self {
             effect_builder,
@@ -90,6 +93,7 @@ impl<'a> ChainSyncContext<'a> {
             metrics,
             bad_peer_list: RwLock::new(VecDeque::new()),
             filter_count: AtomicI64::new(0),
+            locally_available_block_range_on_start,
         }
     }
 
@@ -1002,33 +1006,55 @@ async fn fetch_forward(
 async fn fetch_to_genesis(trusted_block: &Block, ctx: &ChainSyncContext<'_>) -> Result<(), Error> {
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fetch_to_genesis_duration_seconds);
 
-    let locally_available_block_range = ctx
-        .effect_builder
-        .get_available_block_range_from_storage()
-        .await;
+    info!(
+        trusted_block_height = %trusted_block.height(),
+        locally_available_block_range_on_start = %ctx.locally_available_block_range_on_start,
+        "starting fetch to genesis",
+    );
 
     let mut walkback_block = trusted_block.clone();
     loop {
         // The available range from storage indicates a range of blocks for which we already have
         // all the corresponding deploys and global state stored locally.  Skip fetching for such a
         // range.
-        if locally_available_block_range.contains(walkback_block.height()) {
+        if ctx
+            .locally_available_block_range_on_start
+            .contains(walkback_block.height())
+        {
             let maybe_lowest_available_block = ctx
                 .effect_builder
-                .get_lowest_available_block_from_storage()
+                .get_block_at_height_with_metadata_from_storage(
+                    ctx.locally_available_block_range_on_start.low(),
+                    false,
+                )
                 .await;
             if let Some(lowest_available_block) = maybe_lowest_available_block {
-                if lowest_available_block.height() == 0 {
+                info!(
+                    skip_to_height = %ctx.locally_available_block_range_on_start.low(),
+                    current_walkback_height = %walkback_block.height(),
+                    "skipping fetch for blocks, deploys and tries in available block range"
+                );
+
+                if lowest_available_block.block.height() == 0 {
                     ctx.effect_builder
                         .update_lowest_available_block_height_in_storage(0)
                         .await;
                     break;
                 }
                 walkback_block = *fetch_and_store_block_by_hash(
-                    *lowest_available_block.header().parent_hash(),
+                    *lowest_available_block.block.header().parent_hash(),
                     ctx,
                 )
                 .await?;
+            } else if ctx.locally_available_block_range_on_start != AvailableBlockRange::RANGE_0_0 {
+                // For a first run with no blocks previously stored locally, it is expected that the
+                // reported lowest available block is actually unavailable. In this case the
+                // available range at startup will be [0, 0]. For all other cases, this is an error.
+                error!(
+                    locally_available_block_range_on_start =
+                        %ctx.locally_available_block_range_on_start,
+                    "failed to get lowest block reported as available"
+                );
             }
         }
 
@@ -1060,7 +1086,16 @@ pub(super) async fn run_chain_sync_task(
 ) -> Result<BlockHeader, Error> {
     let _metric = ScopeTimer::new(&metrics.chain_sync_total_duration_seconds);
 
-    let mut chain_sync_context = ChainSyncContext::new(&effect_builder, &config, &metrics);
+    let locally_available_block_range_on_start = effect_builder
+        .get_available_block_range_from_storage()
+        .await;
+
+    let mut chain_sync_context = ChainSyncContext::new(
+        &effect_builder,
+        &config,
+        &metrics,
+        locally_available_block_range_on_start,
+    );
 
     let trusted_block_header =
         fetch_and_store_initial_trusted_block_header(&chain_sync_context, &metrics, trusted_hash)

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -51,7 +51,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use casper_types::{EraId, PublicKey};
 use datasize::DataSize;
 use futures::{future::BoxFuture, FutureExt};
 use openssl::{error::ErrorStack as OpenSslErrorStack, pkey};
@@ -72,8 +71,17 @@ use tokio_openssl::SslStream;
 use tokio_util::codec::LengthDelimitedCodec;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
-use self::{
+use casper_types::{EraId, PublicKey};
+
+pub(crate) use self::{
     bincode_format::BincodeFormat,
+    config::Config,
+    error::Error,
+    event::Event,
+    gossiped_address::GossipedAddress,
+    message::{EstimatorWeights, FromIncoming, Message, MessageKind, Payload},
+};
+use self::{
     chain_info::ChainInfo,
     counting_format::{ConnectionId, CountingFormat, Role},
     error::{ConnectionError, Result},
@@ -85,13 +93,7 @@ use self::{
     symmetry::ConnectionSymmetry,
     tasks::NetworkContext,
 };
-pub(crate) use self::{
-    config::Config,
-    error::Error,
-    event::Event,
-    gossiped_address::GossipedAddress,
-    message::{EstimatorWeights, FromIncoming, Message, MessageKind, Payload},
-};
+
 use crate::{
     components::{consensus, Component},
     effect::{

--- a/node/src/components/small_network/bincode_format.rs
+++ b/node/src/components/small_network/bincode_format.rs
@@ -22,7 +22,7 @@ use super::Message;
 pub struct BincodeFormat(
     // Note: `bincode` encodes its options at the type level. The exact shape is determined by
     // `BincodeFormat::default()`.
-    WithOtherTrailing<
+    pub(crate)  WithOtherTrailing<
         WithOtherIntEncoding<
             WithOtherEndian<
                 WithOtherLimit<bincode::DefaultOptions, bincode::config::Infinite>,

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use casper_types::{ProtocolVersion, PublicKey};
+use bincode::Options;
 use futures::{
     future::{self, Either},
     stream::{SplitSink, SplitStream},
@@ -30,10 +30,12 @@ use tokio::{
 use tokio_openssl::SslStream;
 use tokio_serde::{Deserializer, Serializer};
 use tracing::{
-    debug, error_span,
+    debug, error, error_span,
     field::{self, Empty},
     info, trace, warn, Instrument, Span,
 };
+
+use casper_types::{ProtocolVersion, PublicKey};
 
 use super::{
     chain_info::ChainInfo,
@@ -47,7 +49,7 @@ use super::{
     Event, FramedTransport, FullTransport, Message, Metrics, Payload, Transport,
 };
 use crate::{
-    components::small_network::framed_transport,
+    components::small_network::{framed_transport, BincodeFormat},
     reactor::{EventQueueHandle, QueueKind},
     tls::{self, TlsCert},
     types::{NodeId, TimeDiff},
@@ -590,12 +592,16 @@ pub(super) async fn message_sender<P>(
     while let Some(message) = queue.recv().await {
         counter.dec();
 
-        // TODO: Refactor message sending to not use `tokio_serde` anymore to avoid duplicate
-        //       serialization.
-        let estimated_wire_size = rmp_serde::to_vec(&message)
-            .as_ref()
-            .map(Vec::len)
-            .unwrap_or(0) as u32;
+        let estimated_wire_size = match BincodeFormat::default().0.serialized_size(&*message) {
+            Ok(size) => size as u32,
+            Err(error) => {
+                error!(
+                    error = display_error(&error),
+                    "failed to get serialized size of outgoing message, closing outgoing connection"
+                );
+                break;
+            }
+        };
         limiter.request_allowance(estimated_wire_size).await;
 
         // We simply error-out if the sink fails, it means that our connection broke.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1162,11 +1162,6 @@ impl StorageInner {
             StorageRequest::GetAvailableBlockRange { responder } => responder
                 .respond(self.get_available_block_range()?)
                 .ignore(),
-            StorageRequest::GetLowestAvailableBlock { responder } => {
-                let maybe_lowest_block =
-                    self.read_block_by_height(self.get_lowest_available_block_height()?)?;
-                responder.respond(maybe_lowest_block).ignore()
-            }
             StorageRequest::StoreFinalizedApprovals {
                 ref deploy_hash,
                 ref finalized_approvals,
@@ -1905,10 +1900,6 @@ impl StorageInner {
                 Ok(AvailableBlockRange::default())
             }
         }
-    }
-
-    fn get_lowest_available_block_height(&self) -> Result<u64, FatalStorageError> {
-        Ok(self.indices.read()?.lowest_available_block_height)
     }
 
     fn update_lowest_available_block_height(

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1263,18 +1263,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the lowest block from the available range in storage.
-    pub(crate) async fn get_lowest_available_block_from_storage(self) -> Option<Block>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetLowestAvailableBlock { responder },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Fetches an item from a fetcher.
     pub(crate) async fn fetch<T>(self, id: T::Id, peer: NodeId) -> FetchResult<T>
     where

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -431,11 +431,6 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.
         responder: Responder<AvailableBlockRange>,
     },
-    /// Get the lowest block of the available range.
-    GetLowestAvailableBlock {
-        /// Responder to call with the block if it exists.
-        responder: Responder<Option<Block>>,
-    },
     /// Store a set of finalized approvals for a specific deploy.
     StoreFinalizedApprovals {
         /// The deploy hash to store the finalized approvals for.
@@ -543,9 +538,6 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetAvailableBlockRange { .. } => {
                 write!(formatter, "get available block range",)
-            }
-            StorageRequest::GetLowestAvailableBlock { .. } => {
-                write!(formatter, "get lowest available block",)
             }
             StorageRequest::StoreFinalizedApprovals { deploy_hash, .. } => {
                 write!(formatter, "finalized approvals for deploy {}", deploy_hash)

--- a/node/src/types/available_block_range.rs
+++ b/node/src/types/available_block_range.rs
@@ -32,6 +32,9 @@ pub struct AvailableBlockRange {
 }
 
 impl AvailableBlockRange {
+    /// An `AvailableRange` of [0, 0].
+    pub const RANGE_0_0: AvailableBlockRange = AvailableBlockRange { low: 0, high: 0 };
+
     /// Returns a new `AvailableBlockRange`.
     pub fn new(low: u64, high: u64) -> Result<Self, AvailableBlockRangeError> {
         if low > high {

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -103,11 +103,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Cursor, sync::Arc};
+    use std::{pin::Pin, sync::Arc};
 
-    use serde::{de::DeserializeOwned, Serialize};
+    use bytes::BytesMut;
+    use serde::{Deserialize, Serialize};
+    use tokio_serde::{Deserializer, Serializer};
 
-    use crate::types::Deploy;
+    use crate::{
+        components::small_network::{BincodeFormat, Message},
+        types::Deploy,
+    };
 
     use super::SharedObject;
 
@@ -123,16 +128,22 @@ mod tests {
         }
     }
 
-    // TODO: Import fixed serialization settings from `small_network::message_pack_format` as soon
-    //       as merged, instead of using these `rmp_serde` helper functions.
-    #[inline]
     fn serialize<T: Serialize>(value: &T) -> Vec<u8> {
-        rmp_serde::to_vec(value).expect("could not serialize value")
+        let msg = Arc::new(Message::Payload(value));
+        Pin::new(&mut BincodeFormat::default())
+            .serialize(&msg)
+            .expect("could not serialize value")
+            .to_vec()
     }
 
-    #[inline]
-    fn deserialize<T: DeserializeOwned>(raw: &[u8]) -> T {
-        rmp_serde::from_read(Cursor::new(raw)).expect("could not deserialize value")
+    fn deserialize<T: for<'de> Deserialize<'de>>(raw: &[u8]) -> T {
+        let msg = Pin::new(&mut BincodeFormat::default())
+            .deserialize(&BytesMut::from(raw))
+            .expect("could not deserialize value");
+        match msg {
+            Message::Payload(payload) => payload,
+            Message::Handshake { .. } => panic!("expected payload"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR includes multiple fixes for chain sync:

* reverts #2896 which was an attempt to fix an issue only able to occur in a misconfigured emergency-upgrade test.

  The change in that PR caused `fetch_forward` in chain sync to exit once it had downloaded the final switch block and associated state of the previous protocol version.  From that point, chain sync would try to execute forwards.  However, the first block of the new era is the immediate switch block created after the upgrade is committed, and chain sync does not attempt to call `commit_upgrade` at that point.  This causes the execution of the first block to yield invalid results and causes a fatal error.
  
  The fix is to allow `fetch_forward` to download the immediate switch block and associated state before exiting.
* ensures all deploys and global state under the trusted block hash are downloaded
* ensures chain sync takes a copy of the available block range on startup, rather than trying to retrieve it from storage once chain-syncing has already started and possibly affected it

The PR also includes some cleanups of overlooked instances of `rmp_serde` in the `small_network` component.

Closes #2927.