### PR TITLE
Retry downloading the right approvals forever

### DIFF
--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -71,16 +71,6 @@ pub(crate) enum Error {
     #[error(transparent)]
     FinalizedApprovalsFetcher(#[from] FetcherError<FinalizedApprovalsWithId>),
 
-    #[error(
-        "executed block is not the same as downloaded block. \
-         executed block: {executed_block:?}, \
-         downloaded block: {downloaded_block:?}"
-    )]
-    ExecutedBlockIsNotTheSameAsDownloadedBlock {
-        executed_block: Box<Block>,
-        downloaded_block: Box<Block>,
-    },
-
     #[error(transparent)]
     BlockExecution(#[from] BlockExecutionError),
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1330,10 +1330,6 @@ async fn retry_execution_with_approvals_from_peer(
         .await?)
 }
 
-/// Maximum number of times the node will try to download finalized approvals from a single peer in
-/// an attempt to find a set of approvals matching the block execution results.
-const APPROVAL_FETCH_RETRIES: usize = 2;
-
 async fn execute_blocks(
     most_recent_block_header: &BlockHeader,
     trusted_key_block_info: &KeyBlockInfo,
@@ -1404,16 +1400,15 @@ async fn execute_blocks(
             )
             .await?;
 
-        if block != *block_and_execution_effects.block() {
+        let mut blocks_match = block == *block_and_execution_effects.block();
+
+        while !blocks_match {
             // Could be wrong approvals - fetch new sets of approvals from a single peer and retry.
-            // Retry up to two times.
-            let mut success = false;
             for peer in ctx
                 .effect_builder
                 .get_fully_connected_non_joiner_peers()
                 .await
                 .into_iter()
-                .take(APPROVAL_FETCH_RETRIES)
             {
                 info!(block_hash=%block.hash(), "start - re-executing finalized block");
                 let block_and_execution_effects = retry_execution_with_approvals_from_peer(
@@ -1426,8 +1421,8 @@ async fn execute_blocks(
                 )
                 .await?;
                 info!(block_hash=%block.hash(), "finish - re-executing finalized block");
-                if block == *block_and_execution_effects.block() {
-                    success = true;
+                blocks_match = block == *block_and_execution_effects.block();
+                if blocks_match {
                     break;
                 } else {
                     warn!(
@@ -1438,23 +1433,16 @@ async fn execute_blocks(
                     ctx.effect_builder.announce_disconnect_from_peer(peer).await;
                 }
             }
-            if success {
-                // matching now! store new approval sets for the deploys
-                for deploy in deploys.into_iter().chain(transfers.into_iter()) {
-                    ctx.effect_builder
-                        .store_finalized_approvals(
-                            *deploy.id(),
-                            FinalizedApprovals::new(deploy.approvals().clone()),
-                        )
-                        .await;
-                }
-            } else {
-                // didn't work again - give up
-                return Err(Error::ExecutedBlockIsNotTheSameAsDownloadedBlock {
-                    executed_block: Box::new(Block::from(block_and_execution_effects)),
-                    downloaded_block: Box::new(block.clone()),
-                });
-            }
+        }
+
+        // matching now! store new approval sets for the deploys
+        for deploy in deploys.into_iter().chain(transfers.into_iter()) {
+            ctx.effect_builder
+                .store_finalized_approvals(
+                    *deploy.id(),
+                    FinalizedApprovals::new(deploy.approvals().clone()),
+                )
+                .await;
         }
 
         most_recent_block_header = block.take_header();


### PR DESCRIPTION
Instead of retrying just twice and giving up, we'll be retrying forever until the executed block matches the one we downloaded.
