### PR TITLE
Bring feat-2.0 up to date with dev since `3dfcbc1`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -246,6 +246,7 @@ steps:
   - "./ci/nctl_upgrade_stage.sh"
   when:
     branch:
+    - dev
     - "release-*"
 
 - name: nctl-bucket-upload
@@ -264,6 +265,7 @@ steps:
     path: /tmp/nctl_upgrade_stage
   when:
     branch:
+    - dev
     - "release-*"
 
 - name: notify

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -112,7 +112,7 @@ impl Error {
     ///
     /// Other than when providing a [`ReservedErrorCode`], the converted "code" must not fall in the
     /// reserved range as defined in the JSON-RPC specification, i.e. it must not be between -32768
-    /// and -32000 inclusive.
+    /// and -32100 inclusive.
     ///
     /// If the converted code is within the reserved range when it should not be, or if
     /// JSON-encoding `additional_data` fails, the returned `Self` is built from
@@ -121,7 +121,7 @@ impl Error {
     pub fn new<C: ErrorCodeT, T: Serialize>(error_code: C, additional_info: T) -> Self {
         let (code, message): (i64, &'static str) = error_code.into();
 
-        if !C::is_reserved() && code >= -32768 && code <= -32000 {
+        if !C::is_reserved() && code >= -32768 && code <= -32100 {
             warn!(%code, "provided json-rpc error code is reserved; returning internal error");
             let (code, message) = ReservedErrorCode::InternalError.into();
             return Error {

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -114,6 +114,10 @@ impl Error {
     /// reserved range as defined in the JSON-RPC specification, i.e. it must not be between -32768
     /// and -32100 inclusive.
     ///
+    /// Note that in an upcoming release, the restriction will be tightened to disallow error codes
+    /// in the implementation-defined server-errors range.  I.e. codes in the range -32768 to -32000
+    /// inclusive will be disallowed.
+    ///
     /// If the converted code is within the reserved range when it should not be, or if
     /// JSON-encoding `additional_data` fails, the returned `Self` is built from
     /// [`ReservedErrorCode::InternalError`] with the "data" field being a String providing more

--- a/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
+++ b/json_rpc/src/filters/tests/main_filter_with_recovery_tests.rs
@@ -55,7 +55,9 @@ fn main_filter_with_recovery() -> BoxedFilter<(impl Reply,)> {
     handlers.register_handler(GET_BAD_THING, Arc::new(get_bad_thing));
     let handlers = handlers.build();
 
-    main_filter(handlers).recover(handle_rejection).boxed()
+    main_filter(handlers, false)
+        .recover(handle_rejection)
+        .boxed()
 }
 
 #[tokio::test]

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Deprecated
 * Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.
+* `null` should no longer be used as a value for `params` in JSON-RPC requests.  Prefer an empty Array or Object.
 
 ### Removed
 * Legacy synchronization from genesis in favor of fast sync has been removed.
@@ -73,7 +74,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.
 * Dropped connections no longer cause the outstanding messages metric to become incorrect.
-* JSON-RPC server is now compliant with the standard. Specifically, correct error values are now returned in responses, and `null` is no longer accepted as a value for `params` in requests.
+* JSON-RPC server is now mostly compliant with the standard. Specifically, correct error values are now returned in responses in many failure cases.
 
 ### Security
 * OpenSSL has been bumped to version 1.1.1.n, if compiling with vendored OpenSSL to address [CVE-2022-0778](https://www.openssl.org/news/secadv/20220315.txt).

--- a/node/src/components/chain_synchronizer/metrics.rs
+++ b/node/src/components/chain_synchronizer/metrics.rs
@@ -25,22 +25,24 @@ pub(crate) struct Metrics {
     /// Time in seconds to get the trusted key block.
     #[data_size(skip)]
     pub(super) chain_sync_get_trusted_key_block_info_duration_seconds: IntGauge,
-    /// Time in seconds to fetch to genesis during sync to genesis.
+    /// Time in seconds to fetch block headers from highest available block back to genesis during
+    /// sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_to_genesis_duration_seconds: IntGauge,
-    /// Time in seconds to fetch forward during sync to genesis.
+    /// Time in seconds to fetch blocks, deploys and tries from genesis forward to initial highest
+    /// available block during sync to genesis.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_forward_duration_seconds: IntGauge,
-    /// Total time in seconds of performing the fast sync.
+    /// Total time in seconds of performing the chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_fast_sync_total_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers during fast sync.
+    /// Time in seconds of fetching block headers during chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_fetch_block_headers_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers for replay protection during fast sync.
+    /// Time in seconds of fetching block headers for replay protection during chain sync.
     #[data_size(skip)]
     pub(super) chain_sync_replay_protection_duration_seconds: IntGauge,
-    /// Time in seconds of fetching block headers for era supervisor initialization during fast
+    /// Time in seconds of fetching block headers for era supervisor initialization during chain
     /// sync.
     #[data_size(skip)]
     pub(super) chain_sync_era_supervisor_init_duration_seconds: IntGauge,

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -33,6 +33,12 @@ pub use common::ErrorData;
 use docs::DocExample;
 pub use error_code::ErrorCode;
 
+/// This setting causes the server to ignore extra fields in JSON-RPC requests other than the
+/// standard 'id', 'jsonrpc', 'method', and 'params' fields.
+///
+/// It will be changed to `false` for casper-node v2.0.0.
+const ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST: bool = true;
+
 /// A JSON-RPC requiring the "params" field to be present.
 #[async_trait]
 pub(super) trait RpcWithParams {
@@ -256,7 +262,12 @@ pub(super) async fn run(
     server_name: &'static str,
 ) {
     let make_svc = hyper::service::make_service_fn(move |_| {
-        let service_routes = casper_json_rpc::route(api_path, max_body_bytes, handlers.clone());
+        let service_routes = casper_json_rpc::route(
+            api_path,
+            max_body_bytes,
+            handlers.clone(),
+            ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST,
+        );
 
         // Supports content negotiation for gzip responses. This is an interim fix until
         // https://github.com/seanmonstar/warp/pull/513 moves forward.
@@ -333,7 +344,7 @@ mod tests {
             GetDeploy::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }
@@ -400,7 +411,7 @@ mod tests {
             GetPeers::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }
@@ -454,7 +465,7 @@ mod tests {
             GetBlock::register_as_test_handler(&mut handlers);
             let handlers = handlers.build();
 
-            filters::main_filter(handlers)
+            filters::main_filter(handlers, ALLOW_UNKNOWN_FIELDS_IN_JSON_RPC_REQUEST)
                 .recover(filters::handle_rejection)
                 .boxed()
         }

--- a/node/src/components/rpc_server/rpcs/error_code.rs
+++ b/node/src/components/rpc_server/rpcs/error_code.rs
@@ -3,35 +3,38 @@ use serde::{Deserialize, Serialize};
 use casper_json_rpc::ErrorCodeT;
 
 /// The various codes which can be returned in the JSON-RPC Response's error object.
+///
+/// **NOTE:** These values will be changed to lie outside the restricted range as defined in the
+/// JSON-RPC spec as of casper-node v2.0.0.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 #[repr(i64)]
 pub enum ErrorCode {
     /// The requested Deploy was not found.
-    NoSuchDeploy = -1,
+    NoSuchDeploy = -32000,
     /// The requested Block was not found.
-    NoSuchBlock = -2,
+    NoSuchBlock = -32001,
     /// Parsing the Key for a query failed.
-    FailedToParseQueryKey = -3,
+    FailedToParseQueryKey = -32002,
     /// The query failed to find a result.
-    QueryFailed = -4,
+    QueryFailed = -32003,
     /// Executing the query failed.
-    QueryFailedToExecute = -5,
+    QueryFailedToExecute = -32004,
     /// Parsing the URef while getting a balance failed.
-    FailedToParseGetBalanceURef = -6,
+    FailedToParseGetBalanceURef = -32005,
     /// Failed to get the requested balance.
-    FailedToGetBalance = -7,
+    FailedToGetBalance = -32006,
     /// Executing the query to retrieve the balance failed.
-    GetBalanceFailedToExecute = -8,
+    GetBalanceFailedToExecute = -32007,
     /// The given Deploy cannot be executed as it is invalid.
-    InvalidDeploy = -9,
+    InvalidDeploy = -32008,
     /// The given account was not found.
-    NoSuchAccount = -10,
+    NoSuchAccount = -32009,
     /// Failed to get the requested dictionary URef.
-    FailedToGetDictionaryURef = -11,
+    FailedToGetDictionaryURef = -32010,
     /// Failed to get the requested dictionary trie.
-    FailedToGetTrie = -12,
+    FailedToGetTrie = -32011,
     /// The requested state root hash was not found.
-    NoSuchStateRoot = -13,
+    NoSuchStateRoot = -32012,
 }
 
 impl From<ErrorCode> for (i64, &'static str) {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -518,8 +518,6 @@ where
                     // joiners, to the joining node, because the outgoing connection may outlive the
                     // incoming connection, i.e. it may take some time to drop "our" outgoing
                     // connection after a peer has closed the corresponding incoming connection.
-
-                    // self.update_joining_set(peer_id, is_joiner);
                 }
 
                 // Now we can start the message reader.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -473,7 +473,6 @@ where
                 peer_id,
                 peer_consensus_public_key,
                 stream,
-                is_joiner,
             } => {
                 if self.cfg.max_incoming_peer_connections != 0 {
                     if let Some(symmetries) = self.connection_symmetries.get(&peer_id) {
@@ -510,7 +509,17 @@ where
                     .add_incoming(peer_addr, Instant::now())
                 {
                     self.connection_completed(peer_id);
-                    self.update_joining_set(peer_id, is_joiner);
+
+                    // We should not update the joining set when we receive an incoming connection,
+                    // because the `message_sender` which is handling the corresponding outgoing
+                    // connection will not receive the update of the remote joiner state.
+                    //
+                    // Such desync may cause the node to try to send requests that are not safe for
+                    // joiners, to the joining node, because the outgoing connection may outlive the
+                    // incoming connection, i.e. it may take some time to drop "our" outgoing
+                    // connection after a peer has closed the corresponding incoming connection.
+
+                    // self.update_joining_set(peer_id, is_joiner);
                 }
 
                 // Now we can start the message reader.

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -182,8 +182,6 @@ pub(crate) enum IncomingConnection<P> {
         /// Stream of incoming messages. for incoming connections.
         #[serde(skip_serializing)]
         stream: SplitStream<FullTransport<P>>,
-        /// Flag indicating whether we've established a connection to a joining node.
-        is_joiner: bool,
     },
 }
 
@@ -205,12 +203,11 @@ impl<P> Display for IncomingConnection<P> {
                 peer_id,
                 peer_consensus_public_key,
                 stream: _,
-                is_joiner,
             } => {
                 write!(
                     f,
-                    "connection established from {}/{}; public: {}, joiner: {}",
-                    peer_addr, peer_id, public_addr, is_joiner,
+                    "connection established from {}/{}; public: {}",
+                    peer_addr, peer_id, public_addr,
                 )?;
 
                 if let Some(public_key) = peer_consensus_public_key {

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -63,10 +63,15 @@ use crate::{
 /// successfully handed over to the kernel for sending.
 pub(super) type MessageQueueItem<P> = (Arc<Message<P>>, Option<AutoClosingResponder<()>>);
 
+/// The outcome of the handshake process.
 struct HandshakeOutcome {
+    /// A framed transport for peer.
     framed_transport: FramedTransport,
+    /// Public address advertised by the peer.
     public_addr: SocketAddr,
+    /// The public key the peer is validating with, if any.
     peer_consensus_public_key: Option<PublicKey>,
+    /// True, if the peer identifies itself as "joiner".
     is_peer_joiner: bool,
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -250,7 +250,7 @@ where
 
     // Negotiate the handshake, concluding the incoming connection process.
     match negotiate_handshake::<P, _>(&context, framed, connection_id).await {
-        Ok((framed, public_addr, peer_consensus_public_key, is_peer_joiner)) => {
+        Ok((framed, public_addr, peer_consensus_public_key, _is_peer_joiner)) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
             }
@@ -271,7 +271,6 @@ where
                 peer_id,
                 peer_consensus_public_key,
                 stream,
-                is_joiner: is_peer_joiner,
             }
         }
         Err(error) => IncomingConnection::Failed {
@@ -688,7 +687,7 @@ pub(super) async fn message_sender<P>(
                 // We should never attempt to send an unsafe message to a peer that we know is a
                 // joiner. Since "unsafe" does usually not mean immediately catastrophic, we attempt
                 // to carry on, but warn loudly.
-                warn!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
+                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
             }
         }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -67,7 +67,7 @@ struct HandshakeOutcome {
     framed_transport: FramedTransport,
     public_addr: SocketAddr,
     peer_consensus_public_key: Option<PublicKey>,
-    is_joiner: bool,
+    is_peer_joiner: bool,
 }
 
 /// Low-level TLS connection function.
@@ -149,7 +149,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner,
+            is_peer_joiner: is_joiner,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
@@ -266,7 +266,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner: _,
+            is_peer_joiner: _,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
                 Span::current().record("validator_id", &field::display(public_key));
@@ -466,7 +466,7 @@ where
             framed_transport,
             public_addr,
             peer_consensus_public_key,
-            is_joiner,
+            is_peer_joiner: is_joiner,
         })
     } else {
         // Received a non-handshake, this is an error.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -709,7 +709,7 @@ pub(super) async fn message_sender<P>(
                 // We should never attempt to send an unsafe message to a peer that we know is a
                 // joiner. Since "unsafe" does usually not mean immediately catastrophic, we attempt
                 // to carry on, but warn loudly.
-                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
+                warn!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
             }
         }
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -96,6 +96,7 @@ impl Sequence {
 /// For example, if `sequences` contains `[9,9], [7,3]` and `8` is inserted, then `sequences` will
 /// be reduced to `[9,3]`.
 #[derive(Default, Debug, DataSize)]
+#[cfg_attr(test, derive(Clone))]
 pub(super) struct DisjointSequences {
     sequences: Vec<Sequence>,
 }
@@ -462,46 +463,44 @@ mod tests {
         const SEQ_HIGH: Sequence = Sequence { high: 11, low: 9 };
         const SEQ_MID: Sequence = Sequence { high: 6, low: 6 };
         const SEQ_LOW: Sequence = Sequence { high: 3, low: 1 };
-        fn new_sequences() -> DisjointSequences {
-            DisjointSequences {
-                sequences: vec![SEQ_HIGH, SEQ_MID, SEQ_LOW],
-            }
-        }
+        let initial_sequences = DisjointSequences {
+            sequences: vec![SEQ_HIGH, SEQ_MID, SEQ_LOW],
+        };
 
         // Truncate with `max_value` greater or equal to current highest value should be a no-op.
-        let mut disjoint_sequences = new_sequences();
+        let mut disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(12);
-        assert_eq!(disjoint_sequences.sequences, new_sequences().sequences);
+        assert_eq!(disjoint_sequences.sequences, initial_sequences.sequences);
         disjoint_sequences.truncate(11);
-        assert_eq!(disjoint_sequences.sequences, new_sequences().sequences);
+        assert_eq!(disjoint_sequences.sequences, initial_sequences.sequences);
 
         // Truncate with `max_value` between two sequences should cause the higher sequences to get
         // removed and the lower ones retained unchanged.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_HIGH.low - 1);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_MID.high);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_MID.low - 1);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_LOW.high);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_LOW]);
 
         // Truncate with `max_value` lower than the lowest value should cause all sequences to get
         // removed.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         disjoint_sequences.truncate(SEQ_LOW.low - 1);
         assert!(disjoint_sequences.sequences.is_empty());
 
         // Truncate with `max_value` within a sequence should cause that sequence to get updated,
         // any higher sequences to get removed, and any lower ones retained unchanged.
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_HIGH.high - 1;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -509,7 +508,7 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_HIGH.low), SEQ_MID, SEQ_LOW]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_HIGH.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -517,12 +516,12 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_HIGH.low), SEQ_MID, SEQ_LOW]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_MID.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(disjoint_sequences.sequences, vec![SEQ_MID, SEQ_LOW]);
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences.clone();
         let max_value = SEQ_LOW.high - 1;
         disjoint_sequences.truncate(max_value);
         assert_eq!(
@@ -530,7 +529,7 @@ mod tests {
             vec![Sequence::new(max_value, SEQ_LOW.low)]
         );
 
-        disjoint_sequences = new_sequences();
+        disjoint_sequences = initial_sequences;
         let max_value = SEQ_LOW.low;
         disjoint_sequences.truncate(max_value);
         assert_eq!(

--- a/utils/nctl/docs/setup.md
+++ b/utils/nctl/docs/setup.md
@@ -23,8 +23,8 @@ To find out which branch of the client and launcher are compatible with the curr
 # Supervisor - cross-platform process manager.
 python3 -m pip install supervisor
 
-# toml - Config file parser.
-python3 -m pip install toml
+# Utilities for config file parsing and generation.
+python3 -m pip install toml tomlkit
 
 # Rust toolchain and smart contracts - required by casper-node software.
 cd YOUR_WORKING_DIRECTORY/casper-node


### PR DESCRIPTION
This PR brings all recent commits since https://github.com/casper-network/casper-node/commit/3dfcbc1ca0c3a17973ad7ff274d940ecedc26cae from the dev branch to the feat-2.0 branch.

Merge had no conflicts.
