### PR TITLE
Simplify fetcher flow

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -122,17 +122,8 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
         peer: NodeId,
         responder: FetchResponder<T>,
     ) -> Effects<Event<T>> {
-        // Capture responder for later signalling.
-        let responders = self.responders();
-        responders
-            .entry(id)
-            .or_default()
-            .entry(peer)
-            .or_default()
-            .push(responder);
-
         // Get the item from the storage component.
-        self.get_from_storage(effect_builder, id, peer)
+        self.get_from_storage(effect_builder, id, peer, responder)
     }
 
     // Handles attempting to get the item from storage.
@@ -141,6 +132,7 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
         effect_builder: EffectBuilder<REv>,
         id: T::Id,
         peer: NodeId,
+        responder: FetchResponder<T>,
     ) -> Effects<Event<T>>;
 
     /// Handles the `Err` case for a `Result` of attempting to get the item from the storage
@@ -150,8 +142,17 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
         effect_builder: EffectBuilder<REv>,
         id: T::Id,
         peer: NodeId,
+        responder: FetchResponder<T>,
     ) -> Effects<Event<T>> {
         let peer_timeout = self.peer_timeout();
+        // Capture responder for later signalling.
+        let responders = self.responders();
+        responders
+            .entry(id)
+            .or_default()
+            .entry(peer)
+            .or_default()
+            .push(responder);
         match Message::new_get_request::<T>(&id) {
             Ok(message) => {
                 self.metrics().fetch_total.inc();
@@ -193,7 +194,7 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
     fn send_response_from_peer(
         &mut self,
         id: T::Id,
-        result: FetchResult<T>,
+        result: Result<T, FetcherError<T>>,
         peer: NodeId,
     ) -> Effects<Event<T>> {
         let mut effects = Effects::new();
@@ -202,16 +203,20 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
             Ok(item) => {
                 // Since this is a success, we can safely respond to all awaiting processes.
                 for responder in all_responders.remove(&peer).into_iter().flatten() {
-                    effects.extend(responder.respond(Ok(item.clone())).ignore());
+                    effects.extend(
+                        responder
+                            .respond(Ok(FetchedData::from_peer(item.clone(), peer)))
+                            .ignore(),
+                    );
                 }
             }
-            Err(FetcherError::TimedOut { .. }) => {
+            Err(error @ FetcherError::TimedOut { .. }) => {
                 let mut responders = all_responders.remove(&peer).into_iter().flatten();
                 // We take just one responder as only one request had timed out. We want to avoid
                 // prematurely failing too many waiting processes since other requests may still
                 // succeed before timing out.
                 if let Some(responder) = responders.next() {
-                    effects.extend(responder.respond(result.clone()).ignore());
+                    effects.extend(responder.respond(Err(error)).ignore());
                     // Only if there's still a responder waiting for the item we increment the
                     // metric. Otherwise we will count every request as timed out, even if the item
                     // had been fetched.
@@ -224,11 +229,14 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
                     all_responders.insert(peer, responders);
                 }
             }
-            Err(FetcherError::Absent { .. } | FetcherError::CouldNotConstructGetRequest { .. }) => {
+            Err(
+                error @ FetcherError::Absent { .. }
+                | error @ FetcherError::CouldNotConstructGetRequest { .. },
+            ) => {
                 // For all other error variants we can safely respond with failure as there's no
                 // chance for the request to succeed.
                 for responder in all_responders.remove(&peer).into_iter().flatten() {
-                    effects.extend(responder.respond(result.clone()).ignore());
+                    effects.extend(responder.respond(Err(error.clone())).ignore());
                 }
             }
         }
@@ -239,25 +247,17 @@ pub(crate) trait ItemFetcher<T: Item + 'static> {
     }
 
     /// Handles signalling responders with the item or an error.
-    fn signal(&mut self, id: T::Id, result: FetchResult<T>, peer: NodeId) -> Effects<Event<T>> {
+    fn signal(
+        &mut self,
+        id: T::Id,
+        result: Result<T, FetcherError<T>>,
+        peer: NodeId,
+    ) -> Effects<Event<T>> {
         match result {
-            Ok(fetched_data_from_storage @ FetchedData::FromStorage { .. }) => {
-                debug!(
-                    ?fetched_data_from_storage,
-                    ?peer,
-                    "Got from storage when fetching {:?} from peer",
-                    T::TAG,
-                );
-                // It is always safe to respond to all when we retrieved from storage.
-                self.respond_to_all(id, fetched_data_from_storage)
+            Ok(fetched_item) if Self::SAFE_TO_RESPOND_TO_ALL => {
+                self.respond_to_all(id, FetchedData::from_peer(fetched_item, peer))
             }
-            Ok(fetched_data_from_peer @ FetchedData::FromPeer { .. }) => {
-                if Self::SAFE_TO_RESPOND_TO_ALL {
-                    self.respond_to_all(id, fetched_data_from_peer)
-                } else {
-                    self.send_response_from_peer(id, Ok(fetched_data_from_peer), peer)
-                }
-            }
+            Ok(_) => self.send_response_from_peer(id, result, peer),
             Err(_) => self.send_response_from_peer(id, result, peer),
         }
     }
@@ -319,6 +319,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
         effect_builder: EffectBuilder<REv>,
         id: DeployHash,
         peer: NodeId,
+        responder: FetchResponder<Deploy>,
     ) -> Effects<Event<Deploy>> {
         effect_builder
             .get_deploys_from_storage(vec![id])
@@ -331,6 +332,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
                         .expect("can only contain one result")
                         .map(DeployWithFinalizedApprovals::into_naive),
                 ),
+                responder,
             })
     }
 }
@@ -359,6 +361,7 @@ impl ItemFetcher<FinalizedApprovalsWithId> for Fetcher<FinalizedApprovalsWithId>
         effect_builder: EffectBuilder<REv>,
         id: DeployHash,
         peer: NodeId,
+        responder: FetchResponder<FinalizedApprovalsWithId>,
     ) -> Effects<Event<FinalizedApprovalsWithId>> {
         effect_builder
             .get_deploys_from_storage(vec![id])
@@ -373,6 +376,7 @@ impl ItemFetcher<FinalizedApprovalsWithId> for Fetcher<FinalizedApprovalsWithId>
                         )
                     },
                 )),
