### PR TITLE
Bring feat-2.0 up to date with dev since `4ac7870`

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `enable_server` option to all HTTP server configuration sections (`rpc_server`, `rest_server`, `event_stream_server`) which allow users to enable/disable each server independently (enabled by default).
 * Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
 * Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
+* The network handshake now contains the hash of the chainspec used and will be successful only if they match.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
@@ -69,6 +70,7 @@ All notable changes to this project will be documented in this file.  The format
 * Remove a temporary chainspec setting `max_stored_value_size` to limit the size of individual values stored in global state.
 * Remove asymmetric key functionality (move to `casper-types` crate behind feature "std").
 * Remove time types (move to `casper-types` with some functionality behind feature "std").
+* Remove `reject_incompatible_versions` option from `config.toml`, meaning now all versions different than the current one are rejected through the `chainspec_hash` check in the network handshake.
 
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 * Nodes will now also gossip deploys onwards while joining.
-* Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
+* Add `node_state` field to the `/status` endpoint and the `info_get_status` JSON-RPC, giving an indication of the node's operating mode (joining or participating) and the progress of any ongoing chain-sync task.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 * Add a new parameter to `info_get_deploys` JSON-RPC, `finalized_approvals` - controlling whether the approvals returned with the deploy should be the ones originally received by the node, or overridden by the approvals that were finalized along with the deploy.
 * Add metrics `accumulated_outgoing_limiter_delay` and `accumulated_incoming_limiter_delay` to report how much time was spent throttling other peers.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
 * Add `strict_argument_checking` to the chainspec to enable strict args checking when executing a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
-* In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
+* In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests`, `trie_responses` and `sync_finished`.
 * Nodes will now also gossip deploys onwards while joining.
 * Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
 * Add `strict_argument_checking` to the chainspec to enable strict args checking when executing a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
-* In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests`, `trie_responses` and `sync_finished`.
+* In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 * Nodes will now also gossip deploys onwards while joining.
 * Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
 * Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -92,7 +92,8 @@ pub(crate) struct ChainSynchronizer<REv> {
     config: Config,
     /// This will be populated once the synchronizer has completed all work, indicating the joiner
     /// reactor can stop running.  It is passed to the participating reactor's constructor via its
-    /// config.
+    /// config. The participating reactor may still use the chain synchronizer component to run a
+    /// sync to genesis in the background.
     joining_outcome: Option<JoiningOutcome>,
     /// Metrics for the chain synchronization process.
     metrics: Metrics,

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -126,7 +126,7 @@ impl ChainSynchronizer<ParticipatingEvent> {
         if !synchronizer.config.sync_to_genesis() {
             return Ok((
                 synchronizer,
-                effect_builder.announce_finished_syncing().ignore(),
+                effect_builder.announce_finished_chain_syncing().ignore(),
             ));
         }
 

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -47,6 +47,12 @@ pub(crate) use metrics::Metrics;
 use operations::FastSyncOutcome;
 pub(crate) use operations::KeyBlockInfo;
 
+// #[derive(Debug, Serialize)]
+// pub(crate) enum LinearChainSyncAnnouncement {
+//     /// Chain sync finished.
+//     SyncStateFinished,
+// }
+
 #[derive(DataSize, Debug)]
 pub(crate) enum JoiningOutcome {
     /// We need to shutdown for upgrade as we downloaded a block from a higher protocol version.
@@ -120,9 +126,13 @@ impl ChainSynchronizer<ParticipatingEvent> {
             _phantom: PhantomData,
         };
 
-        // If we're not configured to sync-to-genesis, return without doing anything.
+        // If we're not configured to sync-to-genesis, return without doing anything but announcing
+        // that the sync process has finished.
         if !synchronizer.config.sync_to_genesis() {
-            return Ok((synchronizer, Effects::new()));
+            return Ok((
+                synchronizer,
+                effect_builder.announce_finished_syncing().ignore(),
+            ));
         }
 
         let effects = operations::run_sync_to_genesis_task(

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -75,7 +75,10 @@ pub(crate) enum JoiningOutcome {
 /// A chain synchronizer announcement.
 #[derive(Debug)]
 pub(crate) enum ChainSynchronizerAnnouncement {
-    /// Synchronization has been finished.
+    /// The node has finished the synchronization it was doing (fast-sync or sync-to-genesis,
+    /// depending on config) and may now accept requests that are unsafe for nodes that are
+    /// synchronizing. Once this message is received, the only way for the peer to signal it's in
+    /// the syncing process is to reconnect.
     SyncFinished,
 }
 

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -3,6 +3,7 @@ mod error;
 mod event;
 mod metrics;
 mod operations;
+mod progress;
 
 use std::{collections::HashSet, convert::Infallible, fmt::Debug, marker::PhantomData, sync::Arc};
 
@@ -28,7 +29,7 @@ use crate::{
         },
         requests::{
             ChainspecLoaderRequest, ContractRuntimeRequest, FetcherRequest,
-            MarkBlockCompletedRequest, NetworkInfoRequest,
+            MarkBlockCompletedRequest, NetworkInfoRequest, NodeStateRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -37,7 +38,7 @@ use crate::{
     types::{
         Block, BlockAndDeploys, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
         BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec, Deploy,
-        FinalizedApprovalsWithId, FinalizedBlock, NodeConfig,
+        FinalizedApprovalsWithId, FinalizedBlock, NodeConfig, NodeState,
     },
     NodeRng, SmallNetworkConfig,
 };
@@ -47,6 +48,8 @@ pub(crate) use event::Event;
 pub(crate) use metrics::Metrics;
 use operations::FastSyncOutcome;
 pub(crate) use operations::KeyBlockInfo;
+pub(crate) use progress::Progress;
+use progress::ProgressHolder;
 
 #[derive(DataSize, Debug)]
 pub(crate) enum JoiningOutcome {
@@ -76,6 +79,10 @@ pub(crate) struct ChainSynchronizer<REv> {
     joining_outcome: Option<JoiningOutcome>,
     /// Metrics for the chain synchronization process.
     metrics: Metrics,
+    /// Records the ongoing progress of chain synchronization.
+    progress: ProgressHolder,
+    /// The current state of operation of the node.
+    node_state: NodeState,
     /// Association with the reactor event used in subtasks.
     _phantom: PhantomData<REv>,
 }
@@ -110,15 +117,23 @@ where
     ) -> Result<(Self, Effects<Event>), Error> {
         let config = Config::new(chainspec, node_config, small_network_config);
         let metrics = Metrics::new(registry)?;
+        let progress = ProgressHolder::new_fast_sync();
+        let node_state = NodeState::Joining(progress.progress());
 
-        let effects =
-            operations::run_fast_sync_task(effect_builder, config.clone(), metrics.clone())
-                .event(Event::FastSyncResult);
+        let effects = operations::run_fast_sync_task(
+            effect_builder,
+            config.clone(),
+            metrics.clone(),
+            progress.clone(),
+        )
+        .event(Event::FastSyncResult);
 
         let synchronizer = ChainSynchronizer {
             config,
             joining_outcome: None,
             metrics,
+            progress,
+            node_state,
             _phantom: PhantomData,
         };
 
@@ -142,6 +157,7 @@ where
         effect_builder: EffectBuilder<REv>,
         result: Result<FastSyncOutcome, Error>,
     ) -> Effects<Event> {
+        self.progress.finish();
         match result {
             Ok(FastSyncOutcome::ShouldCommitGenesis) => self.commit_genesis(effect_builder),
             Ok(FastSyncOutcome::ShouldCommitUpgrade {
@@ -442,6 +458,7 @@ where
                 effect_builder,
                 self.config.clone(),
                 self.metrics.clone(),
+                self.progress.clone(),
             )
             .event(|result| Event::FastSyncAfterEmergencyUpgradeResult {
                 immediate_switch_block_and_exec_effects,
@@ -469,6 +486,7 @@ where
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         result: Result<FastSyncOutcome, Error>,
     ) -> Effects<Event> {
+        self.progress.finish();
         match result {
             Ok(FastSyncOutcome::ShouldCommitGenesis) => {
                 let msg = "fast sync after emergency upgrade should not require commit genesis";
@@ -504,6 +522,95 @@ where
                 fatal!(effect_builder, "{}", error).ignore()
             }
         }
+    }
+}
+
+impl<REv> ChainSynchronizer<REv>
+where
+    REv: From<StorageRequest>
+        + From<NetworkInfoRequest>
+        + From<FetcherRequest<TrieOrChunk>>
+        + From<FetcherRequest<BlockAndDeploys>>
+        + From<FetcherRequest<BlockSignatures>>
+        + From<FetcherRequest<BlockHeadersBatch>>
+        + From<ContractRuntimeRequest>
+        + From<BlocklistAnnouncement>
+        + From<MarkBlockCompletedRequest>
+        + From<ChainSynchronizerAnnouncement>
+        + Send,
+{
+    /// Constructs a new `ChainSynchronizer` suitable for use in the participating reactor to sync
+    /// to genesis.
+    pub(crate) fn new_for_sync_to_genesis(
+        chainspec: Arc<Chainspec>,
+        node_config: NodeConfig,
+        small_network_config: SmallNetworkConfig,
+        metrics: Metrics,
+        effect_builder: EffectBuilder<REv>,
+    ) -> Result<(Self, Effects<Event>), Error> {
+        let config = Config::new(chainspec, node_config, small_network_config);
+        let progress = ProgressHolder::new_sync_to_genesis();
+
+        if config.sync_to_genesis() {
+            let node_state = NodeState::ParticipatingAndSyncingToGenesis {
+                sync_progress: progress.progress(),
+            };
+
+            let synchronizer = ChainSynchronizer {
+                config,
+                joining_outcome: None,
+                metrics,
+                progress: progress.clone(),
+                node_state,
+                _phantom: PhantomData,
+            };
+
+            let effects = operations::run_sync_to_genesis_task(
+                effect_builder,
+                synchronizer.config.clone(),
+                synchronizer.metrics.clone(),
+                progress,
+            )
+            .ignore();
+
+            return Ok((synchronizer, effects));
+        }
+
+        // If we're not configured to sync-to-genesis, return without doing anything but announcing
+        // that the sync process has finished.
+        progress.finish();
+        let synchronizer = ChainSynchronizer {
+            config,
+            joining_outcome: None,
+            metrics,
+            progress,
+            node_state: NodeState::Participating,
+            _phantom: PhantomData,
+        };
+
+        Ok((
+            synchronizer,
+            effect_builder.announce_finished_chain_syncing().ignore(),
+        ))
+    }
+}
+
+impl<REv> ChainSynchronizer<REv> {
+    fn handle_get_node_state_request(&mut self, request: NodeStateRequest) -> Effects<Event> {
+        self.node_state = match self.node_state {
+            NodeState::Joining(_) => NodeState::Joining(self.progress.progress()),
+            NodeState::ParticipatingAndSyncingToGenesis { .. } => {
+                let sync_progress = self.progress.progress();
+                if sync_progress.is_finished() {
+                    NodeState::Participating
+                } else {
+                    NodeState::ParticipatingAndSyncingToGenesis { sync_progress }
+                }
+            }
+            NodeState::Participating => NodeState::Participating,
+        };
+
+        request.0.respond(self.node_state.clone()).ignore()
     }
 }
 
@@ -572,56 +679,7 @@ where
                 validators_to_sign_immediate_switch_block,
                 result,
             ),
+            Event::GetNodeState(request) => self.handle_get_node_state_request(request),
         }
-    }
-}
-
-impl<REv> ChainSynchronizer<REv>
-where
-    REv: From<StorageRequest>
-        + From<NetworkInfoRequest>
-        + From<FetcherRequest<TrieOrChunk>>
-        + From<FetcherRequest<BlockAndDeploys>>
-        + From<FetcherRequest<BlockSignatures>>
-        + From<FetcherRequest<BlockHeadersBatch>>
-        + From<ContractRuntimeRequest>
-        + From<BlocklistAnnouncement>
-        + From<MarkBlockCompletedRequest>
-        + From<ChainSynchronizerAnnouncement>
-        + Send,
-{
-    /// Constructs a new `ChainSynchronizer` suitable for use in the participating reactor to sync
-    /// to genesis.
-    pub(crate) fn new_for_sync_to_genesis(
-        chainspec: Arc<Chainspec>,
-        node_config: NodeConfig,
-        small_network_config: SmallNetworkConfig,
-        metrics: Metrics,
-        effect_builder: EffectBuilder<REv>,
-    ) -> Result<(Self, Effects<Event>), Error> {
-        let synchronizer = ChainSynchronizer {
-            config: Config::new(chainspec, node_config, small_network_config),
-            joining_outcome: None,
-            metrics,
-            _phantom: PhantomData,
-        };
-
-        // If we're not configured to sync-to-genesis, return without doing anything but announcing
-        // that the sync process has finished.
-        if !synchronizer.config.sync_to_genesis() {
-            return Ok((
-                synchronizer,
-                effect_builder.announce_finished_chain_syncing().ignore(),
-            ));
-        }
-
-        let effects = operations::run_sync_to_genesis_task(
-            effect_builder,
-            synchronizer.config.clone(),
-            synchronizer.metrics.clone(),
-        )
-        .ignore();
-
-        Ok((synchronizer, effects))
     }
 }

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -4,14 +4,7 @@ mod event;
 mod metrics;
 mod operations;
 
-use core::fmt;
-use std::{
-    collections::HashSet,
-    convert::Infallible,
-    fmt::{Debug, Display, Formatter},
-    marker::PhantomData,
-    sync::Arc,
-};
+use std::{collections::HashSet, convert::Infallible, fmt::Debug, marker::PhantomData, sync::Arc};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -70,24 +63,6 @@ pub(crate) enum JoiningOutcome {
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         highest_block_header: BlockHeader,
     },
-}
-
-/// A chain synchronizer announcement.
-#[derive(Debug)]
-pub(crate) enum ChainSynchronizerAnnouncement {
-    /// The node has finished the synchronization it was doing (fast-sync or sync-to-genesis,
-    /// depending on config) and may now accept requests that are unsafe for nodes that are
-    /// synchronizing. Once this message is received, the only way for the peer to signal it's in
-    /// the syncing process is to reconnect.
-    SyncFinished,
-}
-
-impl Display for ChainSynchronizerAnnouncement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            ChainSynchronizerAnnouncement::SyncFinished => write!(f, "chain sync finished"),
-        }
-    }
 }
 
 #[derive(DataSize, Debug)]

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -4,7 +4,14 @@ mod event;
 mod metrics;
 mod operations;
 
-use std::{collections::HashSet, convert::Infallible, fmt::Debug, marker::PhantomData, sync::Arc};
+use core::fmt;
+use std::{
+    collections::HashSet,
+    convert::Infallible,
+    fmt::{Debug, Display, Formatter},
+    marker::PhantomData,
+    sync::Arc,
+};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -47,12 +54,6 @@ pub(crate) use metrics::Metrics;
 use operations::FastSyncOutcome;
 pub(crate) use operations::KeyBlockInfo;
 
-// #[derive(Debug, Serialize)]
-// pub(crate) enum LinearChainSyncAnnouncement {
-//     /// Chain sync finished.
-//     SyncStateFinished,
-// }
-
 #[derive(DataSize, Debug)]
 pub(crate) enum JoiningOutcome {
     /// We need to shutdown for upgrade as we downloaded a block from a higher protocol version.
@@ -69,6 +70,21 @@ pub(crate) enum JoiningOutcome {
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         highest_block_header: BlockHeader,
     },
+}
+
+/// A chain synchronizer announcement.
+#[derive(Debug)]
+pub(crate) enum ChainSynchronizerAnnouncement {
+    /// Synchronization has been finished.
+    SyncFinished,
+}
+
+impl Display for ChainSynchronizerAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ChainSynchronizerAnnouncement::SyncFinished => write!(f, "chain sync finished"),
+        }
+    }
 }
 
 #[derive(DataSize, Debug)]

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,9 +33,9 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
-    /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
-    /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
-    /// items on the `known_addresses` list in the node config.
+    /// Block and block header fetch operations are retried *once* when at the initial trial there
+    /// were fewer peers than `minimum_peer_count_threshold_for_fetch_retry` available. By default,
+    /// this is the number of items on the `known_addresses` list in the node config.
     pub(crate) minimum_peer_count_threshold_for_fetch_retry: usize,
 }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -36,7 +36,7 @@ pub(super) struct Config {
     /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
     /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
     /// items on the `known_addresses` list in the node config.
-    pub(crate) minimum_peer_count_threshold: usize,
+    pub(crate) minimum_peer_count_threshold_for_fetch_retry: usize,
 }
 
 impl Config {
@@ -58,7 +58,9 @@ impl Config {
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
             redemption_interval: node_config.sync_peer_redemption_interval,
-            minimum_peer_count_threshold: node_config.known_addresses.len(),
+            minimum_peer_count_threshold_for_fetch_retry: small_network_config
+                .known_addresses
+                .len(),
         }
     }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,6 +33,7 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
+    pub(crate) minimum_peer_count_threshold: usize,
 }
 
 impl Config {
@@ -54,6 +55,7 @@ impl Config {
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
             redemption_interval: node_config.sync_peer_redemption_interval,
+            minimum_peer_count_threshold: node_config.known_addresses.len(),
         }
     }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,6 +33,9 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
+    /// Some of the fetch operations are retried *once* when at the initial trial there were fewer
+    /// peers than `minimum_peer_count_threshold` available. By default, this is the number of
+    /// items on the `known_addresses` list in the node config.
     pub(crate) minimum_peer_count_threshold: usize,
 }
 

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
+use derive_more::From;
 use serde::Serialize;
 
 use casper_execution_engine::core::engine_state::{self, genesis::GenesisSuccess, UpgradeSuccess};
@@ -11,10 +12,11 @@ use casper_types::PublicKey;
 use super::{Error, FastSyncOutcome};
 use crate::{
     contract_runtime::{BlockAndExecutionEffects, BlockExecutionError},
+    effect::requests::NodeStateRequest,
     types::BlockHeader,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, From)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Event {
     /// The result of running the fast sync task.
@@ -42,6 +44,9 @@ pub(crate) enum Event {
         validators_to_sign_immediate_switch_block: HashSet<PublicKey>,
         result: Result<FastSyncOutcome, Error>,
     },
+    /// A request to provide the node state.
+    #[from]
+    GetNodeState(NodeStateRequest),
 }
 
 impl Display for Event {
@@ -73,6 +78,7 @@ impl Display for Event {
                     fast_sync_result
                 )
             }
+            Event::GetNodeState(_) => write!(formatter, "get node state"),
         }
     }
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -38,7 +38,7 @@ use crate::{
         fetcher::{FetchResult, FetchedData, FetcherError},
     },
     effect::{
-        announcements::BlocklistAnnouncement,
+        announcements::{BlocklistAnnouncement, ChainSynchronizerAnnouncement},
         requests::{
             ContractRuntimeRequest, FetcherRequest, MarkBlockCompletedRequest, NetworkInfoRequest,
         },
@@ -53,8 +53,6 @@ use crate::{
     },
     utils::work_queue::WorkQueue,
 };
-
-use super::ChainSynchronizerAnnouncement;
 
 const FINALITY_SIGNATURE_FETCH_RETRY_COUNT: usize = 3;
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -738,8 +738,6 @@ where
             parent: Box::new(parent_header.clone()),
         })?;
 
