### PR TITLE
Warn if messages are unsafe for joiners

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -678,7 +678,7 @@ where
                     self.update_joining_set(peer_id, is_joiner);
                 }
 
-                let joiner_id = if is_joiner {
+                let remote_joiner_id = if is_joiner {
                     Some((peer_addr, peer_id))
                 } else {
                     None
@@ -691,7 +691,7 @@ where
                         self.outgoing_limiter
                             .create_handle(peer_id, peer_consensus_public_key),
                         self.net_metrics.queued_messages.clone(),
-                        joiner_id,
+                        remote_joiner_id,
                     )
                     .instrument(span)
                     .event(move |_| Event::OutgoingDropped {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -678,6 +678,12 @@ where
                     self.update_joining_set(peer_id, is_joiner);
                 }
 
+                let joiner_id = if is_joiner {
+                    Some((peer_addr, peer_id))
+                } else {
+                    None
+                };
+
                 effects.extend(
                     tasks::message_sender(
                         receiver,
@@ -685,6 +691,7 @@ where
                         self.outgoing_limiter
                             .create_handle(peer_id, peer_consensus_public_key),
                         self.net_metrics.queued_messages.clone(),
+                        joiner_id,
                     )
                     .instrument(span)
                     .event(move |_| Event::OutgoingDropped {

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -73,6 +73,15 @@ impl<P: Payload> Message<P> {
         }
     }
 
+    /// Returns whether or not the payload is unsafe for joiner consumption.
+    #[inline]
+    pub(super) fn payload_is_unsafe_for_joiners(&self) -> bool {
+        match self {
+            Message::Handshake { .. } => false,
+            Message::Payload(payload) => payload.is_unsafe_for_joiners(),
+        }
+    }
+
     /// Attempts to create a demand-event from this message.
     ///
     /// Succeeds if the outer message contains a payload that can be converd into a demand.
@@ -325,6 +334,11 @@ pub(crate) trait Payload:
     fn is_low_priority(&self) -> bool {
         false
     }
+
+    /// Indicates a message is not safe to send to a joiner.
+    ///
+    /// This functionality should be removed once multiplexed networking lands.
+    fn is_unsafe_for_joiners(&self) -> bool;
 }
 
 /// Network message conversion support.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -672,11 +672,19 @@ pub(super) async fn message_sender<P>(
     mut sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
     limiter: Box<dyn LimiterHandle>,
     counter: IntGauge,
+    joiner_id: Option<(SocketAddr, NodeId)>,
 ) where
     P: Payload,
 {
     while let Some((message, opt_responder)) = queue.recv().await {
         counter.dec();
+
+        if let Some((ref addr, ref node_id)) = joiner_id {
+            if message.payload_is_unsafe_for_joiners() {
+                // We should never receive this kind of message here.
+                error!(kind=%message.classify(), %addr, %node_id, "sending trie request to joiner");
+            }
+        }
 
         let estimated_wire_size = match BincodeFormat::default().0.serialized_size(&*message) {
             Ok(size) => size as u32,

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -159,6 +159,10 @@ impl Payload for Message {
     fn incoming_resource_estimate(&self, _weights: &super::EstimatorWeights) -> u32 {
         0
     }
+
+    fn is_unsafe_for_joiners(&self) -> bool {
+        false
+    }
 }
 
 /// Test reactor.

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -133,6 +133,19 @@ impl Payload for Message {
             Message::FinalitySignature(_) => weights.finality_signatures,
         }
     }
+
+    fn is_unsafe_for_joiners(&self) -> bool {
+        match self {
+            Message::Consensus(_) => false,
+            Message::DeployGossiper(_) => false,
+            Message::AddressGossiper(_) => false,
+            // Trie requests can deadlock between joiners.
+            Message::GetRequest { tag, .. } if *tag == Tag::TrieOrChunk => true,
+            Message::GetRequest { .. } => false,
+            Message::GetResponse { .. } => false,
+            Message::FinalitySignature(_) => false,
+        }
+    }
 }
 
 impl Message {


### PR DESCRIPTION
Adds a warning (actually an `error`, because this should never happen) if a `TrieRequest` is ever sent to a joiner. Since there is no guarantee this will lock up the connection, we will still attempt to send and hope for the best.

The fast sync code's peer selection should prevent this error from ever occuring, this is purely a (loud) safety measure.