### PR TITLE
Add option to disable HTTP servers

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -37,8 +37,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add new `block_hash` and `block_height` optional fields to `info_get_deploy` RPC query which will be present when execution results aren't available.
 * Add a new config option `[rpc_server.max_body_bytes]` to allow a configurable value for the maximum size of the body of a JSON-RPC request.
 * Add new JSON RPC endpoint `/speculative_exec` that accepts a deploy and a block hash and executes that deploy, returning the execution effects.
-* Add `speculative_execution_address` to `rpc_server` section in `config.toml` to control address which the speculative execution server binds to.
-* Add `speculative_execution_qps_limit` to `rpc_server` section in `config.toml` to control requests per second the node handles. Setting to 0 disbles the endpoint.
+* Add `enable_server` option to all HTTP server configuration sections (`rpc_server`, `rest_server`, `event_stream_server`) which allow users to enable/disable each server independently (enabled by default).
+* Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/event_stream_server/config.rs
+++ b/node/src/components/event_stream_server/config.rs
@@ -17,6 +17,9 @@ const DEFAULT_MAX_CONCURRENT_SUBSCRIBERS: u32 = 100;
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Setting to enable the HTTP server.
+    pub enable_server: bool,
+
     /// Address to bind event stream SSE HTTP server to.
     pub address: String,
 
