### PR TITLE
Bring feat-2.0 up to date with dev since `7f58386`

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -678,7 +678,7 @@ where
                     self.update_joining_set(peer_id, is_joiner);
                 }
 
-                let joiner_id = if is_joiner {
+                let remote_joiner_id = if is_joiner {
                     Some((peer_addr, peer_id))
                 } else {
                     None
@@ -691,7 +691,7 @@ where
                         self.outgoing_limiter
                             .create_handle(peer_id, peer_consensus_public_key),
                         self.net_metrics.queued_messages.clone(),
-                        joiner_id,
+                        remote_joiner_id,
                     )
                     .instrument(span)
                     .event(move |_| Event::OutgoingDropped {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -678,6 +678,12 @@ where
                     self.update_joining_set(peer_id, is_joiner);
                 }
 
+                let joiner_id = if is_joiner {
+                    Some((peer_addr, peer_id))
+                } else {
+                    None
+                };
+
                 effects.extend(
                     tasks::message_sender(
                         receiver,
@@ -685,6 +691,7 @@ where
                         self.outgoing_limiter
                             .create_handle(peer_id, peer_consensus_public_key),
                         self.net_metrics.queued_messages.clone(),
+                        joiner_id,
                     )
                     .instrument(span)
                     .event(move |_| Event::OutgoingDropped {

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -73,6 +73,15 @@ impl<P: Payload> Message<P> {
         }
     }
 
+    /// Returns whether or not the payload is unsafe for joiner consumption.
+    #[inline]
+    pub(super) fn payload_is_unsafe_for_joiners(&self) -> bool {
+        match self {
+            Message::Handshake { .. } => false,
+            Message::Payload(payload) => payload.is_unsafe_for_joiners(),
+        }
+    }
+
     /// Attempts to create a demand-event from this message.
     ///
     /// Succeeds if the outer message contains a payload that can be converd into a demand.
@@ -325,6 +334,11 @@ pub(crate) trait Payload:
     fn is_low_priority(&self) -> bool {
         false
     }
+
+    /// Indicates a message is not safe to send to a joiner.
+    ///
+    /// This functionality should be removed once multiplexed networking lands.
+    fn is_unsafe_for_joiners(&self) -> bool;
 }
 
 /// Network message conversion support.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -672,11 +672,19 @@ pub(super) async fn message_sender<P>(
     mut sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
     limiter: Box<dyn LimiterHandle>,
     counter: IntGauge,
+    joiner_id: Option<(SocketAddr, NodeId)>,
 ) where
     P: Payload,
 {
     while let Some((message, opt_responder)) = queue.recv().await {
         counter.dec();
+
+        if let Some((ref addr, ref node_id)) = joiner_id {
+            if message.payload_is_unsafe_for_joiners() {
+                // We should never receive this kind of message here.
+                error!(kind=%message.classify(), %addr, %node_id, "sending trie request to joiner");
+            }
+        }
 
         let estimated_wire_size = match BincodeFormat::default().0.serialized_size(&*message) {
             Ok(size) => size as u32,

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -159,6 +159,10 @@ impl Payload for Message {
     fn incoming_resource_estimate(&self, _weights: &super::EstimatorWeights) -> u32 {
         0
     }
+
+    fn is_unsafe_for_joiners(&self) -> bool {
+        false
+    }
 }
 
 /// Test reactor.

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -133,6 +133,19 @@ impl Payload for Message {
             Message::FinalitySignature(_) => weights.finality_signatures,
         }
     }
+
+    fn is_unsafe_for_joiners(&self) -> bool {
+        match self {
+            Message::Consensus(_) => false,
+            Message::DeployGossiper(_) => false,
+            Message::AddressGossiper(_) => false,
+            // Trie requests can deadlock between joiners.
+            Message::GetRequest { tag, .. } if *tag == Tag::TrieOrChunk => true,
+            Message::GetRequest { .. } => false,
+            Message::GetResponse { .. } => false,
+            Message::FinalitySignature(_) => false,
+        }
+    }
 }
 
 impl Message {

--- a/utils/nctl/sh/misc/await_n_eras.sh
+++ b/utils/nctl/sh/misc/await_n_eras.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 unset OFFSET
+unset EMIT_LOG
+unset SLEEP_INTERVAL
+unset NODE_ID
+unset TIME_OUT
 
 for ARGUMENT in "$@"
 do
@@ -8,11 +12,19 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in        
         offset) OFFSET=${VALUE} ;;
+        emit_log) EMIT_LOG=${VALUE} ;;
+        sleep_interval) SLEEP_INTERVAL=${VALUE} ;;
+        node_id) NODE_ID=${VALUE} ;;
+        timeout) TIME_OUT=${VALUE} ;;
         *)
     esac
 done
 
