### PR TITLE
Bring feat-2.0 up to date with dev since `940c508`

### DIFF
--- a/hashing/src/error.rs
+++ b/hashing/src/error.rs
@@ -1,8 +1,20 @@
 //! Errors in constructing and validating indexed Merkle proofs, chunks with indexed Merkle proofs.
 use crate::{ChunkWithProof, Digest};
 
+/// Possible hashing errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Incorrect digest length {0}, expected length {}.", Digest::LENGTH)]
+    /// The digest length was an incorrect size.
+    IncorrectDigestLength(usize),
+    /// There was a decoding error.
+    #[error("Base16 decode error {0}.")]
+    Base16DecodeError(base16::DecodeError),
+}
+
 /// Error validating a Merkle proof of a chunk.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MerkleVerificationError {
     /// Index out of bounds.
     #[error("Index out of bounds. Count: {count}, index: {index}")]
@@ -33,6 +45,7 @@ pub enum MerkleVerificationError {
 
 /// Error validating a chunk with proof.
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum ChunkWithProofVerificationError {
     /// Indexed Merkle proof verification error.
     #[error(transparent)]
@@ -61,6 +74,7 @@ pub enum ChunkWithProofVerificationError {
 
 /// Error during the construction of a Merkle proof.
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum MerkleConstructionError {
     /// Chunk index was out of bounds.
     #[error(

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 
 mod chunk_with_proof;
-pub mod error;
+mod error;
 mod indexed_merkle_proof;
 
 use std::{
@@ -35,18 +35,9 @@ use casper_types::{
     checksummed_hex, CLType, CLTyped,
 };
 pub use chunk_with_proof::ChunkWithProof;
-pub use error::MerkleConstructionError;
-
-/// Possible hashing errors.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Incorrect digest length {0}, expected length {}.", Digest::LENGTH)]
-    /// The digest length was an incorrect size.
-    IncorrectDigestLength(usize),
-    /// There was a decoding error.
-    #[error("Base16 decode error {0}.")]
-    Base16DecodeError(base16::DecodeError),
-}
+pub use error::{
+    ChunkWithProofVerificationError, Error, MerkleConstructionError, MerkleVerificationError,
+};
 
 /// The output of the hash function.
 #[derive(Copy, Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Default, JsonSchema)]
@@ -123,6 +114,12 @@ impl Digest {
             result.copy_from_slice(slice);
         });
         Digest(result)
+    }
+
+    /// Provides the same functionality as [`hash_merkle_tree`].
+    #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
+    pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
+        Digest::hash_merkle_tree(vec)
     }
 
     /// Returns the underlying BLAKE2b hash bytes

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -116,7 +116,7 @@ impl Digest {
         Digest(result)
     }
 
-    /// Provides the same functionality as [`hash_merkle_tree`].
+    /// Provides the same functionality as [`Digest::hash_merkle_tree`].
     #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
     pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
         Digest::hash_merkle_tree(vec)

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -42,7 +42,7 @@ const MAX_EVENT_COUNT: u32 = 100_000_000;
 const BUFFER_LENGTH: u32 = EVENT_COUNT / 2;
 /// The maximum amount of time to wait for a test server to complete.  If this time is exceeded, the
 /// test has probably hung, and should be deemed to have failed.
-const MAX_TEST_TIME: Duration = Duration::from_secs(1);
+const MAX_TEST_TIME: Duration = Duration::from_secs(2);
 /// The duration of the sleep called between each event being sent by the server.
 const DELAY_BETWEEN_EVENTS: Duration = Duration::from_millis(1);
 

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -10,7 +10,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
 
 use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
-use casper_hashing::{error::ChunkWithProofVerificationError, Digest};
+use casper_hashing::{ChunkWithProofVerificationError, Digest};
 use casper_types::EraId;
 
 use crate::types::{BlockHash, BlockHeader};

--- a/utils/global-state-update-gen/src/validators/validators_manager.rs
+++ b/utils/global-state-update-gen/src/validators/validators_manager.rs
@@ -262,7 +262,9 @@ impl ValidatorsUpdateManager {
             .get_bids()
             .into_iter()
             .filter(|(pub_key, bid)| {
-                bid.staked_amount() >= min_bid && !seigniorage_recipients.contains_key(pub_key)
+                bid.total_staked_amount()
+                    .map_or(true, |amount| amount >= *min_bid)
+                    && !seigniorage_recipients.contains_key(pub_key)
             })
             .map(|(pub_key, _bid)| pub_key)
             .collect()

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -16,6 +16,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -72,8 +73,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 10.0
-    await_until_era_n 1 'true'
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Populate global state -> native + wasm transfers.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -27,6 +27,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,8 +92,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Add bid non-genesis node and start

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -25,6 +25,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -106,7 +107,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -25,6 +25,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -106,7 +107,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -26,6 +26,7 @@ source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/assets/upgrade.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE.sh"
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,7 +92,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -26,6 +26,7 @@ source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/assets/upgrade.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE.sh"
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -91,7 +92,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
-    await_until_era_n 1
+
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Stage nodes 2-9 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
@@ -14,6 +14,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -70,8 +71,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Upgrade node-6 from stage.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -21,6 +21,7 @@
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/views/utils.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -84,7 +85,8 @@ function _step_01()
 function _step_02()
 {
     log_step_upgrades 2 "awaiting until era 2"
-    await_until_era_n 2
+
+    do_wait_until_era '2' 'false' '180'
 }
 
 # Step 03: Stage nodes 1-5 and upgrade.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -17,6 +17,7 @@
 
 source "$NCTL/sh/utils/main.sh"
 source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL/sh/scenarios/common/itst.sh"
 
 # ----------------------------------------------------------------
 # MAIN
@@ -69,8 +70,7 @@ function _step_02()
 {
     log_step_upgrades 2 "awaiting genesis era completion"
 
-    sleep 60.0
-    await_until_era_n 1
+    do_await_genesis_era_to_complete 'false'
 }
 
 # Step 03: Query auction info

--- a/utils/nctl/sh/scenarios/client.sh
+++ b/utils/nctl/sh/scenarios/client.sh
@@ -246,7 +246,7 @@ function test_sign_deploy() {
 
     # Test Valid JSON
     if [ -f "$OUTPUT_FILE" ]; then
-        cat "$OUTPUT_FILE" | jq
+        cat "$OUTPUT_FILE" | jq '.'
     fi
 
     SIGNER_1=$(jq -r '.approvals[0].signer' "$OUTPUT_FILE")
@@ -336,7 +336,7 @@ function test_make_deploy() {
 
     # Test Valid JSON
     if [ -f "$DEPLOY_FILE" ]; then
-        cat "$DEPLOY_FILE" | jq
+        cat "$DEPLOY_FILE" | jq '.'
     fi
 
     # Test Inputs Match Output
@@ -810,7 +810,7 @@ function test_make_transfer() {
 
     # Test Valid JSON
     if [ -f "$DEPLOY_FILE" ]; then
-        cat "$DEPLOY_FILE" | jq
+        cat "$DEPLOY_FILE" | jq '.'
     fi
 
     # Test Inputs Match Output
@@ -907,7 +907,7 @@ function test_get_chainspec() {
     compare_md5sum "$OUTPUT_PATH/rpc_chainspec.toml" "$(get_path_to_node 1)/config/1_0_0/chainspec.toml"
     compare_md5sum "$OUTPUT_PATH/rpc_accounts.toml" "$(get_path_to_node 1)/config/1_0_0/accounts.toml"
     # Test JSON OUTPUT is Valid, jq will balk if invalid json
-    get_chainspec_json_from_rpc | jq
+    get_chainspec_json_from_rpc | jq '.'
 }
 
 # casper-client get-block
@@ -1418,7 +1418,7 @@ function test_with_jq() {
     log "... testing client returned valid json"
 
     # Test Valid Json
-    echo "$JSON_OUTPUT" | jq
+    echo "$JSON_OUTPUT" | jq '.'
 }
 
 # cleans up test

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -46,9 +46,43 @@ function log_step() {
 }
 
 function do_await_genesis_era_to_complete() {
-    log_step "awaiting genesis era to complete"
+    local LOG_STEP=${1:-'true'}
+    local TIMEOUT=${2:-'120'}
+
+    if [ "$LOG_STEP" = "true" ]; then
+        log_step "awaiting genesis era to complete: timeout=$TIMEOUT"
+    fi
+
     while [ "$(get_chain_era)" -lt "1" ]; do
         sleep 1.0
+        TIMEOUT=$((TIMEOUT-1))
+        if [ "$TIMEOUT" = '0' ]; then
+            log "ERROR: Timed out before genesis era completed"
+            exit 1
+        else
+            log "... waiting for genesis era to complete: timeout=$TIMEOUT"
+        fi
+    done
+}
+
+function do_wait_until_era() {
+    local WAIT_FOR_ERA=${1}
+    local LOG_STEP=${2:-'true'}
+    local TIMEOUT=${3:-'120'}
+
+    if [ "$LOG_STEP" = "true" ]; then
+        log_step "waiting until era $WAIT_FOR_ERA: timeout=$TIMEOUT"
+    fi
+
+    while [ "$(get_chain_era)" -lt "$WAIT_FOR_ERA" ]; do
+        sleep 1.0
+        TIMEOUT=$((TIMEOUT-1))
+        if [ "$TIMEOUT" = '0' ]; then
+            log "ERROR: Timed out before reaching era $WAIT_FOR_ERA"
+            exit 1
+        else
+            log "... waiting for era $WAIT_FOR_ERA to complete: timeout=$TIMEOUT"
+        fi
     done
 }
 


### PR DESCRIPTION
This PR brings all recent commits since [940c508](https://github.com/casper-network/casper-node/commit/940c508d745a2aff75be6e5a796a0dddd2c9fc25) from the dev branch to the feat-2.0 branch.

Merge had no conflicts.