@@ -31,6 +34,7 @@ impl Config {
     /// Creates a default instance for `EventStreamServer`.
     pub fn new() -> Self {
         Config {
+            enable_server: true,
             address: DEFAULT_ADDRESS.to_string(),
             event_stream_buffer_length: DEFAULT_EVENT_STREAM_BUFFER_LENGTH,
             max_concurrent_subscribers: DEFAULT_MAX_CONCURRENT_SUBSCRIBERS,

--- a/node/src/components/event_stream_server/tests.rs
+++ b/node/src/components/event_stream_server/tests.rs
@@ -269,11 +269,12 @@ impl TestFixture {
             self.protocol_version,
         )
         .unwrap();
+        assert!(server.inner.is_some());
 
-        self.first_event_id = server.event_indexer.current_index();
+        self.first_event_id = server.inner.as_ref().unwrap().event_indexer.current_index();
 
-        let first_event_id = server.event_indexer.current_index();
-        let server_address = server.listening_address;
+        let first_event_id = server.inner.as_ref().unwrap().event_indexer.current_index();
+        let server_address = server.inner.as_ref().unwrap().listening_address;
         let events = self.events.clone();
         let server_stopper = self.server_stopper.clone();
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -78,7 +78,7 @@ impl<REv> ReactorEventT for REv where
 
 #[derive(DataSize, Debug)]
 pub(crate) struct RestServer {
-    /// Enable.
+    /// Indicates whether the REST server is enabled or not.
     enable: bool,
     /// When the message is sent, it signals the server loop to exit cleanly.
     #[data_size(skip)]

--- a/node/src/components/rest_server/config.rs
+++ b/node/src/components/rest_server/config.rs
@@ -13,6 +13,9 @@ const DEFAULT_QPS_LIMIT: u64 = 100;
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Setting to enable the HTTP server.
+    pub enable_server: bool,
+
     /// Address to bind REST HTTP server to.
     pub address: String,
 
@@ -24,6 +27,7 @@ impl Config {
     /// Creates a default instance for `RestServer`.
     pub fn new() -> Self {
         Config {
+            enable_server: true,
             address: DEFAULT_ADDRESS.to_string(),
             qps_limit: DEFAULT_QPS_LIMIT,
         }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -86,6 +86,10 @@ impl<REv> ReactorEventT for REv where
 
 #[derive(DataSize, Debug)]
 pub(crate) struct RpcServer {
+    /// Enabled.
+    enable: bool,
+    /// Enabled.
+    speculative_exec_enable: bool,
     /// The instant at which the node has started.
     node_startup_instant: Instant,
     /// The current state of the node.
@@ -104,14 +108,16 @@ impl RpcServer {
     where
         REv: ReactorEventT,
     {
-        let builder = utils::start_listening(&config.address)?;
-        tokio::spawn(http_server::run(
-            builder,
-            effect_builder,
-            api_version,
-            config.qps_limit,
-            config.max_body_bytes,
-        ));
+        if config.enable_server {
+            let builder = utils::start_listening(&config.address)?;
+            tokio::spawn(http_server::run(
+                builder,
+                effect_builder,
+                api_version,
+                config.qps_limit,
+                config.max_body_bytes,
+            ));
+        }
 
         // Set the speculative execution HTTP server up.
         if speculative_exec_config.enable_server {
@@ -126,6 +132,8 @@ impl RpcServer {
         }
 
         Ok(RpcServer {
+            enable: config.enable_server,
+            speculative_exec_enable: speculative_exec_config.enable_server,
             node_startup_instant,
             node_state,
         })
@@ -222,14 +230,16 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::RpcRequest(RpcRequest::SubmitDeploy { deploy, responder }) => effect_builder
-                .announce_deploy_received(deploy, Some(responder))
-                .ignore(),
+            Event::RpcRequest(RpcRequest::SubmitDeploy { deploy, responder }) if self.enable => {
+                effect_builder
+                    .announce_deploy_received(deploy, Some(responder))
+                    .ignore()
+            }
             Event::RpcRequest(RpcRequest::GetBlock {
                 maybe_id: Some(BlockIdentifier::Hash(hash)),
                 only_from_available_block_range,
                 responder,
-            }) => effect_builder
+            }) if self.enable => effect_builder
                 .get_block_with_metadata_from_storage(hash, only_from_available_block_range)
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Hash(hash)),
@@ -240,7 +250,7 @@ where
                 maybe_id: Some(BlockIdentifier::Height(height)),
                 only_from_available_block_range,
                 responder,
-            }) => effect_builder
+            }) if self.enable => effect_builder
                 .get_block_at_height_with_metadata_from_storage(
                     height,
                     only_from_available_block_range,
@@ -255,7 +265,7 @@ where
                 only_from_available_block_range: _, /* Requesting for higest block cannot be
                                                      * restricted by block availability index */
                 responder,
-            }) => effect_builder
+            }) if self.enable => effect_builder
                 .get_highest_block_with_metadata_from_storage()
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: None,
@@ -265,7 +275,7 @@ where
             Event::RpcRequest(RpcRequest::GetBlockTransfers {
                 block_hash,
                 responder,
-            }) => effect_builder
+            }) if self.enable => effect_builder
                 .get_block_transfers_from_storage(block_hash)
                 .event(move |result| Event::GetBlockTransfersResult {
                     block_hash,
@@ -277,12 +287,14 @@ where
                 base_key,
                 path,
                 responder,
-            }) => self.handle_query(effect_builder, state_root_hash, base_key, path, responder),
+            }) if self.enable => {
+                self.handle_query(effect_builder, state_root_hash, base_key, path, responder)
+            }
             Event::RpcRequest(RpcRequest::QueryEraValidators {
                 state_root_hash,
                 protocol_version,
                 responder,
-            }) => self.handle_era_validators(
+            }) if self.enable => self.handle_era_validators(
                 effect_builder,
                 state_root_hash,
                 protocol_version,
@@ -291,7 +303,7 @@ where
             Event::RpcRequest(RpcRequest::GetBids {
                 state_root_hash,
                 responder,
-            }) => {
+            }) if self.enable => {
                 let get_bids_request = GetBidsRequest::new(state_root_hash);
                 effect_builder
                     .get_bids(get_bids_request)
@@ -304,12 +316,14 @@ where
                 state_root_hash,
                 purse_uref,
                 responder,
-            }) => self.handle_get_balance(effect_builder, state_root_hash, purse_uref, responder),
+            }) if self.enable => {
+                self.handle_get_balance(effect_builder, state_root_hash, purse_uref, responder)
+            }
             Event::RpcRequest(RpcRequest::GetDeploy {
                 hash,
                 responder,
                 finalized_approvals,
-            }) => effect_builder
+            }) if self.enable => effect_builder
                 .get_deploy_and_metadata_from_storage(hash)
                 .event(move |result| Event::GetDeployResult {
                     hash,
@@ -327,13 +341,13 @@ where
                     )),
                     main_responder: responder,
                 }),
-            Event::RpcRequest(RpcRequest::GetPeers { responder }) => effect_builder
+            Event::RpcRequest(RpcRequest::GetPeers { responder }) if self.enable => effect_builder
                 .network_peers()
                 .event(move |peers| Event::GetPeersResult {
                     peers,
                     main_responder: responder,
                 }),
