### PR TITLE
Clear visited trie cache after transitioning to participating reactor.

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -152,6 +152,12 @@ impl EngineState<LmdbGlobalState> {
             .put_stored_values(CorrelationId::new(), state_root_hash, stored_values)
             .map_err(Into::into)
     }
+
+    /// Clears the cache of visited descendants.
+    /// NOTE: Should be called only after node transition to participating mode.
+    pub fn clear_visited_tries_cache(&self) -> Result<(), Error> {
+        self.state.clear_visited_tries_cache().map_err(Into::into)
+    }
 }
 
 impl<S> EngineState<S>

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -154,7 +154,6 @@ impl EngineState<LmdbGlobalState> {
     }
 
     /// Clears the cache of visited descendants.
-    /// NOTE: Should be called only after node transition to participating mode.
     pub fn clear_visited_tries_cache(&self) -> Result<(), Error> {
         self.state.clear_visited_tries_cache().map_err(Into::into)
     }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -154,8 +154,8 @@ impl EngineState<LmdbGlobalState> {
     }
 
     /// Clears the cache of visited descendants.
-    pub fn clear_visited_tries_cache(&self) -> Result<(), Error> {
-        self.state.clear_visited_tries_cache().map_err(Into::into)
+    pub fn clear_visited_tries_cache(&self) {
+        self.state.clear_visited_tries_cache();
     }
 }
 

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -111,6 +111,16 @@ impl LmdbGlobalState {
         )
         .map_err(Into::into)
     }
+
+    /// Clears the cache of visited descendants.
+    /// NOTE: Should be called only after node transition to participating mode.
+    pub fn clear_visited_tries_cache(&self) -> Result<(), error::Error> {
+        self.digests_without_missing_descendants
+            .write()
+            .expect("digest cache write lock")
+            .clear();
+        Ok(())
+    }
 }
 
 impl StateReader<Key, StoredValue> for LmdbGlobalStateView {

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -113,12 +113,11 @@ impl LmdbGlobalState {
     }
 
     /// Clears the cache of visited descendants.
-    pub fn clear_visited_tries_cache(&self) -> Result<(), error::Error> {
+    pub fn clear_visited_tries_cache(&self) {
         self.digests_without_missing_descendants
             .write()
             .expect("digest cache write lock")
             .clear();
-        Ok(())
     }
 }
 

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -113,7 +113,6 @@ impl LmdbGlobalState {
     }
 
     /// Clears the cache of visited descendants.
-    /// NOTE: Should be called only after node transition to participating mode.
     pub fn clear_visited_tries_cache(&self) -> Result<(), error::Error> {
         self.digests_without_missing_descendants
             .write()

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -547,7 +547,7 @@ impl ContractRuntime {
 
     /// Clears the cache of visited descendants.
     /// NOTE: Should be called only after node transition to participating mode.
-    pub fn clear_visited_tries_cache(&self) -> Result<(), engine_state::Error> {
+    pub fn clear_visited_tries_cache(&self) {
         self.engine_state.clear_visited_tries_cache()
     }
 }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -544,6 +544,12 @@ impl ContractRuntime {
             }
         }
     }
+
+    /// Clears the cache of visited descendants.
+    /// NOTE: Should be called only after node transition to participating mode.
+    pub fn clear_visited_tries_cache(&self) -> Result<(), engine_state::Error> {
+        self.engine_state.clear_visited_tries_cache()
+    }
 }
 
 impl ContractRuntime {

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -537,6 +537,9 @@ impl reactor::Reactor for Reactor {
             node_startup_instant,
         } = config;
 
+        // Clear the visited trie cache. It's not needed in the participator reactor anymore.
+        contract_runtime.clear_visited_tries_cache()?;
+
         let (our_secret_key, our_public_key) = config.consensus.load_keys(&root)?;
 
         let effect_builder = EffectBuilder::new(event_queue);

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -537,7 +537,7 @@ impl reactor::Reactor for Reactor {
             node_startup_instant,
         } = config;
 
-        // Clear the visited trie cache. It's not needed in the participator reactor anymore.
+        // Clear the visited trie cache. It's not needed in the participating reactor anymore.
         contract_runtime.clear_visited_tries_cache()?;
 
         let (our_secret_key, our_public_key) = config.consensus.load_keys(&root)?;

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -538,7 +538,7 @@ impl reactor::Reactor for Reactor {
         } = config;
 
         // Clear the visited trie cache. It's not needed in the participating reactor anymore.
-        contract_runtime.clear_visited_tries_cache()?;
+        contract_runtime.clear_visited_tries_cache();
 
         let (our_secret_key, our_public_key) = config.consensus.load_keys(&root)?;
 


### PR DESCRIPTION
When joining, we're caching set of visited trie nodes to speed up the `missing_trie_keys` function call. After transitioning to a participator reactor we don't need that cache anymore and it can be safely cleared.