### PR TITLE
NCTL: fix broke s3 link to nctl dump on test failure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -138,6 +138,11 @@ steps:
 
 - name: nctl-upgrade-test
   <<: *buildenv
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nctl_upgrade.sh
 
@@ -470,6 +475,11 @@ steps:
 
 - name: nctl-nightly-tests
   <<: *buildenv
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: put-drone-aws-ak
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: put-drone-aws-sk
   commands:
   - bash -i ./ci/nightly-test.sh
 


### PR DESCRIPTION
Changes:
- Adds keys needed to upload to s3 on NCTL failure

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/439
