### PR TITLE
Add a chain-sync progress tracker to enhance status output

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 * Nodes will now also gossip deploys onwards while joining.
-* Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
+* Add `node_state` field to the `/status` endpoint and the `info_get_status` JSON-RPC, giving an indication of the node's operating mode (joining or participating) and the progress of any ongoing chain-sync task.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
 * Add metrics `accumulated_outgoing_limiter_delay` and `accumulated_incoming_limiter_delay` to report how much time was spent throttling other peers.

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -3,6 +3,7 @@ mod error;
 mod event;
 mod metrics;
 mod operations;
+mod progress;
 
 use std::{collections::HashSet, convert::Infallible, fmt::Debug, marker::PhantomData, sync::Arc};
 
@@ -28,7 +29,7 @@ use crate::{
         },
         requests::{
             ChainspecLoaderRequest, ContractRuntimeRequest, FetcherRequest,
-            MarkBlockCompletedRequest, NetworkInfoRequest,
+            MarkBlockCompletedRequest, NetworkInfoRequest, NodeStateRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -37,7 +38,7 @@ use crate::{
     types::{
         Block, BlockAndDeploys, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
         BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec, Deploy,
-        FinalizedApprovalsWithId, FinalizedBlock, NodeConfig,
+        FinalizedApprovalsWithId, FinalizedBlock, NodeConfig, NodeState,
     },
     NodeRng, SmallNetworkConfig,
 };
@@ -47,6 +48,8 @@ pub(crate) use event::Event;
 pub(crate) use metrics::Metrics;
 use operations::FastSyncOutcome;
 pub(crate) use operations::KeyBlockInfo;
+pub(crate) use progress::Progress;
+use progress::ProgressHolder;
 
 #[derive(DataSize, Debug)]
 pub(crate) enum JoiningOutcome {
@@ -76,6 +79,10 @@ pub(crate) struct ChainSynchronizer<REv> {
     joining_outcome: Option<JoiningOutcome>,
     /// Metrics for the chain synchronization process.
     metrics: Metrics,
+    /// Records the ongoing progress of chain synchronization.
+    progress: ProgressHolder,
+    /// The current state of operation of the node.
+    node_state: NodeState,
     /// Association with the reactor event used in subtasks.
     _phantom: PhantomData<REv>,
 }
@@ -110,15 +117,23 @@ where
     ) -> Result<(Self, Effects<Event>), Error> {
         let config = Config::new(chainspec, node_config, small_network_config);
         let metrics = Metrics::new(registry)?;
+        let progress = ProgressHolder::new_fast_sync();
+        let node_state = NodeState::Joining(progress.progress());
 
-        let effects =
-            operations::run_fast_sync_task(effect_builder, config.clone(), metrics.clone())
-                .event(Event::FastSyncResult);
+        let effects = operations::run_fast_sync_task(
+            effect_builder,
+            config.clone(),
+            metrics.clone(),
+            progress.clone(),
+        )
+        .event(Event::FastSyncResult);
 
         let synchronizer = ChainSynchronizer {
             config,
             joining_outcome: None,
             metrics,
+            progress,
+            node_state,
             _phantom: PhantomData,
         };
 
@@ -142,6 +157,7 @@ where
         effect_builder: EffectBuilder<REv>,
         result: Result<FastSyncOutcome, Error>,
     ) -> Effects<Event> {
+        self.progress.finish();
         match result {
             Ok(FastSyncOutcome::ShouldCommitGenesis) => self.commit_genesis(effect_builder),
             Ok(FastSyncOutcome::ShouldCommitUpgrade {
@@ -442,6 +458,7 @@ where
                 effect_builder,
                 self.config.clone(),
                 self.metrics.clone(),
+                self.progress.clone(),
             )
             .event(|result| Event::FastSyncAfterEmergencyUpgradeResult {
                 immediate_switch_block_and_exec_effects,
@@ -469,6 +486,7 @@ where
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         result: Result<FastSyncOutcome, Error>,
     ) -> Effects<Event> {
+        self.progress.finish();
         match result {
             Ok(FastSyncOutcome::ShouldCommitGenesis) => {
                 let msg = "fast sync after emergency upgrade should not require commit genesis";
@@ -504,6 +522,95 @@ where
                 fatal!(effect_builder, "{}", error).ignore()
             }
         }
+    }
+}
+
+impl<REv> ChainSynchronizer<REv>
+where
+    REv: From<StorageRequest>
+        + From<NetworkInfoRequest>
+        + From<FetcherRequest<TrieOrChunk>>
+        + From<FetcherRequest<BlockAndDeploys>>
+        + From<FetcherRequest<BlockSignatures>>
+        + From<FetcherRequest<BlockHeadersBatch>>
+        + From<ContractRuntimeRequest>
+        + From<BlocklistAnnouncement>
+        + From<MarkBlockCompletedRequest>
+        + From<ChainSynchronizerAnnouncement>
+        + Send,
+{
+    /// Constructs a new `ChainSynchronizer` suitable for use in the participating reactor to sync
+    /// to genesis.
+    pub(crate) fn new_for_sync_to_genesis(
+        chainspec: Arc<Chainspec>,
+        node_config: NodeConfig,
+        small_network_config: SmallNetworkConfig,
+        metrics: Metrics,
+        effect_builder: EffectBuilder<REv>,
+    ) -> Result<(Self, Effects<Event>), Error> {
+        let config = Config::new(chainspec, node_config, small_network_config);
+        let progress = ProgressHolder::new_sync_to_genesis();
+
+        if config.sync_to_genesis() {
+            let node_state = NodeState::ParticipatingAndSyncingToGenesis {
+                sync_progress: progress.progress(),
+            };
+
+            let synchronizer = ChainSynchronizer {
+                config,
+                joining_outcome: None,
+                metrics,
+                progress: progress.clone(),
+                node_state,
+                _phantom: PhantomData,
+            };
+
+            let effects = operations::run_sync_to_genesis_task(
+                effect_builder,
+                synchronizer.config.clone(),
+                synchronizer.metrics.clone(),
+                progress,
+            )
+            .ignore();
+
+            return Ok((synchronizer, effects));
+        }
+
+        // If we're not configured to sync-to-genesis, return without doing anything but announcing
+        // that the sync process has finished.
+        progress.finish();
+        let synchronizer = ChainSynchronizer {
+            config,
+            joining_outcome: None,
+            metrics,
+            progress,
+            node_state: NodeState::Participating,
+            _phantom: PhantomData,
+        };
+
+        Ok((
+            synchronizer,
+            effect_builder.announce_finished_chain_syncing().ignore(),
+        ))
+    }
+}
+
+impl<REv> ChainSynchronizer<REv> {
+    fn handle_get_node_state_request(&mut self, request: NodeStateRequest) -> Effects<Event> {
+        self.node_state = match self.node_state {
+            NodeState::Joining(_) => NodeState::Joining(self.progress.progress()),
+            NodeState::ParticipatingAndSyncingToGenesis { .. } => {
+                let sync_progress = self.progress.progress();
+                if sync_progress.is_finished() {
+                    NodeState::Participating
+                } else {
+                    NodeState::ParticipatingAndSyncingToGenesis { sync_progress }
+                }
+            }
+            NodeState::Participating => NodeState::Participating,
+        };
+
+        request.0.respond(self.node_state.clone()).ignore()
     }
 }
 
@@ -572,56 +679,7 @@ where
                 validators_to_sign_immediate_switch_block,
                 result,
             ),
+            Event::GetNodeState(request) => self.handle_get_node_state_request(request),
         }
-    }
-}
-
-impl<REv> ChainSynchronizer<REv>
-where
-    REv: From<StorageRequest>
-        + From<NetworkInfoRequest>
-        + From<FetcherRequest<TrieOrChunk>>
-        + From<FetcherRequest<BlockAndDeploys>>
-        + From<FetcherRequest<BlockSignatures>>
-        + From<FetcherRequest<BlockHeadersBatch>>
-        + From<ContractRuntimeRequest>
-        + From<BlocklistAnnouncement>
-        + From<MarkBlockCompletedRequest>
-        + From<ChainSynchronizerAnnouncement>
-        + Send,
-{
-    /// Constructs a new `ChainSynchronizer` suitable for use in the participating reactor to sync
-    /// to genesis.
-    pub(crate) fn new_for_sync_to_genesis(
-        chainspec: Arc<Chainspec>,
-        node_config: NodeConfig,
-        small_network_config: SmallNetworkConfig,
-        metrics: Metrics,
-        effect_builder: EffectBuilder<REv>,
-    ) -> Result<(Self, Effects<Event>), Error> {
-        let synchronizer = ChainSynchronizer {
-            config: Config::new(chainspec, node_config, small_network_config),
-            joining_outcome: None,
-            metrics,
-            _phantom: PhantomData,
-        };
-
-        // If we're not configured to sync-to-genesis, return without doing anything but announcing
-        // that the sync process has finished.
-        if !synchronizer.config.sync_to_genesis() {
-            return Ok((
-                synchronizer,
-                effect_builder.announce_finished_chain_syncing().ignore(),
-            ));
-        }
-
-        let effects = operations::run_sync_to_genesis_task(
-            effect_builder,
-            synchronizer.config.clone(),
-            synchronizer.metrics.clone(),
-        )
-        .ignore();
-
-        Ok((synchronizer, effects))
     }
 }

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
+use derive_more::From;
 use serde::Serialize;
 
 use casper_execution_engine::core::engine_state::{self, genesis::GenesisSuccess, UpgradeSuccess};
