### PR TITLE
Update storage to persist indices on disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
+	$(CARGO) audit --ignore RUSTSEC-2020-0071
 
 .PHONY: audit-as
 audit-as:

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -612,7 +612,7 @@ impl reactor::Reactor for Reactor {
 
 fn put_block_to_storage(
     block: Box<Block>,
-    responder: Responder<bool>,
+    responder: Responder<()>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
         effect_builder
@@ -711,7 +711,7 @@ async fn run_deploy_acceptor_without_timeout(
     while runner.try_crank(&mut rng).await.is_none() {
         time::sleep(POLL_INTERVAL).await;
     }
-    assert!(block_receiver.await.unwrap());
+    block_receiver.await.unwrap();
 
     // Create a responder to assert the validity of the deploy
     let (deploy_sender, deploy_receiver) = oneshot::channel();

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -35,7 +35,11 @@
 //! The storage component itself is panic free and in general reports three classes of errors:
 //! Corruption, temporary resource exhaustion and potential bugs.
 
+mod block_getter_id;
+mod block_height_index_value;
+mod config;
 mod error;
+mod index_dbs;
 mod lmdb_ext;
 mod object_pool;
 #[cfg(test)]
@@ -44,7 +48,8 @@ mod tests;
 #[cfg(test)]
 use std::collections::BTreeSet;
 use std::{
-    collections::{btree_map::Entry, BTreeMap, HashSet},
+    cmp,
+    collections::HashMap,
     convert::TryFrom,
     fmt::{self, Display, Formatter},
     fs, mem,
@@ -59,17 +64,15 @@ use lmdb::{
     WriteFlags,
 };
 use num_rational::Ratio;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use smallvec::SmallVec;
 use static_assertions::const_assert;
-#[cfg(test)]
-use tempfile::TempDir;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 use casper_hashing::Digest;
 use casper_types::{
-    bytesrepr::{FromBytes, ToBytes},
+    bytesrepr::{self, FromBytes, ToBytes},
     EraId, ExecutionResult, ProtocolVersion, PublicKey, TimeDiff, Transfer, Transform,
 };
 
@@ -86,39 +89,32 @@ use crate::{
     protocol::Message,
     reactor::ReactorEvent,
     types::{
-        AvailableBlockRange, Block, BlockAndDeploys, BlockBody, BlockHash, BlockHashAndHeight,
-        BlockHeader, BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata, Deploy,
-        DeployHash, DeployMetadata, DeployMetadataExt, DeployWithFinalizedApprovals,
-        FinalizedApprovals, FinalizedApprovalsWithId, HashingAlgorithmVersion, Item,
-        MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode, NodeId,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockBody, BlockHash, BlockHeader,
+        BlockHeaderWithMetadata, BlockSignatures, BlockWithMetadata, Deploy, DeployHash,
+        DeployMetadata, DeployMetadataExt, DeployWithFinalizedApprovals, FinalizedApprovals,
+        FinalizedApprovalsWithId, HashingAlgorithmVersion, Item, MerkleBlockBody,
+        MerkleBlockBodyPart, MerkleLinkedListNode, NodeId,
     },
     utils::{display_error, FlattenResult, WithDir},
     NodeRng,
 };
+use block_getter_id::BlockGetterId;
+use block_height_index_value::BlockHeightIndexValue;
+pub use config::Config;
 pub use error::FatalStorageError;
 use error::GetRequestError;
+use index_dbs::IndexDbs;
 use lmdb_ext::{LmdbExtError, TransactionExt, WriteTransactionExt};
 use object_pool::ObjectPool;
 
 /// Filename for the LMDB database created by the Storage component.
 const STORAGE_DB_FILENAME: &str = "storage.lmdb";
-/// The key in the state store DB under which the storage component's
-/// `lowest_available_block_height` field is persisted.
-const KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT: &str = "lowest_available_block_height";
 
-/// One Gibibyte.
-const GIB: usize = 1024 * 1024 * 1024;
+/// LMDB key for recording progress of populating the indices.
+const PROGRESS_KEY: &str = "populating indices progress";
 
-/// Default max block store size.
-const DEFAULT_MAX_BLOCK_STORE_SIZE: usize = 450 * GIB;
-/// Default max deploy store size.
-const DEFAULT_MAX_DEPLOY_STORE_SIZE: usize = 300 * GIB;
-/// Default max deploy metadata store size.
-const DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE: usize = 300 * GIB;
-/// Default max state store size.
-const DEFAULT_MAX_STATE_STORE_SIZE: usize = 10 * GIB;
 /// Maximum number of allowed dbs.
-const MAX_DB_COUNT: u32 = 12;
+const MAX_DB_COUNT: u32 = 16;
 
 /// OS-specific lmdb flags.
 #[cfg(not(target_os = "macos"))]
@@ -149,15 +145,6 @@ pub struct Storage {
     sync_task_limiter: Arc<Semaphore>,
 }
 
-/// Groups databases used by storage.
-struct Databases {
-    block_body_v1_db: Database,
-    block_body_v2_db: Database,
-    deploy_hashes_db: Database,
-    transfer_hashes_db: Database,
-    proposer_db: Database,
-}
-
 /// The inner storage component.
 #[derive(DataSize, Debug)]
 pub struct StorageInner {
@@ -166,47 +153,54 @@ pub struct StorageInner {
     /// Environment holding LMDB databases.
     #[data_size(skip)]
     env: Environment,
-    /// The block header database.
+    /// A map of block ID (`BlockHash`) to block header (`BlockHeader`).
     #[data_size(skip)]
     block_header_db: Database,
-    /// The block body database.
+    /// A map of block v1 body hash (`Digest`) to block body (`BlockBody`).
     #[data_size(skip)]
     block_body_v1_db: Database,
-    /// The Merkle-hashed block body database.
+    /// A map of block v2 (Merklized) body part (`Digest`) to a pair of hashes of the value of the
+    /// block body part and the linked list node (`(Digest, Digest)`).
     #[data_size(skip)]
     block_body_v2_db: Database,
-    /// The deploy hashes database.
+    /// A collection of block v2 deploy hashes as Merklized body parts.  The map is from body part
+    /// hash (`Digest`) to set of deploy IDs (`Vec<DeployHash>`).
     #[data_size(skip)]
     deploy_hashes_db: Database,
-    /// The transfer hashes database.
+    /// A collection of block v2 transfer hashes as Merklized body parts.  The map is from body
+    /// part hash (`Digest`) to set of deploy IDs (`Vec<DeployHash>`).
     #[data_size(skip)]
     transfer_hashes_db: Database,
-    /// The proposers database.
+    /// A collection of block v2 proposers as Merklized body parts.  The map is from body part hash
+    /// (`Digest`) to proposer ID (`PublicKey`).
     #[data_size(skip)]
     proposer_db: Database,
-    /// The block metadata db.
-    #[data_size(skip)]
-    block_metadata_db: Database,
-    /// The deploy database.
-    #[data_size(skip)]
-    deploy_db: Database,
-    /// The deploy metadata database.
-    #[data_size(skip)]
-    deploy_metadata_db: Database,
-    /// The transfer database.
+    /// A map of block ID (`BlockHash`) to set of transfers associated with the block
+    /// (`Vec<Transfer>`).
     #[data_size(skip)]
     transfer_db: Database,
-    /// The state storage database.
+    /// A map of block ID (`BlockHash`) to set of block proofs (`BlockSignatures`).
     #[data_size(skip)]
-    state_store_db: Database,
-    /// The finalized approvals database.
+    block_metadata_db: Database,
+    /// A map of deploy ID (`DeployHash`) to deploy (`Deploy`).
+    #[data_size(skip)]
+    deploy_db: Database,
+    /// A map of deploy ID (`DeployHash`) to deploy metadata (`DeployMetadata`) which is
+    /// essentially the execution results.
+    #[data_size(skip)]
+    deploy_metadata_db: Database,
+    /// A map of deploy ID (`DeployHash`) to set of finalized approvals as per included in a
+    /// finalized block (`FinalizedApprovals`).
     #[data_size(skip)]
     finalized_approvals_db: Database,
+    /// A general purpose database allowing components to persist arbitrary state.
+    #[data_size(skip)]
+    state_store_db: Database,
+    /// The index databases.
+    #[data_size(skip)]
+    indices: IndexDbs,
     /// Highest block available when storage is constructed.
     highest_block_at_startup: u64,
-    /// Various indices used by the component.
-    #[data_size(skip)]
-    indices: RwLock<Indices>,
     /// Whether or not memory deduplication is enabled.
     enable_mem_deduplication: bool,
     /// An in-memory pool of already loaded serialized items.
@@ -222,20 +216,6 @@ pub struct StorageInner {
     last_emergency_restart: Option<EraId>,
     /// The era ID starting at which the new Merkle tree-based hashing scheme is applied.
     verifiable_chunked_hash_activation: EraId,
-}
-
-/// Database indices used by the storage component.
-#[derive(Clone, DataSize, Debug, Default)]
-struct Indices {
-    /// A map of block height to block ID.
-    block_height_index: BTreeMap<u64, BlockHash>,
-    /// A map of era ID to switch block ID.
-    switch_block_era_id_index: BTreeMap<EraId, BlockHash>,
-    /// A map of deploy hashes to hashes and heights of blocks containing them.
-    deploy_hash_index: BTreeMap<DeployHash, BlockHashAndHeight>,
-    /// The height of the highest block from which this node has an unbroken sequence of full
-    /// blocks stored (and the corresponding global state).
-    lowest_available_block_height: u64,
 }
 
 /// A storage component event.
@@ -293,22 +273,26 @@ where
                 match event {
                     Event::StorageRequest(req) => storage.handle_storage_request::<REv>(req),
                     Event::NetRequestIncoming(ref incoming) => {
-                        match storage
-                            .handle_net_request_incoming::<REv>(effect_builder, incoming)
-                        {
+                        match storage.handle_net_request_incoming::<REv>(effect_builder, incoming) {
                             Ok(effects) => Ok(effects),
                             Err(GetRequestError::Fatal(fatal_error)) => Err(fatal_error),
                             Err(ref other_err) => {
-                                warn!(sender=%incoming.sender, err=display_error(other_err), "error handling net request");
-                                // We could still send the requestor a "not found" message, and could do
-                                // so even in the fatal case, but it is safer to not do so at the
-                                // moment, giving less surface area for possible amplification attacks.
+                                warn!(
+                                    sender=%incoming.sender,
+                                    err=display_error(other_err),
+                                    "error handling net request"
+                                );
+                                // We could still send the requester a "not found" message, and
+                                // could do so even in the fatal case, but it is safer to not do so
+                                // at the moment, giving less surface area for possible
+                                // amplification attacks.
                                 Ok(Effects::new())
                             }
                         }
                     }
-                    Event::StateStoreRequest(req) => storage
-                        .handle_state_store_request::<REv>(effect_builder, req),
+                    Event::StateStoreRequest(req) => {
+                        storage.handle_state_store_request::<REv>(effect_builder, req)
+                    }
                 }
             };
 
@@ -317,12 +301,11 @@ where
             // meaningful bounds on these by default. For this reason, we limit the maximum number
             // of blocking tasks using a semaphore.
             let outcome = match sync_task_limiter.acquire().await {
-                Ok(_permit) =>{
-                    tokio::task::spawn_blocking(perform_op).await.map_err(FatalStorageError::FailedToJoinBackgroundTask).flatten_result()
-                },
-                Err(err) => Err(
-                    FatalStorageError::SemaphoreClosedUnexpectedly(err),
-                ),
+                Ok(_permit) => tokio::task::spawn_blocking(perform_op)
+                    .await
+                    .map_err(FatalStorageError::FailedToJoinBackgroundTask)
+                    .flatten_result(),
+                Err(err) => Err(FatalStorageError::SemaphoreClosedUnexpectedly(err)),
             };
 
             // On success, execute the effects (we are in an async function, so we can await them
@@ -338,15 +321,16 @@ where
                     // Flatten resulting events.
                     let events: Multiple<_> = outputs.into_iter().flatten().collect();
 
-                     events
-                },
+                    events
+                }
                 Err(ref err) => {
                     // Any error is turned into a fatal effect, the component itself does not panic.
                     fatal!(effect_builder, "storage error: {}", display_error(err)).await;
                     Multiple::new()
                 }
             }
-        }.ignore()
+        }
+        .ignore()
     }
 }
 
