### PR TITLE
Add chainspec hash to network handshake

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `enable_server` option to all HTTP server configuration sections (`rpc_server`, `rest_server`, `event_stream_server`) which allow users to enable/disable each server independently (enabled by default).
 * Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
 * Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
+* The network handshake now contains the hash of the chainspec used and will be successful only if they match.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
@@ -69,6 +70,7 @@ All notable changes to this project will be documented in this file.  The format
 * Remove a temporary chainspec setting `max_stored_value_size` to limit the size of individual values stored in global state.
 * Remove asymmetric key functionality (move to `casper-types` crate behind feature "std").
 * Remove time types (move to `casper-types` with some functionality behind feature "std").
+* Remove `reject_incompatible_versions` option from `config.toml`, meaning now all versions different than the current one are rejected through the `chainspec_hash` check in the network handshake.
 
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -303,7 +303,6 @@ where
             consensus_keys,
             handshake_timeout: cfg.handshake_timeout,
             payload_weights: cfg.estimator_weights.clone(),
-            reject_incompatible_versions: cfg.reject_incompatible_versions,
             tarpit_version_threshold: cfg.tarpit_version_threshold,
             tarpit_duration: cfg.tarpit_duration,
             tarpit_chance: cfg.tarpit_chance,
@@ -602,7 +601,9 @@ where
             | ConnectionError::InvalidConsensusCertificate(_) => false,
 
             // Definitely something we want to avoid.
-            ConnectionError::WrongNetwork(_) | ConnectionError::WrongChainspecHash => true,
+            ConnectionError::WrongNetwork(_)
+            | ConnectionError::WrongChainspecHash(_)
+            | ConnectionError::MissingChainspecHash => true,
         }
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -602,7 +602,7 @@ where
             | ConnectionError::InvalidConsensusCertificate(_) => false,
 
             // Definitely something we want to avoid.
-            ConnectionError::WrongNetwork(_) => true,
+            ConnectionError::WrongNetwork(_) | ConnectionError::WrongChainspecHash => true,
         }
     }
 

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -5,6 +5,7 @@
 
 use std::net::SocketAddr;
 
+use casper_hashing::Digest;
 use casper_types::ProtocolVersion;
 use datasize::DataSize;
 
@@ -27,16 +28,20 @@ pub(crate) struct ChainInfo {
     pub(super) maximum_net_message_size: u32,
     /// The protocol version.
     pub(super) protocol_version: ProtocolVersion,
+    /// The hash of the chainspec.
+    pub(super) chainspec_hash: Digest,
 }
 
 impl ChainInfo {
     /// Create an instance of `ChainInfo` for testing.
     #[cfg(test)]
     pub fn create_for_testing() -> Self {
+        let network_name = "rust-tests-network";
         ChainInfo {
-            network_name: "rust-tests-network".to_string(),
+            network_name: network_name.to_string(),
             maximum_net_message_size: 22 * 1024 * 1024, // Hardcoded at 22M.
             protocol_version: ProtocolVersion::V1_0_0,
+            chainspec_hash: Digest::hash(format!("{}-chainspec", network_name)),
         }
     }
 
@@ -55,6 +60,7 @@ impl ChainInfo {
             consensus_certificate: consensus_keys
                 .map(|key_pair| ConsensusCertificate::create(connection_id, key_pair)),
             is_joiner,
+            chainspec_hash: Some(self.chainspec_hash),
         }
     }
 }