-    let minimum_peer_count_threshold: usize = 10;
-
     for _ in 0..=1 {
         let peers = prepare_applicable_peers(ctx).await;
         let peer_count = peers.len();
@@ -755,7 +753,7 @@ where
                 return Ok(Some(item));
             }
             None => {
-                if peer_count >= minimum_peer_count_threshold {
+                if peer_count >= ctx.config.minimum_peer_count_threshold {
                     warn!(
                         %height,
                         attempts_to_get_fully_connected_peers =
@@ -767,7 +765,7 @@ where
                 info!(
                     %height,
                     %peer_count,
-                    %minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
+                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
                 );
             }
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1297,7 +1297,7 @@ where
     let ctx = ChainSyncContext::new_for_sync_to_genesis(&effect_builder, &config, &metrics).await?;
     fetch_headers_till_genesis(&ctx).await?;
     fetch_blocks_and_state_and_finality_signatures_since_genesis(&ctx).await?;
-    effect_builder.announce_finished_syncing().await;
+    effect_builder.announce_finished_chain_syncing().await;
     info!("finished chain sync to genesis");
     Ok(())
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -38,7 +38,7 @@ use crate::{
         fetcher::{FetchResult, FetchedData, FetcherError},
     },
     effect::{
-        announcements::{BlocklistAnnouncement, LinearChainAnnouncement},
+        announcements::BlocklistAnnouncement,
         requests::{
             ContractRuntimeRequest, FetcherRequest, MarkBlockCompletedRequest, NetworkInfoRequest,
         },
@@ -53,6 +53,8 @@ use crate::{
     },
     utils::work_queue::WorkQueue,
 };
+
+use super::ChainSynchronizerAnnouncement;
 
 const FINALITY_SIGNATURE_FETCH_RETRY_COUNT: usize = 3;
 
@@ -2001,7 +2003,7 @@ where
         + From<FetcherRequest<BlockSignatures>>
         + From<BlocklistAnnouncement>
         + From<MarkBlockCompletedRequest>
-        + From<LinearChainAnnouncement>
+        + From<ChainSynchronizerAnnouncement>
         + Send,
 {
     info!("starting chain sync to genesis");

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -38,7 +38,7 @@ use crate::{
         fetcher::{FetchResult, FetchedData, FetcherError},
     },
     effect::{
-        announcements::BlocklistAnnouncement,
+        announcements::{BlocklistAnnouncement, LinearChainAnnouncement},
         requests::{
             ContractRuntimeRequest, FetcherRequest, MarkBlockCompletedRequest, NetworkInfoRequest,
         },
@@ -2001,6 +2001,7 @@ where
         + From<FetcherRequest<BlockSignatures>>
         + From<BlocklistAnnouncement>
         + From<MarkBlockCompletedRequest>
+        + From<LinearChainAnnouncement>
         + Send,
 {
     info!("starting chain sync to genesis");
@@ -2012,6 +2013,9 @@ where
             Error::NoHighestBlockHeader
         })?;
     sync_to_genesis(&ctx).await?;
+
+    effect_builder.announce_finished_syncing().await;
+
     info!("finished chain sync to genesis");
     Ok(())
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -760,7 +760,7 @@ where
                 return Ok(Some(item));
             }
             None => {
-                if peer_count >= ctx.config.minimum_peer_count_threshold {
+                if peer_count >= ctx.config.minimum_peer_count_threshold_for_fetch_retry {
                     warn!(
                         %height,
                         attempts_to_get_fully_connected_peers =
@@ -772,7 +772,7 @@ where
                 info!(
                     %height,
                     %peer_count,
-                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold, "tried fetching with not enough peers, may try again"
+                    minimum_peer_count_threshold = %ctx.config.minimum_peer_count_threshold_for_fetch_retry, "tried fetching with not enough peers, may try again"
                 );
             }
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -740,7 +740,7 @@ where
         })?;
 
     for _ in 0..=1 {
-        let peers = prepare_applicable_peers(ctx).await;
+        let peers = prepare_peers_applicable_for_block_fetch(ctx).await;
         let peer_count = peers.len();
         let maybe_item = try_fetch_block_or_block_header_by_height(
             peers.clone(),
@@ -876,7 +876,9 @@ where
 }
 
 /// Prepares a list of peers applicable for the next fetch operation.
-async fn prepare_applicable_peers<REv>(ctx: &ChainSyncContext<'_, REv>) -> Vec<NodeId>
+async fn prepare_peers_applicable_for_block_fetch<REv>(
+    ctx: &ChainSyncContext<'_, REv>,
+) -> Vec<NodeId>
 where
     REv: From<NetworkInfoRequest>,
 {

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, VecDeque},
     mem,
     sync::{
-        atomic::{self, AtomicBool, AtomicI64, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, RwLock,
     },
 };
@@ -23,9 +23,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
 use casper_hashing::Digest;
-use casper_types::{
-    bytesrepr::Bytes, EraId, ProtocolVersion, PublicKey, TimeDiff, Timestamp, U512,
-};
+use casper_types::{bytesrepr::Bytes, EraId, PublicKey, TimeDiff, Timestamp, U512};
 
 use crate::{
     components::{
@@ -847,25 +845,14 @@ where
         });
     }
 
-    check_block_version(item.header(), ctx.config.protocol_version())?;
-
-    Ok(Some(item))
-}
-
-/// Compares the block's version with the current and parent version and returns an error if it is
-/// too new or old.
-fn check_block_version(
-    header: &BlockHeader,
-    current_version: ProtocolVersion,
-) -> Result<(), Error> {
-    if header.protocol_version() > current_version {
+    if item.header().protocol_version() > ctx.config.protocol_version() {
         return Err(Error::RetrievedBlockHeaderFromFutureVersion {
-            current_version,
-            block_header_with_future_version: Box::new(header.clone()),
+            current_version: ctx.config.protocol_version(),
+            block_header_with_future_version: Box::new(item.header().clone()),
         });
     }
 
-    Ok(())
+    Ok(Some(item))
 }
 
 /// Queries all of the peers for a trie, puts the trie found from the network in the trie-store, and
@@ -964,12 +951,12 @@ where
         let child_jobs = fetch_and_store_trie(*job.inner(), ctx)
             .await
             .map_err(|err| {
-                abort.store(true, atomic::Ordering::Relaxed);
+                abort.store(true, Ordering::Relaxed);
                 warn!(?err, trie_key = %job.inner(), "failed to download trie");
                 err
             })?;
         trace!(?child_jobs, trie_key = %job.inner(), "downloaded trie node");
-        if abort.load(atomic::Ordering::Relaxed) {
+        if abort.load(Ordering::Relaxed) {
             return Ok(()); // Another task failed and sent an error.
         }
         for child_job in child_jobs {
@@ -1050,13 +1037,14 @@ where
 ///
 ///  1. Starting at the trusted block, fetches block headers by iterating forwards towards tip until
 ///     getting to one from the current era or failing to get a higher one from any peer.
-///  2. Starting at that most recent block, iterates backwards towards genesis, fetching
+///  2. Starting at that highest synced block, iterates backwards towards genesis, fetching
 ///     `deploy_max_ttl`'s worth of blocks (for deploy replay protection).
-///  3. Starting at the most recent block, again iterates backwards, fetching enough block headers
-///     to allow consensus to be initialized.
-///  4. Fetches the tries under the most recent block's state root hash (parallelized tasks).
+///  3. Starting at the same highest synced block, again iterates backwards, fetching enough block
+///     headers to allow consensus to be initialized.
+///  4. Fetches the tries under the same highest synced block's state root hash (parallelized
+///     tasks).
 ///
-/// Returns the most recent block header and the corresponding most recent key block info.
+/// Returns the highest synced block header and the corresponding highest synced key block info.
 async fn fast_sync<REv>(
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<(BlockHeader, KeyBlockInfo), Error>
@@ -1074,23 +1062,23 @@ where
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fast_sync_total_duration_seconds);
 
     let trusted_key_block_info = get_trusted_key_block_info(ctx).await?;
-    let (most_recent_block_header, most_recent_key_block_info) =
-        fetch_block_headers_up_to_the_most_recent_one(&trusted_key_block_info, ctx).await?;
+    let (highest_synced_block_header, highest_synced_key_block_info) =
+        fetch_block_headers_up_to_current_era(&trusted_key_block_info, ctx).await?;
 
     fetch_blocks_for_deploy_replay_protection(
-        &most_recent_block_header,
-        &most_recent_key_block_info,
+        &highest_synced_block_header,
+        &highest_synced_key_block_info,
         ctx,
     )
     .await?;
 
-    fetch_block_headers_needed_for_era_supervisor_initialization(&most_recent_block_header, ctx)
+    fetch_block_headers_needed_for_era_supervisor_initialization(&highest_synced_block_header, ctx)
         .await?;
 
-    // Synchronize the trie store for the most recent block header.
-    sync_trie_store(&most_recent_block_header, ctx).await?;
+    // Synchronize the trie store for the highest synced block header.
+    sync_trie_store(&highest_synced_block_header, ctx).await?;
 
-    Ok((most_recent_block_header, most_recent_key_block_info))
+    Ok((highest_synced_block_header, highest_synced_key_block_info))
 }
 
 /// Gets the trusted key block info for a trusted block header.
@@ -1144,11 +1132,11 @@ where
     }
 }
 
-/// Get the most recent header which has the same version as ours.
+/// Get the highest header which has the same version as ours.
 ///
 /// We keep fetching by height until none of our peers have a block at that height and we are in
 /// the current era.
-async fn fetch_block_headers_up_to_the_most_recent_one<REv>(
+async fn fetch_block_headers_up_to_current_era<REv>(
     trusted_key_block_info: &KeyBlockInfo,
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<(BlockHeader, KeyBlockInfo), Error>
@@ -1161,60 +1149,63 @@ where
 {
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fetch_block_headers_duration_seconds);
 
-    let mut most_recent_block_header = ctx.trusted_block_header().clone();
-    let mut most_recent_key_block_info = trusted_key_block_info.clone();
+    let mut highest_synced_block_header = ctx.trusted_block_header().clone();
+    let mut highest_synced_key_block_info = trusted_key_block_info.clone();
     loop {
         // If we synced up to the current era, we can consider syncing done.
         if is_current_era(
-            &most_recent_block_header,
-            &most_recent_key_block_info,
+            &highest_synced_block_header,
+            &highest_synced_key_block_info,
             ctx.config,
         ) {
             info!(
-                era = most_recent_block_header.era_id().value(),
-                height = most_recent_block_header.height(),
-                timestamp = %most_recent_block_header.timestamp(),
+                era = highest_synced_block_header.era_id().value(),
+                height = highest_synced_block_header.height(),
+                timestamp = %highest_synced_block_header.timestamp(),
                 "fetched block headers up to the current era",
             );
             break;
         }
 
         let maybe_fetched_block = fetch_and_store_next::<_, BlockHeaderWithMetadata>(
-            &most_recent_block_header,
-            &most_recent_key_block_info,
+            &highest_synced_block_header,
+            &highest_synced_key_block_info,
             ctx,
         )
         .await?;
 
-        if let Some(more_recent_block_header_with_metadata) = maybe_fetched_block {
-            most_recent_block_header = more_recent_block_header_with_metadata.block_header;
+        if let Some(higher_block_header_with_metadata) = maybe_fetched_block {
+            highest_synced_block_header = higher_block_header_with_metadata.block_header;
 
             // If the new block is a switch block, update the validator weights, etc...
             if let Some(key_block_info) = KeyBlockInfo::maybe_from_block_header(
-                &most_recent_block_header,
+                &highest_synced_block_header,
                 ctx.config.verifiable_chunked_hash_activation(),
             ) {
-                most_recent_key_block_info = key_block_info;
+                highest_synced_key_block_info = key_block_info;
             }
         } else {
-            // If we timed out, consider syncing done.
+            // If we timed out, consider syncing done.  The only way we should reach this code
+            // branch is if the network just underwent an emergency upgrade, where there was an
+            // outage long enough that the highest block of the network now causes `is_current_era`
+            // to return `false`.
             info!(
-                era = most_recent_block_header.era_id().value(),
-                height = most_recent_block_header.height(),
-                timestamp = %most_recent_block_header.timestamp(),
-                "failed to fetch a more recent block header",
+                era = highest_synced_block_header.era_id().value(),
+                height = highest_synced_block_header.height(),
+                timestamp = %highest_synced_block_header.timestamp(),
+                "failed to fetch a higher block header",
             );
             break;
         }
     }
-    Ok((most_recent_block_header, most_recent_key_block_info))
+    Ok((highest_synced_block_header, highest_synced_key_block_info))
 }
 
 /// Fetch and store all blocks that can contain not-yet-expired deploys. These are needed for
 /// replay detection.
 async fn fetch_blocks_for_deploy_replay_protection<REv>(
-    most_recent_block_header: &BlockHeader,
-    most_recent_key_block_info: &KeyBlockInfo,
+    highest_synced_block_header: &BlockHeader,
+    highest_synced_key_block_info: &KeyBlockInfo,
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<(), Error>
 where
@@ -1222,8 +1213,8 @@ where
 {
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_replay_protection_duration_seconds);
 
-    let mut current_header = most_recent_block_header.clone();
-    while most_recent_key_block_info
+    let mut current_header = highest_synced_block_header.clone();
+    while highest_synced_key_block_info
         .era_start
         .saturating_diff(current_header.timestamp())
         < ctx.config.deploy_max_ttl()
@@ -1239,7 +1230,7 @@ where
 /// The era supervisor requires enough switch blocks to be stored in the database to be able to
 /// initialize the most recent eras.
 async fn fetch_block_headers_needed_for_era_supervisor_initialization<REv>(
-    most_recent_block_header: &BlockHeader,
+    highest_synced_block_header: &BlockHeader,
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<(), Error>
 where
@@ -1249,10 +1240,10 @@ where
 
     let earliest_open_era = ctx
         .config
-        .earliest_open_era(most_recent_block_header.era_id());
+        .earliest_open_era(highest_synced_block_header.era_id());
     let earliest_era_needed_by_era_supervisor =
         ctx.config.earliest_switch_block_needed(earliest_open_era);
-    let mut current_walk_back_header = most_recent_block_header.clone();
+    let mut current_walk_back_header = highest_synced_block_header.clone();
     while current_walk_back_header.era_id() > earliest_era_needed_by_era_supervisor {
         current_walk_back_header =
             *fetch_and_store_block_header(ctx, *current_walk_back_header.parent_hash()).await?;
@@ -1875,20 +1866,24 @@ where
         return Ok(outcome);
     }
 
-    let (most_recent_block_header, most_recent_key_block_info) = fast_sync(&ctx).await?;
+    let (highest_synced_block_header, highest_synced_key_block_info) = fast_sync(&ctx).await?;
 
     // Iterate forwards, fetching each full block and deploys but executing each block to generate
     // global state. Stop once we get to a block in the current era.
-    let most_recent_block_header =
-        execute_blocks(&most_recent_block_header, most_recent_key_block_info, &ctx).await?;
+    let highest_synced_block_header = fetch_and_execute_blocks(
+        &highest_synced_block_header,
+        highest_synced_key_block_info,
+        &ctx,
+    )
+    .await?;
 
     // If we just committed an emergency upgrade and are re-syncing right after this, potentially
-    // the call to `fast_sync` and `execute_blocks` could yield a `most_recent_block_header` which
-    // is older than the `highest_block_header` (which is the immediate switch block of the
+    // the call to `fast_sync` and `execute_blocks` could yield a `highest_synced_block_header`
+    // which is lower than the `highest_block_header` (which is the immediate switch block of the
     // upgrade).  Ensure we take the actual highest block to allow consensus to be initialised
     // properly.
-    if most_recent_block_header.height() > highest_block_header.height() {
-        highest_block_header = most_recent_block_header;
+    if highest_synced_block_header.height() > highest_block_header.height() {
+        highest_block_header = highest_synced_block_header;
     }
 
     ctx.effect_builder
@@ -2092,11 +2087,11 @@ where
         .await?)
 }
 
-/// Executes forwards from the block after `most_recent_block_header` until we can get no more
-/// recent block from any peer, or the block we executed is in the current era.
-async fn execute_blocks<REv>(
-    most_recent_block_header: &BlockHeader,
-    most_recent_key_block_info: KeyBlockInfo,
+/// Executes forwards from the block after `highest_synced_block_header` until we can get no higher
+/// block from any peer, or the block we executed is in the current era.
+async fn fetch_and_execute_blocks<REv>(
+    highest_synced_block_header: &BlockHeader,
+    highest_synced_key_block_info: KeyBlockInfo,
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<BlockHeader, Error>
 where
@@ -2114,22 +2109,22 @@ where
 
     // Execute blocks to get to current.
     let mut execution_pre_state = ExecutionPreState::from_block_header(
-        most_recent_block_header,
+        highest_synced_block_header,
         ctx.config.verifiable_chunked_hash_activation(),
     );
     info!(
-        era_id = ?most_recent_block_header.era_id(),
-        height = most_recent_block_header.height(),
+        era_id = ?highest_synced_block_header.era_id(),
+        height = highest_synced_block_header.height(),
         now = %Timestamp::now(),
-        block_timestamp = %most_recent_block_header.timestamp(),
+        block_timestamp = %highest_synced_block_header.timestamp(),
         "fetching and executing blocks to synchronize to current",
     );
 
-    let mut most_recent_block_header = most_recent_block_header.clone();
-    let mut key_block_info = most_recent_key_block_info;
+    let mut highest_synced_block_header = highest_synced_block_header.clone();
+    let mut key_block_info = highest_synced_key_block_info;
     loop {
         let result = fetch_and_store_next::<_, BlockWithMetadata>(
-            &most_recent_block_header,
+            &highest_synced_block_header,
             &key_block_info,
             ctx,
         )
@@ -2137,13 +2132,13 @@ where
         let block = match result {
             None => {
                 let in_current_era =
-                    is_current_era(&most_recent_block_header, &key_block_info, ctx.config);
+                    is_current_era(&highest_synced_block_header, &key_block_info, ctx.config);
                 info!(
-                    era = most_recent_block_header.era_id().value(),
+                    era = highest_synced_block_header.era_id().value(),
                     in_current_era,
-                    height = most_recent_block_header.height(),
-                    timestamp = %most_recent_block_header.timestamp(),
-                    "couldn't download a more recent block; finishing syncing",
+                    height = highest_synced_block_header.height(),
+                    timestamp = %highest_synced_block_header.timestamp(),
+                    "couldn't download a higher block; finishing syncing",
                 );
                 break;
             }
@@ -2177,7 +2172,10 @@ where
         while !blocks_match {
             // Could be wrong approvals - fetch new sets of approvals from a single peer and retry.
             for peer in get_filtered_fully_connected_peers(ctx).await {
-                info!(block_hash=%block.hash(), "start - re-executing finalized block");
+                warn!(
+                    block_hash=%block.hash(),
+                    "retrying execution due to deploy approvals mismatch"
+                );
                 let block_and_execution_effects = retry_execution_with_approvals_from_peer(
                     &mut deploys,
                     &mut transfers,
@@ -2187,22 +2185,21 @@ where
                     ctx,
                 )
                 .await?;
-                info!(block_hash=%block.hash(), "finish - re-executing finalized block");
+                debug!(block_hash=%block.hash(), "finish - re-executing finalized block");
                 blocks_match = block == *block_and_execution_effects.block();
                 if blocks_match {
                     break;
-                } else {
-                    warn!(
-                        %peer,
-                        "block executed with approvals from this peer doesn't match the received \
-                        block; blocking peer"
-                    );
-                    ctx.effect_builder.announce_disconnect_from_peer(peer).await;
                 }
+                warn!(
+                    %peer,
+                    "block executed with approvals from this peer doesn't match the received \
+                    block; blocking peer"
+                );
+                ctx.effect_builder.announce_disconnect_from_peer(peer).await;
             }
         }
 
-        // matching now! store new approval sets for the deploys
+        // Matching now - store new approval sets for the deploys.
         for deploy in deploys.into_iter().chain(transfers.into_iter()) {
             ctx.effect_builder
                 .store_finalized_approvals(
@@ -2215,14 +2212,14 @@ where
             .mark_block_completed(block_and_execution_effects.block().height())
             .await;
 
-        most_recent_block_header = block.take_header();
+        highest_synced_block_header = block.take_header();
         execution_pre_state = ExecutionPreState::from_block_header(
-            &most_recent_block_header,
+            &highest_synced_block_header,
             ctx.config.verifiable_chunked_hash_activation(),
         );
 
         if let Some(new_key_block_info) = KeyBlockInfo::maybe_from_block_header(
-            &most_recent_block_header,
+            &highest_synced_block_header,
             ctx.config.verifiable_chunked_hash_activation(),
         ) {
             key_block_info = new_key_block_info;
@@ -2230,17 +2227,17 @@ where
 
         // If we managed to sync up to the current era, stop - we'll have to sync the consensus
         // protocol state, anyway.
-        if is_current_era(&most_recent_block_header, &key_block_info, ctx.config) {
+        if is_current_era(&highest_synced_block_header, &key_block_info, ctx.config) {
             info!(
-                era = most_recent_block_header.era_id().value(),
-                height = most_recent_block_header.height(),
-                timestamp = %most_recent_block_header.timestamp(),
+                era = highest_synced_block_header.era_id().value(),
+                height = highest_synced_block_header.height(),
+                timestamp = %highest_synced_block_header.timestamp(),
                 "synchronized up to the current era; finishing syncing",
             );
             break;
         }
     }
-    Ok(most_recent_block_header)
+    Ok(highest_synced_block_header)
 }
 
 async fn fetch_and_store_deploys<REv>(
@@ -2268,17 +2265,17 @@ where
     Ok(deploys)
 }
 
-/// Returns `true` if `most_recent_block` indicates that we're currently in an ongoing era.
+/// Returns `true` if `highest_synced_block` indicates that we're currently in an ongoing era.
 ///
-/// The ongoing era is either the one in which `most_recent_block` was created, or in the case where
-/// `most_recent_block` is a switch block, it is the era immediately following it.
+/// The ongoing era is either the one in which `highest_synced_block` was created, or in the case
+/// where `highest_synced_block` is a switch block, it is the era immediately following it.
 pub(super) fn is_current_era(
-    most_recent_block: &BlockHeader,
+    highest_synced_block: &BlockHeader,
     trusted_key_block_info: &KeyBlockInfo,
     config: &Config,
 ) -> bool {
     is_current_era_given_current_timestamp(
-        most_recent_block,
+        highest_synced_block,
         trusted_key_block_info,
         config,
         Timestamp::now(),
@@ -2286,7 +2283,7 @@ pub(super) fn is_current_era(
 }
 
 fn is_current_era_given_current_timestamp(
-    most_recent_block: &BlockHeader,
+    highest_synced_block: &BlockHeader,
     trusted_key_block_info: &KeyBlockInfo,
     config: &Config,
     current_timestamp: Timestamp,
@@ -2303,10 +2300,10 @@ fn is_current_era_given_current_timestamp(
     // Otherwise estimate the earliest possible end of this era based on how many blocks remain.
     let remaining_blocks_in_this_era = config
         .min_era_height()
-        .saturating_sub(most_recent_block.height() - *height);
-    let time_since_most_recent_block =
-        current_timestamp.saturating_diff(most_recent_block.timestamp());
-    time_since_most_recent_block < config.min_round_length() * remaining_blocks_in_this_era
+        .saturating_sub(highest_synced_block.height() - *height);
+    let time_since_highest_synced_block =
+        current_timestamp.saturating_diff(highest_synced_block.timestamp());
+    time_since_highest_synced_block < config.min_round_length() * remaining_blocks_in_this_era
 }
 
 #[cfg(test)]
@@ -2315,7 +2312,7 @@ mod tests {
 
     use rand::Rng;
 
-    use casper_types::{testing::TestRng, EraId, ProtocolVersion, PublicKey, SecretKey};
+    use casper_types::{testing::TestRng, EraId, PublicKey, SecretKey};
 
     use super::*;
     use crate::{
@@ -2470,41 +2467,6 @@ mod tests {
             &config,
             now
         ));
-    }
-
-    #[test]
-    fn test_check_block_version() {
-        let mut rng = TestRng::new();
-        let v1_2_0 = ProtocolVersion::from_parts(1, 2, 0);
-        let v1_3_0 = ProtocolVersion::from_parts(1, 3, 0);
-
-        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
-        let header = Block::random_with_specifics(
-            &mut rng,
-            EraId::from(6),
-            101,
-            v1_3_0,
-            false,
-            verifiable_chunked_hash_activation,
-            None,
-        )
-        .take_header();
-
-        // The new block's protocol version is the current one, 1.3.0.
-        check_block_version(&header, v1_3_0).expect("versions are valid");
-
-        // If the current version is only 1.2.0 but the block's is 1.3.0, we have to upgrade.
-        match check_block_version(&header, v1_2_0) {
-            Err(Error::RetrievedBlockHeaderFromFutureVersion {
-                current_version,
-                block_header_with_future_version,
-            }) => {
-                assert_eq!(v1_2_0, current_version);
-                assert_eq!(header, *block_header_with_future_version);
-            }
-            result => panic!("expected future block version error, got {:?}", result),
-        }
     }
 
     #[test]

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -260,31 +260,31 @@ impl<'a, REv> ChainSyncContext<'a, REv> {
 /// Restrict the fan-out for a trie being retrieved by chunks to query at most 10 peers at a time.
 const TRIE_CHUNK_FETCH_FAN_OUT: usize = 10;
 
-/// Allows us to decide whether joiner peers can also be used when calling `fetch_retry_forever`.
-trait CanUseJoiners {
-    fn can_use_joiners() -> bool {
+/// Allows us to decide whether syncing peers can also be used when calling `fetch_retry_forever`.
+trait CanUseSyncingNodes {
+    fn can_use_syncing_nodes() -> bool {
         true
     }
 }
 
-/// Tries and trie chunks can only be retrieved from non-joining peers to avoid joining nodes
+/// Tries and trie chunks can only be retrieved from non-syncing peers to avoid syncing nodes
 /// deadlocking while requesting these from each other.
-impl CanUseJoiners for TrieOrChunk {
-    fn can_use_joiners() -> bool {
+impl CanUseSyncingNodes for TrieOrChunk {
+    fn can_use_syncing_nodes() -> bool {
         false
     }
 }
 
-/// All other `Item` types can safely be retrieved from joiner peers, as there is no networking
+/// All other `Item` types can safely be retrieved from syncing peers, as there is no networking
 /// backpressure implemented for these fetch requests.
-impl CanUseJoiners for BlockHeader {}
-impl CanUseJoiners for Block {}
-impl CanUseJoiners for Deploy {}
-impl CanUseJoiners for BlockAndDeploys {}
-impl CanUseJoiners for BlockHeadersBatch {}
+impl CanUseSyncingNodes for BlockHeader {}
+impl CanUseSyncingNodes for Block {}
+impl CanUseSyncingNodes for Deploy {}
+impl CanUseSyncingNodes for BlockAndDeploys {}
+impl CanUseSyncingNodes for BlockHeadersBatch {}
 
-/// Returns fully-connected, non-joiner peers that are known to be not banned.
-async fn get_filtered_fully_connected_non_joiner_peers<REv>(
+/// Returns fully-connected, non-syncing peers that are known to be not banned.
+async fn get_filtered_fully_connected_non_syncing_peers<REv>(
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Vec<NodeId>
 where
@@ -292,13 +292,13 @@ where
 {
     let mut peer_list = ctx
         .effect_builder
-        .get_fully_connected_non_joiner_peers()
+        .get_fully_connected_non_syncing_peers()
         .await;
     ctx.filter_bad_peers(&mut peer_list);
     peer_list
 }
 
-/// Returns fully-connected, joiner and non-joiner peers that are known to be not banned.
+/// Returns fully-connected, syncing and non-syncing peers that are known to be not banned.
 async fn get_filtered_fully_connected_peers<REv>(ctx: &ChainSyncContext<'_, REv>) -> Vec<NodeId>
 where
     REv: From<NetworkInfoRequest>,
@@ -312,15 +312,15 @@ where
 /// header or block by height, which require verification with finality signatures.
 async fn fetch_retry_forever<REv, T>(ctx: &ChainSyncContext<'_, REv>, id: T::Id) -> FetchResult<T>
 where
-    T: Item + CanUseJoiners + 'static,
+    T: Item + CanUseSyncingNodes + 'static,
     REv: From<FetcherRequest<T>> + From<NetworkInfoRequest>,
 {
     let mut attempts = 0_usize;
     loop {
-        let new_peer_list = if T::can_use_joiners() {
+        let new_peer_list = if T::can_use_syncing_nodes() {
             get_filtered_fully_connected_peers(ctx).await
         } else {
-            get_filtered_fully_connected_non_joiner_peers(ctx).await
+            get_filtered_fully_connected_non_syncing_peers(ctx).await
         };
 
         if new_peer_list.is_empty() && attempts % 100 == 0 {
@@ -328,7 +328,7 @@ where
                 attempts,
                 item_type = ?T::TAG,
                 ?id,
-                can_use_joiners = %T::can_use_joiners(),
+                can_use_syncing_nodes = %T::can_use_syncing_nodes(),
                 "failed to attempt to fetch item due to no fully-connected peers"
             );
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1640,7 +1640,7 @@ impl BlockSignaturesCollector {
             .check_if_sufficient(&validator_weights, ctx.config.finality_threshold_fraction())
             .is_ok()
         {
-            info!(
+            debug!(
                 block_header_hash =
                     ?block_header.hash(ctx.config.verifiable_chunked_hash_activation()),
                 height = block_header.height(),

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -493,7 +493,7 @@ impl ProgressHolder {
 }
 
 /// This impl is specific to functionality used for `debug_assert`s.
-#[cfg(debug_assertions)]
+#[cfg_attr(not(debug_assertions), allow(unused))]
 impl ProgressHolder {
     pub(super) fn is_fast_sync(&self) -> bool {
         matches!(*self.inner.lock().unwrap(), Progress::FastSync(_))

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -1,0 +1,526 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use casper_hashing::Digest;
+
+use crate::types::BlockHash;
+
+/// The reason for syncing the trie store under a given state root hash.
+//
+// Note: this is used when calling `sync_trie_store`.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+pub enum FetchingTriesReason {
+    /// Performing a trie-store sync during fast-sync before moving to the "execute forwards"
+    /// phase.
+    #[serde(rename = "for fast sync")]
+    FastSync,
+    /// Performing a trie-store sync during fast-sync before performing an emergency upgrade.
+    #[serde(rename = "preparing for emergency upgrade")]
+    EmergencyUpgrade,
+    /// Performing a trie-store sync during fast-sync before performing an upgrade.
+    #[serde(rename = "preparing for upgrade")]
+    Upgrade,
+}
+
+/// The progress of the fast-sync task, performed by all nodes while in joining mode.
+///
+/// The fast-sync task generally progresses from each variant to the next linearly.  An exception is
+/// that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and
+/// possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then
+/// executing.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FastSync {
+    /// Fast-syncing has not started yet.
+    #[serde(rename = "not yet started")]
+    NotYetStarted,
+    /// Initial setup is being performed.
+    Starting,
+    /// Currently fetching the trusted block header.
+    FetchingTrustedBlockHeader(BlockHash),
+    /// Currently syncing the trie-store under the given state root hash.
+    #[serde(rename = "fetching_global_state_under_given_block")]
+    FetchingTries {
+        /// The height of the block containing the given state root hash.
+        block_height: u64,
+        /// The global state root hash.
+        state_root_hash: Digest,
+        /// The reason for syncing the trie-store.
+        reason: FetchingTriesReason,
+        /// The number of remaining tries to fetch (this value can rise and fall as the task
+        /// proceeds).
+        #[serde(rename = "number_of_remaining_tries_to_fetch")]
+        num_tries_to_fetch: usize,
+    },
+    /// Currently fetching the block at the given height and its deploys in preparation for
+    /// executing it.
+    #[serde(rename = "fetching_block_and_deploys_at_given_block_height_before_execution")]
+    FetchingBlockAndDeploysToExecute(u64),
+    /// Currently executing the block at the given height.
+    #[serde(rename = "executing_block_at_height")]
+    ExecutingBlock(u64),
+    /// Currently retrying the execution of the block at the given height, due to an unexpected
+    /// mismatch in the previous execution result (due to a mismatch in the deploys' approvals).
+    RetryingBlockExecution {
+        /// The height of the block being executed.
+        block_height: u64,
+        /// The retry attempt number.
+        attempt: usize,
+    },
+    /// Fast-syncing has finished, and the node will shortly transition to participating mode.
+    Finished,
+}
+
+/// The progress of a single sync-block task, many of which are performed in parallel during
+/// sync-to-genesis.
+///
+/// The task progresses from each variant to the next linearly.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+pub enum SyncBlockFetching {
+    /// Currently fetching the block and all its deploys.
+    #[serde(rename = "block and deploys")]
+    BlockAndDeploys,
+    /// Currently syncing the trie-store under the state root hash held in the block.
+    #[serde(rename = "global_state_under_given_block")]
+    Tries {
+        /// The global state root hash.
+        state_root_hash: Digest,
+        /// The number of remaining tries to fetch (this value can rise and fall as the task
+        /// proceeds).
+        #[serde(rename = "number_of_remaining_tries_to_fetch")]
+        num_tries_to_fetch: usize,
+    },
+    /// Currently fetching the block's signatures.
+    #[serde(rename = "block signatures")]
+    BlockSignatures,
+}
+
+/// Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the
+/// relative block.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SyncBlock {
+    /// The height of the block being synced.
+    block_height: u64,
+    /// The progress of the sync-block task.
+    fetching: SyncBlockFetching,
+}
+
+/// The progress of the sync-to-genesis task, only performed by nodes configured to do this, and
+/// performed by them while in participating mode.
+///
+/// The sync-to-genesis task progresses from each variant to the next linearly.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncToGenesis {
+    /// Syncing-to-genesis has not started yet.
+    #[serde(rename = "not yet started")]
+    NotYetStarted,
+    /// Initial setup is being performed.
+    Starting,
+    /// Currently fetching block headers in batches back towards the genesis block.
+    FetchingHeadersBackToGenesis {
+        /// The current lowest block header retrieved by this fetch-headers-to-genesis task.
+        lowest_block_height: u64,
+    },
+    /// Currently syncing all blocks from genesis towards the tip of the chain.
+    ///
+    /// This is done via many parallel sync-block tasks, with each such ongoing task being
+    /// represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.
+    SyncingForwardFromGenesis(Vec<SyncBlock>),
+    /// Syncing-to-genesis has finished.
+    Finished,
+}
+
+/// The progress of the chain-synchronizer task.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, JsonSchema)]
+#[serde(untagged)]
+pub enum Progress {
+    /// The chain-synchronizer is performing the fast-sync task.
+    FastSync(FastSync),
+    /// The chain-synchronizer is performing the sync-to-genesis task.
+    SyncToGenesis(SyncToGenesis),
+}
+
+impl Progress {
+    pub(super) fn is_finished(&self) -> bool {
+        match self {
+            Progress::FastSync(progress) => *progress == FastSync::Finished,
+            Progress::SyncToGenesis(progress) => *progress == SyncToGenesis::Finished,
+        }
+    }
+}
+
+#[derive(Clone, DataSize, Debug)]
+pub(super) struct ProgressHolder {
+    inner: Arc<Mutex<Progress>>,
+}
+
+/// This impl is specific to fast-sync progress.
+impl ProgressHolder {
+    pub(super) fn new_fast_sync() -> Self {
+        ProgressHolder {
+            inner: Arc::new(Mutex::new(Progress::FastSync(FastSync::NotYetStarted))),
+        }
+    }
+
+    pub(super) fn start_fetching_trusted_block_header(&self, trusted_hash: BlockHash) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_trusted_block_header");
+        *inner = Progress::FastSync(FastSync::FetchingTrustedBlockHeader(trusted_hash));
+    }
+
+    pub(super) fn start_fetching_tries_for_fast_sync(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_fast_sync");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::FastSync,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_tries_for_emergency_upgrade(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_emergency_upgrade");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::EmergencyUpgrade,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_tries_for_upgrade(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_upgrade");
+        *inner = Progress::FastSync(FastSync::FetchingTries {
+            block_height,
+            state_root_hash,
+            reason: FetchingTriesReason::Upgrade,
+            num_tries_to_fetch: 0,
+        });
+    }
+
+    pub(super) fn start_fetching_block_and_deploys_to_execute(&self, block_height: u64) {
+        let mut inner = self.get_inner_while_fast_syncing("fetching_block_and_deploys_to_execute");
+        *inner = Progress::FastSync(FastSync::FetchingBlockAndDeploysToExecute(block_height));
+    }
+
+    pub(super) fn start_executing_block(&self, block_height: u64) {
+        let mut inner = self.get_inner_while_fast_syncing("executing_block");
+        *inner = Progress::FastSync(FastSync::ExecutingBlock(block_height));
+    }
+
+    pub(super) fn retry_executing_block(&self, block_height: u64, attempt: usize) {
+        let mut inner = self.get_inner_while_fast_syncing("retrying_execute_block");
+        *inner = Progress::FastSync(FastSync::RetryingBlockExecution {
+            block_height,
+            attempt,
+        });
+    }
+
+    fn get_inner_while_fast_syncing(&self, new_state: &str) -> MutexGuard<Progress> {
+        let inner = self.inner.lock().unwrap();
+        match *inner {
+            Progress::SyncToGenesis(_) => {
+                error!(
+                    current_progress=?inner,
+                    "should be fast syncing if setting progress to {}",
+                    new_state
+                );
+            }
+            Progress::FastSync(_) => (),
+        }
+        inner
+    }
+}
+
+/// This impl is specific to sync-to-genesis progress.
+impl ProgressHolder {
+    pub(super) fn new_sync_to_genesis() -> Self {
+        ProgressHolder {
+            inner: Arc::new(Mutex::new(Progress::SyncToGenesis(
+                SyncToGenesis::NotYetStarted,
+            ))),
+        }
+    }
+
+    pub(super) fn set_fetching_headers_back_to_genesis(&self, lowest_block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        *inner = Progress::SyncToGenesis(SyncToGenesis::FetchingHeadersBackToGenesis {
+            lowest_block_height,
+        })
+    }
+
+    pub(super) fn start_syncing_block_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        if !matches!(
+            inner,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(_))
+        ) {
+            *inner = Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(Vec::new()))
+        }
+
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching block"
+                );
+                return;
+            };
+
+        match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+            Ok(_) => error!(
+                %block_height,
+                existing_progress=?tasks,
+                "expected to only start fetching block and deploys once"
+            ),
+            Err(index) => tasks.insert(
+                index,
+                SyncBlock {
+                    block_height,
+                    fetching: SyncBlockFetching::BlockAndDeploys,
+                },
+            ),
+        }
+    }
+
+    pub(super) fn start_fetching_tries_for_sync_forward(
+        &self,
+        block_height: u64,
+        state_root_hash: Digest,
+    ) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching tries"
+                );
+                return;
+            };
+
+        let existing_progress =
+            match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                Ok(index) => tasks.get_mut(index).expect("just found index"),
+                Err(_) => {
+                    error!(
+                        %block_height,
+                        current_progress=?inner,
+                        "should be syncing this block if setting progress to fetching tries"
+                    );
+                    return;
+                }
+            };
+
+        if !matches!(
+            existing_progress.fetching,
+            SyncBlockFetching::BlockAndDeploys { .. }
+        ) {
+            error!(
+                %block_height,
+                current_progress=?existing_progress,
+                "should be fetching block and deploys if setting progress to fetching tries"
+            );
+        }
+        existing_progress.fetching = SyncBlockFetching::Tries {
+            state_root_hash,
+            num_tries_to_fetch: 0,
+        };
+    }
+
+    pub(super) fn start_fetching_block_signatures_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if setting progress to fetching block \
+                    signatures"
+                );
+                return;
+            };
+
+        let existing_progress =
+            match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                Ok(index) => tasks.get_mut(index).expect("just found index"),
+                Err(_) => {
+                    error!(
+                        %block_height,
+                        current_progress=?inner,
+                        "should be syncing this block if setting progress to fetching block \
+                        signatures"
+                    );
+                    return;
+                }
+            };
+
+        if !matches!(existing_progress.fetching, SyncBlockFetching::Tries { .. }) {
+            error!(
+                %block_height,
+                current_progress=?existing_progress,
+                "should be fetching tries if setting progress to fetching block signatures"
+            );
+        }
+        existing_progress.fetching = SyncBlockFetching::BlockSignatures;
+    }
+
+    pub(super) fn finish_syncing_block_for_sync_forward(&self, block_height: u64) {
+        let inner = &mut *self.inner.lock().unwrap();
+        let tasks =
+            if let Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) = inner
+            {
+                tasks
+            } else {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing forward from genesis if finishing sync block"
+                );
+                return;
+            };
+
+        match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+            Ok(index) => {
+                let existing_progress = tasks.remove(index);
+                if !matches!(
+                    existing_progress.fetching,
+                    SyncBlockFetching::BlockSignatures
+                ) {
+                    error!(
+                        %block_height,
+                        current_progress=?existing_progress,
+                        "should be fetching block signatures if finishing sync block"
+                    );
+                }
+            }
+            Err(_) => {
+                error!(
+                    %block_height,
+                    current_progress=?inner,
+                    "should be syncing this block if finishing sync block"
+                );
+            }
+        }
+    }
+}
+
+/// This impl has functionality common to fast-sync and sync-to-genesis.
+impl ProgressHolder {
+    pub(super) fn start(&self) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(progress) => *progress = FastSync::Starting,
+            Progress::SyncToGenesis(progress) => *progress = SyncToGenesis::Starting,
+        }
+    }
+
+    pub(super) fn set_num_tries_to_fetch(&self, block_height: u64, num_tries: usize) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(FastSync::FetchingTries {
+                num_tries_to_fetch, ..
+            }) => *num_tries_to_fetch = num_tries,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) => {
+                match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                    Ok(index) => {
+                        if let Some(SyncBlock {
+                            fetching:
+                                SyncBlockFetching::Tries {
+                                    num_tries_to_fetch, ..
+                                },
+                            ..
+                        }) = tasks.get_mut(index)
+                        {
+                            *num_tries_to_fetch = num_tries;
+                        } else {
+                            error!(
+                                block_height,
+                                "not currently fetching tries for this block during sync to genesis"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        error!(
+                            block_height,
+                            "not currently syncing block during sync to genesis"
+                        );
+                    }
+                }
+            }
+            _ => error!(
+                block_height,
+                "failed to set num tries to fetch as not currently syncing"
+            ),
+        }
+    }
+
+    pub(super) fn finish(&self) {
+        match &mut *self.inner.lock().unwrap() {
+            Progress::FastSync(progress) => *progress = FastSync::Finished,
+            Progress::SyncToGenesis(progress) => *progress = SyncToGenesis::Finished,
+        }
+    }
+
+    pub(super) fn progress(&self) -> Progress {
+        self.inner.lock().unwrap().clone()
+    }
+}
+
+/// This impl is specific to functionality used for `debug_assert`s.
+#[cfg(debug_assertions)]
+impl ProgressHolder {
+    pub(super) fn is_fast_sync(&self) -> bool {
+        matches!(*self.inner.lock().unwrap(), Progress::FastSync(_))
+    }
+
+    pub(super) fn is_sync_to_genesis(&self) -> bool {
+        matches!(*self.inner.lock().unwrap(), Progress::SyncToGenesis(_))
+    }
+
+    pub(super) fn is_fetching_tries(&self, block_height: u64) -> bool {
+        match &*self.inner.lock().unwrap() {
+            Progress::FastSync(FastSync::FetchingTries { .. }) => true,
+            Progress::SyncToGenesis(SyncToGenesis::SyncingForwardFromGenesis(tasks)) => {
+                match tasks.binary_search_by(|task| task.block_height.cmp(&block_height)) {
+                    Ok(index) => {
+                        matches!(
+                            tasks.get(index),
+                            Some(SyncBlock {
+                                fetching: SyncBlockFetching::Tries { .. },
+                                ..
+                            })
+                        )
+                    }
+                    Err(_) => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -336,7 +336,7 @@ mod tests {
         //   and `finality_threshold_fraction` = 1/3 (~=  6.666)
         //   and the `quorum fraction` = 2/3         (~= 13.333)
         //
-        // we need signaturess of weight:
+        // we need signatures of weight:
         //   - 13 or less for `InsufficientWeightForFinality`
         //   - 14 for Ok
         //   - 15 or more for `TooManySignatures`
@@ -411,7 +411,7 @@ mod tests {
         //   and `finality_threshold_fraction` = 1/3 (~= 6.666)
         //   and the `quorum fraction` = 1/3         (~= 6.666)
         //
-        // we need signaturess of weight:
+        // we need signatures of weight:
         //   - 6 or less for `InsufficientWeightForFinality`
         //   - 7 for Ok
         //   - 8 or more for `TooManySignatures`

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -774,6 +774,7 @@ where
             Message::Payload(payload) => {
                 effect_builder.announce_incoming(peer_id, payload).ignore()
             }
+            Message::SyncStateChanged => todo!(),
         })
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -702,6 +702,9 @@ where
                     .mark_outgoing(now)
                 {
                     self.connection_completed(peer_id);
+
+                    // By default, we assume that newly connecting peer is joiner.
+                    self.update_syncing_nodes_set(peer_id, true);
                 }
 
                 effects.extend(
@@ -795,7 +798,7 @@ where
             }
             Message::SyncFinished => {
                 info!(%peer_id, "peer reported sync finished");
-                self.update_syncing_set(peer_id, false);
+                self.update_syncing_nodes_set(peer_id, false);
                 Effects::new()
             }
         })
@@ -809,7 +812,7 @@ where
 
     /// Updates a set of known joining nodes.
     /// If we've just connected to a non-joining node that peer will be removed from the set.
-    fn update_syncing_set(&mut self, peer_id: NodeId, is_syncing: bool) {
+    fn update_syncing_nodes_set(&mut self, peer_id: NodeId, is_syncing: bool) {
         // Update set of syncing peers.
         if is_syncing {
             self.syncing_nodes.insert(peer_id);

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1093,8 +1093,8 @@ where
             }
             Event::SyncFinished => {
                 info!("notifying peers that chain sync has finished");
-                self.broadcast_message(Arc::new(Message::SyncFinished));
                 self.synchronization_in_progress = false;
+                self.broadcast_message(Arc::new(Message::SyncFinished));
                 Effects::new()
             }
         }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -772,7 +772,11 @@ where
             Message::Payload(payload) => {
                 effect_builder.announce_incoming(peer_id, payload).ignore()
             }
-            Message::SyncStateChanged => todo!(),
+            Message::SyncStateChanged => {
+                // TODO[RC]: Mark peer as non joiner
+                self.update_joining_set(peer_id, false);
+                Effects::new()
+            }
         })
     }
 
@@ -1066,6 +1070,12 @@ where
                 );
 
                 effects
+            }
+            Event::SyncStateFinished => {
+                // TODO[RC]: Update internal flag
+                self.net_metrics.broadcast_requests.inc();
+                self.broadcast_message(Arc::new(Message::SyncStateChanged));
+                Effects::new()
             }
         }
     }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -303,7 +303,6 @@ where
             consensus_keys,
             handshake_timeout: cfg.handshake_timeout,
             payload_weights: cfg.estimator_weights.clone(),
-            reject_incompatible_versions: cfg.reject_incompatible_versions,
             tarpit_version_threshold: cfg.tarpit_version_threshold,
             tarpit_duration: cfg.tarpit_duration,
             tarpit_chance: cfg.tarpit_chance,
@@ -602,7 +601,9 @@ where
             | ConnectionError::InvalidConsensusCertificate(_) => false,
 
             // Definitely something we want to avoid.
-            ConnectionError::WrongNetwork(_) | ConnectionError::WrongChainspecHash => true,
+            ConnectionError::WrongNetwork(_)
+            | ConnectionError::WrongChainspecHash(_)
+            | ConnectionError::MissingChainspecHash => true,
         }
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -512,7 +512,7 @@ where
                     self.connection_completed(peer_id);
 
                     // By default, we assume that the peer is syncing. It'll send us the
-                    // `SyncStateChanged` message in case it isn't.
+                    // `SyncFinished` message in case it isn't.
                     self.update_joining_set(peer_id, true);
                 }
 
@@ -522,7 +522,7 @@ where
                 // component.
                 if !self.chain_sync_in_progress {
                     info!("telling the newly connected peer that we already finished syncing");
-                    self.send_message(peer_id, Arc::new(Message::SyncStateChanged), None);
+                    self.send_message(peer_id, Arc::new(Message::SyncFinished), None);
                 }
 
                 // Now we can start the message reader.
@@ -689,7 +689,7 @@ where
                 }
 
                 // By default, we assume that the peer is syncing. It'll send us the
-                // `SyncStateChanged` message in case it isn't.
+                // `SyncFinished` message in case it isn't.
                 //
                 // TODO[RC]: Rename `remote_joiner_id` to make it clear it is related to "syncing".
                 let remote_joiner_id = Some((peer_addr, peer_id));
@@ -784,7 +784,7 @@ where
             Message::Payload(payload) => {
                 effect_builder.announce_incoming(peer_id, payload).ignore()
             }
-            Message::SyncStateChanged => {
+            Message::SyncFinished => {
                 info!(%peer_id, "peer reported sync finished");
                 self.update_joining_set(peer_id, false);
                 Effects::new()
@@ -1083,10 +1083,10 @@ where
 
                 effects
             }
-            Event::SyncStateFinished => {
+            Event::SyncFinished => {
                 info!("notifying peers that chain sync has finished");
                 self.net_metrics.broadcast_requests.inc();
-                self.broadcast_message(Arc::new(Message::SyncStateChanged));
+                self.broadcast_message(Arc::new(Message::SyncFinished));
                 self.chain_sync_in_progress = false;
                 Effects::new()
             }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -97,7 +97,9 @@ use self::{
 use crate::{
     components::{consensus, Component},
     effect::{
-        announcements::{BlocklistAnnouncement, ContractRuntimeAnnouncement},
+        announcements::{
+            BlocklistAnnouncement, ChainSynchronizerAnnouncement, ContractRuntimeAnnouncement,
+        },
         requests::{BeginGossipRequest, NetworkInfoRequest, NetworkRequest, StorageRequest},
         AutoClosingResponder, EffectBuilder, EffectExt, Effects,
     },
@@ -1094,7 +1096,7 @@ where
 
                 effects
             }
-            Event::SyncFinished => {
+            Event::ChainSynchronizerAnnouncement(ChainSynchronizerAnnouncement::SyncFinished) => {
                 info!("notifying peers that chain sync has finished");
                 self.synchronization_in_progress = false;
                 self.broadcast_message(Arc::new(Message::SyncFinished));

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -602,7 +602,7 @@ where
             | ConnectionError::InvalidConsensusCertificate(_) => false,
 
             // Definitely something we want to avoid.
-            ConnectionError::WrongNetwork(_) => true,
+            ConnectionError::WrongNetwork(_) | ConnectionError::WrongChainspecHash => true,
         }
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -376,6 +376,7 @@ where
 
     /// Queues a message to be sent to all nodes.
     fn broadcast_message(&self, msg: Arc<Message<P>>) {
+        self.net_metrics.broadcast_requests.inc();
         for peer_id in self.outgoing_manager.connected_peers() {
             self.send_message(peer_id, msg.clone(), None);
         }
@@ -944,7 +945,6 @@ where
                         auto_closing_responder,
                     } => {
                         // We're given a message to broadcast.
-                        self.net_metrics.broadcast_requests.inc();
                         self.broadcast_message(Arc::new(Message::Payload(*payload)));
                         auto_closing_responder.respond(()).ignore()
                     }
@@ -1093,7 +1093,6 @@ where
             }
             Event::SyncFinished => {
                 info!("notifying peers that chain sync has finished");
-                self.net_metrics.broadcast_requests.inc();
                 self.broadcast_message(Arc::new(Message::SyncFinished));
                 self.synchronization_in_progress = false;
                 Effects::new()

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -703,7 +703,7 @@ where
                 {
                     self.connection_completed(peer_id);
 
-                    // By default, we assume that newly connecting peer is joiner.
+                    // By default, we assume that newly connecting peer is syncing.
                     self.update_syncing_nodes_set(peer_id, true);
                 }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -342,6 +342,7 @@ where
             incoming_limiter,
             // We start with an empty set of validators for era 0 and expect to be updated.
             active_era: EraId::new(0),
+            // Initially, we assume that we are in the sync process.
             chain_sync_in_progress: true,
         };
 
@@ -516,7 +517,7 @@ where
                     self.update_joining_set(peer_id, true);
                 }
 
-                // Tell the peer that we have finished syncing, because he'll asssume he's
+                // Tell the peer that we have finished syncing because it'll assume it's
                 // connecting to a node that is still syncing. If we're actually
                 // still syncing, the peer will be notified later by the chain synchronizer
                 // component.

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -5,6 +5,7 @@
 
 use std::net::SocketAddr;
 
+use casper_hashing::Digest;
 use casper_types::ProtocolVersion;
 use datasize::DataSize;
 
@@ -27,16 +28,20 @@ pub(crate) struct ChainInfo {
     pub(super) maximum_net_message_size: u32,
     /// The protocol version.
     pub(super) protocol_version: ProtocolVersion,
+    /// The hash of the chainspec.
+    pub(super) chainspec_hash: Digest,
 }
 
 impl ChainInfo {
     /// Create an instance of `ChainInfo` for testing.
     #[cfg(test)]
     pub fn create_for_testing() -> Self {
+        let network_name = "rust-tests-network";
         ChainInfo {
-            network_name: "rust-tests-network".to_string(),
+            network_name: network_name.to_string(),
             maximum_net_message_size: 22 * 1024 * 1024, // Hardcoded at 22M.
             protocol_version: ProtocolVersion::V1_0_0,
+            chainspec_hash: Digest::hash(format!("{}-chainspec", network_name)),
         }
     }
 
@@ -55,6 +60,7 @@ impl ChainInfo {
             consensus_certificate: consensus_keys
                 .map(|key_pair| ConsensusCertificate::create(connection_id, key_pair)),
             is_joiner,
+            chainspec_hash: Some(self.chainspec_hash),
         }
     }
 }
@@ -65,6 +71,7 @@ impl From<&Chainspec> for ChainInfo {
             network_name: chainspec.network_config.name.clone(),
             maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
             protocol_version: chainspec.protocol_version(),
+            chainspec_hash: chainspec.hash(),
         }
     }
 }

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -46,6 +46,7 @@ impl ChainInfo {
         public_addr: SocketAddr,
         consensus_keys: Option<&ConsensusKeyPair>,
         connection_id: ConnectionId,
+        is_syncing: bool,
     ) -> Message<P> {
         Message::Handshake {
             network_name: self.network_name.clone(),
@@ -53,6 +54,7 @@ impl ChainInfo {
             protocol_version: self.protocol_version,
             consensus_certificate: consensus_keys
                 .map(|key_pair| ConsensusCertificate::create(connection_id, key_pair)),
+            is_syncing,
         }
     }
 }

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -46,7 +46,6 @@ impl ChainInfo {
         public_addr: SocketAddr,
         consensus_keys: Option<&ConsensusKeyPair>,
         connection_id: ConnectionId,
-        is_joiner: bool,
     ) -> Message<P> {
         Message::Handshake {
             network_name: self.network_name.clone(),
@@ -54,7 +53,6 @@ impl ChainInfo {
             protocol_version: self.protocol_version,
             consensus_certificate: consensus_keys
                 .map(|key_pair| ConsensusCertificate::create(connection_id, key_pair)),
-            is_joiner,
         }
     }
 }

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -44,7 +44,6 @@ impl Default for Config {
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
-            reject_incompatible_versions: true,
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
@@ -83,8 +82,6 @@ pub struct Config {
     pub max_incoming_message_rate_non_validators: u32,
     /// Weight distribution for the payload impact estimator.
     pub estimator_weights: EstimatorWeights,
-    /// Whether or not to reject incompatible versions during handshake.
-    pub reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -189,6 +189,9 @@ pub enum ConnectionError {
     /// This is usually a bug.
     #[error("handshake sink/stream could not be reunited")]
     FailedToReuniteHandshakeSinkAndStream,
+    /// Peer is running a different chainspec.
+    #[error("peer is on different chainspec")]
+    WrongChainspecHash,
 }
 
 /// IO operation that can time out or close.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -1,5 +1,6 @@
 use std::{error, io, net::SocketAddr, result, sync::Arc};
 
+use casper_hashing::Digest;
 use casper_types::{crypto, ProtocolVersion, SecretKey};
 use datasize::DataSize;
 use openssl::{error::ErrorStack, ssl};
@@ -151,6 +152,13 @@ pub enum ConnectionError {
     /// Peer reported an incompatible version.
     #[error("peer is running incompatible version: {0}")]
     IncompatibleVersion(ProtocolVersion),
+    /// Peer is using a different chainspec.
+    #[error("peer is using a different chainspec, hash: {0}")]
+    WrongChainspecHash(Digest),
+    /// Peer should have included the chainspec hash in the handshake message,
+    /// but didn't.
+    #[error("peer did not include mandatory chainspec hash in the handshake")]
+    MissingChainspecHash,
     /// Peer did not send any message, or a non-handshake as its first message.
     #[error("peer did not send handshake")]
     DidNotSendHandshake,
@@ -189,9 +197,6 @@ pub enum ConnectionError {
     /// This is usually a bug.
     #[error("handshake sink/stream could not be reunited")]
     FailedToReuniteHandshakeSinkAndStream,
-    /// Peer is running a different chainspec.
-    #[error("peer is on different chainspec")]
-    WrongChainspecHash,
 }
 
 /// IO operation that can time out or close.

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -157,7 +157,7 @@ pub enum ConnectionError {
     WrongChainspecHash(Digest),
     /// Peer should have included the chainspec hash in the handshake message,
     /// but didn't.
-    #[error("peer did not include mandatory chainspec hash in the handshake")]
+    #[error("peer did not include chainspec hash in the handshake when it was required")]
     MissingChainspecHash,
     /// Peer did not send any message, or a non-handshake as its first message.
     #[error("peer did not send handshake")]

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -95,6 +95,9 @@ pub(crate) enum Event<P> {
     /// Contract runtime announcement.
     #[from]
     ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
+
+    #[from]
+    SyncStateFinished,
 }
 
 impl From<NetworkRequest<ProtocolMessage>> for Event<ProtocolMessage> {
@@ -144,6 +147,7 @@ impl<P: Display> Display for Event<P> {
             Event::SweepOutgoing => {
                 write!(f, "sweep outgoing connections")
             }
+            Event::SyncStateFinished => write!(f, "syncing finished"),
         }
     }
 }

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -182,8 +182,6 @@ pub(crate) enum IncomingConnection<P> {
         /// Stream of incoming messages. for incoming connections.
         #[serde(skip_serializing)]
         stream: SplitStream<FullTransport<P>>,
-        /// Flag indicating whether we've established a connection to a joining node.
-        is_joiner: bool,
     },
 }
 
@@ -205,12 +203,11 @@ impl<P> Display for IncomingConnection<P> {
                 peer_id,
                 peer_consensus_public_key,
                 stream: _,
-                is_joiner,
             } => {
                 write!(
                     f,
-                    "connection established from {}/{}; public: {}, joiner: {}",
-                    peer_addr, peer_id, public_addr, is_joiner,
+                    "connection established from {}/{}; public: {}",
+                    peer_addr, peer_id, public_addr
                 )?;
 
                 if let Some(public_key) = peer_consensus_public_key {
@@ -255,8 +252,6 @@ pub(crate) enum OutgoingConnection<P> {
         /// Sink for outgoing messages.
         #[serde(skip_serializing)]
         sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
-        /// Flag indicating whether the peer we've connected to is a joining node.
-        is_joiner: bool,
     },
 }
 
@@ -277,13 +272,8 @@ impl<P> Display for OutgoingConnection<P> {
                 peer_id,
                 peer_consensus_public_key,
                 sink: _,
-                is_joiner,
             } => {
-                write!(
-                    f,
-                    "connection established to {}/{}, joiner: {}",
-                    peer_addr, peer_id, is_joiner
-                )?;
+                write!(f, "connection established to {}/{}", peer_addr, peer_id)?;
 
                 if let Some(public_key) = peer_consensus_public_key {
                     write!(f, " [{}]", public_key)

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -15,7 +15,9 @@ use tracing::Span;
 use super::{error::ConnectionError, FullTransport, GossipedAddress, Message, NodeId};
 use crate::{
     effect::{
-        announcements::{BlocklistAnnouncement, ContractRuntimeAnnouncement},
+        announcements::{
+            BlocklistAnnouncement, ChainSynchronizerAnnouncement, ContractRuntimeAnnouncement,
+        },
         requests::{NetworkInfoRequest, NetworkRequest},
     },
     protocol::Message as ProtocolMessage,
@@ -96,8 +98,9 @@ pub(crate) enum Event<P> {
     #[from]
     ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
 
-    /// The chain synchronization process has finished.
-    SyncFinished,
+    /// Chain synchronizer announcement.
+    #[from]
+    ChainSynchronizerAnnouncement(ChainSynchronizerAnnouncement),
 }
 
 impl From<NetworkRequest<ProtocolMessage>> for Event<ProtocolMessage> {
@@ -147,7 +150,9 @@ impl<P: Display> Display for Event<P> {
             Event::SweepOutgoing => {
                 write!(f, "sweep outgoing connections")
             }
-            Event::SyncFinished => write!(f, "syncing finished"),
+            Event::ChainSynchronizerAnnouncement(ann) => {
+                write!(f, "handling chain synchronizer announcement: {}", ann)
+            }
         }
     }
 }

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -261,6 +261,8 @@ pub(crate) enum OutgoingConnection<P> {
         /// Sink for outgoing messages.
         #[serde(skip_serializing)]
         sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
+        /// Holds the information whether the remote node is syncing.
+        is_syncing: bool,
     },
 }
 
@@ -281,8 +283,13 @@ impl<P> Display for OutgoingConnection<P> {
                 peer_id,
                 peer_consensus_public_key,
                 sink: _,
+                is_syncing,
             } => {
-                write!(f, "connection established to {}/{}", peer_addr, peer_id)?;
+                write!(
+                    f,
+                    "connection established to {}/{}, is_syncing: {}",
+                    peer_addr, peer_id, is_syncing
+                )?;
 
                 if let Some(public_key) = peer_consensus_public_key {
                     write!(f, " [{}]", public_key)

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -96,7 +96,7 @@ pub(crate) enum Event<P> {
     #[from]
     ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
 
-    #[from]
+    /// The chain synchronization process has finished.
     SyncFinished,
 }
 

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -97,7 +97,7 @@ pub(crate) enum Event<P> {
     ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
 
     #[from]
-    SyncStateFinished,
+    SyncFinished,
 }
 
 impl From<NetworkRequest<ProtocolMessage>> for Event<ProtocolMessage> {
@@ -147,7 +147,7 @@ impl<P: Display> Display for Event<P> {
             Event::SweepOutgoing => {
                 write!(f, "sweep outgoing connections")
             }
-            Event::SyncStateFinished => write!(f, "syncing finished"),
+            Event::SyncFinished => write!(f, "syncing finished"),
         }
     }
 }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -38,9 +38,6 @@ pub(crate) enum Message<P> {
         /// A self-signed certificate indicating validator status.
         #[serde(default)]
         consensus_certificate: Option<ConsensusCertificate>,
-        /// Joiner node flag.
-        #[serde(default)]
-        is_joiner: bool,
     },
     Payload(P),
     /// Indicates that peer has finished its syncing process and should no longer be considered a
@@ -262,12 +259,11 @@ impl<P: Display> Display for Message<P> {
                 public_addr,
                 protocol_version,
                 consensus_certificate,
-                is_joiner,
             } => {
                 write!(
                     f,
-                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: , is_joiner: {}",
-                    network_name, public_addr, protocol_version, is_joiner
+                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: {:?}",
+                    network_name, public_addr, protocol_version, consensus_certificate
                 )?;
 
                 if let Some(cert) = consensus_certificate {
@@ -562,7 +558,6 @@ mod tests {
             public_addr: ([12, 34, 56, 78], 12346).into(),
             protocol_version: ProtocolVersion::from_parts(5, 6, 7),
             consensus_certificate: Some(ConsensusCertificate::random(&mut rng)),
-            is_joiner: false,
         };
 
         let legacy_handshake: V1_0_0_Message = roundtrip_message(&modern_handshake);
@@ -596,13 +591,11 @@ mod tests {
                 public_addr,
                 protocol_version,
                 consensus_certificate,
-                is_joiner,
             } => {
                 assert_eq!(network_name, "example-handshake");
                 assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
                 assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
                 assert!(consensus_certificate.is_none());
-                assert!(!is_joiner)
             }
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
@@ -623,13 +616,11 @@ mod tests {
                 public_addr,
                 protocol_version,
                 consensus_certificate,
-                is_joiner,
             } => {
                 assert_eq!(network_name, "serialization-test");
                 assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
                 assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
                 assert!(consensus_certificate.is_none());
-                assert!(!is_joiner);
             }
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
@@ -650,7 +641,6 @@ mod tests {
                 public_addr,
                 protocol_version,
                 consensus_certificate,
-                is_joiner,
             } => {
                 assert_eq!(network_name, "example-handshake");
                 assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
@@ -675,7 +665,6 @@ mod tests {
                     )
                     .unwrap()
                 );
-                assert!(!is_joiner)
             }
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
@@ -696,7 +685,6 @@ mod tests {
                 public_addr,
                 protocol_version,
                 consensus_certificate,
-                is_joiner,
             } => {
                 assert_eq!(network_name, "example-handshake");
                 assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
@@ -721,7 +709,6 @@ mod tests {
                     )
                     .unwrap()
                 );
-                assert!(!is_joiner);
             }
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -39,6 +39,7 @@ pub(crate) enum Message<P> {
         #[serde(default)]
         consensus_certificate: Option<ConsensusCertificate>,
         /// Holds the information whether the node is syncing.
+        #[serde(default)]
         is_syncing: bool,
     },
     Payload(P),

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -15,7 +15,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::{effect::EffectBuilder, types::NodeId};
+use crate::{effect::EffectBuilder, types::NodeId, utils::opt_display::OptDisplay};
 
 use super::counting_format::ConnectionId;
 
@@ -268,21 +268,14 @@ impl<P: Display> Display for Message<P> {
             } => {
                 write!(
                     f,
-                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: , is_joiner: {}, chainspec_hash: ",
-                    network_name, public_addr, protocol_version, is_joiner
-                )?;
-
-                if let Some(cert) = consensus_certificate {
-                    write!(f, "{}", cert)?;
-                } else {
-                    f.write_str("-")?;
-                }
-
-                if let Some(hash) = chainspec_hash {
-                    write!(f, "{}", hash)
-                } else {
-                    f.write_str("-")
-                }
+                    "handshake: {}, public addr: {}, protocol_version: {}, consensus_certificate: {}, is_joiner: {}, chainspec_hash: {}",
+                    network_name,
+                    public_addr,
+                    protocol_version,
+                    OptDisplay::new(consensus_certificate.as_ref(), "none"),
+                    is_joiner,
+                    OptDisplay::new(chainspec_hash.as_ref(), "none")
+                )
             }
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -42,7 +42,7 @@ pub(crate) enum Message<P> {
     Payload(P),
     /// Indicates that peer has finished its syncing process and should no longer be considered a
     /// "joiner".
-    SyncStateChanged,
+    SyncFinished,
 }
 
 impl<P: Payload> Message<P> {
@@ -50,7 +50,7 @@ impl<P: Payload> Message<P> {
     #[inline]
     pub(super) fn classify(&self) -> MessageKind {
         match self {
-            Message::Handshake { .. } | Message::SyncStateChanged => MessageKind::Protocol,
+            Message::Handshake { .. } | Message::SyncFinished => MessageKind::Protocol,
             Message::Payload(payload) => payload.classify(),
         }
     }
@@ -59,7 +59,7 @@ impl<P: Payload> Message<P> {
     #[inline]
     pub(super) fn is_low_priority(&self) -> bool {
         match self {
-            Message::Handshake { .. } | Message::SyncStateChanged => false,
+            Message::Handshake { .. } | Message::SyncFinished => false,
             Message::Payload(payload) => payload.is_low_priority(),
         }
     }
@@ -68,7 +68,7 @@ impl<P: Payload> Message<P> {
     #[inline]
     pub(super) fn payload_incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
         match self {
-            Message::Handshake { .. } | Message::SyncStateChanged => 0,
+            Message::Handshake { .. } | Message::SyncFinished => 0,
             Message::Payload(payload) => payload.incoming_resource_estimate(weights),
         }
     }
@@ -77,7 +77,7 @@ impl<P: Payload> Message<P> {
     #[inline]
     pub(super) fn payload_is_unsafe_for_joiners(&self) -> bool {
         match self {
-            Message::Handshake { .. } | Message::SyncStateChanged => false,
+            Message::Handshake { .. } | Message::SyncFinished => false,
             Message::Payload(payload) => payload.is_unsafe_for_joiners(),
         }
     }
@@ -94,7 +94,7 @@ impl<P: Payload> Message<P> {
         REv: FromIncoming<P> + Send,
     {
         match self {
-            Message::Handshake { .. } | Message::SyncStateChanged => Err(self),
+            Message::Handshake { .. } | Message::SyncFinished => Err(self),
             Message::Payload(payload) => {
                 // Note: For now, the wrapping/unwrapp of the payload is a bit unfortunate here.
                 REv::try_demand_from_incoming(effect_builder, sender, payload)
@@ -273,7 +273,7 @@ impl<P: Display> Display for Message<P> {
                 }
             }
             Message::Payload(payload) => write!(f, "payload: {}", payload),
-            Message::SyncStateChanged => {
+            Message::SyncFinished => {
                 write!(f, "sync_state_changed")
             }
         }
@@ -600,8 +600,8 @@ mod tests {
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
             }
-            Message::SyncStateChanged => {
-                panic!("did not expect modern handshake to deserialize to sync_state_changed")
+            Message::SyncFinished => {
+                panic!("did not expect modern handshake to deserialize to sync finished")
             }
         }
     }
@@ -625,8 +625,8 @@ mod tests {
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
             }
-            Message::SyncStateChanged => {
-                panic!("did not expect modern handshake to deserialize to sync_state_changed")
+            Message::SyncFinished => {
+                panic!("did not expect modern handshake to deserialize to sync finished")
             }
         }
     }
@@ -669,8 +669,8 @@ mod tests {
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
             }
-            Message::SyncStateChanged => {
-                panic!("did not expect modern handshake to deserialize to sync_state_changed")
+            Message::SyncFinished => {
+                panic!("did not expect modern handshake to deserialize to sync finished")
             }
         }
     }
@@ -713,8 +713,8 @@ mod tests {
             Message::Payload(_) => {
                 panic!("did not expect modern handshake to deserialize to payload")
             }
-            Message::SyncStateChanged => {
-                panic!("did not expect modern handshake to deserialize to sync_state_changed")
+            Message::SyncFinished => {
+                panic!("did not expect modern handshake to deserialize to sync finished")
             }
         }
     }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -39,7 +39,7 @@ pub(crate) enum Message<P> {
         /// A self-signed certificate indicating validator status.
         #[serde(default)]
         consensus_certificate: Option<ConsensusCertificate>,
-        /// Holds the information whether the node is syncing.
+        /// True if the node is syncing.
         #[serde(default)]
         is_syncing: bool,
         /// Hash of the chainspec the node is running.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -68,8 +68,9 @@ impl<P: Payload> Message<P> {
     #[inline]
     pub(super) fn payload_incoming_resource_estimate(&self, weights: &EstimatorWeights) -> u32 {
         match self {
-            Message::Handshake { .. } | Message::SyncFinished => 0,
+            Message::Handshake { .. } => 0,
             Message::Payload(payload) => payload.incoming_resource_estimate(weights),
+            Message::SyncFinished => weights.sync_finished,
         }
     }
 
@@ -395,6 +396,8 @@ pub struct EstimatorWeights {
     pub trie_requests: u32,
     /// Weight to attach to trie responses.
     pub trie_responses: u32,
+    /// Weight to attach to "sync finished" messages.
+    pub sync_finished: u32,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -41,7 +41,7 @@ pub(crate) enum Message<P> {
     },
     Payload(P),
     /// Indicates that peer has finished its syncing process and should no longer be considered a
-    /// "joiner".
+    /// "syncing peer".
     SyncFinished,
 }
 
@@ -73,12 +73,12 @@ impl<P: Payload> Message<P> {
         }
     }
 
-    /// Returns whether or not the payload is unsafe for joiner consumption.
+    /// Returns whether or not the payload is unsafe for syncing node consumption.
     #[inline]
-    pub(super) fn payload_is_unsafe_for_joiners(&self) -> bool {
+    pub(super) fn payload_is_unsafe_for_syncing_nodes(&self) -> bool {
         match self {
             Message::Handshake { .. } | Message::SyncFinished => false,
-            Message::Payload(payload) => payload.is_unsafe_for_joiners(),
+            Message::Payload(payload) => payload.is_unsafe_for_syncing_peers(),
         }
     }
 
@@ -337,10 +337,10 @@ pub(crate) trait Payload:
         false
     }
 
-    /// Indicates a message is not safe to send to a joiner.
+    /// Indicates a message is not safe to send to a syncing node.
     ///
     /// This functionality should be removed once multiplexed networking lands.
-    fn is_unsafe_for_joiners(&self) -> bool;
+    fn is_unsafe_for_syncing_peers(&self) -> bool;
 }
 
 /// Network message conversion support.

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -687,19 +687,19 @@ pub(super) async fn message_sender<P>(
     mut sink: SplitSink<FullTransport<P>, Arc<Message<P>>>,
     limiter: Box<dyn LimiterHandle>,
     counter: IntGauge,
-    remote_joiner_id: Option<(SocketAddr, NodeId)>,
+    remote_peer_id: Option<(SocketAddr, NodeId)>,
 ) where
     P: Payload,
 {
     while let Some((message, opt_responder)) = queue.recv().await {
         counter.dec();
 
-        if let Some((ref addr, ref node_id)) = remote_joiner_id {
-            if message.payload_is_unsafe_for_joiners() {
-                // We should never attempt to send an unsafe message to a peer that we know is a
-                // joiner. Since "unsafe" does usually not mean immediately catastrophic, we attempt
-                // to carry on, but warn loudly.
-                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to joiner");
+        if let Some((ref addr, ref node_id)) = remote_peer_id {
+            if message.payload_is_unsafe_for_syncing_nodes() {
+                // We should never attempt to send an unsafe message to a peer that we know is still
+                // syncing. Since "unsafe" does usually not mean immediately catastrophic, we
+                // attempt to carry on, but warn loudly.
+                error!(kind=%message.classify(), %addr, %node_id, "sending unsafe message to syncing node");
             }
         }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -420,6 +420,7 @@ where
         protocol_version,
         consensus_certificate,
         is_joiner,
+        chainspec_hash,
     } = remote_message
     {
         debug!(%protocol_version, "handshake received");
@@ -427,6 +428,14 @@ where
         // The handshake was valid, we can check the network name.
         if network_name != context.chain_info.network_name {
             return Err(ConnectionError::WrongNetwork(network_name));
+        }
+
+        // We check the chainspec hash to ensure peer is running on the
+        // same chainspec as us.
+        if let Some(hash) = chainspec_hash {
+            if hash != context.chain_info.chainspec_hash {
+                return Err(ConnectionError::WrongChainspecHash);
+            }
         }
 
         // If there is a version mismatch, we treat it as a connection error. We do not ban peers

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -215,8 +215,6 @@ where
     pub(super) handshake_timeout: TimeDiff,
     /// Weights to estimate payloads with.
     pub(super) payload_weights: EstimatorWeights,
-    /// Whether or not to reject incompatible versions during handshake.
-    pub(super) reject_incompatible_versions: bool,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub(super) tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.
@@ -430,23 +428,13 @@ where
             return Err(ConnectionError::WrongNetwork(network_name));
         }
 
-        // We check the chainspec hash to ensure peer is running on the
-        // same chainspec as us.
-        if let Some(hash) = chainspec_hash {
-            if hash != context.chain_info.chainspec_hash {
-                return Err(ConnectionError::WrongChainspecHash);
-            }
-        }
-
         // If there is a version mismatch, we treat it as a connection error. We do not ban peers
         // for this error, but instead rely on exponential backoff, as bans would result in issues
         // during upgrades where nodes may have a legitimate reason for differing versions.
         //
         // Since we are not using SemVer for versioning, we cannot make any assumptions about
         // compatibility, so we allow only exact version matches.
-        if context.reject_incompatible_versions
-            && protocol_version != context.chain_info.protocol_version
-        {
+        if protocol_version != context.chain_info.protocol_version {
             if let Some(threshold) = context.tarpit_version_threshold {
                 if protocol_version <= threshold {
                     let mut rng = crate::new_rng();
@@ -463,6 +451,14 @@ where
                 }
             }
             return Err(ConnectionError::IncompatibleVersion(protocol_version));
+        }
+
+        // We check the chainspec hash to ensure peer is using the same chainspec as us.
+        // The remote message should always have a chainspec hash at this point since
+        // we checked the protocol version previously.
+        let peer_chainspec_hash = chainspec_hash.ok_or(ConnectionError::MissingChainspecHash)?;
+        if peer_chainspec_hash != context.chain_info.chainspec_hash {
+            return Err(ConnectionError::WrongChainspecHash(peer_chainspec_hash));
         }
 
         let peer_consensus_public_key = consensus_certificate

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -559,112 +559,113 @@ where
 {
     let demands_in_flight = Arc::new(Semaphore::new(context.max_in_flight_demands));
 
-    let read_messages =
-        async move {
-            while let Some(msg_result) = stream.next().await {
-                match msg_result {
-                    Ok(msg) => {
-                        trace!(%msg, "message received");
+    let read_messages = async move {
+        while let Some(msg_result) = stream.next().await {
+            match msg_result {
+                Ok(msg) => {
+                    trace!(%msg, "message received");
 
-                        let effect_builder = EffectBuilder::new(context.event_queue);
+                    let effect_builder = EffectBuilder::new(context.event_queue);
 
-                        match msg.try_into_demand(effect_builder, peer_id) {
-                            Ok((event, wait_for_response)) => {
-                                // Note: For now, demands bypass the limiter, as we expect the
-                                //       backpressure to handle this instead.
+                    match msg.try_into_demand(effect_builder, peer_id) {
+                        Ok((event, wait_for_response)) => {
+                            // Note: For now, demands bypass the limiter, as we expect the
+                            //       backpressure to handle this instead.
 
-                                // Acquire a permit. If we are handling too many demands at this
-                                // time, this will block, halting the processing of new message,
-                                // thus letting the peer they have reached their maximum allowance.
-                                let in_flight = demands_in_flight
-                                    .clone()
-                                    .acquire_owned()
-                                    .await
-                                    // Note: Since the semaphore is reference counted, it must
-                                    //       explicitly be closed for acquisition to fail, which we
-                                    //       never do. If this happens, there is a bug in the code;
-                                    //       we exit with an error and close the connection.
-                                    .map_err(|_| {
-                                        io::Error::new(
-                                            io::ErrorKind::Other,
-                                            "demand limiter semaphore closed unexpectedly",
-                                        )
-                                    })?;
-
-                                Metrics::record_trie_request_start(&context.net_metrics);
-
-                                let net_metrics = context.net_metrics.clone();
-                                // Spawn a future that will eventually send the returned message. It
-                                // will essentially buffer the response.
-                                tokio::spawn(async move {
-                                    if let Some(payload) = wait_for_response.await {
-                                        // Send message and await its return. `send_message` should
-                                        // only return when the message has been buffered, if the
-                                        // peer is not accepting data, we will block here until the
-                                        // send buffer has sufficient room.
-                                        effect_builder.send_message(peer_id, payload).await;
-
-                                        // Note: We could short-circuit the event queue here and
-                                        //       directly insert into the outgoing message queue,
-                                        //       which may be potential performance improvement.
-                                    }
-
-                                    // Missing else: The handler of the demand did not deem it
-                                    // worthy a response. Just drop it.
-
-                                    // After we have either successfully buffered the message for
-                                    // sending, failed to do so or did not have a message to send
-                                    // out, we consider the request handled and free up the permit.
-                                    Metrics::record_trie_request_end(&net_metrics);
-                                    drop(in_flight);
-                                });
-
-                                // Schedule the created event.
-                                context
-                                    .event_queue
-                                    .schedule::<REv>(event, QueueKind::NetworkDemand)
-                                    .await;
-                            }
-                            Err(msg) => {
-                                // We've received a non-demand message. Ensure we have the proper amount
-                                // of resources, then push it to the reactor.
-                                limiter
-                                    .request_allowance(msg.payload_incoming_resource_estimate(
-                                        &context.payload_weights,
-                                    ))
-                                    .await;
-
-                                let queue_kind = if msg.is_low_priority() {
-                                    QueueKind::NetworkLowPriority
-                                } else {
-                                    QueueKind::NetworkIncoming
-                                };
-
-                                context
-                                    .event_queue
-                                    .schedule(
-                                        Event::IncomingMessage {
-                                            peer_id: Box::new(peer_id),
-                                            msg: Box::new(msg),
-                                            span: span.clone(),
-                                        },
-                                        queue_kind,
+                            // Acquire a permit. If we are handling too many demands at this
+                            // time, this will block, halting the processing of new message,
+                            // thus letting the peer they have reached their maximum allowance.
+                            let in_flight = demands_in_flight
+                                .clone()
+                                .acquire_owned()
+                                .await
+                                // Note: Since the semaphore is reference counted, it must
+                                //       explicitly be closed for acquisition to fail, which we
+                                //       never do. If this happens, there is a bug in the code;
+                                //       we exit with an error and close the connection.
+                                .map_err(|_| {
+                                    io::Error::new(
+                                        io::ErrorKind::Other,
+                                        "demand limiter semaphore closed unexpectedly",
                                     )
-                                    .await;
-                            }
+                                })?;
+
+                            Metrics::record_trie_request_start(&context.net_metrics);
+
+                            let net_metrics = context.net_metrics.clone();
+                            // Spawn a future that will eventually send the returned message. It
+                            // will essentially buffer the response.
+                            tokio::spawn(async move {
+                                if let Some(payload) = wait_for_response.await {
+                                    // Send message and await its return. `send_message` should
+                                    // only return when the message has been buffered, if the
+                                    // peer is not accepting data, we will block here until the
+                                    // send buffer has sufficient room.
+                                    effect_builder.send_message(peer_id, payload).await;
+
+                                    // Note: We could short-circuit the event queue here and
+                                    //       directly insert into the outgoing message queue,
+                                    //       which may be potential performance improvement.
+                                }
+
+                                // Missing else: The handler of the demand did not deem it
+                                // worthy a response. Just drop it.
+
+                                // After we have either successfully buffered the message for
+                                // sending, failed to do so or did not have a message to send
+                                // out, we consider the request handled and free up the permit.
+                                Metrics::record_trie_request_end(&net_metrics);
+                                drop(in_flight);
+                            });
+
+                            // Schedule the created event.
+                            context
+                                .event_queue
+                                .schedule::<REv>(event, QueueKind::NetworkDemand)
+                                .await;
+                        }
+                        Err(msg) => {
+                            // We've received a non-demand message. Ensure we have the proper amount
+                            // of resources, then push it to the reactor.
+                            limiter
+                                .request_allowance(
+                                    msg.payload_incoming_resource_estimate(
+                                        &context.payload_weights,
+                                    ),
+                                )
+                                .await;
+
+                            let queue_kind = if msg.is_low_priority() {
+                                QueueKind::NetworkLowPriority
+                            } else {
+                                QueueKind::NetworkIncoming
+                            };
+
+                            context
+                                .event_queue
+                                .schedule(
+                                    Event::IncomingMessage {
+                                        peer_id: Box::new(peer_id),
+                                        msg: Box::new(msg),
+                                        span: span.clone(),
+                                    },
+                                    queue_kind,
+                                )
+                                .await;
                         }
                     }
-                    Err(err) => {
-                        warn!(
-                            err = display_error(&err),
-                            "receiving message failed, closing connection"
-                        );
-                        return Err(err);
-                    }
+                }
+                Err(err) => {
+                    warn!(
+                        err = display_error(&err),
+                        "receiving message failed, closing connection"
+                    );
+                    return Err(err);
                 }
             }
-            Ok(())
-        };
+        }
+        Ok(())
+    };
 
     let shutdown_messages = async move { while shutdown_receiver.changed().await.is_ok() {} };
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -6,7 +6,10 @@ use std::{
     io,
     net::SocketAddr,
     pin::Pin,
-    sync::{Arc, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Weak,
+    },
     time::Duration,
 };
 
@@ -225,8 +228,8 @@ where
     pub(super) tarpit_chance: f32,
     /// Maximum number of demands allowed to be running at once. If 0, no limit is enforced.
     pub(super) max_in_flight_demands: usize,
-    /// Flag indicating whether this node is syncing node.
-    pub(super) is_syncing: bool,
+    /// Flag indicating whether this node is syncing.
+    pub(super) is_syncing: AtomicBool,
 }
 
 /// Handles an incoming connection.
@@ -381,7 +384,7 @@ where
         context.public_addr,
         context.consensus_keys.as_ref(),
         connection_id,
-        context.is_syncing,
+        context.is_syncing.load(Ordering::SeqCst),
     );
 
     let serialized_handshake_message = Pin::new(&mut encoder)

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -160,7 +160,7 @@ impl Payload for Message {
         0
     }
 
-    fn is_unsafe_for_joiners(&self) -> bool {
+    fn is_unsafe_for_syncing_peers(&self) -> bool {
         false
     }
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -193,7 +193,6 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             ChainInfo::create_for_testing(),
-            false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();
         let address_gossiper =

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -133,6 +133,7 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
+        chain_synchronizer::ChainSynchronizerAnnouncement,
         chainspec_loader::{CurrentRunInfo, NextUpgrade},
         consensus::{BlockContext, ClContext, EraDump, ValidatorChange},
         contract_runtime::{
@@ -1665,11 +1666,14 @@ impl<REv> EffectBuilder<REv> {
     /// Announce that the sync process has finished.
     pub(crate) async fn announce_finished_syncing(self)
     where
-        REv: From<LinearChainAnnouncement>,
+        REv: From<ChainSynchronizerAnnouncement>,
     {
         info!("announcing chain sync finished");
         self.event_queue
-            .schedule(LinearChainAnnouncement::SyncFinished, QueueKind::Network)
+            .schedule(
+                ChainSynchronizerAnnouncement::SyncFinished,
+                QueueKind::Network,
+            )
             .await
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -766,13 +766,13 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the current network non-joiner peers in random order.
-    pub async fn get_fully_connected_non_joiner_peers(self) -> Vec<NodeId>
+    /// Gets the current network non-syncing peers in random order.
+    pub async fn get_fully_connected_non_syncing_peers(self) -> Vec<NodeId>
     where
         REv: From<NetworkInfoRequest>,
     {
         self.make_request(
-            |responder| NetworkInfoRequest::FullyConnectedNonJoinerPeers { responder },
+            |responder| NetworkInfoRequest::FullyConnectedNonSyncingPeers { responder },
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -112,7 +112,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize, Serializer};
 use smallvec::{smallvec, SmallVec};
 use tokio::{sync::Semaphore, time};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -1667,6 +1667,7 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<LinearChainAnnouncement>,
     {
+        info!("announcing chain sync finished");
         self.event_queue
             .schedule(
                 LinearChainAnnouncement::SyncStateFinished,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1669,10 +1669,7 @@ impl<REv> EffectBuilder<REv> {
     {
         info!("announcing chain sync finished");
         self.event_queue
-            .schedule(
-                LinearChainAnnouncement::SyncStateFinished,
-                QueueKind::Network,
-            )
+            .schedule(LinearChainAnnouncement::SyncFinished, QueueKind::Network)
             .await
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -112,7 +112,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize, Serializer};
 use smallvec::{smallvec, SmallVec};
 use tokio::{sync::Semaphore, time};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -1664,11 +1664,10 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announce that the sync process has finished.
-    pub(crate) async fn announce_finished_syncing(self)
+    pub(crate) async fn announce_finished_chain_syncing(self)
     where
         REv: From<ChainSynchronizerAnnouncement>,
     {
-        info!("announcing chain sync finished");
         self.event_queue
             .schedule(
                 ChainSynchronizerAnnouncement::SyncFinished,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1662,6 +1662,19 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
+    /// Announce that the sync process has finished.
+    pub(crate) async fn announce_finished_syncing(self)
+    where
+        REv: From<LinearChainAnnouncement>,
+    {
+        self.event_queue
+            .schedule(
+                LinearChainAnnouncement::SyncStateFinished,
+                QueueKind::Network,
+            )
+            .await
+    }
+
     /// The linear chain has stored a newly-created block.
     pub(crate) async fn announce_block_added(self, block: Box<Block>)
     where

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1765,8 +1765,7 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<NodeStateRequest> + Send,
     {
-        self.make_request(NodeStateRequest, QueueKind::Regular)
-            .await
+        self.make_request(NodeStateRequest, QueueKind::Api).await
     }
 
     /// Retrieves finalized blocks with timestamps no older than the maximum deploy TTL.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -133,7 +133,6 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
-        chain_synchronizer::ChainSynchronizerAnnouncement,
         chainspec_loader::{CurrentRunInfo, NextUpgrade},
         consensus::{BlockContext, ClContext, EraDump, ValidatorChange},
         contract_runtime::{
@@ -144,6 +143,7 @@ use crate::{
         small_network::FromIncoming,
     },
     contract_runtime::SpeculativeExecutionState,
+    effect::announcements::ChainSynchronizerAnnouncement,
     reactor::{EventQueueHandle, QueueKind},
     types::{
         AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -150,7 +150,7 @@ use crate::{
         BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
         BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
         DeployHash, DeployHeader, DeployMetadataExt, DeployWithFinalizedApprovals,
-        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId,
+        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
     },
     utils::{SharedFlag, Source},
 };
@@ -165,7 +165,7 @@ use requests::{
     BeginGossipRequest, BlockPayloadRequest, BlockProposerRequest, BlockValidationRequest,
     ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, FetcherRequest,
     MarkBlockCompletedRequest, MetricsRequest, NetworkInfoRequest, NetworkRequest,
-    StateStoreRequest, StorageRequest,
+    NodeStateRequest, StateStoreRequest, StorageRequest,
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
@@ -1759,6 +1759,14 @@ impl<REv> EffectBuilder<REv> {
             QueueKind::Regular,
         )
         .await
+    }
+
+    pub(crate) async fn get_node_state(self) -> NodeState
+    where
+        REv: From<NodeStateRequest> + Send,
+    {
+        self.make_request(NodeStateRequest, QueueKind::Regular)
+            .await
     }
 
     /// Retrieves finalized blocks with timestamps no older than the maximum deploy TTL.

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -346,3 +346,23 @@ impl Display for ContractRuntimeAnnouncement {
         }
     }
 }
+
+/// A chain synchronizer announcement.
+#[derive(Debug, Serialize)]
+pub(crate) enum ChainSynchronizerAnnouncement {
+    /// The node has finished the synchronization it was doing (fast-sync or sync-to-genesis,
+    /// depending on config) and may now accept requests that are unsafe for nodes that are
+    /// synchronizing. Once this message is received, the only way for the peer to signal it's in
+    /// the syncing process is to reconnect.
+    SyncFinished,
+}
+
+impl Display for ChainSynchronizerAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ChainSynchronizerAnnouncement::SyncFinished => {
+                write!(f, "synchronization finished")
+            }
+        }
+    }
+}

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -260,12 +260,14 @@ impl<T: Item> Display for GossiperAnnouncement<T> {
 }
 
 /// A linear chain announcement.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub(crate) enum LinearChainAnnouncement {
     /// A new block has been created and stored locally.
     BlockAdded(Box<Block>),
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),
+    // TODO[RC]: temp location
+    SyncStateFinished,
 }
 
 impl Display for LinearChainAnnouncement {
@@ -277,6 +279,7 @@ impl Display for LinearChainAnnouncement {
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)
             }
+            LinearChainAnnouncement::SyncStateFinished => write!(f, "chain sync finished"),
         }
     }
 }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -260,7 +260,7 @@ impl<T: Item> Display for GossiperAnnouncement<T> {
 }
 
 /// A linear chain announcement.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub(crate) enum LinearChainAnnouncement {
     /// A new block has been created and stored locally.
     BlockAdded(Box<Block>),

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -267,7 +267,7 @@ pub(crate) enum LinearChainAnnouncement {
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),
     // TODO[RC]: temp location
-    SyncStateFinished,
+    SyncFinished,
 }
 
 impl Display for LinearChainAnnouncement {
@@ -279,7 +279,7 @@ impl Display for LinearChainAnnouncement {
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)
             }
-            LinearChainAnnouncement::SyncStateFinished => write!(f, "chain sync finished"),
+            LinearChainAnnouncement::SyncFinished => write!(f, "chain sync finished"),
         }
     }
 }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -266,8 +266,6 @@ pub(crate) enum LinearChainAnnouncement {
     BlockAdded(Box<Block>),
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),
-    // TODO[RC]: temp location
-    SyncFinished,
 }
 
 impl Display for LinearChainAnnouncement {
@@ -279,7 +277,6 @@ impl Display for LinearChainAnnouncement {
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)
             }
-            LinearChainAnnouncement::SyncFinished => write!(f, "chain sync finished"),
         }
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -53,7 +53,7 @@ use crate::{
         BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
         BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
         DeployHash, DeployMetadataExt, DeployWithFinalizedApprovals, FinalizedApprovals,
-        FinalizedBlock, Item, NodeId, StatusFeed,
+        FinalizedBlock, Item, NodeId, NodeState, StatusFeed,
     },
     utils::{DisplayIter, Source},
 };
@@ -1220,11 +1220,21 @@ pub(crate) enum ChainspecLoaderRequest {
 }
 
 impl Display for ChainspecLoaderRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
             ChainspecLoaderRequest::GetCurrentRunInfo(_) => write!(f, "get current run info"),
             ChainspecLoaderRequest::GetChainspecRawBytes(_) => write!(f, "get chainspec raw bytes"),
         }
+    }
+}
+
+/// ChainSynchronizer component request.
+#[derive(Debug, Serialize)]
+pub(crate) struct NodeStateRequest(pub(crate) Responder<NodeState>);
+
+impl Display for NodeStateRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "node state request")
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -201,9 +201,9 @@ pub(crate) enum NetworkInfoRequest {
         /// Responder to be called with all connected in random order peers.
         responder: Responder<Vec<NodeId>>,
     },
-    /// Get only non-joiner peers in random order.
-    FullyConnectedNonJoinerPeers {
-        /// Responder to be called with all connected non-joiner peers in random order.
+    /// Get only non-syncing peers in random order.
+    FullyConnectedNonSyncingPeers {
+        /// Responder to be called with all connected non-syncing peers in random order.
         responder: Responder<Vec<NodeId>>,
     },
 }
@@ -217,8 +217,8 @@ impl Display for NetworkInfoRequest {
             NetworkInfoRequest::FullyConnectedPeers { responder: _ } => {
                 write!(formatter, "get fully connected peers")
             }
-            NetworkInfoRequest::FullyConnectedNonJoinerPeers { responder: _ } => {
-                write!(formatter, "get fully connected non-joiner peers")
+            NetworkInfoRequest::FullyConnectedNonSyncingPeers { responder: _ } => {
+                write!(formatter, "get fully connected non-syncing peers")
             }
         }
     }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -137,12 +137,12 @@ impl Payload for Message {
         }
     }
 
-    fn is_unsafe_for_joiners(&self) -> bool {
+    fn is_unsafe_for_syncing_peers(&self) -> bool {
         match self {
             Message::Consensus(_) => false,
             Message::DeployGossiper(_) => false,
             Message::AddressGossiper(_) => false,
-            // Trie requests can deadlock between joiners.
+            // Trie requests can deadlock between syncing nodes.
             Message::GetRequest { tag, .. } if *tag == Tag::TrieOrChunk => true,
             Message::GetRequest { .. } => false,
             Message::GetResponse { .. } => false,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -54,7 +54,7 @@ use crate::{
         requests::{
             BeginGossipRequest, ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest,
             FetcherRequest, MarkBlockCompletedRequest, MetricsRequest, NetworkInfoRequest,
-            NetworkRequest, RestRequest, StorageRequest,
+            NetworkRequest, NodeStateRequest, RestRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -68,7 +68,7 @@ use crate::{
     },
     types::{
         Block, BlockAndDeploys, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
-        BlockSignatures, BlockWithMetadata, Deploy, ExitCode, FinalizedApprovalsWithId, NodeState,
+        BlockSignatures, BlockWithMetadata, Deploy, ExitCode, FinalizedApprovalsWithId,
     },
     utils::WithDir,
     NodeRng,
@@ -97,6 +97,8 @@ pub(crate) enum JoinerEvent {
     ChainspecLoader(#[serde(skip_serializing)] chainspec_loader::Event),
     #[from]
     ChainspecLoaderRequest(#[serde(skip_serializing)] ChainspecLoaderRequest),
+    #[from]
+    ChainSynchronizerRequest(#[serde(skip_serializing)] NodeStateRequest),
     #[from]
     NetworkInfoRequest(#[serde(skip_serializing)] NetworkInfoRequest),
     #[from]
@@ -230,6 +232,7 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::MetricsRequest(_) => "MetricsRequest",
             JoinerEvent::ChainspecLoader(_) => "ChainspecLoader",
             JoinerEvent::ChainspecLoaderRequest(_) => "ChainspecLoaderRequest",
+            JoinerEvent::ChainSynchronizerRequest(_) => "ChainSynchronizerRequest",
             JoinerEvent::NetworkInfoRequest(_) => "NetworkInfoRequest",
             JoinerEvent::BlockFetcher(_) => "BlockFetcher",
             JoinerEvent::BlockByHeightFetcher(_) => "BlockByHeightFetcher",
@@ -331,6 +334,9 @@ impl Display for JoinerEvent {
             JoinerEvent::ChainspecLoader(event) => write!(f, "chainspec loader: {}", event),
             JoinerEvent::ChainspecLoaderRequest(req) => {
                 write!(f, "chainspec loader request: {}", req)
+            }
+            JoinerEvent::ChainSynchronizerRequest(req) => {
+                write!(f, "chain synchronizer request: {}", req)
             }
             JoinerEvent::StorageRequest(req) => write!(f, "storage request: {}", req),
             JoinerEvent::MarkBlockCompletedRequest(req) => {
@@ -564,17 +570,11 @@ impl reactor::Reactor for Reactor {
             .protocol_config
             .verifiable_chunked_hash_activation;
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
-        let node_state = if config.node.sync_to_genesis {
-            NodeState::SyncingToGenesis
-        } else {
-            NodeState::FastSyncing
-        };
         let rest_server = RestServer::new(
             config.rest_server.clone(),
             effect_builder,
             *protocol_version,
             node_startup_instant,
-            node_state,
         )?;
 
         let event_stream_server = EventStreamServer::new(
@@ -890,6 +890,11 @@ impl reactor::Reactor for Reactor {
                 effect_builder,
                 rng,
                 JoinerEvent::ChainspecLoader(req.into()),
+            ),
+            JoinerEvent::ChainSynchronizerRequest(req) => self.dispatch_event(
+                effect_builder,
+                rng,
+                JoinerEvent::ChainSynchronizer(req.into()),
             ),
             JoinerEvent::NetworkInfoRequest(req) => {
                 let event = JoinerEvent::SmallNetwork(small_network::Event::from(req));

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -528,7 +528,6 @@ impl reactor::Reactor for Reactor {
             registry,
             small_network_identity,
             chainspec,
-            true,
         )?;
 
         let mut effects = reactor::wrap_effects(JoinerEvent::SmallNetwork, small_network_effects);

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -856,9 +856,8 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
             JoinerEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncStateFinished) => {
-                // TODO[RC]
-                // ignore + warn
-                todo!();
+                warn!("unexpected sync state finished announcement in the joiner");
+                Effects::new()
             }
             JoinerEvent::RestServer(event) => reactor::wrap_effects(
                 JoinerEvent::RestServer,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -855,6 +855,11 @@ impl reactor::Reactor for Reactor {
                 );
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
+            JoinerEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncStateFinished) => {
+                // TODO[RC]
+                // ignore + warn
+                todo!();
+            }
             JoinerEvent::RestServer(event) => reactor::wrap_effects(
                 JoinerEvent::RestServer,
                 self.rest_server.handle_event(effect_builder, rng, event),

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -23,9 +23,7 @@ use casper_execution_engine::storage::trie::TrieOrChunk;
 
 use crate::{
     components::{
-        chain_synchronizer::{
-            self, ChainSynchronizer, ChainSynchronizerAnnouncement, JoiningOutcome,
-        },
+        chain_synchronizer::{self, ChainSynchronizer, JoiningOutcome},
         chainspec_loader::{self, ChainspecLoader},
         contract_runtime::ContractRuntime,
         deploy_acceptor::{self, DeployAcceptor},
@@ -43,9 +41,9 @@ use crate::{
     contract_runtime,
     effect::{
         announcements::{
-            BlocklistAnnouncement, ChainspecLoaderAnnouncement, ContractRuntimeAnnouncement,
-            ControlAnnouncement, DeployAcceptorAnnouncement, GossiperAnnouncement,
-            LinearChainAnnouncement,
+            BlocklistAnnouncement, ChainSynchronizerAnnouncement, ChainspecLoaderAnnouncement,
+            ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
+            GossiperAnnouncement, LinearChainAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -23,7 +23,9 @@ use casper_execution_engine::storage::trie::TrieOrChunk;
 
 use crate::{
     components::{
-        chain_synchronizer::{self, ChainSynchronizer, JoiningOutcome},
+        chain_synchronizer::{
+            self, ChainSynchronizer, ChainSynchronizerAnnouncement, JoiningOutcome,
+        },
         chainspec_loader::{self, ChainspecLoader},
         contract_runtime::ContractRuntime,
         deploy_acceptor::{self, DeployAcceptor},
@@ -178,6 +180,8 @@ pub(crate) enum JoinerEvent {
     #[from]
     ChainspecLoaderAnnouncement(#[serde(skip_serializing)] ChainspecLoaderAnnouncement),
     #[from]
+    ChainSynchronizerAnnouncement(#[serde(skip_serializing)] ChainSynchronizerAnnouncement),
+    #[from]
     ConsensusRequest(#[serde(skip_serializing)] ConsensusRequest),
     #[from]
     ConsensusMessageIncoming(ConsensusMessageIncoming),
@@ -279,6 +283,7 @@ impl ReactorEvent for JoinerEvent {
             JoinerEvent::DeployGossiperAnnouncement(_) => "DeployGossiperAnnouncement",
             JoinerEvent::BlockHeadersBatchFetcherRequest(_) => "BlockHeadersBatchFetcherRequest",
             JoinerEvent::FinalitySignaturesFetcherRequest(_) => "FinalitySignaturesFetcherRequest",
+            JoinerEvent::ChainSynchronizerAnnouncement(_) => "ChainSynchronizerAnnouncement",
         }
     }
 }
@@ -436,6 +441,9 @@ impl Display for JoinerEvent {
             }
             JoinerEvent::FinalitySignaturesFetcherRequest(inner) => {
                 write!(f, "finality signatures fetch request: {}", inner)
+            }
+            JoinerEvent::ChainSynchronizerAnnouncement(ann) => {
+                write!(f, "chain synchronizer announcement: {}", ann)
             }
         }
     }
@@ -855,7 +863,9 @@ impl reactor::Reactor for Reactor {
                 );
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
-            JoinerEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncFinished) => {
+            JoinerEvent::ChainSynchronizerAnnouncement(
+                ChainSynchronizerAnnouncement::SyncFinished,
+            ) => {
                 warn!("unexpected sync finished announcement in the joiner");
                 Effects::new()
             }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -855,8 +855,8 @@ impl reactor::Reactor for Reactor {
                 );
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
-            JoinerEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncStateFinished) => {
-                warn!("unexpected sync state finished announcement in the joiner");
+            JoinerEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncFinished) => {
+                warn!("unexpected sync finished announcement in the joiner");
                 Effects::new()
             }
             JoinerEvent::RestServer(event) => reactor::wrap_effects(

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -546,13 +546,14 @@ impl reactor::Reactor for Reactor {
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
         let effect_builder = EffectBuilder::new(event_queue);
-        let (chain_synchronizer, sync_effects) = ChainSynchronizer::<JoinerEvent>::new(
-            Arc::clone(chainspec_loader.chainspec()),
-            config.node.clone(),
-            config.network.clone(),
-            effect_builder,
-            registry,
-        )?;
+        let (chain_synchronizer, sync_effects) =
+            ChainSynchronizer::<JoinerEvent>::new_for_fast_sync(
+                Arc::clone(chainspec_loader.chainspec()),
+                config.node.clone(),
+                config.network.clone(),
+                effect_builder,
+                registry,
+            )?;
         effects.extend(reactor::wrap_effects(
             JoinerEvent::ChainSynchronizer,
             sync_effects,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -793,7 +793,6 @@ impl reactor::Reactor for Reactor {
             registry,
             small_network_identity,
             chainspec.as_ref(),
-            false,
         )?;
 
         effects.extend(reactor::wrap_effects(

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -844,7 +844,7 @@ impl reactor::Reactor for Reactor {
         )?;
 
         let (chain_synchronizer, chain_synchronizer_effects) =
-            ChainSynchronizer::<ParticipatingEvent>::new(
+            ChainSynchronizer::<ParticipatingEvent>::new_for_sync_to_genesis(
                 chainspec.clone(),
                 config.node.clone(),
                 config.network.clone(),

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1362,13 +1362,11 @@ impl reactor::Reactor for Reactor {
             }
             ParticipatingEvent::LinearChainAnnouncement(
                 LinearChainAnnouncement::SyncStateFinished,
-            ) => {
-                self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    ParticipatingEvent::SmallNetwork(small_network::Event::SyncStateFinished),
-                )
-            }
+            ) => self.dispatch_event(
+                effect_builder,
+                rng,
+                ParticipatingEvent::SmallNetwork(small_network::Event::SyncStateFinished),
+            ),
             ParticipatingEvent::ChainspecLoaderAnnouncement(
                 ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => {

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1360,6 +1360,15 @@ impl reactor::Reactor for Reactor {
                 );
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
+            ParticipatingEvent::LinearChainAnnouncement(
+                LinearChainAnnouncement::SyncStateFinished,
+            ) => {
+                self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    ParticipatingEvent::SmallNetwork(small_network::Event::SyncStateFinished),
+                )
+            }
             ParticipatingEvent::ChainspecLoaderAnnouncement(
                 ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => {

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -28,9 +28,7 @@ use crate::{
     components::{
         block_proposer::{self, BlockProposer},
         block_validator::{self, BlockValidator},
-        chain_synchronizer::{
-            self, ChainSynchronizer, ChainSynchronizerAnnouncement, JoiningOutcome,
-        },
+        chain_synchronizer::{self, ChainSynchronizer, JoiningOutcome},
         chainspec_loader::{self, ChainspecLoader},
         consensus::{self, EraSupervisor, HighwayProtocol},
         contract_runtime::{BlockAndExecutionEffects, ContractRuntime, ExecutionPreState},
@@ -50,10 +48,10 @@ use crate::{
     contract_runtime,
     effect::{
         announcements::{
-            BlockProposerAnnouncement, BlocklistAnnouncement, ChainspecLoaderAnnouncement,
-            ConsensusAnnouncement, ContractRuntimeAnnouncement, ControlAnnouncement,
-            DeployAcceptorAnnouncement, GossiperAnnouncement, LinearChainAnnouncement,
-            RpcServerAnnouncement,
+            BlockProposerAnnouncement, BlocklistAnnouncement, ChainSynchronizerAnnouncement,
+            ChainspecLoaderAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
+            ControlAnnouncement, DeployAcceptorAnnouncement, GossiperAnnouncement,
+            LinearChainAnnouncement, RpcServerAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
@@ -1373,7 +1371,11 @@ impl reactor::Reactor for Reactor {
             ) => self.dispatch_event(
                 effect_builder,
                 rng,
-                ParticipatingEvent::SmallNetwork(small_network::Event::SyncFinished),
+                ParticipatingEvent::SmallNetwork(
+                    small_network::Event::ChainSynchronizerAnnouncement(
+                        ChainSynchronizerAnnouncement::SyncFinished,
+                    ),
+                ),
             ),
             ParticipatingEvent::ChainspecLoaderAnnouncement(
                 ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -1360,13 +1360,13 @@ impl reactor::Reactor for Reactor {
                 );
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
-            ParticipatingEvent::LinearChainAnnouncement(
-                LinearChainAnnouncement::SyncStateFinished,
-            ) => self.dispatch_event(
-                effect_builder,
-                rng,
-                ParticipatingEvent::SmallNetwork(small_network::Event::SyncStateFinished),
-            ),
+            ParticipatingEvent::LinearChainAnnouncement(LinearChainAnnouncement::SyncFinished) => {
+                self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    ParticipatingEvent::SmallNetwork(small_network::Event::SyncFinished),
+                )
+            }
             ParticipatingEvent::ChainspecLoaderAnnouncement(
                 ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => {

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -39,6 +39,9 @@ pub struct NodeConfig {
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
+
+    /// Known address of a node on the network used for joining.
+    pub known_addresses: Vec<String>,
 }
 
 impl Default for NodeConfig {
@@ -51,6 +54,7 @@ impl Default for NodeConfig {
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,
+            known_addresses: Default::default(),
         }
     }
 }

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -39,9 +39,6 @@ pub struct NodeConfig {
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
-
-    /// Known address of a node on the network used for joining.
-    pub known_addresses: Vec<String>,
 }
 
 impl Default for NodeConfig {
@@ -54,7 +51,6 @@ impl Default for NodeConfig {
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,
-            known_addresses: Default::default(),
         }
     }
 }

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -142,7 +142,7 @@ mod tests {
             .expect("could not deserialize value");
         match msg {
             Message::Payload(payload) => payload,
-            Message::Handshake { .. } | Message::SyncFinished => panic!("expected payload"),
+            Message::Handshake { .. } => panic!("expected payload"),
         }
     }
 

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -142,7 +142,7 @@ mod tests {
             .expect("could not deserialize value");
         match msg {
             Message::Payload(payload) => payload,
-            Message::Handshake { .. } | Message::SyncStateChanged => panic!("expected payload"),
+            Message::Handshake { .. } | Message::SyncFinished => panic!("expected payload"),
         }
     }
 

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -142,7 +142,7 @@ mod tests {
             .expect("could not deserialize value");
         match msg {
             Message::Payload(payload) => payload,
-            Message::Handshake { .. } => panic!("expected payload"),
+            Message::Handshake { .. } | Message::SyncStateChanged => panic!("expected payload"),
         }
     }
 

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -17,6 +17,7 @@ use casper_types::{EraId, ProtocolVersion, PublicKey, TimeDiff, Timestamp};
 
 use crate::{
     components::{
+        chain_synchronizer::Progress,
         chainspec_loader::NextUpgrade,
         rpc_server::rpcs::docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
     },
@@ -76,12 +77,16 @@ impl ChainspecInfo {
 }
 
 /// The various possible states of operation for the node.
-#[derive(Clone, Copy, PartialEq, Eq, DataSize, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, DataSize, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum NodeState {
-    /// The node is currently in the fast syncing state.
-    FastSyncing,
-    /// The node is currently in syncing to genesis state.
-    SyncingToGenesis,
+    /// The node is currently in joining mode.
+    Joining(Progress),
+    /// The node is currently in participating mode, but also syncing to genesis in the background.
+    ParticipatingAndSyncingToGenesis {
+        /// The progress of the chain sync-to-genesis task.
+        sync_progress: Progress,
+    },
     /// The node is currently in the participating state.
     Participating,
 }

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -4,6 +4,7 @@
 mod display_error;
 pub(crate) mod ds;
 mod external;
+pub(crate) mod opt_display;
 pub(crate) mod rlimit;
 pub(crate) mod round_robin;
 pub(crate) mod umask;

--- a/node/src/utils/opt_display.rs
+++ b/node/src/utils/opt_display.rs
@@ -1,0 +1,25 @@
+use std::fmt::{Display, Formatter, Result};
+
+pub struct OptDisplay<'a, 'b, T> {
+    inner: Option<&'a T>,
+    empty_display: &'b str,
+}
+
+impl<'a, 'b, T: Display> OptDisplay<'a, 'b, T> {
+    pub fn new(maybe_display: Option<&'a T>, empty_display: &'b str) -> Self {
+        Self {
+            inner: maybe_display,
+            empty_display,
+        }
+    }
+}
+
+impl<'a, 'b, T: Display> Display for OptDisplay<'a, 'b, T> {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self.inner {
+            None => f.write_str(self.empty_display),
+            Some(val) => val.fmt(f),
+        }
+    }
+}

--- a/node/src/utils/work_queue.rs
+++ b/node/src/utils/work_queue.rs
@@ -169,6 +169,11 @@ impl<T> WorkQueue<T> {
         self.notify.notify_waiters();
     }
 
+    /// Returns the number of jobs in the queue.
+    pub fn num_jobs(&self) -> usize {
+        self.inner.lock().expect("lock poisoned").jobs.len()
+    }
+
     /// Creates a streaming consumer of the work queue.
     #[inline]
     pub fn to_stream(self: Arc<Self>) -> impl Stream<Item = JobHandle<T>> {

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -164,13 +164,6 @@ max_incoming_message_rate_non_validators = 0
 # `0` means unlimited.
 max_in_flight_demands = 50
 
-# Reject incompatible node versions
-#
-# Causes the node to immediately disconnect from versions on a different protocol version than
-# itself. In general, this feature should be enabled on the entire network, it can be disabled in
-# the case of problems during upgrades if the nodes are still compatible on the networking level.
-reject_incompatible_versions = true
-
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a
@@ -180,8 +173,6 @@ reject_incompatible_versions = true
 # This option makes most sense to enable on known nodes with addresses where legacy nodes that are
 # still in operation are connecting to, as these older versions will only attempt to reconnect to
 # other nodes once they have exhausted their set of known nodes.
-#
-# This feature is only enabled if `reject_incompatible_versions` is enabled.
 tarpit_version_threshold = '1.2.1'
 
 # How long to hold connections to trapped legacy nodes.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -214,6 +214,7 @@ trie_requests = 1
 trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
+sync_finished = 1
 
 
 # ==================================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -214,7 +214,6 @@ trie_requests = 1
 trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
-sync_finished = 1
 
 
 # ==================================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -214,7 +214,7 @@ trie_requests = 1
 trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
-
+sync_finished = 1
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -164,13 +164,6 @@ max_incoming_message_rate_non_validators = 3000
 # `0` means unlimited.
 max_in_flight_demands = 50
 
-# Reject incompatible node versions
-#
-# Causes the node to immediately disconnect from versions on a different protocol version than
-# itself. In general, this feature should be enabled on the entire network, it can be disabled in
-# the case of problems during upgrades if the nodes are still compatible on the networking level.
-reject_incompatible_versions = true
-
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a
@@ -180,8 +173,6 @@ reject_incompatible_versions = true
 # This option makes most sense to enable on known nodes with addresses where legacy nodes that are
 # still in operation are connecting to, as these older versions will only attempt to reconnect to
 # other nodes once they have exhausted their set of known nodes.
-#
-# This feature is only enabled if `reject_incompatible_versions` is enabled.
 tarpit_version_threshold = '1.2.1'
 
 # How long to hold connections to trapped legacy nodes.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -214,7 +214,7 @@ trie_requests = 1
 trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
-sync_finished = 1
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -229,11 +229,340 @@
     },
     "NodeState": {
       "description": "The various possible states of operation for the node.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "participating"
+          ]
+        },
+        {
+          "description": "The node is currently in joining mode.",
+          "type": "object",
+          "required": [
+            "joining"
+          ],
+          "properties": {
+            "joining": {
+              "$ref": "#/definitions/Progress"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
+          "type": "object",
+          "required": [
+            "participating_and_syncing_to_genesis"
+          ],
+          "properties": {
+            "participating_and_syncing_to_genesis": {
+              "type": "object",
+              "required": [
+                "sync_progress"
+              ],
+              "properties": {
+                "sync_progress": {
+                  "description": "The progress of the chain sync-to-genesis task.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Progress"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Progress": {
+      "description": "The progress of the chain-synchronizer task.",
+      "anyOf": [
+        {
+          "description": "The chain-synchronizer is performing the fast-sync task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FastSync"
+            }
+          ]
+        },
+        {
+          "description": "The chain-synchronizer is performing the sync-to-genesis task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SyncToGenesis"
+            }
+          ]
+        }
+      ]
+    },
+    "FastSync": {
+      "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "not yet started",
+            "starting",
+            "finished"
+          ]
+        },
+        {
+          "description": "Currently fetching the trusted block header.",
+          "type": "object",
+          "required": [
+            "fetching_trusted_block_header"
+          ],
+          "properties": {
+            "fetching_trusted_block_header": {
+              "$ref": "#/definitions/BlockHash"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently syncing the trie-store under the given state root hash.",
+          "type": "object",
+          "required": [
+            "fetching_global_state_under_given_block"
+          ],
+          "properties": {
+            "fetching_global_state_under_given_block": {
+              "type": "object",
+              "required": [
+                "block_height",
+                "number_of_remaining_tries_to_fetch",
+                "reason",
+                "state_root_hash"
+              ],
+              "properties": {
+                "block_height": {
+                  "description": "The height of the block containing the given state root hash.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "state_root_hash": {
+                  "description": "The global state root hash.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Digest"
+                    }
+                  ]
+                },
+                "reason": {
+                  "description": "The reason for syncing the trie-store.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/FetchingTriesReason"
+                    }
+                  ]
+                },
+                "number_of_remaining_tries_to_fetch": {
+                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
+          "type": "object",
+          "required": [
+            "fetching_block_and_deploys_at_given_block_height_before_execution"
+          ],
+          "properties": {
+            "fetching_block_and_deploys_at_given_block_height_before_execution": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently executing the block at the given height.",
+          "type": "object",
+          "required": [
+            "executing_block_at_height"
+          ],
+          "properties": {
+            "executing_block_at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
+          "type": "object",
+          "required": [
+            "retrying_block_execution"
+          ],
+          "properties": {
+            "retrying_block_execution": {
+              "type": "object",
+              "required": [
+                "attempt",
+                "block_height"
+              ],
+              "properties": {
+                "block_height": {
+                  "description": "The height of the block being executed.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "attempt": {
+                  "description": "The retry attempt number.",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "FetchingTriesReason": {
+      "description": "The reason for syncing the trie store under a given state root hash.",
       "type": "string",
       "enum": [
-        "FastSyncing",
-        "SyncingToGenesis",
-        "Participating"
+        "for fast sync",
+        "preparing for emergency upgrade",
+        "preparing for upgrade"
+      ]
+    },
+    "SyncToGenesis": {
+      "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "not yet started",
+            "starting",
+            "finished"
+          ]
+        },
+        {
+          "description": "Currently fetching block headers in batches back towards the genesis block.",
+          "type": "object",
+          "required": [
+            "fetching_headers_back_to_genesis"
+          ],
+          "properties": {
+            "fetching_headers_back_to_genesis": {
+              "type": "object",
+              "required": [
+                "lowest_block_height"
+              ],
+              "properties": {
+                "lowest_block_height": {
+                  "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+          "type": "object",
+          "required": [
+            "syncing_forward_from_genesis"
+          ],
+          "properties": {
+            "syncing_forward_from_genesis": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SyncBlock"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SyncBlock": {
+      "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
+      "type": "object",
+      "required": [
+        "block_height",
+        "fetching"
+      ],
+      "properties": {
+        "block_height": {
+          "description": "The height of the block being synced.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "fetching": {
+          "description": "The progress of the sync-block task.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SyncBlockFetching"
+            }
+          ]
+        }
+      }
+    },
+    "SyncBlockFetching": {
+      "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "block and deploys",
+            "block signatures"
+          ]
+        },
+        {
+          "description": "Currently syncing the trie-store under the state root hash held in the block.",
+          "type": "object",
+          "required": [
+            "global_state_under_given_block"
+          ],
+          "properties": {
+            "global_state_under_given_block": {
+              "type": "object",
+              "required": [
+                "number_of_remaining_tries_to_fetch",
+                "state_root_hash"
+              ],
+              "properties": {
+                "state_root_hash": {
+                  "description": "The global state root hash.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Digest"
+                    }
+                  ]
+                },
+                "number_of_remaining_tries_to_fetch": {
+                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     }
   }

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -479,7 +479,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
           "type": "object",
           "required": [
             "syncing_forward_from_genesis"

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -1371,6 +1371,151 @@
             ],
             "description": "The result of executing a single deploy."
           },
+          "FastSync": {
+            "anyOf": [
+              {
+                "enum": [
+                  "not yet started",
+                  "starting",
+                  "finished"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching the trusted block header.",
+                "properties": {
+                  "fetching_trusted_block_header": {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                },
+                "required": [
+                  "fetching_trusted_block_header"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing the trie-store under the given state root hash.",
+                "properties": {
+                  "fetching_global_state_under_given_block": {
+                    "properties": {
+                      "block_height": {
+                        "description": "The height of the block containing the given state root hash.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "number_of_remaining_tries_to_fetch": {
+                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/FetchingTriesReason"
+                          }
+                        ],
+                        "description": "The reason for syncing the trie-store."
+                      },
+                      "state_root_hash": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Digest"
+                          }
+                        ],
+                        "description": "The global state root hash."
+                      }
+                    },
+                    "required": [
+                      "block_height",
+                      "number_of_remaining_tries_to_fetch",
+                      "reason",
+                      "state_root_hash"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "fetching_global_state_under_given_block"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
+                "properties": {
+                  "fetching_block_and_deploys_at_given_block_height_before_execution": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "fetching_block_and_deploys_at_given_block_height_before_execution"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently executing the block at the given height.",
+                "properties": {
+                  "executing_block_at_height": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "executing_block_at_height"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
+                "properties": {
+                  "retrying_block_execution": {
+                    "properties": {
+                      "attempt": {
+                        "description": "The retry attempt number.",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "block_height": {
+                        "description": "The height of the block being executed.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "attempt",
+                      "block_height"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "retrying_block_execution"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing."
+          },
+          "FetchingTriesReason": {
+            "description": "The reason for syncing the trie store under a given state root hash.",
+            "enum": [
+              "for fast sync",
+              "preparing for emergency upgrade",
+              "preparing for upgrade"
+            ],
+            "type": "string"
+          },
           "GlobalStateIdentifier": {
             "anyOf": [
               {
@@ -1962,13 +2107,54 @@
             "type": "object"
           },
           "NodeState": {
-            "description": "The various possible states of operation for the node.",
-            "enum": [
-              "FastSyncing",
-              "SyncingToGenesis",
-              "Participating"
+            "anyOf": [
+              {
+                "enum": [
+                  "participating"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The node is currently in joining mode.",
+                "properties": {
+                  "joining": {
+                    "$ref": "#/components/schemas/Progress"
+                  }
+                },
+                "required": [
+                  "joining"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
+                "properties": {
+                  "participating_and_syncing_to_genesis": {
+                    "properties": {
+                      "sync_progress": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Progress"
+                          }
+                        ],
+                        "description": "The progress of the chain sync-to-genesis task."
+                      }
+                    },
+                    "required": [
+                      "sync_progress"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "participating_and_syncing_to_genesis"
+                ],
+                "type": "object"
+              }
             ],
-            "type": "string"
+            "description": "The various possible states of operation for the node."
           },
           "OpKind": {
             "description": "The type of operation performed while executing a deploy.",
@@ -2044,6 +2230,27 @@
               "$ref": "#/components/schemas/PeerEntry"
             },
             "type": "array"
+          },
+          "Progress": {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/FastSync"
+                  }
+                ],
+                "description": "The chain-synchronizer is performing the fast-sync task."
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncToGenesis"
+                  }
+                ],
+                "description": "The chain-synchronizer is performing the sync-to-genesis task."
+              }
+            ],
+            "description": "The progress of the chain-synchronizer task."
           },
           "ProtocolVersion": {
             "description": "Casper Platform protocol version",
@@ -2365,6 +2572,128 @@
               }
             ],
             "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
+          },
+          "SyncBlock": {
+            "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
+            "properties": {
+              "block_height": {
+                "description": "The height of the block being synced.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "fetching": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncBlockFetching"
+                  }
+                ],
+                "description": "The progress of the sync-block task."
+              }
+            },
+            "required": [
+              "block_height",
+              "fetching"
+            ],
+            "type": "object"
+          },
+          "SyncBlockFetching": {
+            "anyOf": [
+              {
+                "enum": [
+                  "block and deploys",
+                  "block signatures"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing the trie-store under the state root hash held in the block.",
+                "properties": {
+                  "global_state_under_given_block": {
+                    "properties": {
+                      "number_of_remaining_tries_to_fetch": {
+                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
+                        "format": "uint",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "state_root_hash": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Digest"
+                          }
+                        ],
+                        "description": "The global state root hash."
+                      }
+                    },
+                    "required": [
+                      "number_of_remaining_tries_to_fetch",
+                      "state_root_hash"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "global_state_under_given_block"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly."
+          },
+          "SyncToGenesis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "not yet started",
+                  "starting",
+                  "finished"
+                ],
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently fetching block headers in batches back towards the genesis block.",
+                "properties": {
+                  "fetching_headers_back_to_genesis": {
+                    "properties": {
+                      "lowest_block_height": {
+                        "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
+                        "format": "uint64",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "lowest_block_height"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "fetching_headers_back_to_genesis"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+                "properties": {
+                  "syncing_forward_from_genesis": {
+                    "items": {
+                      "$ref": "#/components/schemas/SyncBlock"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "syncing_forward_from_genesis"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly."
           },
           "TimeDiff": {
             "description": "Human-readable duration.",
@@ -3657,7 +3986,7 @@
                     "activation_point": 42,
                     "protocol_version": "2.0.1"
                   },
-                  "node_state": "Participating",
+                  "node_state": "participating",
                   "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
                   "peers": [
                     {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2678,7 +2678,7 @@
               },
               {
                 "additionalProperties": false,
-                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted by lowest block height.",
+                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
                 "properties": {
                   "syncing_forward_from_genesis": {
                     "items": {

--- a/smart_contracts/contracts_as/example/counter-installer/README.md
+++ b/smart_contracts/contracts_as/example/counter-installer/README.md
@@ -1,0 +1,98 @@
+# Counter Contract Session Code
+
+This example code will call our [previously installed Counter Contract](https://github.com/casper-network/casper-node/tree/dev/smart_contracts/contracts_as/example/counter-installer) using AssemblyScript. Instructions for getting started on Casper using AssemblyScript can be found in our [Getting Started with AssemblyScript](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/assembly-script/) guide.
+
+## Calling Contract Code
+
+Previously, we installed a simple counter smart contract that contains an incrementing variable. We defined two entry points, `entryPointInc` and `entryPointGet`. We also defined the `call` function that initialized the contract. This constitutes the contract code that we will now call using session code.
+
+### Step 1. Configuring the Index.ts File
+
+The first section of *assembly/index.ts* outlines the necessary dependencies to include and the constants to establish.
+
+1. Begin with `//@ts-nocheck` to disable semantic checks.
+
+2. Establish imported dependencies from other packages.
+
+3. Establish constants for use within the installed contract.
+
+```typescript
+
+//@ts-nocheck
+// Importing necessary components from other packages.
+import * as CL from "../../../../contract_as/assembly";
+import { Error, ErrorCode } from "../../../../contract_as/assembly/error";
+import { fromBytesI32, fromBytesString, toBytesMap } from "../../../../contract_as/assembly/bytesrepr";
+import { Key } from "../../../../contract_as/assembly/key";
+import { CLValue, CLType, CLTypeTag } from "../../../../contract_as/assembly/clvalue";
+import { Pair } from "../../../../contract_as/assembly/pair";
+import { RuntimeArgs } from "../../../../contract_as/assembly/runtime_args";
+
+
+// Establishing constants for use within our session code.
+const COUNT_KEY = "count";
+const COUNTER_INC = "counter_inc";
+const COUNTER_GET = "counter_get";
+const COUNTER_KEY = "counter";
+const CONTRACT_VERSION_KEY = "version";
+
+```
+
+### Step 2. Defining Functions for Interacting with the Smart Contract
+
+While our `call` function will execute the session code and interact with the installed counter contract, we will need to define the actions our `call` function will take.
+
+* `counterGet` retrieves the current value of the counter.
+
+* `counterInc` increments the counter value by 1.
+
+```typescript
+
+function counterGet(contractHash: Uint8Array): i32 {
+  let bytes = CL.callContract(contractHash, COUNTER_GET, new RuntimeArgs());
+  return fromBytesI32(bytes).unwrap();
+}
+
+function counterInc(contractHash: Uint8Array): void {
+  CL.callContract(contractHash, COUNTER_INC, new RuntimeArgs());
+}
+
+```
+
+### Step 3. Defining the `Call` Function
+
+The `call` function serves to execute the session code, calling the counter contract. To do so, it uses the `COUNTER_KEY` constant, which should contain the `contractHash` of the counter contract.
+
+It then reads the current value of the counter, increments the value by 1 and then reads the updated value of the counter. Finally, it observes the difference between the first value observed (`currentCounterValue`) and the new value (`newCounterValue`). If the the difference is not equal to 1, it will cause an error.
+
+```typescript
+
+export function call(): void {
+  // Read the Counter smart contract's ContractHash.
+  let contractHashKey = CL.getKey(COUNTER_KEY);
+  if (!contractHashKey) {
+    Error.fromUserError(66).revert();
+    return;
+  }
+  let contractHash = contractHashKey.hash;
+  if (!contractHash) {
+    Error.fromUserError(66).revert();
+    return;
+  }
+
+  // Call Counter to get the current value.
+  let currentCounterValue = counterGet(contractHash);
+
+  // Call Counter to increment the value.
+  counterInc(contractHash);
+
+  // Call Counter to get the new value.
+  let newCounterValue = counterGet(contractHash);
+
+  // Expect counter to increment by one.
+  if (newCounterValue - currentCounterValue != 1) {
+    Error.fromUserError(67).revert();
+  }
+}
+
+```

--- a/smart_contracts/contracts_as/example/increment-counter/README.md
+++ b/smart_contracts/contracts_as/example/increment-counter/README.md
@@ -1,0 +1,136 @@
+# Counter Contract
+
+This example code will install a simple counter using AssemblyScript. Instructions for getting started on Casper using AssemblyScript can be found in our [Getting Started with AssemblyScript](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/assembly-script/) guide.
+
+## Session Code
+
+Installing a smart contract to global state on a Casper Network requires the use of session code. This example code uses AssemblyScript to send a Wasm-bearing [Deploy](https://docs.casperlabs.io/glossary/D/#deploy) containing the contract to be installed.
+
+
+### Step 1. Configuring the Index.ts File
+
+The first section of *assembly/index.ts* outlines the necessary dependencies to include and the constants to establish.
+
+1. Begin with `//@ts-nocheck` to disable semantic checks.
+
+2. Establish imported dependencies from other packages.
+
+3. Establish constants for use within the installed contract.
+
+```typescript
+
+// Importing necessary aspects of external packages.
+import * as CL from "../../../../contract_as/assembly";
+import { Error, ErrorCode } from "../../../../contract_as/assembly/error";
+import { fromBytesI32, fromBytesString, toBytesMap } from "../../../../contract_as/assembly/bytesrepr";
+import { Key } from "../../../../contract_as/assembly/key";
+import { CLValue, CLType, CLTypeTag } from "../../../../contract_as/assembly/clvalue";
+import { Pair } from "../../../../contract_as/assembly/pair";
+
+// Establishing constants for use within the installing contract.
+const COUNT_KEY = "count";
+const COUNTER_INC = "counter_inc";
+const COUNTER_GET = "counter_get";
+const COUNTER_KEY = "counter";
+const CONTRACT_VERSION_KEY = "version";
+
+```
+
+### Step 2. Defining the Contract Entry Points
+
+Each entry point that we later establish will require an associated function to perform the desired action. In the next section of *index.ts* we define these functions to perform the actions of incrementing the counter and viewing the current counter value.
+
+```typescript
+
+// Creating a function that will be used by the incrementing entry point.
+export function counter_inc(): void {
+  let countKey = CL.getKey(COUNT_KEY);
+  if (!countKey) {
+    Error.fromErrorCode(ErrorCode.MissingKey).revert();
+    return;
+  }
+
+  if (!countKey.isURef()) {
+    Error.fromErrorCode(ErrorCode.UnexpectedKeyVariant).revert();
+    return;
+  }
+
+  const one = CLValue.fromI32(1);
+
+  countKey.add(one);
+}
+
+// Creating a function that will be used by the value retrieval entry point.
+export function counter_get(): void {
+  let countKey = CL.getKey(COUNT_KEY);
+
+  if (!countKey) {
+    Error.fromErrorCode(ErrorCode.MissingKey).revert();
+    return;
+  }
+
+  if (!countKey.isURef()) {
+    Error.fromErrorCode(ErrorCode.UnexpectedKeyVariant).revert();
+    return;
+  }
+  let countData = countKey.read();
+  if (!countData) {
+    Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
+    return;
+  }
+  let value = fromBytesI32(<Uint8Array>countData).unwrap();
+  CL.ret(CLValue.fromI32(value));
+}
+
+```
+
+### Step 3. Defining the `Call` Function
+
+We will also define the `Call` function that will start the code execution and perform the actual code installation. This function initializes the contract by setting the counter to 0 and creates `NamedKeys` in the current context. Specifically, it creates the keys `counter_package_name` and `counter_access_uref`.
+
+Further, it establishes the entry points `entryPointInc` and `entryPointGet` tied to their respective functions as defined above. Finally, it creates a key with the `ContractHash` to allow access to the installed contract code.
+
+```typescript
+
+export function call(): void {
+  // Create entry points to get the counter value and to increment the counter by 1.
+  let counterEntryPoints = new CL.EntryPoints();
+
+  let entryPointInc = new CL.EntryPoint(COUNTER_INC, new Array(), new CLType(CLTypeTag.Unit), new CL.PublicAccess(), CL.EntryPointType.Contract);
+  counterEntryPoints.addEntryPoint(entryPointInc);
+  let entryPointGet = new CL.EntryPoint(COUNTER_GET, new Array(), new CLType(CLTypeTag.I32), new CL.PublicAccess(), CL.EntryPointType.Contract);
+  counterEntryPoints.addEntryPoint(entryPointGet);
+
+  // Initialize counter to 0.
+  let counterLocalKey = Key.create(CLValue.fromI32(0));
+  if (!counterLocalKey) {
+    Error.fromUserError(0).revert();
+    return;
+  }
+
+  // Create initial named keys of the contract.
+  let counterNamedKeys = new Array<Pair<String, Key>>();
+  counterNamedKeys.push(new Pair<String, Key>(COUNT_KEY, counterLocalKey));
+
+  const result = CL.newContract(
+    counterEntryPoints,
+    counterNamedKeys,
+    "counter_package_name",
+    "counter_access_uref",
+  );
+
+  // To create a locked contract instead, use new_locked_contract and throw away the contract version returned
+  // const result = CL.newLockedContract(counterEntryPoints, counterNamedKeys, "counter_package_name", "counter_access_uref");
+
+  // The current version of the contract will be reachable through named keys
+  const versionURef = Key.create(CLValue.fromI32(result.contractVersion));
+  if (!versionURef) {
+    return;
+  }
+  CL.putKey(CONTRACT_VERSION_KEY, versionURef);
+
+  // Hash of the installed contract will be reachable through named keys
+  CL.putKey(COUNTER_KEY, Key.fromHash(result.contractHash));
+}
+
+```

--- a/smart_contracts/contracts_as/example/increment-counter/README.md
+++ b/smart_contracts/contracts_as/example/increment-counter/README.md
@@ -1,11 +1,10 @@
-# Counter Contract Installation
+# Counter Contract Session Code
 
-This example code will install a simple counter using AssemblyScript. Instructions for getting started on Casper using AssemblyScript can be found in our [Getting Started with AssemblyScript](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/assembly-script/) guide.
+This example code will call our [previously installed Counter Contract](https://github.com/casper-network/casper-node/tree/dev/smart_contracts/contracts_as/example/counter-installer) using AssemblyScript. Instructions for getting started on Casper using AssemblyScript can be found in our [Getting Started with AssemblyScript](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/assembly-script/) guide.
 
-## Session Code
+## Calling Contract Code
 
-Installing a smart contract to global state on a Casper Network requires the use of session code. This example code uses AssemblyScript to send a Wasm-bearing [Deploy](https://docs.casperlabs.io/glossary/D/#deploy) containing the contract to be installed.
-
+Previously, we installed a simple counter smart contract that contains an incrementing variable. We defined two entry points, `entryPointInc` and `entryPointGet`. We also defined the `call` function that initialized the contract. This constitutes the contract code that we will now call using session code.
 
 ### Step 1. Configuring the Index.ts File
 
@@ -19,15 +18,18 @@ The first section of *assembly/index.ts* outlines the necessary dependencies to 
 
 ```typescript
 
-// Importing necessary aspects of external packages.
+//@ts-nocheck
+// Importing necessary components from other packages.
 import * as CL from "../../../../contract_as/assembly";
 import { Error, ErrorCode } from "../../../../contract_as/assembly/error";
 import { fromBytesI32, fromBytesString, toBytesMap } from "../../../../contract_as/assembly/bytesrepr";
 import { Key } from "../../../../contract_as/assembly/key";
 import { CLValue, CLType, CLTypeTag } from "../../../../contract_as/assembly/clvalue";
 import { Pair } from "../../../../contract_as/assembly/pair";
+import { RuntimeArgs } from "../../../../contract_as/assembly/runtime_args";
 
-// Establishing constants for use within the installing contract.
+
+// Establishing constants for use within our session code.
 const COUNT_KEY = "count";
 const COUNTER_INC = "counter_inc";
 const COUNTER_GET = "counter_get";
@@ -36,101 +38,61 @@ const CONTRACT_VERSION_KEY = "version";
 
 ```
 
-### Step 2. Defining the Contract Entry Points
+### Step 2. Defining Functions for Interacting with the Smart Contract
 
-Each entry point that we later establish will require an associated function to perform the desired action. In the next section of *index.ts* we define these functions to perform the actions of incrementing the counter and viewing the current counter value.
+While our `call` function will execute the session code and interact with the installed counter contract, we will need to define the actions our `call` function will take.
+
+* `counterGet` retrieves the current value of the counter.
+
+* `counterInc` increments the counter value by 1.
 
 ```typescript
 
-// Creating a function that will be used by the incrementing entry point.
-export function counter_inc(): void {
-  let countKey = CL.getKey(COUNT_KEY);
-  if (!countKey) {
-    Error.fromErrorCode(ErrorCode.MissingKey).revert();
-    return;
-  }
-
-  if (!countKey.isURef()) {
-    Error.fromErrorCode(ErrorCode.UnexpectedKeyVariant).revert();
-    return;
-  }
-
-  const one = CLValue.fromI32(1);
-
-  countKey.add(one);
+function counterGet(contractHash: Uint8Array): i32 {
+  let bytes = CL.callContract(contractHash, COUNTER_GET, new RuntimeArgs());
+  return fromBytesI32(bytes).unwrap();
 }
 
-// Creating a function that will be used by the value retrieval entry point.
-export function counter_get(): void {
-  let countKey = CL.getKey(COUNT_KEY);
-
-  if (!countKey) {
-    Error.fromErrorCode(ErrorCode.MissingKey).revert();
-    return;
-  }
-
-  if (!countKey.isURef()) {
-    Error.fromErrorCode(ErrorCode.UnexpectedKeyVariant).revert();
-    return;
-  }
-  let countData = countKey.read();
-  if (!countData) {
-    Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
-    return;
-  }
-  let value = fromBytesI32(<Uint8Array>countData).unwrap();
-  CL.ret(CLValue.fromI32(value));
+function counterInc(contractHash: Uint8Array): void {
+  CL.callContract(contractHash, COUNTER_INC, new RuntimeArgs());
 }
 
 ```
 
 ### Step 3. Defining the `Call` Function
 
-We will also define the `Call` function that will start the code execution and perform the contract installation. This function initializes the contract by setting the counter to 0 and creating `NamedKeys` to be passed to the contract. Specifically, it creates the keys `counter_package_name` and `counter_access_uref` which will persist within the contract's context.
+The `call` function serves to execute the session code, calling the counter contract. To do so, it uses the `COUNTER_KEY` constant, which should contain the `contractHash` of the counter contract.
 
-Further, it establishes the entry points `entryPointInc` and `entryPointGet` tied to their respective functions as defined above. Finally, it creates a key with the `ContractHash` to allow access to the installed contract code.
+It then reads the current value of the counter, increments the value by 1 and then reads the updated value of the counter. Finally, it observes the difference between the first value observed (`currentCounterValue`) and the new value (`newCounterValue`). If the the difference is not equal to 1, it will cause an error.
 
 ```typescript
 
 export function call(): void {
-  // Create entry points to get the counter value and to increment the counter by 1.
-  let counterEntryPoints = new CL.EntryPoints();
-
-  let entryPointInc = new CL.EntryPoint(COUNTER_INC, new Array(), new CLType(CLTypeTag.Unit), new CL.PublicAccess(), CL.EntryPointType.Contract);
-  counterEntryPoints.addEntryPoint(entryPointInc);
-  let entryPointGet = new CL.EntryPoint(COUNTER_GET, new Array(), new CLType(CLTypeTag.I32), new CL.PublicAccess(), CL.EntryPointType.Contract);
-  counterEntryPoints.addEntryPoint(entryPointGet);
-
-  // Initialize counter to 0.
-  let counterLocalKey = Key.create(CLValue.fromI32(0));
-  if (!counterLocalKey) {
-    Error.fromUserError(0).revert();
+  // Read the Counter smart contract's ContractHash.
+  let contractHashKey = CL.getKey(COUNTER_KEY);
+  if (!contractHashKey) {
+    Error.fromUserError(66).revert();
+    return;
+  }
+  let contractHash = contractHashKey.hash;
+  if (!contractHash) {
+    Error.fromUserError(66).revert();
     return;
   }
 
-  // Create initial named keys of the contract.
-  let counterNamedKeys = new Array<Pair<String, Key>>();
-  counterNamedKeys.push(new Pair<String, Key>(COUNT_KEY, counterLocalKey));
+  // Call Counter to get the current value.
+  let currentCounterValue = counterGet(contractHash);
 
-  const result = CL.newContract(
-    counterEntryPoints,
-    counterNamedKeys,
-    "counter_package_name",
-    "counter_access_uref",
-  );
+  // Call Counter to increment the value.
+  counterInc(contractHash);
 
-  // To create a locked contract instead, use new_locked_contract and throw away the contract version returned
-  // const result = CL.newLockedContract(counterEntryPoints, counterNamedKeys, "counter_package_name", "counter_access_uref");
+  // Call Counter to get the new value.
+  let newCounterValue = counterGet(contractHash);
 
-  // The current version of the contract will be reachable through named keys
-  const versionURef = Key.create(CLValue.fromI32(result.contractVersion));
-  if (!versionURef) {
-    return;
+  // Expect counter to increment by one.
+  if (newCounterValue - currentCounterValue != 1) {
+    Error.fromUserError(67).revert();
   }
-  CL.putKey(CONTRACT_VERSION_KEY, versionURef);
-
-  // Hash of the installed contract will be reachable through named keys
-  CL.putKey(COUNTER_KEY, Key.fromHash(result.contractHash));
 }
 
 ```

--- a/smart_contracts/contracts_as/example/increment-counter/README.md
+++ b/smart_contracts/contracts_as/example/increment-counter/README.md
@@ -1,4 +1,4 @@
-# Counter Contract
+# Counter Contract Installation
 
 This example code will install a simple counter using AssemblyScript. Instructions for getting started on Casper using AssemblyScript can be found in our [Getting Started with AssemblyScript](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/assembly-script/) guide.
 

--- a/smart_contracts/contracts_as/example/increment-counter/README.md
+++ b/smart_contracts/contracts_as/example/increment-counter/README.md
@@ -86,7 +86,7 @@ export function counter_get(): void {
 
 ### Step 3. Defining the `Call` Function
 
-We will also define the `Call` function that will start the code execution and perform the actual code installation. This function initializes the contract by setting the counter to 0 and creates `NamedKeys` in the current context. Specifically, it creates the keys `counter_package_name` and `counter_access_uref`.
+We will also define the `Call` function that will start the code execution and perform the contract installation. This function initializes the contract by setting the counter to 0 and creating `NamedKeys` to be passed to the contract. Specifically, it creates the keys `counter_package_name` and `counter_access_uref` which will persist within the contract's context.
 
 Further, it establishes the entry points `entryPointInc` and `entryPointGet` tied to their respective functions as defined above. Finally, it creates a key with the `ContractHash` to allow access to the installed contract code.
 


### PR DESCRIPTION
This PR brings all recent commits since https://github.com/casper-network/casper-node/commit/4ac78700e2de3f704e9902434cbab73e33e49919 from the dev branch to the feat-2.0 branch.

Merge had no conflicts.
