### PR TITLE
Provide remote address in SSE log messages

### DIFF
--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -42,7 +42,7 @@ const MAX_EVENT_COUNT: u32 = 100_000_000;
 const BUFFER_LENGTH: u32 = EVENT_COUNT / 2;
 /// The maximum amount of time to wait for a test server to complete.  If this time is exceeded, the
 /// test has probably hung, and should be deemed to have failed.
-const MAX_TEST_TIME: Duration = Duration::from_secs(1);
+const MAX_TEST_TIME: Duration = Duration::from_secs(2);
 /// The duration of the sleep called between each event being sent by the server.
 const DELAY_BETWEEN_EVENTS: Duration = Duration::from_millis(1);
 


### PR DESCRIPTION
This PR adds logging of the socket address of the client if known in the cases of:
1. SSE server rejecting a new client as it has exceeded the `max_concurrent_subscribers` limit
2. SSE server dropping a client connection due to the client lagging

Example log lines are:
```json
{"timestamp":"Jun 16 00:38:31.020","level":"INFO","fields":{"message":"event stream server has max subscribers: rejecting new one","remote_address":"127.0.0.1:51408","max_concurrent_subscribers":"100"},"target":"casper_node::components::event_stream_server::sse_server"}
{"timestamp":"Jun 16 00:48:34.992","level":"INFO","fields":{"message":"client lagged: dropping event stream connection to client","remote_address":"127.0.0.1:39112","lagged_count":"24"},"target":"casper_node::components::event_stream_server::sse_server"}
```
