### PR TITLE
Mark immediate switch blocks after emergency upgrades

### DIFF
--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -346,8 +346,9 @@ impl ChainSynchronizer {
         finalized_block: FinalizedBlock,
     ) -> Effects<Event> {
         let protocol_version = self.config.protocol_version();
+        let last_emergency_restart = self.config.last_emergency_restart();
         async move {
-            let block_and_execution_effects = effect_builder
+            let mut block_and_execution_effects = effect_builder
                 .execute_finalized_block(
                     protocol_version,
                     initial_pre_state,
@@ -356,6 +357,12 @@ impl ChainSynchronizer {
                     vec![],
                 )
                 .await?;
+
+            if last_emergency_restart == Some(block_and_execution_effects.block.header().era_id()) {
+                block_and_execution_effects
+                    .block
+                    .mark_after_emergency_upgrade();
+            }
             // We need to store the block now so that the era supervisor can be properly
             // initialized in the participating reactor's constructor.
             effect_builder

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -347,6 +347,7 @@ impl ChainSynchronizer {
     ) -> Effects<Event> {
         let protocol_version = self.config.protocol_version();
         let last_emergency_restart = self.config.last_emergency_restart();
+        let verifiable_chunked_hash_activation = self.config.verifiable_chunked_hash_activation();
         async move {
             let mut block_and_execution_effects = effect_builder
                 .execute_finalized_block(
@@ -361,7 +362,7 @@ impl ChainSynchronizer {
             if last_emergency_restart == Some(block_and_execution_effects.block.header().era_id()) {
                 block_and_execution_effects
                     .block
-                    .mark_after_emergency_upgrade();
+                    .mark_after_emergency_upgrade(verifiable_chunked_hash_activation);
             }
             // We need to store the block now so that the era supervisor can be properly
             // initialized in the participating reactor's constructor.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1741,6 +1741,12 @@ impl Block {
         })
     }
 
+    pub(crate) fn mark_after_emergency_upgrade(&mut self) {
+        // accumulated seed being equal to the parent hash will mean that the block is an immediate
+        // switch block created right after an emergency upgrade
+        self.header.accumulated_seed = *self.header.parent_hash.inner();
+    }
+
     pub(crate) fn new_from_header_and_body(
         header: BlockHeader,
         body: BlockBody,


### PR DESCRIPTION
This makes the accumulated seed equal the parent hash in immediate switch blocks created right after emergency upgrades to make them recognizable.

Closes #3135
