### PR TITLE
Retry once when failed fetching block and not enough peers available

### DIFF
--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,9 +33,9 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
-    /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
-    /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
-    /// items on the `known_addresses` list in the node config.
+    /// Block and block header fetch operations are retried *once* when at the initial trial there
+    /// were fewer peers than `minimum_peer_count_threshold_for_fetch_retry` available. By default,
+    /// this is the number of items on the `known_addresses` list in the node config.
     pub(crate) minimum_peer_count_threshold_for_fetch_retry: usize,
 }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -36,7 +36,7 @@ pub(super) struct Config {
     /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
     /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
     /// items on the `known_addresses` list in the node config.
-    pub(crate) minimum_peer_count_threshold: usize,
+    pub(crate) minimum_peer_count_threshold_for_fetch_retry: usize,
 }
 
 impl Config {
@@ -58,7 +58,9 @@ impl Config {
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
             redemption_interval: node_config.sync_peer_redemption_interval,
-            minimum_peer_count_threshold: node_config.known_addresses.len(),
+            minimum_peer_count_threshold_for_fetch_retry: small_network_config
+                .known_addresses
+                .len(),
         }
     }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,6 +33,7 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
+    pub(crate) minimum_peer_count_threshold: usize,
 }
 
 impl Config {
@@ -54,6 +55,7 @@ impl Config {
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
             redemption_interval: node_config.sync_peer_redemption_interval,
+            minimum_peer_count_threshold: node_config.known_addresses.len(),
         }
     }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,6 +33,9 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
+    /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
+    /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
+    /// items on the `known_addresses` list in the node config.
     pub(crate) minimum_peer_count_threshold: usize,
 }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -738,8 +738,6 @@ where
             parent: Box::new(parent_header.clone()),
         })?;
 
-    let minimum_peer_count_threshold: usize = 10;
-
     for _ in 0..=1 {
         let peers = prepare_applicable_peers(ctx).await;
         let peer_count = peers.len();
@@ -755,7 +753,7 @@ where
                 return Ok(Some(item));
             }
             None => {
-                if peer_count >= minimum_peer_count_threshold {
+                if peer_count >= ctx.config.minimum_peer_count_threshold {
                     warn!(
                         %height,
                         attempts_to_get_fully_connected_peers =
@@ -767,7 +765,7 @@ where
                 info!(
                     %height,
                     %peer_count,
-                    %minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
+                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
                 );
             }
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -760,7 +760,7 @@ where
                 return Ok(Some(item));
             }
             None => {
-                if peer_count >= ctx.config.minimum_peer_count_threshold {
+                if peer_count >= ctx.config.minimum_peer_count_threshold_for_fetch_retry {
                     warn!(
                         %height,
                         attempts_to_get_fully_connected_peers =
@@ -772,7 +772,7 @@ where
                 info!(
                     %height,
                     %peer_count,
-                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
+                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold_for_fetch_retry, "tried fetching with not enough peers, may try again"
                 );
             }
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -740,7 +740,7 @@ where
         })?;
 
     for _ in 0..=1 {
-        let peers = prepare_applicable_peers(ctx).await;
+        let peers = prepare_peers_applicable_for_block_fetch(ctx).await;
         let peer_count = peers.len();
         let maybe_item = try_fetch_block_or_block_header_by_height(
             peers.clone(),
@@ -876,7 +876,9 @@ where
 }
 
 /// Prepares a list of peers applicable for the next fetch operation.
-async fn prepare_applicable_peers<REv>(ctx: &ChainSyncContext<'_, REv>) -> Vec<NodeId>
+async fn prepare_peers_applicable_for_block_fetch<REv>(
+    ctx: &ChainSyncContext<'_, REv>,
+) -> Vec<NodeId>
 where
     REv: From<NetworkInfoRequest>,
 {

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -39,6 +39,9 @@ pub struct NodeConfig {
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
+
+    /// Known address of a node on the network used for joining.
+    pub known_addresses: Vec<String>,
 }
 
 impl Default for NodeConfig {
@@ -51,6 +54,7 @@ impl Default for NodeConfig {
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,
+            known_addresses: Default::default(),
         }
     }
 }

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -39,9 +39,6 @@ pub struct NodeConfig {
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
-
-    /// Known address of a node on the network used for joining.
-    pub known_addresses: Vec<String>,
 }
 
 impl Default for NodeConfig {
@@ -54,7 +51,6 @@ impl Default for NodeConfig {
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,
-            known_addresses: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This PR changes the behavior of block and block header fetching during the chain synchronization process.

Currently, the fetch operation is retried *once* when at the initial trial there were fewer peers than the minimum threshold available. By default, the threshold is the number of items on the `known_addresses` list in the node config.
