### PR TITLE
Fix for new clippy warnings

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -768,7 +768,7 @@ where
         let key = Key::Account(system_account_addr);
         let value = { StoredValue::Account(virtual_system_account) };
 
-        let _ = tracking_copy.borrow_mut().write(key, value);
+        tracking_copy.borrow_mut().write(key, value);
 
         GenesisInstaller {
             protocol_version,
@@ -784,28 +784,28 @@ where
     }
 
     fn create_mint(&mut self) -> Result<Key, GenesisError> {
-        let round_seigniorage_rate_uref = {
-            let round_seigniorage_rate_uref = self
-                .address_generator
-                .borrow_mut()
-                .new_uref(AccessRights::READ_ADD_WRITE);
+        let round_seigniorage_rate_uref =
+            {
+                let round_seigniorage_rate_uref = self
+                    .address_generator
+                    .borrow_mut()
+                    .new_uref(AccessRights::READ_ADD_WRITE);
 
-            let (round_seigniorage_rate_numer, round_seigniorage_rate_denom) =
-                self.exec_config.round_seigniorage_rate().into();
-            let round_seigniorage_rate: Ratio<U512> = Ratio::new(
-                round_seigniorage_rate_numer.into(),
-                round_seigniorage_rate_denom.into(),
-            );
+                let (round_seigniorage_rate_numer, round_seigniorage_rate_denom) =
+                    self.exec_config.round_seigniorage_rate().into();
+                let round_seigniorage_rate: Ratio<U512> = Ratio::new(
+                    round_seigniorage_rate_numer.into(),
+                    round_seigniorage_rate_denom.into(),
+                );
 
-            let _ =
                 self.tracking_copy.borrow_mut().write(
                     round_seigniorage_rate_uref.into(),
                     StoredValue::CLValue(CLValue::from_t(round_seigniorage_rate).map_err(
                         |_| GenesisError::CLValue(ARG_ROUND_SEIGNIORAGE_RATE.to_string()),
                     )?),
                 );
-            round_seigniorage_rate_uref
-        };
+                round_seigniorage_rate_uref
+            };
 
         let total_supply_uref = {
             let total_supply_uref = self
@@ -813,7 +813,7 @@ where
                 .borrow_mut()
                 .new_uref(AccessRights::READ_ADD_WRITE);
 
-            let _ = self.tracking_copy.borrow_mut().write(
+            self.tracking_copy.borrow_mut().write(
                 total_supply_uref.into(),
                 StoredValue::CLValue(
                     CLValue::from_t(U512::zero())
@@ -851,7 +851,7 @@ where
             partial_registry.insert(HANDLE_PAYMENT.to_string(), DEFAULT_ADDRESS.into());
             let cl_registry = CLValue::from_t(partial_registry)
                 .map_err(|error| GenesisError::CLValue(error.to_string()))?;
-            let _ = self.tracking_copy.borrow_mut().write(
+            self.tracking_copy.borrow_mut().write(
                 Key::SystemContractRegistry,
                 StoredValue::CLValue(cl_registry),
             );
@@ -1016,7 +1016,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             era_id_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(INITIAL_ERA_ID)
@@ -1029,7 +1029,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             era_end_timestamp_millis_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(INITIAL_ERA_END_TIMESTAMP_MILLIS)
@@ -1045,7 +1045,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             initial_seigniorage_recipients_uref.into(),
             StoredValue::CLValue(CLValue::from_t(initial_seigniorage_recipients).map_err(
                 |_| GenesisError::CLValue(SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY.to_string()),
@@ -1058,7 +1058,7 @@ where
 
         for (validator_public_key, bid) in validators.into_iter() {
             let validator_account_hash = AccountHash::from(&validator_public_key);
-            let _ = self.tracking_copy.borrow_mut().write(
+            self.tracking_copy.borrow_mut().write(
                 Key::Bid(validator_account_hash),
                 StoredValue::Bid(Box::new(bid)),
             );
@@ -1069,7 +1069,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             validator_slots_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(validator_slots)
@@ -1082,7 +1082,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             auction_delay_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(auction_delay)
@@ -1095,7 +1095,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             locked_funds_period_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(locked_funds_period_millis)
@@ -1112,7 +1112,7 @@ where
             .address_generator
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             unbonding_delay_uref.into(),
             StoredValue::CLValue(
                 CLValue::from_t(unbonding_delay)
@@ -1173,12 +1173,12 @@ where
                 main_purse,
             ));
 
-            let _ = self.tracking_copy.borrow_mut().write(key, stored_value);
+            self.tracking_copy.borrow_mut().write(key, stored_value);
 
             total_supply += account.balance().value();
         }
 
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             total_supply_key,
             StoredValue::CLValue(
                 CLValue::from_t(total_supply)
@@ -1216,15 +1216,14 @@ where
 
         let balance_cl_value =
             CLValue::from_t(amount).map_err(|error| GenesisError::CLValue(error.to_string()))?;
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             Key::Balance(purse_addr),
             StoredValue::CLValue(balance_cl_value),
         );
 
         let purse_cl_value = CLValue::unit();
         let purse_uref = URef::new(purse_addr, AccessRights::READ_ADD_WRITE);
-        let _ = self
-            .tracking_copy
+        self.tracking_copy
             .borrow_mut()
             .write(Key::URef(purse_uref), StoredValue::CLValue(purse_cl_value));
 
@@ -1267,15 +1266,14 @@ where
             contract_package
         };
 
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             contract_wasm_hash.into(),
             StoredValue::ContractWasm(contract_wasm),
         );
-        let _ = self
-            .tracking_copy
+        self.tracking_copy
             .borrow_mut()
             .write(contract_hash.into(), StoredValue::Contract(contract));
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             contract_package_hash.into(),
             StoredValue::ContractPackage(contract_package),
         );
@@ -1304,7 +1302,7 @@ where
         partial_registry.insert(contract_name.to_string(), contract_hash);
         let cl_registry = CLValue::from_t(partial_registry)
             .map_err(|error| GenesisError::CLValue(error.to_string()))?;
-        let _ = self.tracking_copy.borrow_mut().write(
+        self.tracking_copy.borrow_mut().write(
             Key::SystemContractRegistry,
             StoredValue::CLValue(cl_registry),
         );

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -359,7 +359,7 @@ where
                 CLValue::from_t(new_validator_slots)
                     .map_err(|_| Error::Bytesrepr("new_validator_slots".to_string()))?,
             );
-            let _ = tracking_copy.borrow_mut().write(validator_slots_key, value);
+            tracking_copy.borrow_mut().write(validator_slots_key, value);
         }
 
         if let Some(new_auction_delay) = upgrade_config.new_auction_delay() {
@@ -372,7 +372,7 @@ where
                 CLValue::from_t(new_auction_delay)
                     .map_err(|_| Error::Bytesrepr("new_auction_delay".to_string()))?,
             );
-            let _ = tracking_copy.borrow_mut().write(auction_delay_key, value);
+            tracking_copy.borrow_mut().write(auction_delay_key, value);
         }
 
         if let Some(new_locked_funds_period) = upgrade_config.new_locked_funds_period_millis() {
@@ -385,7 +385,7 @@ where
                 CLValue::from_t(new_locked_funds_period)
                     .map_err(|_| Error::Bytesrepr("new_locked_funds_period".to_string()))?,
             );
-            let _ = tracking_copy
+            tracking_copy
                 .borrow_mut()
                 .write(locked_funds_period_key, value);
         }
@@ -400,7 +400,7 @@ where
                 CLValue::from_t(new_unbonding_delay)
                     .map_err(|_| Error::Bytesrepr("new_unbonding_delay".to_string()))?,
             );
-            let _ = tracking_copy.borrow_mut().write(unbonding_delay_key, value);
+            tracking_copy.borrow_mut().write(unbonding_delay_key, value);
         }
 
         if let Some(new_round_seigniorage_rate) = upgrade_config.new_round_seigniorage_rate() {
@@ -418,7 +418,7 @@ where
                 CLValue::from_t(new_round_seigniorage_rate)
                     .map_err(|_| Error::Bytesrepr("new_round_seigniorage_rate".to_string()))?,
             );
