### PR TITLE
Revert breaking changes in `casper-test-support` and tidy up `casper-execution-engine`

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -18,6 +18,7 @@ use crate::{
 
 /// Engine state errors.
 #[derive(Clone, Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Specified state root hash is not found.
     #[error("Root not found: {0}")]

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -147,7 +147,7 @@ impl EngineState<LmdbGlobalState> {
     }
 
     /// Writes state cached in an EngineState<ScratchEngineState> to LMDB.
-    pub fn write_scratch_to_lmdb(
+    pub fn write_scratch_to_db(
         &self,
         state_root_hash: Digest,
         scratch_global_state: ScratchGlobalState,
@@ -156,16 +156,6 @@ impl EngineState<LmdbGlobalState> {
         self.state
             .put_stored_values(CorrelationId::new(), state_root_hash, stored_values)
             .map_err(Into::into)
-    }
-
-    /// Writes state cached in an EngineState<ScratchEngineState> to LMDB.
-    #[deprecated(since = "2.0.0", note = "renamed to `write_scratch_to_lmdb`")]
-    pub fn write_scratch_to_db(
-        &self,
-        state_root_hash: Digest,
-        scratch_global_state: ScratchGlobalState,
-    ) -> Result<Digest, Error> {
-        self.write_scratch_to_lmdb(state_root_hash, scratch_global_state)
     }
 }
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -157,6 +157,16 @@ impl EngineState<LmdbGlobalState> {
             .put_stored_values(CorrelationId::new(), state_root_hash, stored_values)
             .map_err(Into::into)
     }
+
+    /// Writes state cached in an EngineState<ScratchEngineState> to LMDB.
+    #[deprecated(since = "2.0.0", note = "renamed to `write_scratch_to_lmdb`")]
+    pub fn write_scratch_to_db(
+        &self,
+        state_root_hash: Digest,
+        scratch_global_state: ScratchGlobalState,
+    ) -> Result<Digest, Error> {
+        self.write_scratch_to_lmdb(state_root_hash, scratch_global_state)
+    }
 }
 
 impl<S> EngineState<S>

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -16,6 +16,7 @@ use crate::{
 
 /// Possible execution errors.
 #[derive(Error, Debug, Clone)]
+#[non_exhaustive]
 pub enum Error {
     /// WASM interpreter error.
     #[error("Interpreter error: {}", _0)]

--- a/execution_engine/src/core/resolvers/error.rs
+++ b/execution_engine/src/core/resolvers/error.rs
@@ -5,6 +5,7 @@ use casper_types::ProtocolVersion;
 
 /// Error conditions of a host function resolver.
 #[derive(Error, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum ResolverError {
     /// Unknown protocol version.
     #[error("Unknown protocol version: {}", _0)]

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -24,6 +24,7 @@ use casper_types::{
 /// b > i32::MAX then a `AddInt32(a).apply(Value::Int32(b))` would
 /// cause an overflow).
 #[derive(PartialEq, Eq, Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Error while (de)serializing data.
     #[error("{0}")]

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -11,6 +11,7 @@ const DEFAULT_GAS_MODULE_NAME: &str = "env";
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum PreprocessingError {
     /// Unable to deserialize Wasm bytes.
     Deserialize(String),

--- a/execution_engine/src/storage/error/in_memory.rs
+++ b/execution_engine/src/storage/error/in_memory.rs
@@ -7,6 +7,7 @@ use casper_types::bytesrepr;
 
 /// Error enum encapsulating possible errors from in-memory implementation of data storage.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// (De)serialization error.
     #[error("{0}")]

--- a/execution_engine/src/storage/error/lmdb.rs
+++ b/execution_engine/src/storage/error/lmdb.rs
@@ -10,6 +10,7 @@ use crate::storage::{error::in_memory, global_state::CommitError};
 
 /// Error enum representing possible error states in LMDB interactions.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// LMDB error returned from underlying `lmdb` crate.
     #[error(transparent)]

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -398,5 +398,5 @@ pub fn step_and_run_auction(builder: &mut LmdbWasmTestBuilder, validator_keys: &
         .with_next_era_id(builder.get_era().successor())
         .build();
     builder.step_with_scratch(step_request);
-    builder.write_scratch_to_lmdb();
+    builder.write_scratch_to_db();
 }

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -67,7 +67,7 @@ pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 pub const DEFAULT_MAX_ASSOCIATED_KEYS: u32 = 100;
 /// Default max serialized size of `StoredValue`s.
 #[deprecated(
-    since = "2.2.0",
+    since = "2.3.0",
     note = "not used in `casper-execution-engine` config anymore"
 )]
 pub const DEFAULT_MAX_STORED_VALUE_SIZE: u32 = 8 * 1024 * 1024;

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -65,6 +65,12 @@ pub const DEFAULT_CHAIN_NAME: &str = "casper-execution-engine-testing";
 pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 /// Default maximum number of associated keys.
 pub const DEFAULT_MAX_ASSOCIATED_KEYS: u32 = 100;
+/// Default max serialized size of `StoredValue`s.
+#[deprecated(
+    since = "2.2.0",
+    note = "not used in `casper-execution-engine` config anymore"
+)]
+pub const DEFAULT_MAX_STORED_VALUE_SIZE: u32 = 8 * 1024 * 1024;
 /// Default block time.
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
 /// Default gas price.

--- a/execution_engine_testing/test_support/src/transfer.rs
+++ b/execution_engine_testing/test_support/src/transfer.rs
@@ -239,7 +239,7 @@ pub fn transfer_to_account_multiple_native_transfers(
         }
     }
     if use_scratch {
-        builder.write_scratch_to_lmdb();
+        builder.write_scratch_to_db();
     }
     // flush to disk only after entire block (simulates manual_sync_enabled=true config entry)
     builder.flush_environment();

