### PR TITLE
GH-3097: Disabled contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-3097-regression"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
+name = "gh-3097-regression-call"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2153,7 +2153,8 @@ fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool 
                 | ExecError::MissingSystemContractHash(_)
                 | ExecError::RuntimeStackOverflow
                 | ExecError::ValueTooLarge
-                | ExecError::MissingRuntimeStack => false,
+                | ExecError::MissingRuntimeStack
+                | ExecError::DisabledContract(_) => false,
             },
             Error::WasmPreprocessing(_) => true,
             Error::WasmSerialization(_) => true,

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -170,6 +170,9 @@ pub enum Error {
     /// The runtime stack is `None`.
     #[error("Runtime stack missing")]
     MissingRuntimeStack,
+    /// Contract is disabled.
+    #[error("Contract is disabled")]
+    DisabledContract(ContractHash),
 }
 
 impl From<wasm_prep::PreprocessingError> for Error {

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -60,6 +60,16 @@ use crate::{
 };
 pub use stack::{RuntimeStack, RuntimeStackFrame, RuntimeStackOverflow};
 
+enum CallContractIdentifier {
+    Contract {
+        contract_hash: ContractHash,
+    },
+    ContractPackage {
+        contract_package_hash: ContractPackageHash,
+        version: Option<ContractVersion>,
+    },
+}
+
 /// Represents the runtime properties of a WASM execution.
 pub struct Runtime<'a, R> {
     config: EngineConfig,
@@ -1065,37 +1075,9 @@ where
         entry_point_name: &str,
         args: RuntimeArgs,
     ) -> Result<CLValue, Error> {
-        let key = contract_hash.into();
-        let contract = match self.context.read_gs(&key)? {
-            Some(StoredValue::Contract(contract)) => contract,
-            Some(_) => {
-                return Err(Error::InvalidContract(contract_hash));
-            }
-            None => return Err(Error::KeyNotFound(key)),
-        };
+        let identifier = CallContractIdentifier::Contract { contract_hash };
 
-        let contract_entry_point = contract
-            .entry_point(entry_point_name)
-            .cloned()
-            .ok_or_else(|| Error::NoSuchMethod(entry_point_name.to_owned()))?;
-
-        let contract_package_hash = contract.contract_package_hash();
-
-        let contract_package = match self.context.read_gs(&contract_package_hash.into())? {
-            Some(StoredValue::ContractPackage(contract_package)) => contract_package,
-            Some(_) => {
-                return Err(Error::InvalidContractPackage(contract_package_hash));
-            }
-            None => return Err(Error::KeyNotFound(key)),
-        };
-
-        self.execute_contract(
-            contract_package,
-            contract_hash,
-            contract,
-            contract_entry_point,
-            args,
-        )
+        self.execute_contract(identifier, entry_point_name, args)
     }
 
     /// Calls `version` of the contract living at `key`, invoking `method` with
