### PR TITLE
Change nctl to use query-balance subcommand

### DIFF
--- a/utils/nctl/sh/utils/accounts.sh
+++ b/utils/nctl/sh/utils/accounts.sh
@@ -14,13 +14,13 @@ function get_account_balance()
 
     NODE_ADDRESS=$(get_node_address_rpc)
     ACCOUNT_BALANCE=$(
-        $(get_path_to_client) get-balance \
+        $(get_path_to_client) query-balance \
             --node-address "$NODE_ADDRESS" \
             --state-root-hash "$STATE_ROOT_HASH" \
             --purse-uref "$PURSE_UREF" \
-            | jq '.result.balance_value' \
+            | jq '.result.balance' \
             | sed -e 's/^"//' -e 's/"$//'
-        )    
+        )
 
     echo "$ACCOUNT_BALANCE"
 }
@@ -87,7 +87,7 @@ function get_account_prefix()
     local PREFIX="net-$NET_ID.$ACCOUNT_TYPE"
     if [ "$ACCOUNT_TYPE" != "$NCTL_ACCOUNT_TYPE_FAUCET" ]; then
         PREFIX=$PREFIX"-"$ACCOUNT_IDX
-    fi 
+    fi
 
     echo "$PREFIX"
 }

--- a/utils/nctl/sh/views/view_chain_balance.sh
+++ b/utils/nctl/sh/views/view_chain_balance.sh
@@ -28,11 +28,11 @@ NODE_ADDRESS=$(get_node_address_rpc)
 STATE_ROOT_HASH=${STATE_ROOT_HASH:-$(get_state_root_hash)}
 
 ACCOUNT_BALANCE=$(
-    $(get_path_to_client) get-balance \
+    $(get_path_to_client) query-balance \
         --node-address "$NODE_ADDRESS" \
         --state-root-hash "$STATE_ROOT_HASH" \
         --purse-uref "$PURSE_UREF" \
-        | jq '.result.balance_value' \
+        | jq '.result.balance' \
         | sed -e 's/^"//' -e 's/"$//'
     )
 


### PR DESCRIPTION
This PR fixes the nctl scripts to use the new `query-balance` client subcommand in favour of the deprecated `get-balance`.

Closes [#463](https://github.com/casper-network/sre/issues/463).