### PR TITLE
Verify finality signature cryptographic correctness at the end of the process.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -41,7 +41,6 @@ pub(crate) struct LinearChainComponent {
     metrics: Metrics,
     /// If true, the process should stop execution to allow an upgrade to proceed.
     stop_for_upgrade: bool,
-    verifiable_chunked_hash_activation: EraId,
 }
 
 impl LinearChainComponent {
@@ -61,21 +60,17 @@ impl LinearChainComponent {
             unbonding_delay,
             finality_threshold_fraction,
             next_upgrade_activation_point,
+            verifiable_chunked_hash_activation,
         );
         Ok(LinearChainComponent {
             linear_chain_state,
             metrics,
             stop_for_upgrade: false,
-            verifiable_chunked_hash_activation,
         })
     }
 
     pub(crate) fn stop_for_upgrade(&self) -> bool {
         self.stop_for_upgrade
-    }
-
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.verifiable_chunked_hash_activation
     }
 }
 
@@ -179,9 +174,7 @@ where
                 self.metrics
                     .block_completion_duration
                     .set(completion_duration as i64);
-                let outcomes = self
-                    .linear_chain_state
-                    .handle_put_block_result(block, self.verifiable_chunked_hash_activation());
+                let outcomes = self.linear_chain_state.handle_put_block_result(block);
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::FinalitySignatureReceived(fs, gossiped) => {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -138,6 +138,10 @@ where
                         panic!("couldn't check if validator is bonded")
                     },
                 ),
+            Outcome::DuplicateSignature(_) | Outcome::InvalidSignature { .. } => {
+                // No action. Yet.
+                Effects::new()
+            }
         })
         .concat()
 }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -177,23 +177,23 @@ where
                     .set(completion_duration as i64);
                 let outcomes = self
                     .linear_chain_state
