### PR TITLE
Do not mark peers as bad if they cannot redeem themselves

### DIFF
--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -167,6 +167,11 @@ impl<'a> ChainSyncContext<'a> {
 
     /// Marks a peer as bad.
     fn mark_bad_peer(&self, peer: NodeId) {
+        if self.config.redemption_interval == 0 {
+            info!(%peer, "not marking peer as bad for syncing, redemption is disabled");
+            return;
+        }
+
         let mut bad_peer_list = self
             .bad_peer_list
             .write()


### PR DESCRIPTION
This disables marking peers as bad if the redemption interval is 0. High values can still be used to get the same effect.
