### PR TITLE
Adds support for the new `speculative_exec` endpoint.

### DIFF
--- a/ci/nctl_upgrade_stage.sh
+++ b/ci/nctl_upgrade_stage.sh
@@ -30,6 +30,7 @@ WASM_BUILD_DIR="$ROOT_DIR/target/wasm32-unknown-unknown/release"
 CONFIG_DIR="$ROOT_DIR/resources/local"
 TEMP_STAGE_DIR='/tmp/nctl_upgrade_stage'
 NCTL_UPGRADE_CHAINSPECS="$ROOT_DIR/utils/nctl/sh/scenarios/chainspecs"
+NCTL_UPGRADE_CONFIGS="$ROOT_DIR/utils/nctl/sh/scenarios/configs"
 
 # FILES
 BIN_ARRAY=(casper-node)
@@ -96,5 +97,9 @@ done
 
 # Copy NCTL upgrade chainspecs
 pushd "$NCTL_UPGRADE_CHAINSPECS"
+cp upgrade* "$TEMP_STAGE_DIR"
+popd
+
+pushd "$NCTL_UPGRADE_CONFIGS"
 cp upgrade* "$TEMP_STAGE_DIR"
 popd

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -369,6 +369,33 @@ impl From<&ExecutionResult> for casper_types::ExecutionResult {
     }
 }
 
+impl From<ExecutionResult> for casper_types::ExecutionResult {
+    fn from(ee_execution_result: ExecutionResult) -> Self {
+        match ee_execution_result {
+            ExecutionResult::Success {
+                transfers,
+                cost,
+                execution_journal,
+            } => casper_types::ExecutionResult::Success {
+                effect: execution_journal.into(),
+                transfers,
+                cost: cost.value(),
+            },
+            ExecutionResult::Failure {
+                error,
+                transfers,
+                cost,
+                execution_journal,
+            } => casper_types::ExecutionResult::Failure {
+                effect: execution_journal.into(),
+                transfers,
+                cost: cost.value(),
+                error_message: error.to_string(),
+            },
+        }
+    }
+}
+
 /// Represents error conditions of an execution result builder.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ExecutionResultBuilderError {

--- a/execution_engine/src/shared/execution_journal.rs
+++ b/execution_engine/src/shared/execution_journal.rs
@@ -56,6 +56,21 @@ impl From<&ExecutionJournal> for JsonExecutionEffect {
     }
 }
 
+impl From<ExecutionJournal> for JsonExecutionEffect {
+    fn from(execution_journal: ExecutionJournal) -> Self {
+        Self::new(
+            execution_journal
+                .0
+                .iter()
+                .map(|(key, transform)| JsonTransformEntry {
+                    key: key.to_formatted_string(),
+                    transform: transform.into(),
+                })
+                .collect(),
+        )
+    }
+}
+
 impl IntoIterator for ExecutionJournal {
     type Item = (Key, Transform);
     type IntoIter = IntoIter<Self::Item>;

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this project will be documented in this file.  The format
 * Add a new RPC endpoint `query_balance` which queries for balances underneath a URef identified by a given `PurseIdentifier`.
 * Add new `block_hash` and `block_height` optional fields to `info_get_deploy` RPC query which will be present when execution results aren't available.
 * Add a new config option `[rpc_server.max_body_bytes]` to allow a configurable value for the maximum size of the body of a JSON-RPC request.
+* Add new JSON RPC endpoint `/speculative_exec` that accepts a deploy and a block hash and executes that deploy, returning the execution effects.
+* Add `speculative_execution_address` to `rpc_server` section in `config.toml` to control address which the speculative execution server binds to.
+* Add `speculative_execution_qps_limit` to `rpc_server` section in `config.toml` to control requests per second the node handles. Setting to 0 disbles the endpoint.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -38,7 +38,7 @@ use casper_execution_engine::{
     },
 };
 use casper_hashing::Digest;
-use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion};
+use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion, Timestamp};
 
 use crate::{
     components::{contract_runtime::types::StepEffectAndUpcomingEraValidators, Component},
@@ -58,6 +58,8 @@ pub(crate) use error::{BlockExecutionError, ConfigError};
 use metrics::Metrics;
 pub use operations::execute_finalized_block;
 pub(crate) use types::{BlockAndExecutionEffects, EraValidatorsRequest};
+
+use self::operations::execute_only;
 
 use super::fetcher::FetchedOrNotFound;
 
@@ -96,6 +98,17 @@ where
     tokio::task::spawn_blocking(task)
         .await
         .expect("task panicked")
+}
+
+#[derive(DataSize, Debug, Clone, Serialize)]
+/// Wrapper for speculative execution prestate.
+pub struct SpeculativeExecutionState {
+    /// State root on top of which to execute deploy.
+    pub state_root_hash: Digest,
+    /// Block time.
+    pub block_time: Timestamp,
+    /// Protocol version used when creating the original block.
+    pub protocol_version: ProtocolVersion,
 }
 
 /// State to use to construct the next block in the blockchain. Includes the state root hash for the
@@ -571,6 +584,21 @@ impl ContractRuntime {
                         .missing_trie_keys
                         .observe(start.elapsed().as_secs_f64());
                     trace!(?result, "find missing descendant trie keys");
+                    responder.respond(result).await
+                }
+                .ignore()
+            }
+            ContractRuntimeRequest::SpeculativeDeployExecution {
+                execution_prestate,
+                deploy,
+                responder,
+            } => {
+                let engine_state = Arc::clone(&self.engine_state);
+                async move {
+                    let result = run_intensive_task(move || {
+                        execute_only(engine_state.as_ref(), execution_prestate, (*deploy).into())
+                    })
+                    .await;
                     responder.respond(result).await
                 }
                 .ignore()

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use itertools::Itertools;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -29,6 +29,8 @@ use casper_execution_engine::{
     core::{engine_state::execution_result::ExecutionResults, execution},
     storage::global_state::{CommitProvider, StateProvider},
 };
+
+use super::SpeculativeExecutionState;
 
 /// Executes a finalized block.
 #[allow(clippy::too_many_arguments)]
@@ -246,6 +248,51 @@ where
     }
     trace!(?result, "commit result");
     result.map(Digest::from)
+}
+
+/// Execute the transaction without commiting the effects.
+/// Intended to be used for discovery operations on read-only nodes.
+///
+/// Returns effects of the execution.
+pub fn execute_only<S>(
+    engine_state: &EngineState<S>,
+    execution_state: SpeculativeExecutionState,
+    deploy: DeployItem,
+) -> Result<Option<ExecutionResult>, engine_state::Error>
+where
+    S: StateProvider + CommitProvider,
+    S::Error: Into<execution::Error>,
+{
+    let SpeculativeExecutionState {
+        state_root_hash,
+        block_time,
+        protocol_version,
+    } = execution_state;
+    let deploy_hash = deploy.deploy_hash;
+    let execute_request = ExecuteRequest::new(
+        state_root_hash,
+        block_time.millis(),
+        vec![deploy],
+        protocol_version,
+        PublicKey::System,
+    );
+    let results = execute(engine_state, None, execute_request);
+    results.map(|mut execution_results| {
+        let len = execution_results.len();
+        if len != 1 {
+            warn!(
+                ?deploy_hash,
+                "got more ({}) execution results from a single transaction", len
+            );
+            None
+        } else {
+            // We know it must be 1, we could unwrap and then wrap
+            // with `Some(_)` but `pop_front` already returns an `Option`.
+            // We need to transform the `engine_state::ExecutionResult` into
+            // `casper_types::ExecutionResult` as well.
+            execution_results.pop_front().map(Into::into)
+        }
+    })
 }
 
 fn execute<S>(

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -109,14 +109,17 @@ impl RpcServer {
             config.max_body_bytes,
         ));
 
