### PR TITLE
NCTL: setup nightlies on feat-2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -508,4 +508,4 @@ volumes:
   temp: {}
 
 trigger:
-  cron: [ nightly-tests-cron, release-2-0-0 ]
+  cron: [ nightly-tests-cron, feat-2-0 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -508,4 +508,4 @@ volumes:
   temp: {}
 
 trigger:
-  cron: [ nightly-tests-cron, feat-fast-sync ]
+  cron: [ nightly-tests-cron, release-2-0-0 ]

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -2,7 +2,7 @@
     "external_deps": {
         "casper-client-rs": {
             "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
-            "branch": "dev"
+            "branch": "release-2.0.0"
         },
         "casper-node-launcher": {
             "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -2,7 +2,7 @@
     "external_deps": {
         "casper-client-rs": {
             "github_repo_url": "https://github.com/casper-ecosystem/casper-client-rs.git",
-            "branch": "release-2.0.0"
+            "branch": "dev"
         },
         "casper-node-launcher": {
             "github_repo_url": "https://github.com/casper-network/casper-node-launcher.git",


### PR DESCRIPTION
Changes:
- utilize release-2.0.0 branch of `casper-client-rs`
- rename second cron to match branch

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/436