### PR TITLE
Add `bytesrepr` codec to `muxink`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
+ "casper-types 1.5.0",
  "futures",
  "serde",
  "thiserror",

--- a/muxink/Cargo.toml
+++ b/muxink/Cargo.toml
@@ -18,5 +18,5 @@ casper-types = { path = "../types", optional = true }
 tokio-stream = "0.1.8"
 
 [features]
-bincode = [ "dep:serde", "dep:bincode" ]
-bytesrepr = [ "dep:casper-types" ] 
+muxink_bincode_codec = [ "serde", "bincode" ]
+muxink_bytesrepr_codec = [ "casper-types" ] 

--- a/muxink/Cargo.toml
+++ b/muxink/Cargo.toml
@@ -12,9 +12,11 @@ serde = { version = "1.0.138", optional = true }
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = [ "full" ] }
 tokio-util = "0.7.2"
+casper-types = { path = "../types", optional = true }
 
 [dev-dependencies]
 tokio-stream = "0.1.8"
 
 [features]
 bincode = [ "dep:serde", "dep:bincode" ]
+bytesrepr = [ "dep:casper-types" ] 

--- a/muxink/src/backpressured.rs
+++ b/muxink/src/backpressured.rs
@@ -80,7 +80,9 @@ impl<S, A, Item> BackpressuredSink<S, A, Item> {
 
 impl<Item, A, S> Sink<Item> for BackpressuredSink<S, A, Item>
 where
-    // TODO: `Unpin` trait bounds can be removed by using `map_unchecked` if necessary.
+    // TODO: `Unpin` trait bounds can be
+    // removed by using `map_unchecked` if
+    // necessary.
     S: Sink<Item> + Unpin,
     Self: Unpin,
     A: Stream<Item = u64> + Unpin,

--- a/muxink/src/codec.rs
+++ b/muxink/src/codec.rs
@@ -24,6 +24,8 @@
 
 #[cfg(feature = "bincode")]
 pub mod bincode;
+#[cfg(feature = "bytesrepr")]
+pub mod bytesrepr;
 pub mod length_delimited;
 
 use std::{

--- a/muxink/src/codec.rs
+++ b/muxink/src/codec.rs
@@ -22,9 +22,9 @@
 //! * [`length_delimited`]: Transforms byte-like values into self-contained frames with a
 //!   length-prefix.
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "muxink_bincode_codec")]
 pub mod bincode;
-#[cfg(feature = "bytesrepr")]
+#[cfg(feature = "muxink_bytesrepr_codec")]
 pub mod bytesrepr;
 pub mod length_delimited;
 

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -17,10 +17,10 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::{DecodeResult, FrameDecoder, Transcoder};
 
-/// A bincode encoder.
+/// Bincode encoder.
 ///
 /// Every value is encoded with the default settings of `bincode`.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BincodeEncoder<T> {
     /// Item type processed by this encoder.
     ///
@@ -57,7 +57,7 @@ where
 /// Like [`BincodeEncoder`], uses default settings for decoding. Can be used on bytestreams (via
 /// [`FrameDecoder`]) as well as frames (through [`Transcoder`]). See module documentation for
 /// caveats.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BincodeDecoder<T> {
     item_type: PhantomData<T>,
 }

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -46,8 +46,7 @@ where
     type Output = Bytes;
 
     fn transcode(&mut self, input: T) -> Result<Self::Output, Self::Error> {
-        DefaultOptions::new()
-            .reject_trailing_bytes()
+        bincode_transcode_options()
             .serialize(&input)
             .map(Bytes::from)
     }
@@ -82,9 +81,7 @@ where
     type Output = T;
 
     fn transcode(&mut self, input: R) -> Result<Self::Output, Self::Error> {
-        DefaultOptions::new()
-            .reject_trailing_bytes()
-            .deserialize(input.as_ref())
+        bincode_transcode_options().deserialize(input.as_ref())
     }
 }
 
@@ -131,6 +128,12 @@ where
             },
         }
     }
+}
+
+fn bincode_transcode_options() -> impl bincode::config::Options {
+    DefaultOptions::new()
+        .reject_trailing_bytes()
+        .with_varint_encoding()
 }
 
 #[cfg(test)]

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -119,7 +119,15 @@ where
                 bincode::ErrorKind::Io(io_err) if io_err.kind() == io::ErrorKind::UnexpectedEof => {
                     DecodeResult::Incomplete
                 }