-        let builder = utils::start_listening(&config.speculative_execution_address)?;
-        tokio::spawn(speculative_exec_server::run(
-            builder,
-            effect_builder,
-            api_version,
-            config.speculative_execution_qps_limit,
-            config.max_body_bytes,
-        ));
+        // QPS limit set to 0 disables the server.
+        if config.speculative_execution_qps_limit > 0 {
+            let builder = utils::start_listening(&config.speculative_execution_address)?;
+            tokio::spawn(speculative_exec_server::run(
+                builder,
+                effect_builder,
+                api_version,
+                config.speculative_execution_qps_limit,
+                config.max_body_bytes,
+            ));
+        }
 
         Ok(RpcServer {
             node_startup_instant,

--- a/node/src/components/rpc_server/config.rs
+++ b/node/src/components/rpc_server/config.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 /// Default rate limit in qps.
 const DEFAULT_QPS_LIMIT: u64 = 100;
+const SPECULATIVE_EXEC_DEFAULT_ADDRESS: &str = "0.0.0.0:1";
+/// Default rate limit in qps.
+/// 0 means that the endpoint is turned off.
+const SPECULATIVE_EXEC_DEFAULT_QPS_LIMIT: u64 = 0;
 /// Default max body bytes.  This is 2.5MB which should be able to accommodate the largest valid
 /// JSON-RPC request, which would be an "account_put_deploy".
 const DEFAULT_MAX_BODY_BYTES: u32 = 2_621_440;
@@ -22,6 +26,10 @@ pub struct Config {
     pub qps_limit: u64,
     /// Maximum number of bytes to accept in a single request body.
     pub max_body_bytes: u32,
+    /// Address to bind JSON-RPC speculative execution server to.
+    pub speculative_execution_address: String,
+    /// Maximum rate limit in queries for speculative execition endpoint, per second.
+    pub speculative_execution_qps_limit: u64,
 }
 
 impl Config {
@@ -31,6 +39,8 @@ impl Config {
             address: DEFAULT_ADDRESS.to_string(),
             qps_limit: DEFAULT_QPS_LIMIT,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            speculative_execution_address: SPECULATIVE_EXEC_DEFAULT_ADDRESS.to_string(),
+            speculative_execution_qps_limit: SPECULATIVE_EXEC_DEFAULT_QPS_LIMIT,
         }
     }
 }

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -22,9 +22,12 @@ use super::{
         },
         RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
     },
-    ReactorEventT, RPC_API_PATH,
+    ReactorEventT,
 };
 use crate::effect::EffectBuilder;
+
+/// The URL path for all JSON-RPC requests.
+pub const RPC_API_PATH: &str = "rpc";
 
 /// Run the JSON-RPC server.
 pub(super) async fn run<REv: ReactorEventT>(

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -1,11 +1,4 @@
-use std::{convert::Infallible, time::Duration};
-
-use http::header::ACCEPT_ENCODING;
 use hyper::server::{conn::AddrIncoming, Builder};
-use tokio::sync::oneshot;
-use tower::builder::ServiceBuilder;
-use tracing::{info, trace};
-use warp::Filter;
 
 use casper_json_rpc::RequestHandlersBuilder;
 use casper_types::ProtocolVersion;
@@ -28,6 +21,8 @@ use crate::effect::EffectBuilder;
 
 /// The URL path for all JSON-RPC requests.
 pub const RPC_API_PATH: &str = "rpc";
+
+pub const RPC_API_SERVER_NAME: &str = "JSON RPC";
 
 /// Run the JSON-RPC server.
 pub(super) async fn run<REv: ReactorEventT>(
@@ -59,32 +54,13 @@ pub(super) async fn run<REv: ReactorEventT>(
     QueryBalance::register_as_handler(effect_builder, api_version, &mut handlers);
     let handlers = handlers.build();
 
-    let make_svc = hyper::service::make_service_fn(move |_| {
-        let service_routes = casper_json_rpc::route(RPC_API_PATH, max_body_bytes, handlers.clone());
-
-        // Supports content negotiation for gzip responses. This is an interim fix until
-        // https://github.com/seanmonstar/warp/pull/513 moves forward.
-        let service_routes_gzip = warp::header::exact(ACCEPT_ENCODING.as_str(), "gzip")
-            .and(service_routes.clone())
-            .with(warp::compression::gzip());
-
-        let service = warp::service(service_routes_gzip.or(service_routes));
-        async move { Ok::<_, Infallible>(service.clone()) }
-    });
-
-    let make_svc = ServiceBuilder::new()
-        .rate_limit(qps_limit, Duration::from_secs(1))
-        .service(make_svc);
-
-    let server = builder.serve(make_svc);
-    info!(address = %server.local_addr(), "started JSON-RPC server");
-
-    let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
-    let server_with_shutdown = server.with_graceful_shutdown(async {
-        shutdown_receiver.await.ok();
-    });
-
-    let _ = tokio::spawn(server_with_shutdown).await;
-    let _ = shutdown_sender.send(());
-    trace!("JSON-RPC server stopped");
+    super::rpcs::run(
+        builder,
+        handlers,
+        qps_limit,
+        max_body_bytes,
+        RPC_API_PATH,
+        RPC_API_SERVER_NAME,
+    )
+    .await;
 }

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -8,6 +8,7 @@ mod common;
 pub mod docs;
 mod error_code;
 pub mod info;
+pub mod speculative_exec;
 pub mod state;
 
 use std::{str, sync::Arc};

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -11,14 +11,20 @@ pub mod info;
 pub mod speculative_exec;
 pub mod state;
 
-use std::{str, sync::Arc};
+use std::{convert::Infallible, str, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use http::header::ACCEPT_ENCODING;
+use hyper::server::{conn::AddrIncoming, Builder};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::oneshot;
+use tower::ServiceBuilder;
+use tracing::info;
+use warp::Filter;
 
-use casper_json_rpc::{Error, RequestHandlersBuilder, ReservedErrorCode};
+use casper_json_rpc::{Error, RequestHandlers, RequestHandlersBuilder, ReservedErrorCode};
 use casper_types::ProtocolVersion;
 
 use super::{ReactorEventT, RpcRequest};
@@ -225,6 +231,45 @@ pub(super) trait RpcWithOptionalParams {
         api_version: ProtocolVersion,
         params: Option<Self::OptionalRequestParams>,
     ) -> Result<Self::ResponseResult, Error>;
+}
+
+/// Start JSON RPC server in a background.
+pub(super) async fn run(
+    builder: Builder<AddrIncoming>,
+    handlers: RequestHandlers,
+    qps_limit: u64,
+    max_body_bytes: u32,
+    api_path: &'static str,
+    server_name: &'static str,
+) {
+    let make_svc = hyper::service::make_service_fn(move |_| {
+        let service_routes = casper_json_rpc::route(api_path, max_body_bytes, handlers.clone());
+
+        // Supports content negotiation for gzip responses. This is an interim fix until
+        // https://github.com/seanmonstar/warp/pull/513 moves forward.
+        let service_routes_gzip = warp::header::exact(ACCEPT_ENCODING.as_str(), "gzip")
+            .and(service_routes.clone())
+            .with(warp::compression::gzip());
+
+        let service = warp::service(service_routes_gzip.or(service_routes));
+        async move { Ok::<_, Infallible>(service.clone()) }
+    });
+
+    let make_svc = ServiceBuilder::new()
+        .rate_limit(qps_limit, Duration::from_secs(1))
+        .service(make_svc);
+
+    let server = builder.serve(make_svc);
+    info!(address = %server.local_addr(), "started {} server", server_name);
+
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
+    let server_with_shutdown = server.with_graceful_shutdown(async {
+        shutdown_receiver.await.ok();
+    });
+
+    let _ = tokio::spawn(server_with_shutdown).await;
+    let _ = shutdown_sender.send(());
+    info!("{} server shut down", server_name);
 }
 
 #[cfg(test)]

--- a/node/src/components/rpc_server/rpcs/speculative_exec.rs
+++ b/node/src/components/rpc_server/rpcs/speculative_exec.rs
@@ -1,0 +1,151 @@
+//! RPC related to speculative execution.
+
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
+use std::str;
+
+use async_trait::async_trait;
+use casper_execution_engine::core::engine_state;
+use casper_json_rpc::ReservedErrorCode;
+use once_cell::sync::Lazy;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use casper_types::{ExecutionResult, ProtocolVersion};
+
+use super::{
+    docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
+    Error, ErrorCode, ReactorEventT, RpcWithParams,
+};
+use crate::{
+    effect::{requests::RpcRequest, EffectBuilder},
+    reactor::QueueKind,
+    types::{Block, BlockHash, Deploy},
+};
+
+static SPECULATIVE_EXEC_PARAMS: Lazy<SpeculativeExecParams> = Lazy::new(|| SpeculativeExecParams {
+    block_hash: *Block::doc_example().hash(),
+    deploy: Deploy::doc_example().clone(),
+});
+static SPECULATIVE_EXEC_RESULT: Lazy<SpeculativeExecResult> = Lazy::new(|| SpeculativeExecResult {
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
+    execution_result: ExecutionResult::example().clone(),
+});
+
+/// Params for "speculative_exec" RPC request.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SpeculativeExecParams {
+    /// Block hash on top of which to execute the deploy.
+    pub block_hash: BlockHash,
+    /// Deploy to execute.
+    pub deploy: Deploy,
+}
+
+impl DocExample for SpeculativeExecParams {
+    fn doc_example() -> &'static Self {
+        &*SPECULATIVE_EXEC_PARAMS
+    }
+}
+
+/// Result for "speculative_exec" RPC response.
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SpeculativeExecResult {
+    /// The RPC API version.
+    #[schemars(with = "String")]
+    pub api_version: ProtocolVersion,
+    /// Result of the execution.
+    pub execution_result: ExecutionResult,
+}
+
+impl DocExample for SpeculativeExecResult {
+    fn doc_example() -> &'static Self {
+        &*SPECULATIVE_EXEC_RESULT
+    }
+}
+
+/// "speculative_exec" RPC
+pub struct SpeculativeExec {}
+
+#[async_trait]
+impl RpcWithParams for SpeculativeExec {
+    const METHOD: &'static str = "speculative_exec";
+    type RequestParams = SpeculativeExecParams;
+    type ResponseResult = SpeculativeExecResult;
+
+    async fn do_handle_request<REv: ReactorEventT>(
+        effect_builder: EffectBuilder<REv>,
+        api_version: ProtocolVersion,
+        params: Self::RequestParams,
+    ) -> Result<Self::ResponseResult, Error> {
+        let SpeculativeExecParams { block_hash, deploy } = params;
+        let result = effect_builder
+            .make_request(
+                |responder| RpcRequest::SpeculativeDeployExecute {
+                    block_hash,
+                    deploy: Box::new(deploy),
+                    responder,
+                },
+                QueueKind::Api,
+            )
+            .await;
+
+        match result {
+            Ok(Some(execution_result)) => {
+                let result = Self::ResponseResult {
+                    api_version,
+                    execution_result,
+                };
+                Ok(result)
+            }
+            Ok(None) => Err(Error::new(
+                ErrorCode::NoSuchBlock,
+                "block hash not found".to_string(),
+            )),
+            Err(error) => {
+                let rpc_error = match error {
+                    engine_state::Error::RootNotFound(_) => {
+                        Error::new(ErrorCode::NoSuchStateRoot, "")
+                    }
+                    engine_state::Error::WasmPreprocessing(error) => {
+                        Error::new(ErrorCode::InvalidDeploy, &format!("{}", error))
+                    }
+                    engine_state::Error::InvalidDeployItemVariant(error) => {
+                        Error::new(ErrorCode::InvalidDeploy, &error)
+                    }
+                    engine_state::Error::InvalidProtocolVersion(_) => Error::new(
+                        ErrorCode::InvalidDeploy,
+                        &format!("deploy used invalid protocol version {}", error),
+                    ),
+                    engine_state::Error::Deploy => Error::new(ErrorCode::InvalidDeploy, ""),
+                    engine_state::Error::Genesis(_)
+                    | engine_state::Error::WasmSerialization(_)
+                    | engine_state::Error::Exec(_)
+                    | engine_state::Error::Storage(_)
+                    | engine_state::Error::Authorization
+                    | engine_state::Error::InsufficientPayment
+                    | engine_state::Error::GasConversionOverflow
+                    | engine_state::Error::Finalization
+                    | engine_state::Error::Bytesrepr(_)
+                    | engine_state::Error::Mint(_)
+                    | engine_state::Error::InvalidKeyVariant
+                    | engine_state::Error::ProtocolUpgrade(_)
+                    | engine_state::Error::CommitError(_)
+                    | engine_state::Error::MissingSystemContractRegistry
+                    | engine_state::Error::MissingSystemContractHash(_)
+                    | engine_state::Error::RuntimeStackOverflow
+                    | engine_state::Error::FailedToGetWithdrawKeys
+                    | engine_state::Error::FailedToGetStoredWithdraws
+                    | engine_state::Error::FailedToGetWithdrawPurses
+                    | engine_state::Error::FailedToRetrieveUnbondingDelay
+                    | engine_state::Error::FailedToRetrieveEraId => {
+                        Error::new(ReservedErrorCode::InternalError, &format!("{}", error))
+                    }
+                };
+                Err(rpc_error)
+            }
+        }
+    }
+}

