### PR TITLE
Take delegations into account when looking for large bids

### DIFF
--- a/utils/global-state-update-gen/src/validators/validators_manager.rs
+++ b/utils/global-state-update-gen/src/validators/validators_manager.rs
@@ -262,7 +262,9 @@ impl ValidatorsUpdateManager {
             .get_bids()
             .into_iter()
             .filter(|(pub_key, bid)| {
-                bid.staked_amount() >= min_bid && !seigniorage_recipients.contains_key(pub_key)
+                bid.total_staked_amount()
+                    .map_or(true, |amount| amount >= *min_bid)
+                    && !seigniorage_recipients.contains_key(pub_key)
             })
             .map(|(pub_key, _bid)| pub_key)
             .collect()


### PR DESCRIPTION
This should fix a bug encountered by AJ during testing where a validator with a small bid, but large delegated stake didn't get removed properly in the upgrade and caused the network to stall.