### PR TITLE
NCTL: timeout nctl upgrade steps

### DIFF
--- a/utils/nctl/sh/misc/await_n_eras.sh
+++ b/utils/nctl/sh/misc/await_n_eras.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 unset OFFSET
+unset EMIT_LOG
+unset SLEEP_INTERVAL
+unset NODE_ID
+unset TIME_OUT
 
 for ARGUMENT in "$@"
 do
@@ -8,11 +12,19 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in        
         offset) OFFSET=${VALUE} ;;
+        emit_log) EMIT_LOG=${VALUE} ;;
+        sleep_interval) SLEEP_INTERVAL=${VALUE} ;;
+        node_id) NODE_ID=${VALUE} ;;
+        timeout) TIME_OUT=${VALUE} ;;
         *)
     esac
 done
 
-OFFSET=${OFFSET:-1}
+OFFSET=${OFFSET:-'1'}
+EMIT_LOG=${EMIT_LOG:-'true'}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-'20.0'}
+NODE_ID=${NODE_ID:-''}
+TIME_OUT=${TIME_OUT:-''}
 
 # ----------------------------------------------------------------
 # MAIN
@@ -20,4 +32,4 @@ OFFSET=${OFFSET:-1}
 
 source "$NCTL"/sh/utils/main.sh
 
-await_n_eras "$OFFSET" true
+await_n_eras "$OFFSET" "$EMIT_LOG" "$SLEEP_INTERVAL" "$NODE_ID" "$TIME_OUT"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -113,7 +113,7 @@ function _step_05()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_1.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras 2 'true' '2.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -213,7 +213,7 @@ function _step_08()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_3.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -138,7 +138,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -138,7 +138,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -117,7 +117,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -117,7 +117,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -112,7 +112,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -95,7 +95,7 @@ function _step_04()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_10.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -9,22 +9,43 @@
 #######################################
 function await_n_eras()
 {
-    local OFFSET=${1}
-    local EMIT_LOG=${2:-false}
+    local OFFSET=${1:-'1'}
+    local EMIT_LOG=${2:-'false'}
     local SLEEP_INTERVAL=${3:-'20.0'}
     local NODE_ID=${4:-''}
+    local TIME_OUT=${5:-''}
     local CURRENT
     local FUTURE
+    local LOG_OUTPUT
 
     CURRENT=$(get_chain_era "$NODE_ID")
     FUTURE=$((CURRENT + OFFSET))
 
     while [ "$CURRENT" -lt "$FUTURE" ];
     do
-        if [ "$EMIT_LOG" = true ]; then
-            log "current era = $CURRENT :: future era = $FUTURE ... sleeping $SLEEP_INTERVAL seconds"
+
+        LOG_OUTPUT="current era = $CURRENT :: future era = $FUTURE :: sleeping $SLEEP_INTERVAL seconds"
+
+        if [ "$EMIT_LOG" = true ] && [ ! -z "$TIME_OUT" ]; then
+            log "$LOG_OUTPUT :: timeout = $TIME_OUT seconds"
+        elif [ "$EMIT_LOG" = true ]; then
+            log "$LOG_OUTPUT"
         fi
+
         sleep "$SLEEP_INTERVAL"
+
+        if [ ! -z "$TIME_OUT" ]; then
+            # Using jq since its required by NCTL anyway to do this floating point arith
+            # ... done to maintain backwards compatibility
+            TIME_OUT=$(jq -n "$TIME_OUT-$SLEEP_INTERVAL")
+
+            if [ "$TIME_OUT" -le "0" ]; then
+                log "ERROR: Timed out before reaching future era = $FUTURE"
+                # https://stackoverflow.com/a/54344104
+                return 1 2>/dev/null
+            fi
+        fi
+
         CURRENT=$(get_chain_era "$NODE_ID")
     done
 


### PR DESCRIPTION
Changes:
- adds additional args to `await_n_eras.sh` 
- updates nctl binary upgrade tests to use `nctl-await-n-eras` which is an alias of `await_n_eras.sh`
- adds timeout to `await_n_eras` function and maintain backwards compatibility where possible

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/506