### PR TITLE
Add better error messages to nctl when repos are missing

### DIFF
--- a/utils/nctl/sh/assets/compile_client.sh
+++ b/utils/nctl/sh/assets/compile_client.sh
@@ -30,7 +30,8 @@ make build-contract-rs/nctl-dictionary
 popd || exit
 
 # Build client utility.
-pushd "$NCTL_CASPER_CLIENT_HOME" || exit
+pushd "$NCTL_CASPER_CLIENT_HOME" || \
+    { echo "Could not find the casper-client-rs repo - have you cloned it into your working directory?"; exit; }
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
     cargo build

--- a/utils/nctl/sh/assets/compile_node_launcher.sh
+++ b/utils/nctl/sh/assets/compile_node_launcher.sh
@@ -11,7 +11,8 @@
 # Import utils.
 source "$NCTL"/sh/utils/main.sh
 
-pushd "$NCTL_CASPER_NODE_LAUNCHER_HOME" || exit
+pushd "$NCTL_CASPER_NODE_LAUNCHER_HOME" || \
+    { echo "Could not find the casper-node-launcher repo - have you cloned it into your working directory?"; exit; }
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
     cargo build


### PR DESCRIPTION
Closes #2906 

Point 1 from the issue is actually already covered - the prerequisites are documented in `utils/nctl/docs/setup.md`. This PR addresses point 2.