### PR TITLE
Revert breaking changes in `casper-hashing`

### DIFF
--- a/hashing/src/error.rs
+++ b/hashing/src/error.rs
@@ -1,8 +1,20 @@
 //! Errors in constructing and validating indexed Merkle proofs, chunks with indexed Merkle proofs.
 use crate::{ChunkWithProof, Digest};
 
+/// Possible hashing errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Incorrect digest length {0}, expected length {}.", Digest::LENGTH)]
+    /// The digest length was an incorrect size.
+    IncorrectDigestLength(usize),
+    /// There was a decoding error.
+    #[error("Base16 decode error {0}.")]
+    Base16DecodeError(base16::DecodeError),
+}
+
 /// Error validating a Merkle proof of a chunk.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MerkleVerificationError {
     /// Index out of bounds.
     #[error("Index out of bounds. Count: {count}, index: {index}")]
@@ -33,6 +45,7 @@ pub enum MerkleVerificationError {
 
 /// Error validating a chunk with proof.
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum ChunkWithProofVerificationError {
     /// Indexed Merkle proof verification error.
     #[error(transparent)]
@@ -61,6 +74,7 @@ pub enum ChunkWithProofVerificationError {
 
 /// Error during the construction of a Merkle proof.
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum MerkleConstructionError {
     /// Chunk index was out of bounds.
     #[error(

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 
 mod chunk_with_proof;
-pub mod error;
+mod error;
 mod indexed_merkle_proof;
 
 use std::{
@@ -35,18 +35,9 @@ use casper_types::{
     checksummed_hex, CLType, CLTyped,
 };
 pub use chunk_with_proof::ChunkWithProof;
-pub use error::MerkleConstructionError;
-
-/// Possible hashing errors.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Incorrect digest length {0}, expected length {}.", Digest::LENGTH)]
-    /// The digest length was an incorrect size.
-    IncorrectDigestLength(usize),
-    /// There was a decoding error.
-    #[error("Base16 decode error {0}.")]
-    Base16DecodeError(base16::DecodeError),
-}
+pub use error::{
+    ChunkWithProofVerificationError, Error, MerkleConstructionError, MerkleVerificationError,
+};
 
 /// The output of the hash function.
 #[derive(Copy, Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Default, JsonSchema)]
@@ -123,6 +114,12 @@ impl Digest {
             result.copy_from_slice(slice);
         });
         Digest(result)
+    }
+
+    /// Provides the same functionality as [`hash_merkle_tree`].
+    #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
+    pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
+        Digest::hash_merkle_tree(vec)
     }
 
     /// Returns the underlying BLAKE2b hash bytes

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -116,7 +116,7 @@ impl Digest {
         Digest(result)
     }
 
-    /// Provides the same functionality as [`hash_merkle_tree`].
+    /// Provides the same functionality as [`Digest::hash_merkle_tree`].
     #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
     pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
         Digest::hash_merkle_tree(vec)

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -10,7 +10,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
 
 use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
-use casper_hashing::{error::ChunkWithProofVerificationError, Digest};
+use casper_hashing::{ChunkWithProofVerificationError, Digest};
 use casper_types::EraId;
 
 use crate::types::{BlockHash, BlockHeader};


### PR DESCRIPTION
Fixes #3071 

This PR reverts the breaking changes in `casper-hashing` since the v1.4.6 release.

Changes were found using the `cargo-public-api` tool.