@@ -379,8 +363,12 @@ impl Storage {
         &self,
         switch_block_era_id: EraId,
     ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        self.storage
-            .read_switch_block_header_by_era_id(switch_block_era_id)
+        let getter_id = BlockGetterId::SwitchBlock(switch_block_era_id);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        Ok(self
+            .storage
+            .get_block_header(&mut txn, getter_id)?
+            .map(|(_block_hash, header)| header))
     }
 
     pub(crate) fn root_path(&self) -> &Path {
@@ -388,25 +376,32 @@ impl Storage {
     }
 
     // Note: Methods on `Storage` other than new should disappear and be replaced by an accessor
-    // that exposes `StorageInner`, once the latter becomes the publically shared storage object.
+    // that exposes `StorageInner`, once the latter becomes the publicly shared storage object.
 
     /// Reads a block from storage.
     #[inline]
     pub fn read_block(&self, block_hash: &BlockHash) -> Result<Option<Block>, FatalStorageError> {
-        self.storage.read_block(block_hash)
+        let getter_id = BlockGetterId::with_block_hash(*block_hash);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_block(&mut txn, getter_id)
     }
 
     /// Retrieves single block by height by looking it up in the index and returning it.
     #[inline]
-    pub fn read_block_by_height(&self, height: u64) -> Result<Option<Block>, FatalStorageError> {
-        self.storage.read_block_by_height(height)
+    pub fn read_block_by_height(
+        &self,
+        block_height: u64,
+    ) -> Result<Option<Block>, FatalStorageError> {
+        let getter_id = BlockGetterId::with_block_height(block_height);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_block(&mut txn, getter_id)
     }
 
     /// Gets the highest block.
     pub fn read_highest_block(&self) -> Result<Option<Block>, FatalStorageError> {
-        let mut tx = self.storage.env.begin_ro_txn()?;
-        let indices = self.storage.indices.read()?;
-        self.storage.get_highest_block(&mut tx, &indices)
+        let getter_id = BlockGetterId::HighestBlock;
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_block(&mut txn, getter_id)
     }
 
     /// Directly returns a deploy from internal store.
@@ -415,25 +410,81 @@ impl Storage {
         &self,
         deploy_hash: DeployHash,
     ) -> Result<Option<Deploy>, FatalStorageError> {
-        self.storage.read_deploy_by_hash(deploy_hash)
+        self.storage.get_deploy(&deploy_hash)
     }
 
-    /// Put a single deploy into storage.
+    /// Commits a single deploy into storage.
     #[inline]
-    pub fn put_deploy(&self, deploy: &Deploy) -> Result<bool, FatalStorageError> {
-        self.storage.put_deploy(deploy)
+    pub fn commit_deploy(&self, deploy: &Deploy) -> Result<bool, FatalStorageError> {
+        self.storage.commit_deploy(deploy)
     }
 
-    /// Write a block to storage.
+    /// Commits a block to storage.
     #[inline]
-    pub fn write_block(&self, block: &Block) -> Result<bool, FatalStorageError> {
-        self.storage.write_block(block)
+    pub fn commit_block(&self, block: &Block) -> Result<(), FatalStorageError> {
+        self.storage.commit_block(block)
+    }
+}
+
+#[derive(Eq, PartialEq, Debug)]
+struct PopulateIndicesProgress {
+    lowest_block_height: u64,
+    num_blocks_indexed: u64,
+    highest_block_at_startup: u64,
+    cursor_start_key: Digest,
+}
+
+impl Default for PopulateIndicesProgress {
+    fn default() -> Self {
+        PopulateIndicesProgress {
+            lowest_block_height: u64::MAX,
+            num_blocks_indexed: 0,
+            highest_block_at_startup: 0,
+            cursor_start_key: Digest::default(),
+        }
+    }
+}
+
+impl ToBytes for PopulateIndicesProgress {
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.lowest_block_height.write_bytes(writer)?;
+        self.num_blocks_indexed.write_bytes(writer)?;
+        self.highest_block_at_startup.write_bytes(writer)?;
+        self.cursor_start_key.write_bytes(writer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.lowest_block_height.serialized_length()
+            + self.num_blocks_indexed.serialized_length()
+            + self.highest_block_at_startup.serialized_length()
+            + self.cursor_start_key.serialized_length()
+    }
+}
+
+impl FromBytes for PopulateIndicesProgress {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (lowest_block_height, remainder) = u64::from_bytes(bytes)?;
+        let (num_blocks, remainder) = u64::from_bytes(remainder)?;
+        let (highest_block_at_startup, remainder) = u64::from_bytes(remainder)?;
+        let (cursor_start_key, remainder) = Digest::from_bytes(remainder)?;
+        let value = PopulateIndicesProgress {
+            lowest_block_height,
+            num_blocks_indexed: num_blocks,
+            highest_block_at_startup,
+            cursor_start_key,
+        };
+        Ok((value, remainder))
     }
 }
 
 impl StorageInner {
     /// Creates a new inner storage.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cfg: &WithDir<Config>,
         hard_reset_to_start_of_era: Option<EraId>,
@@ -471,141 +522,44 @@ impl StorageInner {
         let env = Environment::new()
             .set_flags(
                 OS_FLAGS
-                // We manage our own directory.
-                | EnvironmentFlags::NO_SUB_DIR
-                // Disable thread local storage, strongly suggested for operation with tokio.
-                | EnvironmentFlags::NO_TLS
-                // Disable read-ahead. Our data is not storead/read in sequence that would benefit from the read-ahead.
-                | EnvironmentFlags::NO_READAHEAD,
+                    // We manage our own directory.
+                    | EnvironmentFlags::NO_SUB_DIR
+                    // Disable thread local storage, strongly suggested for operation with tokio.
+                    | EnvironmentFlags::NO_TLS
+                    // Disable read-ahead. Our data is not stored/read in sequence that would benefit
+                    // from the read-ahead.
+                    | EnvironmentFlags::NO_READAHEAD,
             )
-            // We need at least `max_sync_tasks` readers, add an additional 8 for unforseen external
-            // reads (not likely, but it does not hurt to increase this limit).
+            // We need at least `max_sync_tasks` readers, add an additional 8 for unforeseen
+            // external reads (not likely, but it does not hurt to increase this limit).
             .set_max_readers(config.max_sync_tasks as u32 + 8)
             .set_max_dbs(MAX_DB_COUNT)
             .set_map_size(total_size)
             .open(&root.join(STORAGE_DB_FILENAME))?;
 
         let block_header_db = env.create_db(Some("block_header"), DatabaseFlags::empty())?;
-        let block_metadata_db = env.create_db(Some("block_metadata"), DatabaseFlags::empty())?;
-        let deploy_db = env.create_db(Some("deploys"), DatabaseFlags::empty())?;
-        let deploy_metadata_db = env.create_db(Some("deploy_metadata"), DatabaseFlags::empty())?;
-        let transfer_db = env.create_db(Some("transfer"), DatabaseFlags::empty())?;
-        let state_store_db = env.create_db(Some("state_store"), DatabaseFlags::empty())?;
-        let finalized_approvals_db =
-            env.create_db(Some("finalized_approvals"), DatabaseFlags::empty())?;
         let block_body_v1_db = env.create_db(Some("block_body"), DatabaseFlags::empty())?;
         let block_body_v2_db = env.create_db(Some("block_body_merkle"), DatabaseFlags::empty())?;
         let deploy_hashes_db = env.create_db(Some("deploy_hashes"), DatabaseFlags::empty())?;
         let transfer_hashes_db = env.create_db(Some("transfer_hashes"), DatabaseFlags::empty())?;
         let proposer_db = env.create_db(Some("proposers"), DatabaseFlags::empty())?;
+        let transfer_db = env.create_db(Some("transfer"), DatabaseFlags::empty())?;
+        let block_metadata_db = env.create_db(Some("block_metadata"), DatabaseFlags::empty())?;
+        let deploy_db = env.create_db(Some("deploys"), DatabaseFlags::empty())?;
+        let deploy_metadata_db = env.create_db(Some("deploy_metadata"), DatabaseFlags::empty())?;
+        let finalized_approvals_db =
+            env.create_db(Some("finalized_approvals"), DatabaseFlags::empty())?;
+        let state_store_db = env.create_db(Some("state_store"), DatabaseFlags::empty())?;
+        let indices = IndexDbs::new(&env, state_store_db)?;
 
-        // We now need to restore the block-height index. Log messages allow timing here.
-        info!("reindexing block store");
-        let mut indices = Indices::default();
-        let mut block_txn = env.begin_rw_txn()?;
-        let mut cursor = block_txn.open_rw_cursor(block_header_db)?;
-
-        let mut deleted_block_hashes = HashSet::new();
-        let mut deleted_block_body_hashes_v1 = HashSet::new();
-        let mut deleted_deploy_hashes = HashSet::<DeployHash>::new();
-
-        let databases = Databases {
-            block_body_v1_db,
-            block_body_v2_db,
-            deploy_hashes_db,
-            transfer_hashes_db,
-            proposer_db,
-        };
-
-        // Note: `iter_start` has an undocumented panic if called on an empty database. We rely on
-        //       the iterator being at the start when created.
-        for (_, raw_val) in cursor.iter() {
-            let mut body_txn = env.begin_ro_txn()?;
-            let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
-            let (maybe_block_body, is_v1) = get_body_for_block_header(
-                &mut body_txn,
-                &block_header,
-                &databases,
-                verifiable_chunked_hash_activation,
-            );
-            if let Some(invalid_era) = hard_reset_to_start_of_era {
-                // Remove blocks that are in to-be-upgraded eras, but have obsolete protocol
-                // versions - they were most likely created before the upgrade and should be
-                // reverted.
-                if block_header.era_id() >= invalid_era
-                    && block_header.protocol_version() < protocol_version
-                {
-                    let _ = deleted_block_hashes
-                        .insert(block_header.hash(verifiable_chunked_hash_activation));
-
-                    if let Some(block_body) = maybe_block_body? {
-                        deleted_deploy_hashes.extend(block_body.deploy_hashes());
-                        deleted_deploy_hashes.extend(block_body.transfer_hashes());
-                    }
-
-                    if is_v1 {
-                        let _ = deleted_block_body_hashes_v1.insert(*block_header.body_hash());
-                    }
-
-                    cursor.del(WriteFlags::empty())?;
-                    continue;
-                }
-            }
-
-            insert_to_block_header_indices(
-                &mut indices,
-                &block_header,
-                verifiable_chunked_hash_activation,
-            )?;
-
-            if let Some(block_body) = maybe_block_body? {
-                insert_to_deploy_index(
-                    &mut indices.deploy_hash_index,
-                    block_header.hash(verifiable_chunked_hash_activation),
-                    &block_body,
-                    block_header.height(),
-                )?;
-            }
-        }
-        info!("block store reindexing complete");
-        drop(cursor);
-        block_txn.commit()?;
-
-        indices.lowest_available_block_height = {
+        let highest_block_at_startup = {
             let mut txn = env.begin_ro_txn()?;
-            txn.get_value_bytesrepr(state_store_db, &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT)?
+            indices
+                .get_highest_available_block_height(&mut txn)?
                 .unwrap_or_default()
         };
-        let highest_block_at_startup = indices
-            .block_height_index
-            .keys()
-            .last()
-            .copied()
-            .unwrap_or_default();
-        if let Err(error) = AvailableBlockRange::new(
-            indices.lowest_available_block_height,
-            highest_block_at_startup,
-        ) {
-            error!(%error);
-            indices.lowest_available_block_height = highest_block_at_startup;
-        }
 
-        let deleted_block_hashes_raw = deleted_block_hashes.iter().map(BlockHash::as_ref).collect();
-
-        initialize_block_body_v1_db(
-            &env,
-            &block_header_db,
-            &block_body_v1_db,
-            &deleted_block_body_hashes_v1
-                .iter()
-                .map(Digest::as_ref)
-                .collect(),
-        )?;
-
-        initialize_block_metadata_db(&env, &block_metadata_db, &deleted_block_hashes_raw)?;
-        initialize_deploy_metadata_db(&env, &deploy_metadata_db, &deleted_deploy_hashes)?;
-
-        Ok(Self {
+        let mut inner = Self {
             root,
             env,
             block_header_db,
@@ -614,20 +568,278 @@ impl StorageInner {
             deploy_hashes_db,
             transfer_hashes_db,
             proposer_db,
+            transfer_db,
             block_metadata_db,
             deploy_db,
             deploy_metadata_db,
-            transfer_db,
-            state_store_db,
             finalized_approvals_db,
+            state_store_db,
+            indices,
             highest_block_at_startup,
-            indices: RwLock::new(indices),
             enable_mem_deduplication: config.enable_mem_deduplication,
             serialized_item_pool: RwLock::new(ObjectPool::new(config.mem_pool_prune_interval)),
             finality_threshold_fraction,
             last_emergency_restart,
             verifiable_chunked_hash_activation,
-        })
+        };
+
+        inner.populate_indices()?;
+
+        if let Some(era_to_reset_to) = hard_reset_to_start_of_era {
+            inner.hard_reset(era_to_reset_to, protocol_version)?;
+        }
+
+        Ok(inner)
+    }
+
+    /// If required, populates the `indices` databases by iterating the block header database.
+    ///
+    /// This is essentially a one-time migration from using in-mem indices to on-disk indices.  When
+    /// it has been completed once, all further calls to `populate_indices` will be no-ops.
+    ///
+    /// The ongoing progress is committed every 10,000th block, providing reasonable ability for
+    /// resumption in the case of cancellation.
+    fn populate_indices(&mut self) -> Result<(), FatalStorageError> {
+        let mut ro_txn = self.env.begin_ro_txn()?;
+        if self
+            .indices
+            .get_highest_available_block_height(&mut ro_txn)?
+            .is_some()
+        {
+            info!("indexing block store completed previously");
+            // We already completed indexing the database previously.
+            return Ok(());
+        }
+
+        let mut progress = ro_txn
+            .get_value_bytesrepr::<_, PopulateIndicesProgress>(self.state_store_db, &PROGRESS_KEY)?
+            .unwrap_or_default();
+
+        let mut rw_txn = self.env.begin_rw_txn()?;
+        let mut block_header_cursor = ro_txn.open_ro_cursor(self.block_header_db)?;
+        #[allow(clippy::needless_late_init)]
+        let mut iter;
+        if progress.cursor_start_key == Digest::default() {
+            iter = block_header_cursor.iter();
+        } else {
+            iter = block_header_cursor.iter_from(progress.cursor_start_key);
+        }
+        loop {
+            info!(
+                "indexing block store: completed {} blocks",
+                progress.num_blocks_indexed
+            );
+            for (raw_key, raw_val) in &mut iter {
+                let block_hash = BlockHash::new(
+                    Digest::try_from(raw_key)
+                        .map_err(|error| LmdbExtError::DataCorrupted(Box::new(error)))?,
+                );
+                let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
+                let block_height = block_header.height();
+                let era_id = block_header.era_id();
+                progress.lowest_block_height = cmp::min(progress.lowest_block_height, block_height);
+                progress.highest_block_at_startup =
+                    cmp::max(progress.highest_block_at_startup, block_height);
+
+                self.indices.put_to_block_height_index(
+                    &mut rw_txn,
+                    block_height,
+                    block_hash,
+                    era_id,
+                    block_header.protocol_version(),
+                )?;
+
+                if block_header.is_switch_block() {
+                    self.indices.put_to_switch_block_era_id_index(
+                        &mut rw_txn,
+                        era_id,
+                        &block_hash,
+                    )?;
+                }
+
+                if let Some(block_body) =
+                    self.get_body_for_block_header(&mut rw_txn, &block_header)?
+                {
+                    if self.is_v1_block(&block_header) {
+                        self.indices.put_to_v1_body_hash_index(
+                            &mut rw_txn,
+                            block_header.body_hash(),
+                            block_hash,
+                            block_height,
+                        )?;
+                    }
+
+                    for deploy_hash in block_body
+                        .deploy_hashes()
+                        .iter()
+                        .chain(block_body.transfer_hashes().iter())
+                    {
+                        self.indices.put_to_deploy_hash_index(
+                            &mut rw_txn,
+                            deploy_hash,
+                            block_hash,
+                            block_height,
+                        )?;
+                    }
+                }
+
+                progress.num_blocks_indexed += 1;
+                if progress.num_blocks_indexed % 10000 == 0 {
+                    break;
+                }
+            }
+            match iter.next() {
+                Some((raw_key, _)) => {
+                    progress.cursor_start_key = Digest::try_from(raw_key)
+                        .map_err(|error| LmdbExtError::DataCorrupted(Box::new(error)))?
+                }
+                None => break,
+            };
+            block_header_cursor = ro_txn.open_ro_cursor(self.block_header_db)?;
+            iter = block_header_cursor.iter_from(progress.cursor_start_key);
+            rw_txn.put_value_bytesrepr(self.state_store_db, &PROGRESS_KEY, &progress, true)?;
+            rw_txn.commit()?;
+            rw_txn = self.env.begin_rw_txn()?;
+        }
+
+        let lowest_block_height = if progress.num_blocks_indexed == 0 {
+            0
+        } else {
+            progress.lowest_block_height
+        };
+        self.indices
+            .put_lowest_available_block_height(&mut rw_txn, lowest_block_height)?;
+        self.indices
+            .put_highest_available_block_height(&mut rw_txn, progress.highest_block_at_startup)?;
+
+        rw_txn.commit()?;
+        self.highest_block_at_startup = progress.highest_block_at_startup;
+        info!(
+            "indexing block store complete - indexed {} blocks",
+            progress.num_blocks_indexed
+        );
+
+        Ok(())
+    }
+
+    fn hard_reset(
+        &mut self,
+        era_to_reset_to: EraId,
+        current_protocol_version: ProtocolVersion,
+    ) -> Result<(), FatalStorageError> {
+        info!(%era_to_reset_to, "hard resetting storage");
+        let mut txn = self.env.begin_rw_txn()?;
+
+        // Clear all DBs if we're resetting to era 0.
+        if era_to_reset_to.value() == 0 {
+            // To avoid removing valid blocks on a restart outside of an upgrade shutdown, only
+            // remove blocks for an older protocol version.
+            if let Some((_block_hash, block_header)) =
+                self.get_block_header(&mut txn, BlockGetterId::with_block_height(0))?
+            {
+                if block_header.protocol_version() >= current_protocol_version {
+                    return Ok(());
+                }
+            }
+            info!("hard-resetting storage to genesis");
+            txn.clear_db(self.block_header_db)?;
+            txn.clear_db(self.block_body_v1_db)?;
+            txn.clear_db(self.block_body_v2_db)?;
+            txn.clear_db(self.deploy_hashes_db)?;
+            txn.clear_db(self.transfer_hashes_db)?;
+            txn.clear_db(self.proposer_db)?;
+            txn.clear_db(self.transfer_db)?;
+            txn.clear_db(self.block_metadata_db)?;
+            // Don't clear the deploy DB.
+            txn.clear_db(self.deploy_metadata_db)?;
+            txn.clear_db(self.finalized_approvals_db)?;
+            self.indices.clear_all(&mut txn)?;
+            self.highest_block_at_startup = 0;
+            txn.commit()?;
+            return Ok(());
+        }
+
+        // Get the height of the highest block to not delete, i.e. the switch block of
+        // `era_to_reset_to - 1`.
+        let mut block_height = match self
+            .get_block_header(&mut txn, BlockGetterId::SwitchBlock(era_to_reset_to - 1))?
+        {
+            Some(hash_and_header) => hash_and_header.1.height(),
+            None => {
+                // If we don't have the switch block, there's nothing to purge.
+                return Ok(());
+            }
+        };
+
+        // Set this as the new highest block, and the new lowest if required.
+        self.indices
+            .put_highest_available_block_height(&mut txn, block_height)?;
+        if block_height
+            < self
+                .indices
+                .get_lowest_available_block_height(&mut txn)?
+                .unwrap_or_default()
+        {
+            self.indices
+                .put_lowest_available_block_height(&mut txn, block_height)?;
+        }
+        self.highest_block_at_startup = block_height;
+
+        // Iterate all higher blocks, deleting relevant data.
+        loop {
+            block_height += 1;
+
+            // Gather the data needed to remove entries before we start actually deleting them.
+            let (block_hash, header) = match self
+                .get_block_header(&mut txn, BlockGetterId::with_block_height(block_height))?
+            {
+                Some(hash_and_header) => hash_and_header,
+                None => break,
+            };
+            let maybe_block_body = self.get_body_for_block_header(&mut txn, &header)?;
+
+            // Delete the relevant entries.
+            txn.delete(self.block_header_db, &block_hash)?;
+            txn.delete(self.transfer_db, &block_hash)?;
+            txn.delete(self.block_metadata_db, &block_hash)?;
+            self.indices
+                .delete_from_block_height_index(&mut txn, header.height())?;
+            if header.is_switch_block() {
+                self.indices
+                    .delete_from_switch_block_era_id_index(&mut txn, header.era_id())?;
+            }
+            if self.is_v1_block(&header) {
+                let should_delete_v1_block_body = self.indices.delete_from_v1_body_hash_index(
+                    &mut txn,
+                    header.body_hash(),
+                    block_hash,
+                    header.height(),
+                )?;
+                if should_delete_v1_block_body {
+                    txn.delete(self.block_body_v1_db, header.body_hash())?;
+                }
+            }
+
+            let block_body = match maybe_block_body {
+                Some(body) => body,
+                None => continue,
+            };
+
+            for deploy_hash in block_body
+                .deploy_hashes()
+                .iter()
+                .chain(block_body.transfer_hashes().iter())
+            {
+                // Don't delete the actual deploy - just the metadata and finalized approvals.
+                txn.delete(self.deploy_metadata_db, deploy_hash)?;
+                txn.delete(self.finalized_approvals_db, deploy_hash)?;
+                self.indices
+                    .delete_from_deploy_hash_index(&mut txn, deploy_hash)?;
+            }
+        }
+
+        txn.commit()?;
+        Ok(())
     }
 
     /// Handles a state store request.
@@ -650,7 +862,7 @@ impl StorageInner {
                 Ok(responder.respond(()).ignore())
             }
             StateStoreRequest::Load { key, responder } => {
-                let bytes = self.read_state_store(&key)?;
+                let bytes = self.get_from_state_store(&key)?;
                 Ok(responder.respond(bytes).ignore())
             }
         }
@@ -659,10 +871,10 @@ impl StorageInner {
     /// Reads from the state storage DB.
     /// If key is non-empty, returns bytes from under the key. Otherwise returns `Ok(None)`.
     /// May also fail with storage errors.
-    pub(crate) fn read_state_store<K>(&self, key: &K) -> Result<Option<Vec<u8>>, FatalStorageError>
-    where
-        K: AsRef<[u8]>,
-    {
+    fn get_from_state_store<K: AsRef<[u8]>>(
+        &self,
+        key: &K,
+    ) -> Result<Option<Vec<u8>>, FatalStorageError> {
         let txn = self.env.begin_ro_txn()?;
         let bytes = match txn.get(self.state_store_db, &key) {
             Ok(slice) => Some(slice.to_owned()),
@@ -673,7 +885,7 @@ impl StorageInner {
     }
 
     /// Returns the path to the storage folder.
-    pub(crate) fn root_path(&self) -> &Path {
+    fn root_path(&self) -> &Path {
         &self.root
     }
 
@@ -695,9 +907,8 @@ impl StorageInner {
             if let Some(serialized_item) =
                 serialized_item_pool.get(AsRef::<[u8]>::as_ref(&unique_id))
             {
-                // We found an item in the pool. We can short-circuit all
-                // deserialization/serialization and return the canned item
-                // immediately.
+                // We found an item in the pool. We can short-circuit all deserialization/
+                // serialization and return the canned item immediately.
                 let found = Message::new_get_response_from_serialized(
                     incoming.message.tag(),
                     serialized_item,
@@ -706,32 +917,30 @@ impl StorageInner {
             }
         }
 
+        let mut txn = self.env.begin_ro_txn().map_err(FatalStorageError::from)?;
         match incoming.message {
             NetRequest::Deploy(ref serialized_id) => {
-                let id = decode_item_id::<Deploy>(serialized_id)?;
-                let opt_item = self.get_deploy(id).map_err(FatalStorageError::from)?;
+                let deploy_hash = decode_item_id::<Deploy>(serialized_id)?;
+                let opt_item: Option<Deploy> = txn
+                    .get_value(self.deploy_db, &deploy_hash)
+                    .map_err(FatalStorageError::from)?;
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    id,
+                    deploy_hash,
                     opt_item,
                 )?)
             }
             NetRequest::FinalizedApprovals(ref serialized_id) => {
-                let id = decode_item_id::<FinalizedApprovalsWithId>(serialized_id)?;
+                let deploy_hash = decode_item_id::<FinalizedApprovalsWithId>(serialized_id)?;
                 let opt_item = self
-                    .env
-                    .begin_ro_txn()
-                    .map_err(Into::into)
-                    .and_then(|mut tx| {
-                        self.get_deploy_with_finalized_approvals(&mut tx, &id)
-                            .map_err(FatalStorageError::from)
-                    })?
+                    .get_deploy_with_finalized_approvals(&mut txn, &deploy_hash)
+                    .map_err(FatalStorageError::from)?
                     .map(|deploy| {
                         FinalizedApprovalsWithId::new(
-                            id,
+                            deploy_hash,
                             FinalizedApprovals::new(deploy.into_naive().approvals().clone()),
                         )
                     });
@@ -740,76 +949,83 @@ impl StorageInner {
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    id,
+                    deploy_hash,
                     opt_item,
                 )?)
             }
             NetRequest::Block(ref serialized_id) => {
-                let id = decode_item_id::<Block>(serialized_id)?;
-                let opt_item = self.read_block(&id).map_err(FatalStorageError::from)?;
+                let block_hash = decode_item_id::<Block>(serialized_id)?;
+                let getter_id = BlockGetterId::with_block_hash(block_hash);
+                let opt_item = self
+                    .get_block(&mut txn, getter_id)
+                    .map_err(FatalStorageError::from)?;
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    id,
+                    block_hash,
                     opt_item,
                 )?)
             }
             NetRequest::GossipedAddress(_) => Err(GetRequestError::GossipedAddressNotGettable),
             NetRequest::BlockAndMetadataByHeight(ref serialized_id) => {
-                let item_id = decode_item_id::<BlockWithMetadata>(serialized_id)?;
+                let block_height = decode_item_id::<BlockWithMetadata>(serialized_id)?;
+                let getter_id = BlockGetterId::with_block_height(block_height);
                 let opt_item = self
-                    .read_block_and_sufficient_finality_signatures_by_height(item_id)
+                    .get_block_with_sigs(&mut txn, getter_id)
                     .map_err(FatalStorageError::from)?;
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    item_id,
+                    block_height,
                     opt_item,
                 )?)
             }
             NetRequest::BlockHeaderByHash(ref serialized_id) => {
-                let item_id = decode_item_id::<BlockHeader>(serialized_id)?;
+                let block_hash = decode_item_id::<BlockHeader>(serialized_id)?;
+                let getter_id = BlockGetterId::with_block_hash(block_hash);
                 let opt_item = self
-                    .read_block_header_by_hash(&item_id)
-                    .map_err(FatalStorageError::from)?;
+                    .get_block_header(&mut txn, getter_id)
+                    .map_err(FatalStorageError::from)?
+                    .map(|(_block_hash, header)| header);
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    item_id,
+                    block_hash,
                     opt_item,
                 )?)
             }
             NetRequest::BlockHeaderAndFinalitySignaturesByHeight(ref serialized_id) => {
-                let item_id = decode_item_id::<BlockHeaderWithMetadata>(serialized_id)?;
+                let block_height = decode_item_id::<BlockHeaderWithMetadata>(serialized_id)?;
+                let getter_id = BlockGetterId::with_block_height(block_height);
                 let opt_item = self
-                    .read_block_header_and_sufficient_finality_signatures_by_height(item_id)
+                    .get_block_header_with_enough_sigs(&mut txn, getter_id)
                     .map_err(FatalStorageError::from)?;
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    item_id,
+                    block_height,
                     opt_item,
                 )?)
             }
             NetRequest::BlockAndDeploys(ref serialized_id) => {
-                let item_id = decode_item_id::<BlockAndDeploys>(serialized_id)?;
+                let block_hash = decode_item_id::<BlockAndDeploys>(serialized_id)?;
                 let opt_item = self
-                    .read_block_and_deploys_by_hash(item_id)
+                    .get_block_and_deploys(&mut txn, block_hash)
                     .map_err(FatalStorageError::from)?;
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,
                     serialized_id,
-                    item_id,
+                    block_hash,
                     opt_item,
                 )?)
             }