@@ -1108,53 +1090,12 @@ where
         entry_point_name: String,
         args: RuntimeArgs,
     ) -> Result<CLValue, Error> {
-        let contract_package_key = contract_package_hash.into();
-        let contract_package = match self.context.read_gs(&contract_package_key)? {
-            Some(StoredValue::ContractPackage(contract_package)) => contract_package,
-            Some(_) => {
-                return Err(Error::InvalidContractPackage(contract_package_hash));
-            }
-            None => return Err(Error::KeyNotFound(contract_package_key)),
+        let identifier = CallContractIdentifier::ContractPackage {
+            contract_package_hash,
+            version: contract_version,
         };
 
-        let contract_version_key = match contract_version {
-            Some(version) => {
-                ContractVersionKey::new(self.context.protocol_version().value().major, version)
-            }
-            None => match contract_package.current_contract_version() {
-                Some(v) => v,
-                None => return Err(Error::NoActiveContractVersions(contract_package_hash)),
-            },
-        };
-
-        // Get contract entry point hash
-        let contract_hash = contract_package
-            .lookup_contract_hash(contract_version_key)
-            .cloned()
-            .ok_or(Error::InvalidContractVersion(contract_version_key))?;
-
-        // Get contract data
-        let contract_key = contract_hash.into();
-        let contract = match self.context.read_gs(&contract_key)? {
-            Some(StoredValue::Contract(contract)) => contract,
-            Some(_) => {
-                return Err(Error::InvalidContract(contract_hash));
-            }
-            None => return Err(Error::KeyNotFound(contract_key)),
-        };
-
-        let contract_entry_point = contract
-            .entry_point(&entry_point_name)
-            .cloned()
-            .ok_or_else(|| Error::NoSuchMethod(entry_point_name.to_owned()))?;
-
-        self.execute_contract(
-            contract_package,
-            contract_hash,
-            contract,
-            contract_entry_point,
-            args,
-        )
+        self.execute_contract(identifier, &entry_point_name, args)
     }
 
     fn get_context_key_for_contract_call(
@@ -1196,12 +1137,92 @@ where
 
     fn execute_contract(
         &mut self,
-        contract_package: ContractPackage,
-        contract_hash: ContractHash,
-        contract: Contract,
-        entry_point: EntryPoint,
+        identifier: CallContractIdentifier,
+        entry_point_name: &str,
         args: RuntimeArgs,
     ) -> Result<CLValue, Error> {
+        let (contract, contract_hash, contract_package) = match identifier {
+            CallContractIdentifier::Contract { contract_hash } => {
+                let key = contract_hash.into();
+                let contract = match self.context.read_gs(&key)? {
+                    Some(StoredValue::Contract(contract)) => contract,
+                    Some(_) => {
+                        return Err(Error::InvalidContract(contract_hash));
+                    }
+                    None => return Err(Error::KeyNotFound(key)),
+                };
+
+                let contract_package_hash = contract.contract_package_hash();
+                let contract_package_key = contract_package_hash.into();
+                let contract_package = match self.context.read_gs(&contract_package_key)? {
+                    Some(StoredValue::ContractPackage(contract_package)) => contract_package,
+                    Some(_) => {
+                        return Err(Error::InvalidContractPackage(contract_package_hash));
+                    }
+                    None => return Err(Error::KeyNotFound(contract_package_key)),
+                };
+
+                // System contract hashes are disabled at upgrade point
+                let is_calling_system_contract =
+                    self.is_system_contract(Key::from(contract_hash))?;
+
+                // Check if provided contract hash is disabled
+                let is_contract_enabled = contract_package.is_contract_enabled(&contract_hash);
+
+                if !is_calling_system_contract && !is_contract_enabled {
+                    return Err(Error::DisabledContract(contract_hash));
+                }
+
+                (contract, contract_hash, contract_package)
+            }
+            CallContractIdentifier::ContractPackage {
+                contract_package_hash,
+                version,
+            } => {
+                let contract_package_key = contract_package_hash.into();
+                let contract_package = match self.context.read_gs(&contract_package_key)? {
+                    Some(StoredValue::ContractPackage(contract_package)) => contract_package,
+                    Some(_) => {
+                        return Err(Error::InvalidContractPackage(contract_package_hash));
+                    }
+                    None => return Err(Error::KeyNotFound(contract_package_key)),
+                };
+                let contract_version_key = match version {
+                    Some(version) => ContractVersionKey::new(
+                        self.context.protocol_version().value().major,
+                        version,
+                    ),
+                    None => match contract_package.current_contract_version() {
+                        Some(v) => v,
+                        None => {
+                            return Err(Error::NoActiveContractVersions(contract_package_hash));
+                        }
+                    },
+                };
+                let contract_hash = contract_package
+                    .lookup_contract_hash(contract_version_key)
+                    .copied()
+                    .ok_or(Error::InvalidContractVersion(contract_version_key))?;
+
+                let contract_key = contract_hash.into();
+                let contract = match self.context.read_gs(&contract_key)? {
+                    Some(StoredValue::Contract(contract)) => contract,
+                    Some(_) => {
+                        return Err(Error::InvalidContract(contract_hash));
+                    }
+                    None => return Err(Error::KeyNotFound(contract_key)),
+                };
+
+                (contract, contract_hash, contract_package)
+            }
+        };
+
+        let entry_point = contract
+            .entry_point(entry_point_name)
+            .cloned()
+            .ok_or_else(|| Error::NoSuchMethod(entry_point_name.to_owned()))?;
+
+        // Get contract entry point hash
         // if public, allowed
         // if not public, restricted to user group access
         self.validate_group_membership(&contract_package, entry_point.access())?;

--- a/execution_engine_testing/tests/src/test/regression/gh_3097.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3097.rs
@@ -1,0 +1,345 @@
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    PRODUCTION_RUN_GENESIS_REQUEST,
+};
+use casper_types::{
+    runtime_args, ContractHash, ContractPackageHash, ContractVersionKey, RuntimeArgs,
+};
+use gh_1470_regression::CONTRACT_PACKAGE_HASH_NAME;
+
+const GH_3097_REGRESSION_WASM: &str = "gh_3097_regression.wasm";
+const GH_3097_REGRESSION_CALL_WASM: &str = "gh_3097_regression_call.wasm";
+const DO_SOMETHING_ENTRYPOINT: &str = "do_something";
+const CONTRACT_HASH_V1_KEY: &str = "contract_hash_v1";
+const CONTRACT_HASH_V2_KEY: &str = "contract_hash_v2";
+const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
+const ARG_METHOD: &str = "method";
+const ARG_CONTRACT_HASH_KEY: &str = "contract_hash_key";
+const ARG_CONTRACT_VERSION: &str = "contract_version";
+const METHOD_CALL_CONTRACT: &str = "call_contract";
+const METHOD_CALL_VERSIONED_CONTRACT: &str = "call_versioned_contract";
+
+#[ignore]
+#[test]
+fn should_run_regression() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_WASM,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
+        .exec(exec_request)
+        .expect_success()
+        .commit();
+
+    let account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    let contract_hash_v1 = account.named_keys()[CONTRACT_HASH_V1_KEY]
+        .into_hash()
+        .map(ContractHash::new)
+        .unwrap();
+    let contract_hash_v2 = account.named_keys()[CONTRACT_HASH_V2_KEY]
+        .into_hash()
+        .map(ContractHash::new)
+        .unwrap();
+    let contract_package_hash = account.named_keys()[CONTRACT_PACKAGE_HASH_KEY]
+        .into_hash()
+        .map(ContractPackageHash::new)
+        .unwrap();
+
+    // Versioned contract calls by name
+
+    let direct_call_latest_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_PACKAGE_HASH_NAME,
+        None,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    let direct_call_v2_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_PACKAGE_HASH_NAME,
+        Some(2),
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_PACKAGE_HASH_NAME,
+        Some(1),
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .exec(direct_call_latest_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(direct_call_v2_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(direct_call_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::InvalidContractVersion(version)
+            )
+            if version == ContractVersionKey::new(1, 1),
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    // Versioned contract calls by hash
+
+    let direct_call_latest_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_package_hash,
+        None,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    let direct_call_v2_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_package_hash,
+        Some(2),
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_package_hash,
+        Some(1),
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .exec(direct_call_latest_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(direct_call_v2_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(direct_call_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::InvalidContractVersion(version)
+            )
+            if version == ContractVersionKey::new(1, 1),
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    // Versioned call from a session wasm
+
+    let session_call_v1_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_CALL_WASM,
+        runtime_args! {
+            ARG_METHOD => METHOD_CALL_VERSIONED_CONTRACT,
+            ARG_CONTRACT_VERSION => Some(1u32),
+        },
+    )
+    .build();
+
+    let session_call_v2_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_CALL_WASM,
+        runtime_args! {
+            ARG_METHOD => METHOD_CALL_VERSIONED_CONTRACT,
+            ARG_CONTRACT_VERSION => Some(2u32),
+        },
+    )
+    .build();
+
+    let session_call_latest_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_CALL_WASM,
+        runtime_args! {
+            ARG_METHOD => METHOD_CALL_VERSIONED_CONTRACT,
+            ARG_CONTRACT_VERSION => Option::<u32>::None,
+        },
+    )
+    .build();
+
+    builder
+        .exec(session_call_latest_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(session_call_v2_request)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(session_call_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::InvalidContractVersion(version)
+            )
+            if version == ContractVersionKey::new(1, 1),
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    // Call by contract hashes
+
+    let call_by_hash_v2_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_hash_v2,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .exec(call_by_hash_v2_request)
+        .expect_success()
+        .commit();
+
+    let call_by_name_v2_request = ExecuteRequestBuilder::contract_call_by_name(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_HASH_V2_KEY,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+    builder
+        .exec(call_by_name_v2_request)
+        .expect_success()
+        .commit();
+
+    // This direct contract by name/hash should fail
+    let call_by_hash_v1_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_hash_v1,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+    builder
+        .exec(call_by_hash_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(_)
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    // This direct contract by name/hash should fail
+    let call_by_name_v1_request = ExecuteRequestBuilder::contract_call_by_name(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_HASH_V1_KEY,
+        DO_SOMETHING_ENTRYPOINT,
+        RuntimeArgs::new(),
+    )
+    .build();
+    builder
+        .exec(call_by_name_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(_)
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    // Session calls into hashes
+
+    let session_call_hash_v1_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_CALL_WASM,
+        runtime_args! {
+            ARG_METHOD => METHOD_CALL_CONTRACT,
+            ARG_CONTRACT_HASH_KEY => CONTRACT_HASH_V1_KEY,
+        },
+    )
+    .build();
+
+    let session_call_hash_v2_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        GH_3097_REGRESSION_CALL_WASM,
+        runtime_args! {
+            ARG_METHOD => METHOD_CALL_CONTRACT,
+            ARG_CONTRACT_HASH_KEY => CONTRACT_HASH_V2_KEY,
+        },
+    )
+    .build();
+
+    builder
+        .exec(session_call_hash_v1_request)
+        .expect_failure()
+        .commit();
+
+    let error = builder.get_error().expect("should have error");
+    assert!(
+        matches!(
+            error,
+            casper_execution_engine::core::engine_state::Error::Exec(_)
+        ),
+        "Expected invalid contract version, found {:?}",
+        error,
+    );
+
+    builder
+        .exec(session_call_hash_v2_request)
+        .expect_success()
+        .commit();
+}

--- a/execution_engine_testing/tests/src/test/regression/gh_3097.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3097.rs
@@ -272,7 +272,10 @@ fn should_run_regression() {
     assert!(
         matches!(
             error,
-            casper_execution_engine::core::engine_state::Error::Exec(_)
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+            )
+            if disabled_contract_hash == contract_hash_v1
         ),
         "Expected invalid contract version, found {:?}",
         error,
@@ -295,7 +298,10 @@ fn should_run_regression() {
     assert!(
         matches!(
             error,
-            casper_execution_engine::core::engine_state::Error::Exec(_)
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+            )
+            if disabled_contract_hash == contract_hash_v1
         ),
         "Expected invalid contract version, found {:?}",
         error,
@@ -332,7 +338,10 @@ fn should_run_regression() {
     assert!(
         matches!(
             error,
-            casper_execution_engine::core::engine_state::Error::Exec(_)
+            casper_execution_engine::core::engine_state::Error::Exec(
+                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+            )
+            if disabled_contract_hash == contract_hash_v1
         ),
         "Expected invalid contract version, found {:?}",
         error,

--- a/execution_engine_testing/tests/src/test/regression/gh_3097.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3097.rs
@@ -10,8 +10,8 @@ use gh_1470_regression::CONTRACT_PACKAGE_HASH_NAME;
 const GH_3097_REGRESSION_WASM: &str = "gh_3097_regression.wasm";
 const GH_3097_REGRESSION_CALL_WASM: &str = "gh_3097_regression_call.wasm";
 const DO_SOMETHING_ENTRYPOINT: &str = "do_something";
-const CONTRACT_HASH_V1_KEY: &str = "contract_hash_v1";
-const CONTRACT_HASH_V2_KEY: &str = "contract_hash_v2";
+const DISABLED_CONTRACT_HASH_KEY: &str = "disabled_contract_hash";
+const ENABLED_CONTRACT_HASH_KEY: &str = "enabled_contract_hash";
 const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
 const ARG_METHOD: &str = "method";
 const ARG_CONTRACT_HASH_KEY: &str = "contract_hash_key";
@@ -41,11 +41,11 @@ fn should_run_regression() {
     let account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");
-    let contract_hash_v1 = account.named_keys()[CONTRACT_HASH_V1_KEY]
+    let disabled_contract_hash = account.named_keys()[DISABLED_CONTRACT_HASH_KEY]
         .into_hash()
         .map(ContractHash::new)
         .unwrap();
-    let contract_hash_v2 = account.named_keys()[CONTRACT_HASH_V2_KEY]
+    let enabled_contract_hash = account.named_keys()[ENABLED_CONTRACT_HASH_KEY]
         .into_hash()
         .map(ContractHash::new)
         .unwrap();
@@ -232,7 +232,7 @@ fn should_run_regression() {
 
     let call_by_hash_v2_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
-        contract_hash_v2,
+        enabled_contract_hash,
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )
@@ -245,7 +245,7 @@ fn should_run_regression() {
 
     let call_by_name_v2_request = ExecuteRequestBuilder::contract_call_by_name(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_HASH_V2_KEY,
+        ENABLED_CONTRACT_HASH_KEY,
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )
@@ -258,7 +258,7 @@ fn should_run_regression() {
     // This direct contract by name/hash should fail
     let call_by_hash_v1_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
-        contract_hash_v1,
+        disabled_contract_hash,
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )
@@ -273,9 +273,9 @@ fn should_run_regression() {
         matches!(
             error,
             casper_execution_engine::core::engine_state::Error::Exec(
-                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+                casper_execution_engine::core::execution::Error::DisabledContract(contract_hash)
             )
-            if disabled_contract_hash == contract_hash_v1
+            if contract_hash == disabled_contract_hash
         ),
         "Expected invalid contract version, found {:?}",
         error,
@@ -284,7 +284,7 @@ fn should_run_regression() {
     // This direct contract by name/hash should fail
     let call_by_name_v1_request = ExecuteRequestBuilder::contract_call_by_name(
         *DEFAULT_ACCOUNT_ADDR,
-        CONTRACT_HASH_V1_KEY,
+        DISABLED_CONTRACT_HASH_KEY,
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )
@@ -299,9 +299,9 @@ fn should_run_regression() {
         matches!(
             error,
             casper_execution_engine::core::engine_state::Error::Exec(
-                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+                casper_execution_engine::core::execution::Error::DisabledContract(contract_hash)
             )
-            if disabled_contract_hash == contract_hash_v1
+            if contract_hash == disabled_contract_hash
         ),
         "Expected invalid contract version, found {:?}",
         error,
@@ -314,7 +314,7 @@ fn should_run_regression() {
         GH_3097_REGRESSION_CALL_WASM,
         runtime_args! {
             ARG_METHOD => METHOD_CALL_CONTRACT,
-            ARG_CONTRACT_HASH_KEY => CONTRACT_HASH_V1_KEY,
+            ARG_CONTRACT_HASH_KEY => DISABLED_CONTRACT_HASH_KEY,
         },
     )
     .build();
@@ -324,7 +324,7 @@ fn should_run_regression() {
         GH_3097_REGRESSION_CALL_WASM,
         runtime_args! {
             ARG_METHOD => METHOD_CALL_CONTRACT,
-            ARG_CONTRACT_HASH_KEY => CONTRACT_HASH_V2_KEY,
+            ARG_CONTRACT_HASH_KEY => ENABLED_CONTRACT_HASH_KEY,
         },
     )
     .build();
@@ -339,9 +339,9 @@ fn should_run_regression() {
         matches!(
             error,
             casper_execution_engine::core::engine_state::Error::Exec(
-                casper_execution_engine::core::execution::Error::DisabledContract(disabled_contract_hash)
+                casper_execution_engine::core::execution::Error::DisabledContract(contract_hash)
             )
-            if disabled_contract_hash == contract_hash_v1
+            if contract_hash == disabled_contract_hash
         ),
         "Expected invalid contract version, found {:?}",
         error,

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -35,6 +35,7 @@ mod gh_1688;
 mod gh_1902;
 mod gh_1931;
 mod gh_2280;
+mod gh_3097;
 mod gov_116;
 mod gov_42;
 mod gov_74;

--- a/smart_contracts/contracts/test/gh-3097-regression-call/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-3097-regression-call/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gh-3097-regression-call"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "gh_3097_regression_call"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/gh-3097-regression-call/src/main.rs
+++ b/smart_contracts/contracts/test/gh-3097-regression-call/src/main.rs
@@ -1,0 +1,54 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::string::String;
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
+use casper_types::{ApiError, ContractHash, ContractPackageHash, RuntimeArgs};
+
+const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
+const DO_SOMETHING_ENTRYPOINT: &str = "do_something";
+const ARG_METHOD: &str = "method";
+const ARG_CONTRACT_HASH_KEY: &str = "contract_hash_key";
+const ARG_CONTRACT_VERSION: &str = "contract_version";
+const METHOD_CALL_CONTRACT: &str = "call_contract";
+const METHOD_CALL_VERSIONED_CONTRACT: &str = "call_versioned_contract";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let method: String = runtime::get_named_arg(ARG_METHOD);
+    if method == METHOD_CALL_CONTRACT {
+        let contract_hash_key_name: String = runtime::get_named_arg(ARG_CONTRACT_HASH_KEY);
+        let contract_hash = runtime::get_key(&contract_hash_key_name)
+            .ok_or(ApiError::MissingKey)
+            .unwrap_or_revert()
+            .into_hash()
+            .ok_or(ApiError::UnexpectedKeyVariant)
+            .map(ContractHash::new)
+            .unwrap_or_revert();
+        runtime::call_contract::<()>(
+            contract_hash,
+            DO_SOMETHING_ENTRYPOINT,
+            RuntimeArgs::default(),
+        )
+    } else if method == METHOD_CALL_VERSIONED_CONTRACT {
+        let contract_package_hash = runtime::get_key(CONTRACT_PACKAGE_HASH_KEY)
+            .ok_or(ApiError::MissingKey)
+            .unwrap_or_revert()
+            .into_hash()
+            .ok_or(ApiError::UnexpectedKeyVariant)
+            .map(ContractPackageHash::new)
+            .unwrap_or_revert();
+
+        let contract_version = runtime::get_named_arg(ARG_CONTRACT_VERSION);
+        runtime::call_versioned_contract::<()>(
+            contract_package_hash,
+            contract_version,
+            DO_SOMETHING_ENTRYPOINT,
+            RuntimeArgs::default(),
+        );
+    } else {
+        runtime::revert(ApiError::User(0));
+    }
+}

--- a/smart_contracts/contracts/test/gh-3097-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-3097-regression/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gh-3097-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "gh_3097_regression"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/gh-3097-regression/src/main.rs
+++ b/smart_contracts/contracts/test/gh-3097-regression/src/main.rs
@@ -12,6 +12,8 @@ use casper_types::{
 };
 
 const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
+const DISABLED_CONTRACT_HASH_KEY: &str = "disabled_contract_hash";
+const ENABLED_CONTRACT_HASH_KEY: &str = "enabled_contract_hash";
 
 #[no_mangle]
 pub extern "C" fn do_something() {
@@ -38,19 +40,20 @@ pub extern "C" fn call() {
 
     let (contract_package_hash, _access_key) = storage::create_contract_package_at_hash();
 
-    let (contract_hash_v1, _version) = storage::add_contract_version(
+    let (disabled_contract_hash, _version) = storage::add_contract_version(
         contract_package_hash,
         entry_points.clone(),
         Default::default(),
     );
 
-    let (contract_hash_v2, _version) =
+    let (enabled_contract_hash, _version) =
         storage::add_contract_version(contract_package_hash, entry_points, Default::default());
 
     runtime::put_key(CONTRACT_PACKAGE_HASH_KEY, contract_package_hash.into());
 
-    runtime::put_key("contract_hash_v1", contract_hash_v1.into());
-    runtime::put_key("contract_hash_v2", contract_hash_v2.into());
+    runtime::put_key(DISABLED_CONTRACT_HASH_KEY, disabled_contract_hash.into());
+    runtime::put_key(ENABLED_CONTRACT_HASH_KEY, enabled_contract_hash.into());
 
-    storage::disable_contract_version(contract_package_hash, contract_hash_v1).unwrap_or_revert();
+    storage::disable_contract_version(contract_package_hash, disabled_contract_hash)
+        .unwrap_or_revert();
 }

--- a/smart_contracts/contracts/test/gh-3097-regression/src/main.rs
+++ b/smart_contracts/contracts/test/gh-3097-regression/src/main.rs
@@ -1,0 +1,56 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use casper_contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{
+    contracts::Parameters, CLType, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints,
+};
+
+const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
+
+#[no_mangle]
+pub extern "C" fn do_something() {
+    let _ = runtime::list_authorization_keys();
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let entry_points = {
+        let mut entry_points = EntryPoints::new();
+
+        let do_something = EntryPoint::new(
+            "do_something",
+            Parameters::new(),
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Contract,
+        );
+
+        entry_points.add_entry_point(do_something);
+
+        entry_points
+    };
+
+    let (contract_package_hash, _access_key) = storage::create_contract_package_at_hash();
+
+    let (contract_hash_v1, _version) = storage::add_contract_version(
+        contract_package_hash,
+        entry_points.clone(),
+        Default::default(),
+    );
+
+    let (contract_hash_v2, _version) =
+        storage::add_contract_version(contract_package_hash, entry_points, Default::default());
+
+    runtime::put_key(CONTRACT_PACKAGE_HASH_KEY, contract_package_hash.into());
+
+    runtime::put_key("contract_hash_v1", contract_hash_v1.into());
+    runtime::put_key("contract_hash_v2", contract_hash_v2.into());
+
+    storage::disable_contract_version(contract_package_hash, contract_hash_v1).unwrap_or_revert();
+}


### PR DESCRIPTION
Closes #3097

This PR makes the contract execution flow easier to follow by moving most of the logic shared between call_contract and call_versioned_contract into execute_contract. It decreases duplication and allows for an extra validation step that will reject calls to disabled contract hashes - when a disabled contract is now called, a special error `DisabledContract(contract_hash)` will be raised.