### PR TITLE
NCTL: Add timeout to waiting for genesis in upgrade scenarios

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -16,6 +16,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -72,8 +73,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 10.0
-    await_until_era_n 1 'true'
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Populate global state -> native + wasm transfers.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -27,6 +27,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,8 +92,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Add bid non-genesis node and start

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -25,6 +25,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -106,7 +107,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -25,6 +25,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -106,7 +107,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -26,6 +26,7 @@ source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/assets/upgrade.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE.sh"
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,7 +92,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -26,6 +26,7 @@ source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/assets/upgrade.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE.sh"
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,7 +92,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
@@ -14,6 +14,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -70,8 +71,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Upgrade node-6 from stage.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -21,6 +21,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -84,7 +85,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting until era 2"
-    await_until_era_n 2
+
+    do_wait_until_era '2' 'false' '180'
 }
 
 # Step 03: Stage nodes 1-5 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -17,6 +17,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -69,8 +70,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Query auction info

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -46,9 +46,43 @@ function log_step() {
 }
 
 function do_await_genesis_era_to_complete() {
-    log_step "awaiting genesis era to complete"
+    local LOG_STEP=${1:-'true'}
+    local TIMEOUT=${2:-'120'}
+
+    if [ "$LOG_STEP" = "true" ]; then
+        log_step "awaiting genesis era to complete: timeout=$TIMEOUT"
+    fi
+
     while [ "$(get_chain_era)" -lt "1" ]; do
         sleep 1.0
+        TIMEOUT=$((TIMEOUT-1))
+        if [ "$TIMEOUT" = '0' ]; then
+            log "ERROR: Timed out before genesis era completed"
+            exit 1
+        else
+            log "... waiting for genesis era to complete: timeout=$TIMEOUT"
+        fi
+    done
+}
+
+function do_wait_until_era() {
+    local WAIT_FOR_ERA=${1}
+    local LOG_STEP=${2:-'true'}
+    local TIMEOUT=${3:-'120'}
+
+    if [ "$LOG_STEP" = "true" ]; then
+        log_step "waiting until era $WAIT_FOR_ERA: timeout=$TIMEOUT"
+    fi
+
+    while [ "$(get_chain_era)" -lt "$WAIT_FOR_ERA" ]; do
+        sleep 1.0
+        TIMEOUT=$((TIMEOUT-1))
+        if [ "$TIMEOUT" = '0' ]; then
+            log "ERROR: Timed out before reaching era $WAIT_FOR_ERA"
+            exit 1
+        else
+            log "... waiting for era $WAIT_FOR_ERA to complete: timeout=$TIMEOUT"
+        fi
     done
 }
 


### PR DESCRIPTION
Changes:
- `do_await_genesis_era_to_complete`
    - added timeout to command 
        - prevents hanging forever in CI
        - will allow CI to dump the logs
    - maintained backwards compatibility for non-upgrade tests

Adds:
- `do_wait_until_era`
    - utilized by `upgrade_scenario_09.sh` which doesn't use `do_await_genesis_era_to_complete`

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/494