+                responder,
             })
     }
 }
@@ -399,6 +403,7 @@ impl ItemFetcher<Block> for Fetcher<Block> {
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
         peer: NodeId,
+        responder: FetchResponder<Block>,
     ) -> Effects<Event<Block>> {
         effect_builder
             .get_block_from_storage(id)
@@ -406,6 +411,7 @@ impl ItemFetcher<Block> for Fetcher<Block> {
                 id,
                 peer,
                 maybe_item: Box::new(result),
+                responder,
             })
     }
 }
@@ -432,6 +438,7 @@ impl ItemFetcher<BlockWithMetadata> for Fetcher<BlockWithMetadata> {
         effect_builder: EffectBuilder<REv>,
         id: u64,
         peer: NodeId,
+        responder: FetchResponder<BlockWithMetadata>,
     ) -> Effects<Event<BlockWithMetadata>> {
         effect_builder
             .get_block_and_sufficient_finality_signatures_by_height_from_storage(id)
@@ -439,6 +446,7 @@ impl ItemFetcher<BlockWithMetadata> for Fetcher<BlockWithMetadata> {
                 id,
                 peer,
                 maybe_item: Box::new(result),
+                responder,
             })
     }
 }
@@ -465,6 +473,7 @@ impl ItemFetcher<BlockHeaderWithMetadata> for Fetcher<BlockHeaderWithMetadata> {
         effect_builder: EffectBuilder<REv>,
         id: u64,
         peer: NodeId,
+        responder: FetchResponder<BlockHeaderWithMetadata>,
     ) -> Effects<Event<BlockHeaderWithMetadata>> {
         effect_builder
             .get_block_header_and_sufficient_finality_signatures_by_height_from_storage(id)
@@ -472,6 +481,7 @@ impl ItemFetcher<BlockHeaderWithMetadata> for Fetcher<BlockHeaderWithMetadata> {
                 id,
                 peer,
                 maybe_item: Box::new(result),
+                responder,
             })
     }
 }
