### PR TITLE
Fix update of joining set

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -518,8 +518,6 @@ where
                     // joiners, to the joining node, because the outgoing connection may outlive the
                     // incoming connection, i.e. it may take some time to drop "our" outgoing
                     // connection after a peer has closed the corresponding incoming connection.
-
-                    // self.update_joining_set(peer_id, is_joiner);
                 }
 
                 // Now we can start the message reader.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -473,7 +473,6 @@ where
                 peer_id,
                 peer_consensus_public_key,
                 stream,
-                is_joiner,
             } => {
                 if self.cfg.max_incoming_peer_connections != 0 {
                     if let Some(symmetries) = self.connection_symmetries.get(&peer_id) {
@@ -510,7 +509,17 @@ where
                     .add_incoming(peer_addr, Instant::now())
                 {
                     self.connection_completed(peer_id);
-                    self.update_joining_set(peer_id, is_joiner);
+
+                    // We should not update the joining set when we receive an incoming connection,
+                    // because the `message_sender` which is handling the corresponding outgoing
+                    // connection will not receive the update of the remote joiner state.
+                    //
+                    // Such desync may cause the node to try to send requests that are not safe for
+                    // joiners, to the joining node, because the outgoing connection may outlive the
+                    // incoming connection, i.e. it may take some time to drop "our" outgoing
+                    // connection after a peer has closed the corresponding incoming connection.
+
+                    // self.update_joining_set(peer_id, is_joiner);
                 }
 
                 // Now we can start the message reader.

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -182,8 +182,6 @@ pub(crate) enum IncomingConnection<P> {
         /// Stream of incoming messages. for incoming connections.
         #[serde(skip_serializing)]
         stream: SplitStream<FullTransport<P>>,
-        /// Flag indicating whether we've established a connection to a joining node.
-        is_joiner: bool,
     },
 }
 
@@ -205,12 +203,11 @@ impl<P> Display for IncomingConnection<P> {
                 peer_id,
                 peer_consensus_public_key,
                 stream: _,
-                is_joiner,
             } => {
                 write!(
                     f,
-                    "connection established from {}/{}; public: {}, joiner: {}",
-                    peer_addr, peer_id, public_addr, is_joiner,
+                    "connection established from {}/{}; public: {}",
+                    peer_addr, peer_id, public_addr,
                 )?;
 
                 if let Some(public_key) = peer_consensus_public_key {

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -63,10 +63,15 @@ use crate::{
 /// successfully handed over to the kernel for sending.
 pub(super) type MessageQueueItem<P> = (Arc<Message<P>>, Option<AutoClosingResponder<()>>);
 
+/// The outcome of the handshake process.
 struct HandshakeOutcome {
+    /// A framed transport for peer.
     framed_transport: FramedTransport,
+    /// Public address advertised by the peer.
     public_addr: SocketAddr,
+    /// The public key the peer is validating with, if any.
     peer_consensus_public_key: Option<PublicKey>,
+    /// True, if the peer identifies itself as "joiner".
     is_peer_joiner: bool,
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -250,7 +250,7 @@ where
 
     // Negotiate the handshake, concluding the incoming connection process.
     match negotiate_handshake::<P, _>(&context, framed, connection_id).await {
-        Ok((framed, public_addr, peer_consensus_public_key, is_peer_joiner)) => {
+        Ok((framed, public_addr, peer_consensus_public_key, _is_peer_joiner)) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
             }
@@ -271,7 +271,6 @@ where
                 peer_id,
                 peer_consensus_public_key,
                 stream,
-                is_joiner: is_peer_joiner,
             }
         }
         Err(error) => IncomingConnection::Failed {
@@ -688,7 +687,7 @@ pub(super) async fn message_sender<P>(
                 // We should never attempt to send an unsafe message to a peer that we know is a
                 // joiner. Since "unsafe" does usually not mean immediately catastrophic, we attempt
                 // to carry on, but warn loudly.
-                warn!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
+                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
             }
         }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -67,7 +67,7 @@ struct HandshakeOutcome {
     framed_transport: FramedTransport,
     public_addr: SocketAddr,
     peer_consensus_public_key: Option<PublicKey>,
-    is_joiner: bool,
+    is_peer_joiner: bool,
 }
 
 /// Low-level TLS connection function.
@@ -149,7 +149,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner,
+            is_peer_joiner: is_joiner,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
@@ -266,7 +266,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner: _,
+            is_peer_joiner: _,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
@@ -466,7 +466,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner,
+            is_peer_joiner: is_joiner,
         })
     } else {
         // Received a non-handshake, this is an error.


### PR DESCRIPTION
This PR changes the following:
* the "joining peer set" is **not** updated upon establishing the incoming connection (such an update may cause the node to try to send requests that are not safe for joiners, to the joining node_)
* bumps the log message severity if we detect that a peer is trying to query a joiner from `warn` to `error`
* introduces the helper `HandshakeOutcome` struct

Closes https://github.com/casper-network/casper-node/issues/3172