### PR TITLE
Increase CHUNK_SIZE_BYTES to 8MiB to avoid chunking tries unnecessarily

### DIFF
--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -409,7 +409,7 @@ mod tests {
     // greater than the chunk limit.
     fn create_test_pairs_with_large_data() -> [TestPair; 2] {
         let val = CLValue::from_t(
-            String::from_utf8(vec![b'a'; ChunkWithProof::CHUNK_SIZE_BYTES * 5]).unwrap(),
+            String::from_utf8(vec![b'a'; ChunkWithProof::CHUNK_SIZE_BYTES * 2]).unwrap(),
         )
         .unwrap();
         [

--- a/hashing/src/chunk_with_proof.rs
+++ b/hashing/src/chunk_with_proof.rs
@@ -53,8 +53,8 @@ impl ChunkWithProof {
     pub const CHUNK_SIZE_BYTES: usize = 10;
 
     #[cfg(not(test))]
-    /// 1 MiB
-    pub const CHUNK_SIZE_BYTES: usize = 1 << 20;
+    /// 8 MiB
+    pub const CHUNK_SIZE_BYTES: usize = 8 * 1024 * 1024;
 
     /// Constructs the [`ChunkWithProof`] that contains the chunk of data with the appropriate index
     /// and the cryptographic proof.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Introduce fast-syncing to join the network, avoiding the need to execute every block to catch up.
-* Add `max_parallel_deploy_fetches_per_peer` and `max_parallel_trie_fetches_per_peer` config options to the `[node]` section to control how many requests are made in parallel while syncing.
+* Add `max_parallel_deploy_fetches` and `max_parallel_trie_fetches` config options to the `[node]` section to control how many requests are made in parallel while syncing.
 * Add `retry_interval` to `[node]` config section to control the delay between retry attempts while syncing.
 * Add `sync_to_genesis` to `[node]` config section, along with syncing to genesis capabilities.
 * Add new event to the main SSE server stream across all endpoints `<IP:PORT>/events/*` which emits a shutdown event when the node shuts down.

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -17,12 +17,10 @@ pub(super) struct Config {
     chainspec: Arc<Chainspec>,
     /// Hash used as a trust anchor when joining, if any.
     trusted_hash: Option<BlockHash>,
-    /// Maximum number of fetch-deploy tasks per peer to run in parallel during chain
-    /// synchronization.
-    max_parallel_deploy_fetches_per_peer: u32,
-    /// Maximum number of fetch-trie tasks per peer to run in parallel during chain
-    /// synchronization.
-    max_parallel_trie_fetches_per_peer: u32,
+    /// Maximum number of deploys to fetch in parallel.
+    max_parallel_deploy_fetches: u32,
+    /// Maximum number of trie nodes to fetch in parallel.
+    max_parallel_trie_fetches: u32,
     /// The duration for which to pause between retry attempts while synchronising.
     retry_interval: Duration,
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
@@ -47,8 +45,8 @@ impl Config {
         Config {
             chainspec: Arc::clone(&chainspec),
             trusted_hash: node_config.trusted_hash,
-            max_parallel_deploy_fetches_per_peer: node_config.max_parallel_deploy_fetches_per_peer,
-            max_parallel_trie_fetches_per_peer: node_config.max_parallel_trie_fetches_per_peer,
+            max_parallel_deploy_fetches: node_config.max_parallel_deploy_fetches,
+            max_parallel_trie_fetches: node_config.max_parallel_trie_fetches,
             retry_interval: Duration::from_millis(node_config.retry_interval.millis()),
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
@@ -117,12 +115,12 @@ impl Config {
         self.trusted_hash
     }
 
-    pub(super) fn max_parallel_deploy_fetches_per_peer(&self) -> usize {
-        self.max_parallel_deploy_fetches_per_peer as usize
+    pub(super) fn max_parallel_deploy_fetches(&self) -> usize {
+        self.max_parallel_deploy_fetches as usize
     }
 
-    pub(super) fn max_parallel_trie_fetches_per_peer(&self) -> usize {
-        self.max_parallel_trie_fetches_per_peer as usize
+    pub(super) fn max_parallel_trie_fetches(&self) -> usize {
+        self.max_parallel_trie_fetches as usize
     }
 
     pub(super) fn retry_interval(&self) -> Duration {

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -5,12 +5,10 @@ use crate::types::BlockHash;
 
 use casper_types::TimeDiff;
 
-/// Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization,
-/// by default.
-const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES_PER_PEER: u32 = 10;
-/// Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization, by
-/// default.
-const DEFAULT_MAX_PARALLEL_TRIE_FETCHES_PER_PEER: u32 = 10;
+/// Maximum number of deploys to fetch in parallel, by default.
+const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 20;
+/// Maximum number of tries to fetch in parallel, by default.
+const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 20;
 const DEFAULT_PEER_REDEMPTION_INTERVAL: u32 = 10_000;
 const DEFAULT_RETRY_INTERVAL: &str = "100ms";
 
@@ -22,13 +20,11 @@ pub struct NodeConfig {
     /// Hash used as a trust anchor when joining, if any.
     pub trusted_hash: Option<BlockHash>,
 
-    /// Maximum number of fetch-deploy tasks per peer to run in parallel during chain
-    /// synchronization.
-    pub max_parallel_deploy_fetches_per_peer: u32,
+    /// Maximum number of deploys to fetch in parallel.
+    pub max_parallel_deploy_fetches: u32,
 
-    /// Maximum number of fetch-trie tasks per peer to run in parallel during chain
-    /// synchronization.
-    pub max_parallel_trie_fetches_per_peer: u32,
+    /// Maximum number of trie nodes to fetch in parallel.
+    pub max_parallel_trie_fetches: u32,
 
     /// The duration for which to pause between retry attempts while synchronising during joining.
     pub retry_interval: TimeDiff,
@@ -45,8 +41,8 @@ impl Default for NodeConfig {
     fn default() -> NodeConfig {
         NodeConfig {
             trusted_hash: None,
-            max_parallel_deploy_fetches_per_peer: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES_PER_PEER,
-            max_parallel_trie_fetches_per_peer: DEFAULT_MAX_PARALLEL_TRIE_FETCHES_PER_PEER,
+            max_parallel_deploy_fetches: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES,
+            max_parallel_trie_fetches: DEFAULT_MAX_PARALLEL_TRIE_FETCHES,
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -5,10 +5,10 @@ use crate::types::BlockHash;
 
 use casper_types::TimeDiff;
 
-/// Maximum number of deploys to fetch in parallel, by default.
-const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 20;
-/// Maximum number of tries to fetch in parallel, by default.
-const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 20;
+/// Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 5000;
+/// Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 5000;
 const DEFAULT_PEER_REDEMPTION_INTERVAL: u32 = 10_000;
 const DEFAULT_RETRY_INTERVAL: &str = "100ms";
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of deploys to fetch in parallel.
-max_parallel_deploy_fetches = 20
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
 
-# Maximum number of trie nodes to fetch in parallel.
-max_parallel_trie_fetches = 20
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization.
-max_parallel_deploy_fetches_per_peer = 10
+# Maximum number of deploys to fetch in parallel.
+max_parallel_deploy_fetches = 20
 
-# Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization.
-max_parallel_trie_fetches_per_peer = 10
+# Maximum number of trie nodes to fetch in parallel.
+max_parallel_trie_fetches = 20
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of deploys to fetch in parallel.
-max_parallel_deploy_fetches = 20
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
 
-# Maximum number of trie nodes to fetch in parallel.
-max_parallel_trie_fetches = 20
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization.
-max_parallel_deploy_fetches_per_peer = 10
+# Maximum number of deploys to fetch in parallel.
+max_parallel_deploy_fetches = 20
 
-# Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization.
-max_parallel_trie_fetches_per_peer = 10
+# Maximum number of trie nodes to fetch in parallel.
+max_parallel_trie_fetches = 20
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of deploys to fetch in parallel.
-max_parallel_deploy_fetches = 20
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
 
-# Maximum number of trie nodes to fetch in parallel.
-max_parallel_trie_fetches = 20
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization.
-max_parallel_deploy_fetches_per_peer = 10
+# Maximum number of deploys to fetch in parallel.
+max_parallel_deploy_fetches = 20
 
-# Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization.
-max_parallel_trie_fetches_per_peer = 10
+# Maximum number of trie nodes to fetch in parallel.
+max_parallel_trie_fetches = 20
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -10,11 +10,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization.
-max_parallel_deploy_fetches_per_peer = 10
+# Maximum number of deploys to fetch in parallel.
+max_parallel_deploy_fetches = 20
 
-# Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization.
-max_parallel_trie_fetches_per_peer = 10
+# Maximum number of trie nodes to fetch in parallel.
+max_parallel_trie_fetches = 20
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -10,11 +10,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of deploys to fetch in parallel.
-max_parallel_deploy_fetches = 20
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
 
-# Maximum number of trie nodes to fetch in parallel.
-max_parallel_trie_fetches = 20
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of deploys to fetch in parallel.
-max_parallel_deploy_fetches = 20
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
 
-# Maximum number of trie nodes to fetch in parallel.
-max_parallel_trie_fetches = 20
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -6,11 +6,11 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks per peer to run in parallel during chain synchronization.
-max_parallel_deploy_fetches_per_peer = 10
+# Maximum number of deploys to fetch in parallel.
+max_parallel_deploy_fetches = 20
 
-# Maximum number of fetch-trie tasks per peer to run in parallel during chain synchronization.
-max_parallel_trie_fetches_per_peer = 10
+# Maximum number of trie nodes to fetch in parallel.
+max_parallel_trie_fetches = 20
 
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'


### PR DESCRIPTION
This is a change which was overlooked when the final decision on the temp chainspec value of `max_stored_value_size` was made in node 1.4.5.

This PR also reverts bfa3a02 since the recent work on networking backpressure makes the previous global form of `max_parallel_deploy/trie_fetches` more appropriate.