### PR TITLE
update to minimise API changes to casper-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,16 +2061,16 @@ dependencies = [
 name = "gh-3097-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract",
- "casper-types",
+ "casper-contract 1.4.4",
+ "casper-types 1.5.0",
 ]
 
 [[package]]
 name = "gh-3097-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract",
- "casper-types",
+ "casper-contract 1.4.4",
+ "casper-types 1.5.0",
 ]
 
 [[package]]

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -318,6 +318,7 @@ pub fn blake2b<T: AsRef<[u8]>>(data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
 /// Errors that can occur while adding a new [`AccountHash`] to an account's associated keys map.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum AddKeyFailure {
     /// There are already maximum [`AccountHash`]s associated with the given account.
     MaxKeysLimit = 1,
@@ -360,6 +361,7 @@ impl TryFrom<i32> for AddKeyFailure {
 /// Errors that can occur while removing a [`AccountHash`] from an account's associated keys map.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum RemoveKeyFailure {
     /// The given [`AccountHash`] is not associated with the given account.
     MissingKey = 1,
@@ -409,6 +411,7 @@ impl TryFrom<i32> for RemoveKeyFailure {
 /// associated keys map.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum UpdateKeyFailure {
     /// The given [`AccountHash`] is not associated with the given account.
     MissingKey = 1,

--- a/types/src/account/error.rs
+++ b/types/src/account/error.rs
@@ -7,10 +7,11 @@ use core::{
 // This error type is not intended to be used by third party crates.
 #[doc(hidden)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct TryFromIntError(pub ());
+pub struct TryFromIntError(pub(super) ());
 
 /// Error returned when decoding an `AccountHash` from a formatted string.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     /// The prefix is invalid.
     InvalidPrefix,
@@ -49,6 +50,7 @@ impl Display for FromStrError {
 /// various actions) on an account.
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[non_exhaustive]
 pub enum SetThresholdFailure {
     /// Setting the key-management threshold to a value lower than the deployment threshold is
     /// disallowed.
@@ -105,4 +107,4 @@ impl Display for SetThresholdFailure {
 
 /// Associated error type of `TryFrom<&[u8]>` for [`AccountHash`](super::AccountHash).
 #[derive(Debug)]
-pub struct TryFromSliceForAccountHashError(pub ());
+pub struct TryFromSliceForAccountHashError(());

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -3,7 +3,6 @@
 use core::{
     convert::TryFrom,
     fmt::{self, Debug, Formatter},
-    u16, u8,
 };
 
 use crate::{
@@ -102,6 +101,7 @@ const AUCTION_ERROR_MAX: u32 = AUCTION_ERROR_OFFSET + u8::MAX as u32;
 /// assert_eq!(65_538, u32::from(ApiError::from(FailureCode::Two)));
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ApiError {
     /// Optional data was unexpectedly `None`.
     /// ```

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -111,6 +111,7 @@ pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Erro
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     /// Early end of stream while deserializing.
     EarlyEndOfStream = 0,

--- a/types/src/contract_wasm.rs
+++ b/types/src/contract_wasm.rs
@@ -27,6 +27,7 @@ const WASM_STRING_PREFIX: &str = "contract-wasm-";
 pub struct TryFromSliceForContractHashError(());
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     InvalidPrefix,
     Hex(base16::DecodeError),

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -44,6 +44,7 @@ const PACKAGE_STRING_LEGACY_EXTRA_PREFIX: &str = "wasm";
 /// Set of errors which may happen when working with contract headers.
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     /// Attempt to override an existing or previously existing version with a
     /// new header (this is not allowed to ensure immutability of a given
@@ -139,6 +140,7 @@ impl Display for TryFromSliceForContractHashError {
 
 /// An error from parsing a formatted contract string
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     /// Invalid formatted string prefix.
     InvalidPrefix,

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -177,6 +177,7 @@ where
 
 /// A secret or private asymmetric key.
 #[cfg_attr(feature = "datasize", derive(DataSize))]
+#[non_exhaustive]
 pub enum SecretKey {
     /// System secret key.
     System,
@@ -467,6 +468,7 @@ impl Tagged<u8> for SecretKey {
 /// A public asymmetric key.
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
+#[non_exhaustive]
 pub enum PublicKey {
     /// System public key.
     System,
@@ -874,6 +876,7 @@ impl CLTyped for PublicKey {
 /// A signature of given data.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
+#[non_exhaustive]
 pub enum Signature {
     /// System signature.  Cannot be verified.
     System,
@@ -1211,7 +1214,7 @@ mod detail {
     ///
     /// The wrapped contents are the result of calling `t_as_ref()` on the type.
     #[derive(Serialize, Deserialize)]
-    pub enum AsymmetricTypeAsBytes {
+    pub(super) enum AsymmetricTypeAsBytes {
         System,
         Ed25519(Vec<u8>),
         Secp256k1(Vec<u8>),
@@ -1237,7 +1240,7 @@ mod detail {
         }
     }
 
-    pub fn serialize<'a, T, S>(value: &'a T, serializer: S) -> Result<S::Ok, S::Error>
+    pub(super) fn serialize<'a, T, S>(value: &'a T, serializer: S) -> Result<S::Ok, S::Error>
     where
         T: AsymmetricType<'a>,
         Vec<u8>: From<&'a T>,
@@ -1251,7 +1254,7 @@ mod detail {
         AsymmetricTypeAsBytes::from(value).serialize(serializer)
     }
 
-    pub fn deserialize<'a, 'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    pub(super) fn deserialize<'a, 'de, T, D>(deserializer: D) -> Result<T, D::Error>
     where
         T: AsymmetricType<'a>,
         Vec<u8>: From<&'a T>,

--- a/types/src/crypto/error.rs
+++ b/types/src/crypto/error.rs
@@ -15,6 +15,7 @@ use crate::file_utils::{ReadFileError, WriteFileError};
 /// Cryptographic errors.
 #[derive(Debug)]
 #[cfg_attr(any(feature = "std", test), derive(Error))]
+#[non_exhaustive]
 pub enum Error {
     /// Error resulting from creating or using asymmetric key types.
     #[cfg_attr(any(feature = "std", test), error("asymmetric key error: {0}"))]
@@ -62,6 +63,7 @@ impl From<SignatureError> for Error {
 /// Cryptographic errors extended with some additional variants.
 #[cfg(any(feature = "std", test))]
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ErrorExt {
     /// A basic crypto error.
     #[error("crypto error: {0:?}")]

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -140,6 +140,7 @@ pub enum Key {
 
 /// Errors produced when converting a `String` into a `Key`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     /// Account parse error.
     Account(account::FromStrError),

--- a/types/src/system.rs
+++ b/types/src/system.rs
@@ -7,7 +7,7 @@ pub mod mint;
 pub mod standard_payment;
 mod system_contract_type;
 
-pub use call_stack_element::CallStackElement;
+pub use call_stack_element::{CallStackElement, CallStackElementTag};
 pub use error::Error;
 pub use system_contract_type::{
     SystemContractType, AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -15,6 +15,7 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     /// Unable to find named key in the contract's named keys.
     /// ```

--- a/types/src/system/error.rs
+++ b/types/src/system/error.rs
@@ -4,6 +4,7 @@ use crate::system::{auction, handle_payment, mint};
 
 /// An aggregate enum error with variants for each system contract's error.
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum Error {
     /// Contains a [`mint::Error`].
     Mint(mint::Error),

--- a/types/src/system/handle_payment/error.rs
+++ b/types/src/system/handle_payment/error.rs
@@ -15,6 +15,7 @@ use crate::{
 // TODO: Split this up into user errors vs. system errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     // ===== User errors =====
     /// The given validator is not bonded.

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -14,6 +14,7 @@ use crate::{
 /// Errors which can occur while executing the Mint contract.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     /// Insufficient funds to complete the transfer.
     /// ```

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -235,6 +235,7 @@ impl ToBytes for Transfer {
 
 /// Error returned when decoding a `TransferAddr` from a formatted string.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     /// The prefix is invalid.
     InvalidPrefix,

--- a/types/src/uint.rs
+++ b/types/src/uint.rs
@@ -56,6 +56,7 @@ pub use self::macro_code::{U128, U256, U512};
 
 /// Error type for parsing [`U128`], [`U256`], [`U512`] from a string.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UIntParseError {
     /// Contains the parsing error from the `uint` crate, which only supports base-10 parsing.
     FromDecStr(uint::FromDecStrErr),

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -38,6 +38,7 @@ pub type URefAddr = [u8; UREF_ADDR_LENGTH];
 
 /// Error while parsing a URef from a formatted string.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromStrError {
     /// Prefix is not "uref-".
     InvalidPrefix,


### PR DESCRIPTION
This PR mainly adds `#[non_exhaustive]` to error enums in the `casper-types` crate in order to avoid new variants in these causing breaking changes in the future.

Closes #3070