### PR TITLE
Avoid logging an error on dropping network-level responders

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -270,16 +270,16 @@ impl ContractRuntime {
             Err(error) => {
                 // Something is wrong in our trie store, but be courteous and still send a reply.
                 debug!("failed to get trie: {}", error);
-                return responder.respond(None).ignore();
+                return responder.into_inner().respond(None).ignore();
             }
         };
 
         match Message::new_get_response(&fetched_or_not_found) {
-            Ok(message) => responder.respond(Some(message)).ignore(),
+            Ok(message) => responder.into_inner().respond(Some(message)).ignore(),
             Err(error) => {
                 // This should never happen, but if it does, we let the peer know we cannot help.
                 error!("failed to create get-response: {}", error);
-                responder.respond(None).ignore()
+                responder.into_inner().respond(None).ignore()
             }
         }
     }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -261,7 +261,7 @@ impl ContractRuntime {
         &self,
         TrieDemand {
             request_msg: TrieRequest(ref serialized_id),
-            responder,
+            auto_closing_responder,
             ..
         }: TrieDemand,
     ) -> Effects<Event> {
@@ -270,16 +270,16 @@ impl ContractRuntime {
             Err(error) => {
                 // Something is wrong in our trie store, but be courteous and still send a reply.
                 debug!("failed to get trie: {}", error);
-                return responder.into_inner().respond(None).ignore();
+                return auto_closing_responder.respond_none().ignore();
             }
         };
 
         match Message::new_get_response(&fetched_or_not_found) {
-            Ok(message) => responder.into_inner().respond(Some(message)).ignore(),
+            Ok(message) => auto_closing_responder.respond(message).ignore(),
             Err(error) => {
                 // This should never happen, but if it does, we let the peer know we cannot help.
                 error!("failed to create get-response: {}", error);
-                responder.into_inner().respond(None).ignore()
+                auto_closing_responder.respond_none().ignore()
             }
         }
     }

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -550,7 +550,7 @@ where
                     error!("network lock has been poisoned")
                 };
 
-                responder.respond(()).ignore()
+                responder.into_inner().respond(Some(())).ignore()
             }
             NetworkRequest::Broadcast { payload, responder } => {
                 if let Ok(guard) = self.nodes.read() {
@@ -561,7 +561,7 @@ where
                     error!("network lock has been poisoned")
                 };
 
-                responder.respond(()).ignore()
+                responder.into_inner().respond(Some(())).ignore()
             }
             NetworkRequest::Gossip {
                 payload,
@@ -581,10 +581,13 @@ where
                     for dest in chosen.iter() {
                         self.send(&guard, *dest, *payload.clone());
                     }
-                    responder.respond(chosen).ignore()
+                    responder.into_inner().respond(Some(chosen)).ignore()
                 } else {
                     error!("network lock has been poisoned");
-                    responder.respond(Default::default()).ignore()
+                    responder
+                        .into_inner()
+                        .respond(Some(Default::default()))
+                        .ignore()
                 }
             }
         }

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -538,7 +538,7 @@ where
                 dest,
                 payload,
                 respond_after_queueing: _,
-                responder,
+                auto_closing_responder,
             } => {
                 if *dest == self.node_id {
                     panic!("can't send message to self");
@@ -550,9 +550,12 @@ where
                     error!("network lock has been poisoned")
                 };
 
-                responder.into_inner().respond(Some(())).ignore()
+                auto_closing_responder.respond(()).ignore()
             }
-            NetworkRequest::Broadcast { payload, responder } => {
+            NetworkRequest::Broadcast {
+                payload,
+                auto_closing_responder,
+            } => {
                 if let Ok(guard) = self.nodes.read() {
                     for dest in guard.keys().filter(|&node_id| node_id != &self.node_id) {
                         self.send(&guard, *dest, *payload.clone());
@@ -561,13 +564,13 @@ where
                     error!("network lock has been poisoned")
                 };
 
-                responder.into_inner().respond(Some(())).ignore()
+                auto_closing_responder.respond(()).ignore()
             }
             NetworkRequest::Gossip {
                 payload,
                 count,
                 exclude,
-                responder,
+                auto_closing_responder,
             } => {
                 if let Ok(guard) = self.nodes.read() {
                     let chosen: HashSet<_> = guard
@@ -581,13 +584,10 @@ where
                     for dest in chosen.iter() {
                         self.send(&guard, *dest, *payload.clone());
                     }
-                    responder.into_inner().respond(Some(chosen)).ignore()
+                    auto_closing_responder.respond(chosen).ignore()
                 } else {
                     error!("network lock has been poisoned");
-                    responder
-                        .into_inner()
-                        .respond(Some(Default::default()))
-                        .ignore()
+                    auto_closing_responder.respond(Default::default()).ignore()
                 }
             }
         }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -891,7 +891,7 @@ where
                         dest,
                         payload,
                         respond_after_queueing,
-                        responder,
+                        auto_closing_responder,
                     } => {
                         // We're given a message to send. Pass on the responder so that confirmation
                         // can later be given once the message has actually been buffered.
@@ -899,27 +899,30 @@ where
 
                         if respond_after_queueing {
                             self.send_message(*dest, Arc::new(Message::Payload(*payload)), None);
-                            responder.into_inner().respond(Some(())).ignore()
+                            auto_closing_responder.respond(()).ignore()
                         } else {
                             self.send_message(
                                 *dest,
                                 Arc::new(Message::Payload(*payload)),
-                                Some(responder),
+                                Some(auto_closing_responder),
                             );
                             Effects::new()
                         }
                     }