-                _ => DecodeResult::Failed(err),
+                bincode::ErrorKind::SizeLimit
+                | bincode::ErrorKind::SequenceMustHaveLength
+                | bincode::ErrorKind::Custom(_)
+                | bincode::ErrorKind::InvalidCharEncoding
+                | bincode::ErrorKind::InvalidTagEncoding(_)
+                | bincode::ErrorKind::DeserializeAnyNotSupported
+                | bincode::ErrorKind::Io(_)
+                | bincode::ErrorKind::InvalidUtf8Encoding(_)
+                | bincode::ErrorKind::InvalidBoolEncoding(_) => DecodeResult::Failed(err),
             },
         }
     }

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -160,6 +160,17 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "'transcode()' should fail here as the buffer is not exhausted"]
+    fn error_when_buffer_not_exhausted() {
+        let data = b"\x03\0\0\0\0\0\0\0abc\x04\0\0\0\0\0\0\0defg";
+
+        let mut decoder = BincodeDecoder::<String>::new();
+        let actual_error = decoder.transcode(data).unwrap_err();
+
+        dbg!(&actual_error);
+    }
+
+    #[test]
     fn error_when_data_incomplete() {
         let data = b"\x03\0\0\0\0\0\0\0ab";
 

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -140,15 +140,15 @@ mod tests {
 
     #[test]
     fn decodes_frame() {
-        let data = b"\x01\x02rem";
+        let data = b"\x03\0\0\0\0\0\0\0abc\x04\0\0\0\0\0\0\0defg";
 
         let mut bytes: BytesMut = BytesMut::new();
         bytes.extend(data);
 
-        let mut decoder = BincodeDecoder::<u8>::new();
+        let mut decoder = BincodeDecoder::<String>::new();
 
-        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == 1));
-        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == 2));
+        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == "abc"));
+        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == "defg"));
     }
 
     #[test]
@@ -157,5 +157,20 @@ mod tests {
 
         let mut decoder = BincodeDecoder::<String>::new();
         let _ = decoder.transcode(data).expect_err("should not decode");
+    }
+
+    #[test]
+    fn error_when_data_incomplete() {
+        let data = b"\x03\0\0\0\0\0\0\0ab";
+
+        let mut bytes: BytesMut = BytesMut::new();
+        bytes.extend(data);
+
+        let mut decoder = BincodeDecoder::<String>::new();
+
+        assert!(matches!(
+            decoder.decode_frame(&mut bytes),
+            DecodeResult::Incomplete
+        ));
     }
 }

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -99,7 +99,10 @@ where
         let (outcome, consumed) = {
             let slice: &[u8] = buffer.as_ref();
             let mut cursor = Cursor::new(slice);
-            let outcome = bincode::deserialize_from(&mut cursor);
+            let outcome = DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .deserialize_from(&mut cursor);
             (outcome, cursor.position() as usize)
         };
 

--- a/muxink/src/codec/bincode.rs
+++ b/muxink/src/codec/bincode.rs
@@ -1,6 +1,6 @@
 //! Bincode encoding/decoding
 //!
-//! Both encoding and decoding are supported by this module. Note that `BincodeDecoder` supports
+//! Both encoding and decoding are supported by this module. Note that `BincodeDecoder`
 //! implements both [`Transcoder`] and [`FrameDecoder`]. The former operates on frames and is safe
 //! to use, the latter attempts to parse incoming buffers until successful. For this reason,
 //! variably sized or large types should be avoided, as decoding will otherwise open up an

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -1,5 +1,4 @@
 //! Bytesrepr encoding/decoding
-//!
 use std::{fmt::Debug, marker::PhantomData};
 
 use bytes::{Buf, Bytes, BytesMut};

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -14,8 +14,8 @@ pub enum Error {
     BytesreprError(bytesrepr::Error),
 }
 