@@ -819,327 +1035,104 @@ impl StorageInner {
     /// Handles a storage request.
     fn handle_storage_request<REv>(
         &self,
-        req: StorageRequest,
+        request: StorageRequest,
     ) -> Result<Effects<Event>, FatalStorageError> {
-        // Note: Database IO is handled in a blocking fashion on purpose throughout this function.
-        // The rationale is that long IO operations are very rare and cache misses frequent, so on
-        // average the actual execution time will be very low.
-        Ok(match req {
+        let getter_id = BlockGetterId::from(&request);
+        Ok(match request {
             StorageRequest::PutBlock { block, responder } => {
-                responder.respond(self.write_block(&*block)?).ignore()
+                responder.respond(self.commit_block(&*block)?).ignore()
             }
-            StorageRequest::GetBlock {
-                block_hash,
-                responder,
-            } => responder.respond(self.read_block(&block_hash)?).ignore(),
-            StorageRequest::GetHighestBlock { responder } => {
+            StorageRequest::GetBlock { responder, .. }
+            | StorageRequest::GetHighestBlock { responder } => {
                 let mut txn = self.env.begin_ro_txn()?;
-                let indices = self.indices.read()?;
-                responder
-                    .respond(self.get_highest_block(&mut txn, &indices)?)
-                    .ignore()
+                let maybe_block = self.get_block(&mut txn, getter_id)?;
+                responder.respond(maybe_block).ignore()
             }
-            StorageRequest::GetHighestBlockHeader { responder } => {
+            StorageRequest::GetBlockHeader { responder, .. }
+            | StorageRequest::GetHighestBlockHeader { responder }
+            | StorageRequest::GetSwitchBlockHeaderAtEraId { responder, .. }
+            | StorageRequest::GetBlockHeaderForDeploy { responder, .. }
+            | StorageRequest::GetBlockHeaderByHeight { responder, .. } => {
                 let mut txn = self.env.begin_ro_txn()?;
-                let indices = self.indices.read()?;
-                responder
-                    .respond(self.get_highest_block_header(&mut txn, &indices)?)
-                    .ignore()
+                let maybe_block_header = self
+                    .get_block_header(&mut txn, getter_id)?
+                    .map(|(_block_hash, header)| header);
+                responder.respond(maybe_block_header).ignore()
             }
-            StorageRequest::GetSwitchBlockHeaderAtEraId { era_id, responder } => {
-                let indices = self.indices.read()?;
-                let mut tx = self.env.begin_ro_txn()?;
-                responder
-                    .respond(self.get_switch_block_header_by_era_id(&mut tx, &indices, era_id)?)
-                    .ignore()
-            }
-            StorageRequest::GetBlockHeaderForDeploy {
-                deploy_hash,
+            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
                 responder,
+                ..
             } => {
-                let mut tx = self.env.begin_ro_txn()?;
-                let indices = self.indices.read()?;
-                responder
-                    .respond(self.get_block_header_by_deploy_hash(
-                        &mut tx,
-                        &indices,
-                        deploy_hash,
-                    )?)
-                    .ignore()
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_block_header =
+                    self.get_block_header_with_enough_sigs(&mut txn, getter_id)?;
+                responder.respond(maybe_block_header).ignore()
             }
-            StorageRequest::GetBlockHeader {
-                block_hash,
-                only_from_available_block_range,
-                responder,
-            } => responder
-                .respond(self.get_single_block_header_restricted(
-                    &mut self.env.begin_ro_txn()?,
-                    &block_hash,
-                    only_from_available_block_range,
-                )?)
-                .ignore(),
+
+            StorageRequest::GetBlockAndMetadataByHash { responder, .. }
+            | StorageRequest::GetBlockAndMetadataByHeight { responder, .. }
+            | StorageRequest::GetHighestBlockWithMetadata { responder } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_block_and_metadata = self.get_block_with_sigs(&mut txn, getter_id)?;
+                responder.respond(maybe_block_and_metadata).ignore()
+            }
+            StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
+                responder, ..
+            } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_block_and_metadata =
+                    self.get_block_with_enough_sigs(&mut txn, getter_id)?;
+                responder.respond(maybe_block_and_metadata).ignore()
+            }
             StorageRequest::CheckBlockHeaderExistence {
                 block_height,
                 responder,
             } => {
-                let indices = self.indices.read()?;
-                responder
-                    .respond(self.block_header_exists(&indices, block_height))
-                    .ignore()
+                let mut txn = self.env.begin_ro_txn()?;
+                let exists = self
+                    .indices
+                    .exists_in_block_height_index(&mut txn, block_height)?;
+                responder.respond(exists).ignore()
             }
             StorageRequest::GetBlockTransfers {
                 block_hash,
                 responder,
-            } => responder
-                .respond(self.get_transfers(&mut self.env.begin_ro_txn()?, &block_hash)?)
-                .ignore(),
+            } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_transfers = self.get_transfers(&mut txn, &block_hash)?;
+                responder.respond(maybe_transfers).ignore()
+            }
             StorageRequest::PutDeploy { deploy, responder } => {
-                responder.respond(self.put_deploy(&*deploy)?).ignore()
+                responder.respond(self.commit_deploy(&*deploy)?).ignore()
             }
             StorageRequest::GetDeploys {
                 deploy_hashes,
                 responder,
-            } => responder
-                .respond(self.get_deploys_with_finalized_approvals(
-                    &mut self.env.begin_ro_txn()?,
-                    deploy_hashes.as_slice(),
-                )?)
-                .ignore(),
+            } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let deploys =
+                    self.get_deploys_with_finalized_approvals(&mut txn, deploy_hashes.as_slice())?;
+                responder.respond(deploys).ignore()
+            }
             StorageRequest::PutExecutionResults {
                 block_hash,
                 execution_results,
                 responder,
-            } => {
-                let mut txn = self.env.begin_rw_txn()?;
-
-                let mut transfers: Vec<Transfer> = vec![];
-
-                for (deploy_hash, execution_result) in execution_results {
-                    let mut metadata = self
-                        .get_deploy_metadata(&mut txn, &deploy_hash)?
-                        .unwrap_or_default();
-
-                    // If we have a previous execution result, we can continue if it is the same.
-                    if let Some(prev) = metadata.execution_results.get(&block_hash) {
-                        if prev == &execution_result {
-                            continue;
-                        } else {
-                            debug!(%deploy_hash, %block_hash, "different execution result");
-                        }
-                    }
-
-                    if let ExecutionResult::Success { effect, .. } = execution_result.clone() {
-                        for transform_entry in effect.transforms {
-                            if let Transform::WriteTransfer(transfer) = transform_entry.transform {
-                                transfers.push(transfer);
-                            }
-                        }
-                    }
-
-                    // TODO: this is currently done like this because rpc get_deploy returns the
-                    // data, but the organization of deploy, block_hash, and
-                    // execution_result is incorrectly represented. it should be
-                    // inverted; for a given block_hash 0n deploys and each deploy has exactly 1
-                    // result (aka deploy_metadata in this context).
-
-                    // Update metadata and write back to db.
-                    metadata
-                        .execution_results
-                        .insert(*block_hash, execution_result);
-                    let was_written =
-                        txn.put_value(self.deploy_metadata_db, &deploy_hash, &metadata, true)?;
-                    if !was_written {
-                        error!(?block_hash, ?deploy_hash, "failed to write deploy metadata");
-                        debug_assert!(was_written);
-                    }
-                }
-
-                let was_written =
-                    txn.put_value(self.transfer_db, &*block_hash, &transfers, true)?;
-                if !was_written {
-                    error!(?block_hash, "failed to write transfers");
-                    debug_assert!(was_written);
-                }
-
-                txn.commit()?;
-                responder.respond(()).ignore()
-            }
+            } => responder
+                .respond(self.put_execution_results(*block_hash, execution_results)?)
+                .ignore(),
             StorageRequest::GetDeployAndMetadata {
                 deploy_hash,
                 responder,
             } => {
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let deploy = {
-                    let opt_deploy =
-                        self.get_deploy_with_finalized_approvals(&mut txn, &deploy_hash)?;
-
-                    if let Some(deploy) = opt_deploy {
-                        deploy
-                    } else {
-                        return Ok(responder.respond(None).ignore());
-                    }
-                };
-
-                // Missing metadata is filled using a default.
-                let metadata_ext: DeployMetadataExt =
-                    if let Some(metadata) = self.get_deploy_metadata(&mut txn, &deploy_hash)? {
-                        metadata.into()
-                    } else {
-                        let indices = self.indices.read()?;
-                        if let Some(block_hash_and_height) =
-                            self.get_block_hash_and_height_by_deploy_hash(&indices, deploy_hash)?
-                        {
-                            block_hash_and_height.into()
-                        } else {
-                            DeployMetadataExt::Empty
-                        }
-                    };
-
-                responder.respond(Some((deploy, metadata_ext))).ignore()
-            }
-            StorageRequest::GetBlockAndMetadataByHash {
-                block_hash,
-                only_from_available_block_range,
-                responder,
-            } => {
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let block: Block =
-                    if let Some(block) = self.get_single_block(&mut txn, &block_hash)? {
-                        block
-                    } else {
-                        return Ok(responder.respond(None).ignore());
-                    };
-
-                if !(self.should_return_block(block.height(), only_from_available_block_range)?) {
-                    return Ok(responder.respond(None).ignore());
-                }
-
-                // Check that the hash of the block retrieved is correct.
-                if block_hash != *block.hash() {
-                    error!(
-                        queried_block_hash = ?block_hash,
-                        actual_block_hash = ?block.hash(),
-                        "block not stored under hash"
-                    );
-                    debug_assert_eq!(&block_hash, block.hash());
-                    return Ok(responder.respond(None).ignore());
-                }
-                let finality_signatures =
-                    match self.get_finality_signatures(&mut txn, &block_hash)? {
-                        Some(signatures) => signatures,
-                        None => BlockSignatures::new(block_hash, block.header().era_id()),
-                    };
-                if finality_signatures.verify().is_err() {
-                    error!(?block, "invalid finality signatures for block");
-                    debug_assert!(finality_signatures.verify().is_ok());
-                    return Ok(responder.respond(None).ignore());
-                }
-                responder
-                    .respond(Some(BlockWithMetadata {
-                        block,
-                        finality_signatures,
-                    }))
-                    .ignore()
-            }
-            StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            } => responder
-                .respond(
-                    self.read_block_and_sufficient_finality_signatures_by_height(block_height)?,
-                )
-                .ignore(),
-            StorageRequest::GetBlockAndMetadataByHeight {
-                block_height,
-                only_from_available_block_range,
-                responder,
-            } => {
-                if !(self.should_return_block(block_height, only_from_available_block_range)?) {
-                    return Ok(responder.respond(None).ignore());
-                }
-
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let block: Block = {
-                    let indices = self.indices.read()?;
-                    if let Some(block) =
-                        self.get_block_by_height(&mut txn, &indices, block_height)?
-                    {
-                        block
-                    } else {
-                        return Ok(responder.respond(None).ignore());
-                    }
-                };
-
-                let hash = block.hash();
-                let finality_signatures = match self.get_finality_signatures(&mut txn, hash)? {
-                    Some(signatures) => signatures,
-                    None => BlockSignatures::new(*hash, block.header().era_id()),
-                };
-                responder
-                    .respond(Some(BlockWithMetadata {
-                        block,
-                        finality_signatures,
-                    }))
-                    .ignore()
-            }
-            StorageRequest::GetHighestBlockWithMetadata { responder } => {
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let highest_block: Block = {
-                    let indices = self.indices.read()?;
-                    if let Some(block) = indices
-                        .block_height_index
-                        .keys()
-                        .last()
-                        .and_then(|&height| {
-                            self.get_block_by_height(&mut txn, &indices, height)
-                                .transpose()
-                        })
-                        .transpose()?
-                    {
-                        block
-                    } else {
-                        return Ok(responder.respond(None).ignore());
-                    }
-                };
-                let hash = highest_block.hash();
-                let finality_signatures = match self.get_finality_signatures(&mut txn, hash)? {
-                    Some(signatures) => signatures,
-                    None => BlockSignatures::new(*hash, highest_block.header().era_id()),
-                };
-                responder
-                    .respond(Some(BlockWithMetadata {
-                        block: highest_block,
-                        finality_signatures,
-                    }))
-                    .ignore()
+                let deploy_and_metadata = self.get_deploy_and_metadata(deploy_hash)?;
+                responder.respond(deploy_and_metadata).ignore()
             }
             StorageRequest::PutBlockSignatures {
                 signatures,
                 responder,
             } => {
-                let mut txn = self.env.begin_rw_txn()?;
-                let old_data: Option<BlockSignatures> =
-                    txn.get_value(self.block_metadata_db, &signatures.block_hash)?;
-                let new_data = match old_data {
-                    None => signatures,
-                    Some(mut data) => {
-                        for (pk, sig) in signatures.proofs {
-                            data.insert_proof(pk, sig);
-                        }
-                        data
-                    }
-                };
-                let outcome = txn.put_value(
-                    self.block_metadata_db,
-                    &new_data.block_hash,
-                    &new_data,
-                    true,
-                )?;
-                txn.commit()?;
+                let outcome = self.commit_block_signatures(signatures)?;
                 responder.respond(outcome).ignore()
             }
             StorageRequest::GetBlockSignatures {
@@ -1147,76 +1140,27 @@ impl StorageInner {
                 responder,
             } => {
                 let result =
-                    self.get_finality_signatures(&mut self.env.begin_ro_txn()?, &block_hash)?;
+                    self.get_block_signatures(&mut self.env.begin_ro_txn()?, &block_hash)?;
                 responder.respond(result).ignore()
             }
             StorageRequest::GetFinalizedBlocks { ttl, responder } => {
                 responder.respond(self.get_finalized_blocks(ttl)?).ignore()
             }
-            StorageRequest::GetBlockHeaderByHeight {
-                block_height,
-                only_from_available_block_range,
-                responder,
-            } => {
-                let indices = self.indices.read()?;
-                let result = self.get_block_header_by_height_restricted(
-                    &mut self.env.begin_ro_txn()?,
-                    &indices,
-                    block_height,
-                    only_from_available_block_range,
-                )?;
-                responder.respond(result).ignore()
-            }
-            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            } => {
-                let indices = self.indices.read()?;
-                let result = self.get_block_header_and_sufficient_finality_signatures_by_height(
-                    &mut self.env.begin_ro_txn()?,
-                    &indices,
-                    block_height,
-                )?;
-                responder.respond(result).ignore()
-            }
             StorageRequest::PutBlockHeader {
                 block_header,
                 responder,
-            } => {
-                let mut txn = self.env.begin_rw_txn()?;
-                if !txn.put_value(
-                    self.block_header_db,
-                    &block_header.hash(self.verifiable_chunked_hash_activation),
-                    &block_header,
-                    false,
-                )? {
-                    error!(
-                        ?block_header,
-                        "Could not insert block header (maybe already inserted?)",
-                    );
-                    txn.abort();
-                    return Ok(responder.respond(false).ignore());
-                }
-
-                {
-                    let mut indices = self.indices.write()?;
-                    insert_to_block_header_indices(
-                        &mut indices,
-                        &block_header,
-                        self.verifiable_chunked_hash_activation,
-                    )?;
-                }
-
-                txn.commit()?;
-                responder.respond(true).ignore()
-            }
+            } => responder
+                .respond(self.commit_block_header(&*block_header)?)
+                .ignore(),
             StorageRequest::UpdateLowestAvailableBlockHeight { height, responder } => {
                 self.update_lowest_available_block_height(height)?;
                 responder.respond(()).ignore()
             }
-            StorageRequest::GetAvailableBlockRange { responder } => responder
-                .respond(self.get_available_block_range()?)
-                .ignore(),
+            StorageRequest::GetAvailableBlockRange { responder } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let available_range = self.get_available_block_range(&mut txn)?;
+                responder.respond(available_range).ignore()
+            }
             StorageRequest::StoreFinalizedApprovals {
                 ref deploy_hash,
                 ref finalized_approvals,
@@ -1225,283 +1169,614 @@ impl StorageInner {
                 .respond(self.store_finalized_approvals(deploy_hash, finalized_approvals)?)
                 .ignore(),
             StorageRequest::PutBlockAndDeploys { block, responder } => responder
-                .respond(self.put_block_and_deploys(&*block)?)
+                .respond(self.commit_block_and_deploys(&*block)?)
                 .ignore(),
             StorageRequest::GetBlockAndDeploys {
                 block_hash,
                 responder,
-            } => responder
-                .respond(self.read_block_and_deploys_by_hash(block_hash)?)
-                .ignore(),
+            } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                let maybe_block_and_deploys = self.get_block_and_deploys(&mut txn, block_hash)?;
+                responder.respond(maybe_block_and_deploys).ignore()
+            }
         })
     }
 
     /// Put a single deploy into storage.