--- a/execution_engine_testing/test_support/src/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/upgrade_request_builder.rs
@@ -118,7 +118,7 @@ impl UpgradeRequestBuilder {
 }
 
 impl Default for UpgradeRequestBuilder {
-    fn default() -> Self {
+    fn default() -> UpgradeRequestBuilder {
         UpgradeRequestBuilder {
             pre_state_hash: Default::default(),
             current_protocol_version: Default::default(),

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -889,7 +889,7 @@ where
     }
 
     /// Returns the results of all execs.
-    #[deprecated(since = "2.2.0", note = "use `get_exec_result` instead")]
+    #[deprecated(since = "2.3.0", note = "use `get_exec_result` instead")]
     pub fn get_exec_results(&self) -> &Vec<Vec<Rc<ExecutionResult>>> {
         &self.exec_results
     }
@@ -902,7 +902,7 @@ where
     }
 
     /// Returns the results of a specific exec.
-    #[deprecated(since = "2.2.0", note = "use `get_exec_result_owned` instead")]
+    #[deprecated(since = "2.3.0", note = "use `get_exec_result_owned` instead")]
     pub fn get_exec_result(&self, index: usize) -> Option<&Vec<Rc<ExecutionResult>>> {
         self.exec_results.get(index)
     }
@@ -1203,7 +1203,7 @@ where
     }
 
     /// Gets [`UnbondingPurses`].
-    #[deprecated(since = "2.2.0", note = "use `get_withdraw_purses` instead")]
+    #[deprecated(since = "2.3.0", note = "use `get_withdraw_purses` instead")]
     pub fn get_withdraws(&mut self) -> UnbondingPurses {
         let withdraw_purses = self.get_withdraw_purses();
         let unbonding_purses: UnbondingPurses = withdraw_purses

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -59,7 +59,7 @@ use casper_types::{
     runtime_args,
     system::{
         auction::{
-            Bids, EraValidators, UnbondingPurses, ValidatorWeights, WithdrawPurses,
+            Bids, EraValidators, UnbondingPurse, UnbondingPurses, ValidatorWeights, WithdrawPurses,
             ARG_ERA_END_TIMESTAMP_MILLIS, ARG_EVICTED_VALIDATORS, AUCTION_DELAY_KEY, ERA_ID_KEY,
             METHOD_RUN_AUCTION, UNBONDING_DELAY_KEY,
         },
@@ -413,10 +413,8 @@ impl LmdbWasmTestBuilder {
     }
 
     /// Commit scratch to global state, and reset the scratch cache.
-    #[deprecated(since = "2.0.0", note = "renamed to `write_scratch_to_lmdb`")]
-    pub fn write_scratch_to_db(
-        &mut self,
-    ) -> &mut Self {
+    #[deprecated(since = "2.2.0", note = "renamed to `write_scratch_to_lmdb`")]
+    pub fn write_scratch_to_db(&mut self) -> &mut Self {
         self.write_scratch_to_lmdb()
     }
 
@@ -896,11 +894,23 @@ where
         Some(exec_results.iter().map(Rc::clone).collect())
     }
 
-    /// Returns the results of a specific exec.
-    pub fn get_exec_result(&self, index: usize) -> Option<Vec<Rc<ExecutionResult>>> {
+    /// Returns the results of all execs.
+    #[deprecated(since = "2.2.0", note = "use `get_exec_result` instead")]
+    pub fn get_exec_results(&self) -> &Vec<Vec<Rc<ExecutionResult>>> {
+        &self.exec_results
+    }
+
+    /// Returns the owned results of a specific exec.
+    pub fn get_exec_result_owned(&self, index: usize) -> Option<Vec<Rc<ExecutionResult>>> {
         let exec_results = self.exec_results.get(index)?;
 
         Some(exec_results.iter().map(Rc::clone).collect())
+    }
+
+    /// Returns the results of a specific exec.
+    #[deprecated(since = "2.2.0", note = "use `get_exec_result_owned` instead")]
+    pub fn get_exec_result(&self, index: usize) -> Option<&Vec<Rc<ExecutionResult>>> {
+        self.exec_results.get(index)
     }
 
     /// Returns a count of exec results.
@@ -1064,7 +1074,7 @@ where
     /// Returns a `Vec<Gas>` representing execution consts.
     pub fn exec_costs(&self, index: usize) -> Vec<Gas> {
         let exec_results = self
-            .get_exec_result(index)
+            .get_exec_result_owned(index)
             .expect("should have exec response");
         utils::get_exec_costs(exec_results)
     }
@@ -1100,7 +1110,7 @@ where
 
     /// Returns the error message of the last exec.
     pub fn exec_error_message(&self, index: usize) -> Option<String> {
-        let response = self.get_exec_result(index)?;
+        let response = self.get_exec_result_owned(index)?;
         Some(utils::get_error_message(response))
     }
 
@@ -1168,7 +1178,7 @@ where
     }
 
     /// Gets [`WithdrawPurses`].
-    pub fn get_withdraws(&mut self) -> WithdrawPurses {
+    pub fn get_withdraw_purses(&mut self) -> WithdrawPurses {
         let correlation_id = CorrelationId::new();
         let state_root_hash = self.get_post_state_hash();
 
@@ -1196,6 +1206,25 @@ where
         }
 
         ret
+    }
+
+    /// Gets [`UnbondingPurses`].
+    #[deprecated(since = "2.2.0", note = "use `get_withdraw_purses` instead")]
+    pub fn get_withdraws(&mut self) -> UnbondingPurses {
+        let withdraw_purses = self.get_withdraw_purses();
+        let unbonding_purses: UnbondingPurses = withdraw_purses
+            .iter()
+            .map(|(key, withdraw_purse)| {
+                (
+                    key.to_owned(),
+                    withdraw_purse
+                        .iter()
+                        .map(|withdraw_purse| withdraw_purse.to_owned().into())
+                        .collect::<Vec<UnbondingPurse>>(),
+                )
+            })
+            .collect::<BTreeMap<AccountHash, Vec<UnbondingPurse>>>();
+        unbonding_purses
     }
 
     /// Gets all `[Key::Balance]`s in global state.

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -359,7 +359,7 @@ impl LmdbWasmTestBuilder {
     }
 
     /// Execute and commit transforms from an ExecuteRequest into a scratch global state.
-    /// You MUST call write_scratch_to_lmdb to flush these changes to LmdbGlobalState.
+    /// You MUST call write_scratch_to_db to flush these changes to LmdbGlobalState.
     pub fn scratch_exec_and_commit(&mut self, mut exec_request: ExecuteRequest) -> &mut Self {
         if self.scratch_engine_state.is_none() {
             self.scratch_engine_state = Some(self.engine_state.get_scratch_engine_state());
@@ -400,22 +400,16 @@ impl LmdbWasmTestBuilder {
     }
 
     /// Commit scratch to global state, and reset the scratch cache.
-    pub fn write_scratch_to_lmdb(&mut self) -> &mut Self {
+    pub fn write_scratch_to_db(&mut self) -> &mut Self {
         let prestate_hash = self.post_state_hash.expect("Should have genesis hash");
         if let Some(scratch) = self.scratch_engine_state.take() {
             let new_state_root = self
                 .engine_state
-                .write_scratch_to_lmdb(prestate_hash, scratch.into_inner())
+                .write_scratch_to_db(prestate_hash, scratch.into_inner())
                 .unwrap();
             self.post_state_hash = Some(new_state_root);
         }
         self
-    }
-
-    /// Commit scratch to global state, and reset the scratch cache.
-    #[deprecated(since = "2.2.0", note = "renamed to `write_scratch_to_lmdb`")]
-    pub fn write_scratch_to_db(&mut self) -> &mut Self {
-        self.write_scratch_to_lmdb()
     }
 
     /// run step against scratch global state.

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -412,6 +412,14 @@ impl LmdbWasmTestBuilder {
         self
     }
 
+    /// Commit scratch to global state, and reset the scratch cache.
+    #[deprecated(since = "2.0.0", note = "renamed to `write_scratch_to_lmdb`")]
+    pub fn write_scratch_to_db(
+        &mut self,
+    ) -> &mut Self {
+        self.write_scratch_to_lmdb()
+    }
+
     /// run step against scratch global state.
     pub fn step_with_scratch(&mut self, step_request: StepRequest) -> &mut Self {
         if self.scratch_engine_state.is_none() {

--- a/execution_engine_testing/tests/benches/transfer_bench.rs
+++ b/execution_engine_testing/tests/benches/transfer_bench.rs
@@ -350,7 +350,7 @@ fn transfer_to_account_multiple_native_transfers(
         }
     }
     if use_scratch {
-        builder.write_scratch_to_lmdb();
+        builder.write_scratch_to_db();
     }
     // flush to disk only after entire block (simulates manual_sync_enabled=true config entry)
     builder.flush_environment();

--- a/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
@@ -77,7 +77,7 @@ fn should_raise_auth_failure_with_invalid_key() {
         .commit();
 
     let deploy_result = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")
         .get(0)
         .cloned()
@@ -127,7 +127,7 @@ fn should_raise_auth_failure_with_invalid_keys() {
         .commit();
 
     let deploy_result = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")
         .get(0)
         .cloned()
@@ -223,7 +223,7 @@ fn should_raise_deploy_authorization_failure() {
 
     {
         let deploy_result = builder
-            .get_exec_result(0)
+            .get_exec_result_owned(0)
             .expect("should have exec response")
             .get(0)
             .cloned()
@@ -285,7 +285,7 @@ fn should_raise_deploy_authorization_failure() {
 
     {
         let deploy_result = builder
-            .get_exec_result(0)
+            .get_exec_result_owned(0)
             .expect("should have exec response")
             .get(0)
             .cloned()
@@ -450,7 +450,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
     };
     builder.clear_results().exec(exec_request_3).commit();
     let deploy_result = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")
         .get(0)
         .cloned()
@@ -538,7 +538,7 @@ fn should_not_authorize_transfer_without_deploy_key_threshold() {
     builder.exec(transfer_request_1).commit();
 
     let response = builder
-        .get_exec_result(3)
+        .get_exec_result_owned(3)
         .expect("should have response")
         .first()
         .cloned()

--- a/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
@@ -25,7 +25,9 @@ fn call_get_arg(args: RuntimeArgs) -> Result<(), String> {
         return Ok(());
     }
 
-    let response = builder.get_exec_result(0).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(0)
+        .expect("should have a response");
 
     let error_message = utils::get_error_message(response);
 

--- a/execution_engine_testing/tests/src/test/contract_api/transfer.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer.rs
@@ -458,7 +458,7 @@ fn should_fail_when_insufficient_funds() {
         .commit();
 
     let exec_results = builder
-        .get_exec_result(2)
+        .get_exec_result_owned(2)
         .expect("should have exec response");
     assert_eq!(exec_results.len(), 1);
     let exec_result = exec_results[0].as_error().expect("should have error");

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
@@ -55,7 +55,7 @@ fn should_transfer_to_account_with_correct_balances() {
         .scratch_exec_and_commit(exec_builder.build())
         .expect_success();
 
-    builder.write_scratch_to_lmdb();
+    builder.write_scratch_to_db();
     builder.flush_environment();
 
     assert_ne!(
@@ -143,7 +143,7 @@ fn should_transfer_from_default_and_then_to_another_account() {
         .scratch_exec_and_commit(exec_builder.build())
         .expect_failure();
 
-    builder.write_scratch_to_lmdb();
+    builder.write_scratch_to_db();
     builder.flush_environment();
 
     assert_ne!(

--- a/execution_engine_testing/tests/src/test/contract_headers.rs
+++ b/execution_engine_testing/tests/src/test/contract_headers.rs
@@ -108,7 +108,7 @@ fn should_enforce_intended_execution_contexts() {
         .expect("should have package hash");
 
     let _foo = builder
-        .get_exec_result(3)
+        .get_exec_result_owned(3)
         .expect("should have exec response");
 
     let account = builder

--- a/execution_engine_testing/tests/src/test/deploy/preconditions.rs
+++ b/execution_engine_testing/tests/src/test/deploy/preconditions.rs
@@ -41,7 +41,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
         .commit();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(&response);
@@ -72,7 +72,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
         .commit();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(&response);
@@ -110,7 +110,7 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
         .commit();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(&response);

--- a/execution_engine_testing/tests/src/test/gas_counter.rs
+++ b/execution_engine_testing/tests/src/test/gas_counter.rs
@@ -60,7 +60,9 @@ fn should_fail_to_overflow_gas_counter() {
 
     builder.exec(exec_request).commit();
 
-    let responses = builder.get_exec_result(0).expect("should have response");
+    let responses = builder
+        .get_exec_result_owned(0)
+        .expect("should have response");
     let response = responses.get(0).expect("should have first element");
 
     let lhs = response.as_error().expect("should have error");

--- a/execution_engine_testing/tests/src/test/regression/ee_1160.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1160.rs
@@ -54,7 +54,7 @@ fn ee_1160_wasmless_transfer_should_empty_account() {
         .expect_success()
         .commit();
 
-    let last_result = builder.get_exec_result(0).unwrap();
+    let last_result = builder.get_exec_result_owned(0).unwrap();
     let last_result = &last_result[0];
 
     assert!(last_result.as_error().is_none(), "{:?}", last_result);
@@ -116,7 +116,7 @@ fn ee_1160_transfer_larger_than_balance_should_fail() {
     )
     .expect("gas overflow");
 
-    let last_result = builder.get_exec_result(0).unwrap();
+    let last_result = builder.get_exec_result_owned(0).unwrap();
     let last_result = &last_result[0];
     assert_eq!(
         balance_before - wasmless_transfer_motes.value(),
@@ -182,7 +182,7 @@ fn ee_1160_large_wasmless_transfer_should_avoid_overflow() {
         balance_after
     );
 
-    let last_result = builder.get_exec_result(0).unwrap();
+    let last_result = builder.get_exec_result_owned(0).unwrap();
     let last_result = &last_result[0];
     assert_eq!(last_result.cost(), wasmless_transfer_gas_cost);
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1163.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1163.rs
@@ -46,7 +46,7 @@ fn should_charge_for_user_error(
     let proposer_purse_balance_after = builder.get_proposer_purse_balance();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have result")
         .get(0)
         .cloned()
@@ -166,7 +166,7 @@ fn should_properly_charge_fixed_cost_with_nondefault_gas_price() {
     let proposer_purse_balance_after = builder.get_proposer_purse_balance();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have result")
         .get(0)
         .cloned()

--- a/execution_engine_testing/tests/src/test/regression/ee_532.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_532.rs
@@ -27,7 +27,7 @@ fn should_run_ee_532_get_uref_regression_test() {
         .commit();
 
     let deploy_result = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")
         .get(0)
         .cloned()

--- a/execution_engine_testing/tests/src/test/regression/ee_572.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_572.rs
@@ -81,7 +81,7 @@ fn should_run_ee_572_regression() {
     // Attempt to forge a new URef with escalated privileges
     let response = builder
         .exec(exec_request_4)
-        .get_exec_result(3)
+        .get_exec_result_owned(3)
         .expect("should have a response");
 
     let error_message = utils::get_error_message(response);

--- a/execution_engine_testing/tests/src/test/regression/ee_597.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_597.rs
@@ -47,7 +47,9 @@ fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
         .exec(exec_request)
         .commit();
 
-    let response = builder.get_exec_result(0).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(0)
+        .expect("should have a response");
 
     let error_message = utils::get_error_message(response);
 

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -87,7 +87,9 @@ fn should_fail_unbonding_more_than_it_was_staked_ee_598_regression() {
 
     builder.exec(exec_request_2).commit();
 
-    let response = builder.get_exec_result(1).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(1)
+        .expect("should have a response");
     let error_message = utils::get_error_message(response);
 
     // Error::UnbondTooLarge,

--- a/execution_engine_testing/tests/src/test/regression/ee_771.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_771.rs
@@ -22,7 +22,9 @@ fn should_run_ee_771_regression() {
         .exec(exec_request)
         .commit();
 
-    let response = builder.get_exec_result(0).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(0)
+        .expect("should have a response");
 
     let error = response[0].as_error().expect("should have error");
     assert_eq!(

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -116,7 +116,7 @@ fn should_run_ee_966_cant_have_too_much_initial_memory() {
     builder.exec(exec_request).commit();
 
     let exec_response = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = exec_response.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Interpreter(_)));
@@ -168,7 +168,7 @@ fn should_run_ee_966_cant_have_too_much_max_memory() {
     builder.exec(exec_request).commit();
 
     let exec_response = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = exec_response.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Interpreter(_)));
@@ -191,7 +191,7 @@ fn should_run_ee_966_cant_have_way_too_much_max_memory() {
     builder.exec(exec_request).commit();
 
     let exec_response = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = exec_response.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Interpreter(_)));
@@ -212,7 +212,7 @@ fn should_run_ee_966_cant_have_larger_initial_than_max_memory() {
     builder.exec(exec_request).commit();
 
     let exec_response = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = exec_response.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Interpreter(_)));
@@ -235,7 +235,7 @@ fn should_run_ee_966_regression_fail_when_growing_mem_past_max() {
     builder.exec(exec_request).commit();
 
     let results = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = results.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Revert(ApiError::OutOfMemory)));
@@ -262,7 +262,7 @@ fn should_run_ee_966_regression_when_growing_mem_after_upgrade() {
     //
 
     let results = &builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("should have exec response")[0];
     let error = results.as_error().expect("should have error");
     assert_matches!(error, Error::Exec(ExecError::Revert(ApiError::OutOfMemory)));

--- a/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
+++ b/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
@@ -91,7 +91,7 @@ fn contract_transforms_should_be_ordered_in_the_journal() {
         .expect_success()
         .commit();
 
-    let exec_result = builder.get_exec_result(1).unwrap();
+    let exec_result = builder.get_exec_result_owned(1).unwrap();
     assert_eq!(exec_result.len(), 1);
     let journal = exec_result[0].execution_journal();
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -291,7 +291,9 @@ fn should_fail_bonding_with_insufficient_funds() {
 
     builder.exec(exec_request_2).commit();
 
-    let response = builder.get_exec_result(1).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(1)
+        .expect("should have a response");
 
     assert_eq!(response.len(), 1);
     let exec_result = response[0].as_error().expect("should have error");
@@ -347,7 +349,9 @@ fn should_fail_unbonding_validator_with_locked_funds() {
 
     builder.exec(exec_request_2).commit();
 
-    let response = builder.get_exec_result(0).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(0)
+        .expect("should have a response");
 
     let error_message = utils::get_error_message(response);
 
@@ -381,7 +385,9 @@ fn should_fail_unbonding_validator_without_bonding_first() {
 
     builder.exec(exec_request).commit();
 
-    let response = builder.get_exec_result(0).expect("should have a response");
+    let response = builder
+        .get_exec_result_owned(0)
+        .expect("should have a response");
 
     let error_message = utils::get_error_message(response);
 

--- a/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
@@ -46,7 +46,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
         .exec(exec_request)
         .expect_success()
         .commit()
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let account_1_request =
@@ -56,7 +56,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     let account_1_response = builder
         .exec(account_1_request)
         .commit()
-        .get_exec_result(1)
+        .get_exec_result_owned(1)
         .expect("there should be a response");
 
     let error_message = utils::get_error_message(account_1_response);
@@ -136,7 +136,7 @@ fn should_forward_payment_execution_runtime_error() {
     );
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let execution_result = utils::get_success_result(&response);
@@ -205,7 +205,7 @@ fn should_forward_payment_execution_gas_limit_error() {
     );
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let execution_result = utils::get_success_result(&response);
@@ -250,7 +250,7 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
         .commit();
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let execution_result = utils::get_success_result(&response);
@@ -301,7 +301,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
     );
 
     let response = builder
-        .get_exec_result(0)
+        .get_exec_result_owned(0)
         .expect("there should be a response");
 
     let success_result = utils::get_success_result(&response);

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -119,7 +119,7 @@ pub fn execute_finalized_block(
             )?;
 
             state_root_hash =
-                engine_state.write_scratch_to_lmdb(state_root_hash, scratch_state.into_inner())?;
+                engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
 
             // In this flow we execute using a recent state root hash where the system contract
             // registry is guaranteed to exist.
@@ -138,7 +138,7 @@ pub fn execute_finalized_block(
             // Finally, the new state-root-hash from the cumulative changes to global state is
             // returned when they are written to LMDB.
             state_root_hash =
-                engine_state.write_scratch_to_lmdb(state_root_hash, scratch_state.into_inner())?;
+                engine_state.write_scratch_to_db(state_root_hash, scratch_state.into_inner())?;
             None
         };
 

--- a/node/src/components/rpc_server/rpcs/speculative_exec.rs
+++ b/node/src/components/rpc_server/rpcs/speculative_exec.rs
@@ -6,7 +6,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use casper_execution_engine::core::engine_state;
+use casper_execution_engine::core::engine_state::Error as EngineStateError;
 use casper_json_rpc::ReservedErrorCode;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
@@ -125,43 +125,45 @@ impl RpcWithParams for SpeculativeExec {
             )),
             Err(error) => {
                 let rpc_error = match error {
-                    engine_state::Error::RootNotFound(_) => {
-                        Error::new(ErrorCode::NoSuchStateRoot, "")
-                    }
-                    engine_state::Error::WasmPreprocessing(error) => {
+                    EngineStateError::RootNotFound(_) => Error::new(ErrorCode::NoSuchStateRoot, ""),
+                    EngineStateError::WasmPreprocessing(error) => {
                         Error::new(ErrorCode::InvalidDeploy, &format!("{}", error))
                     }
-                    engine_state::Error::InvalidDeployItemVariant(error) => {
+                    EngineStateError::InvalidDeployItemVariant(error) => {
                         Error::new(ErrorCode::InvalidDeploy, &error)
                     }
-                    engine_state::Error::InvalidProtocolVersion(_) => Error::new(
+                    EngineStateError::InvalidProtocolVersion(_) => Error::new(
                         ErrorCode::InvalidDeploy,
                         &format!("deploy used invalid protocol version {}", error),
                     ),
-                    engine_state::Error::Deploy => Error::new(ErrorCode::InvalidDeploy, ""),
-                    engine_state::Error::Genesis(_)
-                    | engine_state::Error::WasmSerialization(_)
-                    | engine_state::Error::Exec(_)
-                    | engine_state::Error::Storage(_)
-                    | engine_state::Error::Authorization
-                    | engine_state::Error::InsufficientPayment
-                    | engine_state::Error::GasConversionOverflow
-                    | engine_state::Error::Finalization
-                    | engine_state::Error::Bytesrepr(_)
-                    | engine_state::Error::Mint(_)
-                    | engine_state::Error::InvalidKeyVariant
-                    | engine_state::Error::ProtocolUpgrade(_)
-                    | engine_state::Error::CommitError(_)
-                    | engine_state::Error::MissingSystemContractRegistry
-                    | engine_state::Error::MissingSystemContractHash(_)
-                    | engine_state::Error::RuntimeStackOverflow
-                    | engine_state::Error::FailedToGetWithdrawKeys
-                    | engine_state::Error::FailedToGetStoredWithdraws
-                    | engine_state::Error::FailedToGetWithdrawPurses
-                    | engine_state::Error::FailedToRetrieveUnbondingDelay
-                    | engine_state::Error::FailedToRetrieveEraId => {
+                    EngineStateError::Deploy => Error::new(ErrorCode::InvalidDeploy, ""),
+                    EngineStateError::Genesis(_)
+                    | EngineStateError::WasmSerialization(_)
+                    | EngineStateError::Exec(_)
+                    | EngineStateError::Storage(_)
+                    | EngineStateError::Authorization
+                    | EngineStateError::InsufficientPayment
+                    | EngineStateError::GasConversionOverflow
+                    | EngineStateError::Finalization
+                    | EngineStateError::Bytesrepr(_)
+                    | EngineStateError::Mint(_)
+                    | EngineStateError::InvalidKeyVariant
+                    | EngineStateError::ProtocolUpgrade(_)
+                    | EngineStateError::CommitError(_)
+                    | EngineStateError::MissingSystemContractRegistry
+                    | EngineStateError::MissingSystemContractHash(_)
+                    | EngineStateError::RuntimeStackOverflow
+                    | EngineStateError::FailedToGetWithdrawKeys
+                    | EngineStateError::FailedToGetStoredWithdraws
+                    | EngineStateError::FailedToGetWithdrawPurses
+                    | EngineStateError::FailedToRetrieveUnbondingDelay
+                    | EngineStateError::FailedToRetrieveEraId => {
                         Error::new(ReservedErrorCode::InternalError, &format!("{}", error))
                     }
+                    _ => Error::new(
+                        ReservedErrorCode::InternalError,
+                        &format!("Unhandled engine state error: {}", error),
+                    ),
                 };
                 Err(rpc_error)
             }


### PR DESCRIPTION
Fixes #3072 #3074 

This PR reverts the breaking changes in `casper-test-support` since the v1.4.6 release.
The changes in `casper-execution-engine` cannot be reverted in a backwards compatible way, so this PR adds `non-exhaustive` to enums and restores `write_scratch_to_db` in a deprecated state.

Changes were found using the `cargo-public-api` tool.
