### PR TITLE
Fix sync-to-genesis

### DIFF
--- a/node/src/components/chain_synchronizer/metrics.rs
+++ b/node/src/components/chain_synchronizer/metrics.rs
@@ -25,22 +25,24 @@ pub(crate) struct Metrics {
     /// Time in seconds to get the trusted key block.
     #[data_size(skip)]
     pub(super) chain_sync_get_trusted_key_block_info_duration_seconds: IntGauge,
-    /// Time in seconds to fetch to genesis during sync to genesis.
+    /// Time in seconds to fetch block headers from highest available block back to genesis during
+    /// sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_to_genesis_duration_seconds: IntGauge,
-    /// Time in seconds to fetch forward during sync to genesis.
+    /// Time in seconds to fetch blocks, deploys and tries from genesis forward to initial highest
+    /// available block during sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_forward_duration_seconds: IntGauge,
-    /// Total time in seconds of performing the fast sync.
+    /// Total time in seconds of performing the chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_fast_sync_total_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers during fast sync.
+    /// Time in seconds of fetching block headers during chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_block_headers_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers for replay protection during fast sync.
+    /// Time in seconds of fetching block headers for replay protection during chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_replay_protection_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers for era supervisor initialization during fast
+    /// Time in seconds of fetching block headers for era supervisor initialization during chain
     /// sync.
     #[data_size(skip)]
     pub(super) chain_sync_era_supervisor_init_duration_seconds: IntGauge,

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -96,6 +96,7 @@ impl Sequence {
 /// For example, if `sequences` contains `[9,9], [7,3]` and `8` is inserted, then `sequences` will
 /// be reduced to `[9,3]`.
 #[derive(Default, Debug, DataSize)]
+#[cfg_attr(test, derive(Clone))]
 pub(super) struct DisjointSequences {
     sequences: Vec<Sequence>,
 }
@@ -462,46 +463,44 @@ mod tests {
         const SEQ_HIGH: Sequence = Sequence { high: 11, low: 9 };
         const SEQ_MID: Sequence = Sequence { high: 6, low: 6 };
         const SEQ_LOW: Sequence = Sequence { high: 3, low: 1 };
-        fn new_sequences() -> DisjointSequences {
-            DisjointSequences {
-                sequences: vec![SEQ_HIGH, SEQ_MID, SEQ_LOW],
-            }
-        }
+        let initial_sequences = DisjointSequences {
+            sequences: vec![SEQ_HIGH, SEQ_MID, SEQ_LOW],
+        };
 
         // Truncate with `max_value` greater or equal to current highest value should be a no-op.
-        let mut disjoint_sequences = new_sequences();
+        let mut disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(12);
-        assert_eq!(disjoint_sequences.sequences, new_sequences().sequences);
+        assert_eq!(disjoint_sequences.sequences, initial_sequences.sequences);
         disjoint_sequences.truncate(11);
-        assert_eq!(disjoint_sequences.sequences, new_sequences().sequences);
+        assert_eq!(disjoint_sequences.sequences, initial_sequences.sequences);
 
         // Truncate with `max_value` between two sequences should cause the higher sequences to get
         // removed and the lower ones retained unchanged.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_HIGH.low - 1);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_MID.high);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_MID.low - 1);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_LOW.high);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_LOW]);
 
         // Truncate with `max_value` lower than the lowest value should cause all sequences to get
         // removed.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_LOW.low - 1);
         assert!(disjoint_sequences.sequences.is_empty());
 
         // Truncate with `max_value` within a sequence should cause that sequence to get updated,
         // any higher sequences to get removed, and any lower ones retained unchanged.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_HIGH.high - 1;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -509,7 +508,7 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_HIGH.low), SEQ_MID, SEQ_LOW]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_HIGH.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -517,12 +516,12 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_HIGH.low), SEQ_MID, SEQ_LOW]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_MID.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_LOW.high - 1;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -530,7 +529,7 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_LOW.low)]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences;
         let max_value = SEQ_LOW.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(

--- a/utils/nctl/docs/setup.md
+++ b/utils/nctl/docs/setup.md
@@ -23,8 +23,8 @@ To find out which branch of the client and launcher are compatible with the curr
 # Supervisor - cross-platform process manager.
 python3 -m pip install supervisor
 
-# toml - Config file parser.
-python3 -m pip install toml
+# Utilities for config file parsing and generation.
+python3 -m pip install toml tomlkit
 
 # Rust toolchain and smart contracts - required by casper-node software.
 cd YOUR_WORKING_DIRECTORY/casper-node


### PR DESCRIPTION
This PR changes sync-to-genesis to ensure it syncs forward far enough so that once it's complete the node has a full sequence of complete blocks and corresponding global state.

The main thrust of the change is that sync-from-genesis now uses the block returned by the fast-sync process as its trusted block.  Sync-to-genesis synchronises as far as that block, and all subsequent ones are guaranteed to be "complete" as they will have been executed while the node is in participating mode.

It also provides a fix for an issue discovered while testing the PR: namely that the `completed_blocks` in storage was not being adjusted after a hard reset to account for the fact that some blocks could have been removed.

Finally, it fixes an issue whereby `execute_blocks` was being passed the key block info for the trusted block rather than the most recent block.

Closes #3186, #3192 and #3193.