### PR TITLE
Additional metrics tracking fast sync downloads.

### DIFF
--- a/node/src/components/small_network/counting_format.rs
+++ b/node/src/components/small_network/counting_format.rs
@@ -130,6 +130,7 @@ where
 
         let deserialized = F::deserialize(projection, src)?;
         let msg_kind = deserialized.classify();
+        Metrics::record_payload_in(this.metrics, msg_kind, msg_size);
 
         let trace_id = this
             .connection_id

--- a/node/src/components/small_network/metrics.rs
+++ b/node/src/components/small_network/metrics.rs
@@ -420,7 +420,7 @@ impl Metrics {
     }
 
     /// Records an outgoing payload.
-    pub(crate) fn record_payload_out(this: &mut Weak<Self>, kind: MessageKind, size: u64) {
+    pub(crate) fn record_payload_out(this: &Weak<Self>, kind: MessageKind, size: u64) {
         if let Some(metrics) = this.upgrade() {
             match kind {
                 MessageKind::Protocol => {
@@ -466,7 +466,7 @@ impl Metrics {
     }
 
     /// Records an incoming payload.
-    pub(crate) fn record_payload_in(this: &mut Weak<Self>, kind: MessageKind, size: u64) {
+    pub(crate) fn record_payload_in(this: &Weak<Self>, kind: MessageKind, size: u64) {
         if let Some(metrics) = this.upgrade() {
             match kind {
                 MessageKind::Protocol => {

--- a/node/src/components/small_network/metrics.rs
+++ b/node/src/components/small_network/metrics.rs
@@ -69,6 +69,44 @@ pub(super) struct Metrics {
     /// Number of outgoing connections in loopback state.
     pub(super) out_state_loopback: IntGauge,
 
+    /// Volume in bytes of incoming messages that are protocol overhead.
+    pub(super) in_bytes_protocol: IntCounter,
+    /// Volume in bytes of incoming messages with consensus payload.
+    pub(super) in_bytes_consensus: IntCounter,
+    /// Volume in bytes of incoming messages with deploy gossiper payload.
+    pub(super) in_bytes_deploy_gossip: IntCounter,
+    /// Volume in bytes of incoming messages with address gossiper payload.
+    pub(super) in_bytes_address_gossip: IntCounter,
+    /// Volume in bytes of incoming messages with deploy request/response payload.
+    pub(super) in_bytes_deploy_transfer: IntCounter,
+    /// Volume in bytes of incoming messages with finalized approvals request/response payload.
+    pub(super) in_bytes_finalized_approvals_transfer: IntCounter,
+    /// Volume in bytes of incoming messages with block request/response payload.
+    pub(super) in_bytes_block_transfer: IntCounter,
+    /// Volume in bytes of incoming messages with block request/response payload.
+    pub(super) in_bytes_trie_transfer: IntCounter,
+    /// Volume in bytes of incoming messages with other payload.
+    pub(super) in_bytes_other: IntCounter,
+
+    /// Count of incoming messages that are protocol overhead.
+    pub(super) in_count_protocol: IntCounter,
+    /// Count of incoming messages with consensus payload.
+    pub(super) in_count_consensus: IntCounter,
+    /// Count of incoming messages with deploy gossiper payload.
+    pub(super) in_count_deploy_gossip: IntCounter,
+    /// Count of incoming messages with address gossiper payload.
+    pub(super) in_count_address_gossip: IntCounter,
+    /// Count of incoming messages with deploy request/response payload.
+    pub(super) in_count_deploy_transfer: IntCounter,
+    /// Count of incoming messages with finalized approvals request/response payload.
+    pub(super) in_count_finalized_approvals_transfer: IntCounter,
+    /// Count of incoming messages with block request/response payload.
+    pub(super) in_count_block_transfer: IntCounter,
+    /// Count of incoming messages with trie request/response payload.
+    pub(super) in_count_trie_transfer: IntCounter,
+    /// Count of incoming messages with other payload.
+    pub(super) in_count_other: IntCounter,
+
     /// Total time spent delaying outgoing traffic to non-validators due to limiter, in seconds.
     pub(super) accumulated_outgoing_limiter_delay: Counter,
     /// Total time spent delaying incoming traffic from non-validators due to limiter, in seconds.
@@ -190,6 +228,80 @@ impl Metrics {
             "number of connections in the loopback state",
         )?;
 
+        let in_count_protocol = IntCounter::new(
+            "net_in_count_protocol",
+            "count of incoming messages that are protocol overhead",
+        )?;
+        let in_count_consensus = IntCounter::new(
+            "net_in_count_consensus",
+            "count of incoming messages with consensus payload",
+        )?;
+        let in_count_deploy_gossip = IntCounter::new(
+            "net_in_count_deploy_gossip",
+            "count of incoming messages with deploy gossiper payload",
+        )?;
+        let in_count_address_gossip = IntCounter::new(
+            "net_in_count_address_gossip",
+            "count of incoming messages with address gossiper payload",
+        )?;
+        let in_count_deploy_transfer = IntCounter::new(
+            "net_in_count_deploy_transfer",
+            "count of incoming messages with deploy request/response payload",
+        )?;
+        let in_count_finalized_approvals_transfer = IntCounter::new(
+            "net_in_count_finalized_approvals_transfer",
+            "count of incoming messages with finalized approvals request/response payload",
+        )?;
+        let in_count_block_transfer = IntCounter::new(
+            "net_in_count_block_transfer",
+            "count of incoming messages with block request/response payload",
+        )?;
+        let in_count_trie_transfer = IntCounter::new(
+            "net_in_count_trie_transfer",
+            "count of incoming messages with trie payloads",
+        )?;
+        let in_count_other = IntCounter::new(
+            "net_in_count_other",
+            "count of incoming messages with other payload",
+        )?;
+
+        let in_bytes_protocol = IntCounter::new(
+            "net_in_bytes_protocol",
+            "volume in bytes of incoming messages that are protocol overhead",
+        )?;
+        let in_bytes_consensus = IntCounter::new(
+            "net_in_bytes_consensus",
+            "volume in bytes of incoming messages with consensus payload",
+        )?;
+        let in_bytes_deploy_gossip = IntCounter::new(
+            "net_in_bytes_deploy_gossip",
+            "volume in bytes of incoming messages with deploy gossiper payload",
+        )?;
+        let in_bytes_address_gossip = IntCounter::new(
+            "net_in_bytes_address_gossip",
+            "volume in bytes of incoming messages with address gossiper payload",
+        )?;
+        let in_bytes_deploy_transfer = IntCounter::new(
+            "net_in_bytes_deploy_transfer",
+            "volume in bytes of incoming messages with deploy request/response payload",
+        )?;
+        let in_bytes_finalized_approvals_transfer = IntCounter::new(
+            "net_in_bytes_finalized_approvals_transfer",
+            "volume in bytes of incoming messages with finalized approvals request/response payload",
+        )?;
+        let in_bytes_block_transfer = IntCounter::new(
+            "net_in_bytes_block_transfer",
+            "volume in bytes of incoming messages with block request/response payload",
+        )?;
+        let in_bytes_trie_transfer = IntCounter::new(
+            "net_in_bytes_trie_transfer",
+            "volume in bytes of incoming messages with trie payloads",
+        )?;
+        let in_bytes_other = IntCounter::new(
+            "net_in_bytes_other",
+            "volume in bytes of incoming messages with other payload",
+        )?;
+
         let accumulated_outgoing_limiter_delay = Counter::new(
             "accumulated_outgoing_limiter_delay",
             "seconds spent delaying outgoing traffic to non-validators due to limiter, in seconds",
@@ -231,6 +343,26 @@ impl Metrics {
         registry.register(Box::new(out_state_blocked.clone()))?;
         registry.register(Box::new(out_state_loopback.clone()))?;
 
+        registry.register(Box::new(in_count_protocol.clone()))?;
+        registry.register(Box::new(in_count_consensus.clone()))?;
+        registry.register(Box::new(in_count_deploy_gossip.clone()))?;
+        registry.register(Box::new(in_count_address_gossip.clone()))?;
+        registry.register(Box::new(in_count_deploy_transfer.clone()))?;
+        registry.register(Box::new(in_count_finalized_approvals_transfer.clone()))?;
+        registry.register(Box::new(in_count_block_transfer.clone()))?;
+        registry.register(Box::new(in_count_trie_transfer.clone()))?;
+        registry.register(Box::new(in_count_other.clone()))?;
+
+        registry.register(Box::new(in_bytes_protocol.clone()))?;
+        registry.register(Box::new(in_bytes_consensus.clone()))?;
+        registry.register(Box::new(in_bytes_deploy_gossip.clone()))?;
+        registry.register(Box::new(in_bytes_address_gossip.clone()))?;
+        registry.register(Box::new(in_bytes_deploy_transfer.clone()))?;
+        registry.register(Box::new(in_bytes_finalized_approvals_transfer.clone()))?;
+        registry.register(Box::new(in_bytes_block_transfer.clone()))?;
+        registry.register(Box::new(in_bytes_trie_transfer.clone()))?;
+        registry.register(Box::new(in_bytes_other.clone()))?;
+
         registry.register(Box::new(accumulated_outgoing_limiter_delay.clone()))?;
         registry.register(Box::new(accumulated_incoming_limiter_delay.clone()))?;
 
@@ -263,6 +395,24 @@ impl Metrics {
             out_state_connected,
             out_state_blocked,
             out_state_loopback,
+            in_count_protocol,
+            in_count_consensus,
+            in_count_deploy_gossip,
+            in_count_address_gossip,
+            in_count_deploy_transfer,
+            in_count_finalized_approvals_transfer,
+            in_count_block_transfer,
+            in_count_trie_transfer,
+            in_count_other,
+            in_bytes_protocol,
+            in_bytes_consensus,
+            in_bytes_deploy_gossip,
+            in_bytes_address_gossip,
+            in_bytes_deploy_transfer,
+            in_bytes_finalized_approvals_transfer,
+            in_bytes_block_transfer,
+            in_bytes_trie_transfer,
+            in_bytes_other,
             accumulated_outgoing_limiter_delay,
             accumulated_incoming_limiter_delay,
             registry: registry.clone(),
@@ -315,6 +465,52 @@ impl Metrics {
         }
     }
 
+    /// Records an incoming payload.
+    pub(crate) fn record_payload_in(this: &mut Weak<Self>, kind: MessageKind, size: u64) {
+        if let Some(metrics) = this.upgrade() {
+            match kind {
+                MessageKind::Protocol => {
+                    metrics.in_bytes_protocol.inc_by(size);
+                    metrics.in_count_protocol.inc();
+                }
+                MessageKind::Consensus => {
+                    metrics.in_bytes_consensus.inc_by(size);
+                    metrics.in_count_consensus.inc();
+                }
+                MessageKind::DeployGossip => {
+                    metrics.in_bytes_deploy_gossip.inc_by(size);
+                    metrics.in_count_deploy_gossip.inc();
+                }
+                MessageKind::AddressGossip => {
+                    metrics.in_bytes_address_gossip.inc_by(size);
+                    metrics.in_count_address_gossip.inc();
+                }
+                MessageKind::DeployTransfer => {
+                    metrics.in_bytes_deploy_transfer.inc_by(size);
+                    metrics.in_count_deploy_transfer.inc();
+                }
+                MessageKind::FinalizedApprovalsTransfer => {
+                    metrics.in_bytes_finalized_approvals_transfer.inc_by(size);
+                    metrics.in_count_finalized_approvals_transfer.inc();
+                }
+                MessageKind::BlockTransfer => {
+                    metrics.in_bytes_block_transfer.inc_by(size);
+                    metrics.in_count_block_transfer.inc();
+                }
+                MessageKind::TrieTransfer => {
+                    metrics.in_bytes_trie_transfer.inc_by(size);
+                    metrics.in_count_trie_transfer.inc();
+                }
+                MessageKind::Other => {
+                    metrics.in_bytes_other.inc_by(size);
+                    metrics.in_count_other.inc();
+                }
+            }
+        } else {
+            debug!("not recording metrics, component already shut down");
+        }
+    }
+
     /// Creates a set of outgoing metrics that is connected to this set of metrics.
     pub(super) fn create_outgoing_metrics(&self) -> OutgoingMetrics {
         OutgoingMetrics {
@@ -354,11 +550,32 @@ impl Drop for Metrics {
         unregister_metric!(self.registry, self.out_bytes_block_transfer);
         unregister_metric!(self.registry, self.out_bytes_trie_transfer);
         unregister_metric!(self.registry, self.out_bytes_other);
+
         unregister_metric!(self.registry, self.out_state_connecting);
         unregister_metric!(self.registry, self.out_state_waiting);
         unregister_metric!(self.registry, self.out_state_connected);
         unregister_metric!(self.registry, self.out_state_blocked);
         unregister_metric!(self.registry, self.out_state_loopback);
+
+        unregister_metric!(self.registry, self.in_count_protocol);
+        unregister_metric!(self.registry, self.in_count_consensus);
+        unregister_metric!(self.registry, self.in_count_deploy_gossip);
+        unregister_metric!(self.registry, self.in_count_address_gossip);
+        unregister_metric!(self.registry, self.in_count_deploy_transfer);
+        unregister_metric!(self.registry, self.in_count_finalized_approvals_transfer);
+        unregister_metric!(self.registry, self.in_count_block_transfer);
+        unregister_metric!(self.registry, self.in_count_trie_transfer);
+        unregister_metric!(self.registry, self.in_count_other);
+
+        unregister_metric!(self.registry, self.in_bytes_protocol);
+        unregister_metric!(self.registry, self.in_bytes_consensus);
+        unregister_metric!(self.registry, self.in_bytes_deploy_gossip);
+        unregister_metric!(self.registry, self.in_bytes_address_gossip);
+        unregister_metric!(self.registry, self.in_bytes_deploy_transfer);
+        unregister_metric!(self.registry, self.in_bytes_finalized_approvals_transfer);
+        unregister_metric!(self.registry, self.in_bytes_block_transfer);
+        unregister_metric!(self.registry, self.in_bytes_trie_transfer);
+        unregister_metric!(self.registry, self.in_bytes_other);
 
         unregister_metric!(self.registry, self.accumulated_outgoing_limiter_delay);
         unregister_metric!(self.registry, self.accumulated_incoming_limiter_delay);

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -548,109 +548,112 @@ where
 {
     let demands_in_flight = Arc::new(Semaphore::new(context.max_in_flight_demands));
 
-    let read_messages = async move {
-        while let Some(msg_result) = stream.next().await {
-            match msg_result {
-                Ok(msg) => {
-                    trace!(%msg, "message received");
+    let read_messages =
+        async move {
+            while let Some(msg_result) = stream.next().await {
+                match msg_result {
+                    Ok(msg) => {
+                        trace!(%msg, "message received");
 
-                    let effect_builder = EffectBuilder::new(context.event_queue);
+                        let effect_builder = EffectBuilder::new(context.event_queue);
 
-                    match msg.try_into_demand(effect_builder, peer_id) {
-                        Ok((event, wait_for_response)) => {
-                            // Note: For now, demands bypass the limiter, as we expect the
-                            //       backpressure to handle this instead.
+                        match msg.try_into_demand(effect_builder, peer_id) {
+                            Ok((event, wait_for_response)) => {
+                                // Note: For now, demands bypass the limiter, as we expect the
+                                //       backpressure to handle this instead.
 
-                            // Acquire a permit. If we are handling too many demands at this
-                            // time, this will block, halting the processing of new message,
-                            // thus letting the peer they have reached their maximum allowance.
-                            let in_flight = demands_in_flight
-                                .clone()
-                                .acquire_owned()
-                                .await
-                                // Note: Since the semaphore is reference counted, it must
-                                //       explicitly be closed for acquisition to fail, which we
-                                //       never do. If this happens, there is a bug in the code;
-                                //       we exit with an error and close the connection.
-                                .map_err(|_| {
-                                    io::Error::new(
-                                        io::ErrorKind::Other,
-                                        "demand limiter semaphore closed unexpectedly",
-                                    )
-                                })?;
+                                // Acquire a permit. If we are handling too many demands at this
+                                // time, this will block, halting the processing of new message,
+                                // thus letting the peer they have reached their maximum allowance.
+                                let in_flight = demands_in_flight
+                                    .clone()
+                                    .acquire_owned()
+                                    .await
+                                    // Note: Since the semaphore is reference counted, it must
+                                    //       explicitly be closed for acquisition to fail, which we
+                                    //       never do. If this happens, there is a bug in the code;
+                                    //       we exit with an error and close the connection.
+                                    .map_err(|_| {
+                                        io::Error::new(
+                                            io::ErrorKind::Other,
+                                            "demand limiter semaphore closed unexpectedly",
+                                        )
+                                    })?;
 
-                            // Spawn a future that will eventually send the returned message. It
-                            // will essentially buffer the response.
-                            tokio::spawn(async move {
-                                if let Some(payload) = wait_for_response.await {
-                                    // Send message and await its return. `send_message` should
-                                    // only return when the message has been buffered, if the
-                                    // peer is not accepting data, we will block here until the
-                                    // send buffer has sufficient room.
-                                    effect_builder.send_message(peer_id, payload).await;
+                                Metrics::record_trie_request_start(&context.net_metrics);
 
-                                    // Note: We could short-circuit the event queue here and
-                                    //       directly insert into the outgoing message queue,
-                                    //       which may be potential performance improvement.
-                                }
+                                let net_metrics = context.net_metrics.clone();
+                                // Spawn a future that will eventually send the returned message. It
+                                // will essentially buffer the response.
+                                tokio::spawn(async move {
+                                    if let Some(payload) = wait_for_response.await {
+                                        // Send message and await its return. `send_message` should
+                                        // only return when the message has been buffered, if the
+                                        // peer is not accepting data, we will block here until the
+                                        // send buffer has sufficient room.
+                                        effect_builder.send_message(peer_id, payload).await;
 
-                                // Missing else: The handler of the demand did not deem it
-                                // worthy a response. Just drop it.
+                                        // Note: We could short-circuit the event queue here and
+                                        //       directly insert into the outgoing message queue,
+                                        //       which may be potential performance improvement.
+                                    }
 
-                                // After we have either successfully buffered the message for
-                                // sending, failed to do so or did not have a message to send
-                                // out, we consider the request handled and free up the permit.
-                                drop(in_flight);
-                            });
+                                    // Missing else: The handler of the demand did not deem it
+                                    // worthy a response. Just drop it.
 
-                            // Schedule the created event.
-                            context
-                                .event_queue
-                                .schedule::<REv>(event, QueueKind::NetworkDemand)
-                                .await;
-                        }
-                        Err(msg) => {
-                            // We've received a non-demand message. Ensure we have the proper amount
-                            // of resources, then push it to the reactor.
-                            limiter
-                                .request_allowance(
-                                    msg.payload_incoming_resource_estimate(
+                                    // After we have either successfully buffered the message for
+                                    // sending, failed to do so or did not have a message to send
+                                    // out, we consider the request handled and free up the permit.
+                                    Metrics::record_trie_request_end(&net_metrics);
+                                    drop(in_flight);
+                                });
+
+                                // Schedule the created event.
+                                context
+                                    .event_queue
+                                    .schedule::<REv>(event, QueueKind::NetworkDemand)
+                                    .await;
+                            }
+                            Err(msg) => {
+                                // We've received a non-demand message. Ensure we have the proper amount
+                                // of resources, then push it to the reactor.
+                                limiter
+                                    .request_allowance(msg.payload_incoming_resource_estimate(
                                         &context.payload_weights,
-                                    ),
-                                )
-                                .await;
+                                    ))
+                                    .await;
 
-                            let queue_kind = if msg.is_low_priority() {
-                                QueueKind::NetworkLowPriority
-                            } else {
-                                QueueKind::NetworkIncoming
-                            };
+                                let queue_kind = if msg.is_low_priority() {
+                                    QueueKind::NetworkLowPriority
+                                } else {
+                                    QueueKind::NetworkIncoming
+                                };
 
-                            context
-                                .event_queue
-                                .schedule(
-                                    Event::IncomingMessage {
-                                        peer_id: Box::new(peer_id),
-                                        msg: Box::new(msg),
-                                        span: span.clone(),
-                                    },
-                                    queue_kind,
-                                )
-                                .await;
+                                context
+                                    .event_queue
+                                    .schedule(
+                                        Event::IncomingMessage {
+                                            peer_id: Box::new(peer_id),
+                                            msg: Box::new(msg),
+                                            span: span.clone(),
+                                        },
+                                        queue_kind,
+                                    )
+                                    .await;
+                            }
                         }
                     }
-                }
-                Err(err) => {
-                    warn!(
-                        err = display_error(&err),
-                        "receiving message failed, closing connection"
-                    );
-                    return Err(err);
+                    Err(err) => {
+                        warn!(
+                            err = display_error(&err),
+                            "receiving message failed, closing connection"
+                        );
+                        return Err(err);
+                    }
                 }
             }
-        }
-        Ok(())
-    };
+            Ok(())
+        };
 
     let shutdown_messages = async move { while shutdown_receiver.changed().await.is_ok() {} };
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -548,112 +548,113 @@ where
 {
     let demands_in_flight = Arc::new(Semaphore::new(context.max_in_flight_demands));
 
-    let read_messages =
-        async move {
-            while let Some(msg_result) = stream.next().await {
-                match msg_result {
-                    Ok(msg) => {
-                        trace!(%msg, "message received");
+    let read_messages = async move {
+        while let Some(msg_result) = stream.next().await {
+            match msg_result {
+                Ok(msg) => {
+                    trace!(%msg, "message received");
 
-                        let effect_builder = EffectBuilder::new(context.event_queue);
+                    let effect_builder = EffectBuilder::new(context.event_queue);
 
-                        match msg.try_into_demand(effect_builder, peer_id) {
-                            Ok((event, wait_for_response)) => {
-                                // Note: For now, demands bypass the limiter, as we expect the
-                                //       backpressure to handle this instead.
+                    match msg.try_into_demand(effect_builder, peer_id) {
+                        Ok((event, wait_for_response)) => {
+                            // Note: For now, demands bypass the limiter, as we expect the
+                            //       backpressure to handle this instead.
 
-                                // Acquire a permit. If we are handling too many demands at this
-                                // time, this will block, halting the processing of new message,
-                                // thus letting the peer they have reached their maximum allowance.
-                                let in_flight = demands_in_flight
-                                    .clone()
-                                    .acquire_owned()
-                                    .await
-                                    // Note: Since the semaphore is reference counted, it must
-                                    //       explicitly be closed for acquisition to fail, which we
-                                    //       never do. If this happens, there is a bug in the code;
-                                    //       we exit with an error and close the connection.
-                                    .map_err(|_| {
-                                        io::Error::new(
-                                            io::ErrorKind::Other,
-                                            "demand limiter semaphore closed unexpectedly",
-                                        )
-                                    })?;
-
-                                Metrics::record_trie_request_start(&context.net_metrics);
-
-                                let net_metrics = context.net_metrics.clone();
-                                // Spawn a future that will eventually send the returned message. It
-                                // will essentially buffer the response.
-                                tokio::spawn(async move {
-                                    if let Some(payload) = wait_for_response.await {
-                                        // Send message and await its return. `send_message` should
-                                        // only return when the message has been buffered, if the
-                                        // peer is not accepting data, we will block here until the
-                                        // send buffer has sufficient room.
-                                        effect_builder.send_message(peer_id, payload).await;
-
-                                        // Note: We could short-circuit the event queue here and
-                                        //       directly insert into the outgoing message queue,
-                                        //       which may be potential performance improvement.
-                                    }
-
-                                    // Missing else: The handler of the demand did not deem it
-                                    // worthy a response. Just drop it.
-
-                                    // After we have either successfully buffered the message for
-                                    // sending, failed to do so or did not have a message to send
-                                    // out, we consider the request handled and free up the permit.
-                                    Metrics::record_trie_request_end(&net_metrics);
-                                    drop(in_flight);
-                                });
-
-                                // Schedule the created event.
-                                context
-                                    .event_queue
-                                    .schedule::<REv>(event, QueueKind::NetworkDemand)
-                                    .await;
-                            }
-                            Err(msg) => {
-                                // We've received a non-demand message. Ensure we have the proper amount
-                                // of resources, then push it to the reactor.
-                                limiter
-                                    .request_allowance(msg.payload_incoming_resource_estimate(
-                                        &context.payload_weights,
-                                    ))
-                                    .await;
-
-                                let queue_kind = if msg.is_low_priority() {
-                                    QueueKind::NetworkLowPriority
-                                } else {
-                                    QueueKind::NetworkIncoming
-                                };
-
-                                context
-                                    .event_queue
-                                    .schedule(
-                                        Event::IncomingMessage {
-                                            peer_id: Box::new(peer_id),
-                                            msg: Box::new(msg),
-                                            span: span.clone(),
-                                        },
-                                        queue_kind,
+                            // Acquire a permit. If we are handling too many demands at this
+                            // time, this will block, halting the processing of new message,
+                            // thus letting the peer they have reached their maximum allowance.
+                            let in_flight = demands_in_flight
+                                .clone()
+                                .acquire_owned()
+                                .await
+                                // Note: Since the semaphore is reference counted, it must
+                                //       explicitly be closed for acquisition to fail, which we
+                                //       never do. If this happens, there is a bug in the code;
+                                //       we exit with an error and close the connection.
+                                .map_err(|_| {
+                                    io::Error::new(
+                                        io::ErrorKind::Other,
+                                        "demand limiter semaphore closed unexpectedly",
                                     )
-                                    .await;
-                            }
+                                })?;
+
+                            Metrics::record_trie_request_start(&context.net_metrics);
+
+                            let net_metrics = context.net_metrics.clone();
+                            // Spawn a future that will eventually send the returned message. It
+                            // will essentially buffer the response.
+                            tokio::spawn(async move {
+                                if let Some(payload) = wait_for_response.await {
+                                    // Send message and await its return. `send_message` should
+                                    // only return when the message has been buffered, if the
+                                    // peer is not accepting data, we will block here until the
+                                    // send buffer has sufficient room.
+                                    effect_builder.send_message(peer_id, payload).await;
+
+                                    // Note: We could short-circuit the event queue here and
+                                    //       directly insert into the outgoing message queue,
+                                    //       which may be potential performance improvement.
+                                }
+
+                                // Missing else: The handler of the demand did not deem it
+                                // worthy a response. Just drop it.
+
+                                // After we have either successfully buffered the message for
+                                // sending, failed to do so or did not have a message to send
+                                // out, we consider the request handled and free up the permit.
+                                Metrics::record_trie_request_end(&net_metrics);
+                                drop(in_flight);
+                            });
+
+                            // Schedule the created event.
+                            context
+                                .event_queue
+                                .schedule::<REv>(event, QueueKind::NetworkDemand)
+                                .await;
+                        }
+                        Err(msg) => {
+                            // We've received a non-demand message. Ensure we have the proper amount
+                            // of resources, then push it to the reactor.
+                            limiter
+                                .request_allowance(
+                                    msg.payload_incoming_resource_estimate(
+                                        &context.payload_weights,
+                                    ),
+                                )
+                                .await;
+
+                            let queue_kind = if msg.is_low_priority() {
+                                QueueKind::NetworkLowPriority
+                            } else {
+                                QueueKind::NetworkIncoming
+                            };
+
+                            context
+                                .event_queue
+                                .schedule(
+                                    Event::IncomingMessage {
+                                        peer_id: Box::new(peer_id),
+                                        msg: Box::new(msg),
+                                        span: span.clone(),
+                                    },
+                                    queue_kind,
+                                )
+                                .await;
                         }
                     }
-                    Err(err) => {
-                        warn!(
-                            err = display_error(&err),
-                            "receiving message failed, closing connection"
-                        );
-                        return Err(err);
-                    }
+                }
+                Err(err) => {
+                    warn!(
+                        err = display_error(&err),
+                        "receiving message failed, closing connection"
+                    );
+                    return Err(err);
                 }
             }
-            Ok(())
-        };
+        }
+        Ok(())
+    };
 
     let shutdown_messages = async move { while shutdown_receiver.changed().await.is_ok() {} };
 


### PR DESCRIPTION
Closes #3032.

Adds various metrics:

* A full set of metrics for incoming messages and bandwidth that mirrors the outbound ones, to allow measuring fast sync performance.
* Two metrics tracking trie requests (or more precisely, trie demands), increased when processing starts and ends. The difference between these will be the global number of in-flight requests.