### PR TITLE
NCTL: bug fix for dumping node logs

### DIFF
--- a/utils/nctl/sh/assets/dump.sh
+++ b/utils/nctl/sh/assets/dump.sh
@@ -30,7 +30,7 @@ cp "$PATH_TO_NET"/faucet/public_key.pem "$PATH_TO_DUMP"/faucet-public_key.pem
 cp "$PATH_TO_NET"/faucet/secret_key.pem "$PATH_TO_DUMP"/faucet-secret_key.pem
 
 # Dump nodes.
-for NODE_ID in $(seq 1 "$(get_count_of_genesis_nodes)")
+for NODE_ID in $(seq 1 "$(get_count_of_started_nodes)")
 do
     PATH_TO_NODE_KEYS=$(get_path_to_node_keys "$NODE_ID")
     PATH_TO_NODE_LOGS=$(get_path_to_node_logs "$NODE_ID")

--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -352,3 +352,11 @@ function get_process_name_of_node_group()
         echo "$NCTL_PROCESS_GROUP_3"
     fi
 }
+
+#######################################
+# Returns count of nodes that atleast attempted to start
+#######################################
+function get_count_of_started_nodes()
+{
+    nctl-status | grep -v 'Not started' | wc -l
+}


### PR DESCRIPTION
Changes:
- adds `get_count_of_started_nodes` function that will grab the count of nodes that had been started
- utilize `get_count_of_started_nodes` in dump wrapper