@@ -65,6 +71,7 @@ impl From<&Chainspec> for ChainInfo {
             network_name: chainspec.network_config.name.clone(),
             maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
             protocol_version: chainspec.protocol_version(),
+            chainspec_hash: chainspec.hash(),
         }
     }
 }

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -44,7 +44,6 @@ impl Default for Config {
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
-            reject_incompatible_versions: true,
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
@@ -83,8 +82,6 @@ pub struct Config {
     pub max_incoming_message_rate_non_validators: u32,
     /// Weight distribution for the payload impact estimator.
     pub estimator_weights: EstimatorWeights,
-    /// Whether or not to reject incompatible versions during handshake.
-    pub reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -189,6 +189,9 @@ pub enum ConnectionError {
     /// This is usually a bug.
     #[error("handshake sink/stream could not be reunited")]
     FailedToReuniteHandshakeSinkAndStream,
+    /// Peer is running a different chainspec.
+    #[error("peer is on different chainspec")]
+    WrongChainspecHash,
 }
 
 /// IO operation that can time out or close.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -1,5 +1,6 @@
 use std::{error, io, net::SocketAddr, result, sync::Arc};
 
+use casper_hashing::Digest;
 use casper_types::{crypto, ProtocolVersion, SecretKey};
 use datasize::DataSize;
 use openssl::{error::ErrorStack, ssl};
@@ -151,6 +152,13 @@ pub enum ConnectionError {
     /// Peer reported an incompatible version.
     #[error("peer is running incompatible version: {0}")]
     IncompatibleVersion(ProtocolVersion),
+    /// Peer is using a different chainspec.
+    #[error("peer is using a different chainspec, hash: {0}")]
+    WrongChainspecHash(Digest),
+    /// Peer should have included the chainspec hash in the handshake message,
+    /// but didn't.
+    #[error("peer did not include mandatory chainspec hash in the handshake")]
+    MissingChainspecHash,
     /// Peer did not send any message, or a non-handshake as its first message.
     #[error("peer did not send handshake")]
     DidNotSendHandshake,
@@ -189,9 +197,6 @@ pub enum ConnectionError {
     /// This is usually a bug.
     #[error("handshake sink/stream could not be reunited")]
     FailedToReuniteHandshakeSinkAndStream,
-    /// Peer is running a different chainspec.
-    #[error("peer is on different chainspec")]
-    WrongChainspecHash,
 }
 
 /// IO operation that can time out or close.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -157,7 +157,7 @@ pub enum ConnectionError {
     WrongChainspecHash(Digest),
     /// Peer should have included the chainspec hash in the handshake message,
     /// but didn't.
-    #[error("peer did not include mandatory chainspec hash in the handshake")]
+    #[error("peer did not include chainspec hash in the handshake when it was required")]
     MissingChainspecHash,
     /// Peer did not send any message, or a non-handshake as its first message.
     #[error("peer did not send handshake")]

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -15,7 +15,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::{effect::EffectBuilder, types::NodeId};
+use crate::{effect::EffectBuilder, types::NodeId, utils::opt_display::OptDisplay};
 
 use super::counting_format::ConnectionId;
 
@@ -268,21 +268,14 @@ impl<P: Display> Display for Message<P> {
             } => {
                 write!(
                     f,
-                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: , is_joiner: {}, chainspec_hash: ",
-                    network_name, public_addr, protocol_version, is_joiner
-                )?;
-
-                if let Some(cert) = consensus_certificate {
-                    write!(f, "{}", cert)?;
-                } else {
-                    f.write_str("-")?;
-                }
-
-                if let Some(hash) = chainspec_hash {
-                    write!(f, "{}", hash)
-                } else {
-                    f.write_str("-")
-                }
+                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: {}, is_joiner: {}, chainspec_hash: {}",
+                    network_name,
+                    public_addr,
+                    protocol_version,
+                    OptDisplay::new(consensus_certificate.as_ref(), "none"),
+                    is_joiner,
+                    OptDisplay::new(chainspec_hash.as_ref(), "none")
+                )
             }
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -420,6 +420,7 @@ where
         protocol_version,
         consensus_certificate,
         is_joiner,
+        chainspec_hash,
     } = remote_message
     {
         debug!(%protocol_version, "handshake received");
@@ -427,6 +428,14 @@ where
         // The handshake was valid, we can check the network name.
         if network_name != context.chain_info.network_name {
             return Err(ConnectionError::WrongNetwork(network_name));
+        }
+
+        // We check the chainspec hash to ensure peer is running on the
+        // same chainspec as us.
+        if let Some(hash) = chainspec_hash {
+            if hash != context.chain_info.chainspec_hash {
+                return Err(ConnectionError::WrongChainspecHash);
+            }
         }
 
         // If there is a version mismatch, we treat it as a connection error. We do not ban peers

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -215,8 +215,6 @@ where
     pub(super) handshake_timeout: TimeDiff,
     /// Weights to estimate payloads with.
     pub(super) payload_weights: EstimatorWeights,
-    /// Whether or not to reject incompatible versions during handshake.
-    pub(super) reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub(super) tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.
@@ -430,23 +428,13 @@ where
             return Err(ConnectionError::WrongNetwork(network_name));
         }
 
-        // We check the chainspec hash to ensure peer is running on the
-        // same chainspec as us.
-        if let Some(hash) = chainspec_hash {
-            if hash != context.chain_info.chainspec_hash {
-                return Err(ConnectionError::WrongChainspecHash);
-            }
-        }
-
         // If there is a version mismatch, we treat it as a connection error. We do not ban peers
         // for this error, but instead rely on exponential backoff, as bans would result in issues
         // during upgrades where nodes may have a legitimate reason for differing versions.
         //
         // Since we are not using SemVer for versioning, we cannot make any assumptions about
         // compatibility, so we allow only exact version matches.
-        if context.reject_incompatible_versions
-            && protocol_version != context.chain_info.protocol_version
-        {
+        if protocol_version != context.chain_info.protocol_version {
             if let Some(threshold) = context.tarpit_version_threshold {
                 if protocol_version <= threshold {
                     let mut rng = crate::new_rng();
@@ -463,6 +451,14 @@ where
                 }
             }
             return Err(ConnectionError::IncompatibleVersion(protocol_version));
+        }
+
+        // We check the chainspec hash to ensure peer is using the same chainspec as us.
+        // The remote message should always have a chainspec hash at this point since
+        // we checked the protocol version previously.
+        let peer_chainspec_hash = chainspec_hash.ok_or(ConnectionError::MissingChainspecHash)?;
+        if peer_chainspec_hash != context.chain_info.chainspec_hash {
+            return Err(ConnectionError::WrongChainspecHash(peer_chainspec_hash));
         }
 
         let peer_consensus_public_key = consensus_certificate

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -4,6 +4,7 @@
 mod display_error;
 pub(crate) mod ds;
 mod external;
+pub(crate) mod opt_display;
 pub(crate) mod rlimit;
 pub(crate) mod round_robin;
 pub(crate) mod umask;

--- a/node/src/utils/opt_display.rs
+++ b/node/src/utils/opt_display.rs
@@ -1,0 +1,25 @@
+use std::fmt::{Display, Formatter, Result};
+
+pub struct OptDisplay<'a, 'b, T> {
+    inner: Option<&'a T>,
+    empty_display: &'b str,
+}
+
+impl<'a, 'b, T: Display> OptDisplay<'a, 'b, T> {
+    pub fn new(maybe_display: Option<&'a T>, empty_display: &'b str) -> Self {
+        Self {
+            inner: maybe_display,
+            empty_display,
+        }
+    }
+}
+
+impl<'a, 'b, T: Display> Display for OptDisplay<'a, 'b, T> {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self.inner {
+            None => f.write_str(self.empty_display),
+            Some(val) => val.fmt(f),
+        }
+    }
+}

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -164,13 +164,6 @@ max_incoming_message_rate_non_validators = 0
 # `0` means unlimited.
 max_in_flight_demands = 50
 
-# Reject incompatible node versions
-#
-# Causes the node to immediately disconnect from versions on a different protocol version than
-# itself. In general, this feature should be enabled on the entire network, it can be disabled in
-# the case of problems during upgrades if the nodes are still compatible on the networking level.
-reject_incompatible_versions = true
-
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a
@@ -180,8 +173,6 @@ reject_incompatible_versions = true
 # This option makes most sense to enable on known nodes with addresses where legacy nodes that are
 # still in operation are connecting to, as these older versions will only attempt to reconnect to
 # other nodes once they have exhausted their set of known nodes.
-#
-# This feature is only enabled if `reject_incompatible_versions` is enabled.
 tarpit_version_threshold = '1.2.1'
 
 # How long to hold connections to trapped legacy nodes.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -164,13 +164,6 @@ max_incoming_message_rate_non_validators = 3000
 # `0` means unlimited.
 max_in_flight_demands = 50
 
-# Reject incompatible node versions
-#
-# Causes the node to immediately disconnect from versions on a different protocol version than
-# itself. In general, this feature should be enabled on the entire network, it can be disabled in
-# the case of problems during upgrades if the nodes are still compatible on the networking level.
-reject_incompatible_versions = true
-
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a
@@ -180,8 +173,6 @@ reject_incompatible_versions = true
 # This option makes most sense to enable on known nodes with addresses where legacy nodes that are
 # still in operation are connecting to, as these older versions will only attempt to reconnect to
 # other nodes once they have exhausted their set of known nodes.
-#
-# This feature is only enabled if `reject_incompatible_versions` is enabled.
 tarpit_version_threshold = '1.2.1'
 
 # How long to hold connections to trapped legacy nodes.


### PR DESCRIPTION
Fixes #3184 

This PR adds `chainspec_hash` field to the handshake message in the `small_network` component. When handshaking with current or newer versions, the node now checks that the peer it's connecting with is running on the same chainspec by comparing the hashes.

Deviating from the original requirements in the issue, the `network_name` field cannot be removed as it is part of the `v1.0.0` handshake and therefore it must be present to not break backwards compatibility. Furthermore, we decided not to remove the `protocol_version` field as well.

We should at some point add a new `V1_5_0_Message` entry in `small_network/message.rs` and a unit test for it, similar to other changes in the past.
