### PR TITLE
Revert #3138: marking switch blocks after emergency

### DIFF
--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -373,10 +373,8 @@ where
         is_emergency_upgrade: bool,
     ) -> Effects<Event> {
         let protocol_version = self.config.protocol_version();
-        let last_emergency_restart = self.config.last_emergency_restart();
-        let verifiable_chunked_hash_activation = self.config.verifiable_chunked_hash_activation();
         async move {
-            let mut block_and_execution_effects = effect_builder
+            let block_and_execution_effects = effect_builder
                 .execute_finalized_block(
                     protocol_version,
                     initial_pre_state,
@@ -385,12 +383,6 @@ where
                     vec![],
                 )
                 .await?;
-
-            if last_emergency_restart == Some(block_and_execution_effects.block.header().era_id()) {
-                block_and_execution_effects
-                    .block
-                    .mark_after_emergency_upgrade(verifiable_chunked_hash_activation);
-            }
             // We need to store the block now so that the era supervisor can be properly
             // initialized in the participating reactor's constructor.
             effect_builder

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -819,9 +819,7 @@ pub struct BlockHeader {
     state_root_hash: Digest,
     body_hash: Digest,
     random_bit: bool,
-    /// The seed for the sequence of leaders accumulated from random_bits. If it is equal to the
-    /// parent hash, it means that the block is an immediate switch block created right after an
-    /// emergency upgrade.
+    /// The seed for the sequence of leaders accumulated from random_bits.
     accumulated_seed: Digest,
     era_end: Option<EraEnd>,
     timestamp: Timestamp,
@@ -1761,17 +1759,6 @@ impl Block {
             header,
             body,
         })
-    }
-
-    pub(crate) fn mark_after_emergency_upgrade(
-        &mut self,
-        verifiable_chunked_hash_activation: EraId,
-    ) {
-        // accumulated seed being equal to the parent hash will mean that the block is an immediate
-        // switch block created right after an emergency upgrade
-        self.header.accumulated_seed = *self.header.parent_hash.inner();
-        // changing the seed changes the header hash!
-        self.hash = self.header.hash(verifiable_chunked_hash_activation);
     }
 
     pub(crate) fn new_from_header_and_body(


### PR DESCRIPTION
This removes the code that marks switch blocks after validator-changing upgrades using their `accumulated_seed`. Reverts #3138.

Closes #3232.