@@ -498,6 +508,7 @@ impl ItemFetcher<TrieOrChunk> for Fetcher<TrieOrChunk> {
         effect_builder: EffectBuilder<REv>,
         id: TrieOrChunkId,
         peer: NodeId,
+        responder: FetchResponder<TrieOrChunk>,
     ) -> Effects<Event<TrieOrChunk>> {
         async move {
             let maybe_trie = match effect_builder.get_trie(id).await {
@@ -511,6 +522,7 @@ impl ItemFetcher<TrieOrChunk> for Fetcher<TrieOrChunk> {
                 id,
                 peer,
                 maybe_item: Box::new(maybe_trie),
+                responder,
             }
         }
         .event(std::convert::identity)
@@ -539,6 +551,7 @@ impl ItemFetcher<BlockHeader> for Fetcher<BlockHeader> {
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
         peer: NodeId,
+        responder: FetchResponder<BlockHeader>,
     ) -> Effects<Event<BlockHeader>> {
         // Requests from fetcher are not restricted by the block availability index.
         let only_from_available_block_range = false;
@@ -549,6 +562,7 @@ impl ItemFetcher<BlockHeader> for Fetcher<BlockHeader> {
                 id,
                 peer,
                 maybe_item: Box::new(maybe_block_header),
+                responder,
             })
     }
 }
@@ -579,18 +593,15 @@ where
                 id,
                 peer,
                 maybe_item,
+                responder,
             } => match *maybe_item {
                 Some(item) => {
                     self.metrics().found_in_storage.inc();
-                    self.signal(
-                        id,
-                        Ok(FetchedData::FromStorage {
-                            item: Box::new(item),
-                        }),
-                        peer,
-                    )
+                    responder
+                        .respond(Ok(FetchedData::from_storage(item)))
+                        .ignore()
                 }
-                None => self.failed_to_get_from_storage(effect_builder, id, peer),
+                None => self.failed_to_get_from_storage(effect_builder, id, peer, responder),
             },
             Event::GotRemotely {
                 verifiable_chunked_hash_activation: _,
@@ -606,7 +617,7 @@ where
                         } else {
                             self.signal(
                                 item.id(self.verifiable_chunked_hash_activation()),
-                                Ok(FetchedData::FromPeer { item, peer }),
+                                Ok(*item),
                                 peer,
                             )
                         }

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -36,6 +36,21 @@ pub(crate) enum FetchedData<T> {
     FromPeer { item: Box<T>, peer: NodeId },
 }
 
+impl<T> FetchedData<T> {
+    pub(crate) fn from_storage(item: T) -> Self {
+        FetchedData::FromStorage {
+            item: Box::new(item),
+        }
+    }
+
+    pub(crate) fn from_peer(item: T, peer: NodeId) -> Self {
+        FetchedData::FromPeer {
+            item: Box::new(item),
+            peer,
+        }
+    }
+}
+
 pub(crate) type FetchResult<T> = Result<FetchedData<T>, FetcherError<T>>;
 
 pub(crate) type FetchResponder<T> = Responder<FetchResult<T>>;
@@ -51,6 +66,7 @@ pub(crate) enum Event<T: Item> {
         id: T::Id,
         peer: NodeId,
         maybe_item: Box<Option<T>>,
+        responder: FetchResponder<T>,
     },
     /// An announcement from a different component that we have accepted and stored the given item.
     GotRemotely {


### PR DESCRIPTION
Main things changed in this PR:
 * we will register responder only after failed storage query - there's no need to register the fetcher if data will be found locally since that query will return (almost) immediately.
 * API of methods signaling result to the responder have been refactor to reflect the previous change - if we respond with storage result immediately, there's no need to account for storage result in the API of methods that will get the results only from a peer.