### PR TITLE
Fix and extend fetcher's metrics.

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -623,8 +623,6 @@ where
                 self.signal(id, Err(FetcherError::Absent { id, peer }), peer)
             }
             Event::TimeoutPeer { id, peer } => {
-                info!(TAG=%T::TAG, %id, %peer, "request timed out");
-                self.metrics().timeouts.inc();
                 self.signal(id, Err(FetcherError::TimedOut { id, peer }), peer)
             }
         }

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -198,16 +198,38 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
     ) -> Effects<Event<T>> {
         let mut effects = Effects::new();
         let mut all_responders = self.responders().remove(&id).unwrap_or_default();
-        for responder in all_responders.remove(&peer).into_iter().flatten() {
-            effects.extend(responder.respond(result.clone()).ignore());
-            if let Err(FetcherError::TimedOut { .. }) = result {
-                // Only if there's still a responder waiting for the item we increment the
-                // metric. Otherwise we will count every request as timed out, even if the item
-                // had been fetched. We increment the metric for every responder as that's how
-                // many requests were made in the first place – since requests are duplicated we
-                // will request the same item multiple times.
-                info!(TAG=%T::TAG, %id, %peer, "request timed out");
-                self.metrics().timeouts.inc();
+        match result {
+            Ok(item) => {
+                // Since this is a success, we can safely respond to all awaiting processes.
+                for responder in all_responders.remove(&peer).into_iter().flatten() {
+                    effects.extend(responder.respond(Ok(item.clone())).ignore());
+                }
+            }
+            Err(FetcherError::TimedOut { .. }) => {
+                let mut responders = all_responders.remove(&peer).into_iter().flatten();
+                // We take just one responder as only one request had timed out. We want to avoid
+                // prematurely failing too many waiting processes since other requests may still
+                // succeed before timing out.
+                if let Some(responder) = responders.next() {
+                    effects.extend(responder.respond(result.clone()).ignore());
+                    // Only if there's still a responder waiting for the item we increment the
+                    // metric. Otherwise we will count every request as timed out, even if the item
+                    // had been fetched.
+                    info!(TAG=%T::TAG, %id, %peer, "request timed out");
+                    self.metrics().timeouts.inc();
+                }
+
+                let responders: Vec<_> = responders.collect();
+                if !responders.is_empty() {
+                    all_responders.insert(peer, responders);
+                }
+            }
+            Err(FetcherError::Absent { .. } | FetcherError::CouldNotConstructGetRequest { .. }) => {
+                // For all other error variants we can safely respond with failure as there's no
+                // chance for the request to succeed.
+                for responder in all_responders.remove(&peer).into_iter().flatten() {
+                    effects.extend(responder.respond(result.clone()).ignore());
+                }
             }
         }
         if !all_responders.is_empty() {
@@ -226,12 +248,10 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
                     "Got from storage when fetching {:?} from peer",
                     T::TAG,
                 );
-                self.metrics().found_in_storage.inc();
                 // It is always safe to respond to all when we retrieved from storage.
                 self.respond_to_all(id, fetched_data_from_storage)
             }
             Ok(fetched_data_from_peer @ FetchedData::FromPeer { .. }) => {
-                self.metrics().found_on_peer.inc();
                 if Self::SAFE_TO_RESPOND_TO_ALL {
                     self.respond_to_all(id, fetched_data_from_peer)
                 } else {
@@ -561,7 +581,7 @@ where
                 maybe_item,
             } => match *maybe_item {
                 Some(item) => {
-                    self.metrics.found_in_storage.inc();
+                    self.metrics().found_in_storage.inc();
                     self.signal(
                         id,
                         Ok(FetchedData::FromStorage {
@@ -579,7 +599,7 @@ where
             } => {
                 match source {
                     Source::Peer(peer) => {
-                        self.metrics.found_on_peer.inc();
+                        self.metrics().found_on_peer.inc();
                         if let Err(err) = item.validate(self.verifiable_chunked_hash_activation()) {
                             warn!(?peer, ?err, ?item, "Peer sent invalid item, banning peer");
                             effect_builder.announce_disconnect_from_peer(peer).ignore()
@@ -603,6 +623,8 @@ where
                 self.signal(id, Err(FetcherError::Absent { id, peer }), peer)
             }
             Event::TimeoutPeer { id, peer } => {
+                info!(TAG=%T::TAG, %id, %peer, "request timed out");
+                self.metrics().timeouts.inc();
                 self.signal(id, Err(FetcherError::TimedOut { id, peer }), peer)
             }
         }

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -153,10 +153,13 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
     ) -> Effects<Event<T>> {
         let peer_timeout = self.peer_timeout();
         match Message::new_get_request::<T>(&id) {
-            Ok(message) => async move {
-                effect_builder.send_message(peer, message).await;
+            Ok(message) => {
+                self.metrics().fetch_total.inc();
+                async move {
+                    effect_builder.send_message(peer, message).await;
 
-                effect_builder.set_timeout(peer_timeout).await
+                    effect_builder.set_timeout(peer_timeout).await
+                }
             }
             .event(move |_| Event::TimeoutPeer { id, peer }),
             Err(error) => {

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -57,5 +57,6 @@ impl Drop for Metrics {
         unregister_metric!(self.registry, self.found_in_storage);
         unregister_metric!(self.registry, self.found_on_peer);
         unregister_metric!(self.registry, self.timeouts);
+        unregister_metric!(self.registry, self.fetch_total);
     }
 }

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -10,6 +10,8 @@ pub(crate) struct Metrics {
     pub found_on_peer: IntCounter,
     /// Number of fetch requests that timed out.
     pub timeouts: IntCounter,
+    /// Number of total fetch requests made.
+    pub fetch_total: IntCounter,
     /// Reference to the registry for unregistering.
     registry: Registry,
 }
@@ -31,14 +33,20 @@ impl Metrics {
             format!("{}_timeouts", name),
             format!("number of {} fetch requests that timed out", name),
         )?;
+        let fetch_total = IntCounter::new(
+            format!("{}_fetch_total", name),
+            format!("number of {} all fetch requests made", name),
+        )?;
         registry.register(Box::new(found_in_storage.clone()))?;
         registry.register(Box::new(found_on_peer.clone()))?;
         registry.register(Box::new(timeouts.clone()))?;
+        registry.register(Box::new(fetch_total.clone()))?;
 
         Ok(Metrics {
             found_in_storage,
             found_on_peer,
             timeouts,
+            fetch_total,
             registry: registry.clone(),
         })
     }


### PR DESCRIPTION
This adds a new metric `_fetcher_total` which increments the counter on every new fetcher request sent to a PR.

It also fixes fetcher metric where it would unnecessarily increment metrics:
* `found_on_peer`
* `found_in_storage`
This is achieved by moving the metric incrementation to a single place - at the top level of the component.

Lastly, whenever we receive a timeout we will pop a single responder awaiting for that data and increment the timeout metric only once. This ensures that we don't time out (fail) too many requests prematurely since some of them may have just been sent out and could still succeed before their own time outs fire