### PR TITLE
GH-3209: Validate unbonding delay

### DIFF
--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -82,9 +82,9 @@ impl Chainspec {
 
         let min_era_ms = 1u64 << self.highway_config.minimum_round_exponent;
 
-        if self.core_config.unbonding_delay < self.core_config.auction_delay {
+        if self.core_config.unbonding_delay <= self.core_config.auction_delay {
             warn!(
-                "unbonding delay is set to {} but it should be greater or equal to the auction delay (currently set to {})",
+                "unbonding delay is set to {} but it should be greater than the auction delay (currently set to {})",
                 self.core_config.unbonding_delay, self.core_config.auction_delay);
             return false;
         }

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -81,6 +81,14 @@ impl Chainspec {
         }
 
         let min_era_ms = 1u64 << self.highway_config.minimum_round_exponent;
+
+        if self.core_config.unbonding_delay < self.core_config.auction_delay {
+            warn!(
+                "unbonding delay is set to {} but it should be greater or equal to the auction delay (currently set to {})",
+                self.core_config.unbonding_delay, self.core_config.auction_delay);
+            return false;
+        }
+
         // If the era duration is set to zero, we will treat it as explicitly stating that eras
         // should be defined by height only.
         if self.core_config.era_duration.millis() > 0


### PR DESCRIPTION
Closing #3209

Validates chainspec's `unbonding_delay` to be greater or equal to `auction_delay`