### PR TITLE
Restrict JSON-RPC request `params` to JSON Array or Object type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
+ "itertools",
  "serde",
  "serde_json",
  "tokio",

--- a/json_rpc/Cargo.toml
+++ b/json_rpc/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 bytes = "1.1.0"
 futures = "0.3.21"
 http = "0.2.7"
+itertools = "0.10.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1.34"

--- a/json_rpc/README.md
+++ b/json_rpc/README.md
@@ -21,17 +21,16 @@ Normally usage will involve two steps:
 # Example
 
 ```rust
-use casper_json_rpc::{Error, RequestHandlersBuilder};
-use serde_json::Value;
+use casper_json_rpc::{Error, Params, RequestHandlersBuilder};
 use std::{convert::Infallible, sync::Arc};
 
-async fn get(params: Option<Value>) -> Result<String, Error> {
+async fn get(params: Option<Params>) -> Result<String, Error> {
     // * parse params or return `ReservedErrorCode::InvalidParams` error
     // * handle request and return result
     Ok("got it".to_string())
 }
 
-async fn put(params: Option<Value>, other_input: &str) -> Result<String, Error> {
+async fn put(params: Option<Params>, other_input: &str) -> Result<String, Error> {
     Ok(other_input.to_string())
 }
 
@@ -81,7 +80,7 @@ To return a JSON-RPC response indicating an error, use
 conditions which require returning a reserved error are already handled in the provided warp filters.  The only
 exception is
 [`ReservedErrorCode::InvalidParams`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/enum.ReservedErrorCode.html#variant.InvalidParams)
-which should be returned by any RPC handler which deems the provided `params: Option<Value>` to be invalid for any
+which should be returned by any RPC handler which deems the provided `params: Option<Params>` to be invalid for any
 reason.
 
 Generally a set of custom error codes should be provided.  These should all implement

--- a/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
+++ b/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
@@ -219,7 +219,7 @@ async fn should_handle_request_with_extra_field() {
     let filter = main_filter_with_recovery();
 
     // This should get handled by `filters::handle_body` and return Response::Failure (invalid
-    // request) to the client as the ID has fractional parts.
+    // request) to the client as the request has an extra field.
     let http_response = warp::test::request()
         .body(r#"{"jsonrpc":"2.0","id":1,"method":"get good thing","params":[2],"extra":"field"}"#)
         .filter(&filter)

--- a/json_rpc/src/lib.rs
+++ b/json_rpc/src/lib.rs
@@ -12,19 +12,18 @@
 //! # Example
 //!
 //! ```no_run
-//! use casper_json_rpc::{Error, RequestHandlersBuilder};
-//! use serde_json::Value;
+//! use casper_json_rpc::{Error, Params, RequestHandlersBuilder};
 //! use std::{convert::Infallible, sync::Arc};
 //!
 //! # #[allow(unused)]
-//! async fn get(params: Option<Value>) -> Result<String, Error> {
+//! async fn get(params: Option<Params>) -> Result<String, Error> {
 //!     // * parse params or return `ReservedErrorCode::InvalidParams` error
 //!     // * handle request and return result
 //!     Ok("got it".to_string())
 //! }
 //!
 //! # #[allow(unused)]
-//! async fn put(params: Option<Value>, other_input: &str) -> Result<String, Error> {
+//! async fn put(params: Option<Params>, other_input: &str) -> Result<String, Error> {
 //!     Ok(other_input.to_string())
 //! }
 //!
@@ -60,7 +59,7 @@
 //! To return a JSON-RPC response indicating an error, use [`Error::new`].  Most error conditions
 //! which require returning a reserved error are already handled in the provided warp filters.  The
 //! only exception is [`ReservedErrorCode::InvalidParams`] which should be returned by any RPC
-//! handler which deems the provided `params: Option<Value>` to be invalid for any reason.
+//! handler which deems the provided `params: Option<Params>` to be invalid for any reason.
 //!
 //! Generally a set of custom error codes should be provided.  These should all implement
 //! [`ErrorCodeT`].
@@ -89,6 +88,7 @@ use http::{header::CONTENT_TYPE, Method};
 use warp::{filters::BoxedFilter, Filter, Reply};
 
 pub use error::{Error, ErrorCodeT, ReservedErrorCode};
+pub use request::Params;
 pub use request_handlers::{RequestHandlers, RequestHandlersBuilder};
 pub use response::Response;
 

