### PR TITLE
Disable switch blocks when inserting multiple random blocks in storage

### DIFF
--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1213,7 +1213,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
         thread::spawn(move || {
             let mut harness = ComponentHarness::default();
 
-            let (block, verifiable_chunked_hash_activation) =
+            let (mut block, verifiable_chunked_hash_activation) =
                 random_block_at_height(&mut harness.rng, 42, block_generator);
 
             let mut storage = storage_fixture(&harness, verifiable_chunked_hash_activation);
@@ -1222,7 +1222,15 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
             let deploy = Deploy::random(&mut harness.rng);
             let execution_result: ExecutionResult = harness.rng.gen();
             put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
-            put_block(&mut harness, &mut storage, block.clone());
+            put_block(
+                &mut harness,
+                &mut storage,
+                Box::new(
+                    block
+                        .disable_switch_block(verifiable_chunked_hash_activation)
+                        .clone(),
+                ),
+            );
             let mut execution_results = HashMap::new();
             execution_results.insert(*deploy.id(), execution_result.clone());
             put_execution_results(&mut harness, &mut storage, *block.hash(), execution_results);
@@ -1823,8 +1831,11 @@ fn should_update_lowest_available_block_height_when_not_stored() {
         );
 
         // Store a block at height 100 and update.  Should update the range.
-        let (block, _) = random_block_at_height(&mut harness.rng, NEW_LOW, Block::random_v1);
-        storage.storage.write_block(&block).unwrap();
+        let (mut block, _) = random_block_at_height(&mut harness.rng, NEW_LOW, Block::random_v1);
+        storage
+            .storage
+            .write_block(&block.disable_switch_block(verifiable_chunked_hash_activation))
+            .unwrap();
         storage
             .storage
             .update_lowest_available_block_height(NEW_LOW)

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1834,7 +1834,7 @@ fn should_update_lowest_available_block_height_when_not_stored() {
         let (mut block, _) = random_block_at_height(&mut harness.rng, NEW_LOW, Block::random_v1);
         storage
             .storage
-            .write_block(&block.disable_switch_block(verifiable_chunked_hash_activation))
+            .write_block(block.disable_switch_block(verifiable_chunked_hash_activation))
             .unwrap();
         storage
             .storage

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1633,6 +1633,14 @@ impl Block {
         self
     }
 
+    /// Overrides the era end of a block with a `None`, making it a non-switch block.
+    #[cfg(test)]
+    pub fn disable_switch_block(&mut self, verifiable_chunked_hash_activation: EraId) -> &mut Self {
+        let _ = self.header.era_end.take();
+        self.hash = self.header.hash(verifiable_chunked_hash_activation);
+        self
+    }
+
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {


### PR DESCRIPTION
Fixes #2947 

This PR adds a test method to `Block` to force it to be a non-switch block.

This is used in storage tests where multiple random blocks are generated and inserted into storage. Storage rejects a block if it's a switch block and it already has one for that era, which is undesired behavior for the failing test in #2947 and others.

The original test which surfaced the issue, `should_restrict_returned_blocks`, previously used the storage block generation function `random_block_at_height`, which in turn used `Block::random_v1`, which generates switch blocks ~50% of the time. Since the issue was created, this specific test has moved to `Block::random_with_specifics`, which allows users to specify if they want the block to be a switch block or not, and so the issue was fixed. In this PR, tests which are still using `random_block_at_height` and insert multiple blocks into storage are modified to ensure at most one switch block is inserted. This is done regardless of the `EraId` generated for simplicity, but if need be, we could also test for the `EraId` and disable switch blocks only when ids match, but at that point we should be looking at a function which generates multiple semantically-correct blocks.