-    pub fn put_deploy(&self, deploy: &Deploy) -> Result<bool, FatalStorageError> {
+    fn commit_deploy(&self, deploy: &Deploy) -> Result<bool, FatalStorageError> {
         let mut txn = self.env.begin_rw_txn()?;
-        let outcome = txn.put_value(self.deploy_db, deploy.id(), deploy, false)?;
+        let outcome = self.put_deploy(&mut txn, deploy, None)?;
         txn.commit()?;
+        Ok(outcome)
+    }
+
+    fn put_deploy(
+        &self,
+        txn: &mut RwTransaction,
+        deploy: &Deploy,
+        maybe_block_hash_and_height: Option<(BlockHash, u64)>,
+    ) -> Result<bool, FatalStorageError> {
+        let outcome = txn.put_value(self.deploy_db, deploy.id(), deploy, false)?;
+        if let Some((block_hash, block_height)) = maybe_block_hash_and_height {
+            self.indices
+                .put_to_deploy_hash_index(txn, deploy.id(), block_hash, block_height)?;
+        }
         Ok(outcome)
     }
 
     /// Puts block and its deploys into storage.
     ///
     /// Returns `Ok` only if the block and all deploys were successfully written.
-    pub fn put_block_and_deploys(
+    fn commit_block_and_deploys(
         &self,
         block_and_deploys: &BlockAndDeploys,
     ) -> Result<(), FatalStorageError> {
         let BlockAndDeploys { block, deploys } = block_and_deploys;
 
-        block.verify(self.verifiable_chunked_hash_activation)?;
         let mut txn = self.env.begin_rw_txn()?;
-        match self.write_validated_block(&mut txn, block) {
-            Ok(true) => {}
-            Ok(false) => {
-                txn.abort();
-                return Err(FatalStorageError::FailedToOverwriteBlock);
-            }
-            Err(error) => {
-                txn.abort();
-                return Err(error);
-            }
-        }
+        self.put_block(&mut txn, block)?;
 
+        let maybe_block_hash_and_height = Some((*block.hash(), block.height()));
         for deploy in deploys {
-            let _ = txn.put_value(self.deploy_db, deploy.id(), deploy, false)?;
+            self.put_deploy(&mut txn, deploy, maybe_block_hash_and_height)?;
         }
-        txn.commit()?;
 
+        txn.commit()?;
         Ok(())
     }
 
-    /// Retrieves a block by hash.
-    pub fn read_block(&self, block_hash: &BlockHash) -> Result<Option<Block>, FatalStorageError> {
-        self.get_single_block(&mut self.env.begin_ro_txn()?, block_hash)
+    fn commit_block_signatures(
+        &self,
+        signatures: BlockSignatures,
+    ) -> Result<bool, FatalStorageError> {
+        let mut txn = self.env.begin_rw_txn()?;
+        let old_data: Option<BlockSignatures> =
+            txn.get_value(self.block_metadata_db, &signatures.block_hash)?;
+        let new_data = match old_data {
+            None => signatures,
+            Some(mut data) => {
+                for (public_key, sig) in signatures.proofs {
+                    data.insert_proof(public_key, sig);
+                }
+                data
+            }
+        };
+        let outcome = txn.put_value(
+            self.block_metadata_db,
+            &new_data.block_hash,
+            &new_data,
+            true,
+        )?;
+
+        txn.commit()?;
+        Ok(outcome)
+    }
+
+    fn get_block_header<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<(BlockHash, BlockHeader)>, FatalStorageError> {
+        match getter_id {
+            BlockGetterId::BlockHash {
+                block_hash,
+                only_from_available_range,
+            } => {
+                let header: BlockHeader = match txn.get_value(self.block_header_db, &block_hash)? {
+                    Some(header) => header,
+                    None => return Ok(None),
+                };
+                if only_from_available_range {
+                    let available_range = self.get_available_block_range(txn)?;
+                    if !available_range.contains(header.height()) {
+                        return Ok(None);
+                    }
+                }
+                Ok(Some((block_hash, header)))
+            }
+            BlockGetterId::BlockHeight {
+                block_height,
+                only_from_available_range,
+            } => {
+                if only_from_available_range {
+                    let available_range = self.get_available_block_range(txn)?;
+                    if !available_range.contains(block_height) {
+                        return Ok(None);
+                    }
+                }
+                match self
+                    .indices
+                    .get_from_block_height_index(txn, block_height)?
+                {
+                    Some(value) => Ok(txn
+                        .get_value(self.block_header_db, &value.block_hash)?
+                        .map(|header| (value.block_hash, header))),
+                    None => Ok(None),
+                }
+            }
+            BlockGetterId::HighestBlock => {
+                match self.indices.get_highest_available_block_info(txn)? {
+                    Some(info) => Ok(txn
+                        .get_value(self.block_header_db, &info.block_hash)?
+                        .map(|header| (info.block_hash, header))),
+                    None => Ok(None),
+                }
+            }
+            BlockGetterId::SwitchBlock(era_id) => {
+                match self
+                    .indices
+                    .get_from_switch_block_era_id_index(txn, era_id)?
+                {
+                    Some(block_hash) => Ok(txn
+                        .get_value(self.block_header_db, &block_hash)?
+                        .map(|header| (block_hash, header))),
+                    None => Ok(None),
+                }
+            }
+            BlockGetterId::DeployHash(deploy_hash) => {
+                match self.indices.get_from_deploy_hash_index(txn, &deploy_hash)? {
+                    Some(block_hash_and_height) => Ok(txn
+                        .get_value(self.block_header_db, &block_hash_and_height.block_hash)?
+                        .map(|header| (block_hash_and_height.block_hash, header))),
+                    None => Ok(None),
+                }
+            }
+            BlockGetterId::None => {
+                error!("cannot get a block header with getter id none");
+                Err(FatalStorageError::InvalidBlockGetterId)
+            }
+        }
+    }
+
+    fn get_block_header_with_sigs<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
+        let (block_hash, block_header) = match self.get_block_header(txn, getter_id)? {
+            Some(hash_and_header) => hash_and_header,
+            None => return Ok(None),
+        };
+        let block_signatures: BlockSignatures = txn
+            .get_value(self.block_metadata_db, &block_hash)?
+            .unwrap_or_else(|| BlockSignatures::new(block_hash, block_header.era_id()));
+        Ok(Some(BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        }))
+    }
+
+    /// Retrieves block header and block signatures; returns `None` if there are less than the fault
+    /// tolerance threshold signatures or if the block is from before the most recent emergency
+    /// upgrade, or if the block is from era 0.
+    fn get_block_header_with_enough_sigs<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
+        let BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        } = match self.get_block_header_with_sigs(txn, getter_id)? {
+            Some(header_with_metadata) => header_with_metadata,
+            None => return Ok(None),
+        };
+
+        if let Some(last_emergency_restart) = self.last_emergency_restart {
+            if block_header.era_id() <= last_emergency_restart {
+                debug!(
+                    ?block_header,
+                    ?last_emergency_restart,
+                    "block signatures from before last emergency restart requested"
+                );
+                return Ok(None);
+            }
+        }
+
+        if block_header.era_id().value() == 0 {
+            debug!(?block_header, "block signatures from era 0 requested");
+            return Ok(None);
+        }
+
+        let getter_id = BlockGetterId::SwitchBlock(block_header.era_id() - 1);
+        let switch_block_header = match self.get_block_header(txn, getter_id)? {
+            Some((_block_hash, header)) => header,
+            None => return Ok(None),
+        };
+
+        let validator_weights = match switch_block_header.next_era_validator_weights() {
+            Some(validator_weights) => validator_weights,
+            None => {
+                return Err(FatalStorageError::InvalidSwitchBlock(Box::new(
+                    switch_block_header,
+                )))
+            }
+        };
+
+        let block_signatures = match consensus::get_minimal_set_of_signatures(
+            validator_weights,
+            self.finality_threshold_fraction,
+            block_signatures,
+        ) {
+            Some(sigs) => sigs,
+            None => return Ok(None),
+        };
+
+        Ok(Some(BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        }))
+    }
+
+    fn get_block<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<Block>, FatalStorageError> {
+        let (block_hash, header) = match self.get_block_header(txn, getter_id)? {
+            Some(hash_and_header) => hash_and_header,
+            None => return Ok(None),
+        };
+        match self.get_body_for_block_header(txn, &header)? {
+            Some(body) => Ok(Some(Block::new_unchecked(block_hash, header, body))),
+            None => Ok(None),
+        }
+    }
+
+    fn get_block_with_sigs<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
+        let BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        } = match self.get_block_header_with_sigs(txn, getter_id)? {
+            Some(header_with_metadata) => header_with_metadata,
+            None => return Ok(None),
+        };
+        let block_body = match self.get_body_for_block_header(txn, &block_header)? {
+            Some(block_body) => block_body,
+            None => return Ok(None),
+        };
+        let block = Block::new_unchecked(block_signatures.block_hash, block_header, block_body);
+        Ok(Some(BlockWithMetadata {
+            block,
+            finality_signatures: block_signatures,
+        }))
+    }
+
+    /// Retrieves block and block signatures; returns `None` if there are less than the fault
+    /// tolerance threshold signatures or if the block is from before the most recent emergency
+    /// upgrade, or if the block is from era 0.
+    fn get_block_with_enough_sigs<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        getter_id: BlockGetterId,
+    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
+        let BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        } = match self.get_block_header_with_enough_sigs(txn, getter_id)? {
+            Some(header_with_metadata) => header_with_metadata,
+            None => return Ok(None),
+        };
+        let block_body = match self.get_body_for_block_header(txn, &block_header)? {
+            Some(block_body) => block_body,
+            None => return Ok(None),
+        };
+        let block = Block::new_unchecked(block_signatures.block_hash, block_header, block_body);
+        Ok(Some(BlockWithMetadata {
+            block,
+            finality_signatures: block_signatures,
+        }))
+    }
+
+    fn get_body_for_block_header<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        block_header: &BlockHeader,
+    ) -> Result<Option<BlockBody>, LmdbExtError> {
+        if self.is_v1_block(block_header) {
+            txn.get_value(self.block_body_v1_db, block_header.body_hash())
+        } else {
+            let deploy_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> = match self
+                .get_merkle_linked_list_node(txn, self.deploy_hashes_db, block_header.body_hash())?
+            {
+                Some(deploy_hashes_with_proof) => deploy_hashes_with_proof,
+                None => return Ok(None),
+            };
+            let transfer_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> = match self
+                .get_merkle_linked_list_node(
+                    txn,
+                    self.transfer_hashes_db,
+                    deploy_hashes_with_proof.merkle_proof_of_rest(),
+                )? {
+                Some(transfer_hashes_with_proof) => transfer_hashes_with_proof,
+                None => return Ok(None),
+            };
+            let proposer_with_proof: MerkleLinkedListNode<PublicKey> = match self
+                .get_merkle_linked_list_node(
+                    txn,
+                    self.proposer_db,
+                    transfer_hashes_with_proof.merkle_proof_of_rest(),
+                )? {
+                Some(proposer_with_proof) => {
+                    debug_assert_eq!(
+                        *proposer_with_proof.merkle_proof_of_rest(),
+                        Digest::SENTINEL_RFOLD
+                    );
+                    proposer_with_proof
+                }
+                None => return Ok(None),
+            };
+            let block_body = BlockBody::new(
+                proposer_with_proof.take_value(),
+                deploy_hashes_with_proof.take_value(),
+                transfer_hashes_with_proof.take_value(),
+            );
+
+            Ok(Some(block_body))
+        }
+    }
+
+    fn get_merkle_linked_list_node<Tx: Transaction, T: FromBytes>(
+        &self,
+        txn: &mut Tx,
+        part_database: Database,
+        key_to_block_body_db: &Digest,
+    ) -> Result<Option<MerkleLinkedListNode<T>>, LmdbExtError> {
+        let (part_to_value_db, merkle_proof_of_rest): (Digest, Digest) =
+            match txn.get_value_bytesrepr(self.block_body_v2_db, key_to_block_body_db)? {
+                Some(slice) => slice,
+                None => return Ok(None),
+            };
+        let value = match txn.get_value_bytesrepr(part_database, &part_to_value_db)? {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+        Ok(Some(MerkleLinkedListNode::new(value, merkle_proof_of_rest)))
     }
 
     /// Writes a block to storage, updating indices as necessary.
-    ///
-    /// Returns `Ok(true)` if the block has been successfully written, `Ok(false)` if a part of it
-    /// couldn't be written because it already existed, and `Err(_)` if there was an error.
-    pub fn write_block(&self, block: &Block) -> Result<bool, FatalStorageError> {
-        // Validate the block prior to inserting it into the database
-        block.verify(self.verifiable_chunked_hash_activation)?;
+    fn commit_block(&self, block: &Block) -> Result<(), FatalStorageError> {
         let mut txn = self.env.begin_rw_txn()?;
-        let result = self.write_validated_block(&mut txn, block);
-        match &result {
-            Ok(false) | Err(_) => txn.abort(),
-            Ok(true) => txn.commit()?,
-        }
-        result
+        self.put_block(&mut txn, block)?;
+        txn.commit()?;
+        Ok(())
     }
 
-    /// Writes a block which has already been verified to storage, updating indices as necessary.
-    ///
-    /// Returns `Ok(true)` if the block has been successfully written, `Ok(false)` if a part of it
-    /// couldn't be written because it already existed, and `Err(_)` if there was an error.
-    fn write_validated_block(
+    fn put_block(&self, txn: &mut RwTransaction, block: &Block) -> Result<(), FatalStorageError> {
+        if self.is_v1_block(block.header()) {
+            txn.put_value(
+                self.block_body_v1_db,
+                block.header().body_hash(),
+                block.body(),
+                true,
+            )?;
+            self.indices.put_to_v1_body_hash_index(
+                txn,
+                block.header().body_hash(),
+                *block.hash(),
+                block.height(),
+            )?;
+        } else {
+            self.put_single_block_body_v2(txn, block.body())?;
+        };
+
+        self.put_block_header(txn, block.hash(), block.header())?;
+
+        let current_highest = self
+            .indices
+            .get_highest_available_block_height(txn)?
+            .unwrap_or_default();
+        if block.height() > current_highest {
+            self.indices
+                .put_highest_available_block_height(txn, block.height())?;
+        }
+
+        for deploy_hash in block
+            .body()
+            .deploy_hashes()
+            .iter()
+            .chain(block.body().transfer_hashes().iter())
+        {
+            self.indices.put_to_deploy_hash_index(
+                txn,
+                deploy_hash,
+                *block.hash(),
+                block.height(),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn commit_block_header(&self, block_header: &BlockHeader) -> Result<(), FatalStorageError> {
+        let block_hash = block_header.hash(self.verifiable_chunked_hash_activation);
+        let mut txn = self.env.begin_rw_txn()?;
+        self.put_block_header(&mut txn, &block_hash, block_header)?;
+        txn.commit()?;
+        Ok(())
+    }
+
+    fn put_block_header(
         &self,
         txn: &mut RwTransaction,
-        block: &Block,
-    ) -> Result<bool, FatalStorageError> {
-        {
-            let block_body_hash = block.header().body_hash();
-            let block_body = block.body();
-            let success = match block
-                .header()
-                .hashing_algorithm_version(self.verifiable_chunked_hash_activation)
-            {
-                HashingAlgorithmVersion::V1 => {
-                    self.put_single_block_body_v1(txn, block_body_hash, block_body)?
-                }
-                HashingAlgorithmVersion::V2 => self.put_single_block_body_v2(txn, block_body)?,
-            };
-            if !success {
-                error!("Could not insert body for: {}", block);
-                return Ok(false);
-            }
+        block_hash: &BlockHash,
+        block_header: &BlockHeader,
+    ) -> Result<(), FatalStorageError> {
+        txn.put_value(self.block_header_db, &block_hash, block_header, true)?;
+        if block_header.is_switch_block() {
+            self.indices.put_to_switch_block_era_id_index(
+                txn,
+                block_header.era_id(),
+                block_hash,
+            )?;
         }
+        self.indices.put_to_block_height_index(
+            txn,
+            block_header.height(),
+            *block_hash,
+            block_header.era_id(),
+            block_header.protocol_version(),
+        )?;
+        Ok(())
+    }
 
-        if !txn.put_value(self.block_header_db, block.hash(), block.header(), true)? {
-            error!("Could not insert block header for block: {}", block);
+    fn put_merkle_block_body_part<'a, T>(
+        &self,
+        txn: &mut RwTransaction,
+        part_database: Database,
+        merklized_block_body_part: &MerkleBlockBodyPart<'a, T>,
+    ) -> Result<bool, LmdbExtError>
+    where
+        T: ToBytes,
+    {
+        // It's possible the value is already present (ie, if it is a block proposer).
+        // We put the value and rest hashes in first, since we need that present even if the value
+        // is already there.
+        if !txn.put_value_bytesrepr(
+            self.block_body_v2_db,
+            merklized_block_body_part.merkle_linked_list_node_hash(),
+            &merklized_block_body_part.value_and_rest_hashes_pair(),
+            true,
+        )? {
             return Ok(false);
-        }
+        };
 
-        {
-            let mut indices = self.indices.write()?;
-            insert_to_block_header_indices(
-                &mut indices,
-                block.header(),
-                self.verifiable_chunked_hash_activation,
-            )?;
-            insert_to_deploy_index(
-                &mut indices.deploy_hash_index,
-                block.header().hash(self.verifiable_chunked_hash_activation),
-                block.body(),
-                block.header().height(),
-            )?;
-        }
+        if !txn.put_value_bytesrepr(
+            part_database,
+            merklized_block_body_part.value_hash(),
+            merklized_block_body_part.value(),
+            true,
+        )? {
+            return Ok(false);
+        };
         Ok(true)
     }
 
-    /// Get the switch block header for a specified [`EraID`].
-    pub(crate) fn read_switch_block_header_by_era_id(
+    /// Writes a single Merklized block body in a separate transaction to storage.
+    fn put_single_block_body_v2(
         &self,
-        switch_block_era_id: EraId,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let mut tx = self.env.begin_ro_txn()?;
-        let indices = self.indices.read()?;
-        self.get_switch_block_header_by_era_id(&mut tx, &indices, switch_block_era_id)
+        txn: &mut RwTransaction,
+        block_body: &BlockBody,
+    ) -> Result<bool, LmdbExtError> {
+        let merkle_block_body = block_body.merklize();
+        let MerkleBlockBody {
+            deploy_hashes,
+            transfer_hashes,
+            proposer,
+        } = &merkle_block_body;
+        if !self.put_merkle_block_body_part(txn, self.deploy_hashes_db, deploy_hashes)? {
+            return Ok(false);
+        };
+        if !self.put_merkle_block_body_part(txn, self.transfer_hashes_db, transfer_hashes)? {
+            return Ok(false);
+        };
+        if !self.put_merkle_block_body_part(txn, self.proposer_db, proposer)? {
+            return Ok(false);
+        };
+        Ok(true)
     }
 
-    /// Retrieves a block header by height.
-    /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
-    pub fn read_block_header_and_sufficient_finality_signatures_by_height(
+    fn put_execution_results(
         &self,
-        height: u64,
-    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
+        block_hash: BlockHash,
+        execution_results: HashMap<DeployHash, ExecutionResult>,
+    ) -> Result<(), FatalStorageError> {
+        let mut txn = self.env.begin_rw_txn()?;
+
+        let mut transfers: Vec<Transfer> = vec![];
+
+        for (deploy_hash, execution_result) in execution_results {
+            let mut metadata = self
+                .get_deploy_metadata(&mut txn, &deploy_hash)?
+                .unwrap_or_default();
+
+            // If we have a previous execution result, we can continue if it is the same.
+            if let Some(prev) = metadata.execution_results.get(&block_hash) {
+                if prev == &execution_result {
+                    continue;
+                } else {
+                    debug!(%deploy_hash, %block_hash, "different execution result");
+                }
+            }
+
+            if let ExecutionResult::Success { effect, .. } = execution_result.clone() {
+                for transform_entry in effect.transforms {
+                    if let Transform::WriteTransfer(transfer) = transform_entry.transform {
+                        transfers.push(transfer);
+                    }
+                }
+            }
+
+            // Update metadata and write back to db.
+            metadata
+                .execution_results
+                .insert(block_hash, execution_result);
+            txn.put_value(self.deploy_metadata_db, &deploy_hash, &metadata, true)?;
+        }
+
+        txn.put_value(self.transfer_db, &block_hash, &transfers, true)?;
+        txn.commit()?;
+        Ok(())
+    }
+
+    fn get_deploy_and_metadata(
+        &self,
+        deploy_hash: DeployHash,
+    ) -> Result<Option<(DeployWithFinalizedApprovals, DeployMetadataExt)>, FatalStorageError> {
         let mut txn = self.env.begin_ro_txn()?;
-        let indices = self.indices.read()?;
-        let maybe_block_header_and_finality_signatures = self
-            .get_block_header_and_sufficient_finality_signatures_by_height(
-                &mut txn, &indices, height,
-            )?;
-        drop(txn);
-        Ok(maybe_block_header_and_finality_signatures)
-    }
 
-    /// Retrieves a block by height.
-    /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
-    pub fn read_block_and_sufficient_finality_signatures_by_height(
-        &self,
-        height: u64,
-    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        let indices = self.indices.read()?;
-        let maybe_block_and_finality_signatures = self
-            .get_block_and_sufficient_finality_signatures_by_height(&mut txn, &indices, height)?;
-        drop(txn);
-        Ok(maybe_block_and_finality_signatures)
-    }
+        let deploy = match self.get_deploy_with_finalized_approvals(&mut txn, &deploy_hash)? {
+            Some(deploy) => deploy,
+            None => return Ok(None),
+        };
 
-    /// Retrieves single block by height by looking it up in the index and returning it.
-    pub fn read_block_by_height(&self, height: u64) -> Result<Option<Block>, FatalStorageError> {
-        let indices = self.indices.read()?;
-        self.get_block_by_height(&mut self.env.begin_ro_txn()?, &indices, height)
+        // Missing metadata is filled using a default.
+        let metadata_ext = match self.get_deploy_metadata(&mut txn, &deploy_hash)? {
+            Some(metadata) => DeployMetadataExt::from(metadata),
+            None => match self
+                .indices
+                .get_from_deploy_hash_index(&mut txn, &deploy_hash)?
+            {
+                Some(block_hash_and_height) => DeployMetadataExt::from(block_hash_and_height),
+                None => DeployMetadataExt::Empty,
+            },
+        };
+
+        Ok(Some((deploy, metadata_ext)))
     }
 
     /// Retrieves single block and all of its deploys.
+    ///
     /// If any of the deploys can't be found, returns `Ok(None)`.
-    pub fn read_block_and_deploys_by_hash(
+    fn get_block_and_deploys<Tx: Transaction>(
         &self,
-        hash: BlockHash,
+        txn: &mut Tx,
+        block_hash: BlockHash,
     ) -> Result<Option<BlockAndDeploys>, FatalStorageError> {
-        let block = self.read_block(&hash)?;
-        match block {
-            None => Ok(None),
-            Some(block) => {
-                let deploy_hashes = block
-                    .deploy_hashes()
-                    .iter()
-                    .chain(block.transfer_hashes().iter());
-                let deploys_count = block.deploy_hashes().len() + block.transfer_hashes().len();
-                Ok(self
-                    .read_deploys(deploys_count, deploy_hashes)?
-                    .map(|deploys| BlockAndDeploys { block, deploys }))
+        let getter_id = BlockGetterId::with_block_hash(block_hash);
+        let block = match self.get_block(txn, getter_id)? {
+            Some(block) => block,
+            None => return Ok(None),
+        };
+
+        let deploys_count = block.deploy_hashes().len() + block.transfer_hashes().len();
+        let mut deploys: Vec<Deploy> = Vec::with_capacity(deploys_count);
+
+        for deploy_hash in block
+            .deploy_hashes()
+            .iter()
+            .chain(block.transfer_hashes().iter())
+        {
+            match txn.get_value(self.deploy_db, deploy_hash)? {
+                Some(deploy) => deploys.push(deploy),
+                None => return Ok(None),
             }
         }
-    }
 
-    /// Retrieves single block by height by looking it up in the index and returning it.
-    fn get_block_by_height<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        height: u64,
-    ) -> Result<Option<Block>, FatalStorageError> {
-        indices
-            .block_height_index
-            .get(&height)
-            .and_then(|block_hash| self.get_single_block(tx, block_hash).transpose())
-            .transpose()
-    }
-
-    /// Retrieves single switch block header by era ID by looking it up in the index and returning
-    /// it.
-    fn get_switch_block_header_by_era_id<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        era_id: EraId,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        debug!(switch_block_era_id_index = ?indices.switch_block_era_id_index);
-        indices
-            .switch_block_era_id_index
-            .get(&era_id)
-            .and_then(|block_hash| self.get_single_block_header(tx, block_hash).transpose())
-            .transpose()
-    }
-
-    /// Retrieves a single block header by deploy hash by looking it up in the index and returning
-    /// it.
-    fn get_block_header_by_deploy_hash<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        deploy_hash: DeployHash,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        indices
-            .deploy_hash_index
-            .get(&deploy_hash)
-            .and_then(|block_hash_and_height| {
-                self.get_single_block_header(tx, &block_hash_and_height.block_hash)
-                    .transpose()
-            })
-            .transpose()
-    }
-
-    /// Retrieves the block hash and height for a deploy hash by looking it up in the index
-    /// and returning it.
-    fn get_block_hash_and_height_by_deploy_hash(
-        &self,
-        indices: &Indices,
-        deploy_hash: DeployHash,
-    ) -> Result<Option<BlockHashAndHeight>, FatalStorageError> {
-        Ok(indices.deploy_hash_index.get(&deploy_hash).copied())
-    }
-
-    /// Retrieves the highest block from storage, if one exists. May return an LMDB error.
-    fn get_highest_block<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        indices: &Indices,
-    ) -> Result<Option<Block>, FatalStorageError> {
-        indices
-            .block_height_index
-            .keys()
-            .last()
-            .and_then(|&height| self.get_block_by_height(txn, indices, height).transpose())
-            .transpose()
-    }
-
-    /// Retrieves the highest block header from storage, if one exists. May return an LMDB error.
-    fn get_highest_block_header<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        indices: &Indices,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        indices
-            .block_height_index
-            .iter()
-            .last()
-            .and_then(|(_, hash_of_highest_block)| {
-                self.get_single_block_header(txn, hash_of_highest_block)
-                    .transpose()
-            })
-            .transpose()
+        Ok(Some(BlockAndDeploys { block, deploys }))
     }
 
     /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
@@ -1509,13 +1784,12 @@ impl StorageInner {
     fn get_blocks_while<F, Tx: Transaction>(
         &self,
         txn: &mut Tx,
-        indices: &Indices,
         predicate: F,
     ) -> Result<Vec<Block>, FatalStorageError>
     where
         F: Fn(&Block) -> bool,
     {
-        let mut next_block = self.get_highest_block(txn, indices)?;
+        let mut next_block = self.get_block(txn, BlockGetterId::HighestBlock)?;
         let mut blocks = Vec::new();
         loop {
             match next_block {
@@ -1524,7 +1798,9 @@ impl StorageInner {
                 Some(block) => {
                     next_block = match block.parent() {
                         None => None,
-                        Some(parent_hash) => self.get_single_block(txn, parent_hash)?,
+                        Some(parent_hash) => {
+                            self.get_block(txn, BlockGetterId::with_block_hash(*parent_hash))?
+                        }
                     };
                     blocks.push(block);
                 }
@@ -1536,227 +1812,38 @@ impl StorageInner {
     /// Returns the vector of blocks that could still have deploys whose TTL hasn't expired yet.
     fn get_finalized_blocks(&self, ttl: TimeDiff) -> Result<Vec<Block>, FatalStorageError> {
         let mut txn = self.env.begin_ro_txn()?;
-        let indices = self.indices.read()?;
         // We're interested in deploys whose TTL hasn't expired yet.
         let ttl_not_expired = |block: &Block| block.timestamp().elapsed() < ttl;
-        self.get_blocks_while(&mut txn, &indices, ttl_not_expired)
+        self.get_blocks_while(&mut txn, ttl_not_expired)
     }
 
-    /// Retrieves a single block header in a given transaction from storage
-    /// respecting the possible restriction on whether the block
-    /// should be present in the available blocks index.
-    fn get_single_block_header_restricted<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        block_hash: &BlockHash,
-        only_from_available_block_range: bool,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let block_header: BlockHeader = match tx.get_value(self.block_header_db, &block_hash)? {
-            Some(block_header) => block_header,
-            None => return Ok(None),
-        };
-
-        if !(self.should_return_block(block_header.height(), only_from_available_block_range)?) {
-            return Ok(None);
-        }
-
-        self.validate_block_header_hash(&block_header, block_hash)?;
-        Ok(Some(block_header))
-    }
-
-    fn get_block_header_by_height_restricted<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        block_height: u64,
-        only_from_available_block_range: bool,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let block_hash = match indices.block_height_index.get(&block_height) {
-            None => return Ok(None),
-            Some(block_hash) => block_hash,
-        };
-
-        self.get_single_block_header_restricted(tx, block_hash, only_from_available_block_range)
-    }
-
-    /// Retrieves a single block header in a given transaction from storage.
-    fn get_single_block_header<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        block_hash: &BlockHash,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let block_header: BlockHeader = match tx.get_value(self.block_header_db, &block_hash)? {
-            Some(block_header) => block_header,
-            None => return Ok(None),
-        };
-        self.validate_block_header_hash(&block_header, block_hash)?;
-        Ok(Some(block_header))
-    }
-
-    /// Validates the block header hash against the expected block hash.
-    fn validate_block_header_hash(
-        &self,
-        block_header: &BlockHeader,
-        block_hash: &BlockHash,
-    ) -> Result<(), FatalStorageError> {
-        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
-        if found_block_header_hash != *block_hash {
-            return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
-                queried_block_hash_bytes: block_hash.as_ref().to_vec(),
-                found_block_header_hash,
-                block_header: Box::new(block_header.clone()),
-            });
-        };
-        Ok(())
-    }
-
-    /// Checks whether a block at the given height exists in the block height index (and, since the
-    /// index is initialized on startup based on the actual contents of storage, if it exists in
-    /// storage).
-    fn block_header_exists(&self, indices: &Indices, block_height: u64) -> bool {
-        indices.block_height_index.contains_key(&block_height)
-    }
-
-    /// Writes a single block body in a separate transaction to storage.
-    fn put_single_block_body_v1(
-        &self,
-        tx: &mut RwTransaction,
-        block_body_hash: &Digest,
-        block_body: &BlockBody,
-    ) -> Result<bool, LmdbExtError> {
-        tx.put_value(self.block_body_v1_db, block_body_hash, block_body, true)
-            .map_err(Into::into)
-    }
-
-    fn put_merkle_block_body_part<'a, T>(
-        &self,
-        tx: &mut RwTransaction,
-        part_database: Database,
-        merklized_block_body_part: &MerkleBlockBodyPart<'a, T>,
-    ) -> Result<bool, LmdbExtError>
-    where
-        T: ToBytes,
-    {
-        // It's possible the value is already present (ie, if it is a block proposer).
-        // We put the value and rest hashes in first, since we need that present even if the value
-        // is already there.
-        if !tx.put_value_bytesrepr(
-            self.block_body_v2_db,
-            merklized_block_body_part.merkle_linked_list_node_hash(),
-            &merklized_block_body_part.value_and_rest_hashes_pair(),
-            true,
-        )? {
-            return Ok(false);
-        };
-
-        if !tx.put_value_bytesrepr(
-            part_database,
-            merklized_block_body_part.value_hash(),
-            merklized_block_body_part.value(),
-            true,
-        )? {
-            return Ok(false);
-        };
-        Ok(true)
-    }
-
-    /// Writes a single merklized block body in a separate transaction to storage.
-    fn put_single_block_body_v2(
-        &self,
-        tx: &mut RwTransaction,
-        block_body: &BlockBody,
-    ) -> Result<bool, LmdbExtError> {
-        let merkle_block_body = block_body.merklize();
-        let MerkleBlockBody {
-            deploy_hashes,
-            transfer_hashes,
-            proposer,
-        } = &merkle_block_body;
-        if !self.put_merkle_block_body_part(tx, self.deploy_hashes_db, deploy_hashes)? {
-            return Ok(false);
-        };
-        if !self.put_merkle_block_body_part(tx, self.transfer_hashes_db, transfer_hashes)? {
-            return Ok(false);
-        };
-        if !self.put_merkle_block_body_part(tx, self.proposer_db, proposer)? {
-            return Ok(false);
-        };
-        Ok(true)
-    }
-
-    // Retrieves a block header by hash.
-    pub(crate) fn read_block_header_by_hash(
-        &self,
-        block_hash: &BlockHash,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+    fn get_deploy(&self, deploy_hash: &DeployHash) -> Result<Option<Deploy>, FatalStorageError> {
         let mut txn = self.env.begin_ro_txn()?;
-        let maybe_block_header = self.get_single_block_header(&mut txn, block_hash)?;
-        drop(txn);
-        Ok(maybe_block_header)
-    }
-
-    /// Retrieves a single block in a separate transaction from storage.
-    fn get_single_block<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        block_hash: &BlockHash,
-    ) -> Result<Option<Block>, FatalStorageError> {
-        let block_header: BlockHeader = match self.get_single_block_header(tx, block_hash)? {
-            Some(block_header) => block_header,
-            None => return Ok(None),
-        };
-        let (maybe_block_body, _) = get_body_for_block_header(
-            tx,
-            &block_header,
-            &Databases {
-                block_body_v1_db: self.block_body_v1_db,
-                block_body_v2_db: self.block_body_v2_db,
-                deploy_hashes_db: self.deploy_hashes_db,
-                transfer_hashes_db: self.transfer_hashes_db,
-                proposer_db: self.proposer_db,
-            },
-            self.verifiable_chunked_hash_activation,
-        );
-        let block_body = match maybe_block_body? {
-            Some(block_body) => block_body,
-            None => {
-                info!(
-                    ?block_header,
-                    "retrieved block header but block body is missing from database"
-                );
-                return Ok(None);
-            }
-        };
-        let block = Block::new_from_header_and_body(
-            block_header,
-            block_body,
-            self.verifiable_chunked_hash_activation,
-        )?;
-        Ok(Some(block))
+        Ok(txn.get_value(self.deploy_db, deploy_hash)?)
     }
 
     /// Retrieves a set of deploys from storage, along with their potential finalized approvals.
     fn get_deploys_with_finalized_approvals<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
+        txn: &mut Tx,
         deploy_hashes: &[DeployHash],
     ) -> Result<SmallVec<[Option<DeployWithFinalizedApprovals>; 1]>, LmdbExtError> {
         deploy_hashes
             .iter()
-            .map(|deploy_hash| self.get_deploy_with_finalized_approvals(tx, deploy_hash))
+            .map(|deploy_hash| self.get_deploy_with_finalized_approvals(txn, deploy_hash))
             .collect()
     }
 
     /// Retrieves a single deploy along with its finalized approvals from storage
     fn get_deploy_with_finalized_approvals<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
+        txn: &mut Tx,
         deploy_hash: &DeployHash,
     ) -> Result<Option<DeployWithFinalizedApprovals>, LmdbExtError> {
-        let maybe_original_deploy = tx.get_value(self.deploy_db, deploy_hash)?;
+        let maybe_original_deploy = txn.get_value(self.deploy_db, deploy_hash)?;
         if let Some(deploy) = maybe_original_deploy {
             let maybe_finalized_approvals =
-                tx.get_value(self.finalized_approvals_db, deploy_hash)?;
+                txn.get_value(self.finalized_approvals_db, deploy_hash)?;
             Ok(Some(DeployWithFinalizedApprovals::new(
                 deploy,
                 maybe_finalized_approvals,
@@ -1772,10 +1859,10 @@ impl StorageInner {
     /// created, but not stored.
     fn get_deploy_metadata<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
+        txn: &mut Tx,
         deploy_hash: &DeployHash,
     ) -> Result<Option<DeployMetadata>, FatalStorageError> {
-        Ok(tx.get_value(self.deploy_metadata_db, deploy_hash)?)
+        Ok(txn.get_value(self.deploy_metadata_db, deploy_hash)?)
     }
 
     /// Retrieves transfers associated with block.
@@ -1784,94 +1871,23 @@ impl StorageInner {
     /// created, but not stored.
     fn get_transfers<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
+        txn: &mut Tx,
         block_hash: &BlockHash,
     ) -> Result<Option<Vec<Transfer>>, FatalStorageError> {
-        Ok(tx.get_value(self.transfer_db, block_hash)?)
+        Ok(txn.get_value(self.transfer_db, block_hash)?)
     }
 
     /// Retrieves finality signatures for a block with a given block hash
-    fn get_finality_signatures<Tx: Transaction>(
+    fn get_block_signatures<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
+        txn: &mut Tx,
         block_hash: &BlockHash,
     ) -> Result<Option<BlockSignatures>, FatalStorageError> {
-        Ok(tx.get_value(self.block_metadata_db, block_hash)?)
-    }
-
-    /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
-    fn get_block_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        height: u64,
-    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
-        let BlockHeaderWithMetadata {
-            block_header,
-            block_signatures,
-        } = match self
-            .get_block_header_and_sufficient_finality_signatures_by_height(tx, indices, height)?
-        {
-            None => return Ok(None),
-            Some(block_header_with_metadata) => block_header_with_metadata,
-        };
-        let (maybe_block_body, _) = get_body_for_block_header(
-            tx,
-            &block_header,
-            &Databases {
-                block_body_v1_db: self.block_body_v1_db,
-                block_body_v2_db: self.block_body_v2_db,
-                deploy_hashes_db: self.deploy_hashes_db,
-                transfer_hashes_db: self.transfer_hashes_db,
-                proposer_db: self.proposer_db,
-            },
-            self.verifiable_chunked_hash_activation,
-        );
-        if let Some(block_body) = maybe_block_body? {
-            Ok(Some(BlockWithMetadata {
-                block: Block::new_from_header_and_body(
-                    block_header,
-                    block_body,
-                    self.verifiable_chunked_hash_activation,
-                )?,
-                finality_signatures: block_signatures,
-            }))
-        } else {
-            debug!(?block_header, "Missing block body for header");
-            Ok(None)
-        }
-    }
-
-    /// Directly returns a deploy from internal store.
-    pub fn read_deploy_by_hash(
-        &self,
-        deploy_hash: DeployHash,
-    ) -> Result<Option<Deploy>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        Ok(txn.get_value(self.deploy_db, &deploy_hash)?)
-    }
-
-    /// Directly returns all deploys or None if any is missing.
-    pub fn read_deploys<'a, I: Iterator<Item = &'a DeployHash> + 'a>(
-        &self,
-        deploys_count: usize,
-        deploy_hashes: I,
-    ) -> Result<Option<Vec<Deploy>>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        let mut result = Vec::with_capacity(deploys_count);
-        for deploy_hash in deploy_hashes {
-            match txn.get_value(self.deploy_db, deploy_hash)? {
-                Some(deploy) => result.push(deploy),
-                None => return Ok(None),
-            }
-        }
-        Ok(Some(result))
+        Ok(txn.get_value(self.block_metadata_db, block_hash)?)
     }
 
     /// Stores a set of finalized approvals.
-    pub fn store_finalized_approvals(
+    fn store_finalized_approvals(
         &self,
         deploy_hash: &DeployHash,
         finalized_approvals: &FinalizedApprovals,
@@ -1894,100 +1910,6 @@ impl StorageInner {
             txn.commit()?;
         }
         Ok(())
-    }
-
-    /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
-    fn get_block_header_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        height: u64,
-    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
-        let block_hash = match indices.block_height_index.get(&height) {
-            None => return Ok(None),
-            Some(block_hash) => block_hash,
-        };
-        let block_header = match self.get_single_block_header(tx, block_hash)? {
-            None => return Ok(None),
-            Some(block_header) => block_header,
-        };
-        let block_signatures =
-            match self.get_sufficient_finality_signatures(tx, indices, &block_header)? {
-                None => return Ok(None),
-                Some(signatures) => signatures,
-            };
-        Ok(Some(BlockHeaderWithMetadata {
-            block_header,
-            block_signatures,
-        }))
-    }
-
-    /// Retrieves finality signatures for a block with a given block hash; returns `None` if they
-    /// are less than the fault tolerance threshold or if the block is from before the most recent
-    /// emergency upgrade.
-    fn get_sufficient_finality_signatures<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        indices: &Indices,
-        block_header: &BlockHeader,
-    ) -> Result<Option<BlockSignatures>, FatalStorageError> {
-        if let Some(last_emergency_restart) = self.last_emergency_restart {
-            if block_header.era_id() <= last_emergency_restart {
-                debug!(
-                    ?block_header,
-                    ?last_emergency_restart,
-                    "finality signatures from before last emergency restart requested"
-                );
-                return Ok(None);
-            }
-        }
-        let block_signatures = match self.get_finality_signatures(
-            tx,
-            &block_header.hash(self.verifiable_chunked_hash_activation),
-        )? {
-            None => return Ok(None),
-            Some(block_signatures) => block_signatures,
-        };
-        let switch_block_hash = match indices
-            .switch_block_era_id_index
-            .get(&(block_header.era_id() - 1))
-        {
-            None => return Ok(None),
-            Some(switch_block_hash) => switch_block_hash,
-        };
-        let switch_block_header = match self.get_single_block_header(tx, switch_block_hash)? {
-            None => return Ok(None),
-            Some(switch_block_header) => switch_block_header,
-        };
-
-        let validator_weights = match switch_block_header.next_era_validator_weights() {
-            None => {
-                return Err(FatalStorageError::InvalidSwitchBlock(Box::new(
-                    switch_block_header,
-                )))
-            }
-            Some(validator_weights) => validator_weights,
-        };
-
-        let block_signatures = consensus::get_minimal_set_of_signatures(
-            validator_weights,
-            self.finality_threshold_fraction,
-            block_signatures,
-        );
-
-        // `block_signatures` is already an `Option`, which is `None` if there weren't enough
-        // signatures to bring the total weight over the threshold.
-        Ok(block_signatures)
-    }
-
-    /// Retrieves a deploy from the deploy store.
-    pub fn get_deploy(&self, deploy_hash: DeployHash) -> Result<Option<Deploy>, LmdbExtError> {
-        self.env
-            .begin_ro_txn()
-            .map_err(Into::into)
-            .and_then(|mut tx| tx.get_value(self.deploy_db, &deploy_hash))
     }
 
     /// Creates a serialized representation of a `FetchedOrNotFound` and the resulting message.
@@ -2024,30 +1946,18 @@ impl StorageInner {
         Ok(effect_builder.send_message(sender, message).ignore())
     }
 
-    /// Returns `true` if the storage should attempt to return a block. Depending on the
-    /// `only_from_available_block_range` flag it should be unconditional or restricted by the
-    /// available block range.
-    fn should_return_block(
+    fn get_available_block_range<Tx: Transaction>(
         &self,
-        block_height: u64,
-        only_from_available_block_range: bool,
-    ) -> Result<bool, FatalStorageError> {
-        if only_from_available_block_range {
-            Ok(self.get_available_block_range()?.contains(block_height))
-        } else {
-            Ok(true)
-        }
-    }
-
-    fn get_available_block_range(&self) -> Result<AvailableBlockRange, FatalStorageError> {
-        let indices = self.indices.read()?;
-        let high = indices
-            .block_height_index
-            .keys()
-            .last()
-            .copied()
+        txn: &mut Tx,
+    ) -> Result<AvailableBlockRange, FatalStorageError> {
+        let low = self
+            .indices
+            .get_lowest_available_block_height(txn)?
             .unwrap_or_default();
-        let low = indices.lowest_available_block_height;
+        let high = self
+            .indices
+            .get_highest_available_block_height(txn)?
+            .unwrap_or_default();
         match AvailableBlockRange::new(low, high) {
             Ok(range) => Ok(range),
             Err(error) => {
@@ -2067,137 +1977,49 @@ impl StorageInner {
         // * the new value is 2 or more higher than (after pruning due to hard-reset) the available
         //   range at startup, as that would mean there's a gap of at least one block with
         //   unavailable global state.
-        let should_update = {
+        {
             let mut txn = self.env.begin_ro_txn()?;
-            match txn.get_value_bytesrepr::<_, u64>(
-                self.state_store_db,
-                &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT,
-            )? {
+            let should_update = match self.indices.get_lowest_available_block_height(&mut txn)? {
                 Some(height) => {
                     new_height < height || new_height > self.highest_block_at_startup + 1
                 }
                 None => true,
+            };
+            if !should_update {
+                return Ok(());
             }
-        };
 
-        if !should_update {
-            return Ok(());
+            if self
+                .indices
+                .get_from_block_height_index(&mut txn, new_height)?
+                .is_none()
+            {
+                error!(
+                    %new_height,
+                    "failed to update lowest_available_block_height as not in height index"
+                );
+                // We don't need to return a fatal error here as an invalid
+                // `lowest_available_block_height` is not a critical error.
+                return Ok(());
+            }
         }
 
-        let mut indices = self.indices.write()?;
-        if indices.block_height_index.contains_key(&new_height) {
-            let mut txn = self.env.begin_rw_txn()?;
-            txn.put_value_bytesrepr::<_, u64>(
-                self.state_store_db,
-                &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT,
-                &new_height,
-                true,
-            )?;
-            txn.commit()?;
-            indices.lowest_available_block_height = new_height;
-        } else {
-            error!(
-                %new_height,
-                "failed to update lowest_available_block_height as not in height index"
-            );
-            // We don't need to return a fatal error here as an invalid
-            // `lowest_available_block_height` is not a critical error.
-        }
-
+        let mut txn = self.env.begin_rw_txn()?;
+        self.indices
+            .put_lowest_available_block_height(&mut txn, new_height)?;
+        txn.commit()?;
         Ok(())
+    }
+
+    fn is_v1_block(&self, block_header: &BlockHeader) -> bool {
+        block_header.hashing_algorithm_version(self.verifiable_chunked_hash_activation)
+            == HashingAlgorithmVersion::V1
     }
 }
 
 /// Decodes an item's ID, typically from an incoming request.
-fn decode_item_id<T>(raw: &[u8]) -> Result<T::Id, GetRequestError>
-where
-    T: Item,
-{
+fn decode_item_id<T: Item>(raw: &[u8]) -> Result<T::Id, GetRequestError> {
     bincode::deserialize(raw).map_err(GetRequestError::MalformedIncomingItemId)
-}
-
-/// Inserts the relevant entries to the two indices.
-///
-/// If a duplicate entry is encountered, neither index is updated and an error is returned.
-fn insert_to_block_header_indices(
-    indices: &mut Indices,
-    block_header: &BlockHeader,
-    verifiable_chunked_hash_activation: EraId,
-) -> Result<(), FatalStorageError> {
-    let block_hash = block_header.hash(verifiable_chunked_hash_activation);
-    if let Some(first) = indices.block_height_index.get(&block_header.height()) {
-        if *first != block_hash {
-            return Err(FatalStorageError::DuplicateBlockIndex {
-                height: block_header.height(),
-                first: *first,
-                second: block_hash,
-            });
-        }
-    }
-
-    if block_header.is_switch_block() {
-        match indices
-            .switch_block_era_id_index
-            .entry(block_header.era_id())
-        {
-            Entry::Vacant(entry) => {
-                let _ = entry.insert(block_hash);
-            }
-            Entry::Occupied(entry) => {
-                if *entry.get() != block_hash {
-                    return Err(FatalStorageError::DuplicateEraIdIndex {
-                        era_id: block_header.era_id(),
-                        first: *entry.get(),
-                        second: block_hash,
-                    });
-                }
-            }
-        }
-    }
-
-    let _ = indices
-        .block_height_index
-        .insert(block_header.height(), block_hash);
-    Ok(())
-}
-
-/// Inserts the relevant entries to the index.
-///
-/// If a duplicate entry is encountered, index is not updated and an error is returned.
-fn insert_to_deploy_index(
-    deploy_hash_index: &mut BTreeMap<DeployHash, BlockHashAndHeight>,
-    block_hash: BlockHash,
-    block_body: &BlockBody,
-    block_height: u64,
-) -> Result<(), FatalStorageError> {
-    if let Some(hash) = block_body
-        .deploy_hashes()
-        .iter()
-        .chain(block_body.transfer_hashes().iter())
-        .find(|hash| {
-            deploy_hash_index
-                .get(hash)
-                .map_or(false, |old_block_hash_and_height| {
-                    old_block_hash_and_height.block_hash != block_hash
-                })
-        })
-    {
-        return Err(FatalStorageError::DuplicateDeployIndex {
-            deploy_hash: *hash,
-            first: deploy_hash_index[hash],
-            second: BlockHashAndHeight::new(block_hash, block_height),
-        });
-    }
-
-    for hash in block_body
-        .deploy_hashes()
-        .iter()
-        .chain(block_body.transfer_hashes().iter())
-    {
-        deploy_hash_index.insert(*hash, BlockHashAndHeight::new(block_hash, block_height));
-    }
-
-    Ok(())
 }
 
 fn should_move_storage_files_to_network_subdir(
@@ -2257,70 +2079,6 @@ fn move_storage_files_to_network_subdir(
         file_names, root, subdir
     );
     Ok(())
-}
-
-/// On-disk storage configuration.
-#[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Config {
-    /// The path to the folder where any files created or read by the storage component will exist.
-    ///
-    /// If the folder doesn't exist, it and any required parents will be created.
-    pub path: PathBuf,
-    /// The maximum size of the database to use for the block store.
-    ///
-    /// The size should be a multiple of the OS page size.
-    max_block_store_size: usize,
-    /// The maximum size of the database to use for the deploy store.
-    ///
-    /// The size should be a multiple of the OS page size.
-    max_deploy_store_size: usize,
-    /// The maximum size of the database to use for the deploy metadata store.
-    ///
-    /// The size should be a multiple of the OS page size.
-    max_deploy_metadata_store_size: usize,
-    /// The maximum size of the database to use for the component state store.
-    ///
-    /// The size should be a multiple of the OS page size.
-    max_state_store_size: usize,
-    /// Whether or not memory deduplication is enabled.
-    enable_mem_deduplication: bool,
-    /// How many loads before memory duplication checks for dead references.
-    mem_pool_prune_interval: u16,
-    /// Maximum number of parallel synchronous storage tasks to spawn.
-    max_sync_tasks: u16,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            // No one should be instantiating a config with storage set to default.
-            path: "/dev/null".into(),
-            max_block_store_size: DEFAULT_MAX_BLOCK_STORE_SIZE,
-            max_deploy_store_size: DEFAULT_MAX_DEPLOY_STORE_SIZE,
-            max_deploy_metadata_store_size: DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE,
-            max_state_store_size: DEFAULT_MAX_STATE_STORE_SIZE,
-            enable_mem_deduplication: true,
-            mem_pool_prune_interval: 4096,
-            max_sync_tasks: 32,
-        }
-    }
-}
-
-impl Config {
-    /// Returns a default `Config` suitable for tests, along with a `TempDir` which must be kept
-    /// alive for the duration of the test since its destructor removes the dir from the filesystem.
-    #[cfg(test)]
-    pub(crate) fn default_for_tests() -> (Self, TempDir) {
-        let tempdir = tempfile::tempdir().expect("should get tempdir");
-        let path = tempdir.path().join("lmdb");
-
-        let config = Config {
-            path,
-            ..Default::default()
-        };
-        (config, tempdir)
-    }
 }
 
 // Testing code. The functions below allow direct inspection of the storage component and should
@@ -2407,15 +2165,11 @@ impl Storage {
     /// Retrieves single switch block by era ID by looking it up in the index and returning it.
     fn get_switch_block_by_era_id<Tx: Transaction>(
         &self,
-        tx: &mut Tx,
-        indices: &Indices,
+        txn: &mut Tx,
         era_id: EraId,
     ) -> Result<Option<Block>, FatalStorageError> {
-        indices
-            .switch_block_era_id_index
-            .get(&era_id)
-            .and_then(|block_hash| self.storage.get_single_block(tx, block_hash).transpose())
-            .transpose()
+        let getter_id = BlockGetterId::SwitchBlock(era_id);
+        self.storage.get_block(txn, getter_id)
     }
 
     /// Get the switch block for a specified era number in a read-only LMDB database transaction.
@@ -2432,11 +2186,9 @@ impl Storage {
             .env
             .begin_ro_txn()
             .expect("Could not start read only transaction for lmdb");
-        let indices = self.storage.indices.read()?;
         let switch_block = self
             .get_switch_block_by_era_id(
                 &mut read_only_lmdb_transaction,
-                &indices,
                 EraId::from(switch_block_era_num),
             )
             .expect("LMDB panicked trying to get switch block");
@@ -2446,329 +2198,70 @@ impl Storage {
         Ok(switch_block)
     }
 
+    /// Retrieves a single block header by hash.
+    pub fn read_block_header_by_hash(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let getter_id = BlockGetterId::with_block_hash(*block_hash);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        Ok(self
+            .storage
+            .get_block_header(&mut txn, getter_id)?
+            .map(|(_block_hash, header)| header))
+    }
+
     /// Retrieves a single block header by height by looking it up in the index and returning it.
     pub fn read_block_header_by_height(
         &self,
-        height: u64,
+        block_height: u64,
     ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let mut tx = self.storage.env.begin_ro_txn()?;
-        let indices = self.storage.indices.read()?;
-
-        indices
-            .block_height_index
-            .get(&height)
-            .and_then(|block_hash| {
-                self.storage
-                    .get_single_block_header(&mut tx, block_hash)
-                    .transpose()
-            })
-            .transpose()
+        let getter_id = BlockGetterId::with_block_height(block_height);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        Ok(self
+            .storage
+            .get_block_header(&mut txn, getter_id)?
+            .map(|(_block_hash, header)| header))
     }
 
     /// Retrieves a single block by height by looking it up in the index and returning it.
-    fn get_block_by_height(&self, height: u64) -> Result<Option<Block>, FatalStorageError> {
-        let mut tx = self.storage.env.begin_ro_txn()?;
-        let indices = self.storage.indices.read()?;
-
-        self.storage.get_block_by_height(&mut tx, &indices, height)
+    fn get_block_by_height(&self, block_height: u64) -> Result<Option<Block>, FatalStorageError> {
+        let getter_id = BlockGetterId::with_block_height(block_height);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_block(&mut txn, getter_id)
     }
 
-    pub fn read_block_header_and_sufficient_finality_signatures_by_height(
+    pub fn read_block_header_and_enough_sigs_by_height(
         &self,
-        height: u64,
+        block_height: u64,
     ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
+        let getter_id = BlockGetterId::with_block_height(block_height);
+        let mut txn = self.storage.env.begin_ro_txn()?;
         self.storage
-            .read_block_header_and_sufficient_finality_signatures_by_height(height)
+            .get_block_header_with_enough_sigs(&mut txn, getter_id)
+    }
+
+    pub fn read_block_and_enough_sigs_by_height(
+        &self,
+        block_height: u64,
+    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
+        let getter_id = BlockGetterId::with_block_height(block_height);
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_block_with_enough_sigs(&mut txn, getter_id)
     }
 
     /// Retrieves the highest block header from the storage, if one exists.
     pub fn read_highest_block_header(&self) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let indices = self.storage.indices.read()?;
-
-        let highest_block_hash = match indices.block_height_index.iter().last() {
-            Some((_, highest_block_hash)) => highest_block_hash,
-            None => return Ok(None),
-        };
-        self.storage.read_block_header_by_hash(highest_block_hash)
-    }
-}
-
-fn construct_block_body_to_block_header_reverse_lookup(
-    tx: &impl Transaction,
-    block_header_db: &Database,
-) -> Result<BTreeMap<Digest, BlockHeader>, LmdbExtError> {
-    let mut block_body_hash_to_header_map: BTreeMap<Digest, BlockHeader> = BTreeMap::new();
-    for (_raw_key, raw_val) in tx.open_ro_cursor(*block_header_db)?.iter() {
-        let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
-        block_body_hash_to_header_map.insert(block_header.body_hash().to_owned(), block_header);
-    }
-    Ok(block_body_hash_to_header_map)
-}
-
-/// Purges stale entries from the block body database.
-fn initialize_block_body_v1_db(
-    env: &Environment,
-    block_header_db: &Database,
-    block_body_v1_db: &Database,
-    deleted_block_body_hashes_raw: &HashSet<&[u8]>,
-) -> Result<(), FatalStorageError> {
-    info!("initializing v1 block body database");
-    let mut txn = env.begin_rw_txn()?;
-
-    let block_body_hash_to_header_map =
-        construct_block_body_to_block_header_reverse_lookup(&txn, block_header_db)?;
-
-    let mut cursor = txn.open_rw_cursor(*block_body_v1_db)?;
-
-    for (raw_key, _raw_val) in cursor.iter() {
-        let block_body_hash =
-            Digest::try_from(raw_key).map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))?;
-        if !block_body_hash_to_header_map.contains_key(&block_body_hash) {
-            if !deleted_block_body_hashes_raw.contains(raw_key) {
-                // This means that the block body isn't referenced by any header, but no header
-                // referencing it was just deleted, either
-                warn!(?raw_key, "orphaned block body detected");
-            }
-            info!(?raw_key, "deleting v1 block body");
-            cursor.del(WriteFlags::empty())?;
-        }
+        let getter_id = BlockGetterId::HighestBlock;
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        Ok(self
+            .storage
+            .get_block_header(&mut txn, getter_id)?
+            .map(|(_block_hash, header)| header))
     }
 
-    drop(cursor);
-
-    txn.commit()?;
-    info!("v1 block body database initialized");
-    Ok(())
-}
-
-fn get_merkle_linked_list_node<Tx, T>(
-    tx: &mut Tx,
-    block_body_v2_db: Database,
-    part_database: Database,
-    key_to_block_body_db: &Digest,
-) -> Result<Option<MerkleLinkedListNode<T>>, LmdbExtError>
-where
-    Tx: Transaction,
-    T: FromBytes,
-{
-    let (part_to_value_db, merkle_proof_of_rest): (Digest, Digest) =
-        match tx.get_value_bytesrepr(block_body_v2_db, key_to_block_body_db)? {
-            Some(slice) => slice,
-            None => return Ok(None),
-        };
-    let value = match tx.get_value_bytesrepr(part_database, &part_to_value_db)? {
-        Some(value) => value,
-        None => return Ok(None),
-    };
-    Ok(Some(MerkleLinkedListNode::new(value, merkle_proof_of_rest)))
-}
-
-/// Retrieves the block body for the given block header.
-/// Returns the block body (if existing) along with the information on whether the block uses the v1
-/// or v2 hashing scheme.
-fn get_body_for_block_header<Tx: Transaction>(
-    tx: &mut Tx,
-    block_header: &BlockHeader,
-    databases: &Databases,
-    verifiable_chunked_hash_activation: EraId,
-) -> (Result<Option<BlockBody>, LmdbExtError>, bool) {
-    match block_header.hashing_algorithm_version(verifiable_chunked_hash_activation) {
-        HashingAlgorithmVersion::V1 => (
-            get_single_block_body_v1(tx, block_header.body_hash(), databases.block_body_v1_db),
-            true,
-        ),
-        HashingAlgorithmVersion::V2 => (
-            get_single_block_body_v2(tx, block_header.body_hash(), databases),
-            false,
-        ),
+    pub fn get_available_block_range(&self) -> Result<AvailableBlockRange, FatalStorageError> {
+        let mut txn = self.storage.env.begin_ro_txn()?;
+        self.storage.get_available_block_range(&mut txn)
     }
-}
-
-fn get_single_block_body_v1<Tx: Transaction>(
-    tx: &mut Tx,
-    block_body_hash: &Digest,
-    block_body_v1_db: Database,
-) -> Result<Option<BlockBody>, LmdbExtError> {
-    tx.get_value(block_body_v1_db, block_body_hash)
-}
-
-/// Retrieves a single Merklized block body in a separate transaction from storage.
-fn get_single_block_body_v2<Tx: Transaction>(
-    tx: &mut Tx,
-    block_body_hash: &Digest,
-    Databases {
-        block_body_v1_db: _,
-        block_body_v2_db,
-        deploy_hashes_db,
-        transfer_hashes_db,
-        proposer_db,
-    }: &Databases,
-) -> Result<Option<BlockBody>, LmdbExtError> {
-    let deploy_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> =
-        match get_merkle_linked_list_node(
-            tx,
-            *block_body_v2_db,
-            *deploy_hashes_db,
-            block_body_hash,
-        )? {
-            Some(deploy_hashes_with_proof) => deploy_hashes_with_proof,
-            None => return Ok(None),
-        };
-    let transfer_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> =
-        match get_merkle_linked_list_node(
-            tx,
-            *block_body_v2_db,
-            *transfer_hashes_db,
-            deploy_hashes_with_proof.merkle_proof_of_rest(),
-        )? {
-            Some(transfer_hashes_with_proof) => transfer_hashes_with_proof,
-            None => return Ok(None),
-        };
-    let proposer_with_proof: MerkleLinkedListNode<PublicKey> = match get_merkle_linked_list_node(
-        tx,
-        *block_body_v2_db,
-        *proposer_db,
-        transfer_hashes_with_proof.merkle_proof_of_rest(),
-    )? {
-        Some(proposer_with_proof) => {
-            debug_assert_eq!(
-                *proposer_with_proof.merkle_proof_of_rest(),
-                Digest::SENTINEL_RFOLD
-            );
-            proposer_with_proof
-        }
-        None => return Ok(None),
-    };
-    let block_body = BlockBody::new(
-        proposer_with_proof.take_value(),
-        deploy_hashes_with_proof.take_value(),
-        transfer_hashes_with_proof.take_value(),
-    );
-
-    Ok(Some(block_body))
-}
-
-// TODO: remove once we run the garbage collection again
-#[allow(dead_code)]
-fn garbage_collect_block_body_v2_db(
-    txn: &mut RwTransaction,
-    block_body_v2_db: &Database,
-    deploy_hashes_db: &Database,
-    transfer_hashes_db: &Database,
-    proposer_db: &Database,
-    block_body_hash_to_header_map: &BTreeMap<Digest, BlockHeader>,
-    verifiable_chunked_hash_activation: EraId,
-) -> Result<(), FatalStorageError> {
-    // This will store all the keys that are reachable from a block header, in all the parts
-    // databases (we're basically doing a mark-and-sweep below).
-    // The entries correspond to: the block_body_v2_db, deploy_hashes_db, transfer_hashes_db,
-    // proposer_db respectively.
-    let mut live_digests: [HashSet<Digest>; BlockBody::PARTS_COUNT + 1] = [
-        HashSet::new(),
-        HashSet::new(),
-        HashSet::new(),
-        HashSet::new(),
-    ];
-
-    for (body_hash, header) in block_body_hash_to_header_map {
-        if header.hashing_algorithm_version(verifiable_chunked_hash_activation)
-            != HashingAlgorithmVersion::V2
-        {
-            // We're only interested in body hashes for V2 blocks here
-            continue;
-        }
-        let mut current_digest = *body_hash;
-        let mut live_digests_index = 1;
-        while current_digest != Digest::SENTINEL_RFOLD && !live_digests[0].contains(&current_digest)
-        {
-            live_digests[0].insert(current_digest);
-            let (key_to_part_db, merkle_proof_of_rest): (Digest, Digest) =
-                match txn.get_value_bytesrepr(*block_body_v2_db, &current_digest)? {
-                    Some(slice) => slice,
-                    None => {
-                        return Err(FatalStorageError::CouldNotFindBlockBodyPart {
-                            block_hash: header.hash(verifiable_chunked_hash_activation),
-                            merkle_linked_list_node_hash: current_digest,
-                        })
-                    }
-                };
-            if live_digests_index < live_digests.len() {
-                live_digests[live_digests_index].insert(key_to_part_db);
-            } else {
-                return Err(FatalStorageError::UnexpectedBlockBodyPart {
-                    block_body_hash: *body_hash,
-                    part_hash: key_to_part_db,
-                });
-            }
-            live_digests_index += 1;
-            current_digest = merkle_proof_of_rest;
-        }
-    }
-
-    let databases_to_clean: [(&Database, &str); BlockBody::PARTS_COUNT + 1] = [
-        (block_body_v2_db, "deleting v2 block body part"),
-        (deploy_hashes_db, "deleting v2 deploy hashes entry"),
-        (transfer_hashes_db, "deleting v2 transfer hashes entry"),
-        (proposer_db, "deleting v2 proposer entry"),
-    ];
-
-    // Clean dead entries from all the databases
-    for (index, (database, info_text)) in databases_to_clean.iter().enumerate() {
-        let mut cursor = txn.open_rw_cursor(**database)?;
-        for (raw_key, _raw_val) in cursor.iter() {
-            let key = Digest::try_from(raw_key)
-                .map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))?;
-            if !live_digests[index].contains(&key) {
-                info!(?raw_key, info_text);
-                cursor.del(WriteFlags::empty())?;
-            }
-        }
-        drop(cursor);
-    }
-
-    Ok(())
-}
-
-/// Purges stale entries from the block metadata database.
-fn initialize_block_metadata_db(
-    env: &Environment,
-    block_metadata_db: &Database,
-    deleted_block_hashes: &HashSet<&[u8]>,
-) -> Result<(), FatalStorageError> {
-    info!("initializing block metadata database");
-    let mut txn = env.begin_rw_txn()?;
-    let mut cursor = txn.open_rw_cursor(*block_metadata_db)?;
-
-    for (raw_key, _) in cursor.iter() {
-        if deleted_block_hashes.contains(raw_key) {
-            cursor.del(WriteFlags::empty())?;
-            continue;
-        }
-    }
-
-    drop(cursor);
-    txn.commit()?;
-
-    info!("block metadata database initialized");
-    Ok(())
-}
-
-/// Purges stale entries from the deploy metadata database.
-fn initialize_deploy_metadata_db(
-    env: &Environment,
-    deploy_metadata_db: &Database,
-    deleted_deploy_hashes: &HashSet<DeployHash>,
-) -> Result<(), LmdbExtError> {
-    info!("initializing deploy metadata database");
-
-    let mut txn = env.begin_rw_txn()?;
-    deleted_deploy_hashes.iter().for_each(|deleted_deploy_hash| {
-        if txn.del(*deploy_metadata_db, deleted_deploy_hash, None).is_err() {
-            debug!(%deleted_deploy_hash, "not purging from 'deploy_metadata_db' because not existing");
-        }
-    });
-    txn.commit()?;
-
-    info!("deploy metadata database initialized");
-    Ok(())
 }

--- a/node/src/components/storage/block_getter_id.rs
+++ b/node/src/components/storage/block_getter_id.rs
@@ -1,0 +1,128 @@
+use casper_types::EraId;
+
+use crate::{
+    storage::StorageRequest,
+    types::{BlockHash, DeployHash},
+};
+
+/// An identifier used when getting a block or block header from storage.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(super) enum BlockGetterId {
+    BlockHash {
+        block_hash: BlockHash,
+        only_from_available_range: bool,
+    },
+    BlockHeight {
+        block_height: u64,
+        only_from_available_range: bool,
+    },
+    HighestBlock,
+    SwitchBlock(EraId),
+    DeployHash(DeployHash),
+    None,
+}
+
+impl BlockGetterId {
+    pub(super) fn with_block_hash(block_hash: BlockHash) -> Self {
+        BlockGetterId::BlockHash {
+            block_hash,
+            only_from_available_range: false,
+        }
+    }
+
+    pub(super) fn with_block_hash_from_avail_range(
+        block_hash: BlockHash,
+        only_from_available_range: bool,
+    ) -> Self {
+        BlockGetterId::BlockHash {
+            block_hash,
+            only_from_available_range,
+        }
+    }
+
+    pub(super) fn with_block_height(block_height: u64) -> Self {
+        BlockGetterId::BlockHeight {
+            block_height,
+            only_from_available_range: false,
+        }
+    }
+
+    pub(super) fn with_block_height_from_avail_range(
+        block_height: u64,
+        only_from_available_range: bool,
+    ) -> Self {
+        BlockGetterId::BlockHeight {
+            block_height,
+            only_from_available_range,
+        }
+    }
+}
+
+impl From<&StorageRequest> for BlockGetterId {
+    fn from(request: &StorageRequest) -> Self {
+        match request {
+            StorageRequest::GetBlock { block_hash, .. }
+            | StorageRequest::GetBlockAndDeploys { block_hash, .. } => {
+                BlockGetterId::with_block_hash(*block_hash)
+            }
+            StorageRequest::GetBlockHeader {
+                block_hash,
+                only_from_available_block_range,
+                ..
+            }
+            | StorageRequest::GetBlockAndMetadataByHash {
+                block_hash,
+                only_from_available_block_range,
+                ..
+            } => BlockGetterId::with_block_hash_from_avail_range(
+                *block_hash,
+                *only_from_available_block_range,
+            ),
+            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
+                block_height,
+                ..
+            }
+            | StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
+                block_height,
+                ..
+            } => BlockGetterId::with_block_height(*block_height),
+            StorageRequest::GetBlockHeaderByHeight {
+                block_height,
+                only_from_available_block_range,
+                ..
+            }
+            | StorageRequest::GetBlockAndMetadataByHeight {
+                block_height,
+                only_from_available_block_range,
+                ..
+            } => BlockGetterId::with_block_height_from_avail_range(
+                *block_height,
+                *only_from_available_block_range,
+            ),
+            StorageRequest::GetHighestBlock { .. }
+            | StorageRequest::GetHighestBlockHeader { .. }
+            | StorageRequest::GetHighestBlockWithMetadata { .. } => BlockGetterId::HighestBlock,
+            StorageRequest::GetSwitchBlockHeaderAtEraId { era_id, .. } => {
+                BlockGetterId::SwitchBlock(*era_id)
+            }
+            StorageRequest::GetBlockHeaderForDeploy { deploy_hash, .. } => {
+                BlockGetterId::DeployHash(*deploy_hash)
+            }
+            StorageRequest::PutBlock { .. }
+            | StorageRequest::PutBlockHeader { .. }
+            | StorageRequest::PutDeploy { .. }
+            | StorageRequest::PutExecutionResults { .. }
+            | StorageRequest::PutBlockSignatures { .. }
+            | StorageRequest::PutBlockAndDeploys { .. }
+            | StorageRequest::StoreFinalizedApprovals { .. }
+            | StorageRequest::CheckBlockHeaderExistence { .. }
+            | StorageRequest::GetBlockTransfers { .. }
+            | StorageRequest::GetBlockSignatures { .. }
+            | StorageRequest::GetFinalizedBlocks { .. }
+            | StorageRequest::GetDeploys { .. }
+            | StorageRequest::GetDeployAndMetadata { .. }
+            | StorageRequest::UpdateLowestAvailableBlockHeight { .. }
+            | StorageRequest::GetAvailableBlockRange { .. } => BlockGetterId::None,
+        }
+    }
+}

--- a/node/src/components/storage/block_height_index_value.rs
+++ b/node/src/components/storage/block_height_index_value.rs
@@ -1,0 +1,68 @@
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    EraId, ProtocolVersion,
+};
+
+use crate::types::BlockHash;
+
+/// The value stored under a given block height in the block height index DB.
+#[derive(PartialEq, Eq, Debug)]
+pub(super) struct BlockHeightIndexValue {
+    pub(super) block_hash: BlockHash,
+    pub(super) era_id: EraId,
+    pub(super) protocol_version: ProtocolVersion,
+}
+
+impl ToBytes for BlockHeightIndexValue {
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.block_hash.write_bytes(writer)?;
+        self.era_id.write_bytes(writer)?;
+        self.protocol_version.write_bytes(writer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.block_hash.serialized_length()
+            + self.era_id.serialized_length()
+            + self.protocol_version.serialized_length()
+    }
+}
+
+impl FromBytes for BlockHeightIndexValue {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (block_hash, remainder) = BlockHash::from_bytes(bytes)?;
+        let (era_id, remainder) = EraId::from_bytes(remainder)?;
+        let (protocol_version, remainder) = ProtocolVersion::from_bytes(remainder)?;
+        let value = BlockHeightIndexValue {
+            block_hash,
+            era_id,
+            protocol_version,
+        };
+        Ok((value, remainder))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use casper_types::testing::TestRng;
+
+    use super::*;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let mut rng = TestRng::new();
+        let value = BlockHeightIndexValue {
+            block_hash: BlockHash::random(&mut rng),
+            era_id: EraId::new(rng.gen()),
+            protocol_version: ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen()),
+        };
+        bytesrepr::test_serialization_roundtrip(&value);
+    }
+}