--- a/json_rpc/src/request.rs
+++ b/json_rpc/src/request.rs
@@ -1,7 +1,9 @@
+mod params;
+
 use std::convert::TryFrom;
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use itertools::Itertools;
+use serde_json::{Map, Value};
 use warp::reject::{self, Rejection};
 
 use crate::{
@@ -9,20 +11,12 @@ use crate::{
     rejections::MissingId,
     JSON_RPC_VERSION,
 };
+pub use params::Params;
 
-/// A JSON-RPC request, prior to validation of conformance to the JSON-RPC specification.
-///
-/// This overly-permissive type used in the warp filters allows for non-conformance to be detected
-/// and a useful error message returned to the client, rather than a somewhat opaque HTTP 404
-/// response.
-#[derive(Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct UnvalidatedRequest {
-    jsonrpc: String,
-    id: Option<Value>,
-    method: String,
-    params: Option<Value>,
-}
+const JSONRPC_FIELD_NAME: &str = "jsonrpc";
+const METHOD_FIELD_NAME: &str = "method";
+const PARAMS_FIELD_NAME: &str = "params";
+const ID_FIELD_NAME: &str = "id";
 
 /// Errors are returned to the client as a JSON-RPC response and HTTP 200 (OK), whereas rejections
 /// cause no JSON-RPC response to be sent, but an appropriate HTTP 4xx error will be returned.
