### PR TITLE
NCTL: use staged chainspecs for remote

### DIFF
--- a/ci/nctl_upgrade_stage.sh
+++ b/ci/nctl_upgrade_stage.sh
@@ -29,6 +29,7 @@ BIN_BUILD_DIR="$ROOT_DIR/target/release"
 WASM_BUILD_DIR="$ROOT_DIR/target/wasm32-unknown-unknown/release"
 CONFIG_DIR="$ROOT_DIR/resources/local"
 TEMP_STAGE_DIR='/tmp/nctl_upgrade_stage'
+NCTL_UPGRADE_CHAINSPECS="$ROOT_DIR/utils/nctl/sh/scenarios/chainspecs"
 
 # FILES
 BIN_ARRAY=(casper-node)
@@ -92,3 +93,8 @@ for i in "${CONFIG_ARRAY[@]}"; do
     fi
     echo ""
 done
+
+# Copy NCTL upgrade chainspecs
+pushd "$NCTL_UPGRADE_CHAINSPECS"
+cp upgrade* "$TEMP_STAGE_DIR"
+popd

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -10,6 +10,6 @@
         }
     },
     "nctl_upgrade_tests": {
-        "protocol_1": "1.5.0"
+        "protocol_1": "1.4.6"
     }
 }

--- a/utils/nctl/sh/assets/upgrade_from_stage.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage.sh
@@ -74,6 +74,7 @@ function _main()
     local STAGE_ID=${1}
     local ACTIVATION_POINT=${2}
     local VERBOSE=${3}
+    local CHAINSPEC_PATH=${4}
     local CHUNKED_HASH_ACTIVATION
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
@@ -85,6 +86,10 @@ function _main()
     PATH_TO_STAGE="$NCTL/stages/stage-$STAGE_ID"
     COUNT_NODES=$(get_count_of_nodes)
     PROTOCOL_VERSION=$(_get_protocol_version_of_next_upgrade "$PATH_TO_STAGE")
+
+    if [ -z "$CHAINSPEC_PATH" ]; then
+        CHAINSPEC_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml"
+    fi
 
     if [ "$PROTOCOL_VERSION" != "" ]; then
         if [ $VERBOSE == true ]; then
@@ -101,7 +106,7 @@ function _main()
         setup_asset_chainspec "$COUNT_NODES" \
                               "$(get_protocol_version_for_chainspec "$PROTOCOL_VERSION")" \
                               "$ACTIVATION_POINT" \
-                              "$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml" \
+                              "$CHAINSPEC_PATH" \
                               false \
                               "$CHUNKED_HASH_ACTIVATION"
         setup_asset_node_configs "$COUNT_NODES" \
@@ -124,6 +129,7 @@ unset ACTIVATION_POINT
 unset NET_ID
 unset STAGE_ID
 unset VERBOSE
+unset CHAINSPEC_PATH
 
 for ARGUMENT in "$@"
 do
@@ -134,6 +140,7 @@ do
         net) NET_ID=${VALUE} ;;
         stage) STAGE_ID=${VALUE} ;;
         verbose) VERBOSE=${VALUE} ;;
+        chainspec_path) CHAINSPEC_PATH=${VALUE} ;;
         *)
     esac
 done
@@ -146,4 +153,5 @@ fi
 
 _main "${STAGE_ID:-1}" \
       $((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET)) \
-      "${VERBOSE:-true}"
+      "${VERBOSE:-true}" \
+      "${CHAINSPEC_PATH}"

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -322,6 +322,7 @@ function _main()
     local ACTIVATION_POINT=${2}
     local VERBOSE=${3}
     local NODE_ID=${4}
+    local CHAINSPEC_PATH=${5}
     local CHUNKED_HASH_ACTIVATION
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
@@ -331,6 +332,10 @@ function _main()
 
     PATH_TO_STAGE="$NCTL/stages/stage-$STAGE_ID"
     PROTOCOL_VERSION=$(_get_protocol_version_of_next_upgrade "$PATH_TO_STAGE" "$NODE_ID")
+
+    if [ -z "$CHAINSPEC_PATH" ]; then
+        CHAINSPEC_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml"
+    fi
 
     if [ "$PROTOCOL_VERSION" != "" ]; then
         if [ "$VERBOSE" == true ]; then