--- a/node/src/components/storage/config.rs
+++ b/node/src/components/storage/config.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use tempfile::TempDir;
+
+/// One Gibibyte.
+const GIB: usize = 1024 * 1024 * 1024;
+/// Default max block store size.
+const DEFAULT_MAX_BLOCK_STORE_SIZE: usize = 450 * GIB;
+/// Default max deploy store size.
+const DEFAULT_MAX_DEPLOY_STORE_SIZE: usize = 300 * GIB;
+/// Default max deploy metadata store size.
+const DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE: usize = 300 * GIB;
+/// Default max state store size.
+const DEFAULT_MAX_STATE_STORE_SIZE: usize = 10 * GIB;
+
+/// On-disk storage configuration.
+#[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// The path to the folder where any files created or read by the storage component will exist.
+    ///
+    /// If the folder doesn't exist, it and any required parents will be created.
+    pub path: PathBuf,
+    /// The maximum size of the database to use for the block store.
+    ///
+    /// The size should be a multiple of the OS page size.
+    pub(super) max_block_store_size: usize,
+    /// The maximum size of the database to use for the deploy store.
+    ///
+    /// The size should be a multiple of the OS page size.
+    pub(super) max_deploy_store_size: usize,
+    /// The maximum size of the database to use for the deploy metadata store.
+    ///
+    /// The size should be a multiple of the OS page size.
+    pub(super) max_deploy_metadata_store_size: usize,
+    /// The maximum size of the database to use for the component state store.
+    ///
+    /// The size should be a multiple of the OS page size.
+    pub(super) max_state_store_size: usize,
+    /// Whether or not memory deduplication is enabled.
+    pub(super) enable_mem_deduplication: bool,
+    /// How many loads before memory duplication checks for dead references.
+    pub(super) mem_pool_prune_interval: u16,
+    /// Maximum number of parallel synchronous storage tasks to spawn.
+    pub(super) max_sync_tasks: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            // No one should be instantiating a config with storage set to default.
+            path: "/dev/null".into(),
+            max_block_store_size: DEFAULT_MAX_BLOCK_STORE_SIZE,
+            max_deploy_store_size: DEFAULT_MAX_DEPLOY_STORE_SIZE,
+            max_deploy_metadata_store_size: DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE,
+            max_state_store_size: DEFAULT_MAX_STATE_STORE_SIZE,
+            enable_mem_deduplication: true,
+            mem_pool_prune_interval: 4096,
+            max_sync_tasks: 32,
+        }
+    }
+}
+
+impl Config {
+    /// Returns a default `Config` suitable for tests, along with a `TempDir` which must be kept
+    /// alive for the duration of the test since its destructor removes the dir from the filesystem.
+    #[cfg(test)]
+    pub(crate) fn default_for_tests() -> (Self, TempDir) {
+        let tempdir = tempfile::tempdir().expect("should get tempdir");
+        let path = tempdir.path().join("lmdb");
+
+        let config = Config {
+            path,
+            ..Default::default()
+        };
+        (config, tempdir)
+    }
+}