@@ -36,7 +30,7 @@ pub(crate) enum ErrorOrRejection {
 pub(crate) struct Request {
     pub id: Value,
     pub method: String,
-    pub params: Option<Value>,
+    pub params: Option<Params>,
 }
 
 /// Returns `Ok` if `id` is a String, Null or a Number with no fractional part.
@@ -61,20 +55,76 @@ fn is_valid(id: &Value) -> Result<(), Error> {
     Ok(())
 }
 
-impl TryFrom<UnvalidatedRequest> for Request {
+impl TryFrom<Map<String, Value>> for Request {
     type Error = ErrorOrRejection;
 
     /// Returns `Ok` if the request is valid as per
     /// [the JSON-RPC specification](https://www.jsonrpc.org/specification#request_object).
     ///
-    /// Returns an `Error` in the following cases:
+    /// Returns an `Error` in any of the following cases:
     ///   * "jsonrpc" field is not "2.0"
+    ///   * "method" field is not a String
+    ///   * "params" field is present, but is not an Array or Object
     ///   * "id" field is not a String, valid Number or Null
     ///   * "id" field is a Number with fractional part
+    ///   * extra fields exist
     ///
     /// Returns a `Rejection` if the "id" field is `None`.
-    fn try_from(request: UnvalidatedRequest) -> Result<Self, Self::Error> {
-        let id = match request.id {
+    fn try_from(mut request: Map<String, Value>) -> Result<Self, Self::Error> {
+        // Just copy "id" field for now to return verbatim in any errors before we get to actually
+        // validating the "id" field itself.
+        let id = request.get(ID_FIELD_NAME).cloned().unwrap_or_default();
+
+        match request.remove(JSONRPC_FIELD_NAME) {
+            Some(Value::String(jsonrpc)) => {
+                if jsonrpc != JSON_RPC_VERSION {
+                    let error = Error::new(
+                        ReservedErrorCode::InvalidRequest,
+                        format!("'jsonrpc' must be '2.0', but was '{}'", jsonrpc),
+                    );
+                    return Err(ErrorOrRejection::Error { id, error });
+                }
+            }
+            Some(jsonrpc) => {
+                let error = Error::new(
+                    ReservedErrorCode::InvalidRequest,
+                    format!("'jsonrpc' must be '2.0', but was '{}'", jsonrpc),
+                );
+                return Err(ErrorOrRejection::Error { id, error });
+            }
+            None => {
+                let error = Error::new(
+                    ReservedErrorCode::InvalidRequest,
+                    format!("Missing '{}' field", JSONRPC_FIELD_NAME),
+                );
+                return Err(ErrorOrRejection::Error { id, error });
+            }
+        }
+
+        let method = match request.remove(METHOD_FIELD_NAME) {
+            Some(Value::String(method)) => method,
+            Some(_) => {
+                let error = Error::new(
+                    ReservedErrorCode::InvalidRequest,
+                    format!("Expected '{}' to be a String", METHOD_FIELD_NAME),
+                );
+                return Err(ErrorOrRejection::Error { id, error });
+            }
+            None => {
+                let error = Error::new(
+                    ReservedErrorCode::InvalidRequest,
+                    format!("Missing '{}' field", METHOD_FIELD_NAME),
+                );
+                return Err(ErrorOrRejection::Error { id, error });
+            }
+        };
+
+        let params = match request.remove(PARAMS_FIELD_NAME) {
+            Some(unvalidated_params) => Some(Params::try_from(&id, unvalidated_params)?),
+            None => None,
+        };
+
+        let id = match request.remove(ID_FIELD_NAME) {
             Some(id) => {
                 is_valid(&id).map_err(|error| ErrorOrRejection::Error {
                     id: Value::Null,
@@ -85,19 +135,19 @@ impl TryFrom<UnvalidatedRequest> for Request {
             None => return Err(ErrorOrRejection::Rejection(reject::custom(MissingId))),
         };
 
-        if request.jsonrpc != JSON_RPC_VERSION {
+        if !request.is_empty() {
             let error = Error::new(
                 ReservedErrorCode::InvalidRequest,
-                format!("'jsonrpc' must be '2.0', but was '{}'", request.jsonrpc),
+                format!(
+                    "Unexpected field{}: {}",
+                    if request.len() > 1 { "s" } else { "" },
+                    request.keys().map(|f| format!("'{}'", f)).join(", ")
+                ),
             );
             return Err(ErrorOrRejection::Error { id, error });
         }
 
-        Ok(Request {
-            id,
-            method: request.method,
-            params: request.params,
-        })
+        Ok(Request { id, method, params })
     }
 }
 
@@ -111,19 +161,22 @@ mod tests {
     fn should_validate_using_valid_id() {
         fn run_test(id: Value) {
             let method = "a".to_string();
-            let params = Some(Value::Array(vec![Value::Bool(true)]));
+            let params_inner = vec![Value::Bool(true)];
 
-            let unvalidated = UnvalidatedRequest {
-                jsonrpc: JSON_RPC_VERSION.to_string(),
-                id: Some(id.clone()),
-                method: method.clone(),
-                params: params.clone(),
-            };
+            let unvalidated = json!({
+                JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+                ID_FIELD_NAME: id,
+                METHOD_FIELD_NAME: method,
+                PARAMS_FIELD_NAME: params_inner,
+            })
+            .as_object()
+            .cloned()
+            .unwrap();
 
             let request = Request::try_from(unvalidated).unwrap();
             assert_eq!(request.id, id);
             assert_eq!(request.method, method);
-            assert_eq!(request.params, params);
+            assert_eq!(request.params.unwrap(), Params::Array(params_inner));
         }
 
         run_test(Value::String("the id".to_string()));
@@ -133,12 +186,14 @@ mod tests {
 
     #[test]
     fn should_fail_to_validate_id_with_wrong_type() {
-        let request = UnvalidatedRequest {
-            jsonrpc: JSON_RPC_VERSION.to_string(),
-            id: Some(Value::Bool(true)),
-            method: "a".to_string(),
-            params: None,
-        };
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: true,
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
 
         let error = match Request::try_from(request) {
             Err(ErrorOrRejection::Error {
@@ -158,12 +213,14 @@ mod tests {
 
     #[test]
     fn should_fail_to_validate_id_with_fractional_part() {
-        let request = UnvalidatedRequest {
-            jsonrpc: JSON_RPC_VERSION.to_string(),
-            id: Some(json!(1.1)),
-            method: "a".to_string(),
-            params: None,
-        };
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: 1.1,
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
 
         let error = match Request::try_from(request) {
             Err(ErrorOrRejection::Error {
@@ -182,13 +239,31 @@ mod tests {
     }
 
     #[test]
-    fn should_fail_to_validate_with_invalid_jsonrpc_field() {
-        let request = UnvalidatedRequest {
-            jsonrpc: "2.1".to_string(),
-            id: Some(json!("a")),
-            method: "a".to_string(),
-            params: None,
+    fn should_reject_with_missing_id() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        match Request::try_from(request) {
+            Err(ErrorOrRejection::Rejection(_)) => (),
+            _ => panic!("should be rejection"),
         };
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_invalid_jsonrpc_field_value() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: "2.1",
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
 
         let error = match Request::try_from(request) {
             Err(ErrorOrRejection::Error {
@@ -202,6 +277,165 @@ mod tests {
             Error::new(
                 ReservedErrorCode::InvalidRequest,
                 "'jsonrpc' must be '2.0', but was '2.1'"
+            )
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_invalid_jsonrpc_field_type() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: true,
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(
+                ReservedErrorCode::InvalidRequest,
+                "'jsonrpc' must be '2.0', but was 'true'"
+            )
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_missing_jsonrpc_field() {
+        let request = json!({
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(ReservedErrorCode::InvalidRequest, "Missing 'jsonrpc' field")
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_invalid_method_field_type() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: 1,
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(
+                ReservedErrorCode::InvalidRequest,
+                "Expected 'method' to be a String"
+            )
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_missing_method_field() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: "a",
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(ReservedErrorCode::InvalidRequest, "Missing 'method' field")
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_invalid_params_type() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: "a",
+            PARAMS_FIELD_NAME: Value::Null,
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(
+                ReservedErrorCode::InvalidRequest,
+                "If present, 'params' must be an Array or Object, but was 'null'. If not required \
+                for this request, omit the field or provide an empty Array '[]' or empty Object \
+                '{}'"
+            )
+        );
+    }
+
+    #[test]
+    fn should_fail_to_validate_with_extra_fields() {
+        let request = json!({
+            JSONRPC_FIELD_NAME: JSON_RPC_VERSION,
+            ID_FIELD_NAME: "a",
+            METHOD_FIELD_NAME: "a",
+            "extra": 1,
+            "another": true,
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let error = match Request::try_from(request) {
+            Err(ErrorOrRejection::Error {
+                id: Value::String(id),
+                error,
+            }) if id == "a" => error,
+            _ => panic!("should be error"),
+        };
+        assert_eq!(
+            error,
+            Error::new(
+                ReservedErrorCode::InvalidRequest,
+                "Unexpected fields: 'another', 'extra'"
             )
         );
     }

--- a/json_rpc/src/request.rs
+++ b/json_rpc/src/request.rs
@@ -80,7 +80,7 @@ impl TryFrom<Map<String, Value>> for Request {
                 if jsonrpc != JSON_RPC_VERSION {
                     let error = Error::new(
                         ReservedErrorCode::InvalidRequest,
-                        format!("'jsonrpc' must be '2.0', but was '{}'", jsonrpc),
+                        format!("Expected 'jsonrpc' to be '2.0', but got '{}'", jsonrpc),
                     );
                     return Err(ErrorOrRejection::Error { id, error });
                 }
@@ -88,7 +88,7 @@ impl TryFrom<Map<String, Value>> for Request {
             Some(jsonrpc) => {
                 let error = Error::new(
                     ReservedErrorCode::InvalidRequest,
-                    format!("'jsonrpc' must be '2.0', but was '{}'", jsonrpc),
+                    format!("Expected 'jsonrpc' to be '2.0', but got '{}'", jsonrpc),
                 );
                 return Err(ErrorOrRejection::Error { id, error });
             }
@@ -276,7 +276,7 @@ mod tests {
             error,
             Error::new(
                 ReservedErrorCode::InvalidRequest,
-                "'jsonrpc' must be '2.0', but was '2.1'"
+                "Expected 'jsonrpc' to be '2.0', but got '2.1'"
             )
         );
     }
@@ -303,7 +303,7 @@ mod tests {
             error,
             Error::new(
                 ReservedErrorCode::InvalidRequest,
-                "'jsonrpc' must be '2.0', but was 'true'"
+                "Expected 'jsonrpc' to be '2.0', but got 'true'"
             )
         );
     }

--- a/json_rpc/src/request/params.rs
+++ b/json_rpc/src/request/params.rs
@@ -1,0 +1,245 @@
+use std::fmt::{self, Display, Formatter};
+
+use serde_json::{Map, Value};
+
+use super::ErrorOrRejection;
+use crate::error::{Error, ReservedErrorCode};
+
+/// The "params" field of a JSON-RPC request.
+///
+/// As per [the JSON-RPC specification](https://www.jsonrpc.org/specification#parameter_structures),
+/// if present these must be a JSON Array or Object.
+///
+/// `Params` is effectively a restricted [`serde_json::Value`], and can be converted to a `Value`
+/// using `Value::from()` if required.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum Params {
+    /// Represents a JSON Array.
+    Array(Vec<Value>),
+    /// Represents a JSON Object.
+    Object(Map<String, Value>),
+}
+
+impl Params {
+    pub(super) fn try_from(request_id: &Value, params: Value) -> Result<Self, ErrorOrRejection> {
+        let err_invalid_request = |additional_info: &str| {
+            let error = Error::new(ReservedErrorCode::InvalidRequest, additional_info);
+            Err(ErrorOrRejection::Error {
+                id: request_id.clone(),
+                error,
+            })
+        };
+
+        match params {
+            Value::Null => err_invalid_request(
+                "If present, 'params' must be an Array or Object, but was 'null'. If not required \
+                for this request, omit the field or provide an empty Array '[]' or empty Object \
+                '{}'",
+            ),
+            Value::Bool(false) => err_invalid_request(
+                "If present, 'params' must be an Array or Object, but was 'false'",
+            ),
+            Value::Bool(true) => err_invalid_request(
+                "If present, 'params' must be an Array or Object, but was 'true'",
+            ),
+            Value::Number(_) => err_invalid_request(
+                "If present, 'params' must be an Array or Object, but was a Number",
+            ),
+            Value::String(_) => err_invalid_request(
+                "If present, 'params' must be an Array or Object, but was a String",
+            ),
+            Value::Array(array) => Ok(Params::Array(array)),
+            Value::Object(map) => Ok(Params::Object(map)),
+        }
+    }
+
+    /// Returns `true` if `self` is an Array, otherwise returns `false`.
+    pub fn is_array(&self) -> bool {
+        self.as_array().is_some()
+    }
+
+    /// Returns a reference to the inner `Vec` if `self` is an Array, otherwise returns `None`.
+    pub fn as_array(&self) -> Option<&Vec<Value>> {
+        match self {
+            Params::Array(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the inner `Vec` if `self` is an Array, otherwise returns
+    /// `None`.
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+        match self {
+            Params::Array(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if `self` is an Object, otherwise returns `false`.
+    pub fn is_object(&self) -> bool {
+        self.as_object().is_some()
+    }
+
+    /// Returns a reference to the inner `Map` if `self` is an Object, otherwise returns `None`.
+    pub fn as_object(&self) -> Option<&Map<String, Value>> {
+        match self {
+            Params::Object(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the inner `Map` if `self` is an Object, otherwise returns
+    /// `None`.
+    pub fn as_object_mut(&mut self) -> Option<&mut Map<String, Value>> {
+        match self {
+            Params::Object(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if `self` is an empty Array or an empty Object, otherwise returns `false`.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Params::Array(array) => array.is_empty(),
+            Params::Object(map) => map.is_empty(),
+        }
+    }
+}
+
+impl Display for Params {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        Display::fmt(&Value::from(self.clone()), formatter)
+    }
+}
+
+/// The default value for `Params` is an empty Array.
+impl Default for Params {
+    fn default() -> Self {
+        Params::Array(vec![])
+    }
+}
+
+impl From<Params> for Value {
+    fn from(params: Params) -> Self {
+        match params {
+            Params::Array(array) => Value::Array(array),
+            Params::Object(map) => Value::Object(map),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expected_error(invalid_type: &str) -> String {
+        format!(
+            r#"{{"code":-32600,"message":"Invalid Request","data":"If present, 'params' must be an Array or Object, but was {}"}}"#,
+            invalid_type
+        )
+    }
+
+    #[test]
+    fn should_fail_to_convert_params_from_null() {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, Value::Null).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                assert_eq!(
+                    serde_json::to_string(&error).unwrap(),
+                    expected_error(
+                        "'null'. If not required for this request, omit the field or provide an \
+                        empty Array '[]' or empty Object '{}'"
+                    )
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_fail_to_convert_params_from_false() {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, Value::Bool(false)).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                assert_eq!(
+                    serde_json::to_string(&error).unwrap(),
+                    expected_error("'false'")
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_fail_to_convert_params_from_true() {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, Value::Bool(true)).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                assert_eq!(
+                    serde_json::to_string(&error).unwrap(),
+                    expected_error("'true'")
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_fail_to_convert_params_from_a_number() {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, Value::from(9_u8)).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                assert_eq!(
+                    serde_json::to_string(&error).unwrap(),
+                    expected_error("a Number")
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_fail_to_convert_params_from_a_string() {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, Value::from("s")).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                assert_eq!(
+                    serde_json::to_string(&error).unwrap(),
+                    expected_error("a String")
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_convert_params_from_an_array() {
+        let original_id = Value::from(1_i8);
+
+        let params = Params::try_from(&original_id, Value::Array(vec![])).unwrap();
+        assert!(matches!(params, Params::Array(v) if v.is_empty()));
+
+        let array = vec![Value::from(9_i16), Value::Bool(false)];
+        let params = Params::try_from(&original_id, Value::Array(array.clone())).unwrap();
+        assert!(matches!(params, Params::Array(v) if v == array));
+    }
+
+    #[test]
+    fn should_convert_params_from_an_object() {
+        let original_id = Value::from(1_i8);
+
+        let params = Params::try_from(&original_id, Value::Object(Map::new())).unwrap();
+        assert!(matches!(params, Params::Object(v) if v.is_empty()));
+
+        let mut map = Map::new();
+        map.insert("a".to_string(), Value::from(9_i16));
+        map.insert("b".to_string(), Value::Bool(false));
+        let params = Params::try_from(&original_id, Value::Object(map.clone())).unwrap();
+        assert!(matches!(params, Params::Object(v) if v == map));
+    }
+}

--- a/json_rpc/src/request/params.rs
+++ b/json_rpc/src/request/params.rs
@@ -132,89 +132,48 @@ impl From<Params> for Value {
 mod tests {
     use super::*;
 
-    fn expected_error(invalid_type: &str) -> String {
-        format!(
-            r#"{{"code":-32600,"message":"Invalid Request","data":"If present, 'params' must be an Array or Object, but was {}"}}"#,
-            invalid_type
-        )
+    fn should_fail_to_convert_invalid_params(bad_params: Value, expected_invalid_type_msg: &str) {
+        let original_id = Value::from(1_i8);
+        match Params::try_from(&original_id, bad_params).unwrap_err() {
+            ErrorOrRejection::Error { id, error } => {
+                assert_eq!(id, original_id);
+                let expected_error = format!(
+                    r#"{{"code":-32600,"message":"Invalid Request","data":"If present, 'params' must be an Array or Object, but was {}"}}"#,
+                    expected_invalid_type_msg
+                );
+                assert_eq!(serde_json::to_string(&error).unwrap(), expected_error);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
     }
 
     #[test]
     fn should_fail_to_convert_params_from_null() {
-        let original_id = Value::from(1_i8);
-        match Params::try_from(&original_id, Value::Null).unwrap_err() {
-            ErrorOrRejection::Error { id, error } => {
-                assert_eq!(id, original_id);
-                assert_eq!(
-                    serde_json::to_string(&error).unwrap(),
-                    expected_error(
-                        "'null'. If not required for this request, omit the field or provide an \
-                        empty Array '[]' or empty Object '{}'"
-                    )
-                );
-            }
-            other => panic!("unexpected: {:?}", other),
-        }
+        should_fail_to_convert_invalid_params(
+            Value::Null,
+            "'null'. If not required for this request, omit the field or provide an empty Array \
+            '[]' or empty Object '{}'",
+        )
     }
 
     #[test]
     fn should_fail_to_convert_params_from_false() {
-        let original_id = Value::from(1_i8);
-        match Params::try_from(&original_id, Value::Bool(false)).unwrap_err() {
-            ErrorOrRejection::Error { id, error } => {
-                assert_eq!(id, original_id);
-                assert_eq!(
-                    serde_json::to_string(&error).unwrap(),
-                    expected_error("'false'")
-                );
-            }
-            other => panic!("unexpected: {:?}", other),
-        }
+        should_fail_to_convert_invalid_params(Value::Bool(false), "'false'")
     }
 
     #[test]
     fn should_fail_to_convert_params_from_true() {
-        let original_id = Value::from(1_i8);
-        match Params::try_from(&original_id, Value::Bool(true)).unwrap_err() {
-            ErrorOrRejection::Error { id, error } => {
-                assert_eq!(id, original_id);
-                assert_eq!(
-                    serde_json::to_string(&error).unwrap(),
-                    expected_error("'true'")
-                );
-            }
-            other => panic!("unexpected: {:?}", other),
-        }
+        should_fail_to_convert_invalid_params(Value::Bool(true), "'true'")
     }
 
     #[test]
     fn should_fail_to_convert_params_from_a_number() {
-        let original_id = Value::from(1_i8);
-        match Params::try_from(&original_id, Value::from(9_u8)).unwrap_err() {
-            ErrorOrRejection::Error { id, error } => {
-                assert_eq!(id, original_id);
-                assert_eq!(
-                    serde_json::to_string(&error).unwrap(),
-                    expected_error("a Number")
-                );
-            }
-            other => panic!("unexpected: {:?}", other),
-        }
+        should_fail_to_convert_invalid_params(Value::from(9_u8), "a Number")
     }
 
     #[test]
     fn should_fail_to_convert_params_from_a_string() {
-        let original_id = Value::from(1_i8);
-        match Params::try_from(&original_id, Value::from("s")).unwrap_err() {
-            ErrorOrRejection::Error { id, error } => {
-                assert_eq!(id, original_id);
-                assert_eq!(
-                    serde_json::to_string(&error).unwrap(),
-                    expected_error("a String")
-                );
-            }
-            other => panic!("unexpected: {:?}", other),
-        }
+        should_fail_to_convert_invalid_params(Value::from("s"), "a String")
     }
 
     #[test]

--- a/json_rpc/src/request_handlers.rs
+++ b/json_rpc/src/request_handlers.rs
@@ -7,14 +7,14 @@ use tracing::{debug, error};
 
 use crate::{
     error::{Error, ReservedErrorCode},
-    request::Request,
+    request::{Params, Request},
     response::Response,
 };
 
 /// A boxed future of `Result<Value, Error>`; the return type of a request-handling closure.
 type HandleRequestFuture = Pin<Box<dyn Future<Output = Result<Value, Error>> + Send>>;
 /// A request-handling closure.
-type RequestHandler = Arc<dyn Fn(Option<Value>) -> HandleRequestFuture + Send + Sync>;
+type RequestHandler = Arc<dyn Fn(Option<Params>) -> HandleRequestFuture + Send + Sync>;
 
 /// A collection of request-handlers, indexed by the JSON-RPC "method" applicable to each.
 ///
@@ -73,12 +73,12 @@ impl RequestHandlersBuilder {
     ///
     /// The handler should be an async closure or function with a signature like:
     /// ```ignore
-    /// async fn handle_it(params: Option<Value>) -> Result<T, Error>
+    /// async fn handle_it(params: Option<Params>) -> Result<T, Error>
     /// ```
     /// where `T` implements `Serialize` and will be used as the JSON-RPC response's "result" field.
     pub fn register_handler<Func, Fut, T>(&mut self, method: &'static str, handler: Arc<Func>)
     where
-        Func: Fn(Option<Value>) -> Fut + Send + Sync + 'static,
+        Func: Fn(Option<Params>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<T, Error>> + Send,
         T: Serialize + 'static,
     {

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.  The format
 * Storage operations are now executed in parallel, the degree of parallelism can be controlled through the `storage.max_sync_tasks` setting.
 * The network message format has been replaced with a more efficient encoding while keeping the initial handshake intact.
 * The node flushes outgoing messages immediately, trading bandwidth for latecy. This change is made to optimize feedback loops of various components in the system.
+* The JSON-RPC server now returns more useful responses in many error cases.
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.
@@ -72,6 +73,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.
 * Dropped connections no longer cause the outstanding messages metric to become incorrect.
+* JSON-RPC server is now compliant with the standard. Specifically, correct error values are now returned in responses, and `null` is no longer accepted as a value for `params` in requests.
 
 ### Security
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -24,7 +24,7 @@ use tower::ServiceBuilder;
 use tracing::info;
 use warp::Filter;
 
-use casper_json_rpc::{Error, RequestHandlers, RequestHandlersBuilder, ReservedErrorCode};
+use casper_json_rpc::{Error, Params, RequestHandlers, RequestHandlersBuilder, ReservedErrorCode};
 use casper_types::ProtocolVersion;
 
 use super::{ReactorEventT, RpcRequest};
@@ -57,14 +57,16 @@ pub(super) trait RpcWithParams {
         + 'static;
 
     /// Tries to parse the incoming JSON-RPC request's "params" field as `RequestParams`.
-    fn try_parse_params(maybe_params: Option<Value>) -> Result<Self::RequestParams, Error> {
-        let params = maybe_params.unwrap_or(Value::Null);
-        if params.is_null() {
-            return Err(Error::new(
-                ReservedErrorCode::InvalidParams,
-                "Missing or null 'params' field",
-            ));
-        }
+    fn try_parse_params(maybe_params: Option<Params>) -> Result<Self::RequestParams, Error> {
+        let params = match maybe_params {
+            Some(params) => Value::from(params),
+            None => {
+                return Err(Error::new(
+                    ReservedErrorCode::InvalidParams,
+                    "Missing 'params' field",
+                ))
+            }
+        };
         serde_json::from_value::<Self::RequestParams>(params).map_err(|error| {
             Error::new(
                 ReservedErrorCode::InvalidParams,
@@ -120,12 +122,13 @@ pub(super) trait RpcWithoutParams {
         + Send
         + 'static;
 
-    /// Returns an error if the incoming JSON-RPC request's "params" field is not `None` or `Null`.
-    fn check_no_params(maybe_params: Option<Value>) -> Result<(), Error> {
-        if !maybe_params.unwrap_or(Value::Null).is_null() {
+    /// Returns an error if the incoming JSON-RPC request's "params" field is not `None` or an empty
+    /// Array or Object.
+    fn check_no_params(maybe_params: Option<Params>) -> Result<(), Error> {
+        if !maybe_params.unwrap_or_default().is_empty() {
             return Err(Error::new(
                 ReservedErrorCode::InvalidParams,
-                "'params' field should be null or absent",
+                "'params' field should be an empty Array '[]', an empty Object '{}' or absent",
             ));
         }
         Ok(())
@@ -162,6 +165,9 @@ pub(super) trait RpcWithoutParams {
 }
 
 /// A JSON-RPC where the "params" field is optional.
+///
+/// Note that "params" being an empty JSON Array or empty JSON Object is treated the same as if
+/// the "params" field is absent - i.e. it represents the `None` case.
 #[async_trait]
 pub(super) trait RpcWithOptionalParams {
     /// The JSON-RPC "method" name.
@@ -188,12 +194,19 @@ pub(super) trait RpcWithOptionalParams {
     /// Tries to parse the incoming JSON-RPC request's "params" field as
     /// `Option<OptionalRequestParams>`.
     fn try_parse_params(
-        maybe_params: Option<Value>,
+        maybe_params: Option<Params>,
     ) -> Result<Option<Self::OptionalRequestParams>, Error> {
-        serde_json::from_value::<Option<Self::OptionalRequestParams>>(
-            maybe_params.unwrap_or(Value::Null),
-        )
-        .map_err(|error| {
+        let params = match maybe_params {
+            Some(params) => {
+                if params.is_empty() {
+                    Value::Null
+                } else {
+                    Value::from(params)
+                }
+            }
+            None => Value::Null,
+        };
+        serde_json::from_value::<Option<Self::OptionalRequestParams>>(params).map_err(|error| {
             Error::new(
                 ReservedErrorCode::InvalidParams,
                 format!("Failed to parse 'params' field: {}", error),
@@ -347,18 +360,16 @@ mod tests {
             let rpc_response = send_request(GetDeploy::METHOD, None, &filter).await;
             assert_eq!(
                 rpc_response.error().unwrap(),
-                &Error::new(
-                    ReservedErrorCode::InvalidParams,
-                    "Missing or null 'params' field"
-                )
+                &Error::new(ReservedErrorCode::InvalidParams, "Missing 'params' field")
             );
 
-            let rpc_response = send_request(GetDeploy::METHOD, Some("null"), &filter).await;
+            let rpc_response = send_request(GetDeploy::METHOD, Some("[]"), &filter).await;
             assert_eq!(
                 rpc_response.error().unwrap(),
                 &Error::new(
                     ReservedErrorCode::InvalidParams,
-                    "Missing or null 'params' field"
+                    "Failed to parse 'params' field: invalid length 0, expected struct \
+                    GetDeployParams with 2 elements"
                 )
             );
         }
@@ -367,13 +378,12 @@ mod tests {
         async fn should_return_error_on_failure_to_parse_params() {
             let filter = main_filter_with_recovery();
 
-            let rpc_response = send_request(GetDeploy::METHOD, Some("3"), &filter).await;
+            let rpc_response = send_request(GetDeploy::METHOD, Some("[3]"), &filter).await;
             assert_eq!(
                 rpc_response.error().unwrap(),
                 &Error::new(
                     ReservedErrorCode::InvalidParams,
-                    "Failed to parse 'params' field: invalid type: integer `3`, expected struct \
-                    GetDeployParams"
+                    "Failed to parse 'params' field: invalid type: integer `3`, expected a string"
                 )
             );
         }
@@ -403,7 +413,13 @@ mod tests {
                 Some(GetPeersResult::doc_example())
             );
 
-            let rpc_response = send_request(GetPeers::METHOD, Some("null"), &filter).await;
+            let rpc_response = send_request(GetPeers::METHOD, Some("[]"), &filter).await;
+            assert_eq!(
+                rpc_response.result().as_ref(),
+                Some(GetPeersResult::doc_example())
+            );
+
+            let rpc_response = send_request(GetPeers::METHOD, Some("{}"), &filter).await;
             assert_eq!(
                 rpc_response.result().as_ref(),
                 Some(GetPeersResult::doc_example())
@@ -411,15 +427,15 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_error_if_params_not_null() {
+        async fn should_return_error_if_params_not_empty() {
             let filter = main_filter_with_recovery();
 
-            let rpc_response = send_request(GetPeers::METHOD, Some("3"), &filter).await;
+            let rpc_response = send_request(GetPeers::METHOD, Some("[3]"), &filter).await;
             assert_eq!(
                 rpc_response.error().unwrap(),
                 &Error::new(
                     ReservedErrorCode::InvalidParams,
-                    "'params' field should be null or absent"
+                    "'params' field should be an empty Array '[]', an empty Object '{}' or absent"
                 )
             );
         }
@@ -451,7 +467,13 @@ mod tests {
                 Some(GetBlockResult::doc_example())
             );
 
-            let rpc_response = send_request(GetBlock::METHOD, Some("null"), &filter).await;
+            let rpc_response = send_request(GetBlock::METHOD, Some("[]"), &filter).await;
+            assert_eq!(
+                rpc_response.result().as_ref(),
+                Some(GetBlockResult::doc_example())
+            );
+
+            let rpc_response = send_request(GetBlock::METHOD, Some("{}"), &filter).await;
             assert_eq!(
                 rpc_response.result().as_ref(),
                 Some(GetBlockResult::doc_example())
@@ -479,13 +501,13 @@ mod tests {
         async fn should_return_error_on_failure_to_parse_params() {
             let filter = main_filter_with_recovery();
 
-            let rpc_response = send_request(GetBlock::METHOD, Some("3"), &filter).await;
+            let rpc_response = send_request(GetBlock::METHOD, Some(r#"["a"]"#), &filter).await;
             assert_eq!(
                 rpc_response.error().unwrap(),
                 &Error::new(
                     ReservedErrorCode::InvalidParams,
-                    "Failed to parse 'params' field: invalid type: integer `3`, expected struct \
-                    GetBlockParams"
+                    "Failed to parse 'params' field: unknown variant `a`, expected `Hash` or \
+                    `Height`"
                 )
             );
         }


### PR DESCRIPTION
This PR corrects the JSON-RPC handling of the `params` field of requests to be compliant with the standard.

Specifically, the server will now reject a request where the `params` field is set to `null`.

Closes #3149.