@@ -346,7 +351,7 @@ function _main()
                              "$PATH_TO_STAGE/$PROTOCOL_VERSION"
         _setup_asset_chainspec "$(get_protocol_version_for_chainspec "$PROTOCOL_VERSION")" \
                               "$ACTIVATION_POINT" \
-                              "$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml" \
+                              "$CHAINSPEC_PATH" \
                               false \
                               "$CHUNKED_HASH_ACTIVATION"
         _setup_asset_node_configs "$NODE_ID" \
@@ -372,6 +377,7 @@ unset NET_ID
 unset STAGE_ID
 unset VERBOSE
 unset NODE_ID
+unset CHAINSPEC_PATH
 
 for ARGUMENT in "$@"
 do
@@ -383,6 +389,7 @@ do
         stage) STAGE_ID=${VALUE} ;;
         verbose) VERBOSE=${VALUE} ;;
         node) NODE_ID=${VALUE} ;;
+        chainspec_path) CHAINSPEC_PATH=${VALUE} ;;
         *)
     esac
 done
@@ -396,4 +403,5 @@ fi
 _main "${STAGE_ID:-1}" \
       $((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET)) \
       "${VERBOSE:-true}" \
-      "${NODE_ID}"
+      "${NODE_ID}" \
+      "${CHAINSPEC_PATH}"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -49,12 +49,19 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
         stage="$STAGE_ID" \
-        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.in"
+        chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_1.chainspec.toml.in"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -97,7 +104,7 @@ function _step_05()
     log_step_upgrades 5 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.in"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras 2 'true' '2.0'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -66,12 +66,19 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.in" \
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_3.chainspec.toml.in" \
             accounts_path="$NCTL/sh/scenarios/accounts_toml/upgrade_scenario_3.accounts.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
@@ -196,7 +203,7 @@ function _step_08()
     log_step_upgrades 8 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.in"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras '2' 'true' '5.0'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -77,13 +77,20 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 0 "Begin upgrade_scenario_04"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_4.chainspec.toml.in"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -115,7 +122,7 @@ function _step_03()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in"
         echo ""
     done
 
@@ -248,7 +255,7 @@ function _step_09()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -77,13 +77,20 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 0 "Begin upgrade_scenario_05"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_5.chainspec.toml.in"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -115,7 +122,7 @@ function _step_03()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in"
         echo ""
     done
 
@@ -248,7 +255,7 @@ function _step_09()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
@@ -47,10 +47,17 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID"
+    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID" chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_8.chainspec.toml.in"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -71,7 +78,7 @@ function _step_03()
 
     log_step_upgrades 3 "upgrading node-6 from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT"
+    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_8.chainspec.toml.in"
 }
 
 # Step 04: Join passive node.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -59,13 +59,20 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 0 "Begin upgrade_scenario_09"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_9.chainspec.toml.in"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
 }
@@ -89,7 +96,7 @@ function _step_03()
 
     for i in $(seq 1 5); do
         log "... staging upgrade on validator node-$i"
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in"
         echo ""
     done
 
@@ -174,7 +181,7 @@ function _step_07()
 
     log "... setting upgrade assets"
 
