### PR TITLE
NCTL: initial add of nctl test with validator swap

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -97,6 +97,7 @@ start_run_teardown "emergency_upgrade_test.sh"
 start_run_teardown "emergency_upgrade_test_balances.sh"
 start_run_teardown "sync_test.sh timeout=500"
 start_run_teardown "gov96.sh"
+start_run_teardown "swap_validator_set.sh"
 # Keep this test last
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
 

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -248,7 +248,6 @@ function setup_asset_chainspec()
             "cfg['protocol']['activation_point']='$ACTIVATION_POINT';"
             "cfg['protocol']['version']='$PROTOCOL_VERSION';"
             "cfg['network']['name']='$(get_chain_name)';"
-            "cfg['core']['validator_slots']=$COUNT_NODES;"
             "toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));"
         )
     else
@@ -258,7 +257,6 @@ function setup_asset_chainspec()
             "cfg['protocol']['activation_point']=$ACTIVATION_POINT;"
             "cfg['protocol']['version']='$PROTOCOL_VERSION';"
             "cfg['network']['name']='$(get_chain_name)';"
-            "cfg['core']['validator_slots']=$COUNT_NODES;"
             "toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));"
         )
     fi

--- a/utils/nctl/sh/misc/await_until_era_n.sh
+++ b/utils/nctl/sh/misc/await_until_era_n.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 unset FUTURE_ERA_ID
+unset LOG_OUTPUT
+unset SLEEP_INTERVAL
 
 for ARGUMENT in "$@"
 do
@@ -8,11 +10,15 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in        
         era) FUTURE_ERA_ID=${VALUE} ;;
+        log) LOG_OUTPUT=${VALUE} ;;
+        sleep_interval) SLEEP_INTERVAL=${VALUE} ;;
         *)
     esac
 done
 
 FUTURE_ERA_ID=${FUTURE_ERA_ID:-1}
+LOG_OUTPUT=${LOG_OUTPUT:-'false'}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-'5'}
 
 # ----------------------------------------------------------------
 # MAIN
@@ -22,5 +28,8 @@ source "$NCTL"/sh/utils/main.sh
 
 while [ "$(get_chain_era)" -lt "$FUTURE_ERA_ID" ];
 do
-    sleep 5.0
+    if [ "$LOG_OUTPUT" == 'true' ]; then
+        log "current era = $(get_chain_era) :: future era = $FUTURE_ERA_ID :: sleeping $SLEEP_INTERVAL seconds"
+    fi
+    sleep "$SLEEP_INTERVAL"
 done

--- a/utils/nctl/sh/scenarios/accounts_toml/swap_validator_set.accounts.toml.override
+++ b/utils/nctl/sh/scenarios/accounts_toml/swap_validator_set.accounts.toml.override
@@ -1,0 +1,134 @@
+# FAUCET.
+[[accounts]]
+public_key = "PBK_FAUCET"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 1.
+[[accounts]]
+public_key = "PBK_V1"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 0
+
+# VALIDATOR 2.
+[[accounts]]
+public_key = "PBK_V2"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 0
+
+# VALIDATOR 3.
+[[accounts]]
+public_key = "PBK_V3"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 0
+
+# VALIDATOR 4.
+[[accounts]]
+public_key = "PBK_V4"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 0
+
+# VALIDATOR 5.
+[[accounts]]
+public_key = "PBK_V5"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 0
+
+# VALIDATOR 6.
+[[accounts]]
+public_key = "PBK_V6"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 7.
+[[accounts]]
+public_key = "PBK_V7"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 8.
+[[accounts]]
+public_key = "PBK_V8"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 9.
+[[accounts]]
+public_key = "PBK_V9"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 10.
+[[accounts]]
+public_key = "PBK_V10"
+balance = "1000000000000000000000000000000000"
+
+# USER 1.
+[[delegators]]
+validator_public_key = "PBK_V1"
+delegator_public_key = "PBK_U1"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 2.
+[[delegators]]
+validator_public_key = "PBK_V2"
+delegator_public_key = "PBK_U2"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 3.
+[[delegators]]
+validator_public_key = "PBK_V3"
+delegator_public_key = "PBK_U3"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 4.
+[[delegators]]
+validator_public_key = "PBK_V4"
+delegator_public_key = "PBK_U4"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 5.
+[[delegators]]
+validator_public_key = "PBK_V5"
+delegator_public_key = "PBK_U5"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 6.
+[[accounts]]
+public_key = "PBK_U6"
+balance = "1000000000000000000000000000000000"
+
+# USER 7.
+[[accounts]]
+public_key = "PBK_U7"
+balance = "1000000000000000000000000000000000"
+
+# USER 8.
+[[accounts]]
+public_key = "PBK_U8"
+balance = "1000000000000000000000000000000000"
+
+# USER 9.
+[[accounts]]
+public_key = "PBK_U9"
+balance = "1000000000000000000000000000000000"
+
+# USER 10.
+[[accounts]]
+public_key = "PBK_U10"
+balance = "1000000000000000000000000000000000"

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.override
@@ -1,5 +1,6 @@
 [core]
 round_seigniorage_rate = [0, 1]
