### PR TITLE
Optimize deploy metadata db initialization

### DIFF
--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1716,6 +1716,7 @@ mod tests {
             v1_3_0,
             false,
             verifiable_chunked_hash_activation,
+            None,
         )
         .take_header();
 

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -581,6 +581,7 @@ mod tests {
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
+                None,
             )
             .header()
             .clone(),
@@ -606,6 +607,7 @@ mod tests {
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
+                None,
             )
             .header()
             .clone(),
@@ -624,6 +626,7 @@ mod tests {
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
+                None,
             )
             .header()
             .clone(),
@@ -642,6 +645,7 @@ mod tests {
                 PROTOCOL_VERSION,
                 IS_SWITCH,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
+                None,
             )
             .header()
             .clone(),

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -707,6 +707,7 @@ mod tests {
             ProtocolVersion::V1_0_0,
             false,
             verifiable_chunked_hash_activation,
+            None,
         );
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
@@ -763,6 +764,7 @@ mod tests {
             ProtocolVersion::V1_0_0,
             false,
             verifiable_chunked_hash_activation,
+            None,
         ));
         let block_hash = *block.hash();
         let block_era = block.header().era_id();
@@ -834,7 +836,7 @@ mod tests {
                 BlockHash::random(&mut rng),              // parent hash
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // parent seed
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
-                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true),
+                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true, None),
                 Some(validators.clone()),
                 protocol_version,
                 verifiable_chunked_hash_activation,
@@ -851,7 +853,7 @@ mod tests {
                 BlockHash::random(&mut rng),              // parent hash
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // parent seed
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
-                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true),
+                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true, None),
                 Some(validators),
                 protocol_version,
                 verifiable_chunked_hash_activation,
@@ -952,7 +954,7 @@ mod tests {
                 BlockHash::random(&mut rng),              // parent hash
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // parent seed
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
-                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true),
+                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true, None),
                 Some(validators.clone()),
                 protocol_version,
                 verifiable_chunked_hash_activation,
