### PR TITLE
Remove verifiable_chunked_hash_activation and merklized block hashing

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -23,7 +23,6 @@ All notable changes to this project will be documented in this file.  The format
 * A diagnostic port can now be enabled via the `[diagnostics_port]` section in the configuration file. See the `README.md` for details.
 * Add capabilities for known nodes to slow down the reconnection process of outdated legacy nodes still out on the internet.
 * Add `strict_argument_checking` to the chainspec to enable strict args checking when executing a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
-* Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 * Nodes will now also gossip deploys onwards while joining.
 * Add `node_state` field to the `/status` endpoint and the `info_get_status` JSON-RPC, giving an indication of the node's operating mode (joining or participating) and the progress of any ongoing chain-sync task.

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -327,8 +327,7 @@ where
                 let initial_pre_state = ExecutionPreState::new(
                     switch_block_header_before_upgrade.height() + 1,
                     post_state_hash,
-                    switch_block_header_before_upgrade
-                        .hash(self.config.verifiable_chunked_hash_activation()),
+                    switch_block_header_before_upgrade.hash(),
                     switch_block_header_before_upgrade.accumulated_seed(),
                 );
                 let finalized_block = FinalizedBlock::new(

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -83,12 +83,6 @@ impl Config {
         self.chainspec.protocol_config.last_emergency_restart
     }
 
-    pub(super) fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.chainspec
-            .protocol_config
-            .verifiable_chunked_hash_activation
-    }
-
     pub(super) fn era_duration(&self) -> TimeDiff {
         self.chainspec.core_config.era_duration
     }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -233,8 +233,7 @@ impl<'a, REv> ChainSyncContext<'a, REv> {
     ///
     /// Will panic if not initialized properly using `ChainSyncContext::new`.
     fn trusted_hash(&self) -> BlockHash {
-        self.trusted_block_header()
-            .hash(self.config.verifiable_chunked_hash_activation())
+        self.trusted_block_header().hash()
     }
 
     fn trusted_block_is_last_before_activation(&self) -> bool {
@@ -638,15 +637,12 @@ pub(crate) struct KeyBlockInfo {
 }
 
 impl KeyBlockInfo {
-    pub(crate) fn maybe_from_block_header(
-        block_header: &BlockHeader,
-        verifiable_chunked_hash_activation: EraId,
-    ) -> Option<KeyBlockInfo> {
+    pub(crate) fn maybe_from_block_header(block_header: &BlockHeader) -> Option<KeyBlockInfo> {
         block_header
             .next_era_validator_weights()
             .and_then(|next_era_validator_weights| {
                 Some(KeyBlockInfo {
-                    key_block_hash: block_header.hash(verifiable_chunked_hash_activation),
+                    key_block_hash: block_header.hash(),
                     validator_weights: next_era_validator_weights.clone(),
                     era_start: block_header.timestamp(),
                     height: block_header.height(),
@@ -817,9 +813,7 @@ where
         };
         match ctx.effect_builder.fetch::<I>(height, peer).await {
             Ok(FetchedData::FromStorage { item }) => {
-                if *item.header().parent_hash()
-                    != parent_header.hash(ctx.config.verifiable_chunked_hash_activation())
-                {
+                if *item.header().parent_hash() != parent_header.hash() {
                     return Err(Error::UnexpectedParentHash {
                         parent: Box::new(parent_header.clone()),
                         child: Box::new(item.header().clone()),
@@ -828,9 +822,7 @@ where
                 break Some(item);
             }
             Ok(FetchedData::FromPeer { item, .. }) => {
-                if *item.header().parent_hash()
-                    != parent_header.hash(ctx.config.verifiable_chunked_hash_activation())
-                {
+                if *item.header().parent_hash() != parent_header.hash() {
                     warn!(
                         ?peer,
                         fetched_header = ?item.header(),
@@ -1183,10 +1175,9 @@ where
             _ => {}
         }
 
-        if let Some(key_block_info) = KeyBlockInfo::maybe_from_block_header(
-            &current_header_to_walk_back_from,
-            ctx.config.verifiable_chunked_hash_activation(),
-        ) {
+        if let Some(key_block_info) =
+            KeyBlockInfo::maybe_from_block_header(&current_header_to_walk_back_from)
+        {
             break Ok(key_block_info);
         }
 
@@ -1248,10 +1239,9 @@ where
             highest_synced_block_header = higher_block_header_with_metadata.block_header;
 
             // If the new block is a switch block, update the validator weights, etc...
-            if let Some(key_block_info) = KeyBlockInfo::maybe_from_block_header(
-                &highest_synced_block_header,
-                ctx.config.verifiable_chunked_hash_activation(),
-            ) {
+            if let Some(key_block_info) =
+                KeyBlockInfo::maybe_from_block_header(&highest_synced_block_header)
+            {
                 highest_synced_key_block_info = key_block_info;
             }
         } else {
@@ -1440,12 +1430,7 @@ where
                     .ok_or(FetchBlockHeadersBatchError::EmptyBatchFromStorage)
             }
             FetchedData::FromPeer { item, peer } => {
-                match BlockHeadersBatch::validate(
-                    &*item,
-                    &batch_id,
-                    lowest_trusted_block_header,
-                    ctx.config.verifiable_chunked_hash_activation(),
-                ) {
+                match BlockHeadersBatch::validate(&*item, &batch_id, lowest_trusted_block_header) {
                     Ok(new_lowest) => {
                         info!(?batch_id, ?peer, "received valid batch of headers");
                         ctx.effect_builder
@@ -1539,7 +1524,7 @@ where
             .await
             .ok_or(Error::NoSuchBlockHeight(block_height))?;
 
-        let block_hash = block_header.hash(ctx.config.verifiable_chunked_hash_activation());
+        let block_hash = block_header.hash();
 
         if block_height % 1_000 == 0 {
             info!(
@@ -1692,7 +1677,7 @@ impl BlockSignaturesCollector {
         {
             debug!(
                 block_header_hash =
-                    ?block_header.hash(ctx.config.verifiable_chunked_hash_activation()),
+                    ?block_header.hash(),
                 height = block_header.height(),
                 ?era_for_validators_retrieval,
                 "fetched sufficient finality signatures"
@@ -1777,7 +1762,7 @@ where
 
     let mut sig_collector = BlockSignaturesCollector::new();
 
-    let block_header_hash = block_header.hash(ctx.config.verifiable_chunked_hash_activation());
+    let block_header_hash = block_header.hash();
 
     for peer in peer_list {
         let fetched_signatures = fetch_finality_signatures_with_retry(
@@ -2209,10 +2194,7 @@ where
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_execute_blocks_duration_seconds);
 
     // Execute blocks to get to current.
-    let mut execution_pre_state = ExecutionPreState::from_block_header(
-        highest_synced_block_header,
-        ctx.config.verifiable_chunked_hash_activation(),
-    );
+    let mut execution_pre_state = ExecutionPreState::from_block_header(highest_synced_block_header);
     info!(
         era_id = ?highest_synced_block_header.era_id(),
         height = highest_synced_block_header.height(),
@@ -2321,15 +2303,11 @@ where
             .await;
 
         highest_synced_block_header = block.take_header();
-        execution_pre_state = ExecutionPreState::from_block_header(
-            &highest_synced_block_header,
-            ctx.config.verifiable_chunked_hash_activation(),
-        );
+        execution_pre_state = ExecutionPreState::from_block_header(&highest_synced_block_header);
 
-        if let Some(new_key_block_info) = KeyBlockInfo::maybe_from_block_header(
-            &highest_synced_block_header,
-            ctx.config.verifiable_chunked_hash_activation(),
-        ) {
+        if let Some(new_key_block_info) =
+            KeyBlockInfo::maybe_from_block_header(&highest_synced_block_header)
+        {
             key_block_info = new_key_block_info;
         }
 
@@ -2418,8 +2396,6 @@ fn is_current_era_given_current_timestamp(
 mod tests {
     use std::iter;
 
-    use rand::Rng;
-
     use casper_types::{testing::TestRng, EraId, PublicKey, SecretKey};
 
     use super::*;
@@ -2438,7 +2414,6 @@ mod tests {
         era_id: EraId,
         height: u64,
         switch_block: bool,
-        verifiable_chunked_hash_activation: EraId,
     ) -> BlockHeader {
         let secret_key = SecretKey::doc_example();
         let public_key = PublicKey::from(secret_key);
@@ -2474,7 +2449,6 @@ mod tests {
             finalized_block,
             next_era_validator_weights,
             Default::default(), // protocol version
-            verifiable_chunked_hash_activation,
         )
         .expect("failed to create block for tests")
         .take_header()
@@ -2482,7 +2456,6 @@ mod tests {
 
     #[test]
     fn test_is_current_era() {
-        let mut rng = TestRng::new();
         let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
 
         let genesis_time = chainspec
@@ -2503,36 +2476,18 @@ mod tests {
             SmallNetworkConfig::default(),
         );
 
-        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-        let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
-
         // We assume era 6 started after six minimum era durations, at block 100.
         let era6_start = genesis_time + era_duration * 6;
-        let switch_block5 = create_block(
-            era6_start,
-            EraId::from(5),
-            100,
-            true,
-            verifiable_chunked_hash_activation,
-        );
+        let switch_block5 = create_block(era6_start, EraId::from(5), 100, true);
 
-        let trusted_switch_block_info5 = KeyBlockInfo::maybe_from_block_header(
-            &switch_block5,
-            verifiable_chunked_hash_activation,
-        )
-        .expect("no switch block info for switch block");
+        let trusted_switch_block_info5 = KeyBlockInfo::maybe_from_block_header(&switch_block5)
+            .expect("no switch block info for switch block");
 
         // If we are still within the minimum era duration the era is current, even if we have the
         // required number of blocks (115 - 100 > 10).
         let block_time = era6_start + era_duration - 10.into();
         let now = block_time + 5.into();
-        let block = create_block(
-            block_time,
-            EraId::from(6),
-            115,
-            false,
-            verifiable_chunked_hash_activation,
-        );
+        let block = create_block(block_time, EraId::from(6), 115, false);
         assert!(is_current_era_given_current_timestamp(
             &block,
             &trusted_switch_block_info5,
@@ -2545,13 +2500,7 @@ mod tests {
         // passed.
         let block_time = era6_start + era_duration * 2;
         let now = block_time + min_round_length * 4;
-        let block = create_block(
-            block_time,
-            EraId::from(6),
-            105,
-            false,
-            verifiable_chunked_hash_activation,
-        );
+        let block = create_block(block_time, EraId::from(6), 105, false);
         assert!(is_current_era_given_current_timestamp(
             &block,
             &trusted_switch_block_info5,
@@ -2562,13 +2511,7 @@ mod tests {
         // If both criteria are satisfied, the era could have ended.
         let block_time = era6_start + era_duration * 2;
         let now = block_time + min_round_length * 5;
-        let block = create_block(
-            block_time,
-            EraId::from(6),
-            105,
-            false,
-            verifiable_chunked_hash_activation,
-        );
+        let block = create_block(block_time, EraId::from(6), 105, false);
         assert!(!is_current_era_given_current_timestamp(
             &block,
             &trusted_switch_block_info5,

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -564,7 +564,6 @@ mod tests {
         const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
         const IS_NOT_SWITCH: bool = false;
         const IS_SWITCH: bool = true;
-        const VERIFIABLE_CHUNKED_HASH_ACTIVATION: u64 = 10;
 
         let highest_block_header = None;
         let next_upgrade_activation_point = None;
@@ -580,7 +579,6 @@ mod tests {
                 HEIGHT,
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
-                VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
                 None,
             )
             .header()
@@ -606,7 +604,6 @@ mod tests {
                 HEIGHT,
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
-                VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
                 None,
             )
             .header()
@@ -625,7 +622,6 @@ mod tests {
                 HEIGHT,
                 PROTOCOL_VERSION,
                 IS_NOT_SWITCH,
-                VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
                 None,
             )
             .header()
@@ -644,7 +640,6 @@ mod tests {
                 HEIGHT,
                 PROTOCOL_VERSION,
                 IS_SWITCH,
-                VERIFIABLE_CHUNKED_HASH_ACTIVATION.into(),
                 None,
             )
             .header()

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -236,13 +236,6 @@ impl EraSupervisor {
         Ok((era_supervisor, effects))
     }
 
-    /// Returns the merkle tree hash activation from the chainspec.
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.chainspec
-            .protocol_config
-            .verifiable_chunked_hash_activation
-    }
-
     /// Returns a list of status changes of active validators.
     pub(super) fn get_validator_changes(
         &self,
@@ -402,7 +395,7 @@ impl EraSupervisor {
         let auction_delay = self.chainspec.core_config.auction_delay as usize;
         let booking_block_hash =
             if let Some(booking_block) = switch_blocks.iter().rev().nth(auction_delay) {
-                booking_block.hash(self.verifiable_chunked_hash_activation())
+                booking_block.hash()
             } else {
                 // If there's no booking block for the `era_id`
                 // (b/c it would have been from before Genesis, upgrade or emergency restart),
@@ -430,7 +423,7 @@ impl EraSupervisor {
             .collect();
 
         let chainspec_hash = self.chainspec.hash();
-        let key_block_hash = key_block.hash(self.verifiable_chunked_hash_activation());
+        let key_block_hash = key_block.hash();
         let instance_id = instance_id(chainspec_hash, era_id, key_block_hash);
         let now = Timestamp::now();
 
@@ -682,7 +675,7 @@ impl EraSupervisor {
         let mut effects = if self.is_validator_in(&our_pk, era_id) {
             effect_builder
                 .announce_created_finality_signature(FinalitySignature::new(
-                    block_header.hash(self.verifiable_chunked_hash_activation()),
+                    block_header.hash(),
                     era_id,
                     &our_sk,
                     our_pk,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -38,7 +38,7 @@ use casper_execution_engine::{
     },
 };
 use casper_hashing::Digest;
-use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion, Timestamp};
+use casper_types::{bytesrepr::Bytes, ProtocolVersion, Timestamp};
 
 use crate::{
     components::{contract_runtime::types::StepEffectAndUpcomingEraValidators, Component},
@@ -144,14 +144,11 @@ impl ExecutionPreState {
 
     /// Creates instance of `ExecutionPreState` from given block header nad merkle tree hash
     /// activation point.
-    pub fn from_block_header(
-        block_header: &BlockHeader,
-        verifiable_chunked_hash_activation: EraId,
-    ) -> Self {
+    pub fn from_block_header(block_header: &BlockHeader) -> Self {
         ExecutionPreState {
             pre_state_root_hash: *block_header.state_root_hash(),
             next_block_height: block_header.height() + 1,
-            parent_hash: block_header.hash(verifiable_chunked_hash_activation),
+            parent_hash: block_header.hash(),
             parent_seed: block_header.accumulated_seed(),
         }
     }
@@ -196,7 +193,6 @@ pub(crate) struct ContractRuntime {
     engine_state: Arc<EngineState<LmdbGlobalState>>,
     metrics: Arc<Metrics>,
     protocol_version: ProtocolVersion,
-    verifiable_chunked_hash_activation: EraId,
 
     /// Finalized blocks waiting for their pre-state hash to start executing.
     exec_queue: ExecQueue,
@@ -496,7 +492,6 @@ impl ContractRuntime {
                 );
                 let engine_state = Arc::clone(&self.engine_state);
                 let metrics = Arc::clone(&self.metrics);
-                let verifiable_chunked_hash_activation = self.verifiable_chunked_hash_activation();
                 async move {
                     let result = run_intensive_task(move || {
                         execute_finalized_block(
@@ -507,7 +502,6 @@ impl ContractRuntime {
                             finalized_block,
                             deploys,
                             transfers,
-                            verifiable_chunked_hash_activation,
                         )
                     })
                     .await;
@@ -542,7 +536,6 @@ impl ContractRuntime {
                             finalized_block,
                             deploys,
                             transfers,
-                            self.verifiable_chunked_hash_activation(),
                         )
                         .ignore(),
                     )
@@ -623,7 +616,6 @@ impl ContractRuntime {
         strict_argument_checking: bool,
         vesting_schedule_period_millis: u64,
         registry: &Registry,
-        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, ConfigError> {
         // TODO: This is bogus, get rid of this
         let execution_pre_state = Arc::new(Mutex::new(ExecutionPreState {
@@ -667,14 +659,9 @@ impl ContractRuntime {
             engine_state,
             metrics,
             protocol_version,
-            verifiable_chunked_hash_activation,
             exec_queue: Arc::new(Mutex::new(BTreeMap::new())),
             system_contract_registry: None,
         })
-    }
-
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.verifiable_chunked_hash_activation
     }
 
     /// Commits a genesis request.
@@ -787,7 +774,6 @@ impl ContractRuntime {
         finalized_block: FinalizedBlock,
         deploys: Vec<Deploy>,
         transfers: Vec<Deploy>,
-        verifiable_chunked_hash_activation: EraId,
     ) where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
@@ -809,7 +795,6 @@ impl ContractRuntime {
                 finalized_block,
                 deploys,
                 transfers,
-                verifiable_chunked_hash_activation,
             )
         })
         .await
@@ -818,10 +803,7 @@ impl ContractRuntime {
             Err(error) => return fatal!(effect_builder, "{}", error).await,
         };
 
-        let new_execution_pre_state = ExecutionPreState::from_block_header(
-            block.header(),
-            verifiable_chunked_hash_activation,
-        );
+        let new_execution_pre_state = ExecutionPreState::from_block_header(block.header());
         *execution_pre_state.lock().unwrap() = new_execution_pre_state.clone();
 
         let current_era_id = block.header().era_id();

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -42,7 +42,6 @@ pub fn execute_finalized_block(
     finalized_block: FinalizedBlock,
     deploys: Vec<Deploy>,
     transfers: Vec<Deploy>,
-    verifiable_chunked_hash_activation: EraId,
 ) -> Result<BlockAndExecutionEffects, BlockExecutionError> {
     if finalized_block.height() != execution_pre_state.next_block_height {
         return Err(BlockExecutionError::WrongBlockHeight {
@@ -171,7 +170,6 @@ pub fn execute_finalized_block(
         finalized_block,
         next_era_validator_weights,
         protocol_version,
-        verifiable_chunked_hash_activation,
     )?);
 
     Ok(BlockAndExecutionEffects {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -421,7 +421,6 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            chainspec.protocol_config.verifiable_chunked_hash_activation,
         )
         .unwrap();
 
@@ -692,12 +691,7 @@ async fn run_deploy_acceptor_without_timeout(
     let mut runner: Runner<ConditionCheckReactor<Reactor>> =
         Runner::new(test_scenario, &mut rng).await.unwrap();
 
-    let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
-
-    let block = Box::new(Block::random_with_verifiable_chunked_hash_activation(
-        &mut rng,
-        chainspec.protocol_config.verifiable_chunked_hash_activation,
-    ));
+    let block = Box::new(Block::random(&mut rng));
     // Create a responder to assert that the block was successfully injected into storage.
     let (block_sender, block_receiver) = oneshot::channel();
     let block_responder = Responder::without_shutdown(block_sender);

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -86,21 +86,13 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .last_emergency_restart,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
-                .verifiable_chunked_hash_activation,
+                .last_emergency_restart
         );
         fake_deploy_acceptor = infallible FakeDeployAcceptor();
         deploy_fetcher = Fetcher::<Deploy>(
             "deploy",
             cfg.fetcher_config,
-            registry,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
-                .verifiable_chunked_hash_activation);
+            registry);
     }
 
     events: {

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -227,9 +227,6 @@ impl reactor::Reactor for Reactor {
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let network = NetworkController::create_node(event_queue, rng);
 
-        // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-        let verifiable_chunked_hash_activation = rng.gen_range(0..=10);
-
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
         let storage = Storage::new(
@@ -239,7 +236,6 @@ impl reactor::Reactor for Reactor {
             "test",
             Ratio::new(1, 3),
             None,
-            verifiable_chunked_hash_activation.into(),
         )
         .unwrap();
 
@@ -256,7 +252,6 @@ impl reactor::Reactor for Reactor {
             DEFAULT_STRICT_ARGUMENT_CHECKING,
             DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
             registry,
-            verifiable_chunked_hash_activation.into(),
         )
         .unwrap();
 

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -13,7 +13,7 @@ use num::rational::Ratio;
 use prometheus::Registry;
 use tracing::error;
 
-use casper_types::{EraId, ProtocolVersion};
+use casper_types::ProtocolVersion;
 
 use self::{
     metrics::Metrics,
@@ -41,7 +41,6 @@ pub(crate) struct LinearChainComponent {
     metrics: Metrics,
     /// If true, the process should stop execution to allow an upgrade to proceed.
     stop_for_upgrade: bool,
-    verifiable_chunked_hash_activation: EraId,
 }
 
 impl LinearChainComponent {
@@ -52,7 +51,6 @@ impl LinearChainComponent {
         unbonding_delay: u64,
         finality_threshold_fraction: Ratio<u64>,
         next_upgrade_activation_point: Option<ActivationPoint>,
-        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, prometheus::Error> {
         let metrics = Metrics::new(registry)?;
         let linear_chain_state = LinearChain::new(
@@ -66,16 +64,11 @@ impl LinearChainComponent {
             linear_chain_state,
             metrics,
             stop_for_upgrade: false,
-            verifiable_chunked_hash_activation,
         })
     }
 
     pub(crate) fn stop_for_upgrade(&self) -> bool {
         self.stop_for_upgrade
-    }
-
-    fn verifiable_chunked_hash_activation(&self) -> EraId {
-        self.verifiable_chunked_hash_activation
     }
 }
 
@@ -175,9 +168,7 @@ where
                 self.metrics
                     .block_completion_duration
                     .set(completion_duration as i64);
-                let outcomes = self
-                    .linear_chain_state
-                    .handle_put_block(block, self.verifiable_chunked_hash_activation());
+                let outcomes = self.linear_chain_state.handle_put_block(block);
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::FinalitySignatureReceived(fs, gossiped) => {

--- a/node/src/components/small_network/gossiped_address.rs
+++ b/node/src/components/small_network/gossiped_address.rs
@@ -4,7 +4,6 @@ use std::{
     net::SocketAddr,
 };
 
-use casper_types::EraId;
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
@@ -34,14 +33,11 @@ impl Item for GossipedAddress {
     const TAG: Tag = Tag::GossipedAddress;
     const ID_IS_COMPLETE_ITEM: bool = true;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self) -> Self::Id {
         *self
     }
 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -66,7 +66,7 @@ use tracing::{debug, error, info, warn};
 use casper_hashing::Digest;
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
-    EraId, ExecutionResult, ProtocolVersion, PublicKey, TimeDiff, Transfer, Transform,
+    EraId, ExecutionResult, ProtocolVersion, TimeDiff, Transfer, Transform,
 };
 
 // The reactor! macro needs this in the fetcher tests
@@ -85,9 +85,7 @@ use crate::{
         AvailableBlockRange, Block, BlockAndDeploys, BlockBody, BlockHash, BlockHashAndHeight,
         BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId,
         BlockSignatures, BlockWithMetadata, Deploy, DeployHash, DeployMetadata, DeployMetadataExt,
-        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedApprovalsWithId,
-        HashingAlgorithmVersion, Item, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
-        NodeId,
+        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedApprovalsWithId, Item, NodeId,
     },
     utils::{display_error, WithDir},
     NodeRng,
@@ -117,7 +115,7 @@ const DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE: usize = 300 * GIB;
 /// Default max state store size.
 const DEFAULT_MAX_STATE_STORE_SIZE: usize = 10 * GIB;
 /// Maximum number of allowed dbs.
-const MAX_DB_COUNT: u32 = 12;
+const MAX_DB_COUNT: u32 = 8;
 /// Key under which completed blocks are to be stored.
 const COMPLETED_BLOCKS_STORAGE_KEY: &[u8] = b"completed_blocks_disjoint_sequences";
 
@@ -141,15 +139,6 @@ const STORAGE_FILES: [&str; 5] = [
     "sse_index",
 ];
 
-/// Groups databases used by storage.
-struct Databases {
-    block_body_v1_db: Database,
-    block_body_v2_db: Database,
-    deploy_hashes_db: Database,
-    transfer_hashes_db: Database,
-    proposer_db: Database,
-}
-
 /// The storage component.
 #[derive(DataSize, Debug)]
 pub struct Storage {
@@ -163,19 +152,7 @@ pub struct Storage {
     block_header_db: Database,
     /// The block body database.
     #[data_size(skip)]
-    block_body_v1_db: Database,
-    /// The Merkle-hashed block body database.
-    #[data_size(skip)]
-    block_body_v2_db: Database,
-    /// The deploy hashes database.
-    #[data_size(skip)]
-    deploy_hashes_db: Database,
-    /// The transfer hashes database.
-    #[data_size(skip)]
-    transfer_hashes_db: Database,
-    /// The proposers database.
-    #[data_size(skip)]
-    proposer_db: Database,
+    block_body_db: Database,
     /// The block metadata db.
     #[data_size(skip)]
     block_metadata_db: Database,
@@ -213,8 +190,6 @@ pub struct Storage {
     finality_threshold_fraction: Ratio<u64>,
     /// The most recent era in which the network was manually restarted.
     last_emergency_restart: Option<EraId>,
-    /// The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-    verifiable_chunked_hash_activation: EraId,
 }
 
 /// A storage component event.
@@ -310,7 +285,6 @@ impl Storage {
         network_name: &str,
         finality_threshold_fraction: Ratio<u64>,
         last_emergency_restart: Option<EraId>,
-        verifiable_chunked_hash_activation: EraId,
     ) -> Result<Self, FatalStorageError> {
         let config = cfg.value();
 
@@ -360,11 +334,7 @@ impl Storage {
         let state_store_db = env.create_db(Some("state_store"), DatabaseFlags::empty())?;
         let finalized_approvals_db =
             env.create_db(Some("finalized_approvals"), DatabaseFlags::empty())?;
-        let block_body_v1_db = env.create_db(Some("block_body"), DatabaseFlags::empty())?;
-        let block_body_v2_db = env.create_db(Some("block_body_merkle"), DatabaseFlags::empty())?;
-        let deploy_hashes_db = env.create_db(Some("deploy_hashes"), DatabaseFlags::empty())?;
-        let transfer_hashes_db = env.create_db(Some("transfer_hashes"), DatabaseFlags::empty())?;
-        let proposer_db = env.create_db(Some("proposers"), DatabaseFlags::empty())?;
+        let block_body_db = env.create_db(Some("block_body"), DatabaseFlags::empty())?;
 
         // We now need to restore the block-height index. Log messages allow timing here.
         info!("reindexing block store");
@@ -375,28 +345,16 @@ impl Storage {
         let mut cursor = block_txn.open_rw_cursor(block_header_db)?;
 
         let mut deleted_block_hashes = HashSet::new();
-        let mut deleted_block_body_hashes_v1 = HashSet::new();
+        let mut deleted_block_body_hashes = HashSet::new();
         let mut deleted_deploy_hashes = HashSet::<DeployHash>::new();
-
-        let databases = Databases {
-            block_body_v1_db,
-            block_body_v2_db,
-            deploy_hashes_db,
-            transfer_hashes_db,
-            proposer_db,
-        };
 
         // Note: `iter_start` has an undocumented panic if called on an empty database. We rely on
         //       the iterator being at the start when created.
         for (_, raw_val) in cursor.iter() {
             let mut body_txn = env.begin_ro_txn()?;
             let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
-            let (maybe_block_body, is_v1) = get_body_for_block_header(
-                &mut body_txn,
-                &block_header,
-                &databases,
-                verifiable_chunked_hash_activation,
-            );
+            let maybe_block_body =
+                get_body_for_block_header(&mut body_txn, &block_header, block_body_db);
             if let Some(invalid_era) = hard_reset_to_start_of_era {
                 // Remove blocks that are in to-be-upgraded eras, but have obsolete protocol
                 // versions - they were most likely created before the upgrade and should be
@@ -404,17 +362,14 @@ impl Storage {
                 if block_header.era_id() >= invalid_era
                     && block_header.protocol_version() < protocol_version
                 {
-                    let _ = deleted_block_hashes
-                        .insert(block_header.hash(verifiable_chunked_hash_activation));
+                    let _ = deleted_block_hashes.insert(block_header.hash());
 
                     if let Some(block_body) = maybe_block_body? {
                         deleted_deploy_hashes.extend(block_body.deploy_hashes());
                         deleted_deploy_hashes.extend(block_body.transfer_hashes());
                     }
 
-                    if is_v1 {
-                        let _ = deleted_block_body_hashes_v1.insert(*block_header.body_hash());
-                    }
+                    let _ = deleted_block_body_hashes.insert(*block_header.body_hash());
 
                     cursor.del(WriteFlags::empty())?;
                     continue;
@@ -425,13 +380,12 @@ impl Storage {
                 &mut block_height_index,
                 &mut switch_block_era_id_index,
                 &block_header,
-                verifiable_chunked_hash_activation,
             )?;
 
             if let Some(block_body) = maybe_block_body? {
                 insert_to_deploy_index(
                     &mut deploy_hash_index,
-                    block_header.hash(verifiable_chunked_hash_activation),
+                    block_header.hash(),
                     &block_body,
                     block_header.height(),
                 )?;
@@ -443,11 +397,11 @@ impl Storage {
 
         let deleted_block_hashes_raw = deleted_block_hashes.iter().map(BlockHash::as_ref).collect();
 
-        initialize_block_body_v1_db(
+        initialize_block_body_db(
             &env,
             &block_header_db,
-            &block_body_v1_db,
-            &deleted_block_body_hashes_v1
+            &block_body_db,
+            &deleted_block_body_hashes
                 .iter()
                 .map(Digest::as_ref)
                 .collect(),
@@ -460,11 +414,7 @@ impl Storage {
             root,
             env,
             block_header_db,
-            block_body_v1_db,
-            block_body_v2_db,
-            deploy_hashes_db,
-            transfer_hashes_db,
-            proposer_db,
+            block_body_db,
             block_metadata_db,
             deploy_db,
             deploy_metadata_db,
@@ -479,7 +429,6 @@ impl Storage {
             serialized_item_pool: ObjectPool::new(config.mem_pool_prune_interval),
             finality_threshold_fraction,
             last_emergency_restart,
-            verifiable_chunked_hash_activation,
         };
 
         match component.read_state_store(&Cow::Borrowed(COMPLETED_BLOCKS_STORAGE_KEY))? {
@@ -1107,7 +1056,7 @@ impl Storage {
                 block_header,
                 responder,
             } => {
-                let block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
+                let block_header_hash = block_header.hash();
                 match self.put_block_headers(vec![*block_header]) {
                     Ok(result) => responder.respond(result).ignore(),
                     Err(err) => {
@@ -1190,7 +1139,7 @@ impl Storage {
     ) -> Result<(), FatalStorageError> {
         let BlockAndDeploys { block, deploys } = block_and_deploys;
 
-        block.verify(self.verifiable_chunked_hash_activation)?;
+        block.verify()?;
         let deploy_db = self.deploy_db;
         let (wrote, mut txn) = self.write_validated_block(block)?;
         if !wrote {
@@ -1222,7 +1171,7 @@ impl Storage {
     /// couldn't be written because it already existed, and `Err(_)` if there was an error.
     pub fn write_block(&mut self, block: &Block) -> Result<bool, FatalStorageError> {
         // Validate the block prior to inserting it into the database
-        block.verify(self.verifiable_chunked_hash_activation)?;
+        block.verify()?;
         let (wrote, txn) = self.write_validated_block(block)?;
         if wrote {
             txn.commit()?;
@@ -1242,18 +1191,7 @@ impl Storage {
         {
             let block_body_hash = block.header().body_hash();
             let block_body = block.body();
-            let success = match block
-                .header()
-                .hashing_algorithm_version(self.verifiable_chunked_hash_activation)
-            {
-                HashingAlgorithmVersion::V1 => {
-                    self.put_single_block_body_v1(&mut txn, block_body_hash, block_body)?
-                }
-                HashingAlgorithmVersion::V2 => {
-                    self.put_single_block_body_v2(&mut txn, block_body)?
-                }
-            };
-            if !success {
+            if !self.put_single_block_body(&mut txn, block_body_hash, block_body)? {
                 error!("Could not insert body for: {}", block);
                 return Ok((false, txn));
             }
@@ -1276,11 +1214,10 @@ impl Storage {
                 &mut self.block_height_index,
                 &mut self.switch_block_era_id_index,
                 block.header(),
-                self.verifiable_chunked_hash_activation,
             )?;
             insert_to_deploy_index(
                 &mut self.deploy_hash_index,
-                block.header().hash(self.verifiable_chunked_hash_activation),
+                *block.hash(),
                 block.body(),
                 block.header().height(),
             )?;
@@ -1520,7 +1457,7 @@ impl Storage {
         block_header: &BlockHeader,
         block_hash: &BlockHash,
     ) -> Result<(), FatalStorageError> {
-        let found_block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
+        let found_block_header_hash = block_header.hash();
         if found_block_header_hash != *block_hash {
             return Err(FatalStorageError::BlockHeaderNotStoredUnderItsHash {
                 queried_block_hash_bytes: block_hash.as_ref().to_vec(),
@@ -1549,7 +1486,7 @@ impl Storage {
         let mut result = false;
 
         for block_header in &block_headers {
-            let block_header_hash = block_header.hash(self.verifiable_chunked_hash_activation);
+            let block_header_hash = block_header.hash();
             match txn.put_value(
                 self.block_header_db,
                 &block_header_hash,
@@ -1573,74 +1510,20 @@ impl Storage {
                 &mut self.block_height_index,
                 &mut self.switch_block_era_id_index,
                 block_header,
-                self.verifiable_chunked_hash_activation,
             )?;
         }
         Ok(result)
     }
 
     /// Writes a single block body in a separate transaction to storage.
-    fn put_single_block_body_v1(
+    fn put_single_block_body(
         &self,
         txn: &mut RwTransaction,
         block_body_hash: &Digest,
         block_body: &BlockBody,
     ) -> Result<bool, LmdbExtError> {
-        txn.put_value(self.block_body_v1_db, block_body_hash, block_body, true)
+        txn.put_value(self.block_body_db, block_body_hash, block_body, true)
             .map_err(Into::into)
-    }
-
-    fn put_merkle_block_body_part<'a, T: ToBytes>(
-        &self,
-        txn: &mut RwTransaction,
-        part_database: Database,
-        merklized_block_body_part: &MerkleBlockBodyPart<'a, T>,
-    ) -> Result<bool, LmdbExtError> {
-        // It's possible the value is already present (ie, if it is a block proposer).
-        // We put the value and rest hashes in first, since we need that present even if the value
-        // is already there.
-        if !txn.put_value_bytesrepr(
-            self.block_body_v2_db,
-            merklized_block_body_part.merkle_linked_list_node_hash(),
-            &merklized_block_body_part.value_and_rest_hashes_pair(),
-            true,
-        )? {
-            return Ok(false);
-        };
-
-        if !txn.put_value_bytesrepr(
-            part_database,
-            merklized_block_body_part.value_hash(),
-            merklized_block_body_part.value(),
-            true,
-        )? {
-            return Ok(false);
-        };
-        Ok(true)
-    }
-
-    /// Writes a single merklized block body in a separate transaction to storage.
-    fn put_single_block_body_v2(
-        &self,
-        txn: &mut RwTransaction,
-        block_body: &BlockBody,
-    ) -> Result<bool, LmdbExtError> {
-        let merkle_block_body = block_body.merklize();
-        let MerkleBlockBody {
-            deploy_hashes,
-            transfer_hashes,
-            proposer,
-        } = &merkle_block_body;
-        if !self.put_merkle_block_body_part(txn, self.deploy_hashes_db, deploy_hashes)? {
-            return Ok(false);
-        };
-        if !self.put_merkle_block_body_part(txn, self.transfer_hashes_db, transfer_hashes)? {
-            return Ok(false);
-        };
-        if !self.put_merkle_block_body_part(txn, self.proposer_db, proposer)? {
-            return Ok(false);
-        };
-        Ok(true)
     }
 
     /// Retrieves a block header by hash.
@@ -1664,18 +1547,7 @@ impl Storage {
             Some(block_header) => block_header,
             None => return Ok(None),
         };
-        let (maybe_block_body, _) = get_body_for_block_header(
-            txn,
-            &block_header,
-            &Databases {
-                block_body_v1_db: self.block_body_v1_db,
-                block_body_v2_db: self.block_body_v2_db,
-                deploy_hashes_db: self.deploy_hashes_db,
-                transfer_hashes_db: self.transfer_hashes_db,
-                proposer_db: self.proposer_db,
-            },
-            self.verifiable_chunked_hash_activation,
-        );
+        let maybe_block_body = get_body_for_block_header(txn, &block_header, self.block_body_db);
         let block_body = match maybe_block_body? {
             Some(block_body) => block_body,
             None => {
@@ -1686,11 +1558,7 @@ impl Storage {
                 return Ok(None);
             }
         };
-        let block = Block::new_from_header_and_body(
-            block_header,
-            block_body,
-            self.verifiable_chunked_hash_activation,
-        )?;
+        let block = Block::new_from_header_and_body(block_header, block_body)?;
         Ok(Some(block))
     }
 
@@ -1782,25 +1650,10 @@ impl Storage {
             None => return Ok(None),
             Some(block_header_with_metadata) => block_header_with_metadata,
         };
-        let (maybe_block_body, _) = get_body_for_block_header(
-            txn,
-            &block_header,
-            &Databases {
-                block_body_v1_db: self.block_body_v1_db,
-                block_body_v2_db: self.block_body_v2_db,
-                deploy_hashes_db: self.deploy_hashes_db,
-                transfer_hashes_db: self.transfer_hashes_db,
-                proposer_db: self.proposer_db,
-            },
-            self.verifiable_chunked_hash_activation,
-        );
+        let maybe_block_body = get_body_for_block_header(txn, &block_header, self.block_body_db);
         if let Some(block_body) = maybe_block_body? {
             Ok(Some(BlockWithMetadata {
-                block: Block::new_from_header_and_body(
-                    block_header,
-                    block_body,
-                    self.verifiable_chunked_hash_activation,
-                )?,
+                block: Block::new_from_header_and_body(block_header, block_body)?,
                 finality_signatures: block_signatures,
             }))
         } else {
@@ -1905,10 +1758,7 @@ impl Storage {
                 return Ok(None);
             }
         }
-        let block_signatures = match self.get_finality_signatures(
-            txn,
-            &block_header.hash(self.verifiable_chunked_hash_activation),
-        )? {
+        let block_signatures = match self.get_finality_signatures(txn, &block_header.hash())? {
             None => return Ok(None),
             Some(block_signatures) => block_signatures,
         };
@@ -2064,9 +1914,8 @@ fn insert_to_block_header_indices(
     block_height_index: &mut BTreeMap<u64, BlockHash>,
     switch_block_era_id_index: &mut BTreeMap<EraId, BlockHash>,
     block_header: &BlockHeader,
-    verifiable_chunked_hash_activation: EraId,
 ) -> Result<(), FatalStorageError> {
-    let block_hash = block_header.hash(verifiable_chunked_hash_activation);
+    let block_hash = block_header.hash();
     if let Some(first) = block_height_index.get(&block_header.height()) {
         if *first != block_hash {
             return Err(FatalStorageError::DuplicateBlockIndex {
@@ -2402,19 +2251,19 @@ fn construct_block_body_to_block_header_reverse_lookup(
 }
 
 /// Purges stale entries from the block body database.
-fn initialize_block_body_v1_db(
+fn initialize_block_body_db(
     env: &Environment,
     block_header_db: &Database,
-    block_body_v1_db: &Database,
+    block_body_db: &Database,
     deleted_block_body_hashes_raw: &HashSet<&[u8]>,
 ) -> Result<(), FatalStorageError> {
-    info!("initializing v1 block body database");
+    info!("initializing block body database");
     let mut txn = env.begin_rw_txn()?;
 
     let block_body_hash_to_header_map =
         construct_block_body_to_block_header_reverse_lookup(&txn, block_header_db)?;
 
-    let mut cursor = txn.open_rw_cursor(*block_body_v1_db)?;
+    let mut cursor = txn.open_rw_cursor(*block_body_db)?;
 
     for (raw_key, _raw_val) in cursor.iter() {
         let block_body_hash =
@@ -2425,7 +2274,7 @@ fn initialize_block_body_v1_db(
                 // referencing it was just deleted, either
                 warn!(?raw_key, "orphaned block body detected");
             }
-            info!(?raw_key, "deleting v1 block body");
+            info!(?raw_key, "deleting block body");
             cursor.del(WriteFlags::empty())?;
         }
     }
@@ -2433,196 +2282,17 @@ fn initialize_block_body_v1_db(
     drop(cursor);
 
     txn.commit()?;
-    info!("v1 block body database initialized");
+    info!("block body database initialized");
     Ok(())
-}
-
-fn get_merkle_linked_list_node<Tx, T>(
-    txn: &mut Tx,
-    block_body_v2_db: Database,
-    part_database: Database,
-    key_to_block_body_db: &Digest,
-) -> Result<Option<MerkleLinkedListNode<T>>, LmdbExtError>
-where
-    Tx: Transaction,
-    T: FromBytes,
-{
-    let (part_to_value_db, merkle_proof_of_rest): (Digest, Digest) =
-        match txn.get_value_bytesrepr(block_body_v2_db, key_to_block_body_db)? {
-            Some(slice) => slice,
-            None => return Ok(None),
-        };
-    let value = match txn.get_value_bytesrepr(part_database, &part_to_value_db)? {
-        Some(value) => value,
-        None => return Ok(None),
-    };
-    Ok(Some(MerkleLinkedListNode::new(value, merkle_proof_of_rest)))
 }
 
 /// Retrieves the block body for the given block header.
-/// Returns the block body (if existing) along with the information on whether the block uses the v1
-/// or v2 hashing scheme.
 fn get_body_for_block_header<Tx: Transaction>(
     txn: &mut Tx,
     block_header: &BlockHeader,
-    databases: &Databases,
-    verifiable_chunked_hash_activation: EraId,
-) -> (Result<Option<BlockBody>, LmdbExtError>, bool) {
-    match block_header.hashing_algorithm_version(verifiable_chunked_hash_activation) {
-        HashingAlgorithmVersion::V1 => (
-            get_single_block_body_v1(txn, block_header.body_hash(), databases.block_body_v1_db),
-            true,
-        ),
-        HashingAlgorithmVersion::V2 => (
-            get_single_block_body_v2(txn, block_header.body_hash(), databases),
-            false,
-        ),
-    }
-}
-
-fn get_single_block_body_v1<Tx: Transaction>(
-    txn: &mut Tx,
-    block_body_hash: &Digest,
-    block_body_v1_db: Database,
+    block_body_db: Database,
 ) -> Result<Option<BlockBody>, LmdbExtError> {
-    txn.get_value(block_body_v1_db, block_body_hash)
-}
-
-/// Retrieves a single Merklized block body in a separate transaction from storage.
-fn get_single_block_body_v2<Tx: Transaction>(
-    txn: &mut Tx,
-    block_body_hash: &Digest,
-    Databases {
-        block_body_v1_db: _,
-        block_body_v2_db,
-        deploy_hashes_db,
-        transfer_hashes_db,
-        proposer_db,
-    }: &Databases,
-) -> Result<Option<BlockBody>, LmdbExtError> {
-    let deploy_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> =
-        match get_merkle_linked_list_node(
-            txn,
-            *block_body_v2_db,
-            *deploy_hashes_db,
-            block_body_hash,
-        )? {
-            Some(deploy_hashes_with_proof) => deploy_hashes_with_proof,
-            None => return Ok(None),
-        };
-    let transfer_hashes_with_proof: MerkleLinkedListNode<Vec<DeployHash>> =
-        match get_merkle_linked_list_node(
-            txn,
-            *block_body_v2_db,
-            *transfer_hashes_db,
-            deploy_hashes_with_proof.merkle_proof_of_rest(),
-        )? {
-            Some(transfer_hashes_with_proof) => transfer_hashes_with_proof,
-            None => return Ok(None),
-        };
-    let proposer_with_proof: MerkleLinkedListNode<PublicKey> = match get_merkle_linked_list_node(
-        txn,
-        *block_body_v2_db,
-        *proposer_db,
-        transfer_hashes_with_proof.merkle_proof_of_rest(),
-    )? {
-        Some(proposer_with_proof) => {
-            debug_assert_eq!(
-                *proposer_with_proof.merkle_proof_of_rest(),
-                Digest::SENTINEL_RFOLD
-            );
-            proposer_with_proof
-        }
-        None => return Ok(None),
-    };
-    let block_body = BlockBody::new(
-        proposer_with_proof.take_value(),
-        deploy_hashes_with_proof.take_value(),
-        transfer_hashes_with_proof.take_value(),
-    );
-
-    Ok(Some(block_body))
-}
-
-// TODO: remove once we run the garbage collection again
-#[allow(dead_code)]
-fn garbage_collect_block_body_v2_db(
-    txn: &mut RwTransaction,
-    block_body_v2_db: &Database,
-    deploy_hashes_db: &Database,
-    transfer_hashes_db: &Database,
-    proposer_db: &Database,
-    block_body_hash_to_header_map: &BTreeMap<Digest, BlockHeader>,
-    verifiable_chunked_hash_activation: EraId,
-) -> Result<(), FatalStorageError> {
-    // This will store all the keys that are reachable from a block header, in all the parts
-    // databases (we're basically doing a mark-and-sweep below).
-    // The entries correspond to: the block_body_v2_db, deploy_hashes_db, transfer_hashes_db,
-    // proposer_db respectively.
-    let mut live_digests: [HashSet<Digest>; BlockBody::PARTS_COUNT + 1] = [
-        HashSet::new(),
-        HashSet::new(),
-        HashSet::new(),
-        HashSet::new(),
-    ];
-
-    for (body_hash, header) in block_body_hash_to_header_map {
-        if header.hashing_algorithm_version(verifiable_chunked_hash_activation)
-            != HashingAlgorithmVersion::V2
-        {
-            // We're only interested in body hashes for V2 blocks here
-            continue;
-        }
-        let mut current_digest = *body_hash;
-        let mut live_digests_index = 1;
-        while current_digest != Digest::SENTINEL_RFOLD && !live_digests[0].contains(&current_digest)
-        {
-            live_digests[0].insert(current_digest);
-            let (key_to_part_db, merkle_proof_of_rest): (Digest, Digest) =
-                match txn.get_value_bytesrepr(*block_body_v2_db, &current_digest)? {
-                    Some(slice) => slice,
-                    None => {
-                        return Err(FatalStorageError::CouldNotFindBlockBodyPart {
-                            block_hash: header.hash(verifiable_chunked_hash_activation),
-                            merkle_linked_list_node_hash: current_digest,
-                        })
-                    }
-                };
-            if live_digests_index < live_digests.len() {
-                live_digests[live_digests_index].insert(key_to_part_db);
-            } else {
-                return Err(FatalStorageError::UnexpectedBlockBodyPart {
-                    block_body_hash: *body_hash,
-                    part_hash: key_to_part_db,
-                });
-            }
-            live_digests_index += 1;
-            current_digest = merkle_proof_of_rest;
-        }
-    }
-
-    let databases_to_clean: [(&Database, &str); BlockBody::PARTS_COUNT + 1] = [
-        (block_body_v2_db, "deleting v2 block body part"),
-        (deploy_hashes_db, "deleting v2 deploy hashes entry"),
-        (transfer_hashes_db, "deleting v2 transfer hashes entry"),
-        (proposer_db, "deleting v2 proposer entry"),
-    ];
-
-    // Clean dead entries from all the databases
-    for (index, (database, info_text)) in databases_to_clean.iter().enumerate() {
-        let mut cursor = txn.open_rw_cursor(**database)?;
-        for (raw_key, _raw_val) in cursor.iter() {
-            let key = Digest::try_from(raw_key)
-                .map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))?;
-            if !live_digests[index].contains(&key) {
-                info!(?raw_key, info_text);
-                cursor.del(WriteFlags::empty())?;
-            }
-        }
-        drop(cursor);
-    }
-
-    Ok(())
+    txn.get_value(block_body_db, block_header.body_hash())
 }
 
 /// Purges stale entries from the block metadata database.

--- a/node/src/components/storage/error.rs
+++ b/node/src/components/storage/error.rs
@@ -11,7 +11,7 @@ use crate::{
     components::consensus::error::FinalitySignatureError,
     types::{
         error::BlockValidationError, BlockBody, BlockHash, BlockHashAndHeight, BlockHeader,
-        DeployHash, HashingAlgorithmVersion,
+        DeployHash,
     },
 };
 
@@ -98,39 +98,13 @@ pub enum FatalStorageError {
     #[error(
         "No block header corresponding to block body found in LMDB. \
          Block body hash: {block_body_hash:?}, \
-         Hashing algorithm version: {hashing_algorithm_version:?}, \
          Block body: {block_body:?}"
     )]
     NoBlockHeaderForBlockBody {
         /// The block body hash.
         block_body_hash: Digest,
-        /// The hashing algorithm of the block body.
-        hashing_algorithm_version: HashingAlgorithmVersion,
         /// The block body.
         block_body: Box<BlockBody>,
-    },
-    /// Unexpected hashing algorithm version.
-    #[error(
-        "Unexpected hashing algorithm version. \
-         Expected: {expected_hashing_algorithm_version:?}, \
-         Actual: {actual_hashing_algorithm_version:?}"
-    )]
-    UnexpectedHashingAlgorithmVersion {
-        /// Expected hashing algorithm version.
-        expected_hashing_algorithm_version: HashingAlgorithmVersion,
-        /// Actual hashing algorithm version.
-        actual_hashing_algorithm_version: HashingAlgorithmVersion,
-    },
-    /// Could not find block body part.
-    #[error(
-        "Could not find block body part with Merkle linked list node hash: \
-         {merkle_linked_list_node_hash:?}"
-    )]
-    CouldNotFindBlockBodyPart {
-        /// The block hash queried.
-        block_hash: BlockHash,
-        /// The hash of the node in the Merkle linked list.
-        merkle_linked_list_node_hash: Digest,
     },
     /// Could not verify finality signatures for block.
     #[error("{0} in signature verification. Database is corrupted.")]

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -209,10 +209,6 @@ impl Reactor {
                 .chainspec()
                 .protocol_config
                 .last_emergency_restart,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
-                .verifiable_chunked_hash_activation,
         )?;
 
         let contract_runtime = ContractRuntime::new(
@@ -240,10 +236,6 @@ impl Reactor {
                 .vesting_schedule_period
                 .millis(),
             registry,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
-                .verifiable_chunked_hash_activation,
         )?;
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -565,10 +565,6 @@ impl reactor::Reactor for Reactor {
             sync_effects,
         ));
 
-        let verifiable_chunked_hash_activation = chainspec_loader
-            .chainspec()
-            .protocol_config
-            .verifiable_chunked_hash_activation;
         let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
         let rest_server = RestServer::new(
             config.rest_server.clone(),
@@ -583,8 +579,7 @@ impl reactor::Reactor for Reactor {
             *protocol_version,
         )?;
 
-        let fetcher_builder =
-            FetcherBuilder::new(config.fetcher, registry, verifiable_chunked_hash_activation);
+        let fetcher_builder = FetcherBuilder::new(config.fetcher, registry);
 
         let deploy_fetcher = fetcher_builder.build("deploy")?;
         let finalized_approvals_fetcher = fetcher_builder.build("finalized_approvals")?;
@@ -693,7 +688,6 @@ impl reactor::Reactor for Reactor {
                 ));
 
                 let event = fetcher::Event::GotRemotely {
-                    verifiable_chunked_hash_activation: None,
                     item: deploy,
                     source,
                 };
@@ -954,19 +948,7 @@ impl reactor::Reactor for Reactor {
                     .handle_event(effect_builder, rng, incoming.into()),
             ),
             JoinerEvent::NetResponseIncoming(NetResponseIncoming { sender, message }) => {
-                let verifiable_chunked_hash_activation = self
-                    .chainspec_loader
-                    .chainspec()
-                    .protocol_config
-                    .verifiable_chunked_hash_activation;
-                reactor::handle_get_response(
-                    self,
-                    effect_builder,
-                    rng,
-                    sender,
-                    message,
-                    verifiable_chunked_hash_activation,
-                )
+                reactor::handle_get_response(self, effect_builder, rng, sender, message)
             }
             JoinerEvent::TrieRequestIncoming(incoming) => reactor::wrap_effects(
                 JoinerEvent::ContractRuntime,
@@ -985,10 +967,6 @@ impl reactor::Reactor for Reactor {
                     rng,
                     sender,
                     &message.0,
-                    self.chainspec_loader
-                        .chainspec()
-                        .protocol_config
-                        .verifiable_chunked_hash_activation,
                 )
             }
 

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -55,11 +55,7 @@ impl TestChain {
     /// Instantiates a new test chain configuration.
     ///
     /// Generates secret keys for `size` validators and creates a matching chainspec.
-    async fn new(
-        size: usize,
-        verifiable_chunked_hash_activation: EraId,
-        rng: &mut NodeRng,
-    ) -> Self {
+    async fn new(size: usize, rng: &mut NodeRng) -> Self {
         assert!(
             size >= 1,
             "Network size must have at least one node (size: {})",
@@ -84,7 +80,6 @@ impl TestChain {
         Self::new_with_keys(
             first_node_secret_key_with_stake,
             other_secret_keys_with_stakes,
-            verifiable_chunked_hash_activation,
             rng,
         )
         .await
@@ -96,7 +91,6 @@ impl TestChain {
     async fn new_with_keys(
         first_node_secret_key_with_stake: SecretKeyWithStake,
         other_secret_keys_with_stakes: Vec<SecretKeyWithStake>,
-        verifiable_chunked_hash_activation: EraId,
         rng: &mut NodeRng,
     ) -> Self {
         // Load the `local` chainspec.
@@ -132,9 +126,6 @@ impl TestChain {
         chainspec.core_config.era_duration = 10.into();
         chainspec.core_config.auction_delay = 1;
         chainspec.core_config.unbonding_delay = 3;
-
-        chainspec.protocol_config.verifiable_chunked_hash_activation =
-            verifiable_chunked_hash_activation;
 
         // Assign a port for the first node (TODO: this has a race condition)
         let first_node_port = testing::unused_port_on_localhost();
@@ -275,13 +266,9 @@ async fn run_participating_network() {
 
     let mut rng = crate::new_rng();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
-
     // Instantiate a new chain with a fixed size.
     const NETWORK_SIZE: usize = 5;
-    let mut chain =
-        TestChain::new(NETWORK_SIZE, verifiable_chunked_hash_activation, &mut rng).await;
+    let mut chain = TestChain::new(NETWORK_SIZE, &mut rng).await;
 
     // Wait for all nodes to agree on one era.
     for era_num in 1..=2 {
@@ -319,13 +306,9 @@ async fn run_equivocator_network() {
 
     let other_secret_keys_with_stakes = vec![alice_sk.clone(), alice_sk];
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
-
     let mut chain = TestChain::new_with_keys(
         first_node_secret_key_with_stake,
         other_secret_keys_with_stakes,
-        verifiable_chunked_hash_activation,
         &mut rng,
     )
     .await;
@@ -356,7 +339,6 @@ fn first_node_storage(net: &Network<MultiStageTestReactor>) -> &Storage {
 
 async fn await_switch_block(
     switch_block_era_num: u64,
-    verifiable_chunked_hash_activation: EraId,
     net: &mut Network<MultiStageTestReactor>,
     rng: &mut NodeRng,
 ) -> BlockHeader {
@@ -382,7 +364,7 @@ async fn await_switch_block(
     info!(
         "Found block hash for Era {}: {:?}",
         switch_block_era_num,
-        switch_block_header.hash(verifiable_chunked_hash_activation)
+        switch_block_header.hash()
     );
     switch_block_header
 }
@@ -396,16 +378,8 @@ async fn test_joiner_at_genesis() {
 
     let mut rng = crate::new_rng();
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily
-    let verifiable_chunked_hash_activation = EraId::from(rng.gen_range(0..=10));
-
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -416,19 +390,13 @@ async fn test_joiner_at_genesis() {
     // Get the first switch block hash
     // As part of the chain sync process, we will need to retrieve the first switch block
     let start_era = 2;
-    let _ = await_switch_block(
-        start_era,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await;
+    let _ = await_switch_block(start_era, &mut chain.network, &mut rng).await;
 
     let trusted_hash = first_node_storage(&chain.network)
         .read_block_header_by_height(2)
         .expect("should not have storage error")
         .expect("should have block header")
-        .hash(verifiable_chunked_hash_activation);
+        .hash();
 
     // Have a node join the network with that hash
     info!("Joining with trusted hash {}", trusted_hash);
@@ -472,16 +440,8 @@ async fn test_sync_to_genesis() {
 
     const ERA_TO_JOIN: u64 = 3;
 
-    // We need to make sure we're in the Merkle-based hashing scheme.
-    let verifiable_chunked_hash_activation = EraId::from(ERA_TO_JOIN - 1);
-
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -491,14 +451,9 @@ async fn test_sync_to_genesis() {
 
     // Get the first switch block hash
     // As part of the chain sync process, we will need to retrieve the first switch block
-    let switch_block_hash = await_switch_block(
-        1,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await
-    .hash(verifiable_chunked_hash_activation);
+    let switch_block_hash = await_switch_block(1, &mut chain.network, &mut rng)
+        .await
+        .hash();
 
     info!("Waiting for Era {} to end", ERA_TO_JOIN);
     chain
@@ -553,7 +508,7 @@ async fn test_sync_to_genesis() {
             .expect("must read from storage")
             .expect("must have highest block header");
         // Check every block and its state root going back to genesis
-        let mut block_hash = highest_block_header.hash(verifiable_chunked_hash_activation);
+        let mut block_hash = highest_block_header.hash();
         loop {
             let block = storage
                 .read_block(&block_hash)
@@ -585,21 +540,8 @@ async fn test_joiner() {
 
     const ERA_TO_JOIN: u64 = 3;
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily.
-    // Ideally, we should run this test two times with `verifiable_chunked_hash_activation`
-    // set to "before" and "after" the `ERA_TO_JOIN`. But because this test is
-    // time consuming, we randomize the activation point so it randomly falls
-    // ahead or behind the era.
-    let verifiable_chunked_hash_activation: u64 = rng.gen_range(0..=(ERA_TO_JOIN * 2));
-    let verifiable_chunked_hash_activation = EraId::from(verifiable_chunked_hash_activation);
-
     // Create a chain with just one node
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -609,14 +551,9 @@ async fn test_joiner() {
 
     // Get the first switch block hash
     // As part of the chain sync process, we will need to retrieve the first switch block
-    let switch_block_hash = await_switch_block(
-        1,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await
-    .hash(verifiable_chunked_hash_activation);
+    let switch_block_hash = await_switch_block(1, &mut chain.network, &mut rng)
+        .await
+        .hash();
 
     info!("Waiting for Era {} to end", ERA_TO_JOIN);
     chain
@@ -670,20 +607,7 @@ async fn test_joiner_network() {
 
     const START_ERA: u64 = 2;
 
-    // `verifiable_chunked_hash_activation` can be chosen arbitrarily.
-    // Ideally, we should run this test two times with `verifiable_chunked_hash_activation`
-    // set to "before" and "after" the `ERA_TO_JOIN`. But because this test is
-    // time consuming, we randomize the activation point so it randomly falls
-    // ahead or behind the era.
-    let verifiable_chunked_hash_activation: u64 = rng.gen_range(0..=(START_ERA * 2));
-    let verifiable_chunked_hash_activation = EraId::from(verifiable_chunked_hash_activation);
-
-    let mut chain = TestChain::new(
-        INITIAL_NETWORK_SIZE,
-        verifiable_chunked_hash_activation,
-        &mut rng,
-    )
-    .await;
+    let mut chain = TestChain::new(INITIAL_NETWORK_SIZE, &mut rng).await;
 
     assert_eq!(
         chain.network.nodes().len(),
@@ -692,19 +616,13 @@ async fn test_joiner_network() {
     );
 
     // Get the first switch block hash
-    await_switch_block(
-        START_ERA,
-        verifiable_chunked_hash_activation,
-        &mut chain.network,
-        &mut rng,
-    )
-    .await;
+    await_switch_block(START_ERA, &mut chain.network, &mut rng).await;
 
     let trusted_block_hash = first_node_storage(&chain.network)
         .read_block_header_by_height(2)
         .expect("should not have storage error")
         .expect("should have block header")
-        .hash(verifiable_chunked_hash_activation);
+        .hash();
 
     // Have a node join the network with that hash
     info!("Joining with trusted hash {}", trusted_block_hash);

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -24,8 +24,7 @@ pub use available_block_range::AvailableBlockRange;
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},
     Block, BlockAndDeploys, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature,
-    FinalizedBlock, HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart,
-    MerkleLinkedListNode,
+    FinalizedBlock,
 };
 pub(crate) use block::{
     BlockHashAndHeight, BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId,

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -35,7 +35,6 @@ struct TomlProtocol {
     hard_reset: bool,
     activation_point: ActivationPoint,
     last_emergency_restart: Option<EraId>,
-    verifiable_chunked_hash_activation: EraId,
 }
 
 /// A chainspec configuration as laid out in the TOML-encoded configuration file.
@@ -59,9 +58,6 @@ impl From<&Chainspec> for TomlChainspec {
             hard_reset: chainspec.protocol_config.hard_reset,
             activation_point: chainspec.protocol_config.activation_point,
             last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
-            verifiable_chunked_hash_activation: chainspec
-                .protocol_config
-                .verifiable_chunked_hash_activation,
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
@@ -119,9 +115,6 @@ pub(super) fn parse_toml<P: AsRef<Path>>(
         activation_point: toml_chainspec.protocol.activation_point,
         global_state_update,
         last_emergency_restart: toml_chainspec.protocol.last_emergency_restart,
-        verifiable_chunked_hash_activation: toml_chainspec
-            .protocol
-            .verifiable_chunked_hash_activation,
     };
 
     let chainspec = Chainspec {

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -36,8 +36,8 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     crypto, runtime_args,
     system::standard_payment::ARG_AMOUNT,
-    EraId, ExecutionResult, Motes, PublicKey, RuntimeArgs, SecretKey, Signature, TimeDiff,
-    Timestamp, U512,
+    ExecutionResult, Motes, PublicKey, RuntimeArgs, SecretKey, Signature, TimeDiff, Timestamp,
+    U512,
 };
 
 use super::{BlockHash, BlockHashAndHeight, Item, Tag};
@@ -684,10 +684,7 @@ impl Item for FinalizedApprovalsWithId {
     const TAG: Tag = Tag::FinalizedApprovals;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self) -> Result<(), Self::ValidationError> {
         for approval in &self.approvals.0 {
             crypto::verify(&self.id, approval.signature(), approval.signer()).map_err(|err| {
                 FinalizedApprovalsVerificationError {
@@ -699,7 +696,7 @@ impl Item for FinalizedApprovalsWithId {
         Ok(())
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self) -> Self::Id {
         self.id
     }
 }
@@ -1611,15 +1608,12 @@ impl Item for Deploy {
     const TAG: Tag = Tag::Deploy;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self) -> Result<(), Self::ValidationError> {
         // TODO: Validate approvals later, and only if the approvers are actually authorized!
         validate_deploy(self)
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self) -> Self::Id {
         *self.id()
     }
 }

--- a/node/src/types/item.rs
+++ b/node/src/types/item.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 
 use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
 use casper_hashing::{ChunkWithProofVerificationError, Digest};
-use casper_types::EraId;
 
 use crate::types::{BlockHash, BlockHeader};
 
@@ -72,13 +71,10 @@ pub(crate) trait Item:
     const ID_IS_COMPLETE_ITEM: bool;
 
     /// Checks cryptographic validity of the item, and returns an error if invalid.
-    fn validate(
-        &self,
-        verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError>;
+    fn validate(&self) -> Result<(), Self::ValidationError>;
 
     /// The ID of the specific item.
-    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id;
+    fn id(&self) -> Self::Id;
 }
 
 /// Error type simply conveying that chunk validation failed.
@@ -92,17 +88,14 @@ impl Item for TrieOrChunk {
     const TAG: Tag = Tag::TrieOrChunk;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self) -> Result<(), Self::ValidationError> {
         match self {
             TrieOrChunk::Trie(_) => Ok(()),
             TrieOrChunk::ChunkWithProof(chunk_with_proof) => chunk_with_proof.verify(),
         }
     }
 
-    fn id(&self, _verifiable_chunked_hash_activation: EraId) -> Self::Id {
+    fn id(&self) -> Self::Id {
         match self {
             TrieOrChunk::Trie(node_bytes) => TrieOrChunkId(0, Digest::hash(&node_bytes)),
             TrieOrChunk::ChunkWithProof(chunked_data) => TrieOrChunkId(
@@ -119,14 +112,11 @@ impl Item for BlockHeader {
     const TAG: Tag = Tag::BlockHeaderByHash;
     const ID_IS_COMPLETE_ITEM: bool = false;
 
-    fn validate(
-        &self,
-        _verifiable_chunked_hash_activation: EraId,
-    ) -> Result<(), Self::ValidationError> {
+    fn validate(&self) -> Result<(), Self::ValidationError> {
         Ok(())
     }
 
-    fn id(&self, verifiable_chunked_hash_activation: EraId) -> Self::Id {
-        self.hash(verifiable_chunked_hash_activation)
+    fn id(&self) -> Self::Id {
+        self.hash()
     }
 }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -14,8 +14,6 @@ hard_reset = false
 activation_point = '${TIMESTAMP}'
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
-# The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-verifiable_chunked_hash_activation = 2
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -15,10 +15,6 @@ activation_point = 3000
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 
-# The era ID starting at which the new Merkle tree-based hashing scheme is applied.
-# TODO: Set this to the same value as the upgrade to the first version supporting Merkle tree-based hashing.
-verifiable_chunked_hash_activation = 9999
-
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -2,7 +2,6 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -2,7 +2,6 @@
 version = '0.9.0'
 hard_reset = false
 activation_point = '2020-09-18T18:45:00Z'
-verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -3,7 +3,6 @@ version = '1.0.0'
 hard_reset = false
 activation_point = 1
 last_emergency_restart = 99
-verifiable_chunked_hash_activation = 0
 
 [network]
 name = 'test-chain'

--- a/utils/dry-run-deploys/src/main.rs
+++ b/utils/dry-run-deploys/src/main.rs
@@ -14,8 +14,6 @@ use retrieve_state::{
     storage::{create_storage, get_many_deploys_by_hash, normalize_path},
 };
 
-use casper_types::EraId;
-
 #[derive(Debug, StructOpt)]
 struct Opts {
     #[structopt(short, long, required = true, default_value = retrieve_state::CHAIN_DOWNLOAD_PATH)]
@@ -56,12 +54,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let chain_download_path = normalize_path(&opts.chain_download_path)?;
     let lmdb_path = normalize_path(&opts.lmdb_path)?;
 
-    // TODO: Consider reading the proper `chainspec` in the `dry-run-deploys` tool.
-    let verifiable_chunked_hash_activation = EraId::from(0u64);
-
     // Create a separate lmdb for block/deploy storage at chain_download_path.
-    let storage = create_storage(&chain_download_path, verifiable_chunked_hash_activation)
-        .expect("should create storage");
+    let storage = create_storage(&chain_download_path).expect("should create storage");
 
     let max_db_size = opts
         .max_db_size
@@ -81,10 +75,7 @@ async fn main() -> Result<(), anyhow::Error> {
         opts.manual_sync_enabled,
     )?;
 
-    let mut execution_pre_state = ExecutionPreState::from_block_header(
-        &previous_block_header,
-        verifiable_chunked_hash_activation,
-    );
+    let mut execution_pre_state = ExecutionPreState::from_block_header(&previous_block_header);
     let mut execute_count = 0;
 
     let highest_height_in_chain = storage.read_highest_block()?;
@@ -143,7 +134,6 @@ async fn main() -> Result<(), anyhow::Error> {
             finalized_block,
             deploys,
             transfers,
-            verifiable_chunked_hash_activation,
         )?;
         let elapsed_micros = start.elapsed().as_micros() as u64;
         execution_time_hist
@@ -157,8 +147,7 @@ async fn main() -> Result<(), anyhow::Error> {
             expected.state_root_hash(),
             "state root hash mismatch"
         );
-        execution_pre_state =
-            ExecutionPreState::from_block_header(&header, verifiable_chunked_hash_activation);
+        execution_pre_state = ExecutionPreState::from_block_header(&header);
         execute_count += 1;
         if opts.verbose {
             eprintln!(

--- a/utils/nctl/sh/assets/upgrade_from_stage.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage.sh
@@ -41,7 +41,7 @@ function _get_protocol_version_of_next_upgrade()
     local PATH_TO_N1_BIN
     local SEMVAR_CURRENT
     local SEMVAR_NEXT
-    
+
     PATH_TO_N1_BIN="$(get_path_to_net)/nodes/node-1/bin"
 
     # Set semvar of current version.
@@ -79,8 +79,6 @@ function _main()
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
     local COUNT_NODES
-
-    #Set `verifiable_chunked_hash_activation` equal to upgrade activation point
 
     PATH_TO_STAGE="$NCTL/stages/stage-$STAGE_ID"
     COUNT_NODES=$(get_count_of_nodes)

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -109,7 +109,7 @@ function _setup_asset_chainspec()
     local COUNT_NODES
 
     # Shouldnt matter, maybe, idk ?, blame Tom if this causes an issue :)
-    COUNT_NODES='100' 
+    COUNT_NODES='100'
 
     # Set file.
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"
@@ -299,7 +299,7 @@ function _get_protocol_version_of_next_upgrade()
     local PATH_TO_NX_BIN
     local SEMVAR_CURRENT
     local SEMVAR_NEXT
-    
+
     PATH_TO_NX_BIN="$(get_path_to_net)/nodes/node-$NODE_ID/bin"
 
     # Set semvar of current version.
@@ -337,8 +337,6 @@ function _main()
     local CONFIG_PATH=${6}
     local PATH_TO_STAGE
     local PROTOCOL_VERSION
-
-    #Set `verifiable_chunked_hash_activation` equal to upgrade activation point
 
     PATH_TO_STAGE="$NCTL/stages/stage-$STAGE_ID"
     PROTOCOL_VERSION=$(_get_protocol_version_of_next_upgrade "$PATH_TO_STAGE" "$NODE_ID")

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -61,9 +61,7 @@ function _step_01()
 
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" \
-        stage="$STAGE_ID" \
-        chainspec_path="$NCTL/overrides/upgrade_scenario_1.pre.chainspec.toml.in"
+    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID"
     source "$NCTL/sh/node/start.sh" node=all
 }
 
@@ -107,8 +105,7 @@ function _step_05()
     log "... setting upgrade assets"
     source "$NCTL/sh/assets/upgrade_from_stage.sh" \
         stage="$STAGE_ID" \
-        verbose=false \
-        chainspec_path="$NCTL/overrides/upgrade_scenario_1.post.chainspec.toml.in"
+        verbose=false
 
     log "... awaiting 2 eras + 1 block"
     nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -81,7 +81,6 @@ function _step_01()
 
     source "$NCTL/sh/assets/setup_from_stage.sh" \
             stage="$STAGE_ID" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_3.pre.chainspec.toml.in" \
             accounts_path="$NCTL/overrides/upgrade_scenario_3.pre.accounts.toml"
     source "$NCTL/sh/node/start.sh" node=all
 }
@@ -208,7 +207,6 @@ function _step_08()
     source "$NCTL/sh/assets/upgrade_from_stage.sh" \
         stage="$STAGE_ID" \
         verbose=false \
-        chainspec_path="$NCTL/overrides/upgrade_scenario_3.post.chainspec.toml.in" \
         accounts_path="$NCTL/overrides/upgrade_scenario_3.post.accounts.toml"
 
     log "... awaiting 2 eras + 1 block"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -91,9 +91,7 @@ function _step_01()
     log_step_upgrades 0 "Begin upgrade_scenario_04"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" \
-            stage="$STAGE_ID" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_4.pre.chainspec.toml.in"
+    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -130,8 +128,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$ACTIVATION_POINT" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_4.post.chainspec.toml.in"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -268,8 +265,7 @@ function _step_09()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$ACTIVATION_POINT" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_4.post.chainspec.toml.in"
+            era="$ACTIVATION_POINT"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -91,9 +91,7 @@ function _step_01()
     log_step_upgrades 0 "Begin upgrade_scenario_05"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" \
-            stage="$STAGE_ID" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_5.pre.chainspec.toml.in"
+    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
     log "... Starting 5 non-validators"
@@ -130,8 +128,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$ACTIVATION_POINT" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_5.post.chainspec.toml.in"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -268,8 +265,7 @@ function _step_09()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$ACTIVATION_POINT" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_5.post.chainspec.toml.in"
+            era="$ACTIVATION_POINT"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -73,9 +73,8 @@ function _step_01()
 
     log_step_upgrades 1 "Begin upgrade_scenario_06"
 
-    nctl-assets-setup \
-        "chainspec_path=$NCTL/overrides/upgrade_scenario_6.post.chainspec.toml.in"
-    
+    nctl-assets-setup
+
     # Force Hard Reset
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"
     sed -i 's/hard_reset = false/hard_reset = true/g' "$PATH_TO_CHAINSPEC"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -73,9 +73,8 @@ function _step_01()
 
     log_step_upgrades 1 "Begin upgrade_scenario_07"
 
-    nctl-assets-setup \
-        "chainspec_path=$NCTL/overrides/upgrade_scenario_7.post.chainspec.toml.in"
-    
+    nctl-assets-setup
+
     # Force Hard Reset
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"
     sed -i 's/hard_reset = false/hard_reset = true/g' "$PATH_TO_CHAINSPEC"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -73,9 +73,7 @@ function _step_01()
     log_step_upgrades 0 "Begin upgrade_scenario_09"
     log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
 
-    source "$NCTL/sh/assets/setup_from_stage.sh" \
-            stage="$STAGE_ID" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_9.pre.chainspec.toml.in"
+    source "$NCTL/sh/assets/setup_from_stage.sh" stage="$STAGE_ID"
     log "... Starting 5 validators"
     source "$NCTL/sh/node/start.sh" node=all
 }
@@ -104,8 +102,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$ACTIVATION_POINT" \
-            chainspec_path="$NCTL/overrides/upgrade_scenario_9.post.chainspec.toml.in"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -194,8 +191,7 @@ function _step_07()
         stage="$STAGE_ID" \
         verbose=false \
         node="6" \
-        era="$ACTIVATION_POINT" \
-        chainspec_path="$NCTL/overrides/upgrade_scenario_9.post.chainspec.toml.in"
+        era="$ACTIVATION_POINT"
     echo ""
     # add hash to upgrades config
     PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -89,8 +89,7 @@ function _step_04()
     log "... setting upgrade assets"
     source "$NCTL/sh/assets/upgrade_from_stage.sh" \
         stage="$STAGE_ID" \
-        verbose=false \
-        chainspec_path="$NCTL/overrides/upgrade_scenario_10.post.chainspec.toml.in"
+        verbose=false
 
     log "... awaiting 2 eras + 1 block"
     nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'

--- a/utils/nctl/sh/scenarios/chainspecs/emergency_upgrade_test.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/emergency_upgrade_test.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 3

--- a/utils/nctl/sh/scenarios/chainspecs/sync_upgrade_test.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/sync_upgrade_test.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 5

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_1.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 6

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_10.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 4

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_3.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 7

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_4.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 3

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_5.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 3

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_6.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_6.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 3

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_7.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_7.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 3

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_9.chainspec.toml.override
@@ -1,2 +1,0 @@
-[protocol]
-verifiable_chunked_hash_activation = 4

--- a/utils/retrieve-state/src/main.rs
+++ b/utils/retrieve-state/src/main.rs
@@ -18,8 +18,6 @@ use casper_node::{
 use retrieve_state::{address_to_url, storage::create_storage};
 use tracing::info;
 
-use casper_types::EraId;
-
 const DOWNLOAD_TRIES: &str = "download-tries";
 const DOWNLOAD_BLOCKS: &str = "download-blocks";
 const CONVERT_BLOCK_FILES: &str = "convert-block-files";
@@ -162,9 +160,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let initial_server_address = SocketAddr::V4(SocketAddrV4::new(opts.server_ip, port));
     let url = address_to_url(initial_server_address);
 
-    // TODO: Consider reading the proper `chainspec` in the `retrieve-state` tool.
-    let verifiable_chunked_hash_activation = EraId::from(0u64);
-
     let maybe_highest_block = opts.highest_block;
     let maybe_download_block = opts
         .highest_block
@@ -186,9 +181,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 fs::create_dir_all(&chain_download_path)?;
             }
 
-            let mut storage =
-                create_storage(&chain_download_path, verifiable_chunked_hash_activation)
-                    .expect("should create storage");
+            let mut storage = create_storage(&chain_download_path).expect("should create storage");
             info!("Downloading all blocks to genesis...");
             let (downloaded, read_from_disk) = retrieve_state::download_or_read_blocks(
                 &client,

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use lmdb::DatabaseFlags;
+use num_rational::Ratio;
+use tracing::info;
 
 use casper_execution_engine::{
     core::engine_state::{EngineConfig, EngineState},
@@ -19,9 +21,7 @@ use casper_node::{
     types::{Deploy, DeployHash},
     StorageConfig, WithDir,
 };
-use casper_types::{EraId, ProtocolVersion};
-use num_rational::Ratio;
-use tracing::info;
+use casper_types::ProtocolVersion;
 
 use crate::DEFAULT_MAX_READERS;
 
@@ -128,10 +128,7 @@ pub fn normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, anyhow::Error> 
     }
 }
 
-pub fn create_storage(
-    chain_download_path: impl AsRef<Path>,
-    verifiable_chunked_hash_activation: EraId,
-) -> Result<Storage, anyhow::Error> {
+pub fn create_storage(chain_download_path: impl AsRef<Path>) -> Result<Storage, anyhow::Error> {
     let chain_download_path = normalize_path(chain_download_path)?;
     let mut storage_config = StorageConfig::default();
     storage_config.path = chain_download_path.clone();
@@ -142,7 +139,6 @@ pub fn create_storage(
         "test",
         Ratio::new(1, 3),
         None,
-        verifiable_chunked_hash_activation,
     )?)
 }
 
@@ -166,8 +162,7 @@ mod tests {
             .clone();
 
         let dir = tempfile::tempdir().unwrap().into_path();
-        let mut storage =
-            create_storage(dir, example_block.header.height.into()).expect("should create storage");
+        let mut storage = create_storage(dir).expect("should create storage");
 
         let example_deploy = GetDeployResult::doc_example().deploy.clone();
 


### PR DESCRIPTION
This PR removes all instances of `verifiable_chunked_hash_activation`, and also removes the code supporting v2 (Merklized) block hashing.

The removed Merklized hashing functionality can be restored as and when required in the future.

Closes #3237.