-    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT"
+    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in"
     echo ""
     # add hash to upgrades config
     PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -45,11 +45,18 @@ function _main()
 function _step_01()
 {
     local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
-            stage="$STAGE_ID"
+            stage="$STAGE_ID" chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_10.chainspec.toml.in"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -77,7 +84,7 @@ function _step_04()
     log_step_upgrades 4 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.in"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras '2' 'true' '5.0'

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.in
@@ -1,0 +1,228 @@
+[protocol]
+# Protocol version.
+version = '1.0.0'
+# Whether we need to clear latest blocks back to the switch block just before the activation point or not.
+hard_reset = false
+# This protocol version becomes active at this point.
+#
+# If it is a timestamp string, it represents the timestamp for the genesis block.  This is the beginning of era 0.  By
+# this time, a sufficient majority (> 50% + F/2 — see finality_threshold_fraction below) of validator nodes must be up
+# and running to start the blockchain.  This timestamp is also used in seeding the pseudo-random number generator used
+# in contract-runtime for computing genesis post-state hash.
+#
+# If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
+activation_point = '${TIMESTAMP}'
+# Optional era ID in which the last emergency restart happened.
+#last_emergency_restart = 0
+# The era ID starting at which the new Merkle tree-based hashing scheme is applied.
+verifiable_chunked_hash_activation = 2
+
+[network]
+# Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
+# contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
+# post-state hash.
+name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
+
+[core]
+# Era duration.
+era_duration = '41seconds'
+# Minimum number of blocks per era.  An era will take longer than `era_duration` if that is necessary to reach the
+# minimum height.
+minimum_era_height = 10
+# Number of slots available in validator auction.
+validator_slots = 5
+# Number of eras before an auction actually defines the set of validators.  If you bond with a sufficient bid in era N,
+# you will be a validator in era N + auction_delay + 1.
+auction_delay = 3
+# The period after genesis during which a genesis validator's bid is locked.
+locked_funds_period = '90days'
+# Default number of eras that need to pass to be able to withdraw unbonded funds.
+unbonding_delay = 14
+# Round seigniorage rate represented as a fraction of the total supply.
+#
+# Annual issuance: 2%
+# Minimum round exponent: 12
+# Ticks per year: 31536000000
+#
+# (1+0.02)^((2^12)/31536000000)-1 is expressed as a fractional number below.
+round_seigniorage_rate = [15_959, 6_204_824_582_392]
+# Maximum number of associated keys for a single account.
+max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
+# Minimum allowed delegation amount in motes
+minimum_delegation_amount = 500_000_000_000
+# Enables strict arguments checking when calling a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
+strict_argument_checking = false
+
+[highway]
+# A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.
+# It is the fraction of validators that would need to equivocate to make two honest nodes see two conflicting blocks as
+# finalized: A higher value F makes it safer to rely on finalized blocks.  It also makes it more difficult to finalize
+# blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly.
+finality_threshold_fraction = [1, 3]
+# Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
+# therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
+minimum_round_exponent = 12
+# Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
+# milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
+# means 2^19 milliseconds, i.e. about 8.7 minutes.
+maximum_round_exponent = 19
+# The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
+# Expressed as a fraction (1/5 by default).
+reduced_reward_multiplier = [1, 5]
+
+[deploys]
+# The maximum number of Motes allowed to be spent during payment.  0 means unlimited.
+max_payment_cost = '0'
+# The duration after the deploy timestamp that it can be included in a block.
+max_ttl = '1day'
+# The maximum number of other deploys a deploy can depend on (require to have been executed before it can execute).
+max_dependencies = 10
+# Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
+max_block_size = 10_485_760
+# Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
+max_deploy_size = 1_048_576
+# The maximum number of non-transfer deploys permitted in a single block.
+block_max_deploy_count = 100
+# The maximum number of wasm-less transfer deploys permitted in a single block.
+block_max_transfer_count = 1000
+# The maximum number of approvals permitted in a single block.
+block_max_approval_count = 2600
+# The upper limit of total gas of all deploys in a block.
+block_gas_limit = 10_000_000_000_000
+# The limit of length of serialized payment code arguments.
+payment_args_max_length = 1024
+# The limit of length of serialized session code arguments.
+session_args_max_length = 1024
+# The minimum amount in motes for a valid native transfer.
+native_transfer_minimum_motes = 2_500_000_000
+
+[wasm]
+# Amount of free memory (in 64kB pages) each contract can use for stack.
+max_memory = 64
+# Max stack height (native WebAssembly stack limiter).
+max_stack_height = 188
+
+[wasm.storage_costs]
+# Gas charged per byte stored in the global state.
+gas_per_byte = 630_000
+
+[wasm.opcode_costs]
+# Bit operations multiplier.
+bit = 300
+# Arithmetic add operations multiplier.
+add = 210
+# Mul operations multiplier.
+mul = 240
+# Div operations multiplier.
+div = 320
+# Memory load operation multiplier.
+load = 2_500
+# Memory store operation multiplier.
+store = 4_700
+# Const store operation multiplier.
+const = 110
+# Local operations multiplier.
+local = 390
+# Global operations multiplier.
+global = 390
+# Control flow operations multiplier.
+control_flow = 440
+# Integer operations multiplier.
+integer_comparison = 250
+# Conversion operations multiplier.
+conversion = 420
+# Unreachable operation multiplier.
+unreachable = 270
+# Nop operation multiplier.
+nop = 200
+# Get current memory operation multiplier.
+current_memory = 290
+# Grow memory cost, per page (64kb).
+grow_memory = 240_000
+# Regular opcode cost.
+regular = 210
+
+# Host function declarations are located in smart_contracts/contract/src/ext_ffi.rs
+[wasm.host_function_costs]
+add = { cost = 5_800, arguments = [0, 0, 0, 0] }
+add_associated_key = { cost = 9_000, arguments = [0, 0, 0] }
+add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+blake2b = { cost = 200, arguments = [0, 0, 0, 0] }
+call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
+call_versioned_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 0, 0, 420, 0] }
+create_contract_package_at_hash = { cost = 200, arguments = [0, 0] }
+create_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
+create_purse = { cost = 2_500_000_000, arguments = [0, 0] }
+disable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
+get_balance = { cost = 3_800, arguments = [0, 0, 0] }
+get_blocktime = { cost = 330, arguments = [0] }
+get_caller = { cost = 380, arguments = [0] }
+get_key = { cost = 2_000, arguments = [0, 440, 0, 0, 0] }
+get_main_purse = { cost = 1_300, arguments = [0] }
+get_named_arg = { cost = 200, arguments = [0, 0, 0, 0] }
+get_named_arg_size = { cost = 200, arguments = [0, 0, 0] }
+get_phase = { cost = 710, arguments = [0] }
+get_system_contract = { cost = 1_100, arguments = [0, 0, 0] }
+has_key = { cost = 1_500, arguments = [0, 840] }
+is_valid_uref = { cost = 760, arguments = [0, 0] }
+load_named_keys = { cost = 42_000, arguments = [0, 0] }
+new_uref = { cost = 17_000, arguments = [0, 0, 590] }
+print = { cost = 20_000, arguments = [0, 4_600] }
+provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
+put_key = { cost = 38_000, arguments = [0, 1_100, 0, 0] }
+read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
+read_value = { cost = 6_000, arguments = [0, 0, 0] }
+read_value_local = { cost = 5_500, arguments = [0, 590, 0] }
+remove_associated_key = { cost = 4_200, arguments = [0, 0] }
+remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }
+remove_contract_user_group_urefs = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
+remove_key = { cost = 61_000, arguments = [0, 3_200] }
+ret = { cost = 23_000, arguments = [0, 420_000] }
+revert = { cost = 500, arguments = [0] }
+set_action_threshold = { cost = 74_000, arguments = [0, 0] }
+transfer_from_purse_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
+transfer_from_purse_to_purse = { cost = 82_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
+transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] }
+update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
+write = { cost = 14_000, arguments = [0, 0, 0, 980] }
+write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+
+[system_costs]
+wasmless_transfer_cost = 100_000_000
+
+[system_costs.auction_costs]
+get_era_validators = 10_000
+read_seigniorage_recipients = 10_000
+add_bid = 10_000
+withdraw_bid = 10_000
+delegate = 10_000
+undelegate = 10_000
+run_auction = 10_000
+slash = 10_000
+distribute = 10_000
+withdraw_delegator_reward = 10_000
+withdraw_validator_reward = 10_000
+read_era_id = 10_000
+activate_bid = 10_000
+
+[system_costs.mint_costs]
+mint = 2_500_000_000
+reduce_total_supply = 10_000
+create = 2_500_000_000
+balance = 10_000
+transfer = 10_000
+read_base_round_reward = 10_000
+
+[system_costs.handle_payment_costs]
+get_payment_purse = 10_000
+set_refund_purse = 10_000
+get_refund_purse = 10_000
+finalize_payment = 10_000
+
+[system_costs.standard_payment_costs]
+pay = 10_000

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_8.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_8.chainspec.toml.in
@@ -1,0 +1,228 @@
+[protocol]
+# Protocol version.
+version = '1.0.0'
+# Whether we need to clear latest blocks back to the switch block just before the activation point or not.
+hard_reset = false
+# This protocol version becomes active at this point.
+#
+# If it is a timestamp string, it represents the timestamp for the genesis block.  This is the beginning of era 0.  By
+# this time, a sufficient majority (> 50% + F/2 — see finality_threshold_fraction below) of validator nodes must be up
+# and running to start the blockchain.  This timestamp is also used in seeding the pseudo-random number generator used
+# in contract-runtime for computing genesis post-state hash.
+#
+# If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
+activation_point = '${TIMESTAMP}'
+# Optional era ID in which the last emergency restart happened.
+#last_emergency_restart = 0
+# The era ID starting at which the new Merkle tree-based hashing scheme is applied.
+verifiable_chunked_hash_activation = 2
+
+[network]
+# Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
+# contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
+# post-state hash.
+name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
+
+[core]
+# Era duration.
+era_duration = '41seconds'
+# Minimum number of blocks per era.  An era will take longer than `era_duration` if that is necessary to reach the
+# minimum height.
+minimum_era_height = 10
+# Number of slots available in validator auction.
+validator_slots = 5
+# Number of eras before an auction actually defines the set of validators.  If you bond with a sufficient bid in era N,
+# you will be a validator in era N + auction_delay + 1.
+auction_delay = 3
+# The period after genesis during which a genesis validator's bid is locked.
+locked_funds_period = '90days'
+# Default number of eras that need to pass to be able to withdraw unbonded funds.
+unbonding_delay = 14
+# Round seigniorage rate represented as a fraction of the total supply.
+#
+# Annual issuance: 2%
+# Minimum round exponent: 12
+# Ticks per year: 31536000000
+#
+# (1+0.02)^((2^12)/31536000000)-1 is expressed as a fractional number below.
+round_seigniorage_rate = [15_959, 6_204_824_582_392]
+# Maximum number of associated keys for a single account.
+max_associated_keys = 100
+# Maximum height of contract runtime call stack.
+max_runtime_call_stack_height = 12
+# Minimum allowed delegation amount in motes
+minimum_delegation_amount = 500_000_000_000
+# Enables strict arguments checking when calling a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
+strict_argument_checking = false
+
+[highway]
+# A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.
+# It is the fraction of validators that would need to equivocate to make two honest nodes see two conflicting blocks as
+# finalized: A higher value F makes it safer to rely on finalized blocks.  It also makes it more difficult to finalize
+# blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly.
+finality_threshold_fraction = [1, 3]
+# Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
+# therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
+minimum_round_exponent = 12
+# Integer between 0 and 255.  Must be greater than `minimum_round_exponent`.  The power of two that is the number of
+# milliseconds in the maximum round length, and therefore the maximum delay between a block and its child.  E.g. 19
+# means 2^19 milliseconds, i.e. about 8.7 minutes.
+maximum_round_exponent = 19
+# The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
+# Expressed as a fraction (1/5 by default).
+reduced_reward_multiplier = [1, 5]
+
+[deploys]
+# The maximum number of Motes allowed to be spent during payment.  0 means unlimited.
+max_payment_cost = '0'
+# The duration after the deploy timestamp that it can be included in a block.
+max_ttl = '1day'
+# The maximum number of other deploys a deploy can depend on (require to have been executed before it can execute).
+max_dependencies = 10
+# Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
+max_block_size = 10_485_760
+# Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
+max_deploy_size = 1_048_576
+# The maximum number of non-transfer deploys permitted in a single block.
+block_max_deploy_count = 100
+# The maximum number of wasm-less transfer deploys permitted in a single block.
+block_max_transfer_count = 1000
+# The maximum number of approvals permitted in a single block.
+block_max_approval_count = 2600
+# The upper limit of total gas of all deploys in a block.
+block_gas_limit = 10_000_000_000_000
+# The limit of length of serialized payment code arguments.
+payment_args_max_length = 1024
+# The limit of length of serialized session code arguments.
+session_args_max_length = 1024
+# The minimum amount in motes for a valid native transfer.
+native_transfer_minimum_motes = 2_500_000_000
+
+[wasm]
+# Amount of free memory (in 64kB pages) each contract can use for stack.
+max_memory = 64
+# Max stack height (native WebAssembly stack limiter).
+max_stack_height = 188
+
+[wasm.storage_costs]
+# Gas charged per byte stored in the global state.
+gas_per_byte = 630_000
+
+[wasm.opcode_costs]
+# Bit operations multiplier.
+bit = 300
+# Arithmetic add operations multiplier.
+add = 210
+# Mul operations multiplier.
+mul = 240
+# Div operations multiplier.
+div = 320
+# Memory load operation multiplier.
+load = 2_500
+# Memory store operation multiplier.
+store = 4_700
+# Const store operation multiplier.
+const = 110
+# Local operations multiplier.
+local = 390
+# Global operations multiplier.
+global = 390
+# Control flow operations multiplier.
+control_flow = 440
+# Integer operations multiplier.
+integer_comparison = 250
+# Conversion operations multiplier.
+conversion = 420
+# Unreachable operation multiplier.
+unreachable = 270
+# Nop operation multiplier.
+nop = 200
+# Get current memory operation multiplier.
+current_memory = 290
+# Grow memory cost, per page (64kb).
+grow_memory = 240_000
+# Regular opcode cost.
+regular = 210
+
+# Host function declarations are located in smart_contracts/contract/src/ext_ffi.rs
+[wasm.host_function_costs]
+add = { cost = 5_800, arguments = [0, 0, 0, 0] }
+add_associated_key = { cost = 9_000, arguments = [0, 0, 0] }
+add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+blake2b = { cost = 200, arguments = [0, 0, 0, 0] }
+call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
+call_versioned_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 0, 0, 420, 0] }
+create_contract_package_at_hash = { cost = 200, arguments = [0, 0] }
+create_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
+create_purse = { cost = 2_500_000_000, arguments = [0, 0] }
+disable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
+get_balance = { cost = 3_800, arguments = [0, 0, 0] }
+get_blocktime = { cost = 330, arguments = [0] }
+get_caller = { cost = 380, arguments = [0] }
+get_key = { cost = 2_000, arguments = [0, 440, 0, 0, 0] }
+get_main_purse = { cost = 1_300, arguments = [0] }
+get_named_arg = { cost = 200, arguments = [0, 0, 0, 0] }
+get_named_arg_size = { cost = 200, arguments = [0, 0, 0] }
+get_phase = { cost = 710, arguments = [0] }
+get_system_contract = { cost = 1_100, arguments = [0, 0, 0] }
+has_key = { cost = 1_500, arguments = [0, 840] }
+is_valid_uref = { cost = 760, arguments = [0, 0] }
+load_named_keys = { cost = 42_000, arguments = [0, 0] }
+new_uref = { cost = 17_000, arguments = [0, 0, 590] }
+print = { cost = 20_000, arguments = [0, 4_600] }
+provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
+put_key = { cost = 38_000, arguments = [0, 1_100, 0, 0] }
+read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
+read_value = { cost = 6_000, arguments = [0, 0, 0] }
+read_value_local = { cost = 5_500, arguments = [0, 590, 0] }
+remove_associated_key = { cost = 4_200, arguments = [0, 0] }
+remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }
+remove_contract_user_group_urefs = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
+remove_key = { cost = 61_000, arguments = [0, 3_200] }
+ret = { cost = 23_000, arguments = [0, 420_000] }
+revert = { cost = 500, arguments = [0] }
+set_action_threshold = { cost = 74_000, arguments = [0, 0] }
+transfer_from_purse_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
+transfer_from_purse_to_purse = { cost = 82_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
+transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] }
+update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
+write = { cost = 14_000, arguments = [0, 0, 0, 980] }
+write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+
+[system_costs]
+wasmless_transfer_cost = 100_000_000
+
+[system_costs.auction_costs]
+get_era_validators = 10_000
+read_seigniorage_recipients = 10_000
+add_bid = 10_000
+withdraw_bid = 10_000
+delegate = 10_000
+undelegate = 10_000
+run_auction = 10_000
+slash = 10_000
+distribute = 10_000
+withdraw_delegator_reward = 10_000
+withdraw_validator_reward = 10_000
+read_era_id = 10_000
+activate_bid = 10_000
+
+[system_costs.mint_costs]
+mint = 2_500_000_000
+reduce_total_supply = 10_000
+create = 2_500_000_000
+balance = 10_000
+transfer = 10_000
+read_base_round_reward = 10_000
+
+[system_costs.handle_payment_costs]
+get_payment_purse = 10_000
+set_refund_purse = 10_000
+get_refund_purse = 10_000
+finalize_payment = 10_000
+
+[system_costs.standard_payment_costs]
+pay = 10_000