@@ -11,10 +12,11 @@ use casper_types::PublicKey;
 use super::{Error, FastSyncOutcome};
 use crate::{
     contract_runtime::{BlockAndExecutionEffects, BlockExecutionError},
+    effect::requests::NodeStateRequest,
     types::BlockHeader,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, From)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Event {
     /// The result of running the fast sync task.
@@ -42,6 +44,9 @@ pub(crate) enum Event {
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         result: Result<FastSyncOutcome, Error>,
     },
+    /// A request to provide the node state.
+    #[from]
+    GetNodeState(NodeStateRequest),
 }
 
 impl Display for Event {
@@ -73,6 +78,7 @@ impl Display for Event {
                     fast_sync_result
                 )
             }
+            Event::GetNodeState(_) => write!(formatter, "get node state"),
         }
     }
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1640,7 +1640,7 @@ impl BlockSignaturesCollector {
             .check_if_sufficient(&validator_weights, ctx.config.finality_threshold_fraction())
             .is_ok()
         {
-            info!(
+            debug!(
                 block_header_hash =
                     ?block_header.hash(ctx.config.verifiable_chunked_hash_activation()),
                 height = block_header.height(),

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -493,7 +493,7 @@ impl ProgressHolder {
 }
 
 /// This impl is specific to functionality used for `debug_assert`s.
-#[cfg(debug_assertions)]
+#[cfg_attr(not(debug_assertions), allow(unused))]
 impl ProgressHolder {
     pub(super) fn is_fast_sync(&self) -> bool {
         matches!(*self.inner.lock().unwrap(), Progress::FastSync(_))

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -1,0 +1,526 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use casper_hashing::Digest;
+
+use crate::types::BlockHash;
+
+/// The reason for syncing the trie store under a given state root hash.
+//
+// Note: this is used when calling `sync_trie_store`.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+pub enum FetchingTriesReason {
+    /// Performing a trie-store sync during fast-sync before moving to the "execute forwards"
+    /// phase.
+    #[serde(rename = "for fast sync")]
+    FastSync,
+    /// Performing a trie-store sync during fast-sync before performing an emergency upgrade.
+    #[serde(rename = "preparing for emergency upgrade")]
+    EmergencyUpgrade,
+    /// Performing a trie-store sync during fast-sync before performing an upgrade.
+    #[serde(rename = "preparing for upgrade")]
+    Upgrade,
+}
+
+/// The progress of the fast-sync task, performed by all nodes while in joining mode.
+///
+/// The fast-sync task generally progresses from each variant to the next linearly.  An exception is
+/// that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and
+/// possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then
+/// executing.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FastSync {
+    /// Fast-syncing has not started yet.
+    #[serde(rename = "not yet started")]
+    NotYetStarted,
+    /// Initial setup is being performed.
+    Starting,
+    /// Currently fetching the trusted block header.
+    FetchingTrustedBlockHeader(BlockHash),
+    /// Currently syncing the trie-store under the given state root hash.
+    #[serde(rename = "fetching_global_state_under_given_block")]
+    FetchingTries {
+        /// The height of the block containing the given state root hash.
+        block_height: u64,
+        /// The global state root hash.
+        state_root_hash: Digest,
+        /// The reason for syncing the trie-store.
+        reason: FetchingTriesReason,
+        /// The number of remaining tries to fetch (this value can rise and fall as the task
+        /// proceeds).
+        #[serde(rename = "number_of_remaining_tries_to_fetch")]
+        num_tries_to_fetch: usize,
+    },
+    /// Currently fetching the block at the given height and its deploys in preparation for
+    /// executing it.
+    #[serde(rename = "fetching_block_and_deploys_at_given_block_height_before_execution")]
+    FetchingBlockAndDeploysToExecute(u64),
+    /// Currently executing the block at the given height.
+    #[serde(rename = "executing_block_at_height")]
+    ExecutingBlock(u64),
+    /// Currently retrying the execution of the block at the given height, due to an unexpected
+    /// mismatch in the previous execution result (due to a mismatch in the deploys' approvals).
+    RetryingBlockExecution {
+        /// The height of the block being executed.
+        block_height: u64,
+        /// The retry attempt number.
+        attempt: usize,
+    },
+    /// Fast-syncing has finished, and the node will shortly transition to participating mode.
+    Finished,
+}
+
+/// The progress of a single sync-block task, many of which are performed in parallel during
+/// sync-to-genesis.
+///
+/// The task progresses from each variant to the next linearly.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+pub enum SyncBlockFetching {
+    /// Currently fetching the block and all its deploys.
+    #[serde(rename = "block and deploys")]
+    BlockAndDeploys,
+    /// Currently syncing the trie-store under the state root hash held in the block.
+    #[serde(rename = "global_state_under_given_block")]
+    Tries {
+        /// The global state root hash.
+        state_root_hash: Digest,
+        /// The number of remaining tries to fetch (this value can rise and fall as the task
+        /// proceeds).
+        #[serde(rename = "number_of_remaining_tries_to_fetch")]
+        num_tries_to_fetch: usize,
+    },
+    /// Currently fetching the block's signatures.
+    #[serde(rename = "block signatures")]
+    BlockSignatures,
+}
+
+/// Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the
+/// relative block.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SyncBlock {
+    /// The height of the block being synced.
+    block_height: u64,
+    /// The progress of the sync-block task.
+    fetching: SyncBlockFetching,
+}
+
+/// The progress of the sync-to-genesis task, only performed by nodes configured to do this, and
+/// performed by them while in participating mode.
+///
+/// The sync-to-genesis task progresses from each variant to the next linearly.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncToGenesis {
+    /// Syncing-to-genesis has not started yet.
+    #[serde(rename = "not yet started")]
+    NotYetStarted,
+    /// Initial setup is being performed.
+    Starting,
+    /// Currently fetching block headers in batches back towards the genesis block.
+    FetchingHeadersBackToGenesis {
+        /// The current lowest block header retrieved by this fetch-headers-to-genesis task.
+        lowest_block_height: u64,
+    },
+    /// Currently syncing all blocks from genesis towards the tip of the chain.
+    ///
+    /// This is done via many parallel sync-block tasks, with each such ongoing task being
+    /// represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.
+    SyncingForwardFromGenesis(Vec<SyncBlock>),
+    /// Syncing-to-genesis has finished.
+    Finished,
+}
+
+/// The progress of the chain-synchronizer task.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(untagged)]
+pub enum Progress {
+    /// The chain-synchronizer is performing the fast-sync task.
+    FastSync(FastSync),
+    /// The chain-synchronizer is performing the sync-to-genesis task.
+    SyncToGenesis(SyncToGenesis),
+}
+
+impl Progress {
+    pub(super) fn is_finished(&self) -> bool {
+        match self {
+            Progress::FastSync(progress) => *progress == FastSync::Finished,
+            Progress::SyncToGenesis(progress) => *progress == SyncToGenesis::Finished,
+        }
+    }
+}
+
+#[derive(Clone, DataSize, Debug)]
+pub(super) struct ProgressHolder {
+    inner: Arc<Mutex<Progress>>,
+}
+
+/// This impl is specific to fast-sync progress.
+impl ProgressHolder {
+    pub(super) fn new_fast_sync() -> Self {
+        ProgressHolder {
+            inner: Arc::new(Mutex::new(Progress::FastSync(FastSync::NotYetStarted))),
+        }
+    }
+
+    pub(super) fn start_fetching_trusted_block_header(&self, trusted_hash: BlockHash) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_trusted_block_header");
+        *inner = Progress::FastSync(FastSync::FetchingTrustedBlockHeader(trusted_hash));
+    }
+
+    pub(super) fn start_fetching_tries_for_fast_sync(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_fast_sync");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::FastSync,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_tries_for_emergency_upgrade(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_emergency_upgrade");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::EmergencyUpgrade,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_tries_for_upgrade(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_upgrade");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::Upgrade,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_block_and_deploys_to_execute(&self, block_height: u64) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_block_and_deploys_to_execute");
+        *inner = Progress::FastSync(FastSync::FetchingBlockAndDeploysToExecute(block_height));
+    }
+
+    pub(super) fn start_executing_block(&self, block_height: u64) {
+        let mut inner = self.get_inner_while_fast_syncing("executing_block");
+        *inner = Progress::FastSync(FastSync::ExecutingBlock(block_height));
+    }
+
+    pub(super) fn retry_executing_block(&self, block_height: u64, attempt: usize) {
+        let mut inner = self.get_inner_while_fast_syncing("retrying_execute_block");
+        *inner = Progress::FastSync(FastSync::RetryingBlockExecution {
+            block_height,
+            attempt,
+        });
+    }
+
+    fn get_inner_while_fast_syncing(&self, new_state: &str) -> MutexGuard<Progress> {
+        let inner = self.inner.lock().unwrap();
+        match *inner {
+            Progress::SyncToGenesis(_) => {
+                error!(
+                    current_progress=?inner,
+                    "should be fast syncing if setting progress to {}",
+                    new_state
+                );
+            }
+            Progress::FastSync(_) => (),
+        }
+        inner
+    }
+}
+
+/// This impl is specific to sync-to-genesis progress.
+impl ProgressHolder {
+    pub(super) fn new_sync_to_genesis() -> Self {
+        ProgressHolder {
+            inner: Arc::new(Mutex::new(Progress::SyncToGenesis(
+                SyncToGenesis::NotYetStarted,
+            ))),
+        }
+    }
+
+    pub(super) fn set_fetching_headers_back_to_genesis(&self, lowest_block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        *inner = Progress::SyncToGenesis(SyncToGenesis::FetchingHeadersBackToGenesis {
+            lowest_block_height,
+        })
+    }
+
+    pub(super) fn start_syncing_block_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        if !matches!(
+            inner,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(_))
+        ) {
+            *inner = Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(Vec::new()))
+        }
+
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching block"
+                );
+                return;
+            };
+
+        match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+            Ok(_) => error!(
+                %block_height,
+                existing_progress=?tasks,
+                "expected to only start fetching block and deploys once"
+            ),
+            Err(index) => tasks.insert(
+                index,
+                SyncBlock {
+                    block_height,
+                    fetching: SyncBlockFetching::BlockAndDeploys,
+                },
+            ),
+        }
+    }
+
+    pub(super) fn start_fetching_tries_for_sync_forward(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching tries"
+                );
+                return;
+            };
+
+        let existing_progress =
+            match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                Ok(index) => tasks.get_mut(index).expect("just found index"),
+                Err(_) => {
+                    error!(
+                        %block_height,
+                        current_progress=?inner,
+                        "should be syncing this block if setting progress to fetching tries"
+                    );
+                    return;
+                }
+            };
+
+        if !matches!(
+            existing_progress.fetching,
+            SyncBlockFetching::BlockAndDeploys { .. }
+        ) {
+            error!(
+                %block_height,
+                current_progress=?existing_progress,
+                "should be fetching block and deploys if setting progress to fetching tries"
+            );
+        }
+        existing_progress.fetching = SyncBlockFetching::Tries {
+            state_root_hash,
+            num_tries_to_fetch: 0,
+        };
+    }
+
+    pub(super) fn start_fetching_block_signatures_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching block \
+                    signatures"
+                );
+                return;
+            };
+
+        let existing_progress =
+            match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                Ok(index) => tasks.get_mut(index).expect("just found index"),
+                Err(_) => {
+                    error!(
+                        %block_height,
+                        current_progress=?inner,
+                        "should be syncing this block if setting progress to fetching block \
+                        signatures"
+                    );
+                    return;
+                }
+            };
+
+        if !matches!(existing_progress.fetching, SyncBlockFetching::Tries { .. }) {
+            error!(
+                %block_height,
+                current_progress=?existing_progress,
+                "should be fetching tries if setting progress to fetching block signatures"
+            );
+        }
+        existing_progress.fetching = SyncBlockFetching::BlockSignatures;
+    }
+
+    pub(super) fn finish_syncing_block_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if finishing sync block"
+                );
+                return;
+            };
+
+        match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+            Ok(index) => {
+                let existing_progress = tasks.remove(index);
+                if !matches!(
+                    existing_progress.fetching,
+                    SyncBlockFetching::BlockSignatures
+                ) {
+                    error!(
+                        %block_height,
+                        current_progress=?existing_progress,
+                        "should be fetching block signatures if finishing sync block"
+                    );
+                }
+            }
+            Err(_) => {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing this block if finishing sync block"
+                );
+            }
+        }
+    }
+}
+
+/// This impl has functionality common to fast-sync and sync-to-genesis.
+impl ProgressHolder {
+    pub(super) fn start(&self) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(progress) => *progress = FastSync::Starting,
+            Progress::SyncToGenesis(progress) => *progress = SyncToGenesis::Starting,
+        }
+    }
+
+    pub(super) fn set_num_tries_to_fetch(&self, block_height: u64, num_tries: usize) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(FastSync::FetchingTries {
+                num_tries_to_fetch, ..
+            }) => *num_tries_to_fetch = num_tries,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) => {
+                match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                    Ok(index) => {
+                        if let Some(SyncBlock {
+                            fetching:
+                                SyncBlockFetching::Tries {
+                                    num_tries_to_fetch, ..
+                                },
+                            ..
+                        }) = tasks.get_mut(index)
+                        {
+                            *num_tries_to_fetch = num_tries;
+                        } else {
+                            error!(
+                                block_height,
+                                "not currently fetching tries for this block during sync to genesis"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        error!(
+                            block_height,
+                            "not currently syncing block during sync to genesis"
+                        );
+                    }
+                }
+            }
+            _ => error!(
+                block_height,
+                "failed to set num tries to fetch as not currently syncing"
+            ),
+        }
+    }
+
+    pub(super) fn finish(&self) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(progress) => *progress = FastSync::Finished,
+            Progress::SyncToGenesis(progress) => *progress = SyncToGenesis::Finished,
+        }
+    }
+
+    pub(super) fn progress(&self) -> Progress {
+        self.inner.lock().unwrap().clone()
+    }
+}
+
+/// This impl is specific to functionality used for `debug_assert`s.
+#[cfg(debug_assertions)]
+impl ProgressHolder {
+    pub(super) fn is_fast_sync(&self) -> bool {
+        matches!(*self.inner.lock().unwrap(), Progress::FastSync(_))
+    }
+
+    pub(super) fn is_sync_to_genesis(&self) -> bool {
+        matches!(*self.inner.lock().unwrap(), Progress::SyncToGenesis(_))
+    }
+
+    pub(super) fn is_fetching_tries(&self, block_height: u64) -> bool {
+        match &*self.inner.lock().unwrap() {
+            Progress::FastSync(FastSync::FetchingTries { .. }) => true,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) => {
+                match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                    Ok(index) => {
+                        matches!(
+                            tasks.get(index),
+                            Some(SyncBlock {
+                                fetching: SyncBlockFetching::Tries { .. },
+                                ..
+                            })
+                        )
+                    }
+                    Err(_) => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -336,7 +336,7 @@ mod tests {
         //   and `finality_threshold_fraction` = 1/3 (~=  6.666)
         //   and the `quorum fraction` = 2/3         (~= 13.333)
         //
-        // we need signaturess of weight:
+        // we need signatures of weight:
         //   - 13 or less for `InsufficientWeightForFinality`
         //   - 14 for Ok
         //   - 15 or more for `TooManySignatures`
@@ -411,7 +411,7 @@ mod tests {
         //   and `finality_threshold_fraction` = 1/3 (~= 6.666)
         //   and the `quorum fraction` = 1/3         (~= 6.666)
         //
-        // we need signaturess of weight:
+        // we need signatures of weight:
         //   - 6 or less for `InsufficientWeightForFinality`
         //   - 7 for Ok
         //   - 8 or more for `TooManySignatures`

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1765,8 +1765,7 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<NodeStateRequest> + Send,
     {
-        self.make_request(NodeStateRequest, QueueKind::Regular)
-            .await
+        self.make_request(NodeStateRequest, QueueKind::Api).await
     }
 
     /// Retrieves finalized blocks with timestamps no older than the maximum deploy TTL.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -150,7 +150,7 @@ use crate::{
         BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
         BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
         DeployHash, DeployHeader, DeployMetadataExt, DeployWithFinalizedApprovals,
-        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId,
+        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
     },
     utils::{SharedFlag, Source},
 };
@@ -165,7 +165,7 @@ use requests::{
     BeginGossipRequest, BlockPayloadRequest, BlockProposerRequest, BlockValidationRequest,
     ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, FetcherRequest,
     MarkBlockCompletedRequest, MetricsRequest, NetworkInfoRequest, NetworkRequest,
-    StateStoreRequest, StorageRequest,
+    NodeStateRequest, StateStoreRequest, StorageRequest,
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
@@ -1759,6 +1759,14 @@ impl<REv> EffectBuilder<REv> {
             QueueKind::Regular,
         )
         .await
+    }
+
+    pub(crate) async fn get_node_state(self) -> NodeState
+    where
+        REv: From<NodeStateRequest> + Send,
+    {
+        self.make_request(NodeStateRequest, QueueKind::Regular)
+            .await
     }
 
     /// Retrieves finalized blocks with timestamps no older than the maximum deploy TTL.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -53,7 +53,7 @@ use crate::{
         BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
         BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
         DeployHash, DeployMetadataExt, DeployWithFinalizedApprovals, FinalizedApprovals,
-        FinalizedBlock, Item, NodeId, StatusFeed,
+        FinalizedBlock, Item, NodeId, NodeState, StatusFeed,
     },
     utils::{DisplayIter, Source},
 };
@@ -1220,11 +1220,21 @@ pub(crate) enum ChainspecLoaderRequest {
 }
 
 impl Display for ChainspecLoaderRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
             ChainspecLoaderRequest::GetCurrentRunInfo(_) => write!(f, "get current run info"),
             ChainspecLoaderRequest::GetChainspecRawBytes(_) => write!(f, "get chainspec raw bytes"),
         }
