### PR TITLE
Anti-Spam Sufficient Finality Signatures

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -57,7 +57,7 @@ pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor};
 pub(crate) use protocols::highway::HighwayProtocol;
 
-pub(crate) use utils::check_sufficient_finality_signatures;
+pub(crate) use utils::{check_sufficient_finality_signatures, get_minimal_set_of_signatures};
 pub(crate) use validator_change::ValidatorChange;
 
 #[derive(DataSize, Clone, Serialize, Deserialize)]

--- a/node/src/components/consensus/error.rs
+++ b/node/src/components/consensus/error.rs
@@ -36,6 +36,24 @@ pub enum FinalitySignatureError {
         total_validator_weight: Box<U512>,
         finality_threshold_fraction: Ratio<u64>,
     },
+
+    #[error(
+        "Anti-spam: signature set not minimal. \
+         trusted validator weights: {trusted_validator_weights:?}, \
+         block signatures: {block_signatures:?}, \
+         signature weight: {signature_weight}, \
+         weight minus minimum: {weight_minus_minimum}, \
+         total validator weight: {total_validator_weight}, \
+         finality threshold fraction: {finality_threshold_fraction}"
+    )]
+    TooManySignatures {
+        trusted_validator_weights: BTreeMap<PublicKey, U512>,
+        block_signatures: Box<BlockSignatures>,
+        signature_weight: Box<U512>,
+        weight_minus_minimum: Box<U512>,
+        total_validator_weight: Box<U512>,
+        finality_threshold_fraction: Ratio<u64>,
+    },
 }
 
 #[derive(Error, Debug)]

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -192,6 +192,7 @@ mod tests {
 
         // If the initial set has too few signatures, the result should be `None`.
         let sigs = create_signatures(rng, &keys, threshold.saturating_sub(1));
+        assert!(check_sufficient_finality_signatures(&weights, ftt, &sigs).is_err());
         let minimal_set = get_minimal_set_of_signatures(&weights, ftt, sigs);
         assert!(minimal_set.is_none());
 

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -5,6 +5,12 @@ use num::rational::Ratio;
 
 use crate::{components::consensus::error::FinalitySignatureError, types::BlockSignatures};
 
+/// Computes the lower bound for the fraction of weight of signatures that will be considered
+/// sufficient.
+fn lower_bound(finality_threshold_fraction: Ratio<u64>) -> Ratio<u64> {
+    (finality_threshold_fraction + 1) / 2
+}
+
 /// Returns `Ok(())` if the finality signatures' total weight exceeds the threshold. Returns an
 /// error if it doesn't, or if one of the signatures does not belong to a validator.
 ///
@@ -43,7 +49,7 @@ pub(crate) fn check_sufficient_finality_signatures(
         .map(|(_, weight)| *weight)
         .sum();
 
-    let lower_bound = (finality_threshold_fraction + 1) / 2;
+    let lower_bound = lower_bound(finality_threshold_fraction);
     // Verify: signature_weight / total_weight >= lower_bound
     // Equivalent to the following
     if signature_weight * U512::from(*lower_bound.denom())
@@ -87,7 +93,7 @@ pub(crate) fn get_minimal_set_of_signatures(
         .map(|(_, weight)| *weight)
         .sum();
 
-    let lower_bound = (finality_threshold_fraction + 1) / 2;
+    let lower_bound = lower_bound(finality_threshold_fraction);
 
     let mut sig_weights: Vec<_> = block_signatures
         .proofs

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -107,7 +107,9 @@ pub(crate) fn get_minimal_set_of_signatures(
         .take_while(|(_, weight)| {
             let to_take = accumulated_weight * U512::from(*lower_bound.denom())
                 <= total_weight * U512::from(*lower_bound.numer());
-            accumulated_weight += *weight;
+            if to_take {
+                accumulated_weight += *weight;
+            }
             to_take
         })
         .map(|(pub_key, _)| pub_key)

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -16,6 +16,7 @@ pub(crate) fn check_sufficient_finality_signatures(
 ) -> Result<(), FinalitySignatureError> {
     // Calculate the weight of the signatures
     let mut signature_weight: U512 = U512::zero();
+    let mut minimum_weight: Option<U512> = None;
     for (public_key, _) in block_signatures.proofs.iter() {
         match trusted_validator_weights.get(public_key) {
             None => {
@@ -26,10 +27,15 @@ pub(crate) fn check_sufficient_finality_signatures(
                 })
             }
             Some(validator_weight) => {
+                if minimum_weight.map_or(true, |min_w| *validator_weight < min_w) {
+                    minimum_weight = Some(*validator_weight);
+                }
                 signature_weight += *validator_weight;
             }
         }
     }
+
+    let weight_minus_minimum = signature_weight - minimum_weight.unwrap_or_else(U512::zero);
 
     // Check the finality signatures have sufficient weight
     let total_weight: U512 = trusted_validator_weights
@@ -47,6 +53,21 @@ pub(crate) fn check_sufficient_finality_signatures(
             trusted_validator_weights: trusted_validator_weights.clone(),
             block_signatures: Box::new(block_signatures.clone()),
             signature_weight: Box::new(signature_weight),
+            total_validator_weight: Box::new(total_weight),
+            finality_threshold_fraction,
+        });
+    }
+
+    // Verify: the total weight decreased by the smallest weight of a single signature should be
+    // below threshold (anti-spam countermeasure).
+    if weight_minus_minimum * U512::from(*lower_bound.denom())
+        > total_weight * U512::from(*lower_bound.numer())
+    {
+        return Err(FinalitySignatureError::TooManySignatures {
+            trusted_validator_weights: trusted_validator_weights.clone(),
+            block_signatures: Box::new(block_signatures.clone()),
+            signature_weight: Box::new(signature_weight),
+            weight_minus_minimum: Box::new(weight_minus_minimum),
             total_validator_weight: Box::new(total_weight),
             finality_threshold_fraction,
         });


### PR DESCRIPTION
This makes sure that when sending finality signatures, we send the minimal set that brings the total weight to above the threshold.

Closes #2989 

Note: this doesn't change the way the signatures are represented in storage or messages (the `BlockSignatures` struct), as it would require either every call site of `BlockSignatures::insert_proof` to be aware of the set of validators, or an introduction of a new struct that would keep the signatures ordered by weight. Instead, I opted for checking the condition that the signature with the smallest weight should bring the total weight over the threshold when collecting or validating signatures.