-OFFSET=${OFFSET:-1}
+OFFSET=${OFFSET:-'1'}
+EMIT_LOG=${EMIT_LOG:-'true'}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-'20.0'}
+NODE_ID=${NODE_ID:-''}
+TIME_OUT=${TIME_OUT:-''}
 
 # ----------------------------------------------------------------
 # MAIN
@@ -20,4 +32,4 @@ OFFSET=${OFFSET:-1}
 
 source "$NCTL"/sh/utils/main.sh
 
-await_n_eras "$OFFSET" true
+await_n_eras "$OFFSET" "$EMIT_LOG" "$SLEEP_INTERVAL" "$NODE_ID" "$TIME_OUT"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -113,7 +113,7 @@ function _step_05()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_1.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras 2 'true' '2.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -213,7 +213,7 @@ function _step_08()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_3.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -138,7 +138,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -138,7 +138,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -117,7 +117,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -117,7 +117,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -112,7 +112,7 @@ function _step_03()
     done
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0' '2'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180' node_id='2'
     await_n_blocks '1' 'true' '2'
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -95,7 +95,7 @@ function _step_04()
         config_path="$NCTL/sh/scenarios/configs/upgrade_scenario_10.config.toml"
 
     log "... awaiting 2 eras + 1 block"
-    await_n_eras '2' 'true' '5.0'
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -9,22 +9,43 @@
 #######################################
 function await_n_eras()
 {
-    local OFFSET=${1}
-    local EMIT_LOG=${2:-false}
+    local OFFSET=${1:-'1'}
+    local EMIT_LOG=${2:-'false'}
     local SLEEP_INTERVAL=${3:-'20.0'}
     local NODE_ID=${4:-''}
+    local TIME_OUT=${5:-''}
     local CURRENT
     local FUTURE
+    local LOG_OUTPUT
 
     CURRENT=$(get_chain_era "$NODE_ID")
     FUTURE=$((CURRENT + OFFSET))
 
     while [ "$CURRENT" -lt "$FUTURE" ];
     do
-        if [ "$EMIT_LOG" = true ]; then
-            log "current era = $CURRENT :: future era = $FUTURE ... sleeping $SLEEP_INTERVAL seconds"
+
+        LOG_OUTPUT="current era = $CURRENT :: future era = $FUTURE :: sleeping $SLEEP_INTERVAL seconds"
+
+        if [ "$EMIT_LOG" = true ] && [ ! -z "$TIME_OUT" ]; then
+            log "$LOG_OUTPUT :: timeout = $TIME_OUT seconds"
+        elif [ "$EMIT_LOG" = true ]; then
+            log "$LOG_OUTPUT"
         fi
+
         sleep "$SLEEP_INTERVAL"
+
+        if [ ! -z "$TIME_OUT" ]; then
+            # Using jq since its required by NCTL anyway to do this floating point arith
+            # ... done to maintain backwards compatibility
+            TIME_OUT=$(jq -n "$TIME_OUT-$SLEEP_INTERVAL")
+
+            if [ "$TIME_OUT" -le "0" ]; then
+                log "ERROR: Timed out before reaching future era = $FUTURE"
+                # https://stackoverflow.com/a/54344104
+                return 1 2>/dev/null
+            fi
+        fi
+
         CURRENT=$(get_chain_era "$NODE_ID")
     done
 


### PR DESCRIPTION
This PR brings all recent commits since https://github.com/casper-network/casper-node/commit/7f583868bf8d6612b8b38dff359ee34404bb5f26 from the dev branch to the feat-2.0 branch.

Merge had no conflicts.