-            Event::RpcRequest(RpcRequest::GetStatus { responder }) => {
+            Event::RpcRequest(RpcRequest::GetStatus { responder }) if self.enable => {
                 let node_uptime = self.node_startup_instant.elapsed();
                 let node_state = self.node_state();
                 async move {
@@ -355,56 +369,79 @@ where
                 }
                 .ignore()
             }
-            Event::RpcRequest(RpcRequest::GetAvailableBlockRange { responder }) => async move {
-                responder
-                    .respond(
-                        effect_builder
-                            .get_available_block_range_from_storage()
-                            .await,
-                    )
-                    .await
+            Event::RpcRequest(RpcRequest::GetAvailableBlockRange { responder }) if self.enable => {
+                async move {
+                    responder
+                        .respond(
+                            effect_builder
+                                .get_available_block_range_from_storage()
+                                .await,
+                        )
+                        .await
+                }
+                .ignore()
             }
-            .ignore(),
             Event::RpcRequest(RpcRequest::SpeculativeDeployExecute {
                 block_header,
                 deploy,
                 responder,
-            }) => self.handle_execute_deploy(effect_builder, block_header, *deploy, responder),
+            }) if self.speculative_exec_enable => {
+                self.handle_execute_deploy(effect_builder, block_header, *deploy, responder)
+            }
             Event::GetBlockResult {
                 maybe_id: _,
                 result,
                 main_responder,
-            } => main_responder.respond(*result).ignore(),
+            } if self.enable => main_responder.respond(*result).ignore(),
             Event::GetBlockTransfersResult {
                 result,
                 main_responder,
                 ..
-            } => main_responder.respond(*result).ignore(),
+            } if self.enable => main_responder.respond(*result).ignore(),
             Event::QueryGlobalStateResult {
                 result,
                 main_responder,
-            } => main_responder.respond(result).ignore(),
+            } if self.enable => main_responder.respond(result).ignore(),
             Event::QueryEraValidatorsResult {
                 result,
                 main_responder,
-            } => main_responder.respond(result).ignore(),
+            } if self.enable => main_responder.respond(result).ignore(),
             Event::GetBidsResult {
                 result,
                 main_responder,
-            } => main_responder.respond(result).ignore(),
+            } if self.enable => main_responder.respond(result).ignore(),
             Event::GetBalanceResult {
                 result,
                 main_responder,
-            } => main_responder.respond(result).ignore(),
+            } if self.enable => main_responder.respond(result).ignore(),
             Event::GetDeployResult {
                 hash: _,
                 result,
                 main_responder,
-            } => main_responder.respond(*result).ignore(),
+            } if self.enable => main_responder.respond(*result).ignore(),
             Event::GetPeersResult {
                 peers,
                 main_responder,
-            } => main_responder.respond(peers).ignore(),
+            } if self.enable => main_responder.respond(peers).ignore(),
+            Event::RpcRequest(RpcRequest::SpeculativeDeployExecute { .. })
+                if self.speculative_exec_enable =>
+            {
+                Effects::new()
+            }
+            Event::RpcRequest(_)
+            | Event::GetBalanceResult { .. }
+            | Event::GetBidsResult { .. }
+            | Event::GetBlockResult { .. }
+            | Event::GetBlockTransfersResult { .. }
+            | Event::GetDeployResult { .. }
+            | Event::GetPeersResult { .. }
+            | Event::QueryEraValidatorsResult { .. }
+            | Event::QueryGlobalStateResult { .. }
+                if !self.enable =>
+            {
+                Effects::new()
+            }
+            _ => unreachable!(),
         }
     }
 }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -87,9 +87,9 @@ impl<REv> ReactorEventT for REv where
 
 #[derive(DataSize, Debug)]
 pub(crate) struct RpcServer {
-    /// Enabled.
+    /// Indicates whether the JSON-RPC server is enabled or not.
     enable: bool,
-    /// Enabled.
+    /// Indicates whether the speculative execution JSON-RPC server is enabled or not.
     speculative_exec_enable: bool,
     /// The instant at which the node has started.
     node_startup_instant: Instant,

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -25,6 +25,7 @@ use std::{convert::Infallible, fmt::Debug, time::Instant};
 
 use datasize::DataSize;
 use futures::join;
+use tracing::error;
 
 use casper_execution_engine::core::engine_state::{
     self, BalanceRequest, BalanceResult, GetBidsRequest, GetEraValidatorsError, QueryRequest,
@@ -424,7 +425,7 @@ where
                 main_responder,
             } if self.enable => main_responder.respond(peers).ignore(),
             Event::RpcRequest(RpcRequest::SpeculativeDeployExecute { .. })
-                if self.speculative_exec_enable =>
+                if !self.speculative_exec_enable =>
             {
                 Effects::new()
             }
@@ -441,7 +442,10 @@ where
             {
                 Effects::new()
             }
-            _ => unreachable!(),
+            ev => {
+                error!("Unhandled event in JSON-RPC server: {}", ev);
+                Effects::new()
+            }
         }
     }
 }

