### PR TITLE
Add the option for seeding accounts with tokens in global-state-update-gen

### DIFF
--- a/utils/global-state-update-gen/src/main.rs
+++ b/utils/global-state-update-gen/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
                     Arg::with_name("validator")
                         .short("v")
                         .long("validator")
-                        .value_name("KEY,STAKE")
+                        .value_name("KEY,STAKE[,BALANCE]")
                         .help("A validator config in the format 'public_key,stake[,balance]'")
                         .takes_value(true)
                         .required(true)

--- a/utils/global-state-update-gen/src/main.rs
+++ b/utils/global-state-update-gen/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
                         .short("v")
                         .long("validator")
                         .value_name("KEY,STAKE")
-                        .help("A new validator with their stake")
+                        .help("A validator config in the format 'public_key,stake[,balance]'")
                         .takes_value(true)
                         .required(true)
                         .multiple(true)

--- a/utils/global-state-update-gen/src/utils/state_tracker.rs
+++ b/utils/global-state-update-gen/src/utils/state_tracker.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use rand::Rng;
 
-use casper_types::{AccessRights, CLValue, Key, StoredValue, URef, U512};
+use casper_types::{
+    account::Account, AccessRights, CLValue, Key, PublicKey, StoredValue, URef, U512,
+};
 
 use crate::utils::print_entry;
 
@@ -70,5 +72,21 @@ impl StateTracker {
         self.increase_supply(amount);
 
         new_purse
+    }
+
+    /// Creates a new account for the given public key and seeds it with the given amount of
+    /// tokens.
+    pub fn create_account(&mut self, pub_key: PublicKey, amount: U512) -> Account {
+        let main_purse = self.create_purse(amount);
+
+        let account_hash = pub_key.to_account_hash();
+        let account = Account::create(account_hash, Default::default(), main_purse);
+
+        self.write_entry(
+            Key::Account(account_hash),
+            StoredValue::Account(account.clone()),
+        );
+
+        account
     }
 }

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -1,27 +1,60 @@
 mod validators_manager;
 
+use std::collections::BTreeMap;
+
 use clap::ArgMatches;
 
+use casper_types::{AsymmetricType, PublicKey, U512};
+
 use validators_manager::ValidatorsUpdateManager;
+
+pub struct ValidatorConfig {
+    stake: U512,
+    maybe_balance: Option<U512>,
+}
 
 pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
     let data_dir = matches.value_of("data_dir").unwrap_or(".");
     let state_hash = matches.value_of("hash").unwrap();
     let validators = match matches.values_of("validator") {
-        None => vec![],
+        None => BTreeMap::new(),
         Some(values) => values
             .map(|validator_def| {
                 let mut fields = validator_def.split(',').map(str::to_owned);
-                let field1 = fields.next().unwrap();
-                let field2 = fields.next().unwrap();
-                (field1, field2)
+
+                let pub_key_str = fields
+                    .next()
+                    .expect("validator config should contain a public key");
+                let pub_key = PublicKey::from_hex(pub_key_str.as_bytes())
+                    .expect("validator config should have a valid public key");
+
+                let stake_str = fields
+                    .next()
+                    .expect("validator config should contain a stake");
+                let stake =
+                    U512::from_dec_str(&stake_str).expect("stake should be a valid decimal number");
+
+                let maybe_balance_str = fields.next();
+                let maybe_balance = maybe_balance_str.as_ref().map(|balance_str| {
+                    U512::from_dec_str(balance_str)
+                        .expect("balance should be a valid decimal number")
+                });
+
+                (
+                    pub_key,
+                    ValidatorConfig {
+                        stake,
+                        maybe_balance,
+                    },
+                )
             })
             .collect(),
     };
 
-    let mut validators_upgrade_manager = ValidatorsUpdateManager::new(data_dir, state_hash);
+    let mut validators_upgrade_manager =
+        ValidatorsUpdateManager::new(data_dir, state_hash, validators);
 
-    validators_upgrade_manager.perform_update(validators);
+    validators_upgrade_manager.perform_update();
 
     validators_upgrade_manager.print_writes();
 }

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -10,7 +10,7 @@ use validators_manager::ValidatorsUpdateManager;
 
 pub struct ValidatorConfig {
     stake: U512,
-    maybe_balance: Option<U512>,
+    maybe_new_balance: Option<U512>,
 }
 
 pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
@@ -34,8 +34,8 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
                 let stake =
                     U512::from_dec_str(&stake_str).expect("stake should be a valid decimal number");
 
-                let maybe_balance_str = fields.next();
-                let maybe_balance = maybe_balance_str.as_ref().map(|balance_str| {
+                let maybe_new_balance_str = fields.next();
+                let maybe_new_balance = maybe_new_balance_str.as_ref().map(|balance_str| {
                     U512::from_dec_str(balance_str)
                         .expect("balance should be a valid decimal number")
                 });
@@ -44,7 +44,7 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
                     pub_key,
                     ValidatorConfig {
                         stake,
-                        maybe_balance,
+                        maybe_new_balance,
                     },
                 )
             })

--- a/utils/global-state-update-gen/src/validators/validators_manager.rs
+++ b/utils/global-state-update-gen/src/validators/validators_manager.rs
@@ -99,7 +99,7 @@ impl ValidatorsUpdateManager {
         // If the account already existed, it will get overwritten.
         for (pub_key, validator_cfg) in &self.validators {
             if validator_cfg.stake == U512::zero() {
-                let balance = validator_cfg.maybe_balance.unwrap_or_else(U512::zero);
+                let balance = validator_cfg.maybe_new_balance.unwrap_or_else(U512::zero);
                 let _ = self.state_tracker.create_account(pub_key.clone(), balance);
             }
         }
@@ -107,6 +107,7 @@ impl ValidatorsUpdateManager {
 
     /// Gets the account for the given public key from the global state, or creates one if it
     /// doesn't exist and fills it with the amount of tokens specified in the validators config.
+    /// If the amount is not specified, it defaults to zero.
     fn get_or_create_account(&mut self, pub_key: &PublicKey) -> &Account {
         match self.accounts.entry(pub_key.clone()) {
             Entry::Vacant(vac) => {
@@ -117,7 +118,7 @@ impl ValidatorsUpdateManager {
                         pub_key.clone(),
                         self.validators
                             .get(pub_key)
-                            .and_then(|vcfg| vcfg.maybe_balance)
+                            .and_then(|vcfg| vcfg.maybe_new_balance)
                             .unwrap_or_else(U512::zero),
                     ),
                 };


### PR DESCRIPTION
This PR extends the functionality of `global-state-update-gen` by adding the option for defining account balances for new validators.

The old format of the `-v` parameter for the tool was `-v public_key,stake`. This is now extended by an optional third field, balance, to `-v public_key,stake[,balance]`. If balance is present, it will be used as the initial amount of tokens on the newly created validator's account. If the validator already existed, the balance field won't be used, though.

Note that it's also possible to specify stake for non-validator accounts this way by setting the stake to 0. In this case, however, the account balance _will_ get overwritten even if it already existed. This behavior is somewhat inconsistent, but it's the easiest approach for now and I'd prefer addressing its consistency when working on #3111 .

Closes #2991 