-/// A bytesrepr encoder.
-#[derive(Default)]
+/// Bytesrepr encoder.
+#[derive(Debug, Default)]
 pub struct BytesreprEncoder<T> {
     /// Item type processed by this encoder.
     ///
@@ -46,7 +46,7 @@ where
 }
 
 /// Bytesrepr decoder.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BytesreprDecoder<T> {
     item_type: PhantomData<T>,
 }

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -41,7 +41,7 @@ where
     type Output = Bytes;
 
     fn transcode(&mut self, input: T) -> Result<Self::Output, Self::Error> {
-        Ok(input.to_bytes().map_err(Error::BytesreprError)?.into())
+        Ok(input.into_bytes().map_err(Error::BytesreprError)?.into())
     }
 }
 

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -1,0 +1,183 @@
+//! Bytesrepr encoding/decoding
+//!
+use std::{fmt::Debug, marker::PhantomData};
+
+use bytes::{Buf, Bytes, BytesMut};
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use thiserror::Error;
+
+use super::{DecodeResult, FrameDecoder, Transcoder};
+use crate::codec::DecodeResult::Failed;
+
+#[derive(Debug, Error)]
+pub enum TranscoderError {
+    #[error("buffer not exhausted")]
+    BufferNotExhausted { left: usize },
+    #[error("bytesrepr error")]
+    BytesreprError(bytesrepr::Error),
+}
+
+/// A bytesrepr encoder.
+#[derive(Default)]
+pub struct BytesreprEncoder<T> {
+    /// Item type processed by this encoder.
+    ///
+    /// We restrict encoders to a single message type to make decoding on the other end easier.
+    item_type: PhantomData<T>,
+}
+
+impl<T> BytesreprEncoder<T> {
+    /// Creates a new bytesrepr encoder.
+    pub fn new() -> Self {
+        BytesreprEncoder {
+            item_type: PhantomData,
+        }
+    }
+}
+
+impl<T> Transcoder<T> for BytesreprEncoder<T>
+where
+    T: ToBytes,
+{
+    type Error = TranscoderError;
+
+    type Output = Bytes;
+
+    fn transcode(&mut self, input: T) -> Result<Self::Output, Self::Error> {
+        let bytes = input
+            .to_bytes()
+            .map_err(|e| TranscoderError::BytesreprError(e))?;
+
+        Ok(bytes.into())
+    }
+}
+
+/// Bytesrepr decoder.
+#[derive(Default)]
+pub struct BytesreprDecoder<T> {
+    item_type: PhantomData<T>,
+}
+
+impl<T> BytesreprDecoder<T> {
+    /// Creates a new bytesrepr decoder.
+    pub fn new() -> Self {
+        BytesreprDecoder {
+            item_type: PhantomData,
+        }
+    }
+}
+
+impl<R, T> Transcoder<R> for BytesreprDecoder<T>
+where
+    T: FromBytes + Send + Sync + 'static,
+    R: AsRef<[u8]> + Debug,
+{
+    type Error = TranscoderError;
+
+    type Output = T;
+
+    fn transcode(&mut self, input: R) -> Result<Self::Output, Self::Error> {
+        let (data, rem) = FromBytes::from_bytes(input.as_ref())
+            .map_err(|e| TranscoderError::BytesreprError(e))?;
+
+        if !rem.is_empty() {
+            return Err(TranscoderError::BufferNotExhausted { left: rem.len() }.into());
+        }
+
+        Ok(data)
+    }
+}
+
+impl<T> FrameDecoder for BytesreprDecoder<T>
+where
+    T: FromBytes + Send + Sync + 'static,
+{
+    type Error = TranscoderError;
+    type Output = T;
+
+    fn decode_frame(&mut self, buffer: &mut BytesMut) -> DecodeResult<Self::Output, Self::Error> {
+        let transcoded = FromBytes::from_bytes(buffer.as_ref());
+        match transcoded {
+            Ok((data, rem)) => {
+                let _ = buffer.split_to(buffer.remaining() - rem.len());
+                DecodeResult::Item(data)
+            }
+            Err(err) => match &err {
+                bytesrepr::Error::EarlyEndOfStream => DecodeResult::Incomplete,
+                bytesrepr::Error::Formatting
+                | bytesrepr::Error::LeftOverBytes
+                | bytesrepr::Error::NotRepresentable
+                | bytesrepr::Error::ExceededRecursionDepth
+                | bytesrepr::Error::OutOfMemory => {
+                    Failed(TranscoderError::BytesreprError(err).into())
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DecodeResult;
+    use crate::codec::{
+        bytesrepr::{
+            BytesreprDecoder, BytesreprEncoder,
+            TranscoderError::{self},
+        },
+        BytesMut, FrameDecoder, Transcoder,
+    };
+    use casper_types::bytesrepr;
+
+    #[test]
+    fn roundtrip() {
+        let data = "abc";
+
+        let mut encoder = BytesreprEncoder::new();
+        let value: String = String::from(data);
+        let encoded = encoder.transcode(value).expect("should encode");
+
+        let mut decoder = BytesreprDecoder::<String>::new();
+        let decoded = decoder.transcode(encoded).expect("should decode");
+
+        assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn decodes_frame() {
+        let data = b"\x03\0\0\0abc\x04\0\0\0defg";
+
+        let mut bytes: BytesMut = BytesMut::new();
+        bytes.extend(data);
+
+        let mut decoder = BytesreprDecoder::<String>::new();
+
+        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == "abc"));
+        assert!(matches!(decoder.decode_frame(&mut bytes), DecodeResult::Item(i) if i == "defg"));
+    }
+
+    #[test]
+    fn error_when_buffer_not_exhausted() {
+        let data = b"\x03\0\0\0abc\x04\0\0\0defg";
+
+        let mut decoder = BytesreprDecoder::<String>::new();
+        let actual_error = decoder.transcode(data).unwrap_err();
+
+        assert!(matches!(
+            actual_error,
+            TranscoderError::BufferNotExhausted { left: 8 }
+        ));
+    }
+
+    #[test]
+    fn error_when_data_incomplete() {
+        let data = b"\x03\0\0\0ab";
+
+        let mut decoder = BytesreprDecoder::<String>::new();
+        let actual_error = decoder.transcode(data).unwrap_err();
+
+        assert!(matches!(
+            actual_error,
+            TranscoderError::BytesreprError(bytesrepr::Error::EarlyEndOfStream)
+        ));
+    }
+}

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -44,9 +44,7 @@ where
     type Output = Bytes;
 
     fn transcode(&mut self, input: T) -> Result<Self::Output, Self::Error> {
-        let bytes = input
-            .to_bytes()
-            .map_err(|e| TranscoderError::BytesreprError(e))?;
+        let bytes = input.to_bytes().map_err(TranscoderError::BytesreprError)?;
 
         Ok(bytes.into())
     }
@@ -77,11 +75,11 @@ where
     type Output = T;
 
     fn transcode(&mut self, input: R) -> Result<Self::Output, Self::Error> {
-        let (data, rem) = FromBytes::from_bytes(input.as_ref())
-            .map_err(|e| TranscoderError::BytesreprError(e))?;
+        let (data, rem) =
+            FromBytes::from_bytes(input.as_ref()).map_err(TranscoderError::BytesreprError)?;
 
         if !rem.is_empty() {
-            return Err(TranscoderError::BufferNotExhausted { left: rem.len() }.into());
+            return Err(TranscoderError::BufferNotExhausted { left: rem.len() });
         }
 
         Ok(data)
@@ -108,9 +106,7 @@ where
                 | bytesrepr::Error::LeftOverBytes
                 | bytesrepr::Error::NotRepresentable
                 | bytesrepr::Error::ExceededRecursionDepth
-                | bytesrepr::Error::OutOfMemory => {
-                    Failed(TranscoderError::BytesreprError(err).into())
-                }
+                | bytesrepr::Error::OutOfMemory => Failed(TranscoderError::BytesreprError(err)),
             },
         }
     }

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -151,6 +151,14 @@ mod tests {
     }
 
     #[test]
+    fn error_when_decoding_incorrect_data() {
+        let data = "abc";
+
+        let mut decoder = BytesreprDecoder::<String>::new();
+        let _ = decoder.transcode(data).expect_err("should not decode");
+    }
+
+    #[test]
     fn error_when_buffer_not_exhausted() {
         let data = b"\x03\0\0\0abc\x04\0\0\0defg";
 

--- a/muxink/src/codec/bytesrepr.rs
+++ b/muxink/src/codec/bytesrepr.rs
@@ -1,8 +1,11 @@
 //! Bytesrepr encoding/decoding
-use std::{fmt::Debug, marker::PhantomData};
+//!
+//! Both encoding and decoding are supported by this module. Note that `BytesreprDecoder`
+//! implements both [`Transcoder`] and [`FrameDecoder`].
 
 use bytes::{Buf, Bytes, BytesMut};
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 
 use super::{DecodeResult, FrameDecoder, Transcoder};

--- a/muxink/src/fragmented.rs
+++ b/muxink/src/fragmented.rs
@@ -1,8 +1,8 @@
 //! Splits frames into fragments.
 //!
 //! The wire format for fragments is `NCCC...` where `CCC...` is the data fragment and `N` is the
-//! continuation byte, which is `0x00` if more fragments are following, `0xFF` if this is the frame's
-//! last fragment.
+//! continuation byte, which is `0x00` if more fragments are following, `0xFF` if this is the
+//! frame's last fragment.
 
 use std::{
     num::NonZeroUsize,
@@ -249,8 +249,8 @@ where
 ///
 /// # Notes
 ///
-/// Internally, data is copied into fragments by using `Buf::copy_to_bytes`. It is advisable to use a
-/// `B` that has an efficient implementation for this that avoids copies, like `Bytes` itself.
+/// Internally, data is copied into fragments by using `Buf::copy_to_bytes`. It is advisable to use
+/// a `B` that has an efficient implementation for this that avoids copies, like `Bytes` itself.
 pub fn fragment_frame<B: Buf>(
     mut frame: B,
     fragment_size: NonZeroUsize,

--- a/muxink/src/lib.rs
+++ b/muxink/src/lib.rs
@@ -171,6 +171,7 @@ where
     }
 }
 
+#[rustfmt::skip]
 #[cfg(test)]
 pub(crate) mod tests {
 
@@ -222,10 +223,8 @@ pub(crate) mod tests {
 
     // #[test]
     // fn from_bytestream_to_multiple_frames() {
-    //     let input =
-    // &b"\x06\x00\x00ABCDE\x06\x00\x00FGHIJ\x03\x00\xffKL\x10\x00\xffSINGLE_FRAGMENT\x02\x00\x00C\
-    // x02\x00\x00R\x02\x00\x00U\x02\x00\x00M\x02\x00\x00B\x02\x00\xffS"[..];     let expected:
-    // &[&[u8]] = &[b"ABCDEFGHIJKL", b"SINGLE_FRAGMENT", b"CRUMBS"];
+    //     let input = &b"\x06\x00\x00ABCDE\x06\x00\x00FGHIJ\x03\x00\xffKL\x10\x00\xffSINGLE_FRAGMENT\x02\x00\x00C\x02\x00\x00R\x02\x00\x00U\x02\x00\x00M\x02\x00\x00B\x02\x00\xffS"[..];
+    //     let expected: &[&[u8]] = &[b"ABCDEFGHIJKL", b"SINGLE_FRAGMENT", b"CRUMBS"];
 
     //     let defragmentizer = make_defragmentizer(FrameReader::new(
     //         LengthDelimited,

--- a/muxink/src/lib.rs
+++ b/muxink/src/lib.rs
@@ -12,8 +12,10 @@ pub mod testing;
 use std::num::NonZeroUsize;
 
 use bytes::Buf;
-use codec::length_delimited::{LengthDelimited, LengthPrefixedFrame};
-use codec::{Transcoder, TranscodingSink, TranscodingStream};
+use codec::{
+    length_delimited::{LengthDelimited, LengthPrefixedFrame},
+    Transcoder, TranscodingSink, TranscodingStream,
+};
 use fragmented::{Defragmentizer, Fragmentizer, SingleFragment};
 use futures::Sink;
 
@@ -220,8 +222,10 @@ pub(crate) mod tests {
 
     // #[test]
     // fn from_bytestream_to_multiple_frames() {
-    //     let input = &b"\x06\x00\x00ABCDE\x06\x00\x00FGHIJ\x03\x00\xffKL\x10\x00\xffSINGLE_FRAGMENT\x02\x00\x00C\x02\x00\x00R\x02\x00\x00U\x02\x00\x00M\x02\x00\x00B\x02\x00\xffS"[..];
-    //     let expected: &[&[u8]] = &[b"ABCDEFGHIJKL", b"SINGLE_FRAGMENT", b"CRUMBS"];
+    //     let input =
+    // &b"\x06\x00\x00ABCDE\x06\x00\x00FGHIJ\x03\x00\xffKL\x10\x00\xffSINGLE_FRAGMENT\x02\x00\x00C\
+    // x02\x00\x00R\x02\x00\x00U\x02\x00\x00M\x02\x00\x00B\x02\x00\xffS"[..];     let expected:
+    // &[&[u8]] = &[b"ABCDEFGHIJKL", b"SINGLE_FRAGMENT", b"CRUMBS"];
 
     //     let defragmentizer = make_defragmentizer(FrameReader::new(
     //         LengthDelimited,


### PR DESCRIPTION
This PR adds the `bytesrepr` codec to `muxink` crate.
It also adds unit tests to the `bincode` codec and fixes some minor issues in it.

Closes https://github.com/casper-network/casper-node/issues/3198