+validator_slots = 6
 
 [highway]
 maximum_round_exponent = 14

--- a/utils/nctl/sh/scenarios/chainspecs/swap_validator_set.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/swap_validator_set.chainspec.toml.override
@@ -1,0 +1,5 @@
+[core]
+round_seigniorage_rate = [0, 1]
+locked_funds_period = '0days'
+validator_slots = 5
+vesting_schedule_period = '0days'

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -483,3 +483,12 @@ function assert_eviction() {
         sleep 1
     done
 }
+
+function assert_new_bonded_validator() {
+    local NODE_ID=${1}
+    local HEX=$(get_node_public_key_hex "$NODE_ID")
+    if ! $(nctl-view-chain-auction-info | grep -q "$HEX"); then
+      echo "Could not find key in bids"
+      exit 1
+    fi
+}

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+function main() {
+    local PRE_SWAP_HASH
+    local POST_SWAP_HASH
+    local SWITCHBLOCK_HASH
+
+    log "------------------------------------------------------------"
+    log "Starting Scenario: swap_validator_set"
+    log "------------------------------------------------------------"
+
+    # 0. Wait for network to start up
+    do_await_genesis_era_to_complete
+
+    # 1. Allow the chain to progress
+    do_await_era_change 1
+    PRE_SWAP_HASH=$(do_read_lfb_hash 1)
+
+    # 2. Verify all nodes are in sync
+    check_network_sync
+
+    # 3. Send some wasm to all running nodes
+    log_step "sending wasm trandfers to validators"
+    for i in $(seq 1 5); do
+        send_wasm_transfers "$i"
+    done
+
+    # 4. Bid in nodes 6-10
+    log_step "bidding node's 6 thru 10 for takeover"
+    for i in $(seq 6 10); do
+        source "$NCTL"/sh/contracts-auction/do_bid.sh \
+                node="$i" \
+                amount="1000" \
+                rate="0"
+    done
+
+    # 5-9. Start nodes 6-10
+    for i in $(seq 6 10); do
+        do_start_node "$i" "$PRE_SWAP_HASH"
+    done
+
+    # 10. Wait auction_delay + 2
+    log_step "waiting until era 8 where swap should take place"
+    nctl-await-until-era-n era='8' log='true'
+
+    # Since this walks back to first found switch block, keep this immediately after era 8 starts
+    SWICHBLOCK_HASH=$(get_switch_block '1' '100' | jq -r '.hash' )
+
+    # 11. Assert nodes 6-10 in auction info
+    log_step "checking for new validators"
+    for i in $(seq 6 10); do
+        assert_new_bonded_validator "$i"
+        log "node-$i found in auction info"
+    done
+    nctl-view-chain-auction-info
+
+    # 12-16. Assert nodes 1-5 are evicted
+    for i in $(seq 1 5); do
+        assert_eviction "$i"
+    done
+
+    # 17. Reuse nodes 1-3
+    reuse_original_validators_as_new_nodes
+
+    # 18. Start node 1 with pre validator swap block hash
+    do_node_start '1' "$PRE_SWAP_HASH"
+
+    # 19. Start node 2 with post validator swap block hash
+    POST_SWAP_HASH=$(do_read_lfb_hash 6)
+    do_node_start '2' "$POST_SWAP_HASH"
+
+    # 20. Start node 3 with switch block hash
+    do_node_start '3' "$SWICHBLOCK_HASH"
+
+    # 21. Lets some time pass
+    nctl-await-n-eras offset='3' sleep_interval='10.0' timeout='300' node='6'
+
+    # 22. Check network is in sync
+    check_network_sync
+
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='0' \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
+
+    log "------------------------------------------------------------"
+    log "Scenario swap_validator_set complete"
+    log "------------------------------------------------------------"
+}
+
+
+# Hack to reuse original 3 validators as completely new nodes.
+# Uses existing unused user keys.
+# Note: Tom will revisit this later.
+
+function reuse_original_validators_as_new_nodes() {
+    local DUMP_PATH
+    local NODE_LOG_PATH
+    local NODE_STORAGE_PATH
+    local NODE_KEYS_PATH
+    local USER_KEYS_PATH
+
+    log_step "Converting nodes 1 thru 3 to 'new' joiners"
+
+    # place to move old node stuff
+    DUMP_PATH="/tmp/swap_validator_set"
+
+    # cleanup if it exists already
+    if [ -d "$DUMP_PATH" ]; then
+        rm -rf "$DUMP_PATH"
+    fi
+
+    # make sure it exists
+    mkdir -p "$DUMP_PATH"
+
+    # loop thru the 3 nodes
+    for i in $(seq 1 3); do
+        # stop the three nodes that will become make shift
+        # joining nodes 11, 12, 13
+        log "...stopping node-$i"
+        do_node_stop "$i"
+
+        # mv logs in case needed for failed runs
+        log "...moving logs to $DUMP_PATH"
+        NODE_LOG_PATH=$(get_path_to_node_logs "$i")
+        echo "cp $NODE_LOG_PATH/stdout.log $DUMP_PATH/$i.stdout.log"
+        mv "$NODE_LOG_PATH/stdout.log" "$DUMP_PATH/$i.stdout.log"
+        mv "$NODE_LOG_PATH/stderr.log" "$DUMP_PATH/$i.stderr.log"
+        # delete storage
+        log "...moving previous state"
+        NODE_STORAGE_PATH=$(get_path_to_node_storage "$i")
+        mv "$NODE_STORAGE_PATH/casper-net-1" "$DUMP_PATH/$i-storage"
+
+        # move in "new" validator keys
+        log "... switching in user keys as validator keys"
+        NODE_KEYS_PATH=$(get_path_to_node_keys "$i")
+        USER_KEYS_PATH=$(get_path_to_user "$i")
+        cp "$USER_KEYS_PATH/public_key.pem" "$NODE_KEYS_PATH/public_key.pem"
+        cp "$USER_KEYS_PATH/public_key_hex" "$NODE_KEYS_PATH/public_key_hex"
+        cp "$USER_KEYS_PATH/secret_key.pem" "$NODE_KEYS_PATH/secret_key.pem"
+    done
+}
+
+function send_wasm_transfers() {
+    local NODE_ID=${1}
+    log "sending wasm transfers to node-$NODE_ID"
+    source "$NCTL"/sh/contracts-transfers/do_dispatch_wasm.sh \
+        transfers=100 \
+        amount=2500000000 \
+        node="$NODE_ID" \
+        verbose=false
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset SYNC_TIMEOUT_SEC
+unset LFB_HASH
+STEP=0
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+SYNC_TIMEOUT_SEC=${SYNC_TIMEOUT_SEC:-"300"}
+
+main "$NODE_ID"


### PR DESCRIPTION
### Changes:
- adds new `swap_validator_set.sh` NCTL test and associated files
- `validator_slots` is now defaulted to what is in `resources/local/chainspec.toml.in` unless othewise overridden
    - `bond_its.chainspec.toml.override` updated for this
- better logging and args added around `await-until-era-n`

### Ticket: 
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/523

### Notes: 
- This is dependent on https://github.com/casper-network/casper-node/pull/3219 being merged first.
- Due to the current limitation of NCTL having 10 nodes I repurposed 3 of the original swapped out validators as joiners. This was done by clearing the storage, keys, and logs and using new keys to start the nodes. I plan to revisit this later but this was quickest way to get this out.