### PR TITLE
CI: run nightly for release 1.5.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -508,4 +508,4 @@ volumes:
   temp: {}
 
 trigger:
-  cron: [ nightly-tests-cron, feat-fast-sync ]
+  cron: [ nightly-tests-cron, release-1.5.0 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -138,11 +138,6 @@ steps:
 
 - name: nctl-upgrade-test
   <<: *buildenv
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nctl_upgrade.sh
 
@@ -475,11 +470,6 @@ steps:
 
 - name: nctl-nightly-tests
   <<: *buildenv
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: put-drone-aws-ak
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nightly-test.sh
 

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -3,7 +3,7 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 JSON_CONFIG_FILE="$ROOT_DIR/utils/nctl/ci/ci.json"
-JSON_KEYS=($(jq -r 'keys[]' "$JSON_CONFIG_FILE"))
+JSON_KEYS=($(jq -r '.external_deps | keys[]' "$JSON_CONFIG_FILE"))
 
 function clone_external_repo() {
     local NAME=${1}
@@ -13,8 +13,8 @@ function clone_external_repo() {
     local CLONE_REPO_PATH
 
     CLONE_REPO_PATH="$ROOT_DIR/../$NAME"
-    URL=$(jq -r ".\"${NAME}\".github_repo_url" "$JSON_FILE")
-    BRANCH=$(jq -r ".\"${NAME}\".branch" "$JSON_FILE")
+    URL=$(jq -r ".external_deps.\"${NAME}\".github_repo_url" "$JSON_FILE")
+    BRANCH=$(jq -r ".external_deps.\"${NAME}\".branch" "$JSON_FILE")
 
     if [ ! -d "$CLONE_REPO_PATH" ]; then
         echo "... cloning $NAME: branch=$BRANCH"

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -1,10 +1,15 @@
 {
-    "casper-client-rs": {
-        "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
-        "branch": "release-2.0.0"
+    "external_deps": {
+        "casper-client-rs": {
+            "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
+            "branch": "release-2.0.0"
+        },
+        "casper-node-launcher": {
+            "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",
+            "branch": "main"
+        }
     },
-    "casper-node-launcher": {
-        "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",
-        "branch": "main"
+    "nctl_upgrade_tests": {
+        "protocol_1": "1.4.5"
     }
 }


### PR DESCRIPTION
Changes:
- adds cron job for running nightly nctl tests
- syncs changes from https://github.com/casper-network/casper-node/pull/2925
    - adjusted `ci.json` for release-1.5.0

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/414