-                    .handle_put_block(block, self.verifiable_chunked_hash_activation());
+                    .handle_put_block_result(block, self.verifiable_chunked_hash_activation());
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::FinalitySignatureReceived(fs, gossiped) => {
                 let outcomes = self
                     .linear_chain_state
-                    .handle_finality_signature(fs, gossiped);
+                    .handle_finality_signature_received(fs, gossiped);
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::GetStoredFinalitySignaturesResult(fs, maybe_signatures) => {
                 let outcomes = self
                     .linear_chain_state
-                    .handle_cached_signatures(maybe_signatures, fs);
+                    .handle_stored_signatures_result(maybe_signatures, fs);
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::IsBonded(maybe_known_signatures, new_fs, is_bonded) => {
-                let outcomes = self.linear_chain_state.handle_is_bonded(
+                let outcomes = self.linear_chain_state.handle_is_bonded_result(
                     maybe_known_signatures,
                     new_fs,
                     is_bonded,
@@ -206,7 +206,7 @@ where
             }
             Event::GotUpgradeActivationPoint(activation_point) => {
                 self.linear_chain_state
-                    .got_upgrade_activation_point(activation_point);
+                    .handle_upgrade_activation_point(activation_point);
                 Effects::new()
             }
         }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -193,7 +193,7 @@ where
             Event::GetStoredFinalitySignaturesResult(fs, maybe_signatures) => {
                 let outcomes = self
                     .linear_chain_state
-                    .handle_stored_signatures_result(maybe_signatures, fs);
+                    .handle_get_stored_signatures_result(maybe_signatures, fs);
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::IsBonded(maybe_known_signatures, new_fs, is_bonded) => {

--- a/node/src/components/linear_chain/pending_signatures.rs
+++ b/node/src/components/linear_chain/pending_signatures.rs
@@ -98,8 +98,8 @@ impl PendingSignatures {
 
         // Add the pending signature.
         let value = VerificationStatus::Unknown(signature);
-        sigs.insert(block_hash, value);
-        true
+        // Return boolean indicating whether `sigs` map already had this key.
+        sigs.insert(block_hash, value).is_none()
     }
 
     pub(super) fn remove(

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -174,7 +174,7 @@ impl LinearChain {
                 // TODO: Disconnect from the sender.
                 return vec![];
             }
-            // If signature is already known, we can remove the the new one from collection of
+            // If the signature is already known, we can remove the new one from the collection of
             // pending signatures.
             if known_signatures.has_proof(&fs.public_key) {
                 self.remove_from_pending_fs(&fs);

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -506,14 +506,16 @@ mod tests {
 
     const VERIFIABLE_CHUNKED_HASH_ACTIVATION: EraId = EraId::new(10);
 
+    const AUCTION_DELAY: u64 = 1;
+    const UNBONDING_DELAY: u64 = 2;
+
     #[test]
     fn new_block_no_sigs() {
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
         let mut lc = LinearChain::new(
-            protocol_version,
-            1u64,
-            1u64,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -566,11 +568,10 @@ mod tests {
     #[test]
     fn new_block_unvalidated_pending_sigs() {
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
         let mut lc = LinearChain::new(
-            protocol_version,
-            1u64,
-            1u64,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -612,11 +613,10 @@ mod tests {
     #[test]
     fn new_block_bonded_pending_sigs() {
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
         let mut lc = LinearChain::new(
-            protocol_version,
-            1u64,
-            1u64,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -676,11 +676,10 @@ mod tests {
     #[test]
     fn pending_sig_rejected() {
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
         let mut lc = LinearChain::new(
-            protocol_version,
-            1u64,
-            1u64,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -738,11 +737,10 @@ mod tests {
     fn known_sig_rejected() {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
         let mut lc = LinearChain::new(
-            protocol_version,
-            1u64,
-            1u64,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -758,17 +756,13 @@ mod tests {
         );
     }
 
-    const AUCTION_DELAY: u64 = 1;
-
     fn setup() -> (LinearChain, Block) {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
-        let unbonding_delay = 2;
         let mut lc = LinearChain::new(
-            protocol_version,
+            ProtocolVersion::V1_0_0,
             AUCTION_DELAY,
-            unbonding_delay,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -817,12 +811,10 @@ mod tests {
     fn reject_invalid_signature() {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
-        let unbonding_delay = 2;
         let mut lc = LinearChain::new(
-            protocol_version,
+            ProtocolVersion::V1_0_0,
             AUCTION_DELAY,
-            unbonding_delay,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -872,13 +864,10 @@ mod tests {
     fn new_block_then_own_sig() {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
-        let auction_delay = 1;
-        let unbonding_delay = 2;
         let mut lc = LinearChain::new(
-            protocol_version,
-            auction_delay,
-            unbonding_delay,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             None,
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -931,15 +920,11 @@ mod tests {
     fn upgrade_when_fully_signed() {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
-        let auction_delay = 1;
-        let unbonding_delay = 2;
-
         // The next upgrade is scheduled for era 3.
         let mut lc = LinearChain::new(
-            protocol_version,
-            auction_delay,
-            unbonding_delay,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             Some(ActivationPoint::EraId(3.into())),
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -963,7 +948,7 @@ mod tests {
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true, None),
                 Some(validators.clone()),
-                protocol_version,
+                ProtocolVersion::V1_0_0,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION,
             )
             .unwrap(),
@@ -980,7 +965,7 @@ mod tests {
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true, None),
                 Some(validators),
-                protocol_version,
+                ProtocolVersion::V1_0_0,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION,
             )
             .unwrap(),
@@ -1046,15 +1031,11 @@ mod tests {
     fn upgrade_when_fully_signed_and_got_signatures_before_block() {
         let _ = logging::init();
         let mut rng = TestRng::new();
-        let protocol_version = ProtocolVersion::V1_0_0;
-        let auction_delay = 1;
-        let unbonding_delay = 2;
-
         // The next upgrade is scheduled for era 3.
         let mut lc = LinearChain::new(
-            protocol_version,
-            auction_delay,
-            unbonding_delay,
+            ProtocolVersion::V1_0_0,
+            AUCTION_DELAY,
+            UNBONDING_DELAY,
             Ratio::new(1, 3),
             Some(ActivationPoint::EraId(3.into())),
             VERIFIABLE_CHUNKED_HASH_ACTIVATION,
@@ -1079,7 +1060,7 @@ mod tests {
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(1), 10, true, None),
                 Some(validators.clone()),
-                protocol_version,
+                ProtocolVersion::V1_0_0,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION,
             )
             .unwrap(),
@@ -1095,7 +1076,7 @@ mod tests {
                 rng.gen::<[u8; Digest::LENGTH]>().into(), // state root hash
                 FinalizedBlock::random_with_specifics(&mut rng, EraId::from(2), 20, true, None),
                 Some(validators),
-                protocol_version,
+                ProtocolVersion::V1_0_0,
                 VERIFIABLE_CHUNKED_HASH_ACTIVATION,
             )
             .unwrap(),


### PR DESCRIPTION
Since cryptographic verification of signatures can be "expensive" operation, we want to postpone it until the very end of the validation process - after verifying whether we already know the signature, whether it's from a bonded/correct validator, etc.


Closes https://github.com/casper-network/casper-node/issues/3144