### PR TITLE
Add 'testing' feature to casper-node to expose test-only functionality on block and deploy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,16 +2061,16 @@ dependencies = [
 name = "gh-3097-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract",
- "casper-types",
+ "casper-contract 1.4.4",
+ "casper-types 1.5.0",
 ]
 
 [[package]]
 name = "gh-3097-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract",
- "casper-types",
+ "casper-contract 1.4.4",
+ "casper-types 1.5.0",
 ]
 
 [[package]]

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add new JSON RPC endpoint `/speculative_exec` that accepts a deploy and a block hash and executes that deploy, returning the execution effects.
 * Add `enable_server` option to all HTTP server configuration sections (`rpc_server`, `rest_server`, `event_stream_server`) which allow users to enable/disable each server independently (enabled by default).
 * Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
+* Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -96,7 +96,7 @@ vergen = "3"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
-casper-types = { version = "1.4.5", path = "../types", features = ["datasize", "json-schema", "std", "testing"] }
+casper-types = { path = "../types", features = ["datasize", "json-schema", "std", "testing"] }
 fake_instant = "0.4.0"
 pnet = "0.28.0"
 pretty_assertions = "0.7.2"
@@ -105,7 +105,8 @@ reqwest = { version = "0.11.3", features = ["stream"] }
 tokio = { version = "1", features = ["test-util"] }
 
 [features]
-vendored-openssl = ['openssl/vendored']
+testing = ["casper-types/testing"]
+vendored-openssl = ["openssl/vendored"]
 
 [[bin]]
 name = "casper-node"

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1,7 +1,7 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 use std::iter;
 use std::{
     array::TryFromSliceError,
@@ -16,20 +16,20 @@ use derive_more::Into;
 use hex_fmt::HexList;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use casper_hashing::Digest;
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 use casper_types::testing::TestRng;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     crypto, EraId, ProtocolVersion, PublicKey, SecretKey, Signature, Timestamp, U512,
 };
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 use casper_types::{crypto::generate_ed25519_keypair, system::auction::BLOCK_REWARD};
 use tracing::{error, warn};
 
@@ -185,7 +185,7 @@ static JSON_BLOCK_HEADER: Lazy<JsonBlockHeader> = Lazy::new(|| {
 
 // This should be clearly specified because the `verifiable_chunked_hash_activation`
 // parameter used in various tests strongly rely on this value.
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 const MAX_ERA_FOR_RANDOM_BLOCK: u64 = 6;
 
 /// Error returned from constructing a `Block`.
@@ -296,7 +296,7 @@ impl Display for BlockPayload {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 impl BlockPayload {
     #[allow(unused)] // TODO: remove when used in tests
     pub fn random(
@@ -489,7 +489,7 @@ impl FinalizedBlock {
     }
 
     /// Generates a random instance using a `TestRng`.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         let era = rng.gen_range(0..5);
         let height = era * 10 + rng.gen_range(0..10);
@@ -498,7 +498,7 @@ impl FinalizedBlock {
         FinalizedBlock::random_with_specifics(rng, EraId::from(era), height, is_switch, None)
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     /// Generates a random instance using a `TestRng`, but using the specified values.
     /// If `deploy` is `None`, random deploys will be generated, otherwise, the provided `deploy`
     /// will be used.
@@ -639,7 +639,7 @@ impl BlockHash {
     }
 
     /// Creates a random block hash.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         let hash = rng.gen::<[u8; Digest::LENGTH]>().into();
         BlockHash(hash)
@@ -703,7 +703,7 @@ impl BlockHashAndHeight {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         Self {
             block_hash: BlockHash::random(rng),
@@ -1872,7 +1872,7 @@ impl Block {
     }
 
     /// Overrides the height of a block.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn set_height(
         &mut self,
         height: u64,
@@ -1884,7 +1884,7 @@ impl Block {
     }
 
     /// Overrides the era end of a block with a `None`, making it a non-switch block.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn disable_switch_block(&mut self, verifiable_chunked_hash_activation: EraId) -> &mut Self {
         let _ = self.header.era_end.take();
         self.hash = self.header.hash(verifiable_chunked_hash_activation);
@@ -1892,7 +1892,7 @@ impl Block {
     }
 
     /// Generates a random instance using a `TestRng`.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         let era = rng.gen_range(0..MAX_ERA_FOR_RANDOM_BLOCK);
         let height = era * 10 + rng.gen_range(0..10);
@@ -1912,7 +1912,7 @@ impl Block {
 
     /// Generates a random instance using a `TestRng` with the specified
     /// `verifiable_chunked_hash_activation`
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random_with_verifiable_chunked_hash_activation(
         rng: &mut TestRng,
         verifiable_chunked_hash_activation: EraId,
@@ -1935,7 +1935,7 @@ impl Block {
     /// Generates random instance that is guaranteed to be using
     /// the legacy hashing scheme. Apart from the Block itself
     /// it also returns the EraId used as verifiable_chunked_hash_activation.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random_v1(rng: &mut TestRng) -> (Self, EraId) {
         let verifiable_chunked_hash_activation = EraId::from(MAX_ERA_FOR_RANDOM_BLOCK + 1);
 
@@ -1951,7 +1951,7 @@ impl Block {
     /// Generates random instance that is guaranteed to be using
     /// the merkle tree hashing scheme. Apart from the Block itself
     /// it also returns the EraId used as verifiable_chunked_hash_activation.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random_v2(rng: &mut TestRng) -> (Self, EraId) {
         let verifiable_chunked_hash_activation = EraId::from(0);
 
@@ -1965,7 +1965,7 @@ impl Block {
     }
 
     /// Generates a random instance using a `TestRng`, but using the specified values.
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn random_with_specifics<'a, I: IntoIterator<Item = &'a Deploy>>(
         rng: &mut TestRng,
         era_id: EraId,
@@ -2548,7 +2548,8 @@ impl FinalitySignature {
         crypto::verify(bytes, &self.signature, &self.public_key)
     }
 
-    #[cfg(test)]
+    /// Returns a random `FinalitySignature` for the provided `block_hash` and `era_id`.
+    #[cfg(any(feature = "testing", test))]
     pub fn random_for_block(block_hash: BlockHash, era_id: u64) -> Self {
         let (sec_key, pub_key) = generate_ed25519_keypair();
         FinalitySignature::new(block_hash, EraId::new(era_id), &sec_key, pub_key)


### PR DESCRIPTION
This PR exposes some constructors of `Block` and `Deploy` behind a new feature `testing`.  The constructors allow for creation of random instances and are useful for projects such as the sidecar process to be able to leverage in their test suites.