--- a/node/src/components/rpc_server/config.rs
+++ b/node/src/components/rpc_server/config.rs
@@ -20,6 +20,8 @@ const DEFAULT_MAX_BODY_BYTES: u32 = 2_621_440;
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Setting to enable the HTTP server.
+    pub enable_server: bool,
     /// Address to bind JSON-RPC HTTP server to.
     pub address: String,
     /// Maximum rate limit in queries per second.
@@ -36,6 +38,7 @@ impl Config {
     /// Creates a default instance for `RpcServer`.
     pub fn new() -> Self {
         Config {
+            enable_server: true,
             address: DEFAULT_ADDRESS.to_string(),
             qps_limit: DEFAULT_QPS_LIMIT,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,

--- a/node/src/components/rpc_server/speculative_exec_config.rs
+++ b/node/src/components/rpc_server/speculative_exec_config.rs
@@ -1,14 +1,13 @@
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
-/// Default binding address for the JSON-RPC HTTP server.
+/// Default binding address for the speculative execution RPC HTTP server.
 ///
 /// Uses a fixed port per node, but binds on any interface.
-const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
+const DEFAULT_ADDRESS: &str = "0.0.0.0:1";
 /// Default rate limit in qps.
-const DEFAULT_QPS_LIMIT: u64 = 100;
-/// Default max body bytes.  This is 2.5MB which should be able to accommodate the largest valid
-/// JSON-RPC request, which would be an "account_put_deploy".
+const DEFAULT_QPS_LIMIT: u64 = 1;
+/// Default max body bytes (2.5MB).
 const DEFAULT_MAX_BODY_BYTES: u32 = 2_621_440;
 
 /// JSON-RPC HTTP server configuration.
@@ -18,7 +17,7 @@ const DEFAULT_MAX_BODY_BYTES: u32 = 2_621_440;
 pub struct Config {
     /// Setting to enable the HTTP server.
     pub enable_server: bool,
-    /// Address to bind JSON-RPC HTTP server to.
+    /// Address to bind JSON-RPC speculative execution server to.
     pub address: String,
     /// Maximum rate limit in queries per second.
     pub qps_limit: u64,
@@ -30,7 +29,7 @@ impl Config {
     /// Creates a default instance for `RpcServer`.
     pub fn new() -> Self {
         Config {
-            enable_server: true,
+            enable_server: false,
             address: DEFAULT_ADDRESS.to_string(),
             qps_limit: DEFAULT_QPS_LIMIT,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -52,12 +52,16 @@ use rand::SeedableRng;
 use signal_hook::{consts::TERM_SIGNALS, flag};
 
 pub(crate) use components::{
-    block_proposer::Config as BlockProposerConfig, consensus::Config as ConsensusConfig,
+    block_proposer::Config as BlockProposerConfig,
+    consensus::Config as ConsensusConfig,
     contract_runtime::Config as ContractRuntimeConfig,
     diagnostics_port::Config as DiagnosticsPortConfig,
-    event_stream_server::Config as EventStreamServerConfig, fetcher::Config as FetcherConfig,
-    gossiper::Config as GossipConfig, rest_server::Config as RestServerConfig,
-    rpc_server::Config as RpcServerConfig, small_network::Config as SmallNetworkConfig,
+    event_stream_server::Config as EventStreamServerConfig,
+    fetcher::Config as FetcherConfig,
+    gossiper::Config as GossipConfig,
+    rest_server::Config as RestServerConfig,
+    rpc_server::{Config as RpcServerConfig, SpeculativeExecConfig},
+    small_network::Config as SmallNetworkConfig,
 };
 pub(crate) use types::NodeRng;
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -653,6 +653,7 @@ impl reactor::Reactor for Reactor {
         let protocol_version = chainspec.protocol_config.version;
         let rpc_server = RpcServer::new(
             config.rpc_server.clone(),
+            config.speculative_exec_server.clone(),
             effect_builder,
             protocol_version,
             node_startup_instant,

--- a/node/src/reactor/participating/config.rs
+++ b/node/src/reactor/participating/config.rs
@@ -4,7 +4,8 @@ use serde::Deserialize;
 use crate::{
     logging::LoggingConfig, types::NodeConfig, BlockProposerConfig, ConsensusConfig,
     ContractRuntimeConfig, DiagnosticsPortConfig, EventStreamServerConfig, FetcherConfig,
-    GossipConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig, StorageConfig,
+    GossipConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig, SpeculativeExecConfig,
+    StorageConfig,
 };
 
 /// Root configuration.
@@ -26,6 +27,8 @@ pub(crate) struct Config {
     pub(crate) rest_server: RestServerConfig,
     /// RPC API server configuration.
     pub(crate) rpc_server: RpcServerConfig,
+    /// Speculative execution server configuration.
+    pub(crate) speculative_exec_server: SpeculativeExecConfig,
     /// On-disk storage configuration.
     pub(crate) storage: StorageConfig,
     /// Gossip protocol configuration.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -250,6 +253,9 @@ speculative_execution_qps_limit = 0
 # ==============================================
 [rest_server]
 
+# Flag which enables the REST HTTP server.
+enable_server = true
+
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -267,6 +273,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -240,18 +240,20 @@ qps_limit = 100
 max_body_bytes = 2_621_440
 
 
-# ===================================================================
-# Configuration options for the speculative execution RPC HTTP server
-# ===================================================================
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
 [speculative_exec_server]
 
-# Flag which enables the speculative execution RPC HTTP server.
+# Flag which enables the speculative execution JSON-RPC HTTP server.
 enable_server = false
 
-# Listening address for speculative execution RPC HTTP server.  If the port is set to 0, a random port will be used.
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
 #
-# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
-# the speculative execution RPC HTTP server will not run, but the node will be otherwise unaffected.
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
 #
 # The actual bound address will be reported via a log line if logging is enabled.
 address = '0.0.0.0:7778'

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -239,13 +239,29 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ===================================================================
+# Configuration options for the speculative execution RPC HTTP server
+# ===================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution RPC HTTP server.  If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
+# the speculative execution RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -231,23 +234,45 @@ address = '0.0.0.0:7777'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 50
+qps_limit = 100
 
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -266,6 +291,9 @@ qps_limit = 10
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,18 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -266,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -224,6 +224,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -239,18 +242,39 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -269,6 +293,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,18 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
+
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -266,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
@@ -221,6 +221,9 @@ finalized_approvals_responses = 0
 # ==================================================
 [rpc_server]
 
+# Flag which enables the JSON-RPC HTTP server.
+enable_server = true
+
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
 #
 # If the specified port cannot be bound to, a random port will be tried instead.  If binding fails,
@@ -236,19 +239,40 @@ qps_limit = 100
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440
 
-# Address to which the speculative execution endpoint binds to.
-speculative_execution_address = "0.0.0.0:7778"
+
+# ========================================================================
+# Configuration options for the speculative execution JSON-RPC HTTP server
+# ========================================================================
+[speculative_exec_server]
+
+# Flag which enables the speculative execution JSON-RPC HTTP server.
+enable_server = false
+
+# Listening address for speculative execution JSON-RPC HTTP server.  If the port
+# is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead.
+# If binding fails, the speculative execution JSON-RPC HTTP server will not run,
+# but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7778'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-# Setting to 0 disables the endpoint.
-speculative_execution_qps_limit = 0
+qps_limit = 1
+
+# Maximum number of bytes to accept in a single request body.
+max_body_bytes = 2_621_440
 
 
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================
 [rest_server]
+
+# Flag which enables the REST HTTP server.
+enable_server = true
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
 #
@@ -267,6 +291,9 @@ qps_limit = 100
 # Configuration options for the SSE HTTP event stream server
 # ==========================================================
 [event_stream_server]
+
+# Flag which enables the SSE HTTP event stream server.
+enable_server = true
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
 #


### PR DESCRIPTION
Fixes #3141 

This PR adds functionality to disable the HTTP servers in node (RPC, REST, events, speculative execution). Additionally, it separates the configurations of the RPC and speculative execution servers, which were previously under the same section.

This functionality can't be tested in node, so the tests are in `casper-test`. After this PR gets merged, https://github.com/casper-network/casper-test/pull/88 should also get merged.
