### PR TITLE
NCTL: use ci.json file for selecting default initial protocol version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -138,11 +138,6 @@ steps:
 
 - name: nctl-upgrade-test
   <<: *buildenv
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nctl_upgrade.sh
 
@@ -475,11 +470,6 @@ steps:
 
 - name: nctl-nightly-tests
   <<: *buildenv
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nightly-test.sh
 

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -3,7 +3,7 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 JSON_CONFIG_FILE="$ROOT_DIR/utils/nctl/ci/ci.json"
-JSON_KEYS=($(jq -r 'keys[]' "$JSON_CONFIG_FILE"))
+JSON_KEYS=($(jq -r '.external_deps | keys[]' "$JSON_CONFIG_FILE"))
 
 function clone_external_repo() {
     local NAME=${1}
@@ -13,8 +13,8 @@ function clone_external_repo() {
     local CLONE_REPO_PATH
 
     CLONE_REPO_PATH="$ROOT_DIR/../$NAME"
-    URL=$(jq -r ".\"${NAME}\".github_repo_url" "$JSON_FILE")
-    BRANCH=$(jq -r ".\"${NAME}\".branch" "$JSON_FILE")
+    URL=$(jq -r ".external_deps.\"${NAME}\".github_repo_url" "$JSON_FILE")
+    BRANCH=$(jq -r ".external_deps.\"${NAME}\".branch" "$JSON_FILE")
 
     if [ ! -d "$CLONE_REPO_PATH" ]; then
         echo "... cloning $NAME: branch=$BRANCH"

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -1,10 +1,15 @@
 {
-    "casper-client-rs": {
-        "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
-        "branch": "dev"
+    "external_deps": {
+        "casper-client-rs": {
+            "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
+            "branch": "dev"
+        },
+        "casper-node-launcher": {
+            "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",
+            "branch": "main"
+        }
     },
-    "casper-node-launcher": {
-        "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",
-        "branch": "main"
+    "nctl_upgrade_tests": {
+        "protocol_1": "1.5.0"
     }
 }


### PR DESCRIPTION
Changes:
- utilizes `ci.json` file for the default initial protocol version in upgrade scenarios
- no longer downloads all remotes but just the specified one in `ci.json`
- removes need for AWS keys needed in the drone steps
- adds download of `1.3.0` remote used by upgrade test 10.
- adjust format of `ci.json`