-                    NetworkRequest::Broadcast { payload, responder } => {
+                    NetworkRequest::Broadcast {
+                        payload,
+                        auto_closing_responder,
+                    } => {
                         // We're given a message to broadcast.
                         self.net_metrics.broadcast_requests.inc();
                         self.broadcast_message(Arc::new(Message::Payload(*payload)));
-                        responder.into_inner().respond(Some(())).ignore()
+                        auto_closing_responder.respond(()).ignore()
                     }
                     NetworkRequest::Gossip {
                         payload,
                         count,
                         exclude,
-                        responder,
+                        auto_closing_responder,
                     } => {
                         // We're given a message to gossip.
                         let sent_to = self.gossip_message(
@@ -928,7 +931,7 @@ where
                             count,
                             exclude,
                         );
-                        responder.into_inner().respond(Some(sent_to)).ignore()
+                        auto_closing_responder.respond(sent_to).ignore()
                     }
                 }
             }

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -693,10 +693,10 @@ pub(super) async fn message_sender<P>(
         let mut outcome = sink.send(message).await;
 
         // Notify via responder that the message has been buffered by the kernel.
-        if let Some(responder) = opt_responder {
+        if let Some(auto_closing_responder) = opt_responder {
             // Since someone is interested in the message, flush the socket to ensure it was sent.
             outcome = outcome.and(sink.flush().await);
-            responder.into_inner().respond(Some(())).await;
+            auto_closing_responder.respond(()).await;
         }
 
         // We simply error-out if the sink fails, it means that our connection broke.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -198,17 +198,17 @@ pub(crate) struct Responder<T> {
 
 /// A responder that will automatically send a `None` on drop.
 #[must_use]
-#[derive(DataSize)]
+#[derive(DataSize, Debug)]
 pub(crate) struct AutoClosingResponder<T>(Responder<Option<T>>);
 
 impl<T> AutoClosingResponder<T> {
     /// Creates a new auto closing responder from a responder of `Option<T>`.
-    fn from_opt_responder(responder: Responder<Option<T>>) -> Self {
+    pub(crate) fn from_opt_responder(responder: Responder<Option<T>>) -> Self {
         AutoClosingResponder(responder)
     }
 
     /// Extracts the inner responder.
-    fn into_inner(self) -> Responder<Option<T>> {
+    pub(crate) fn into_inner(self) -> Responder<Option<T>> {
         self.0
     }
 }
@@ -310,6 +310,15 @@ impl<T> Serialize for Responder<T> {
         S: serde::Serializer,
     {
         serializer.serialize_str(&format!("{:?}", self))
+    }
+}
+
+impl<T> Serialize for AutoClosingResponder<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
     }
 }
 

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{FinalitySignature, NodeId, Tag},
 };
 
-use super::Responder;
+use super::AutoClosingResponder;
 
 /// An envelope for an incoming message, attaching a sender address.
 #[derive(DataSize, Debug, Serialize)]
@@ -40,7 +40,7 @@ pub struct DemandIncoming<M> {
     /// The wrapped demand.
     pub(crate) request_msg: M,
     /// Responder to send the answer down through.
-    pub(crate) responder: Responder<Option<Message>>,
+    pub(crate) responder: AutoClosingResponder<Message>,
 }
 
 impl<M> Display for DemandIncoming<M>

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -40,7 +40,7 @@ pub struct DemandIncoming<M> {
     /// The wrapped demand.
     pub(crate) request_msg: M,
     /// Responder to send the answer down through.
-    pub(crate) responder: AutoClosingResponder<Message>,
+    pub(crate) auto_closing_responder: AutoClosingResponder<Message>,
 }
 
 impl<M> Display for DemandIncoming<M>

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -45,7 +45,7 @@ use crate::{
         deploy_acceptor::Error,
         fetcher::FetchResult,
     },
-    effect::Responder,
+    effect::{AutoClosingResponder, Responder},
     rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
         AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
@@ -99,7 +99,7 @@ pub(crate) enum NetworkRequest<P> {
         respond_after_queueing: bool,
         /// Responder to be called when the message has been *buffered for sending*.
         #[serde(skip_serializing)]
-        responder: Responder<()>,
+        responder: AutoClosingResponder<()>,
     },
     /// Send a message on the network to all peers.
     /// Note: This request is deprecated and should be phased out, as not every network
@@ -109,7 +109,7 @@ pub(crate) enum NetworkRequest<P> {
         payload: Box<P>,
         /// Responder to be called when all messages are queued.
         #[serde(skip_serializing)]
-        responder: Responder<()>,
+        responder: AutoClosingResponder<()>,
     },
     /// Gossip a message to a random subset of peers.
     Gossip {
@@ -122,7 +122,7 @@ pub(crate) enum NetworkRequest<P> {
         exclude: HashSet<NodeId>,
         /// Responder to be called when all messages are queued.
         #[serde(skip_serializing)]
-        responder: Responder<HashSet<NodeId>>,
+        responder: AutoClosingResponder<HashSet<NodeId>>,
     },
 }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -99,7 +99,7 @@ pub(crate) enum NetworkRequest<P> {
         respond_after_queueing: bool,
         /// Responder to be called when the message has been *buffered for sending*.
         #[serde(skip_serializing)]
-        responder: AutoClosingResponder<()>,
+        auto_closing_responder: AutoClosingResponder<()>,
     },
     /// Send a message on the network to all peers.
     /// Note: This request is deprecated and should be phased out, as not every network
@@ -109,7 +109,7 @@ pub(crate) enum NetworkRequest<P> {
         payload: Box<P>,
         /// Responder to be called when all messages are queued.
         #[serde(skip_serializing)]
-        responder: AutoClosingResponder<()>,
+        auto_closing_responder: AutoClosingResponder<()>,
     },
     /// Gossip a message to a random subset of peers.
     Gossip {
@@ -122,7 +122,7 @@ pub(crate) enum NetworkRequest<P> {
         exclude: HashSet<NodeId>,
         /// Responder to be called when all messages are queued.
         #[serde(skip_serializing)]
-        responder: AutoClosingResponder<HashSet<NodeId>>,
+        auto_closing_responder: AutoClosingResponder<HashSet<NodeId>>,
     },
 }
 
@@ -139,27 +139,30 @@ impl<P> NetworkRequest<P> {
                 dest,
                 payload,
                 respond_after_queueing,
-                responder,
+                auto_closing_responder,
             } => NetworkRequest::SendMessage {
                 dest,
                 payload: Box::new(wrap_payload(*payload)),
                 respond_after_queueing,
-                responder,
+                auto_closing_responder,
             },
-            NetworkRequest::Broadcast { payload, responder } => NetworkRequest::Broadcast {
+            NetworkRequest::Broadcast {
+                payload,
+                auto_closing_responder,
+            } => NetworkRequest::Broadcast {
                 payload: Box::new(wrap_payload(*payload)),
-                responder,
+                auto_closing_responder,
             },
             NetworkRequest::Gossip {
                 payload,
                 count,
                 exclude,
-                responder,
+                auto_closing_responder,
             } => NetworkRequest::Gossip {
                 payload: Box::new(wrap_payload(*payload)),
                 count,
                 exclude,
-                responder,
+                auto_closing_responder,
             },
         }
     }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -24,7 +24,7 @@ use crate::{
             NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequest,
             TrieRequestIncoming, TrieResponse, TrieResponseIncoming,
         },
