### PR TITLE
Update json-rpc to avoid some breaking changes

### DIFF
--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -112,7 +112,7 @@ impl Error {
     ///
     /// Other than when providing a [`ReservedErrorCode`], the converted "code" must not fall in the
     /// reserved range as defined in the JSON-RPC specification, i.e. it must not be between -32768
-    /// and -32000 inclusive.
+    /// and -32100 inclusive.
     ///
     /// If the converted code is within the reserved range when it should not be, or if
     /// JSON-encoding `additional_data` fails, the returned `Self` is built from
@@ -121,7 +121,7 @@ impl Error {
     pub fn new<C: ErrorCodeT, T: Serialize>(error_code: C, additional_info: T) -> Self {
         let (code, message): (i64, &'static str) = error_code.into();
 
-        if !C::is_reserved() && code >= -32768 && code <= -32000 {
+        if !C::is_reserved() && code >= -32768 && code <= -32100 {
             warn!(%code, "provided json-rpc error code is reserved; returning internal error");
             let (code, message) = ReservedErrorCode::InternalError.into();
             return Error {

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -114,6 +114,10 @@ impl Error {
     /// reserved range as defined in the JSON-RPC specification, i.e. it must not be between -32768
     /// and -32100 inclusive.
     ///
+    /// Note that in an upcoming release, the restriction will be tightened to disallow error codes
+    /// in the implementation-defined server-errors range.  I.e. codes in the range -32768 to -32000
+    /// inclusive will be disallowed.
+    ///
     /// If the converted code is within the reserved range when it should not be, or if
     /// JSON-encoding `additional_data` fails, the returned `Self` is built from
     /// [`ReservedErrorCode::InternalError`] with the "data" field being a String providing more

--- a/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
+++ b/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
@@ -55,7 +55,9 @@ fn main_filter_with_recovery() -> BoxedFilter<(impl Reply,)> {
     handlers.register_handler(GET_BAD_THING, Arc::new(get_bad_thing));
     let handlers = handlers.build();
 
-    main_filter(handlers).recover(handle_rejection).boxed()
+    main_filter(handlers, false)
+        .recover(handle_rejection)
+        .boxed()
 }
 
 #[tokio::test]

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.
+* `null` should no longer be used as a value for `params` in JSON-RPC requests.  Prefer an empty Array or Object.
 
 ### Removed
 * Legacy synchronization from genesis in favor of fast sync has been removed.
@@ -73,7 +74,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.
 * Dropped connections no longer cause the outstanding messages metric to become incorrect.
-* JSON-RPC server is now compliant with the standard. Specifically, correct error values are now returned in responses, and `null` is no longer accepted as a value for `params` in requests.
+* JSON-RPC server is now mostly compliant with the standard. Specifically, correct error values are now returned in responses in many failure cases.
 
 ### Security
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -33,6 +33,12 @@ pub use common::ErrorData;
 use docs::DocExample;
 pub use error_code::ErrorCode;
 
+/// This setting causes the server to ignore extra fields in JSON-RPC requests other than the
+/// standard 'id', 'jsonrpc', 'method', and 'params' fields.
+///
+/// It will be changed to `false` for casper-node v2.0.0.
+const ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST: bool = true;
+
 /// A JSON-RPC requiring the "params" field to be present.
 #[async_trait]
 pub(super) trait RpcWithParams {
@@ -256,7 +262,12 @@ pub(super) async fn run(
     server_name: &'static str,
 ) {
     let make_svc = hyper::service::make_service_fn(move |_| {
-        let service_routes = casper_json_rpc::route(api_path, max_body_bytes, handlers.clone());
+        let service_routes = casper_json_rpc::route(
+            api_path,
+            max_body_bytes,
+            handlers.clone(),
+            ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST,
+        );
 
         // Supports content negotiation for gzip responses. This is an interim fix until
         // https://github.com/seanmonstar/warp/pull/513 moves forward.
@@ -333,7 +344,7 @@ mod tests {
             GetDeploy::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }
@@ -400,7 +411,7 @@ mod tests {
             GetPeers::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }
@@ -454,7 +465,7 @@ mod tests {
             GetBlock::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }

--- a/node/src/components/rpc_server/rpcs/error_code.rs
+++ b/node/src/components/rpc_server/rpcs/error_code.rs
@@ -3,35 +3,38 @@ use serde::{Deserialize, Serialize};
 use casper_json_rpc::ErrorCodeT;
 
 /// The various codes which can be returned in the JSON-RPC Response's error object.
+///
+/// **NOTE:** These values will be changed to lie outside the restricted range as defined in the
+/// JSON-RPC spec as of casper-node v2.0.0.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 #[repr(i64)]
 pub enum ErrorCode {
     /// The requested Deploy was not found.
-    NoSuchDeploy = -1,
+    NoSuchDeploy = -32000,
     /// The requested Block was not found.
-    NoSuchBlock = -2,
+    NoSuchBlock = -32001,
     /// Parsing the Key for a query failed.
-    FailedToParseQueryKey = -3,
+    FailedToParseQueryKey = -32002,
     /// The query failed to find a result.
-    QueryFailed = -4,
+    QueryFailed = -32003,
     /// Executing the query failed.
-    QueryFailedToExecute = -5,
+    QueryFailedToExecute = -32004,
     /// Parsing the URef while getting a balance failed.
-    FailedToParseGetBalanceURef = -6,
+    FailedToParseGetBalanceURef = -32005,
     /// Failed to get the requested balance.
-    FailedToGetBalance = -7,
+    FailedToGetBalance = -32006,
     /// Executing the query to retrieve the balance failed.
-    GetBalanceFailedToExecute = -8,
+    GetBalanceFailedToExecute = -32007,
     /// The given Deploy cannot be executed as it is invalid.
-    InvalidDeploy = -9,
+    InvalidDeploy = -32008,
     /// The given account was not found.
-    NoSuchAccount = -10,
+    NoSuchAccount = -32009,
     /// Failed to get the requested dictionary URef.
-    FailedToGetDictionaryURef = -11,
+    FailedToGetDictionaryURef = -32010,
     /// Failed to get the requested dictionary trie.
-    FailedToGetTrie = -12,
+    FailedToGetTrie = -32011,
     /// The requested state root hash was not found.
-    NoSuchStateRoot = -13,
+    NoSuchStateRoot = -32012,
 }
 
 impl From<ErrorCode> for (i64, &'static str) {

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -709,7 +709,7 @@ pub(super) async fn message_sender<P>(
                 // We should never attempt to send an unsafe message to a peer that we know is a
                 // joiner. Since "unsafe" does usually not mean immediately catastrophic, we attempt
                 // to carry on, but warn loudly.
-                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
+                warn!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
             }
         }
 


### PR DESCRIPTION
This PR updates the `casper-json-rpc` crate to avoid some breaking changes in the node JSON-RPC server.

Specifically:
* it allows the `params` field to be null, interpreting that as an empty array, or equivalently, a `None` value
* it relaxes the range of error codes for which it supports creating an error response, since we currently use reserved values
* it can be configured to ignore extra fields provided in JSON-RPC requests (our usage in node configures the server to ignore extra fields as per current behaviour)

Closes #3175.