+    }
+}
+
+/// ChainSynchronizer component request.
+#[derive(Debug, Serialize)]
+pub(crate) struct NodeStateRequest(pub(crate) Responder<NodeState>);
+
+impl Display for NodeStateRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "node state request")
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -54,7 +54,7 @@ use crate::{
         requests::{
             BeginGossipRequest, ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest,
             FetcherRequest, MarkBlockCompletedRequest, MetricsRequest, NetworkInfoRequest,
-            NetworkRequest, RestRequest, StorageRequest,
+            NetworkRequest, NodeStateRequest, RestRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -68,7 +68,7 @@ use crate::{
     },
     types::{
         Block, BlockAndDeploys, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
-        BlockSignatures, BlockWithMetadata, Deploy, ExitCode, FinalizedApprovalsWithId, NodeState,
+        BlockSignatures, BlockWithMetadata, Deploy, ExitCode, FinalizedApprovalsWithId,
     },
     utils::WithDir,
     NodeRng,
@@ -97,6 +97,8 @@ pub(crate) enum JoinerEvent {
     ChainspecLoader(#[serde(skip_serializing)] chainspec_loader::Event),
     #[from]
     ChainspecLoaderRequest(#[serde(skip_serializing)] ChainspecLoaderRequest),
+    #[from]
+    ChainSynchronizerRequest(#[serde(skip_serializing)] NodeStateRequest),
     #[from]
     NetworkInfoRequest(#[serde(skip_serializing)] NetworkInfoRequest),
     #[from]
@@ -230,6 +232,7 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::MetricsRequest(_) => "MetricsRequest",
             JoinerEvent::ChainspecLoader(_) => "ChainspecLoader",
             JoinerEvent::ChainspecLoaderRequest(_) => "ChainspecLoaderRequest",
+            JoinerEvent::ChainSynchronizerRequest(_) => "ChainSynchronizerRequest",
             JoinerEvent::NetworkInfoRequest(_) => "NetworkInfoRequest",
             JoinerEvent::BlockFetcher(_) => "BlockFetcher",
             JoinerEvent::BlockByHeightFetcher(_) => "BlockByHeightFetcher",
@@ -331,6 +334,9 @@ impl Display for JoinerEvent {
             JoinerEvent::ChainspecLoader(event) => write!(f, "chainspec loader: {}", event),
             JoinerEvent::ChainspecLoaderRequest(req) => {
                 write!(f, "chainspec loader request: {}", req)
+            }
+            JoinerEvent::ChainSynchronizerRequest(req) => {
+                write!(f, "chain synchronizer request: {}", req)
             }
             JoinerEvent::StorageRequest(req) => write!(f, "storage request: {}", req),
             JoinerEvent::MarkBlockCompletedRequest(req) => {
@@ -564,17 +570,11 @@ impl reactor::Reactor for Reactor {
             .protocol_config
             .verifiable_chunked_hash_activation;
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
-        let node_state = if config.node.sync_to_genesis {
-            NodeState::SyncingToGenesis
-        } else {
-            NodeState::FastSyncing
-        };
         let rest_server = RestServer::new(
             config.rest_server.clone(),
             effect_builder,
             *protocol_version,
             node_startup_instant,
-            node_state,
         )?;
 
         let event_stream_server = EventStreamServer::new(
@@ -890,6 +890,11 @@ impl reactor::Reactor for Reactor {
                 effect_builder,
                 rng,
                 JoinerEvent::ChainspecLoader(req.into()),
+            ),
+            JoinerEvent::ChainSynchronizerRequest(req) => self.dispatch_event(
+                effect_builder,
+                rng,
+                JoinerEvent::ChainSynchronizer(req.into()),
             ),
             JoinerEvent::NetworkInfoRequest(req) => {
                 let event = JoinerEvent::SmallNetwork(small_network::Event::from(req));

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -17,6 +17,7 @@ use casper_types::{EraId, ProtocolVersion, PublicKey, TimeDiff, Timestamp};
 
 use crate::{
     components::{
+        chain_synchronizer::Progress,
         chainspec_loader::NextUpgrade,
         rpc_server::rpcs::docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
     },
@@ -76,12 +77,16 @@ impl ChainspecInfo {
 }
 
 /// The various possible states of operation for the node.
-#[derive(Clone, Copy, PartialEq, Eq, DataSize, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, DataSize, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum NodeState {
-    /// The node is currently in the fast syncing state.
-    FastSyncing,
-    /// The node is currently in syncing to genesis state.
-    SyncingToGenesis,
+    /// The node is currently in joining mode.
+    Joining(Progress),
+    /// The node is currently in participating mode, but also syncing to genesis in the background.
+    ParticipatingAndSyncingToGenesis {
+        /// The progress of the chain sync-to-genesis task.
+        sync_progress: Progress,
+    },
     /// The node is currently in the participating state.
     Participating,
 }

--- a/node/src/utils/work_queue.rs
+++ b/node/src/utils/work_queue.rs
@@ -169,6 +169,11 @@ impl<T> WorkQueue<T> {
         self.notify.notify_waiters();
     }
 
+    /// Returns the number of jobs in the queue.
+    pub fn num_jobs(&self) -> usize {
+        self.inner.lock().expect("lock poisoned").jobs.len()
+    }
+
     /// Creates a streaming consumer of the work queue.
     #[inline]
     pub fn to_stream(self: Arc<Self>) -> impl Stream<Item = JobHandle<T>> {

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -229,11 +229,340 @@
     },
     "NodeState": {
       "description": "The various possible states of operation for the node.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "participating"
+          ]
+        },
+        {
+          "description": "The node is currently in joining mode.",
+          "type": "object",
+          "required": [
+            "joining"
+          ],
+          "properties": {
+            "joining": {
+              "$ref": "#/definitions/Progress"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
+          "type": "object",
+          "required": [
+            "participating_and_syncing_to_genesis"
+          ],
+          "properties": {
+            "participating_and_syncing_to_genesis": {
+              "type": "object",
+              "required": [
+                "sync_progress"
+              ],
+              "properties": {
+                "sync_progress": {
+                  "description": "The progress of the chain sync-to-genesis task.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Progress"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Progress": {
+      "description": "The progress of the chain-synchronizer task.",
+      "anyOf": [
+        {
+          "description": "The chain-synchronizer is performing the fast-sync task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FastSync"
+            }
+          ]
+        },
+        {
+          "description": "The chain-synchronizer is performing the sync-to-genesis task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SyncToGenesis"
+            }
+          ]
+        }
+      ]
+    },
+    "FastSync": {
+      "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "not yet started",
+            "starting",
+            "finished"
+          ]
+        },
+        {
+          "description": "Currently fetching the trusted block header.",
+          "type": "object",
+          "required": [
+            "fetching_trusted_block_header"
+          ],
+          "properties": {
+            "fetching_trusted_block_header": {
+              "$ref": "#/definitions/BlockHash"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently syncing the trie-store under the given state root hash.",
+          "type": "object",
+          "required": [
+            "fetching_global_state_under_given_block"
+          ],
+          "properties": {
+            "fetching_global_state_under_given_block": {
+              "type": "object",
+              "required": [
+                "block_height",
+                "number_of_remaining_tries_to_fetch",
+                "reason",
+                "state_root_hash"
+              ],
+              "properties": {
+                "block_height": {
+                  "description": "The height of the block containing the given state root hash.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "state_root_hash": {
+                  "description": "The global state root hash.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Digest"
+                    }
+                  ]
+                },
+                "reason": {
+                  "description": "The reason for syncing the trie-store.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/FetchingTriesReason"
+                    }
+                  ]
+                },
+                "number_of_remaining_tries_to_fetch": {
+                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
+          "type": "object",
+          "required": [
+            "fetching_block_and_deploys_at_given_block_height_before_execution"
+          ],
+          "properties": {
+            "fetching_block_and_deploys_at_given_block_height_before_execution": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently executing the block at the given height.",
+          "type": "object",
+          "required": [
+            "executing_block_at_height"
+          ],
+          "properties": {
+            "executing_block_at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
+          "type": "object",
+          "required": [
+            "retrying_block_execution"
+          ],
+          "properties": {
+            "retrying_block_execution": {
+              "type": "object",
+              "required": [
+                "attempt",
+                "block_height"
+              ],
+              "properties": {
+                "block_height": {
+                  "description": "The height of the block being executed.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "attempt": {
+                  "description": "The retry attempt number.",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "FetchingTriesReason": {
+      "description": "The reason for syncing the trie store under a given state root hash.",
       "type": "string",
       "enum": [
-        "FastSyncing",
-        "SyncingToGenesis",
-        "Participating"
+        "for fast sync",
+        "preparing for emergency upgrade",
+        "preparing for upgrade"
+      ]
+    },
+    "SyncToGenesis": {
+      "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "not yet started",
+            "starting",
+            "finished"
+          ]
+        },
+        {
+          "description": "Currently fetching block headers in batches back towards the genesis block.",
+          "type": "object",
+          "required": [
+            "fetching_headers_back_to_genesis"
+          ],
+          "properties": {
+            "fetching_headers_back_to_genesis": {
+              "type": "object",
+              "required": [
+                "lowest_block_height"
+              ],
+              "properties": {
+                "lowest_block_height": {
+                  "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+          "type": "object",
+          "required": [
+            "syncing_forward_from_genesis"
+          ],
+          "properties": {
+            "syncing_forward_from_genesis": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SyncBlock"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SyncBlock": {
+      "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
+      "type": "object",
+      "required": [
+        "block_height",
+        "fetching"
+      ],
+      "properties": {
+        "block_height": {
+          "description": "The height of the block being synced.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "fetching": {
+          "description": "The progress of the sync-block task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SyncBlockFetching"
+            }
+          ]
+        }
+      }
+    },
+    "SyncBlockFetching": {
+      "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "block and deploys",
+            "block signatures"
+          ]
+        },
+        {
+          "description": "Currently syncing the trie-store under the state root hash held in the block.",
+          "type": "object",
+          "required": [
+            "global_state_under_given_block"
+          ],
+          "properties": {
+            "global_state_under_given_block": {
+              "type": "object",
+              "required": [
+                "number_of_remaining_tries_to_fetch",
+                "state_root_hash"
+              ],
+              "properties": {
+                "state_root_hash": {
+                  "description": "The global state root hash.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Digest"
+                    }
+                  ]
+                },
+                "number_of_remaining_tries_to_fetch": {
+                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     }
   }

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -479,7 +479,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
           "type": "object",
           "required": [
             "syncing_forward_from_genesis"

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -1371,6 +1371,151 @@
             ],
             "description": "The result of executing a single deploy."
           },
+          "FastSync": {
+            "anyOf": [
+              {
+                "enum": [
+                  "not yet started",
+                  "starting",
+                  "finished"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching the trusted block header.",
+                "properties": {
+                  "fetching_trusted_block_header": {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                },
+                "required": [
+                  "fetching_trusted_block_header"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing the trie-store under the given state root hash.",
+                "properties": {
+                  "fetching_global_state_under_given_block": {
+                    "properties": {
+                      "block_height": {
+                        "description": "The height of the block containing the given state root hash.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "number_of_remaining_tries_to_fetch": {
+                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/FetchingTriesReason"
+                          }
+                        ],
+                        "description": "The reason for syncing the trie-store."
+                      },
+                      "state_root_hash": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Digest"
+                          }
+                        ],
+                        "description": "The global state root hash."
+                      }
+                    },
+                    "required": [
+                      "block_height",
+                      "number_of_remaining_tries_to_fetch",
+                      "reason",
+                      "state_root_hash"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "fetching_global_state_under_given_block"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
+                "properties": {
+                  "fetching_block_and_deploys_at_given_block_height_before_execution": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "fetching_block_and_deploys_at_given_block_height_before_execution"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently executing the block at the given height.",
+                "properties": {
+                  "executing_block_at_height": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "executing_block_at_height"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
+                "properties": {
+                  "retrying_block_execution": {
+                    "properties": {
+                      "attempt": {
+                        "description": "The retry attempt number.",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "block_height": {
+                        "description": "The height of the block being executed.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "attempt",
+                      "block_height"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "retrying_block_execution"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing."
+          },
+          "FetchingTriesReason": {
+            "description": "The reason for syncing the trie store under a given state root hash.",
+            "enum": [
+              "for fast sync",
+              "preparing for emergency upgrade",
+              "preparing for upgrade"
+            ],
+            "type": "string"
+          },
           "GlobalStateIdentifier": {
             "anyOf": [
               {
@@ -1962,13 +2107,54 @@
             "type": "object"
           },
           "NodeState": {
-            "description": "The various possible states of operation for the node.",
-            "enum": [
-              "FastSyncing",
-              "SyncingToGenesis",
-              "Participating"
+            "anyOf": [
+              {
+                "enum": [
+                  "participating"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The node is currently in joining mode.",
+                "properties": {
+                  "joining": {
+                    "$ref": "#/components/schemas/Progress"
+                  }
+                },
+                "required": [
+                  "joining"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
+                "properties": {
+                  "participating_and_syncing_to_genesis": {
+                    "properties": {
+                      "sync_progress": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Progress"
+                          }
+                        ],
+                        "description": "The progress of the chain sync-to-genesis task."
+                      }
+                    },
+                    "required": [
+                      "sync_progress"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "participating_and_syncing_to_genesis"
+                ],
+                "type": "object"
+              }
             ],
-            "type": "string"
+            "description": "The various possible states of operation for the node."
           },
           "OpKind": {
             "description": "The type of operation performed while executing a deploy.",
@@ -2044,6 +2230,27 @@
               "$ref": "#/components/schemas/PeerEntry"
             },
             "type": "array"
+          },
+          "Progress": {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/FastSync"
+                  }
+                ],
+                "description": "The chain-synchronizer is performing the fast-sync task."
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncToGenesis"
+                  }
+                ],
+                "description": "The chain-synchronizer is performing the sync-to-genesis task."
+              }
+            ],
+            "description": "The progress of the chain-synchronizer task."
           },
           "ProtocolVersion": {
             "description": "Casper Platform protocol version",
@@ -2365,6 +2572,128 @@
               }
             ],
             "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
+          },
+          "SyncBlock": {
+            "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
+            "properties": {
+              "block_height": {
+                "description": "The height of the block being synced.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "fetching": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncBlockFetching"
+                  }
+                ],
+                "description": "The progress of the sync-block task."
+              }
+            },
+            "required": [
+              "block_height",
+              "fetching"
+            ],
+            "type": "object"
+          },
+          "SyncBlockFetching": {
+            "anyOf": [
+              {
+                "enum": [
+                  "block and deploys",
+                  "block signatures"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing the trie-store under the state root hash held in the block.",
+                "properties": {
+                  "global_state_under_given_block": {
+                    "properties": {
+                      "number_of_remaining_tries_to_fetch": {
+                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "state_root_hash": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Digest"
+                          }
+                        ],
+                        "description": "The global state root hash."
+                      }
+                    },
+                    "required": [
+                      "number_of_remaining_tries_to_fetch",
+                      "state_root_hash"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "global_state_under_given_block"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly."
+          },
+          "SyncToGenesis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "not yet started",
+                  "starting",
+                  "finished"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching block headers in batches back towards the genesis block.",
+                "properties": {
+                  "fetching_headers_back_to_genesis": {
+                    "properties": {
+                      "lowest_block_height": {
+                        "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "lowest_block_height"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "fetching_headers_back_to_genesis"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+                "properties": {
+                  "syncing_forward_from_genesis": {
+                    "items": {
+                      "$ref": "#/components/schemas/SyncBlock"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "syncing_forward_from_genesis"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly."
           },
           "TimeDiff": {
             "description": "Human-readable duration.",
@@ -3657,7 +3986,7 @@
                     "activation_point": 42,
                     "protocol_version": "2.0.1"
                   },
-                  "node_state": "Participating",
+                  "node_state": "participating",
                   "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
                   "peers": [
                     {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2678,7 +2678,7 @@
               },
               {
                 "additionalProperties": false,
-                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
                 "properties": {
                   "syncing_forward_from_genesis": {
                     "items": {


### PR DESCRIPTION
This PR introduces a progress tracker to the `ChainSynchronizer` to allow the progress of the fast-sync or sync-to-genesis tasks to be shown in the node's status output.

The progress tracker is infallible in order to avoid causing the chain-sync processes to fail in the case of a bug there, but it makes heavy use of error logging to alert us to any unexpected progress transitions.

Given that the bulk of the content of the `NodeState` enum is now populated by the `ChainSynchronizer`, I believe it makes sense to have that component just provide the entire current node state to the RPC and REST servers as required, rather than leaving the servers with the "knowledge" of the node's operating mode, and only requesting the sync progress from the `ChainSynchronizer`.

<details>
  <summary>Example output for a node configured to sync-to-genesis on an nctl network</summary>

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [],
  "last_added_block_info": null,
  "our_public_signing_key": null,
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "2ms",
  "node_state": {
    "joining": "not yet started"
  }
}
```

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [],
  "last_added_block_info": null,
  "our_public_signing_key": null,
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "2ms",
  "node_state": {
    "joining": "starting"
  }
}
```  

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [],
  "last_added_block_info": null,
  "our_public_signing_key": null,
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "22ms",
  "node_state": {
    "joining": {
      "fetching_trusted_block_header": "86dfb65b2d10d744477d160937bad28fc4d45df1227e41d9be870849a7d38955"
    }
  }
}
```

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [
    {
      "node_id": "tls:0716..b595",
      "address": "127.0.0.1:22105"
    },
    {
      "node_id": "tls:078d..61ee",
      "address": "127.0.0.1:22102"
    },
    {
      "node_id": "tls:d8bc..a71c",
      "address": "127.0.0.1:22103"
    },
    {
      "node_id": "tls:db04..62b2",
      "address": "127.0.0.1:22101"
    },
    {
      "node_id": "tls:fdf0..d61a",
      "address": "127.0.0.1:22104"
    }
  ],
  "last_added_block_info": {
    "hash": "86dfb65b2d10d744477d160937bad28fc4d45df1227e41d9be870849a7d38955",
    "timestamp": "2022-07-14T22:49:49.312Z",
    "era_id": 13,
    "height": 143,
    "state_root_hash": "ae0f770668136cb937e889f318ff483f258ec8ca253324f3dad687a8e25d7057",
    "creator": "013adf3ca6d46be7e574598fbe25a1a5a507a484e138ede5ca32f1ffbee1535e2c"
  },
  "our_public_signing_key": null,
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "462ms",
  "node_state": {
    "joining": {
      "fetching_trusted_block_header": "86dfb65b2d10d744477d160937bad28fc4d45df1227e41d9be870849a7d38955"
    }
  }
}
```

```
  "node_state": {
    "joining": {
      "fetching_global_state_under_given_block": {
        "block_height": 143,
        "state_root_hash": "ae0f770668136cb937e889f318ff483f258ec8ca253324f3dad687a8e25d7057",
        "reason": "for fast sync",
        "number_of_remaining_tries_to_fetch": 43
      }
    }
  }
```

```
  "node_state": {
    "joining": {
      "fetching_block_and_deploys_at_given_block_height_before_execution": 150
    }
  }
```

```
  "node_state": {
    "joining": {
      "executing_block_at_height": 150
    }
  }
```

Transitions to participating mode:

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [
    {
      "node_id": "tls:0716..b595",
      "address": "127.0.0.1:22105"
    },
    {
      "node_id": "tls:078d..61ee",
      "address": "127.0.0.1:22102"
    },
    {
      "node_id": "tls:d8bc..a71c",
      "address": "127.0.0.1:22103"
    },
    {
      "node_id": "tls:db04..62b2",
      "address": "127.0.0.1:22101"
    },
    {
      "node_id": "tls:fdf0..d61a",
      "address": "127.0.0.1:22104"
    }
  ],
  "last_added_block_info": {
    "hash": "7af56c492db935adf7440b2dc3bdba1fde6c6b8407df0ee63bcfbe4c77775264",
    "timestamp": "2022-07-14T22:50:26.176Z",
    "era_id": 14,
    "height": 152,
    "state_root_hash": "ae0f770668136cb937e889f318ff483f258ec8ca253324f3dad687a8e25d7057",
    "creator": "013adf3ca6d46be7e574598fbe25a1a5a507a484e138ede5ca32f1ffbee1535e2c"
  },
  "our_public_signing_key": "01d48c73d2983017a50458292c014594b5fc6832ee963c296fe4e77589c531102e",
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "2s 268ms",
  "node_state": {
    "participating_and_syncing_to_genesis": {
      "sync_progress": {
        "fetching_headers_back_to_genesis": {
          "lowest_block_height": 152
        }
      }
    }
  }
}
```

```
  "node_state": {
    "participating_and_syncing_to_genesis": {
      "sync_progress": {
        "syncing_forward_from_genesis": [
          {
            "block_height": 50,
            "fetching": "block signatures"
          },
          {
            "block_height": 51,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "52b462946ff9fb70e7dcc69f62d60bd7bd88a80c96dec980a908733d2f24bbff",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 52,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "52b462946ff9fb70e7dcc69f62d60bd7bd88a80c96dec980a908733d2f24bbff",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 53,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "52b462946ff9fb70e7dcc69f62d60bd7bd88a80c96dec980a908733d2f24bbff",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 54,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "52b462946ff9fb70e7dcc69f62d60bd7bd88a80c96dec980a908733d2f24bbff",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 55,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 1
              }
            }
          },
          {
            "block_height": 56,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 1
              }
            }
          },
          {
            "block_height": 57,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 1
              }
            }
          },
          {
            "block_height": 58,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 1
              }
            }
          },
          {
            "block_height": 59,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 60,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 61,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 62,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 63,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 64,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 65,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "5638eba1679e87136f5f61215e377cfba5b86a9316967c62236c9267a4539bab",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 66,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "128dd98ccd5082d06aabdf3422538a283cf61f7b377d75d3ab1586c629832eee",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 67,
            "fetching": {
              "global_state_under_given_block": {
                "state_root_hash": "128dd98ccd5082d06aabdf3422538a283cf61f7b377d75d3ab1586c629832eee",
                "number_of_remaining_tries_to_fetch": 0
              }
            }
          },
          {
            "block_height": 68,
            "fetching": "block and deploys"
          },
          {
            "block_height": 69,
            "fetching": "block and deploys"
          },
          {
            "block_height": 70,
            "fetching": "block and deploys"
          },
          {
            "block_height": 71,
            "fetching": "block and deploys"
          },
          {
            "block_height": 72,
            "fetching": "block and deploys"
          },
          {
            "block_height": 73,
            "fetching": "block and deploys"
          },
          {
            "block_height": 74,
            "fetching": "block and deploys"
          },
          {
            "block_height": 75,
            "fetching": "block and deploys"
          },
          {
            "block_height": 76,
            "fetching": "block and deploys"
          },
          {
            "block_height": 77,
            "fetching": "block and deploys"
          },
          {
            "block_height": 78,
            "fetching": "block and deploys"
          },
          {
            "block_height": 79,
            "fetching": "block and deploys"
          },
          {
            "block_height": 80,
            "fetching": "block and deploys"
          },
          {
            "block_height": 81,
            "fetching": "block and deploys"
          },
          {
            "block_height": 82,
            "fetching": "block and deploys"
          },
          {
            "block_height": 83,
            "fetching": "block and deploys"
          },
          {
            "block_height": 84,
            "fetching": "block and deploys"
          },
          {
            "block_height": 85,
            "fetching": "block and deploys"
          },
          {
            "block_height": 86,
            "fetching": "block and deploys"
          },
          {
            "block_height": 87,
            "fetching": "block and deploys"
          },
          {
            "block_height": 88,
            "fetching": "block and deploys"
          },
          {
            "block_height": 89,
            "fetching": "block and deploys"
          },
          {
            "block_height": 90,
            "fetching": "block and deploys"
          },
          {
            "block_height": 91,
            "fetching": "block and deploys"
          },
          {
            "block_height": 92,
            "fetching": "block and deploys"
          },
          {
            "block_height": 93,
            "fetching": "block and deploys"
          },
          {
            "block_height": 94,
            "fetching": "block and deploys"
          },
          {
            "block_height": 95,
            "fetching": "block and deploys"
          },
          {
            "block_height": 96,
            "fetching": "block and deploys"
          },
          {
            "block_height": 97,
            "fetching": "block and deploys"
          },
          {
            "block_height": 98,
            "fetching": "block and deploys"
          },
          {
            "block_height": 99,
            "fetching": "block and deploys"
          }
        ]
      }
    }
  }
```

```
  "node_state": {
    "participating_and_syncing_to_genesis": {
      "sync_progress": {
        "syncing_forward_from_genesis": [
          {
            "block_height": 137,
            "fetching": "block signatures"
          },
          {
            "block_height": 138,
            "fetching": "block signatures"
          },
          {
            "block_height": 139,
            "fetching": "block signatures"
          },
          {
            "block_height": 140,
            "fetching": "block signatures"
          },
          {
            "block_height": 141,
            "fetching": "block signatures"
          },
          {
            "block_height": 142,
            "fetching": "block signatures"
          }
        ]
      }
    }
  }
```

Finishes sync-to-genesis:

```
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
  "peers": [
    {
      "node_id": "tls:0716..b595",
      "address": "127.0.0.1:22105"
    },
    {
      "node_id": "tls:078d..61ee",
      "address": "127.0.0.1:22102"
    },
    {
      "node_id": "tls:d8bc..a71c",
      "address": "127.0.0.1:22103"
    },
    {
      "node_id": "tls:db04..62b2",
      "address": "127.0.0.1:22101"
    },
    {
      "node_id": "tls:fdf0..d61a",
      "address": "127.0.0.1:22104"
    }
  ],
  "last_added_block_info": {
    "hash": "c10bbc514518b2780efec82f671c033dc038c1b116bfbf54283eee481e48de02",
    "timestamp": "2022-07-14T22:50:42.560Z",
    "era_id": 15,
    "height": 156,
    "state_root_hash": "1eabd4fdef4b9de2acd25d3d6a383f8a06ee5bb5296f799303414f9fd056235f",
    "creator": "01eaefea73a5ce20e993a03b9b28b179006df123840bf434789880fbc509c82797"
  },
  "our_public_signing_key": "01d48c73d2983017a50458292c014594b5fc6832ee963c296fe4e77589c531102e",
  "round_length": null,
  "next_upgrade": null,
  "build_version": "1.4.6-78e525430@DEBUG",
  "uptime": "16s 562ms",
  "node_state": "participating"
}
```

</details>

Closes #3205 and #3206.