--- a/utils/nctl/sh/staging/set_from_remote.sh
+++ b/utils/nctl/sh/staging/set_from_remote.sh
@@ -38,7 +38,7 @@ function _main()
         PATH_TO_STAGE="$(get_path_to_stage "$STAGE_ID")/$PROTOCOL_VERSION"
     fi
 
-    cp "$PATH_TO_REMOTE"/* "$PATH_TO_STAGE"
+    cp -r "$PATH_TO_REMOTE"/* "$PATH_TO_STAGE"
     cp "$(get_path_to_remotes)/casper-node-launcher" "$PATH_TO_STAGE"
     mv "$PATH_TO_STAGE/chainspec.toml.in" "$PATH_TO_STAGE/chainspec.toml"
 }

--- a/utils/nctl/sh/staging/set_remote_chainspecs.sh
+++ b/utils/nctl/sh/staging/set_remote_chainspecs.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+#######################################
+# Downloads remote assets for subsequent staging.
+# Arguments:
+#   Protocol version to be downloaded.
+#######################################
+
+source "$NCTL/sh/utils/main.sh"
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Base URL: nctl.
+_BASE_URL="http://nctl.casperlabs.io.s3-website.us-east-2.amazonaws.com"
+
+# Set of remote files.
+_REMOTE_FILES=($(ls $NCTL/sh/scenarios/chainspecs/upgrade* | xargs -n 1 basename))
+
+function _main()
+{
+    local PROTOCOL_VERSION=${1}
+    local PATH_TO_REMOTE
+    local REMOTE_FILE
+    local RC_VERSION
+
+    PATH_TO_REMOTE="$(get_path_to_remotes)/$PROTOCOL_VERSION/upgrade_chainspecs"
+    mkdir -p "$PATH_TO_REMOTE"
+
+    pushd "$PATH_TO_REMOTE" || exit
+    for REMOTE_FILE in "${_REMOTE_FILES[@]}"
+    do
+        if ( ! curl -Isf "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1 ); then
+            log "... downloading RC $PROTOCOL_VERSION :: $REMOTE_FILE"
+            curl -O "$_BASE_URL/release-$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
+        else
+            log "... downloading tagged release $PROTOCOL_VERSION :: $REMOTE_FILE"
+            curl -O "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
+        fi
+    done
+    if [ "${#PROTOCOL_VERSION}" = '3' ]; then
+        RC_VERSION=$(./casper-node --version | awk '{ print $2 }' |  awk -F'-' '{ print $1 }')
+        cd ..
+        if [ -d "$(get_path_to_remotes)/$RC_VERSION" ]; then
+            rm -rf "$RC_VERSION"
+        fi
+        mv "$PATH_TO_REMOTE" "$RC_VERSION"
+    fi
+    popd
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset _PROTOCOL_VERSION
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        version) _PROTOCOL_VERSION=${VALUE} ;;
+        *)
+    esac
+done
+
+_main "$_PROTOCOL_VERSION"

--- a/utils/nctl/sh/staging/set_remotes.sh
+++ b/utils/nctl/sh/staging/set_remotes.sh
@@ -37,6 +37,7 @@ function _main()
     for PROTOCOL_VERSION in "${_PROTOCOL_VERSIONS[@]}"
     do
         source "$NCTL/sh/staging/set_remote.sh" version=$PROTOCOL_VERSION
+        source "$NCTL/sh/staging/set_remote_chainspecs.sh" version=$PROTOCOL_VERSION
     done
 }
 


### PR DESCRIPTION
PR introduces using remote chainspecs for pre-upgrade protocol versions.

Note: Currently only 1.4.6 and 1.3.0 have the files necessary. Going forward these files are uploaded on push to release branches or tags.
