### PR TITLE
Move compute_rewards from highway to core.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -85,7 +85,6 @@ type ConsensusConstructor = dyn Fn(
         Timestamp,           // start time for this era
         u64,                 // random seed
         Timestamp,           // now timestamp
-        bool,                // compute rewards
     ) -> (
         Box<dyn ConsensusProtocol<ClContext>>,
         Vec<ProtocolOutcome<ClContext>>,
@@ -469,7 +468,6 @@ impl EraSupervisor {
             start_time,
             seed,
             now,
-            self.chainspec.highway_config.compute_rewards,
         );
         let era = Era::new(
             consensus,
@@ -918,10 +916,19 @@ impl EraSupervisor {
                 era.add_accusations(value.accusations());
                 // If this is the era's last block, it contains rewards. Everyone who is accused in
                 // the block or seen as equivocating via the consensus protocol gets faulty.
-                let report = terminal_block_data.map(|tbd| EraReport {
-                    rewards: tbd.rewards,
-                    equivocators: era.accusations(),
-                    inactive_validators: tbd.inactive_validators,
+                let compute_rewards = self.chainspec.core_config.compute_rewards;
+                let report = terminal_block_data.map(|mut tbd| {
+                    // If block rewards are disabled, zero them.
+                    if !compute_rewards {
+                        for reward in tbd.rewards.values_mut() {
+                            *reward = 0;
+                        }
+                    }
+                    EraReport {
+                        rewards: tbd.rewards,
+                        equivocators: era.accusations(),
+                        inactive_validators: tbd.inactive_validators,
+                    }
                 });
                 let proposed_block = Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone());
                 let finalized_approvals: HashMap<_, _> = proposed_block

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -178,10 +178,8 @@ impl<C: Context> FinalityDetector<C> {
         let to_id = |vidx: ValidatorIndex| highway.validators().id(vidx).unwrap().clone();
         let state = highway.state();
 
-        // Compute the rewards (if applicable), and replace each validator index with the validator
-        // ID.
-        let should_compute_rewards = state.params().compute_rewards();
-        let rewards = rewards::compute_rewards(state, bhash, should_compute_rewards);
+        // Compute the rewards, and replace each validator index with the validator ID.
+        let rewards = rewards::compute_rewards(state, bhash);
         let rewards_iter = rewards.enumerate();
         let rewards = rewards_iter.map(|(vidx, r)| (to_id(vidx), *r)).collect();
 

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -57,7 +57,6 @@ pub(crate) const TEST_BLOCK_REWARD: u64 = 1_000_000_000_000;
 pub(crate) const TEST_REDUCED_BLOCK_REWARD: u64 = 200_000_000_000;
 pub(crate) const TEST_INSTANCE_ID: u64 = 42;
 pub(crate) const TEST_ENDORSEMENT_EVIDENCE_LIMIT: u64 = 20;
-pub(crate) const TEST_COMPUTE_REWARDS: bool = true;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 enum HighwayMessage {
@@ -722,7 +721,6 @@ fn test_params() -> Params {
         Timestamp::zero(),
         Timestamp::zero(), // Length depends only on block number.
         TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-        TEST_COMPUTE_REWARDS,
     )
 }
 

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -16,7 +16,6 @@ pub(crate) struct Params {
     start_timestamp: Timestamp,
     end_timestamp: Timestamp,
     endorsement_evidence_limit: u64,
-    compute_rewards: bool,
 }
 
 impl Params {
@@ -50,7 +49,6 @@ impl Params {
         start_timestamp: Timestamp,
         end_timestamp: Timestamp,
         endorsement_evidence_limit: u64,
-        compute_rewards: bool,
     ) -> Params {
         assert!(
             reduced_block_reward <= block_reward,
@@ -67,7 +65,6 @@ impl Params {
             start_timestamp,
             end_timestamp,
             endorsement_evidence_limit,
-            compute_rewards,
         }
     }
 
@@ -134,11 +131,6 @@ impl Params {
     /// than this, you get away with it and are not marked faulty.
     pub(crate) fn endorsement_evidence_limit(&self) -> u64 {
         self.endorsement_evidence_limit
-    }
-
-    /// Get the params's compute rewards.
-    pub(crate) fn compute_rewards(&self) -> bool {
-        self.compute_rewards
     }
 }
 

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -14,10 +14,7 @@ use crate::components::consensus::{
     highway_core::{
         evidence::EvidenceError,
         highway::Dependency,
-        highway_testing::{
-            TEST_BLOCK_REWARD, TEST_COMPUTE_REWARDS, TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-            TEST_INSTANCE_ID,
-        },
+        highway_testing::{TEST_BLOCK_REWARD, TEST_ENDORSEMENT_EVIDENCE_LIMIT, TEST_INSTANCE_ID},
     },
     traits::{ConsensusValueT, ValidatorSecret},
 };
@@ -134,7 +131,6 @@ pub(crate) fn test_params(seed: u64) -> Params {
         Timestamp::from(0),
         Timestamp::from(0),
         TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-        TEST_COMPUTE_REWARDS,
     )
 }
 
@@ -253,7 +249,6 @@ fn ban_and_mark_faulty() -> Result<(), AddUnitError<TestContext>> {
         Timestamp::zero(),
         Timestamp::from(u64::MAX),
         TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-        TEST_COMPUTE_REWARDS,
     );
     // Everyone already knows Alice is faulty, so she is banned.
     let mut state = State::new(WEIGHTS, params, vec![ALICE], vec![]);

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -9,7 +9,7 @@ use crate::{
         consensus_protocol::{ConsensusProtocol, ProtocolOutcome},
         highway_core::{
             highway::{SignedWireUnit, Vertex, WireUnit},
-            highway_testing::{self, TEST_COMPUTE_REWARDS},
+            highway_testing,
             state::{self, tests::ALICE, Observation, Panorama},
             validators::ValidatorIndex,
             State,
@@ -44,7 +44,6 @@ where
         0.into(),
         Timestamp::from(u64::MAX),
         highway_testing::TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-        TEST_COMPUTE_REWARDS,
     );
     let weights = weights.into_iter().map(|w| w.into()).collect::<Vec<_>>();
     state::State::new(weights, params, vec![], vec![])
@@ -90,7 +89,6 @@ where
         start_timestamp,
         0,
         start_timestamp,
-        chainspec.highway_config.compute_rewards,
     );
     // We expect five messages:
     // * log participation timer,

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -48,6 +48,8 @@ pub struct CoreConfig {
     pub(crate) allow_auction_bids: bool,
     /// Allows unrestricted transfers between users.
     pub(crate) allow_unrestricted_transfers: bool,
+    /// If set to false then consensus doesn't compute rewards and always uses 0.
+    pub(crate) compute_rewards: bool,
     /// Administrative accounts are valid option for for a private chain only.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub(crate) administrators: BTreeSet<PublicKey>,
@@ -95,6 +97,7 @@ impl CoreConfig {
         let strict_argument_checking = rng.gen();
         let allow_auction_bids = rng.gen();
         let allow_unrestricted_transfers = rng.gen();
+        let compute_rewards = rng.gen();
         let administrators = (0..rng.gen_range(0..=10u32))
             .map(|_| PublicKey::random(rng))
             .collect();
@@ -125,6 +128,7 @@ impl CoreConfig {
             allow_auction_bids,
             administrators,
             allow_unrestricted_transfers,
+            compute_rewards,
             refund_handling,
             fee_handling,
         }
@@ -149,6 +153,7 @@ impl ToBytes for CoreConfig {
             strict_argument_checking,
             allow_auction_bids,
             allow_unrestricted_transfers,
+            compute_rewards,
             administrators,
             refund_handling,
             fee_handling,
@@ -166,6 +171,7 @@ impl ToBytes for CoreConfig {
         buffer.extend(strict_argument_checking.to_bytes()?);
         buffer.extend(allow_auction_bids.to_bytes()?);
         buffer.extend(allow_unrestricted_transfers.to_bytes()?);
+        buffer.extend(compute_rewards.to_bytes()?);
         buffer.extend(administrators.to_bytes()?);
         buffer.extend(refund_handling.to_bytes()?);
         buffer.extend(fee_handling.to_bytes()?);
@@ -187,6 +193,7 @@ impl ToBytes for CoreConfig {
             strict_argument_checking,
             allow_auction_bids,
             allow_unrestricted_transfers,
+            compute_rewards,
             administrators: administrative_accounts,
             refund_handling,
             fee_handling,
@@ -204,6 +211,7 @@ impl ToBytes for CoreConfig {
             + strict_argument_checking.serialized_length()
             + allow_auction_bids.serialized_length()
             + allow_unrestricted_transfers.serialized_length()
+            + compute_rewards.serialized_length()
             + administrative_accounts.serialized_length()
             + refund_handling.serialized_length()
             + fee_handling.serialized_length()
@@ -225,6 +233,7 @@ impl FromBytes for CoreConfig {
         let (strict_argument_checking, remainder) = bool::from_bytes(remainder)?;
         let (allow_auction_bids, remainder) = FromBytes::from_bytes(remainder)?;
         let (allow_unrestricted_transfers, remainder) = FromBytes::from_bytes(remainder)?;
+        let (compute_rewards, remainder) = bool::from_bytes(remainder)?;
         let (administrative_accounts, remainder) = FromBytes::from_bytes(remainder)?;
         let (refund_handling, remainder) = FromBytes::from_bytes(remainder)?;
         let (fee_handling, remainder) = FromBytes::from_bytes(remainder)?;
@@ -242,6 +251,7 @@ impl FromBytes for CoreConfig {
             strict_argument_checking,
             allow_auction_bids,
             allow_unrestricted_transfers,
+            compute_rewards,
             administrators: administrative_accounts,
             refund_handling,
             fee_handling,

--- a/node/src/types/chainspec/highway_config.rs
+++ b/node/src/types/chainspec/highway_config.rs
@@ -24,8 +24,6 @@ pub(crate) struct HighwayConfig {
     /// quorum, i.e. no finality.
     #[data_size(skip)]
     pub(crate) reduced_reward_multiplier: Ratio<u64>,
-    /// If set to false then consensus doesn't compute rewards and always uses 0.
-    pub(crate) compute_rewards: bool,
 }
 
 impl HighwayConfig {
@@ -75,14 +73,12 @@ impl HighwayConfig {
         let minimum_round_exponent = rng.gen_range(0..16);
         let maximum_round_exponent = rng.gen_range(16..22);
         let reduced_reward_multiplier = Ratio::new(rng.gen_range(0..10), 10);
-        let compute_rewards = rng.gen();
 
         HighwayConfig {
             finality_threshold_fraction,
             minimum_round_exponent,
             maximum_round_exponent,
             reduced_reward_multiplier,
-            compute_rewards,
         }
     }
 }
@@ -94,7 +90,6 @@ impl ToBytes for HighwayConfig {
         buffer.extend(self.minimum_round_exponent.to_bytes()?);
         buffer.extend(self.maximum_round_exponent.to_bytes()?);
         buffer.extend(self.reduced_reward_multiplier.to_bytes()?);
-        buffer.extend(self.compute_rewards.to_bytes()?);
         Ok(buffer)
     }
 
@@ -103,7 +98,6 @@ impl ToBytes for HighwayConfig {
             + self.minimum_round_exponent.serialized_length()
             + self.maximum_round_exponent.serialized_length()
             + self.reduced_reward_multiplier.serialized_length()
-            + self.compute_rewards.serialized_length()
     }
 }
 
@@ -113,13 +107,11 @@ impl FromBytes for HighwayConfig {
         let (minimum_round_exponent, remainder) = u8::from_bytes(remainder)?;
         let (maximum_round_exponent, remainder) = u8::from_bytes(remainder)?;
         let (reduced_reward_multiplier, remainder) = Ratio::<u64>::from_bytes(remainder)?;
-        let (compute_rewards, remainder) = bool::from_bytes(remainder)?;
         let config = HighwayConfig {
             finality_threshold_fraction,
             minimum_round_exponent,
             maximum_round_exponent,
             reduced_reward_multiplier,
-            compute_rewards,
         };
         Ok((config, remainder))
     }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -63,6 +63,8 @@ strict_argument_checking = false
 allow_auction_bids = true
 # Allow peer to peer transfers between users. Setting this to false makes sense only on private chains.
 allow_unrestricted_transfers = true
+# If set to false, then consensus doesn't compute rewards and always uses 0.
+compute_rewards = true
 # Defines how refunds of the unused portion of payment amounts are calculated and handled.
 #
 # The only valid value for 'type' is currently 'refund'.  This causes excess payment amounts to be sent to either a
@@ -94,8 +96,6 @@ maximum_round_exponent = 19
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
-# If set to false, then consensus doesn't compute rewards and always uses 0.
-compute_rewards = true
 
 [deploys]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/resources/private/chainspec.toml.in
+++ b/resources/private/chainspec.toml.in
@@ -63,6 +63,8 @@ strict_argument_checking = false
 allow_auction_bids = false
 # Allow peer to peer transfers between users. Setting this to false makes sense only on private chains.
 allow_unrestricted_transfers = false
+# If set to false, then consensus doesn't compute rewards and always uses 0.
+compute_rewards = false
 # Defines how refunds of the unused portion of payment amounts are calculated and handled.
 #
 # The only valid value for 'type' is currently 'refund'.
@@ -101,8 +103,6 @@ maximum_round_exponent = 19
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
-# If set to false, then consensus doesn't compute rewards and always uses 0.
-compute_rewards = false
 
 [deploys]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -71,6 +71,8 @@ allow_unrestricted_transfers = true
 # Setting this to false makes sense only for private chains which don't need to auction new validator slots. These
 # auction entry points will return an error if called when this option is set to false.
 allow_auction_bids = true
+# If set to false, then consensus doesn't compute rewards and always uses 0.
+compute_rewards = true
 # Defines how refunds of the unused portion of payment amounts are calculated and handled.
 #
 # The only valid value for 'type' is currently 'refund'.
@@ -107,8 +109,6 @@ maximum_round_exponent = 17
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
-# If set to false, then consensus doesn't compute rewards and always uses 0.
-compute_rewards = true
 
 [deploys]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.


### PR DESCRIPTION
Whether rewards should be computed is not Highway-specific, so the setting is moved to the `[core]` section.
The era supervisor also enforces this now, by zeroing the rewards in every finalized block.

Part of https://github.com/CasperLabs/product/issues/56.