-            let _ = tracking_copy
+            tracking_copy
                 .borrow_mut()
                 .write(locked_funds_period_key, value);
         }
@@ -765,7 +765,7 @@ where
                             let new_account =
                                 Account::create(public_key, Default::default(), main_purse);
                             // write new account
-                            let _ = tracking_copy
+                            tracking_copy
                                 .borrow_mut()
                                 .write(Key::Account(public_key), StoredValue::Account(new_account));
                         }
@@ -1057,7 +1057,7 @@ where
                 account.main_purse(),
                 cost,
             );
-            let _ = tracking_copy.borrow_mut().write(
+            tracking_copy.borrow_mut().write(
                 Key::DeployInfo(deploy_item.deploy_hash),
                 StoredValue::DeployInfo(deploy_info),
             );
@@ -1488,7 +1488,7 @@ where
                 account.main_purse(),
                 cost,
             );
-            let _ = session_tracking_copy.borrow_mut().write(
+            session_tracking_copy.borrow_mut().write(
                 Key::DeployInfo(deploy_hash),
                 StoredValue::DeployInfo(deploy_info),
             );

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -313,8 +313,7 @@ where
             entry_points,
             self.new_protocol_version,
         );
-        let _ = self
-            .tracking_copy
+        self.tracking_copy
             .borrow_mut()
             .write(contract_hash.into(), StoredValue::Contract(new_contract));
 

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -571,8 +571,7 @@ where
     pub fn write_transfer(&mut self, key: Key, value: Transfer) {
         if let Key::Transfer(_) = key {
             // Writing a `Transfer` will not exceed write size limit.
-            let _ = self
-                .tracking_copy
+            self.tracking_copy
                 .borrow_mut()
                 .write(key, StoredValue::Transfer(value));
         } else {
@@ -584,8 +583,7 @@ where
     pub fn write_era_info(&mut self, key: Key, value: EraInfo) {
         if let Key::EraInfo(_) = key {
             // Writing an `EraInfo` for 100 validators will not exceed write size limit.
-            let _ = self
-                .tracking_copy
+            self.tracking_copy
                 .borrow_mut()
                 .write(key, StoredValue::EraInfo(value));
         } else {

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -357,7 +357,7 @@ fn contract_key_addable_valid() {
         account_key,
         account.clone(),
     )));
-    let _ = tracking_copy.borrow_mut().write(contract_key, contract);
+    tracking_copy.borrow_mut().write(contract_key, contract);
 
     let default_system_registry = {
         let mut registry = SystemContractRegistry::new();
@@ -368,7 +368,7 @@ fn contract_key_addable_valid() {
         StoredValue::CLValue(CLValue::from_t(registry).unwrap())
     };
 
-    let _ = tracking_copy
+    tracking_copy
         .borrow_mut()
         .write(Key::SystemContractRegistry, default_system_registry);
 
@@ -446,7 +446,7 @@ fn contract_key_addable_invalid() {
         account.clone(),
     )));
 
-    let _ = tracking_copy.borrow_mut().write(contract_key, contract);
+    tracking_copy.borrow_mut().write(contract_key, contract);
 
     let uref_as_key = create_uref_as_key(&mut address_generator, AccessRights::WRITE);
     let uref_name = "NewURef".to_owned();

--- a/execution_engine/src/core/tracking_copy/tests.rs
+++ b/execution_engine/src/core/tracking_copy/tests.rs
@@ -138,7 +138,7 @@ fn tracking_copy_write() {
     let two = StoredValue::CLValue(CLValue::from_t(2_i32).unwrap());
 
     // writing should work
-    let _ = tc.write(k, one.clone());
+    tc.write(k, one.clone());
     // write does not need to query the DB
     let db_value = counter.get();
     assert_eq!(db_value, 0);
@@ -149,7 +149,7 @@ fn tracking_copy_write() {
     );
 
     // writing again should update the values
-    let _ = tc.write(k, two.clone());
+    tc.write(k, two.clone());
     let db_value = counter.get();
     assert_eq!(db_value, 0);
     assert_eq!(
@@ -257,7 +257,7 @@ fn tracking_copy_rw() {
     // reading then writing should update the op
     let value = StoredValue::CLValue(CLValue::from_t(3_i32).unwrap());
     let _ = tc.read(correlation_id, &k);
-    let _ = tc.write(k, value.clone());
+    tc.write(k, value.clone());
     assert_eq!(
         tc.journal,
         ExecutionJournal::new(vec![(k, Transform::Identity), (k, Transform::Write(value))])
@@ -294,7 +294,7 @@ fn tracking_copy_aw() {
     let value = StoredValue::CLValue(CLValue::from_t(3_i32).unwrap());
     let write_value = StoredValue::CLValue(CLValue::from_t(7_i32).unwrap());
     let _ = tc.add(correlation_id, k, value);
-    let _ = tc.write(k, write_value.clone());
+    tc.write(k, write_value.clone());
     assert_eq!(
         tc.journal,
         ExecutionJournal::new(vec![
@@ -931,7 +931,7 @@ fn get_keys_should_return_keys_in_the_uref_keyspace() {
     let cl_value = CLValue::from_t(U512::from(2)).expect("should convert");
     let uref_3_value = StoredValue::CLValue(cl_value);
     let uref_3_key = Key::URef(URef::new([10; 32], AccessRights::READ_ADD_WRITE));
-    let _ = tracking_copy.write(uref_3_key, uref_3_value);
+    tracking_copy.write(uref_3_key, uref_3_value);
 
     let key_set = tracking_copy
         .get_keys(correlation_id, &KeyTag::URef)
@@ -967,7 +967,7 @@ fn get_keys_should_handle_reads_from_empty_trie() {
     let cl_value = CLValue::from_t(U512::zero()).expect("should convert");
     let uref_1_value = StoredValue::CLValue(cl_value);
     let uref_1_key = Key::URef(URef::new([8; 32], AccessRights::READ_ADD_WRITE));
-    let _ = tracking_copy.write(uref_1_key, uref_1_value);
+    tracking_copy.write(uref_1_key, uref_1_value);
 
     let key_set = tracking_copy
         .get_keys(correlation_id, &KeyTag::URef)
@@ -980,7 +980,7 @@ fn get_keys_should_handle_reads_from_empty_trie() {
     let cl_value = CLValue::from_t(U512::one()).expect("should convert");
     let uref_2_value = StoredValue::CLValue(cl_value);
     let uref_2_key = Key::URef(URef::new([9; 32], AccessRights::READ_ADD_WRITE));
-    let _ = tracking_copy.write(uref_2_key, uref_2_value);
+    tracking_copy.write(uref_2_key, uref_2_value);
 
     let key_set = tracking_copy
         .get_keys(correlation_id, &KeyTag::URef)
@@ -999,7 +999,7 @@ fn get_keys_should_handle_reads_from_empty_trie() {
         fake_purse,
     ));
     let account_key = Key::Account(account_hash);
-    let _ = tracking_copy.write(account_key, account_value);
+    tracking_copy.write(account_key, account_value);
 
     assert_eq!(key_set.len(), 2);
     assert!(key_set.contains(&uref_1_key.normalize()));
@@ -1010,7 +1010,7 @@ fn get_keys_should_handle_reads_from_empty_trie() {
     let cl_value = CLValue::from_t(U512::from(2)).expect("should convert");
     let uref_3_value = StoredValue::CLValue(cl_value);
     let uref_3_key = Key::URef(URef::new([10; 32], AccessRights::READ_ADD_WRITE));
-    let _ = tracking_copy.write(uref_3_key, uref_3_value);
+    tracking_copy.write(uref_3_key, uref_3_value);
 
     let key_set = tracking_copy
         .get_keys(correlation_id, &KeyTag::URef)

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -34,12 +36,12 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
 fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
     let mut call_args = String::new();
     for i in 0..arity {
-        call_args.push_str(&format!("({}.const {}) ", arg_type, i));
+        write!(call_args, "({}.const {}) ", arg_type, i).unwrap();
     }
 
     let mut func_params = String::new();
     for i in 0..arity {
-        func_params.push_str(&format!("(param $arg{} {}) ", i, arg_type));
+        write!(func_params, "(param $arg{} {}) ", i, arg_type).unwrap();
     }
 
     // This wasm module contains a function with a specified amount of arguments in it.

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "1.5.0", path = "../types" }
+casper-types = { version = "1.5.0", path = "../types", features = ["datasize", "std"] }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"

--- a/hashing/src/chunk_with_proof.rs
+++ b/hashing/src/chunk_with_proof.rs
@@ -102,7 +102,7 @@ impl ChunkWithProof {
 
     /// Verify the integrity of this chunk with indexed Merkle proof.
     pub fn verify(&self) -> Result<(), ChunkWithProofVerificationError> {
-        let _ = self.proof().verify()?;
+        self.proof().verify()?;
         let first_digest_in_indexed_merkle_proof =
             self.proof().merkle_proof().first().ok_or_else(|| {
                 ChunkWithProofVerificationError::ChunkWithProofHasEmptyMerkleProof {

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -865,7 +865,7 @@ mod tests {
             match *new_units {
                 [] => (),
                 [unit] => {
-                    let _ = self.state.add_unit(unit.clone()).unwrap();
+                    self.state.add_unit(unit.clone()).unwrap();
                 }
                 _ => panic!(
                     "Expected at most one timer to be scheduled: {:?}",

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -456,7 +456,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     fn insert_to_finished(&mut self, data_id: &T) {
         let timeout = Instant::now() + self.finished_entry_duration;
         let _ = self.finished.insert(*data_id);
-        let _ = self.timeouts.push(timeout, *data_id);
+        self.timeouts.push(timeout, *data_id);
     }
 
     /// Retains only those finished entries which still haven't timed out.

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -287,6 +287,8 @@ pub(super) async fn run(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
+
     use http::StatusCode;
     use warp::{filters::BoxedFilter, Filter, Reply};
 
@@ -302,7 +304,7 @@ mod tests {
     ) -> Response {
         let mut body = format!(r#"{{"jsonrpc":"2.0","id":"a","method":"{}""#, method);
         match maybe_params {
-            Some(params) => body += &format!(r#","params":{}}}"#, params),
+            Some(params) => write!(body, r#","params":{}}}"#, params).unwrap(),
             None => body += "}",
         }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -160,8 +160,7 @@ impl DisjointSequences {
         }
 
         if let Some(index_to_insert) = maybe_insertion_index {
-            let _ = self
-                .sequences
+            self.sequences
                 .insert(index_to_insert, Sequence::single(value));
         }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -346,7 +346,7 @@ fn put_execution_results(
     block_hash: BlockHash,
     execution_results: HashMap<DeployHash, ExecutionResult>,
 ) {
-    let response = harness.send_request(storage, move |responder| {
+    harness.send_request(storage, move |responder| {
         StorageRequest::PutExecutionResults {
             block_hash: Box::new(block_hash),
             execution_results,
@@ -355,7 +355,6 @@ fn put_execution_results(
         .into()
     });
     assert!(harness.is_idle());
-    response
 }
 
 #[test]

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -70,8 +70,7 @@ impl EventQueueMetrics {
             .iter()
             .sorted_by_key(|k| k.0)
             .map(|(queue, event_count)| {
-                let _ = self
-                    .event_queue_gauges
+                self.event_queue_gauges
                     .get(queue)
                     .map(|gauge| gauge.set(*event_count as i64))
                     .expect("queue exists.");

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -74,9 +74,9 @@ where
     ///
     /// Panics if a duplicate node ID is being inserted. This should only happen in case a randomly
     /// generated ID collides.
-    pub(crate) async fn add_node(
-        &mut self,
-        rng: &mut TestRng,
+    pub(crate) async fn add_node<'a, 'b: 'a>(
+        &'a mut self,
+        rng: &'b mut TestRng,
     ) -> Result<(NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
         self.add_node_with_config(Default::default(), rng).await
     }
@@ -110,10 +110,10 @@ where
     /// # Panics
     ///
     /// Panics if a duplicate node ID is being inserted.
-    pub(crate) async fn add_node_with_config(
-        &mut self,
+    pub(crate) async fn add_node_with_config<'a, 'b: 'a>(
+        &'a mut self,
         cfg: R::Config,
-        rng: &mut NodeRng,
+        rng: &'b mut NodeRng,
     ) -> Result<(NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
         let runner: Runner<ConditionCheckReactor<R>> = Runner::new(cfg, rng).await?;
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -2169,7 +2169,7 @@ impl Item for BlockAndDeploys {
         &self,
         verifiable_chunked_hash_activation: EraId,
     ) -> Result<(), Self::ValidationError> {
-        let _ = self.block.verify(verifiable_chunked_hash_activation)?;
+        self.block.verify(verifiable_chunked_hash_activation)?;
         // Validate that we've got all of the deploys we should have gotten, and that their hashes
         // are valid.
         for deploy_hash in self

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -741,7 +741,7 @@ impl Distribution<Transform> for Standard {
             11 => {
                 let mut named_keys = Vec::new();
                 for _ in 0..rng.gen_range(1..6) {
-                    let _ = named_keys.push(NamedKey {
+                    named_keys.push(NamedKey {
                         name: rng.gen::<u64>().to_string(),
                         key: rng.gen::<u64>().to_string(),
                     });


### PR DESCRIPTION
This fixes clippy warnings introduced by Rust 1.62.0.  It also adds missing features to the `casper-types` entry of the `casper-hashing` manifest.