### PR TITLE
Fix unbonding purses serialization

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1192,7 +1192,7 @@ impl StorageInner {
     /// Put a single deploy into storage.
     pub fn put_deploy(&self, deploy: &Deploy) -> Result<bool, FatalStorageError> {
         let mut txn = self.env.begin_rw_txn()?;
-        let outcome = txn.put_value(self.deploy_db, deploy.id(), &deploy, false)?;
+        let outcome = txn.put_value(self.deploy_db, deploy.id(), deploy, false)?;
         txn.commit()?;
         Ok(outcome)
     }

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -22,7 +22,7 @@ use casper_types::{
     EraId, PublicKey, URef, U512,
 };
 
-pub const UNBONDING_PURSE_V2_MAGIC_BYTES: &[u8] = &[121, 17, 133, 179, 91, 63, 69, 222];
+const UNBONDING_PURSE_V2_MAGIC_BYTES: &[u8] = &[121, 17, 133, 179, 91, 63, 69, 222];
 
 /// Error wrapper for lower-level storage errors.
 ///

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -179,7 +179,7 @@ pub(crate) fn serialize_internal<V: 'static + Serialize>(
     Ok(buffer)
 }
 
-/// Deerializes an object from the raw bytes.
+/// Deserializes an object from the raw bytes.
 /// In case the expected object is of the `UnbondingPurse` type it uses the specialized
 /// function to provide compatibility with the legacy version of the `UnbondingPurse` struct.
 /// See [`deserialize_unbonding_purse`] for more details.

--- a/node/src/components/storage/lmdb_ext.rs
+++ b/node/src/components/storage/lmdb_ext.rs
@@ -22,7 +22,7 @@ use casper_types::{
     EraId, PublicKey, URef, U512,
 };
 
-pub const UNBONDED_PURSE_V2_MAGIC_BYTES: &[u8] = &[121, 17, 133, 179, 91, 63, 69, 222];
+pub const UNBONDING_PURSE_V2_MAGIC_BYTES: &[u8] = &[121, 17, 133, 179, 91, 63, 69, 222];
 
 /// Error wrapper for lower-level storage errors.
 ///
@@ -240,8 +240,9 @@ pub(super) fn deserialize<T: DeserializeOwned>(raw: &[u8]) -> Result<T, LmdbExtE
     bincode::deserialize(raw).map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))
 }
 
+/// Returns `true` if the specified bytes represent the legacy version of `UnbondingPurse`.
 fn is_legacy(raw: &[u8]) -> bool {
-    !raw.starts_with(UNBONDED_PURSE_V2_MAGIC_BYTES)
+    !raw.starts_with(UNBONDING_PURSE_V2_MAGIC_BYTES)
 }
 
 /// Deserializes `UnbondingPurse` from a buffer.
@@ -269,7 +270,7 @@ pub(super) fn deserialize_unbonding_purse<T: DeserializeOwned>(
         let raw = bincode::serialize(&upgraded_unbonding_purse).unwrap();
         bincode::deserialize(&raw).map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))
     } else {
-        deserialize(&raw[UNBONDED_PURSE_V2_MAGIC_BYTES.len()..])
+        deserialize(&raw[UNBONDING_PURSE_V2_MAGIC_BYTES.len()..])
     }
 }
 
