### PR TITLE
Allow the activation_point and last_emergency_restart to be equal

### DIFF
--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -70,11 +70,11 @@ impl ProtocolConfig {
         if self.global_state_update.is_none() {
             if let Some(last_emergency_restart) = self.last_emergency_restart {
                 let activation_point = self.activation_point.era_id();
-                if last_emergency_restart >= activation_point {
+                if last_emergency_restart > activation_point {
                     error!(
                         %activation_point,
                         %last_emergency_restart,
-                        "[protocol.last_emergency_restart] must be lower than \
+                        "[protocol.last_emergency_restart] cannot be greater than \
                         [protocol.activation_point] in the chainspec."
                     );
                     return false;

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -65,22 +65,18 @@ impl ProtocolConfig {
 
     /// Checks whether the values set in the config make sense and returns `false` if they don't.
     pub(super) fn is_valid(&self) -> bool {
-        // If this is not an emergency restart config, assert the `last_emergency_restart` is `None`
-        // or less than `activation_point`.
-        if self.global_state_update.is_none() {
-            if let Some(last_emergency_restart) = self.last_emergency_restart {
-                let activation_point = self.activation_point.era_id();
-                if last_emergency_restart > activation_point {
-                    error!(
-                        %activation_point,
-                        %last_emergency_restart,
-                        "[protocol.last_emergency_restart] cannot be greater than \
-                        [protocol.activation_point] in the chainspec."
-                    );
-                    return false;
-                };
-            }
-            return true;
+        // Assert the `last_emergency_restart` is `None` or no more than `activation_point`.
+        if let Some(last_emergency_restart) = self.last_emergency_restart {
+            let activation_point = self.activation_point.era_id();
+            if last_emergency_restart > activation_point {
+                error!(
+                    %activation_point,
+                    %last_emergency_restart,
+                    "[protocol.last_emergency_restart] cannot be greater than \
+                    [protocol.activation_point] in the chainspec."
+                );
+                return false;
+            };
         }
 
         true


### PR DESCRIPTION
When an upgrade is an emergency upgrade, we expect the two values to be equal, so that is a legitimate case that should be supported.
