### PR TITLE
Remove storage config option `max_sync_tasks`

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -53,9 +53,8 @@ All notable changes to this project will be documented in this file.  The format
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).
 * Switch blocks immediately after genesis or an upgrade are now signed.
 * Added CORS behavior to allow any route on the JSON-RPC, REST and SSE servers.
-* Storage operations are now executed in parallel, the degree of parallelism can be controlled through the `storage.max_sync_tasks` setting.
 * The network message format has been replaced with a more efficient encoding while keeping the initial handshake intact.
-* The node flushes outgoing messages immediately, trading bandwidth for latecy. This change is made to optimize feedback loops of various components in the system.
+* The node flushes outgoing messages immediately, trading bandwidth for latency. This change is made to optimize feedback loops of various components in the system.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -103,6 +103,10 @@ use self::disjoint_sequences::DisjointSequences;
 /// Filename for the LMDB database created by the Storage component.
 const STORAGE_DB_FILENAME: &str = "storage.lmdb";
 
+/// We can set this very low, as there is only a single reader/writer accessing the component at any
+/// one time.
+const MAX_TRANSACTIONS: u32 = 1;
+
 /// One Gibibyte.
 const GIB: usize = 1024 * 1024 * 1024;
 
@@ -342,12 +346,10 @@ impl Storage {
                 | EnvironmentFlags::NO_SUB_DIR
                 // Disable thread local storage, strongly suggested for operation with tokio.
                 | EnvironmentFlags::NO_TLS
-                // Disable read-ahead. Our data is not storead/read in sequence that would benefit from the read-ahead.
+                // Disable read-ahead. Our data is not stored/read in sequence that would benefit from the read-ahead.
                 | EnvironmentFlags::NO_READAHEAD,
             )
-            // We need at least `max_sync_tasks` readers, add an additional 8 for unforseen external
-            // reads (not likely, but it does not hurt to increase this limit).
-            .set_max_readers(config.max_sync_tasks as u32 + 8)
+            .set_max_readers(MAX_TRANSACTIONS)
             .set_max_dbs(MAX_DB_COUNT)
             .set_map_size(total_size)
             .open(&root.join(STORAGE_DB_FILENAME))?;
@@ -2217,8 +2219,6 @@ pub struct Config {
     enable_mem_deduplication: bool,
     /// How many loads before memory duplication checks for dead references.
     mem_pool_prune_interval: u16,
-    /// Maximum number of parallel synchronous storage tasks to spawn.
-    max_sync_tasks: u16,
 }
 
 impl Default for Config {
@@ -2232,7 +2232,6 @@ impl Default for Config {
             max_state_store_size: DEFAULT_MAX_STATE_STORE_SIZE,
             enable_mem_deduplication: true,
             mem_pool_prune_interval: 4096,
-            max_sync_tasks: 32,
         }
     }
 }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -54,7 +54,6 @@ fn new_config(harness: &ComponentHarness<UnitTestEvent>) -> Config {
         max_state_store_size: 50 * MIB,
         enable_mem_deduplication: true,
         mem_pool_prune_interval: 4,
-        max_sync_tasks: 32,
     }
 }
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -335,11 +335,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -334,11 +334,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -337,11 +337,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -334,10 +334,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_1.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_10.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_3.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_4.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_5.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_6.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_7.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_8.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping

--- a/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
+++ b/utils/nctl/sh/scenarios/configs/upgrade_scenario_9.config.toml
@@ -336,11 +336,6 @@ enable_mem_deduplication = true
 # For example, setting this value to 5 means that every 5th time something is put in the pool the cache is swept.
 mem_pool_prune_interval = 4096
 
-# Parallel storage request execution.
-#
-# Controls the maximum number of threads that are spawned to access storage in parallel.
-max_sync_tasks = 32
-
 
 # ===================================
 # Configuration options for gossiping


### PR DESCRIPTION
The storage option `max_sync_tasks` should have been removed as part of #3094.  This PR rectifies that oversight.

Closes #3092.