### PR TITLE
update broken link

### DIFF
--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -1,5 +1,5 @@
 //! A Rust library for writing smart contracts on the
-//! [Casper Platform](https://techspec.casperlabs.io).
+//! [Casper Platform](https://docs.casperlabs.io/dapp-dev-guide).
 //!
 //! # `no_std`
 //!


### PR DESCRIPTION
This PR fixes a broken link in the rustdocs of `casper-contract`.

Closes [#575](https://github.com/casper-network/docs/issues/575).