### PR TITLE
Don't query local storage unnecessarily.

### DIFF
--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -62,6 +62,7 @@ impl MockReactor {
             id,
             peer,
             responder,
+            local_first: _,
         }) = reactor_event
         {
             match deploy.into() {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -121,7 +121,11 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
         id: T::Id,
         peer: NodeId,
         responder: FetchResponder<T>,
+        local_first: bool,
     ) -> Effects<Event<T>> {
+        if !local_first {
+            return self.failed_to_get_from_storage(effect_builder, id, peer);
+        }
         // Capture responder for later signalling.
         let responders = self.responders();
         responders
@@ -551,7 +555,8 @@ where
                 id,
                 peer,
                 responder,
-            }) => self.fetch(effect_builder, id, peer, responder),
+                local_first,
+            }) => self.fetch(effect_builder, id, peer, responder, local_first),
             Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1386,6 +1386,25 @@ impl<REv> EffectBuilder<REv> {
                 id,
                 peer,
                 responder,
+                local_first: true,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Fetches an item from a fetcher without checking local storage first.
+    pub(crate) async fn fetch_peer_only<T>(self, id: T::Id, peer: NodeId) -> FetchResult<T>
+    where
+        REv: From<FetcherRequest<T>>,
+        T: Item + 'static,
+    {
+        self.make_request(
+            |responder| FetcherRequest {
+                id,
+                peer,
+                responder,
+                local_first: false,
             },
             QueueKind::Regular,
         )

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1056,6 +1056,8 @@ where
     pub(crate) peer: NodeId,
     /// Responder to call with the result.
     pub(crate) responder: Responder<FetchResult<T>>,
+    /// Indicates whether to check local storage before querying peer.
+    pub(crate) local_first: bool,
 }
 
 impl<T: Item> Display for FetcherRequest<T> {


### PR DESCRIPTION
Previous PR introduced an explicit read from a local storage before using `Fetcher`'s API. Unfortunately, this creates unnecessary event requests in the fetcher itself since fetchers will always first query storage and only in case of item absence fallback to querying peers. 

This PR adds a boolean flag to `FetcherRequest` that indicates whether local storage should be queried before requesting the data from a peer.