### PR TITLE
Flush network buffers when sending potential requests

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.  The format
 * Added CORS behavior to allow any route on the JSON-RPC, REST and SSE servers.
 * Storage operations are now executed in parallel, the degree of parallelism can be controlled through the `storage.max_sync_tasks` setting.
 * The network message format has been replaced with a more efficient encoding while keeping the initial handshake intact.
+* The node flushes outgoing messages immediately, trading bandwidth for latecy. This change is made to optimize feedback loops of various components in the system.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -576,6 +576,7 @@ where
             // during regular upgrades.
             ConnectionError::TlsInitialization(_)
             | ConnectionError::TcpConnection(_)
+            | ConnectionError::TcpNoDelay(_)
             | ConnectionError::TlsHandshake(_)
             | ConnectionError::HandshakeSend(_)
             | ConnectionError::HandshakeRecv(_)

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -111,6 +111,13 @@ pub enum ConnectionError {
         #[source]
         io::Error,
     ),
+    /// Did not succeed setting TCP_NODELAY on the connection.
+    #[error("Could not set TCP_NODELAY on outgoing connection")]
+    TcpNoDelay(
+        #[serde(skip_serializing)]
+        #[source]
+        io::Error,
+    ),
     /// Handshaking error.
     #[error("TLS handshake error")]
     TlsHandshake(

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -77,6 +77,10 @@ where
         .await
         .map_err(ConnectionError::TcpConnection)?;
 
+    stream
+        .set_nodelay(true)
+        .map_err(ConnectionError::TcpNoDelay)?;
+
     let mut transport = tls::create_tls_connector(context.our_cert.as_x509(), &context.secret_key)
         .and_then(|connector| connector.configure())
         .and_then(|mut config| {


### PR DESCRIPTION
Disable Nagle's algorithm on outbound sockets and flush after messages which may have an interested party awaiting them. This should alleviate issues where the large OS send buffer was causing buildup of requests without receiving backpressure.