--- a/node/src/components/rpc_server/rpcs/speculative_exec.rs
+++ b/node/src/components/rpc_server/rpcs/speculative_exec.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::{
     effect::{requests::RpcRequest, EffectBuilder},
     reactor::QueueKind,
-    types::{Block, Deploy},
+    types::{Block, BlockHash, Deploy},
 };
 
 static SPECULATIVE_EXEC_PARAMS: Lazy<SpeculativeExecParams> = Lazy::new(|| SpeculativeExecParams {
@@ -32,6 +32,7 @@ static SPECULATIVE_EXEC_PARAMS: Lazy<SpeculativeExecParams> = Lazy::new(|| Specu
 });
 static SPECULATIVE_EXEC_RESULT: Lazy<SpeculativeExecResult> = Lazy::new(|| SpeculativeExecResult {
     api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
+    block_hash: *Block::doc_example().hash(),
     execution_result: ExecutionResult::example().clone(),
 });
 
@@ -58,6 +59,8 @@ pub struct SpeculativeExecResult {
     /// The RPC API version.
     #[schemars(with = "String")]
     pub api_version: ProtocolVersion,
+    /// Hash of the block on top of which the deploy was executed.
+    pub block_hash: BlockHash,
     /// Result of the execution.
     pub execution_result: ExecutionResult,
 }
@@ -95,6 +98,7 @@ impl RpcWithParams for SpeculativeExec {
             effect_builder,
         )
         .await?;
+        let block_hash = *block.hash();
         let result = effect_builder
             .make_request(
                 |responder| RpcRequest::SpeculativeDeployExecute {
@@ -110,6 +114,7 @@ impl RpcWithParams for SpeculativeExec {
             Ok(Some(execution_result)) => {
                 let result = Self::ResponseResult {
                     api_version,
+                    block_hash,
                     execution_result,
                 };
                 Ok(result)

--- a/node/src/components/rpc_server/speculative_exec_server.rs
+++ b/node/src/components/rpc_server/speculative_exec_server.rs
@@ -1,14 +1,7 @@
-use std::{convert::Infallible, time::Duration};
-
-use http::header::ACCEPT_ENCODING;
 use hyper::server::{conn::AddrIncoming, Builder};
-use tokio::sync::oneshot;
-use tower::ServiceBuilder;
-use tracing::info;
 
 use casper_json_rpc::RequestHandlersBuilder;
 use casper_types::ProtocolVersion;
-use warp::Filter;
 
 use super::ReactorEventT;
 use crate::{
@@ -18,6 +11,8 @@ use crate::{
 
 /// The URL path for all JSON-RPC requests.
 pub const SPECULATIVE_EXEC_API_PATH: &str = "rpc";
+
+pub const SPECULATIVE_EXEC_SERVER_NAME: &str = "speculative execution";
 
 /// Run the speculative execution server.
 pub(super) async fn run<REv: ReactorEventT>(
@@ -31,32 +26,13 @@ pub(super) async fn run<REv: ReactorEventT>(
     SpeculativeExec::register_as_handler(effect_builder, api_version, &mut handlers);
     let handlers = handlers.build();
 
-    let make_svc = hyper::service::make_service_fn(move |_| {
-        let service_routes =
-            casper_json_rpc::route(SPECULATIVE_EXEC_API_PATH, max_body_bytes, handlers.clone());
-
-        // Supports content negotiation for gzip responses. This is an interim fix until
-        // https://github.com/seanmonstar/warp/pull/513 moves forward.
-        let service_routes_gzip = warp::header::exact(ACCEPT_ENCODING.as_str(), "gzip")
-            .and(service_routes.clone())
-            .with(warp::compression::gzip());
-
-        let service = warp::service(service_routes_gzip.or(service_routes));
-        async move { Ok::<_, Infallible>(service.clone()) }
-    });
-
-    let make_svc = ServiceBuilder::new()
-        .rate_limit(qps_limit, Duration::from_secs(1))
-        .service(make_svc);
-
-    let server = builder.serve(make_svc);
-    info!(address = %server.local_addr(), "started speculative execution server");
-
-    let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
-    let server_with_shutdown = server.with_graceful_shutdown(async {
-        shutdown_receiver.await.ok();
-    });
-
-    let _ = tokio::spawn(server_with_shutdown).await;
-    let _ = shutdown_sender.send(());
+    super::rpcs::run(
+        builder,
+        handlers,
+        qps_limit,
+        max_body_bytes,
+        SPECULATIVE_EXEC_API_PATH,
+        SPECULATIVE_EXEC_SERVER_NAME,
+    )
+    .await;
 }

--- a/node/src/components/rpc_server/speculative_exec_server.rs
+++ b/node/src/components/rpc_server/speculative_exec_server.rs
@@ -11,7 +11,10 @@ use casper_types::ProtocolVersion;
 use warp::Filter;
 
 use super::ReactorEventT;
-use crate::effect::EffectBuilder;
+use crate::{
+    effect::EffectBuilder,
+    rpcs::{speculative_exec::SpeculativeExec, RpcWithParams},
+};
 
 /// The URL path for all JSON-RPC requests.
 pub const SPECULATIVE_EXEC_API_PATH: &str = "rpc";
@@ -25,6 +28,7 @@ pub(super) async fn run<REv: ReactorEventT>(
     max_body_bytes: u32,
 ) {
     let mut handlers = RequestHandlersBuilder::new();
+    SpeculativeExec::register_as_handler(effect_builder, api_version, &mut handlers);
     let handlers = handlers.build();
 
     let make_svc = hyper::service::make_service_fn(move |_| {

--- a/node/src/components/rpc_server/speculative_exec_server.rs
+++ b/node/src/components/rpc_server/speculative_exec_server.rs
@@ -1,0 +1,58 @@
+use std::{convert::Infallible, time::Duration};
+
+use http::header::ACCEPT_ENCODING;
+use hyper::server::{conn::AddrIncoming, Builder};
+use tokio::sync::oneshot;
+use tower::ServiceBuilder;
+use tracing::info;
+
+use casper_json_rpc::RequestHandlersBuilder;
+use casper_types::ProtocolVersion;
+use warp::Filter;
+
+use super::ReactorEventT;
+use crate::effect::EffectBuilder;
+
+/// The URL path for all JSON-RPC requests.
+pub const SPECULATIVE_EXEC_API_PATH: &str = "rpc";
+
+/// Run the speculative execution server.
+pub(super) async fn run<REv: ReactorEventT>(
+    builder: Builder<AddrIncoming>,
+    effect_builder: EffectBuilder<REv>,
+    api_version: ProtocolVersion,
+    qps_limit: u64,
+    max_body_bytes: u32,
+) {
+    let mut handlers = RequestHandlersBuilder::new();
+    let handlers = handlers.build();
+
+    let make_svc = hyper::service::make_service_fn(move |_| {
+        let service_routes =
+            casper_json_rpc::route(SPECULATIVE_EXEC_API_PATH, max_body_bytes, handlers.clone());
+
+        // Supports content negotiation for gzip responses. This is an interim fix until
+        // https://github.com/seanmonstar/warp/pull/513 moves forward.
+        let service_routes_gzip = warp::header::exact(ACCEPT_ENCODING.as_str(), "gzip")
+            .and(service_routes.clone())
+            .with(warp::compression::gzip());
+
+        let service = warp::service(service_routes_gzip.or(service_routes));
+        async move { Ok::<_, Infallible>(service.clone()) }
+    });
+
+    let make_svc = ServiceBuilder::new()
+        .rate_limit(qps_limit, Duration::from_secs(1))
+        .service(make_svc);
+
+    let server = builder.serve(make_svc);
+    info!(address = %server.local_addr(), "started speculative execution server");
+
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
+    let server_with_shutdown = server.with_graceful_shutdown(async {
+        shutdown_receiver.await.ok();
+    });
+
+    let _ = tokio::spawn(server_with_shutdown).await;
+    let _ = shutdown_sender.send(());
+}

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -787,8 +787,8 @@ pub(crate) enum RpcRequest {
     /// Executs a deploy against a specified block, returning the effects.
     /// Does not commit the effects. This is a "read-only" action.
     SpeculativeDeployExecute {
-        /// Block hash on top of which we will run the deploy.
-        block_hash: BlockHash,
+        /// Block header representing the state on top of which we will run the deploy.
+        block_header: BlockHeader,
         /// Deploy to execute.
         deploy: Box<Deploy>,
         /// Responder.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -238,7 +238,7 @@ speculative_execution_address = "0.0.0.0:7778"
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disabled the endpoint.
+# Setting to 0 disables the endpoint.
 speculative_execution_qps_limit = 0
 
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -233,8 +233,12 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+# Address to which the speculative execution endpoint binds to.
 speculative_execution_address = "0.0.0.0:7778"
 
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disabled the endpoint.
 speculative_execution_qps_limit = 0
 
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -233,6 +233,10 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+speculative_execution_address = "0.0.0.0:7778"
+
+speculative_execution_qps_limit = 0
+
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -233,6 +233,9 @@ qps_limit = 50
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+speculative_execution_address = "0.0.0.0:7778"
+
+speculative_execution_qps_limit = 0
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -238,7 +238,7 @@ speculative_execution_address = "0.0.0.0:7778"
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disabled the endpoint.
+# Setting to 0 disables the endpoint.
 speculative_execution_qps_limit = 0
 
 # ==============================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -233,8 +233,12 @@ qps_limit = 50
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+# Address to which the speculative execution endpoint binds to.
 speculative_execution_address = "0.0.0.0:7778"
 
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disabled the endpoint.
 speculative_execution_qps_limit = 0
 
 # ==============================================

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -82,6 +82,7 @@ function _set_nodes()
             "cfg['storage']['path']='../../storage';"
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
+            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
             "toml.dump(cfg, open('$PATH_TO_FILE', 'w'));"
         )

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -63,6 +63,7 @@ function _set_nodes()
 
     local IDX
     local PATH_TO_FILE
+    local SPECULATIVE_EXEC_ADDR
 
     for IDX in $(seq 1 "$(get_count_of_nodes)")
     do
@@ -71,6 +72,8 @@ function _set_nodes()
 
         cp "$PATH_TO_CONFIG_TOML" "$PATH_TO_CFG"
         cp "$(get_path_to_net)"/chainspec/* "$PATH_TO_CFG"
+
+        SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_FILE || true)
 
         local SCRIPT=(
             "import toml;"
@@ -82,10 +85,20 @@ function _set_nodes()
             "cfg['storage']['path']='../../storage';"
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
-            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
             "toml.dump(cfg, open('$PATH_TO_FILE', 'w'));"
         )
+
+        if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
+            SCRIPT+=(
+                "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
+            )
+        fi
+
+        SCRIPT+=(
+            "toml.dump(cfg, open('$PATH_TO_FILE', 'w'));"
+        )
+
         python3 -c "${SCRIPT[*]}"
     done
 }

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -417,6 +417,7 @@ function setup_asset_node_configs()
             "cfg['storage']['path']='../../storage';"
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
+            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
             "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
         )

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -390,6 +390,7 @@ function setup_asset_node_configs()
     local PATH_TO_CONFIG
     local PATH_TO_CONFIG_FILE
     local SCRIPT
+    local SPECULATIVE_EXEC_ADDR
 
     PATH_TO_NET="$(get_path_to_net)"
 
@@ -406,6 +407,8 @@ function setup_asset_node_configs()
         cp "$PATH_TO_NET/chainspec/chainspec.toml" "$PATH_TO_CONFIG"
         cp "$PATH_TO_TEMPLATE" "$PATH_TO_CONFIG_FILE"
 
+        SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_CONFIG_FILE || true)
+
         # Set node configuration settings.
         SCRIPT=(
             "import toml;"
@@ -417,8 +420,16 @@ function setup_asset_node_configs()
             "cfg['storage']['path']='../../storage';"
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
-            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
+        )
+
+        if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
+            SCRIPT+=(
+                "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
+            )
+        fi
+
+        SCRIPT+=(
             "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
         )
         python3 -c "${SCRIPT[*]}"

--- a/utils/nctl/sh/assets/upgrade_from_stage.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage.sh
@@ -75,6 +75,7 @@ function _main()
     local ACTIVATION_POINT=${2}
     local VERBOSE=${3}
     local CHAINSPEC_PATH=${4}
+    local CONFIG_PATH=${5}
     local CHUNKED_HASH_ACTIVATION
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
@@ -89,6 +90,10 @@ function _main()
 
     if [ -z "$CHAINSPEC_PATH" ]; then
         CHAINSPEC_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml"
+    fi
+
+    if [ -z "$CONFIG_PATH" ]; then
+        CONFIG_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml"
     fi
 
     if [ "$PROTOCOL_VERSION" != "" ]; then
@@ -111,7 +116,7 @@ function _main()
                               "$CHUNKED_HASH_ACTIVATION"
         setup_asset_node_configs "$COUNT_NODES" \
                                  "$PROTOCOL_VERSION" \
-                                 "$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml" \
+                                 "$CONFIG_PATH" \
                                  false
         setup_asset_global_state_toml "$COUNT_NODES" \
                                       "$PROTOCOL_VERSION"
@@ -130,6 +135,7 @@ unset NET_ID
 unset STAGE_ID
 unset VERBOSE
 unset CHAINSPEC_PATH
+unset CONFIG_PATH
 
 for ARGUMENT in "$@"
 do
@@ -141,6 +147,7 @@ do
         stage) STAGE_ID=${VALUE} ;;
         verbose) VERBOSE=${VALUE} ;;
         chainspec_path) CHAINSPEC_PATH=${VALUE} ;;
+        config_path) CONFIG_PATH=${VALUE} ;;
         *)
     esac
 done
@@ -154,4 +161,5 @@ fi
 _main "${STAGE_ID:-1}" \
       $((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET)) \
       "${VERBOSE:-true}" \
-      "${CHAINSPEC_PATH}"
+      "${CHAINSPEC_PATH}" \
+      "${CONFIG_PATH}"

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -167,6 +167,7 @@ function _setup_asset_node_configs()
     local PATH_TO_NET
     local PATH_TO_CONFIG
     local PATH_TO_CONFIG_FILE
+    local SPECULATIVE_EXEC_ADDR
     local SCRIPT
 
     PATH_TO_NET="$(get_path_to_net)"
@@ -182,6 +183,8 @@ function _setup_asset_node_configs()
     cp "$PATH_TO_NET/chainspec/chainspec.toml" "$PATH_TO_CONFIG"
     cp "$PATH_TO_TEMPLATE" "$PATH_TO_CONFIG_FILE"
 
+    SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_CONFIG_FILE || true)
+
     # Set node configuration settings.
     SCRIPT=(
         "import toml;"
@@ -193,10 +196,19 @@ function _setup_asset_node_configs()
         "cfg['storage']['path']='../../storage';"
         "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$NODE_ID")';"
         "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$NODE_ID")';"
-        "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$NODE_ID")';"
         "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$NODE_ID")';"
+    )
+
+    if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
+        SCRIPT+=(
+            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
+        )
+    fi
+
+    SCRIPT+=(
         "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
     )
+
     python3 -c "${SCRIPT[*]}"
 
     # Do workarounds.
@@ -324,6 +336,7 @@ function _main()
     local VERBOSE=${3}
     local NODE_ID=${4}
     local CHAINSPEC_PATH=${5}
+    local CONFIG_PATH=${6}
     local CHUNKED_HASH_ACTIVATION
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
@@ -336,6 +349,10 @@ function _main()
 
     if [ -z "$CHAINSPEC_PATH" ]; then
         CHAINSPEC_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/chainspec.toml"
+    fi
+
+    if [ -z "$CONFIG_PATH" ]; then
+        CONFIG_PATH="$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml"
     fi
 
     if [ "$PROTOCOL_VERSION" != "" ]; then
@@ -357,7 +374,7 @@ function _main()
                               "$CHUNKED_HASH_ACTIVATION"
         _setup_asset_node_configs "$NODE_ID" \
                                  "$PROTOCOL_VERSION" \
-                                 "$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml" \
+                                 "$CONFIG_PATH" \
                                  false
         if [ "$(echo $PROTOCOL_VERSION | tr -d '_')" -ge "140" ]; then
             _setup_asset_global_state_toml "$NODE_ID" \
@@ -379,6 +396,7 @@ unset STAGE_ID
 unset VERBOSE
 unset NODE_ID
 unset CHAINSPEC_PATH
+unset CONFIG_PATH
 
 for ARGUMENT in "$@"
 do
@@ -391,6 +409,7 @@ do
         verbose) VERBOSE=${VALUE} ;;
         node) NODE_ID=${VALUE} ;;
         chainspec_path) CHAINSPEC_PATH=${VALUE} ;;
+        config_path) CONFIG_PATH=${VALUE} ;;
         *)
     esac
 done
@@ -405,4 +424,5 @@ _main "${STAGE_ID:-1}" \
       $((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET)) \
       "${VERBOSE:-true}" \
       "${NODE_ID}" \
-      "${CHAINSPEC_PATH}"
+      "${CHAINSPEC_PATH}" \
+      "${CONFIG_PATH}"

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -193,6 +193,7 @@ function _setup_asset_node_configs()
         "cfg['storage']['path']='../../storage';"
         "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$NODE_ID")';"
         "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$NODE_ID")';"
+        "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$NODE_ID")';"
         "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$NODE_ID")';"
         "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
     )

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -62,7 +62,8 @@ function _step_01()
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
         stage="$STAGE_ID" \
-        chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_1.chainspec.toml.in"
+        chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_1.chainspec.toml.in" \
+        config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_1.config.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -105,7 +106,11 @@ function _step_05()
     log_step_upgrades 5 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.in"
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.in" \
+        config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_1.config.toml"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras 2 'true' '2.0'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -81,7 +81,8 @@ function _step_01()
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
             chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_3.chainspec.toml.in" \
-            accounts_path="$NCTL/sh/scenarios/accounts_toml/upgrade_scenario_3.accounts.toml"
+            accounts_path="$NCTL/sh/scenarios/accounts_toml/upgrade_scenario_3.accounts.toml" \
+            config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_3.config.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -205,7 +206,11 @@ function _step_08()
     log_step_upgrades 8 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.in"
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.in" \
+        config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_3.config.toml"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras '2' 'true' '5.0'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -92,7 +92,8 @@ function _step_01()
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_4.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_4.chainspec.toml.in" \
+            config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_4.config.toml"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -124,7 +125,13 @@ function _step_03()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+            stage="$STAGE_ID" \
+            verbose=false \
+            node="$i" \
+            era="$ACTIVATION_POINT" \
+            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in" \
+            config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_4.config.toml"
         echo ""
     done
 
@@ -257,7 +264,13 @@ function _step_09()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+            stage="$STAGE_ID" \
+            verbose=false \
+            node="$i" \
+            era="$ACTIVATION_POINT" \
+            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.in" \
+            config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_4.config.toml"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -92,7 +92,8 @@ function _step_01()
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_5.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_5.chainspec.toml.in" \
+            config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_5.config.toml"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -124,7 +125,13 @@ function _step_03()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+            stage="$STAGE_ID" \
+            verbose=false \
+            node="$i" \
+            era="$ACTIVATION_POINT" \
+            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in" \
+            config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_5.config.toml"
         echo ""
     done
 
@@ -257,7 +264,13 @@ function _step_09()
         else
             log "... staging upgrade on non-validator node-$i"
         fi
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+            stage="$STAGE_ID" \
+            verbose=false \
+            node="$i" \
+            era="$ACTIVATION_POINT" \
+            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.in" \
+            config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_5.config.toml"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -72,7 +72,9 @@ function _step_01()
 
     log_step_upgrades 1 "Begin upgrade_scenario_06"
 
-    nctl-assets-setup "chainspec_path=$NCTL/sh/scenarios/chainspecs/upgrade_scenario_6.chainspec.toml.in"
+    nctl-assets-setup \
+        "chainspec_path=$NCTL/sh/scenarios/chainspecs/upgrade_scenario_6.chainspec.toml.in" \
+        "config_path=$NCTL/sh/scenarios/configs/upgrade_scenario_6.config.toml"
     
     # Force Hard Reset
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -72,7 +72,9 @@ function _step_01()
 
     log_step_upgrades 1 "Begin upgrade_scenario_07"
 
-    nctl-assets-setup "chainspec_path=$NCTL/sh/scenarios/chainspecs/upgrade_scenario_7.chainspec.toml.in"
+    nctl-assets-setup \
+        "chainspec_path=$NCTL/sh/scenarios/chainspecs/upgrade_scenario_7.chainspec.toml.in" \
+        "config_path=$NCTL/sh/scenarios/configs/upgrade_scenario_7.config.toml"
     
     # Force Hard Reset
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
@@ -58,7 +58,10 @@ function _step_01()
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID" chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_8.chainspec.toml.in"
+    source "$NCTL/sh/assets/setup_from_stage.sh" \
+        stage="$STAGE_ID" \
+        chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_8.chainspec.toml.in" \
+        config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_8.config.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -79,7 +82,13 @@ function _step_03()
 
     log_step_upgrades 3 "upgrading node-6 from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_8.chainspec.toml.in"
+    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        node="6" \
+        era="$ACTIVATION_POINT" \
+        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_8.chainspec.toml.in" \
+        config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_8.config.toml"
 }
 
 # Step 04: Join passive node.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -74,7 +74,8 @@ function _step_01()
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_9.chainspec.toml.in"
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_9.chainspec.toml.in" \
+            config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_9.config.toml"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
 }
@@ -98,7 +99,13 @@ function _step_03()
 
     for i in $(seq 1 5); do
         log "... staging upgrade on validator node-$i"
-        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+            stage="$STAGE_ID" \
+            verbose=false \
+            node="$i" \
+            era="$ACTIVATION_POINT" \
+            chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in" \
+            config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_9.config.toml"
         echo ""
     done
 
@@ -183,7 +190,13 @@ function _step_07()
 
     log "... setting upgrade assets"
 
-    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="6" era="$ACTIVATION_POINT" chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in"
+    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        node="6" \
+        era="$ACTIVATION_POINT" \
+        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.in" \
+        config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_9.config.toml"
     echo ""
     # add hash to upgrades config
     PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -58,7 +58,9 @@ function _step_01()
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
-            stage="$STAGE_ID" chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_10.chainspec.toml.in"
+            stage="$STAGE_ID" \
+            chainspec_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_chainspecs/upgrade_scenario_10.chainspec.toml.in" \
+            config_path="$PATH_TO_STAGE/$PATH_TO_PROTO1/upgrade_configs/upgrade_scenario_10.config.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -86,7 +88,11 @@ function _step_04()
     log_step_upgrades 4 "upgrading network from stage ($STAGE_ID)"
 
     log "... setting upgrade assets"
-    source "$NCTL/sh/assets/upgrade_from_stage.sh" stage="$STAGE_ID" verbose=false chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.in"
+    source "$NCTL/sh/assets/upgrade_from_stage.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        chainspec_path="$NCTL/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.in" \
+        config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_10.config.toml"
 
     log "... awaiting 2 eras + 1 block"
     await_n_eras '2' 'true' '5.0'

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -233,6 +233,13 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disabled the endpoint.
+speculative_execution_qps_limit = 0
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -238,7 +238,7 @@ speculative_execution_address = "0.0.0.0:7778"
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disabled the endpoint.
+# Setting to 0 disables the endpoint.
 speculative_execution_qps_limit = 0
 
 # ==============================================

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -241,7 +241,7 @@ speculative_execution_address = "0.0.0.0:7778"
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disabled the endpoint.
+# Setting to 0 disables the endpoint.
 speculative_execution_qps_limit = 0
 
 # ==============================================

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -236,6 +236,13 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disabled the endpoint.
+speculative_execution_qps_limit = 0
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -233,6 +233,13 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disabled the endpoint.
+speculative_execution_qps_limit = 0
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -238,7 +238,7 @@ speculative_execution_address = "0.0.0.0:7778"
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disabled the endpoint.
+# Setting to 0 disables the endpoint.
 speculative_execution_qps_limit = 0
 
 # ==============================================

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
@@ -1,0 +1,433 @@
+# ================================
+# Configuration options for a node
+# ================================
+[node]
+
+# If set, use this hash as a trust anchor when joining an existing network.
+#trusted_hash = 'HEX-FORMATTED BLOCK HASH'
+
+# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
+max_parallel_deploy_fetches = 5000
+
+# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+max_parallel_trie_fetches = 5000
+
+# The duration for which to pause between retry attempts while synchronising during joining.
+retry_interval = '100ms'
+
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
+# Whether to synchronize all data back to genesis when joining.
+sync_to_genesis = true
+
+
+# =================================
+# Configuration options for logging
+# =================================
+[logging]
+
+# Output format.  Possible values are 'text' or 'json'.
+format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
+
+
+# ===================================
+# Configuration options for consensus
+# ===================================
+[consensus]
+
+# Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
+# consensus messages.
+secret_key_path = 'secret_key.pem'
+
+
+# ===========================================
+# Configuration options for Highway consensus
+# ===========================================
+[consensus.highway]
+
+# The duration for which incoming vertices with missing dependencies should be kept in a queue.
+pending_vertex_timeout = '1min'
+
+# If the current era's protocol state has not progressed for this long, shut down.
+# standstill_timeout = '10min'
+
+# Request the latest protocol state from a random peer periodically, with this interval.
+request_state_interval = '20sec'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
+# Log the synchronizer state periodically, with this interval.
+log_synchronizer_interval = '5sec'
+
+# Log the size of every incoming and outgoing serialized unit.
+log_unit_sizes = false
+
+# The maximum number of blocks by which execution is allowed to lag behind finalization.
+# If it is more than that, consensus will pause, and resume once the executor has caught up.
+max_execution_delay = 3
+
+# The maximum number of peers we request the same vertex from in parallel.
+max_requests_for_vertex = 5
+
+# The maximum number of dependencies we request per validator in a batch.
+# Limits requests per validator in panorama - in order to get a total number of
+# requests, multiply by # of validators.
+max_request_batch_size = 20
+
+[consensus.highway.round_success_meter]
+# The number of most recent rounds we will be keeping track of.
+num_rounds_to_consider = 40
+
+# The number of successful rounds that triggers us to slow down: With this many or fewer
+# successes per `num_rounds_to_consider`, we increase our round exponent.
+num_rounds_slowdown = 10
+
+# The number of successful rounds that triggers us to speed up: With this many or more successes
+# per `num_rounds_to_consider`, we decrease our round exponent.
+num_rounds_speedup = 32
+
+# We will try to accelerate (decrease our round exponent) every `acceleration_parameter` rounds if
+# we have few enough failures.
+acceleration_parameter = 40
+
+# The FTT, as a percentage (i.e. `acceleration_ftt = [1, 100]` means 1% of the validators' total weight), which
+# we will use for looking for a summit in order to determine a proposal's finality.
+# The required quorum in a summit we will look for to check if a round was successful is
+# determined by this FTT.
+acceleration_ftt = [1, 100]
+
+
+# ====================================
+# Configuration options for networking
+# ====================================
+[network]
+
+# The public address of the node.
+#
+# It must be publicly available in order to allow peers to connect to this node.
+# If the port is set to 0, the actual bound port will be substituted.
+public_address = '127.0.0.1:0'
+
+# Address to bind to for listening.
+# If port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:34553'
+
+# Addresses to connect to in order to join the network.
+#
+# If not set, this node will not be able to attempt to connect to the network.  Instead it will
+# depend upon peers connecting to it.  This is normally only useful for the first node of the
+# network.
+#
+# Multiple addresses can be given and the node will attempt to connect to each, requiring at least
+# one connection.
+known_addresses = ['127.0.0.1:34553']
+
+# The interval between each fresh round of gossiping the node's public address.
+gossip_interval = '30sec'
+
+# Initial delay for starting address gossipping after the network starts. This should be slightly
+# more than the expected time required for initial connections to complete.
+initial_gossip_delay = '5sec'
+
+# How long a connection is allowed to be stuck as pending before it is abandoned.
+max_addr_pending_time = '1min'
+
+# Maximum time allowed for a connection handshake between two nodes to be completed. Connections
+# exceeding this threshold are considered unlikely to be healthy or even malicious and thus
+# terminated.
+handshake_timeout = '20sec'
+
+# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
+# connections will be rejected. A value of `0` means unlimited.
+max_incoming_peer_connections = 3
+
+# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
+# A value of `0` means unlimited.
+max_outgoing_byte_rate_non_validators = 0
+
+# The maximum allowed total impact of requests from non-validating peers per second answered.
+# A value of `0` means unlimited.
+max_incoming_message_rate_non_validators = 0
+
+# Maximum number of requests for data from a single peer that are allowed be buffered. A value of
+# `0` means unlimited.
+max_in_flight_demands = 50
+
+# Reject incompatible node versions
+#
+# Causes the node to immediately disconnect from versions on a different protocol version than
+# itself. In general, this feature should be enabled on the entire network, it can be disabled in
+# the case of problems during upgrades if the nodes are still compatible on the networking level.
+reject_incompatible_versions = true
+
+# Version threshold to enable tarpit for.
+#
+# When set to a version (the value may be `null` to disable the feature), any peer that reports a
+# protocol version equal or below the threshold will be rejected only after holding open the
+# connection for a specific (`tarpit_duration`) amount of time.
+#
+# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
+# still in operation are connecting to, as these older versions will only attempt to reconnect to
+# other nodes once they have exhausted their set of known nodes.
+#
+# This feature is only enabled if `reject_incompatible_versions` is enabled.
+tarpit_version_threshold = '1.2.1'
+
+# How long to hold connections to trapped legacy nodes.
+tarpit_duration = '10min'
+
+# The probability [0.0, 1.0] of this node trapping a legacy node.
+#
+# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
+# single known node to hold open a connection to prevent the node from reconnecting. This should be
+# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
+# legacy nodes running this software.
+tarpit_chance = 0.2
+
+# How long peers remain blocked after they get blacklisted.
+blocklist_retain_duration = '1min'
+
+# Weights for impact estimation of incoming messages, used in combination with
+# `max_incoming_message_rate_non_validators`.
+#
+# Any weight set to 0 means that the category of traffic is exempt from throttling.
+[network.estimator_weights]
+consensus = 0
+gossip = 0
+finality_signatures = 0
+deploy_requests = 1
+deploy_responses = 1
+block_requests = 1
+block_responses = 0
+trie_requests = 1
+trie_responses = 0
+finalized_approvals_requests = 1
+finalized_approvals_responses = 0
+
+
+# ==================================================
+# Configuration options for the JSON-RPC HTTP server
+# ==================================================
+[rpc_server]
+
+# Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
+# Address to which the speculative execution endpoint binds to.
+speculative_execution_address = "0.0.0.0:7778"
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+# Setting to 0 disables the endpoint.
+speculative_execution_qps_limit = 0
+
+
+# ==============================================
+# Configuration options for the REST HTTP server
+# ==============================================
+[rest_server]
+
+# Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+
+# The global max rate of requests (per second) before they are limited.
+# Request will be delayed to the next 1 second bucket once limited.
+qps_limit = 100
+
+
+# ==========================================================
+# Configuration options for the SSE HTTP event stream server
+# ==========================================================
+[event_stream_server]
+
+# Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+
+# The number of event stream events to buffer.
+event_stream_buffer_length = 5000
+
+# The maximum number of subscribers across all event streams the server will permit at any one time.
+max_concurrent_subscribers = 100
+
+
+# ===============================================
+# Configuration options for the storage component
+# ===============================================
+[storage]
+
+# Path (absolute, or relative to this config.toml) to the folder where any files created
+# or read by the storage component will exist. A subfolder named with the network name will be
+# automatically created and used for the storage component files.
+#
+# If the folder doesn't exist, it and any required parents will be created.
+#
+# If unset, the path must be supplied as an argument via the CLI.
+path = '../node-storage'
+
+# Maximum size of the database to use for the block store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 483_183_820_800 == 18 GiB.
+max_block_store_size = 19_327_352_832
+
+# Maximum size of the database to use for the deploy store.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the deploy metadata.
+#
+# The size should be a multiple of the OS page size.
+#
+# 322_122_547_200 == 12 GiB.
+max_deploy_metadata_store_size = 12_884_901_888
+
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
+
+# Memory deduplication.
+#
+# If enabled, nodes will attempt to share loaded objects if possible.
+enable_mem_deduplication = true
+
+# Memory duplication garbage collection.
+#
+# Sets the frequency how often the memory pool cache is swept for free references.
+# For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
+mem_pool_prune_interval = 4096
+
+# Parallel storage request execution.
+#
+# Controls the maximum number of threads that are spawned to access storage in parallel.
+max_sync_tasks = 32
+
+
+# ===================================
+# Configuration options for gossiping
+# ===================================
+[gossip]
+
+# Target number of peers to infect with a given piece of data.
+infection_target = 3
+
+# The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
+# condition.
+#
+# Example: assume the `infection_target` is 3, the `saturation_limit_percent` is 80, and we don't
+# manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15 holders
+# excluding us since 80% saturation would imply 3 new infections in 15 peers.
+saturation_limit_percent = 80
+
+# The maximum duration for which to keep finished entries.
+#
+# The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
+# the longer they are retained, the larger the list of finished entries can grow.
+finished_entry_duration = '60sec'
+
+# The timeout duration for a single gossip request, i.e. for a single gossip message
+# sent from this node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+gossip_request_timeout = '10sec'
+
+# The timeout duration for retrieving the remaining part(s) of newly-discovered data
+# from a peer which gossiped information about that data to this node.
+get_remainder_timeout = '5sec'
+
+
+# =================================
+# Configuration options for fetcher
+# =================================
+[fetcher]
+
+# The timeout duration for a single fetcher request, i.e. for a single fetcher message
+# sent from this node to another node, it will be considered timed out if the expected response from that peer is
+# not received within this specified duration.
+get_from_peer_timeout = '3sec'
+
+
+# ========================================================
+# Configuration options for the contract runtime component
+# ========================================================
+[contract_runtime]
+
+# Optional maximum size of the database to use for the global state store.
+#
+# If unset, defaults to 32,212,254,720 == 30 GiB.
+#
+# The size should be a multiple of the OS page size.
+#max_global_state_size = 32_212_254_720
+
+# Optional depth limit to use for global state queries.
+#
+# If unset, defaults to 5.
+#max_query_depth = 5
+
+# Enable manual synchronizing to disk.
+#
+# If unset, defaults to true.
+#enable_manual_sync = true
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if they have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'
+
+
+# ==============================================
+# Configuration options for the diagnostics port
+# ==============================================
+[diagnostics_port]
+
+# If set, the diagnostics port will be available on a UNIX socket.
+enabled = true
+
+# Filename for the UNIX domain socket the diagnostics port listens on.
+socket_path = "debug.socket"
+
+# The umask to set before creating the socket. A restrictive mask like `0o077` will cause the
+# socket to be only accessible by the user the node runs as. A more relaxed variant is `0o007`,
+# which allows for group access as well.
+socket_umask = 0o077

--- a/utils/nctl/sh/staging/set_remote_configs.sh
+++ b/utils/nctl/sh/staging/set_remote_configs.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+#######################################
+# Downloads remote assets for subsequent staging.
+# Arguments:
+#   Protocol version to be downloaded.
+#######################################
+
+source "$NCTL/sh/utils/main.sh"
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Base URL: nctl.
+_BASE_URL="http://nctl.casperlabs.io.s3-website.us-east-2.amazonaws.com"
+
+# Set of remote files.
+_REMOTE_FILES=($(ls $NCTL/sh/scenarios/configs/upgrade* | xargs -n 1 basename))
+
+function _main()
+{
+    local PROTOCOL_VERSION=${1}
+    local PATH_TO_REMOTE
+    local REMOTE_FILE
+    local RC_VERSION
+
+    PATH_TO_REMOTE="$(get_path_to_remotes)/$PROTOCOL_VERSION/upgrade_configs"
+    mkdir -p "$PATH_TO_REMOTE"
+
+    pushd "$PATH_TO_REMOTE" || exit
+    for REMOTE_FILE in "${_REMOTE_FILES[@]}"
+    do
+        if ( ! curl -Isf "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1 ); then
+            log "... downloading RC $PROTOCOL_VERSION :: $REMOTE_FILE"
+            curl -O "$_BASE_URL/release-$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
+        else
+            log "... downloading tagged release $PROTOCOL_VERSION :: $REMOTE_FILE"
+            curl -O "$_BASE_URL/v$PROTOCOL_VERSION/$REMOTE_FILE" > /dev/null 2>&1
+        fi
+    done
+    if [ "${#PROTOCOL_VERSION}" = '3' ]; then
+        RC_VERSION=$(./casper-node --version | awk '{ print $2 }' |  awk -F'-' '{ print $1 }')
+        cd ..
+        if [ -d "$(get_path_to_remotes)/$RC_VERSION" ]; then
+            rm -rf "$RC_VERSION"
+        fi
+        mv "$PATH_TO_REMOTE" "$RC_VERSION"
+    fi
+    popd
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset _PROTOCOL_VERSION
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        version) _PROTOCOL_VERSION=${VALUE} ;;
+        *)
+    esac
+done
+
+_main "$_PROTOCOL_VERSION"

--- a/utils/nctl/sh/staging/set_remotes.sh
+++ b/utils/nctl/sh/staging/set_remotes.sh
@@ -38,6 +38,7 @@ function _main()
     do
         source "$NCTL/sh/staging/set_remote.sh" version=$PROTOCOL_VERSION
         source "$NCTL/sh/staging/set_remote_chainspecs.sh" version=$PROTOCOL_VERSION
+        source "$NCTL/sh/staging/set_remote_configs.sh" version=$PROTOCOL_VERSION
     done
 }
 

--- a/utils/nctl/sh/utils/constants.sh
+++ b/utils/nctl/sh/utils/constants.sh
@@ -21,6 +21,9 @@ export NCTL_BASE_PORT_SSE=18000
 # Base network server port number.
 export NCTL_BASE_PORT_NETWORK=22000
 
+# Base speculative execution RPC server port number.
+export NCTL_BASE_PORT_SPEC_EXEC=25000
+
 # Set of client side auction contracts.
 export NCTL_CONTRACTS_CLIENT_AUCTION=(
     "activate_bid.wasm"

--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -206,6 +206,18 @@ function get_node_port()
 }
 
 #######################################
+# Calculates speculative execution port.
+# Arguments:
+#   Node ordinal identifier.
+#######################################
+function get_node_port_speculative_exec()
+{
+    local NODE_ID=${1}    
+
+    get_node_port "$NCTL_BASE_PORT_SPEC_EXEC" "$NODE_ID"
+}
+
+#######################################
 # Calculates REST port.
 # Arguments:
 #   Node ordinal identifier.


### PR DESCRIPTION
### Adds JSON RPC endpoint executing a deploy and returning effects to the sender.

The new endpoint runs on a separate port from the previous JSON RPC. It can be configured in the `rpc_server` section of the `config.toml`. Setting `speculative_execution_qps_limit` to 0 will disable the endpoint. When sending a request to a node with disabled endpoint we get the following result:
```
* Could not resolve host: POST
* Closing connection 0
curl: (6) Could not resolve host: POST
*   Trying 127.0.0.1:25102...
* TCP_NODELAY set
* connect to 127.0.0.1 port 25102 failed: Connection refused
* Failed to connect to localhost port 25102: Connection refused
* Closing connection 1
curl: (7) Failed to connect to localhost port 25102: Connection refused
```

Endpoint accepts two parameters:
* block_identifier- this can be `BlockHash`, `StateRootHash` or null if deploy is to be executed on top of the latest block
* deploy - a deploy to execute.

(One can think of this as _"deploy dry run"_)

It will execute the deploy on top of the specified block and return the results of the execution to the caller. The effects of the execution won't be committed to the trie (blockchain database/GlobalState). Endpoint can be used for debugging, discovery - for example price estimation. If block_hash can't be found, proper error
will be returned. Any error returned during execution will be forwarded to the caller of the API.


### Example usage
1. Run nctl network - `nctl-compile && nctl-assets-setup && nctl-start`
2. Let it run for a while and then note hash of the recent block: `nctl-view-chain-lfb node=1`.
3. Stop node=1 (`nctl-stop node=1` and edit its config file to enable the new endpoint, its disabled by default. To do that, go to `utils/nctl/assets/net-1/nodes/node-1/config/1_0_0` and edit `speculative_qps_limit` in the `config.toml` to a positive number.
4. Start the node `nctl-start node=1 hash=<hash taken from nctl-view-chain-lfb node=2>`.
5. Create a deploy (in `casper-client-rs` directory), execute the command:
```
./target/release/casper-client make-transfer --chain-name "casper-net-1" --amount 1000 --secret-key ../casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --target-account=01bf65587c501685ca5d0cb5293509fa4cecdb4503c7364084e18e14339e46a46f --transfer-id 1 --payment-amount 25000000 | jq -c
```
6. Send deploy to the node
```
curl -v POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"speculative_exec","params":{"deploy": <previously store deploy formatted as JSON>, "block_identifier": <block_identifier> },"id":1}' 'http://localhost:25101/rpc'
```

where `block_identifier` can be a `{"Hash" : <block_hash> }`, `{"Height" : <block_height>}` or absent entirely (i.e. no `block_identifier` value), in which case it will execute deploy on top of the latest block.

7. Collect the results. If one wants to extract the cost, and the execution was a success, pipe the results into `jq` and extract the cost:
```
<previous command> | jq -c .result.execution_result.Success.cost
```

8. Sample response:
```json
{
  "jsonrpc":"2.0",
  "id":1,
  "result":{
    "api_version":"1.0.0",
    "block_hash":"9b97dab12815eeb84f244e011e1c998c3c4baa950be840256328cafae65d58c4",
    "execution_result":{
      "Success":{
        "cost":"100000000",
        "effect":{
          "operations":[],
          "transforms":[
            {"key":"hash-e256cf4b9f230655c2d1d35f1a36f2e2e0b26fd7cac7210aee941a46a13a1622","transform":"Identity"},
            {"key":"hash-0b87ad80a9a7cd6c9b8e1fc5c0eb61d1f9b9ae0229c34025a40061825abc8acb","transform":"Identity"},
            {"key":"hash-0b87ad80a9a7cd6c9b8e1fc5c0eb61d1f9b9ae0229c34025a40061825abc8acb","transform":"Identity"},
            // more transforms
          ],
         "transfers":["transfer-39cd3c67cc35bfd9faa831ad74f73d4be4b7eb2e8145ea4efb753c07946cecc5"]
}}}}
```

Closes https://github.com/casper-network/casper-node/issues/2880