### PR TITLE
Update nctl docs

### DIFF
--- a/utils/nctl/docs/setup.md
+++ b/utils/nctl/docs/setup.md
@@ -1,13 +1,23 @@
 # NCTL setup
 
-### Step 0 - pre-requisites.
+## Prerequisites
 
-0. bash shell.
+1. bash shell.
 1. python3 + pip3.
-2. The casper-node software (https://github.com/CasperLabs/casper-node) cloned into YOUR_WORKING_DIRECTORY.
-3. The casper-node-launcher software (https://github.com/CasperLabs/casper-node-launcher) cloned into YOUR_WORKING_DIRECTORY.
+1. The [casper-node repository](https://github.com/casper-network/casper-node) cloned into YOUR_WORKING_DIRECTORY.
+1. The [casper-client-rs repository](https://github.com/casper-ecosystem/casper-client-rs) cloned into YOUR_WORKING_DIRECTORY.
+1. The [casper-node-launcher repository](https://github.com/casper-network/casper-node-launcher) cloned into YOUR_WORKING_DIRECTORY.
 
-### Step 1 - install pre-requisites.
+### NOTE
+
+Ensure you are checked out to the correct branch of each of the three repositories above.  Generally this will
+be `dev` (or your working branch recently forked from `dev`) for casper-node and casper-client-rs, and `main` for
+casper-node-launcher.
+
+To find out which branch of the client and launcher are compatible with the current branch of node, refer to
+[ci.json](https://github.com/casper-network/casper-node/blob/dev/utils/nctl/ci/ci.json).
+
+## Install prerequisites
 
 ```
 # Supervisor - cross-platform process manager.
@@ -21,7 +31,7 @@ cd YOUR_WORKING_DIRECTORY/casper-node
 make setup-rs
 ```
 
-### Step 2 - extend bashrc file to make NCTL commands available from terminal session.
+## Extend .bashrc file to make NCTL commands available from terminal session
 
 ```
 cd YOUR_WORKING_DIRECTORY/casper-node
@@ -38,7 +48,7 @@ cat >> $HOME/.bashrc <<- EOM
 EOM
 ```
 
-### Step 3 - refresh bash session.
+## Refresh bash session
 
 ```
 . $HOME/.bashrc

--- a/utils/nctl/docs/usage.md
+++ b/utils/nctl/docs/usage.md
@@ -1,8 +1,8 @@
 # NCTL Usage
 
-Once activated, NCTL commands can be used to setup & control nodes within a local test network.  Most NCTL users will be testing a single local network, however developers wishing to test multiple networks in parallel may do so.  This usage guide focuses upon the former use case, i.e. testing a single network, and thus all NCTL commands described below are executed with their default values.  Please refer [here](commands.md) for full details of supported NCTL commands.
+Once activated, NCTL commands can be used to set up & control nodes within a local test network.  Most NCTL users will be testing a single local network, however developers wishing to test multiple networks in parallel may do so.  This usage guide focuses upon the former use case, i.e. testing a single network, and thus all NCTL commands described below are executed with their default values.  Please refer [here](commands.md) for full details of supported NCTL commands.
 
-## Step 0: Compile network binaries.
+## Step 1: Compile network binaries
 
 Prior to testing a network ensure that the binary sets are available:
 
@@ -10,11 +10,20 @@ Prior to testing a network ensure that the binary sets are available:
 nctl-compile
 ```
 
-This runs `make setup-rs`, and compiles both `casper-node` and `casper-client` in release mode.
+This runs `make setup-rs`, and compiles `casper-node`, `casper-client` and `casper-node-launcher` in release mode.
 
-## Step 1: Create network assets.
+### NOTE
 
-- Once network binary compilation is complete we need to setup test network assets.  The following command instantiates the full set of assets required to run a 5 node local network with 5 users.  It also creates the assets for a further 5 nodes in order to test join/leave scenarios.  The assets are copied to `$NCTL/assets/net-1`, where $NCTL is the nctl home directory.
+Ensure you are checked out to the correct branch of each of the three repositories above.  Generally this will
+be `dev` (or your working branch recently forked from `dev`) for casper-node and casper-client-rs, and `main` for
+casper-node-launcher.
+
+To find out which branch of the client and launcher are compatible with the current branch of node, refer to
+[ci.json](https://github.com/casper-network/casper-node/blob/dev/utils/nctl/ci/ci.json).
+
+## Step 2: Create network assets
+
+- Once network binary compilation is complete we need to set up test network assets.  The following command instantiates the full set of assets required to run a 5 node local network with 5 users.  It also creates the assets for a further 5 nodes in order to test join/leave scenarios.  The assets are copied to `$NCTL/assets/net-1`, where $NCTL is the nctl home directory.
 
 ```
 nctl-assets-setup
@@ -34,6 +43,7 @@ nctl-assets-setup
 - Examining the contents of `$NCTL/assets/net-1/nodes/node-1`, i.e. node 1, you will observe the following (self-explanatory) sub-folders:
 
 ```
+/bin
 /config
 /keys
 /logs
@@ -56,7 +66,7 @@ vi $NCTL/assets/net-1/chainspec/chainspec.toml
 vi $NCTL/assets/net-1/nodes/node-3/config/node-config.toml
 ```
 
-## Step 2: Start a node in interactive mode.
+## Step 3: Start a node in interactive mode
 
 - Starting a node interactively is useful to verify that the network assets have been correctly established and that the network is ready for testing.
 
@@ -64,9 +74,9 @@ vi $NCTL/assets/net-1/nodes/node-3/config/node-config.toml
 nctl-interactive
 ```
 
-## Step 3: Start a network in daemon mode.
+## Step 4: Start a network in daemon mode
 
-- To start with all or a single node in daemonised mode (this is the preferred modus operandi):
+- To start with all or a single node in daemonized mode (this is the preferred operating mode):
 
 ```
 # Start all nodes in daemon mode.
@@ -76,13 +86,13 @@ nctl-start
 nctl-start node=1
 ```
 
-- To view process status of all daemonised nodes:
+- To view process status of all daemonized nodes:
 
 ```
 nctl-status
 ```
 
-- To stop either a single or all daemonised nodes:
+- To stop either a single or all daemonized nodes:
 
 ```
 # Stop all nodes.
@@ -92,7 +102,7 @@ nctl-stop
 nctl-stop node=1
 ```
 
-## Step 4: Dump logs & other files.
+## Step 5: Dump logs & other files
 
 Upon observation of a network behavioral anomaly you can dump relevant assets such as logs & configuration as follows:
 
@@ -101,11 +111,11 @@ Upon observation of a network behavioral anomaly you can dump relevant assets su
 nctl-assets-dump
 ```
 
-## Step 5: Viewing information.
+## Step 6: View information
 
 You can view chain, faucet, node & user information using the set of `nctl-view-*` commands.  See [here](commands.md) for further information.
 
-## Step 6: End testing session.
+## Step 7: End testing session
 
 To teardown a network once a testing session is complete:
 
@@ -116,4 +126,4 @@ nctl-assets-teardown
 
 ## Summary
 
-Using NCTL one can spin up either a single or multiple test networks.  Each network is isolated in terms of its assets - this includes port numbers.  The NCTL commands parameter defaults are set for the general use case of testing a single local 5 node network.  You are encouraged to integrate NCTL into your daily workflow so as to standardise the manner in which the network is tested in a localised setting.
+Using NCTL one can spin up either a single or multiple test networks.  Each network is isolated in terms of its assets - this includes port numbers.  The NCTL commands parameter defaults are set for the general use case of testing a single local 5 node network.  You are encouraged to integrate NCTL into your daily workflow to standardize the manner in which the network is tested in a localized setting.


### PR DESCRIPTION
This PR updates the NCTL docs to include details about the requirement for cloning the casper-client-rs repo.