--- a/node/src/components/storage/index_dbs.rs
+++ b/node/src/components/storage/index_dbs.rs
@@ -1,0 +1,455 @@
+use std::collections::BTreeSet;
+
+use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction};
+
+use casper_hashing::Digest;
+use casper_types::{EraId, ProtocolVersion};
+
+use super::{
+    lmdb_ext::{LmdbExtError, TransactionExt, WriteTransactionExt},
+    BlockHeightIndexValue,
+};
+use crate::types::{BlockHash, BlockHashAndHeight, DeployHash};
+
+/// The name of the block_height_index_db.
+const BLOCK_HEIGHT_INDEX_DB_NAME: &str = "block_height_index";
+/// The name of the switch_block_era_id_index_db.
+const SWITCH_BLOCK_ERA_ID_INDEX_DB_NAME: &str = "switch_block_era_id_index";
+/// The name of the body_hash_index_db.
+const BODY_HASH_INDEX_DB_NAME: &str = "body_hash_index";
+/// The name of the deploy_hash_index_db.
+const DEPLOY_HASH_INDEX_DB_NAME: &str = "deploy_hash_index";
+
+/// The key in the state store DB under which the storage component's lowest available block height
+/// is persisted.
+const KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT: &str = "lowest_available_block_height";
+/// The key in the state store DB under which the storage component's highest available block height
+/// is persisted.
+const KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT: &str = "highest_available_block_height";
+
+/// The databases used to persist the various indices of the storage component.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub(super) struct IndexDbs {
+    /// An index mapping block height (`u64`) to block ID, era ID and protocol version
+    /// (`BlockHeightIndexValue`).
+    block_height_index_db: Database,
+    /// An index mapping era ID (`u64`) to switch block ID (`BlockHash`).
+    switch_block_era_id_index_db: Database,
+    /// An index mapping block v1 body hash (`Digest`) to set of block IDs and heights containing
+    /// it (`BTreeSet<BlockHashAndHeight>`).
+    v1_body_hash_index_db: Database,
+    /// An index mapping deploy ID (`DeployHash`) to block ID and height containing it
+    /// (`BlockHashAndHeight`).
+    deploy_hash_index_db: Database,
+    /// A general purpose database allowing components to persist arbitrary state.
+    state_store_db: Database,
+}
+
+impl IndexDbs {
+    pub(super) fn new(env: &Environment, state_store_db: Database) -> Result<Self, LmdbExtError> {
+        let block_height_index_db =
+            env.create_db(Some(BLOCK_HEIGHT_INDEX_DB_NAME), DatabaseFlags::empty())?;
+        let switch_block_era_id_index_db = env.create_db(
+            Some(SWITCH_BLOCK_ERA_ID_INDEX_DB_NAME),
+            DatabaseFlags::empty(),
+        )?;
+        let v1_body_hash_index_db =
+            env.create_db(Some(BODY_HASH_INDEX_DB_NAME), DatabaseFlags::empty())?;
+        let deploy_hash_index_db =
+            env.create_db(Some(DEPLOY_HASH_INDEX_DB_NAME), DatabaseFlags::empty())?;
+        let index_dbs = IndexDbs {
+            block_height_index_db,
+            switch_block_era_id_index_db,
+            v1_body_hash_index_db,
+            deploy_hash_index_db,
+            state_store_db,
+        };
+        Ok(index_dbs)
+    }
+
+    /// Puts the block hash, era ID and protocol version under the given block height to the
+    /// `block_height_index_db`.
+    pub(super) fn put_to_block_height_index(
+        &self,
+        txn: &mut RwTransaction,
+        block_height: u64,
+        block_hash: BlockHash,
+        era_id: EraId,
+        protocol_version: ProtocolVersion,
+    ) -> Result<(), LmdbExtError> {
+        let value = BlockHeightIndexValue {
+            block_hash,
+            era_id,
+            protocol_version,
+        };
+        txn.put_value_bytesrepr(
+            self.block_height_index_db,
+            &index_key_from_u64(block_height),
+            &value,
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Gets the block hash, era ID and protocol version under the given block height from the
+    /// `block_height_index_db`.
+    pub(super) fn get_from_block_height_index<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        block_height: u64,
+    ) -> Result<Option<BlockHeightIndexValue>, LmdbExtError> {
+        txn.get_value_bytesrepr(
+            self.block_height_index_db,
+            &index_key_from_u64(block_height),
+        )
+    }
+
+    /// Deletes the entry under the given block height from the `block_height_index_db`.
+    pub(super) fn delete_from_block_height_index(
+        &self,
+        txn: &mut RwTransaction,
+        block_height: u64,
+    ) -> Result<(), LmdbExtError> {
+        txn.delete(
+            self.block_height_index_db,
+            &index_key_from_u64(block_height),
+        )
+    }
+
+    /// Returns `true` if the `block_height_index_db` has an entry under the given block height.
+    pub(super) fn exists_in_block_height_index<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        block_height: u64,
+    ) -> Result<bool, LmdbExtError> {
+        match txn.get(
+            self.block_height_index_db,
+            &index_key_from_u64(block_height),
+        ) {
+            Ok(_raw) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Put the block hash under the given era ID to the `switch_block_era_id_index_db`.
+    pub(super) fn put_to_switch_block_era_id_index(
+        &self,
+        txn: &mut RwTransaction,
+        era_id: EraId,
+        block_hash: &BlockHash,
+    ) -> Result<(), LmdbExtError> {
+        txn.put_value_bytesrepr(
+            self.switch_block_era_id_index_db,
+            &index_key_from_u64(era_id.value()),
+            block_hash,
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Get the block hash under the given era ID from the `switch_block_era_id_index_db`.
+    pub(super) fn get_from_switch_block_era_id_index<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        era_id: EraId,
+    ) -> Result<Option<BlockHash>, LmdbExtError> {
+        txn.get_value_bytesrepr(
+            self.switch_block_era_id_index_db,
+            &index_key_from_u64(era_id.value()),
+        )
+    }
+
+    /// Deletes the entry under the given era ID from the `switch_block_era_id_index_db`.
+    pub(super) fn delete_from_switch_block_era_id_index(
+        &self,
+        txn: &mut RwTransaction,
+        era_id: EraId,
+    ) -> Result<(), LmdbExtError> {
+        txn.delete(
+            self.switch_block_era_id_index_db,
+            &index_key_from_u64(era_id.value()),
+        )
+    }
+
+    /// Put the block hash and height under the given v1 block body hash to the
+    /// `v1_body_hash_index_db`.
+    pub(super) fn put_to_v1_body_hash_index(
+        &self,
+        txn: &mut RwTransaction,
+        body_hash: &Digest,
+        block_hash: BlockHash,
+        block_height: u64,
+    ) -> Result<(), LmdbExtError> {
+        let mut all_block_hash_and_heights =
+            match self.get_from_v1_body_hash_index(txn, body_hash)? {
+                Some(existing) => existing,
+                None => BTreeSet::new(),
+            };
+        all_block_hash_and_heights.insert(BlockHashAndHeight::new(block_hash, block_height));
+        txn.put_value_bytesrepr(
+            self.v1_body_hash_index_db,
+            body_hash,
+            &all_block_hash_and_heights,
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Get the block hashes and heights under the given v1 block body hash from the
+    /// `v1_body_hash_index_db`.
+    pub(super) fn get_from_v1_body_hash_index<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        body_hash: &Digest,
+    ) -> Result<Option<BTreeSet<BlockHashAndHeight>>, LmdbExtError> {
+        txn.get_value_bytesrepr(self.v1_body_hash_index_db, body_hash)
+    }
+
+    /// Deletes the block hash and height under the given v1 block body hash of the
+    /// `v1_body_hash_index_db`.
+    ///
+    /// If the set becomes empty, removes the entry entirely and returns `true`.  If the set is not
+    /// empty, it is stored and `false` is returned.
+    pub(super) fn delete_from_v1_body_hash_index(
+        &self,
+        txn: &mut RwTransaction,
+        body_hash: &Digest,
+        block_hash: BlockHash,
+        block_height: u64,
+    ) -> Result<bool, LmdbExtError> {
+        let mut all_block_hash_and_heights =
+            match self.get_from_v1_body_hash_index(txn, body_hash)? {
+                Some(existing) => existing,
+                None => BTreeSet::new(),
+            };
+        all_block_hash_and_heights.remove(&BlockHashAndHeight::new(block_hash, block_height));
+        if all_block_hash_and_heights.is_empty() {
+            txn.delete(self.v1_body_hash_index_db, body_hash)?;
+            Ok(true)
+        } else {
+            txn.put_value_bytesrepr(
+                self.v1_body_hash_index_db,
+                body_hash,
+                &all_block_hash_and_heights,
+                true,
+            )?;
+            Ok(false)
+        }
+    }
+
+    /// Put the block hash and height under the given deploy hash to the `deploy_hash_index_db`.
+    pub(super) fn put_to_deploy_hash_index(
+        &self,
+        txn: &mut RwTransaction,
+        deploy_hash: &DeployHash,
+        block_hash: BlockHash,
+        block_height: u64,
+    ) -> Result<(), LmdbExtError> {
+        txn.put_value_bytesrepr(
+            self.deploy_hash_index_db,
+            deploy_hash,
+            &BlockHashAndHeight::new(block_hash, block_height),
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Get the `BlockHashAndHeight` under the given deploy hash from the `deploy_hash_index_db`.
+    pub(super) fn get_from_deploy_hash_index<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        deploy_hash: &DeployHash,
+    ) -> Result<Option<BlockHashAndHeight>, LmdbExtError> {
+        txn.get_value_bytesrepr(self.deploy_hash_index_db, deploy_hash)
+    }
+
+    /// Delete the entry under the given deploy hash from the `deploy_hash_index_db`.
+    pub(super) fn delete_from_deploy_hash_index(
+        &self,
+        txn: &mut RwTransaction,
+        deploy_hash: &DeployHash,
+    ) -> Result<(), LmdbExtError> {
+        txn.delete(self.deploy_hash_index_db, deploy_hash)
+    }
+
+    /// Put the block height under `KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT` to the `state_store_db`.
+    pub(super) fn put_lowest_available_block_height(
+        &self,
+        txn: &mut RwTransaction,
+        block_height: u64,
+    ) -> Result<(), LmdbExtError> {
+        txn.put_value_bytesrepr(
+            self.state_store_db,
+            &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT,
+            &block_height,
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Get the block height under `KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT` from the `state_store_db`.
+    pub(super) fn get_lowest_available_block_height<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+    ) -> Result<Option<u64>, LmdbExtError> {
+        txn.get_value_bytesrepr(self.state_store_db, &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT)
+    }
+
+    /// Put the block height under `KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT` to the `state_store_db`.
+    pub(super) fn put_highest_available_block_height(
+        &self,
+        txn: &mut RwTransaction,
+        block_height: u64,
+    ) -> Result<(), LmdbExtError> {
+        txn.put_value_bytesrepr(
+            self.state_store_db,
+            &KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT,
+            &block_height,
+            true,
+        )?;
+        Ok(())
+    }
+
+    /// Get the block height under `KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT` from the `state_store_db`.
+    pub(super) fn get_highest_available_block_height<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+    ) -> Result<Option<u64>, LmdbExtError> {
+        txn.get_value_bytesrepr(self.state_store_db, &KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT)
+    }
+
+    /// Get the block height under `KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT` from the `state_store_db`.
+    pub(super) fn get_highest_available_block_info<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+    ) -> Result<Option<BlockHeightIndexValue>, LmdbExtError> {
+        match self.get_highest_available_block_height(txn)? {
+            Some(height) => self.get_from_block_height_index(txn, height),
+            None => Ok(None),
+        }
+    }
+
+    /// Clears all index databases, and resets the highest and lowest block to 0.
+    pub(super) fn clear_all(&self, txn: &mut RwTransaction) -> Result<(), LmdbExtError> {
+        txn.clear_db(self.block_height_index_db)?;
+        txn.clear_db(self.switch_block_era_id_index_db)?;
+        txn.clear_db(self.v1_body_hash_index_db)?;
+        txn.clear_db(self.deploy_hash_index_db)?;
+        txn.delete(self.state_store_db, &KEY_LOWEST_AVAILABLE_BLOCK_HEIGHT)?;
+        txn.delete(self.state_store_db, &KEY_HIGHEST_AVAILABLE_BLOCK_HEIGHT)
+    }
+}
+
+/// We use big-endian encoding of the index keys so they result in a sorted collection as LMDB
+/// orders its data as sorted byte strings.
+///
+/// We don't want to use the `DatabaseFlags::INTEGER_KEY` for these indices as LMDB encodes the keys
+/// in native-endian format.  This doesn't lend itself to being able to use a copy of the DB file
+/// across different machines on different architectures.
+fn index_key_from_u64(key: u64) -> [u8; 8] {
+    key.to_be_bytes()
+}
+
+#[cfg(test)]
+pub(super) mod test_utils {
+    use std::{collections::BTreeMap, convert::TryFrom};
+
+    use lmdb::Cursor;
+
+    use casper_types::bytesrepr;
+
+    use super::*;
+
+    fn u64_from_index_key(raw_key: &[u8]) -> u64 {
+        assert_eq!(raw_key.len(), 8);
+        let mut buffer = [0; 8];
+        buffer.copy_from_slice(raw_key);
+        u64::from_be_bytes(buffer)
+    }
+
+    #[derive(Default, PartialEq, Eq, Debug)]
+    pub(in crate::components::storage) struct InMemIndices {
+        block_height_index: BTreeMap<u64, BlockHeightIndexValue>,
+        switch_block_era_id_index: BTreeMap<u64, BlockHash>,
+        v1_body_hash_index: BTreeMap<Digest, BTreeSet<BlockHashAndHeight>>,
+        deploy_hash_index: BTreeMap<DeployHash, BlockHashAndHeight>,
+        lowest_available_block_height: u64,
+        highest_available_block_height: u64,
+    }
+
+    #[cfg(test)]
+    impl From<(IndexDbs, &Environment)> for InMemIndices {
+        fn from((dbs, env): (IndexDbs, &Environment)) -> Self {
+            let mut indices = InMemIndices::default();
+
+            let mut ro_txn = env.begin_ro_txn().unwrap();
+            {
+                let mut block_height_cursor =
+                    ro_txn.open_ro_cursor(dbs.block_height_index_db).unwrap();
+                for (raw_key, raw_val) in block_height_cursor.iter() {
+                    assert!(indices
+                        .block_height_index
+                        .insert(
+                            u64_from_index_key(raw_key),
+                            bytesrepr::deserialize_from_slice(raw_val).unwrap(),
+                        )
+                        .is_none());
+                }
+
+                let mut switch_block_era_id_cursor = ro_txn
+                    .open_ro_cursor(dbs.switch_block_era_id_index_db)
+                    .unwrap();
+                for (raw_key, raw_val) in switch_block_era_id_cursor.iter() {
+                    assert!(indices
+                        .switch_block_era_id_index
+                        .insert(
+                            u64_from_index_key(raw_key),
+                            bytesrepr::deserialize_from_slice(raw_val).unwrap(),
+                        )
+                        .is_none());
+                }
+
+                let mut v1_body_hash_cursor =
+                    ro_txn.open_ro_cursor(dbs.v1_body_hash_index_db).unwrap();
+                for (raw_key, raw_val) in v1_body_hash_cursor.iter() {
+                    assert!(indices
+                        .v1_body_hash_index
+                        .insert(
+                            Digest::try_from(raw_key).unwrap(),
+                            bytesrepr::deserialize_from_slice(raw_val).unwrap(),
+                        )
+                        .is_none());
+                }
+
+                let mut deploy_hash_cursor =
+                    ro_txn.open_ro_cursor(dbs.deploy_hash_index_db).unwrap();
+                for (raw_key, raw_val) in deploy_hash_cursor.iter() {
+                    assert!(indices
+                        .deploy_hash_index
+                        .insert(
+                            DeployHash::new(Digest::try_from(raw_key).unwrap()),
+                            bytesrepr::deserialize_from_slice(raw_val).unwrap(),
+                        )
+                        .is_none());
+                }
+            }
+
+            indices.lowest_available_block_height = dbs
+                .get_lowest_available_block_height(&mut ro_txn)
+                .expect("should be ok")
+                .expect("should be some");
+            indices.highest_available_block_height = dbs
+                .get_highest_available_block_height(&mut ro_txn)
+                .expect("should be ok")
+                .expect("should be some");
+
+            assert_eq!(
+                *indices.block_height_index.keys().last().unwrap(),
+                indices.highest_available_block_height
+            );
+
+            indices
+        }
+    }
+}

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -967,7 +967,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts the given block into the linear block store.
-    pub(crate) async fn put_block_to_storage(self, block: Box<Block>) -> bool
+    pub(crate) async fn put_block_to_storage(self, block: Box<Block>)
     where
         REv: From<StorageRequest>,
     {
@@ -1096,7 +1096,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts a block header to storage.
-    pub(crate) async fn put_block_header_to_storage(self, block_header: Box<BlockHeader>) -> bool
+    pub(crate) async fn put_block_header_to_storage(self, block_header: Box<BlockHeader>)
     where
         REv: From<StorageRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -259,9 +259,8 @@ pub(crate) enum StorageRequest {
     PutBlock {
         /// Block to be stored.
         block: Box<Block>,
-        /// Responder to call with the result.  Returns true if the block was stored on this
-        /// attempt or false if it was previously stored.
-        responder: Responder<bool>,
+        /// Responder to call with the result.
+        responder: Responder<()>,
     },
     /// Store given block and its deploys.
     PutBlockAndDeploys {
@@ -451,9 +450,8 @@ pub(crate) enum StorageRequest {
     PutBlockHeader {
         /// Block header that is to be stored.
         block_header: Box<BlockHeader>,
-        /// Responder to call with the result, if true then the block header was successfully
-        /// stored.
-        responder: Responder<bool>,
+        /// Responder to call with the result.
+        responder: Responder<()>,
     },
     /// Update the lowest available block height in storage.
     // Note - this is a request rather than an announcement as the chain synchronizer needs to

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -497,7 +497,7 @@ async fn dont_upgrade_without_switch_block() {
         let header = runner
             .participating()
             .storage()
-            .read_block_header_and_sufficient_finality_signatures_by_height(2)
+            .read_block_header_and_enough_sigs_by_height(2)
             .expect("failed to read from storage")
             .expect("missing switch block")
             .block_header;

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -371,7 +371,7 @@ get_remainder_timeout = '5sec'
 # The timeout duration for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-get_from_peer_timeout = '3sec'
+get_from_peer_timeout = '30sec'
 
 
 # ========================================================
@@ -405,7 +405,7 @@ get_from_peer_timeout = '3sec'
 # Deploys are only proposed in a new block if they have been received at least this long ago.
 # A longer delay makes it more likely that many proposed deploys are already known by the
 # other nodes, and don't have to be requested from the proposer afterwards.
-#deploy_delay = '1min'
+deploy_delay = '5sec'
 
 
 # ==============================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -371,7 +371,7 @@ get_remainder_timeout = '5sec'
 # The timeout duration for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
-get_from_peer_timeout = '3sec'
+get_from_peer_timeout = '30sec'
 
 
 # ========================================================

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -406,7 +406,7 @@ get_from_peer_timeout = '3sec'
 # Deploys are only proposed in a new block if they have been received at least this long ago.
 # A longer delay makes it more likely that many proposed deploys are already known by the
 # other nodes, and don't have to be requested from the proposer afterwards.
-#deploy_delay = '1min'
+deploy_delay = '5sec'
 
 
 # ==============================================

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -403,7 +403,7 @@ get_from_peer_timeout = '3sec'
 # Deploys are only proposed in a new block if they have been received at least this long ago.
 # A longer delay makes it more likely that many proposed deploys are already known by the
 # other nodes, and don't have to be requested from the proposer afterwards.
-#deploy_delay = '1min'
+deploy_delay = '5sec'
 
 
 # ==============================================

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -326,20 +326,20 @@ pub fn put_block_with_deploys(
 ) -> Result<(), anyhow::Error> {
     for deploy in block_with_deploys.deploys.iter() {
         if let DeployOrTransferHash::Deploy(_hash) = deploy.deploy_or_transfer_hash() {
-            storage.put_deploy(deploy)?;
+            storage.commit_deploy(deploy)?;
         } else {
             return Err(anyhow::anyhow!("transfer found in list of deploys"));
         }
     }
     for transfer in block_with_deploys.transfers.iter() {
         if let DeployOrTransferHash::Transfer(_hash) = transfer.deploy_or_transfer_hash() {
-            storage.put_deploy(transfer)?;
+            storage.commit_deploy(transfer)?;
         } else {
             return Err(anyhow::anyhow!("deploy found in list of transfers"));
         }
     }
     let block: Block = block_with_deploys.block.clone().try_into()?;
-    storage.write_block(&block)?;
+    storage.commit_block(&block)?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR changes the storage component's indices to be held on disk (in the LMDB database) rather than in memory.

The initial migration should be a one-time cost at the next upgrade.  It has written to be resumable, with progress committed after completing the indices for every 10,000th block.

A test has been provided to allow for checking this against a pre-existing storage LMDB file.  The test is named `should_populate_indices_from_db_file` and reads the env var `CL_TEST_DB_DIR_PATH` to get the path to the DB file.

Example usage:
```
cd casper-node/node
export RUST_LOG=info
export CL_TEST_DB_DIR_PATH=<path to folder containing storage.lmdb>
cargo t --release should_populate_indices_from_db_file -- --nocapture
```

Initial testing using a release build against mainnet data indicates that the indexing performance is probably critically slow, but this should be confirmed using a production spec environment.

Closes #2751.