-        EffectBuilder,
+        AutoClosingResponder, EffectBuilder,
     },
     types::{Deploy, FinalitySignature, Item, NodeId, Tag},
 };
@@ -344,7 +344,7 @@ where
                 let (ev, fut) = effect_builder.create_request_parts(move |responder| TrieDemand {
                     sender,
                     request_msg: TrieRequest(serialized_id),
-                    responder,
+                    responder: AutoClosingResponder::from_opt_responder(responder),
                 });
 
                 Ok((ev, fut.boxed()))

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -344,7 +344,7 @@ where
                 let (ev, fut) = effect_builder.create_request_parts(move |responder| TrieDemand {
                     sender,
                     request_msg: TrieRequest(serialized_id),
-                    responder: AutoClosingResponder::from_opt_responder(responder),
+                    auto_closing_responder: AutoClosingResponder::from_opt_responder(responder),
                 });
 
                 Ok((ev, fut.boxed()))


### PR DESCRIPTION
This PR adds an auto-closing responder which sends a `None` response on being dropped.

It is used in the context of incoming and outgoing network messages, where the enqueued message might be dropped at an arbitrary point, for example when an outgoing network connection is dropped.

Without the auto-close responder, such a case would cause the normal responder type to log an error.  Logging an error is the correct course of action in all other contexts right now, as it could indicate a critical problem in the wireup between components.

However, with the recent backpressure changes to the network, it's now expected that outgoing messages could be dropped under certain conditions, and in that case the corresponding responders being dropped should not cause an error to get logged.

Closes [#438](https://github.com/casper-network/sre/issues/438).
