### PR TITLE
Sync To Genesis Needs to Gather Sufficient Finality Signatures For All Blocks

### DIFF
--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -62,6 +62,7 @@ impl MockReactor {
             id,
             peer,
             responder,
+            ..
         }) = reactor_event
         {
             match deploy.into() {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -624,7 +624,15 @@ where
                 id,
                 peer,
                 responder,
-            }) => self.fetch(effect_builder, id, peer, responder),
+                bypass_storage,
+            }) => {
+                if bypass_storage {
+                    // we don't even try storage
+                    self.failed_to_get_from_storage(effect_builder, id, peer, responder)
+                } else {
+                    self.fetch(effect_builder, id, peer, responder)
+                }
+            }
             Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1417,6 +1417,25 @@ impl<REv> EffectBuilder<REv> {
                 id,
                 peer,
                 responder,
+                bypass_storage: false,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Fetches an item from a fetcher (forcing it to fetch from the network).
+    pub(crate) async fn fetch_from_network<T>(self, id: T::Id, peer: NodeId) -> FetchResult<T>
+    where
+        REv: From<FetcherRequest<T>>,
+        T: Item + 'static,
+    {
+        self.make_request(
+            |responder| FetcherRequest {
+                id,
+                peer,
+                responder,
+                bypass_storage: true,
             },
             QueueKind::Regular,
         )

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1082,13 +1082,20 @@ where
     pub(crate) id: T::Id,
     /// The peer id of the peer to be asked if the item is not held locally
     pub(crate) peer: NodeId,
+    /// If set to true, the fetcher will bypass storage (used for re-fetching data that is in
+    /// storage, but is invalid).
+    pub(crate) bypass_storage: bool,
     /// Responder to call with the result.
     pub(crate) responder: Responder<FetchResult<T>>,
 }
 
 impl<T: Item> Display for FetcherRequest<T> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(formatter, "request item by id {}", self.id)
+        write!(
+            formatter,
+            "request item by id {} (bypass storage: {})",
+            self.id, self.bypass_storage
+        )
     }
 }
 


### PR DESCRIPTION
This PR launches a task downloading and validating signatures for blocks in one era every time it encounters a switch block while walking back from the trusted hash to genesis. This way a node synced to genesis will have sufficient finality signatures for all past blocks.