@@ -968,7 +970,7 @@ mod tests {
                 BlockHash::random(&mut rng),              // parent hash
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // parent seed
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
-                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true),
+                FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true, None),
                 Some(validators),
                 protocol_version,
                 verifiable_chunked_hash_activation,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1163,7 +1163,7 @@ impl StorageInner {
                 let mut txn = self.env.begin_rw_txn()?;
                 if !txn.put_value(
                     self.block_header_db,
-                    &block_header.hash(self.verifiable_chunked_hash_activation()),
+                    &block_header.hash(self.verifiable_chunked_hash_activation),
                     &block_header,
                     false,
                 )? {
@@ -1180,7 +1180,7 @@ impl StorageInner {
                     insert_to_block_header_indices(
                         &mut indices,
                         &block_header,
-                        self.verifiable_chunked_hash_activation(),
+                        self.verifiable_chunked_hash_activation,
                     )?;
                 }
 
@@ -1222,7 +1222,7 @@ impl StorageInner {
     /// couldn't be written because it already existed, and `Err(_)` if there was an error.
     pub fn write_block(&self, block: &Block) -> Result<bool, FatalStorageError> {
         // Validate the block prior to inserting it into the database
-        block.verify(self.verifiable_chunked_hash_activation())?;
+        block.verify(self.verifiable_chunked_hash_activation)?;
         let mut txn = self.env.begin_rw_txn()?;
         // Write the block body
         {
@@ -1230,7 +1230,7 @@ impl StorageInner {
             let block_body = block.body();
             let success = match block
                 .header()
-                .hashing_algorithm_version(self.verifiable_chunked_hash_activation())
+                .hashing_algorithm_version(self.verifiable_chunked_hash_activation)
             {
                 HashingAlgorithmVersion::V1 => {
                     self.put_single_block_body_v1(&mut txn, block_body_hash, block_body)?
@@ -1257,13 +1257,11 @@ impl StorageInner {
             insert_to_block_header_indices(
                 &mut indices,
                 block.header(),
-                self.verifiable_chunked_hash_activation(),
+                self.verifiable_chunked_hash_activation,
             )?;
             insert_to_deploy_index(
                 &mut indices.deploy_hash_index,
-                block
-                    .header()
-                    .hash(self.verifiable_chunked_hash_activation()),
+                block.header().hash(self.verifiable_chunked_hash_activation),
                 block.body(),
             )?;
         }
@@ -1490,7 +1488,7 @@ impl StorageInner {
         block_header: &BlockHeader,
         block_hash: &BlockHash,
     ) -> Result<(), FatalStorageError> {
-        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation());
+        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
         if found_block_header_hash != *block_hash {
             return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
                 queried_block_hash_bytes: block_hash.as_ref().to_vec(),
@@ -1606,7 +1604,7 @@ impl StorageInner {
                 transfer_hashes_db: self.transfer_hashes_db,
                 proposer_db: self.proposer_db,
             },
-            self.verifiable_chunked_hash_activation(),
+            self.verifiable_chunked_hash_activation,
         );
         let block_body = match maybe_block_body? {
             Some(block_body) => block_body,
@@ -1621,7 +1619,7 @@ impl StorageInner {
         let block = Block::new_from_header_and_body(
             block_header,
             block_body,
-            self.verifiable_chunked_hash_activation(),
+            self.verifiable_chunked_hash_activation,
         )?;
         Ok(Some(block))
     }
@@ -1718,14 +1716,14 @@ impl StorageInner {
                 transfer_hashes_db: self.transfer_hashes_db,
                 proposer_db: self.proposer_db,
             },
-            self.verifiable_chunked_hash_activation(),
+            self.verifiable_chunked_hash_activation,
         );
         if let Some(block_body) = maybe_block_body? {
             Ok(Some(BlockWithMetadata {
                 block: Block::new_from_header_and_body(
                     block_header,
                     block_body,
-                    self.verifiable_chunked_hash_activation(),
+                    self.verifiable_chunked_hash_activation,
                 )?,
                 finality_signatures: block_signatures,
             }))
@@ -1819,7 +1817,7 @@ impl StorageInner {
         }
         let block_signatures = match self.get_finality_signatures(
             tx,
-            &block_header.hash(self.verifiable_chunked_hash_activation()),
+            &block_header.hash(self.verifiable_chunked_hash_activation),
         )? {
             None => return Ok(None),
             Some(block_signatures) => block_signatures,
@@ -1984,10 +1982,6 @@ impl StorageInner {
         }
 
         Ok(())
-    }
-
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.verifiable_chunked_hash_activation
     }
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1163,7 +1163,7 @@ impl StorageInner {
                 let mut txn = self.env.begin_rw_txn()?;
                 if !txn.put_value(
                     self.block_header_db,
-                    &block_header.hash(self.verifiable_chunked_hash_activation),
+                    &block_header.hash(self.verifiable_chunked_hash_activation()),
                     &block_header,
                     false,
                 )? {
@@ -1180,7 +1180,7 @@ impl StorageInner {
                     insert_to_block_header_indices(
                         &mut indices,
                         &block_header,
-                        self.verifiable_chunked_hash_activation,
+                        self.verifiable_chunked_hash_activation(),
                     )?;
                 }
 
@@ -1222,7 +1222,7 @@ impl StorageInner {
     /// couldn't be written because it already existed, and `Err(_)` if there was an error.
     pub fn write_block(&self, block: &Block) -> Result<bool, FatalStorageError> {
         // Validate the block prior to inserting it into the database
-        block.verify(self.verifiable_chunked_hash_activation)?;
+        block.verify(self.verifiable_chunked_hash_activation())?;
         let mut txn = self.env.begin_rw_txn()?;
         // Write the block body
         {
@@ -1230,7 +1230,7 @@ impl StorageInner {
             let block_body = block.body();
             let success = match block
                 .header()
-                .hashing_algorithm_version(self.verifiable_chunked_hash_activation)
+                .hashing_algorithm_version(self.verifiable_chunked_hash_activation())
             {
                 HashingAlgorithmVersion::V1 => {
                     self.put_single_block_body_v1(&mut txn, block_body_hash, block_body)?
@@ -1257,11 +1257,13 @@ impl StorageInner {
             insert_to_block_header_indices(
                 &mut indices,
                 block.header(),
-                self.verifiable_chunked_hash_activation,
+                self.verifiable_chunked_hash_activation(),
             )?;
             insert_to_deploy_index(
                 &mut indices.deploy_hash_index,
-                block.header().hash(self.verifiable_chunked_hash_activation),
+                block
+                    .header()
+                    .hash(self.verifiable_chunked_hash_activation()),
                 block.body(),
             )?;
         }
@@ -1488,7 +1490,7 @@ impl StorageInner {
         block_header: &BlockHeader,
         block_hash: &BlockHash,
     ) -> Result<(), FatalStorageError> {
-        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
+        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation());
         if found_block_header_hash != *block_hash {
             return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
                 queried_block_hash_bytes: block_hash.as_ref().to_vec(),
@@ -1604,7 +1606,7 @@ impl StorageInner {
                 transfer_hashes_db: self.transfer_hashes_db,
                 proposer_db: self.proposer_db,
             },
-            self.verifiable_chunked_hash_activation,
+            self.verifiable_chunked_hash_activation(),
         );
         let block_body = match maybe_block_body? {
             Some(block_body) => block_body,
@@ -1619,7 +1621,7 @@ impl StorageInner {
         let block = Block::new_from_header_and_body(
             block_header,
             block_body,
-            self.verifiable_chunked_hash_activation,
+            self.verifiable_chunked_hash_activation(),
         )?;
         Ok(Some(block))
     }
@@ -1716,14 +1718,14 @@ impl StorageInner {
                 transfer_hashes_db: self.transfer_hashes_db,
                 proposer_db: self.proposer_db,
             },
-            self.verifiable_chunked_hash_activation,
+            self.verifiable_chunked_hash_activation(),
         );
         if let Some(block_body) = maybe_block_body? {
             Ok(Some(BlockWithMetadata {
                 block: Block::new_from_header_and_body(
                     block_header,
                     block_body,
-                    self.verifiable_chunked_hash_activation,
+                    self.verifiable_chunked_hash_activation(),
                 )?,
                 finality_signatures: block_signatures,
             }))
@@ -1817,7 +1819,7 @@ impl StorageInner {
         }
         let block_signatures = match self.get_finality_signatures(
             tx,
-            &block_header.hash(self.verifiable_chunked_hash_activation),
+            &block_header.hash(self.verifiable_chunked_hash_activation()),
         )? {
             None => return Ok(None),
             Some(block_signatures) => block_signatures,
@@ -1982,6 +1984,10 @@ impl StorageInner {
         }
 
         Ok(())
+    }
+
+    fn verifiable_chunked_hash_activation(&self) -> EraId {
+        self.verifiable_chunked_hash_activation
     }
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2717,7 +2717,6 @@ fn initialize_deploy_metadata_db_2(
         match raw_val {
             Ok(raw) => {
                 let mut deploy_metadata: DeployMetadata = lmdb_ext::deserialize(raw)?;
-                println!("found metadata: {:?}", deploy_metadata);
                 println!("Deleting v2: {}", deleted_deploy_hash);
                 txn.del(*deploy_metadata_db, deleted_deploy_hash, None);
             }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1203,7 +1203,18 @@ fn should_hard_reset() {
             &mut storage,
             Box::new(block.clone())
         ));
+        //if block.height() >= 6 {
+        println!(
+            "------------------- PUTTING BLOCK {} WITH DEPLOYS",
+            block.height()
+        );
+        dbg!(&block.body().deploy_hashes());
+        dbg!(&block.body().transfer_hashes());
+        println!("------------------- PUTTING BLOCK WITH DEPLOYS END\n\n");
+        //}
     }
+
+    println!("\n\n");
 
     // Create and store signatures for these blocks.
     for block in &blocks {
@@ -1219,6 +1230,7 @@ fn should_hard_reset() {
     // and so on.
     let mut deploys = vec![];
     let mut execution_results = vec![];
+    println!("------------------- PUTTING TEST DEPLOYS");
     for block_hash in blocks.iter().map(|block| block.hash()) {
         let deploy = Deploy::random(&mut harness.rng);
         let execution_result: ExecutionResult = harness.rng.gen();
@@ -1231,9 +1243,11 @@ fn should_hard_reset() {
             *block_hash,
             exec_results.clone(),
         );
+        println!("\t{}", deploy.id());
         deploys.push(deploy);
         execution_results.push(exec_results);
     }
+    println!("------------------- PUTTING TEST DEPLOYS END\n\n");
 
     // Check the highest block is #7.
     assert_eq!(
@@ -1291,9 +1305,9 @@ fn should_hard_reset() {
     // Test with a hard reset to era 2, deleting blocks (and associated data) 6 and 7.
     check(2);
     // Test with a hard reset to era 1, further deleting blocks (and associated data) 3, 4 and 5.
-    check(1);
+    //check(1);
     // Test with a hard reset to era 0, deleting all blocks and associated data.
-    check(0);
+    //check(0);
 }
 
 #[test]

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -497,6 +497,9 @@ impl FinalizedBlock {
     }
 
     #[cfg(test)]
+    /// Generates a random instance using a `TestRng`, but using the specified values.
+    /// If `deploy` is `None`, random deploys will be generated, otherwise, the provided `deploy`
+    /// will be used.
     pub fn random_with_specifics(
         rng: &mut TestRng,
         era_id: EraId,
@@ -1668,8 +1671,6 @@ impl Block {
     }
 
     /// Generates a random instance using a `TestRng`, but using the specified values.
-    /// If `deploy` is `None`, random deploys will be generated, otherwise, the provided `deploy`
-    /// will be used.
     #[cfg(test)]
     pub fn random_with_specifics(
         rng: &mut TestRng,

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -493,26 +493,31 @@ impl FinalizedBlock {
         let height = era * 10 + rng.gen_range(0..10);
         let is_switch = rng.gen_bool(0.1);
 
-        FinalizedBlock::random_with_specifics(rng, EraId::from(era), height, is_switch)
+        FinalizedBlock::random_with_specifics(rng, EraId::from(era), height, is_switch, None)
     }
 
-    /// Generates a random instance using a `TestRng`, but using the specified era ID and height.
     #[cfg(test)]
     pub fn random_with_specifics(
         rng: &mut TestRng,
         era_id: EraId,
         height: u64,
         is_switch: bool,
+        deploy: Option<&Deploy>,
     ) -> Self {
-        let deploy_count = rng.gen_range(0..11);
-        let deploys = iter::repeat_with(|| {
-            DeployWithApprovals::new(
-                DeployHash::new(rng.gen::<[u8; Digest::LENGTH]>().into()),
-                BTreeSet::new(),
-            )
-        })
-        .take(deploy_count)
-        .collect();
+        let deploys = match deploy {
+            Some(deploy) => vec![DeployWithApprovals::new(*deploy.id(), BTreeSet::new())],
+            None => {
+                let deploy_count = rng.gen_range(0..11);
+                iter::repeat_with(|| {
+                    DeployWithApprovals::new(
+                        DeployHash::new(rng.gen::<[u8; Digest::LENGTH]>().into()),
+                        BTreeSet::new(),
+                    )
+                })
+                .take(deploy_count)
+                .collect()
+            }
+        };
         let random_bit = rng.gen();
         // TODO - make Timestamp deterministic.
         let timestamp = Timestamp::now();
@@ -1604,6 +1609,7 @@ impl Block {
             ProtocolVersion::V1_0_0,
             is_switch,
             verifiable_chunked_hash_activation,
+            None,
         )
     }
 
@@ -1625,6 +1631,7 @@ impl Block {
             ProtocolVersion::V1_0_0,
             is_switch,
             verifiable_chunked_hash_activation,
+            None,
         )
     }
 
@@ -1661,6 +1668,8 @@ impl Block {
     }
 
     /// Generates a random instance using a `TestRng`, but using the specified values.
+    /// If `deploy` is `None`, random deploys will be generated, otherwise, the provided `deploy`
+    /// will be used.
     #[cfg(test)]
     pub fn random_with_specifics(
         rng: &mut TestRng,
@@ -1669,10 +1678,12 @@ impl Block {
         protocol_version: ProtocolVersion,
         is_switch: bool,
         verifiable_chunked_hash_activation: EraId,
+        deploy: Option<&Deploy>,
     ) -> Self {
         let parent_hash = BlockHash::new(rng.gen::<[u8; Digest::LENGTH]>().into());
         let state_root_hash = rng.gen::<[u8; Digest::LENGTH]>().into();
-        let finalized_block = FinalizedBlock::random_with_specifics(rng, era_id, height, is_switch);
+        let finalized_block =
+            FinalizedBlock::random_with_specifics(rng, era_id, height, is_switch, deploy);
         let parent_seed = rng.gen::<[u8; Digest::LENGTH]>().into();
         let next_era_validator_weights = finalized_block
             .clone()
@@ -2353,6 +2364,7 @@ mod tests {
             protocol_version,
             is_switch,
             verifiable_chunked_hash_activation,
+            None,
         );
 
         let merkle_block_body = block.body().merklize();

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -245,6 +245,7 @@ mod tests {
             past_version,
             true,
             verifiable_chunked_hash_activation,
+            None,
         );
         assert!(protocol_config.is_last_block_before_activation(block.header()));
 
@@ -256,6 +257,7 @@ mod tests {
             past_version,
             true,
             verifiable_chunked_hash_activation,
+            None,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -267,6 +269,7 @@ mod tests {
             current_version,
             true,
             verifiable_chunked_hash_activation,
+            None,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
         let block = Block::random_with_specifics(
@@ -276,6 +279,7 @@ mod tests {
             future_version,
             true,
             verifiable_chunked_hash_activation,
+            None,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
 
@@ -287,6 +291,7 @@ mod tests {
             past_version,
             false,
             verifiable_chunked_hash_activation,
+            None,
         );
         assert!(!protocol_config.is_last_block_before_activation(block.header()));
     }


### PR DESCRIPTION
This PR optimizes the implementation of `initialize_deploy_metadata_db()` function. Instead of iterating over all entries, it'll just delete the deploys & transfers related to the block that is deleted due to the hard reset.

It also modifies the related tests so they support the invariants required by the new implementation.

Closes https://github.com/casper-network/casper-node/issues/2975