### PR TITLE
Add json_rpc to casper-updater

### DIFF
--- a/ci/casper_updater/src/main.rs
+++ b/ci/casper_updater/src/main.rs
@@ -247,6 +247,9 @@ fn main() {
     let node_macros = Package::cargo("node_macros", &*regex_data::node_macros::DEPENDENT_FILES);
     node_macros.update();
 
+    let json_rpc = Package::cargo("json_rpc", &*regex_data::json_rpc::DEPENDENT_FILES);
+    json_rpc.update();
+
     let node = Package::cargo("node", &*regex_data::node::DEPENDENT_FILES);
     node.update();
 

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -159,6 +159,33 @@ pub mod node_macros {
     });
 }
 
+pub mod json_rpc {
+    use super::*;
+
+    pub static DEPENDENT_FILES: Lazy<Vec<DependentFile>> = Lazy::new(|| {
+        vec![
+            DependentFile::new(
+                "node/Cargo.toml",
+                Regex::new(r#"(?m)(^casper-json-rpc = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                replacement,
+            ),
+            DependentFile::new(
+                "json_rpc/Cargo.toml",
+                MANIFEST_VERSION_REGEX.clone(),
+                replacement,
+            ),
+            DependentFile::new(
+                "json_rpc/src/lib.rs",
+                Regex::new(
+                    r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-json-rpc)/(?:[^"]+)"#,
+                )
+                .unwrap(),
+                replacement_with_slash,
+            ),
+        ]
+    });
+}
+
 pub mod node {
     use super::*;
 


### PR DESCRIPTION
This PR adds the `casper-json-rpc` crate to the CI tool `casper-updater`.

Part of #2911.