### PR TITLE
Make ban duration configurable

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -108,9 +108,6 @@ use crate::{
 const MAX_METRICS_DROP_ATTEMPTS: usize = 25;
 const DROP_RETRY_DELAY: Duration = Duration::from_millis(100);
 
-/// Duration peers are kept on the block list, before being redeemed.
-const BLOCKLIST_RETAIN_DURATION: Duration = Duration::from_secs(60 * 10);
-
 /// How often to keep attempting to reconnect to a node before giving up. Note that reconnection
 /// delays increase exponentially!
 const RECONNECTION_ATTEMPTS: u8 = 8;
@@ -241,7 +238,7 @@ where
             OutgoingConfig {
                 retry_attempts: RECONNECTION_ATTEMPTS,
                 base_timeout: BASE_RECONNECTION_TIMEOUT,
-                unblock_after: BLOCKLIST_RETAIN_DURATION,
+                unblock_after: cfg.blocklist_retain_duration.into(),
                 sweep_timeout: cfg.max_addr_pending_time.into(),
             },
             net_metrics.create_outgoing_metrics(),

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -48,6 +48,7 @@ impl Default for Config {
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
+            blocklist_retain_duration: TimeDiff::from_seconds(600),
         }
     }
 }
@@ -89,6 +90,8 @@ pub struct Config {
     pub tarpit_duration: TimeDiff,
     /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
     pub tarpit_chance: f32,
+    /// Duration peers are kept on the block list, before being redeemed.
+    pub blocklist_retain_duration: TimeDiff,
 }
 
 #[cfg(test)]

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -186,7 +186,7 @@ tarpit_duration = '10min'
 tarpit_chance = 0.2
 
 # How long peers remain blocked after they get blacklisted.
-blocklist_retain_duration = '10min'
+blocklist_retain_duration = '1min'
 
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -185,6 +185,9 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '10min'
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -185,6 +185,9 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '10min'
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -186,7 +186,7 @@ tarpit_duration = '10min'
 tarpit_chance = 0.2
 
 # How long peers remain blocked after they get blacklisted.
-blocklist_retain_duration = '10min'
+blocklist_retain_duration = '1min'
 
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -185,6 +185,9 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '10min'
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -188,6 +188,9 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '10min'
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -189,7 +189,7 @@ tarpit_duration = '10min'
 tarpit_chance = 0.2
 
 # How long peers remain blocked after they get blacklisted.
-blocklist_retain_duration = '10min'
+blocklist_retain_duration = '1min'
 
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -186,7 +186,7 @@ tarpit_duration = '10min'
 tarpit_chance = 0.2
 
 # How long peers remain blocked after they get blacklisted.
-blocklist_retain_duration = '10min'
+blocklist_retain_duration = '1min'
 
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -185,6 +185,9 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '10min'
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #


### PR DESCRIPTION
This makes the duration for which peers remain on the blocklist a value in the network config, instead of hardcoded.