@@ -282,7 +283,7 @@ pub(super) fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, LmdbExtError
 /// Serializes `UnbondingPurse` into a buffer.
 #[inline(always)]
 pub(super) fn serialize_unbonding_purse<T: Serialize>(value: &T) -> Result<Vec<u8>, LmdbExtError> {
-    let mut serialized = UNBONDED_PURSE_V2_MAGIC_BYTES.to_vec();
+    let mut serialized = UNBONDING_PURSE_V2_MAGIC_BYTES.to_vec();
     serialized.extend(bincode::serialize(value).map_err(|err| LmdbExtError::Other(Box::new(err)))?);
     Ok(serialized)
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -12,10 +12,12 @@ use num_rational::Ratio;
 use rand::{prelude::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
+use uint::hex;
 
 use casper_hashing::Digest;
 use casper_types::{
-    testing::TestRng, EraId, ExecutionResult, ProtocolVersion, PublicKey, SecretKey, U512,
+    system::auction::UnbondingPurse, testing::TestRng, AccessRights, EraId, ExecutionResult,
+    ProtocolVersion, PublicKey, SecretKey, URef, U512,
 };
 
 use super::{
@@ -29,6 +31,7 @@ use crate::{
         storage::lmdb_ext::{TransactionExt, WriteTransactionExt},
     },
     effect::{requests::StorageRequest, Multiple},
+    storage::lmdb_ext::{deserialize_internal, serialize_internal},
     testing::{ComponentHarness, UnitTestEvent},
     types::{
         AvailableBlockRange, Block, BlockHash, BlockHeader, BlockPayload, BlockSignatures, Deploy,
@@ -2070,4 +2073,56 @@ fn should_get_block_header_by_height() {
     let maybe_block_header = get_block_header_by_height(&mut harness, &mut storage, height);
     assert!(maybe_block_header.is_some());
     assert_eq!(expected_header, maybe_block_header.unwrap());
+}
+
+#[test]
+fn should_read_legacy_unbonding_purse() {
+    // These bytes represent the `UnbondingPurse` struct with the `new_validator` field removed
+    // and serialized with `bincode`.
+    // In theory, we can generate these bytes by serializing the `WithdrawPurse`, but at some point
+    // these two structs may diverge and it's a safe bet to relay on the bytes
+    // that are consistent with what we keep in the current storage.
+    const LEGACY_BYTES: &str = "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e07010000002000000000000000197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610100000020000000000000004508a07aa941707f3eb2db94c8897a80b2c1197476b6de213ac273df7d86c4ffffffffffffffffff40feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+    let decoded = hex::decode(LEGACY_BYTES).expect("decode");
+    let deserialized: UnbondingPurse = deserialize_internal(&decoded)
+        .expect("should deserialize w/o error")
+        .expect("should be Some");
+
+    // Make sure the new field is set to default.
+    assert_eq!(*deserialized.new_validator(), Option::default())
+}
+
+#[test]
+fn unbonding_purse_serialization_roundtrip() {
+    let original = UnbondingPurse::new(
+        URef::new([14; 32], AccessRights::READ_ADD_WRITE),
+        {
+            let secret_key =
+                SecretKey::ed25519_from_bytes([42; SecretKey::ED25519_LENGTH]).unwrap();
+            PublicKey::from(&secret_key)
+        },
+        {
+            let secret_key =
+                SecretKey::ed25519_from_bytes([43; SecretKey::ED25519_LENGTH]).unwrap();
+            PublicKey::from(&secret_key)
+        },
+        EraId::MAX,
+        U512::max_value() - 1,
+        Some({
+            let secret_key =
+                SecretKey::ed25519_from_bytes([44; SecretKey::ED25519_LENGTH]).unwrap();
+            PublicKey::from(&secret_key)
+        }),
+    );
+
+    let serialized = serialize_internal(&original).expect("serialization");
+    let deserialized: UnbondingPurse = deserialize_internal(&serialized)
+        .expect("should deserialize w/o error")
+        .expect("should be Some");
+
+    assert_eq!(original, deserialized);
+
+    // Explicitely assert that the `new_validator` is not `None`
+    assert!(deserialized.new_validator().is_some())
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -2079,8 +2079,8 @@ fn should_get_block_header_by_height() {
 fn should_read_legacy_unbonding_purse() {
     // These bytes represent the `UnbondingPurse` struct with the `new_validator` field removed
     // and serialized with `bincode`.
-    // In theory, we can generate these bytes by serializing the `WithdrawPurse`, but at some point
-    // these two structs may diverge and it's a safe bet to relay on the bytes
+    // In theory, we can generate these bytes by serializing the `WithdrawPurse`, but at some point,
+    // these two structs may diverge and it's a safe bet to rely on the bytes
     // that are consistent with what we keep in the current storage.
     const LEGACY_BYTES: &str = "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e07010000002000000000000000197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610100000020000000000000004508a07aa941707f3eb2db94c8897a80b2c1197476b6de213ac273df7d86c4ffffffffffffffffff40feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
@@ -2123,6 +2123,6 @@ fn unbonding_purse_serialization_roundtrip() {
 
     assert_eq!(original, deserialized);
 
-    // Explicitely assert that the `new_validator` is not `None`
+    // Explicitly assert that the `new_validator` is not `None`
     assert!(deserialized.new_validator().is_some())
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -12,7 +12,6 @@ use num_rational::Ratio;
 use rand::{prelude::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
-use uint::hex;
 
 use casper_hashing::Digest;
 use casper_types::{
@@ -2084,7 +2083,7 @@ fn should_read_legacy_unbonding_purse() {
     // that are consistent with what we keep in the current storage.
     const LEGACY_BYTES: &str = "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e07010000002000000000000000197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610100000020000000000000004508a07aa941707f3eb2db94c8897a80b2c1197476b6de213ac273df7d86c4ffffffffffffffffff40feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-    let decoded = hex::decode(LEGACY_BYTES).expect("decode");
+    let decoded = base16::decode(LEGACY_BYTES).expect("decode");
     let deserialized: UnbondingPurse = deserialize_internal(&decoded)
         .expect("should deserialize w/o error")
         .expect("should be Some");


### PR DESCRIPTION
This PR makes the `Storage` component aware that the `UnbondingPurses` struct has two different flavors:
1) Legacy one, i.e. without the `new_validator` field
2) Extended one, i.e. with the `new_validator` field

When retrieving the `UnbondingPurses` from DB, the `Storage` will always return the extended `UnbondingPurses` providing the conversion from the legacy struct on the fly, setting the `new_validator` field to `None`.

Closes #2964 