### PR TITLE
Remove the support for trusted hashes from before the last upgrade

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.  The format
 * Remove asymmetric key functionality (move to `casper-types` crate behind feature "std").
 * Remove time types (move to `casper-types` with some functionality behind feature "std").
 * Remove `reject_incompatible_versions` option from `config.toml`, meaning now all versions different than the current one are rejected through the `chainspec_hash` check in the network handshake.
+* Remove the `[protocol][last_emergency_restart]` field from the chainspec - fast sync will use the global state directly for recognizing such restarts instead.
 
 ### Fixed
 * Limiters for incoming requests and outgoing bandwidth will no longer inadvertently delay some validator traffic when maxed out due to joining nodes.

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -68,19 +68,11 @@ impl Config {
         self.chainspec.protocol_config.version
     }
 
-    pub(super) fn activation_point(&self) -> EraId {
-        self.chainspec.protocol_config.activation_point.era_id()
-    }
-
     pub(super) fn genesis_timestamp(&self) -> Option<Timestamp> {
         self.chainspec
             .protocol_config
             .activation_point
             .genesis_timestamp()
-    }
-
-    pub(super) fn last_emergency_restart(&self) -> Option<EraId> {
-        self.chainspec.protocol_config.last_emergency_restart
     }
 
     pub(super) fn verifiable_chunked_hash_activation(&self) -> EraId {

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -31,6 +31,19 @@ pub(crate) enum Error {
         engine_state::Error,
     ),
 
+    #[error(
+        "trusted header is from before the last upgrade and isn't the last header before \
+         activation. \
+         trusted header: {trusted_header:?}, \
+         protocol_version: {protocol_version:?}, \
+         activation_point: {activation_point:?}"
+    )]
+    TrustedHeaderTooEarly {
+        trusted_header: Box<BlockHeader>,
+        protocol_version: ProtocolVersion,
+        activation_point: EraId,
+    },
+
     #[error("cannot get switch block for era: {era_id}")]
     NoSwitchBlockForEra { era_id: EraId },
 

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -31,16 +31,6 @@ pub(crate) enum Error {
         engine_state::Error,
     ),
 
-    #[error(
-        "cannot get trusted validators for such an early era. \
-         trusted header: {trusted_header:?}, \
-         last emergency restart era id: {maybe_last_emergency_restart_era_id:?}"
-    )]
-    TrustedHeaderEraTooEarly {
-        trusted_header: Box<BlockHeader>,
-        maybe_last_emergency_restart_era_id: Option<EraId>,
-    },
-
     #[error("cannot get switch block for era: {era_id}")]
     NoSwitchBlockForEra { era_id: EraId },
 
@@ -95,19 +85,6 @@ pub(crate) enum Error {
 
     #[error(transparent)]
     BlockExecution(#[from] BlockExecutionError),
-
-    #[error(
-        "joining with trusted hash before emergency restart not supported - find a more recent \
-         hash from after the restart. \
-         last emergency restart era: {last_emergency_restart_era}, \
-         trusted hash: {trusted_hash:?}, \
-         trusted block header: {trusted_block_header:?}"
-    )]
-    TryingToJoinBeforeLastEmergencyRestartEra {
-        last_emergency_restart_era: EraId,
-        trusted_hash: BlockHash,
-        trusted_block_header: Box<BlockHeader>,
-    },
 
     #[error("hit genesis block trying to get trusted era validators")]
     HitGenesisBlockTryingToGetTrustedEraValidators { trusted_header: BlockHeader },

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -35,12 +35,12 @@ pub(crate) enum Error {
         "trusted header is from before the last upgrade and isn't the last header before \
          activation. \
          trusted header: {trusted_header:?}, \
-         protocol_version: {protocol_version:?}, \
-         activation_point: {activation_point:?}"
+         current protocol version: {current_protocol_version:?}, \
+         current version activation point: {activation_point:?}"
     )]
     TrustedHeaderTooEarly {
         trusted_header: Box<BlockHeader>,
-        protocol_version: ProtocolVersion,
+        current_protocol_version: ProtocolVersion,
         activation_point: EraId,
     },
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -162,7 +162,7 @@ where
         {
             return Err(Error::TrustedHeaderTooEarly {
                 trusted_header: Box::new(trusted_block_header),
-                protocol_version: config.protocol_version(),
+                current_protocol_version: config.protocol_version(),
                 activation_point: config.chainspec().protocol_config.activation_point.era_id(),
             });
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1866,17 +1866,7 @@ async fn finalize_finality_signature_fetch<REv>(
 /// Returns the EraId whose switch block should be used to obtain validator weights.
 fn get_era_id_for_validators_retrieval(era_id: &EraId) -> EraId {
     // TODO: This function needs to handle upgrades with changes to the validator set.
-    if *era_id != EraId::from(0) {
-        // For eras > 0 we need to use the validator set from the previous era.
-        // TODO: check that it wasn't an upgrade that changed the validator set, in which case we
-        // should be using the validators from the same era.
-        *era_id - 1
-    } else {
-        // If we're in Era 0 there's no previous era, but since validators never change during
-        // that era we can safely use the Era 0's switch block.
-        // TODO: also return the same era if the validators set has been changed during an upgrade.
-        *era_id
-    }
+    era_id.saturating_sub(1)
 }
 
 /// Runs the initial chain synchronization task ("fast sync").

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -227,16 +227,6 @@ impl<'a, REv> ChainSyncContext<'a, REv> {
             .expect("trusted block header not initialized")
     }
 
-    /// Returns the trusted block hash.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if not initialized properly using `ChainSyncContext::new`.
-    fn trusted_hash(&self) -> BlockHash {
-        self.trusted_block_header()
-            .hash(self.config.verifiable_chunked_hash_activation())
-    }
-
     fn trusted_block_is_last_before_activation(&self) -> bool {
         self.config
             .is_last_block_before_activation(self.trusted_block_header())
@@ -1169,20 +1159,6 @@ where
     // Fetch each parent hash one by one until we have the switch block info.
     let mut current_header_to_walk_back_from = ctx.trusted_block_header().clone();
     loop {
-        // Check that we are not restarting right after an emergency restart, which is too early
-        match ctx.config.last_emergency_restart() {
-            Some(last_emergency_restart)
-                if last_emergency_restart > current_header_to_walk_back_from.era_id()
-                    && !ctx.trusted_block_is_last_before_activation() =>
-            {
-                return Err(Error::TrustedHeaderEraTooEarly {
-                    trusted_header: Box::new(ctx.trusted_block_header().clone()),
-                    maybe_last_emergency_restart_era_id: ctx.config.last_emergency_restart(),
-                })
-            }
-            _ => {}
-        }
-
         if let Some(key_block_info) = KeyBlockInfo::maybe_from_block_header(
             &current_header_to_walk_back_from,
             ctx.config.verifiable_chunked_hash_activation(),
@@ -1713,10 +1689,7 @@ async fn era_validator_weights_for_block<'a, REv>(
 where
     REv: From<StorageRequest>,
 {
-    let era_for_validators_retrieval = get_era_id_for_validators_retrieval(
-        &block_header.era_id(),
-        ctx.config.last_emergency_restart(),
-    );
+    let era_for_validators_retrieval = get_era_id_for_validators_retrieval(&block_header.era_id());
     let switch_block_of_previous_era = ctx
         .effect_builder
         .get_switch_block_header_at_era_id_from_storage(era_for_validators_retrieval)
@@ -1881,24 +1854,17 @@ async fn finalize_finality_signature_fetch<REv>(
 }
 
 /// Returns the EraId whose switch block should be used to obtain validator weights.
-fn get_era_id_for_validators_retrieval(
-    era_id: &EraId,
-    last_emergency_restart: Option<EraId>,
-) -> EraId {
-    // TODO: This function needs to handle multiple emergency restarts.
-    if *era_id != EraId::from(0) && last_emergency_restart != Some(*era_id) {
-        // For eras > 0 which are not the last emergency restart eras we need to use validator set
-        // from the previous era
+fn get_era_id_for_validators_retrieval(era_id: &EraId) -> EraId {
+    // TODO: This function needs to handle upgrades with changes to the validator set.
+    if *era_id != EraId::from(0) {
+        // For eras > 0 we need to use the validator set from the previous era.
+        // TODO: check that it wasn't an upgrade that changed the validator set, in which case we
+        // should be using the validators from the same era.
         *era_id - 1
     } else {
-        // When we're in era 0 or in the era of last emergency restart we
-        // use that era as a source for validators, because:
-        //
-        // 1) If we're in Era 0 there's no previous era, but since validators never change during
+        // If we're in Era 0 there's no previous era, but since validators never change during
         // that era we can safely use the Era 0's switch block.
-        //
-        // 2) In case of being in last emergency restart era, the validators from the previous era
-        // may no longer be valid.
+        // TODO: also return the same era if the validators set has been changed during an upgrade.
         *era_id
     }
 }
@@ -1946,12 +1912,6 @@ where
             Some(block_header) => block_header,
             None => return Err(Error::NoHighestBlockHeader),
         };
-
-    if let Some(outcome) =
-        prepare_for_emergency_upgrade_if_needed(&ctx, &highest_block_header).await?
-    {
-        return Ok(outcome);
-    }
 
     if let Some(outcome) = prepare_for_upgrade_if_needed(&ctx, &highest_block_header).await? {
         return Ok(outcome);
@@ -2040,58 +2000,6 @@ fn verify_trusted_block_header<REv>(ctx: &ChainSyncContext<'_, REv>) -> Result<(
     };
 
     Ok(())
-}
-
-/// Returns `Ok(Some(FastSyncOutcome::ShouldCommitUpgrade))` if we should commit an emergency
-/// upgrade before syncing further, or `Ok(None)` if not.
-///
-/// If this returns `Ok(Some...)`, we sync the trie store in preparation for running commit_upgrade.
-async fn prepare_for_emergency_upgrade_if_needed<REv>(
-    ctx: &ChainSyncContext<'_, REv>,
-    highest_block_header: &BlockHeader,
-) -> Result<Option<FastSyncOutcome>, Error>
-where
-    REv: From<FetcherRequest<TrieOrChunk>>
-        + From<NetworkInfoRequest>
-        + From<ContractRuntimeRequest>
-        + From<StorageRequest>,
-{
-    let emergency_restart_era = match ctx.config.last_emergency_restart() {
-        Some(era_id) if era_id == ctx.config.activation_point() => era_id,
-        _ => return Ok(None),
-    };
-
-    // After an emergency restart, the old validators cannot be trusted anymore. So the last block
-    // before the restart or a later block must be given by the trusted hash. That way we never have
-    // to use the untrusted validators' finality signatures.
-    if ctx.trusted_block_header().next_block_era_id() < emergency_restart_era {
-        return Err(Error::TryingToJoinBeforeLastEmergencyRestartEra {
-            last_emergency_restart_era: emergency_restart_era,
-            trusted_hash: ctx.trusted_hash(),
-            trusted_block_header: Box::new(ctx.trusted_block_header().clone()),
-        });
-    }
-    // If the trusted block is the last block before an emergency restart, and we haven't
-    // already run the upgrade, we have to compute the immediate switch block ourselves, since
-    // there's no other way to verify that block. We just sync the trie there and return, so the
-    // upgrade can be applied.
-    if ctx.trusted_block_is_last_before_activation()
-        && highest_block_header.protocol_version() < ctx.config.protocol_version()
-    {
-        info!("synchronizing trie store before committing emergency upgrade");
-        ctx.progress.start_fetching_tries_for_emergency_upgrade(
-            ctx.trusted_block_header().height(),
-            *ctx.trusted_block_header().state_root_hash(),
-        );
-        sync_trie_store(ctx.trusted_block_header(), ctx).await?;
-        info!("finished synchronizing before committing emergency upgrade");
-        return Ok(Some(FastSyncOutcome::ShouldCommitUpgrade {
-            switch_block_header_before_upgrade: ctx.trusted_block_header().clone(),
-            is_emergency_upgrade: true,
-        }));
-    }
-
-    Ok(None)
 }
 
 /// Returns `Ok(Some(FastSyncOutcome::ShouldCommitUpgrade))` if we should commit an upgrade before
@@ -2581,40 +2489,22 @@ mod tests {
     fn gets_correct_era_id_for_validators_retrieval() {
         assert_eq!(
             EraId::from(0),
-            get_era_id_for_validators_retrieval(&EraId::from(0), None)
+            get_era_id_for_validators_retrieval(&EraId::from(0))
         );
 
         assert_eq!(
             EraId::from(0),
-            get_era_id_for_validators_retrieval(&EraId::from(1), None)
+            get_era_id_for_validators_retrieval(&EraId::from(1))
         );
 
         assert_eq!(
             EraId::from(1),
-            get_era_id_for_validators_retrieval(&EraId::from(2), None)
+            get_era_id_for_validators_retrieval(&EraId::from(2))
         );
 
         assert_eq!(
             EraId::from(999),
-            get_era_id_for_validators_retrieval(&EraId::from(1000), None)
-        );
-    }
-
-    #[test]
-    fn gets_correct_era_id_for_validators_when_emergency_restart() {
-        assert_eq!(
-            EraId::from(0),
-            get_era_id_for_validators_retrieval(&EraId::from(0), Some(EraId::from(7)))
-        );
-
-        assert_eq!(
-            EraId::from(0),
-            get_era_id_for_validators_retrieval(&EraId::from(1), Some(EraId::from(2)))
-        );
-
-        assert_eq!(
-            EraId::from(2),
-            get_era_id_for_validators_retrieval(&EraId::from(2), Some(EraId::from(2)))
+            get_era_id_for_validators_retrieval(&EraId::from(1000))
         );
     }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -157,6 +157,16 @@ where
             },
         };
 
+        if trusted_block_header.protocol_version() != config.protocol_version()
+            && !config.is_last_block_before_activation(&trusted_block_header)
+        {
+            return Err(Error::TrustedHeaderTooEarly {
+                trusted_header: Box::new(trusted_block_header),
+                protocol_version: config.protocol_version(),
+                activation_point: config.chainspec().protocol_config.activation_point.era_id(),
+            });
+        }
+
         ctx.trusted_block_header = Some(Arc::new(trusted_block_header));
 
         Ok(Some(ctx))

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -187,20 +187,6 @@ impl ProgressHolder {
         });
     }
 
-    pub(super) fn start_fetching_tries_for_emergency_upgrade(
-        &self,
-        block_height: u64,
-        state_root_hash: Digest,
-    ) {
-        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_emergency_upgrade");
-        *inner = Progress::FastSync(FastSync::FetchingTries {
-            block_height,
-            state_root_hash,
-            reason: FetchingTriesReason::EmergencyUpgrade,
-            num_tries_to_fetch: 0,
-        });
-    }
-
     pub(super) fn start_fetching_tries_for_upgrade(
         &self,
         block_height: u64,

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -133,12 +133,6 @@ impl Display for NextUpgrade {
     }
 }
 
-/// Basic information about the current run of the node software.
-#[derive(Clone, Debug)]
-pub(crate) struct CurrentRunInfo {
-    pub(crate) last_emergency_restart: Option<EraId>,
-}
-
 #[derive(Clone, DataSize, Debug)]
 pub(crate) struct ChainspecLoader {
     chainspec: Arc<Chainspec>,
@@ -348,12 +342,6 @@ impl ChainspecLoader {
         )
     }
 
-    fn get_current_run_info(&self) -> CurrentRunInfo {
-        CurrentRunInfo {
-            last_emergency_restart: self.chainspec.protocol_config.last_emergency_restart,
-        }
-    }
-
     fn check_for_next_upgrade<REv>(&self, effect_builder: EffectBuilder<REv>) -> Effects<Event>
     where
         REv: From<ChainspecLoaderAnnouncement> + Send,
@@ -421,9 +409,6 @@ where
             } => self.handle_initialize(effect_builder, maybe_highest_block),
             Event::Request(ChainspecLoaderRequest::GetChainspecInfo(responder)) => {
                 responder.respond(self.new_chainspec_info()).ignore()
-            }
-            Event::Request(ChainspecLoaderRequest::GetCurrentRunInfo(responder)) => {
-                responder.respond(self.get_current_run_info()).ignore()
             }
             Event::Request(ChainspecLoaderRequest::GetChainspecRawBytes(responder)) => responder
                 .respond(Arc::clone(&self.chainspec_raw_bytes))

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -420,7 +420,6 @@ impl reactor::Reactor for Reactor {
             ProtocolVersion::from_parts(1, 0, 0),
             "test",
             Ratio::new(1, 3),
-            None,
             chainspec.protocol_config.verifiable_chunked_hash_activation,
         )
         .unwrap();

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -86,10 +86,6 @@ reactor!(Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .last_emergency_restart,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
                 .verifiable_chunked_hash_activation,
         );
         fake_deploy_acceptor = infallible FakeDeployAcceptor();

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -238,7 +238,6 @@ impl reactor::Reactor for Reactor {
             ProtocolVersion::from_parts(1, 0, 0),
             "test",
             Ratio::new(1, 3),
-            None,
             verifiable_chunked_hash_activation.into(),
         )
         .unwrap();

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1891,14 +1891,6 @@ impl Storage {
         txn: &mut Tx,
         block_header: &BlockHeader,
     ) -> Result<Option<BlockSignatures>, FatalStorageError> {
-        if block_header.is_first_after_emergency_restart() {
-            warn!(
-                ?block_header,
-                "finality signatures for a block right after an emergency restart requested"
-            );
-            return Ok(None);
-        }
-
         let block_signatures = match self.get_finality_signatures(
             txn,
             &block_header.hash(self.verifiable_chunked_hash_activation),

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -75,7 +75,6 @@ fn storage_fixture(
         ProtocolVersion::from_parts(1, 0, 0),
         "test",
         Ratio::new(1, 3),
-        None,
         verifiable_chunked_hash_activation,
     )
     .expect("could not create storage component fixture")
@@ -100,7 +99,6 @@ fn storage_fixture_with_hard_reset(
         ProtocolVersion::from_parts(1, 1, 0),
         "test",
         Ratio::new(1, 3),
-        None,
         verifiable_chunked_hash_activation,
     )
     .expect("could not create storage component fixture")
@@ -126,7 +124,6 @@ fn storage_fixture_with_hard_reset_and_protocol_version(
         protocol_version,
         "test",
         Ratio::new(1, 3),
-        None,
         verifiable_chunked_hash_activation,
     )
     .expect("could not create storage component fixture")
@@ -1399,7 +1396,6 @@ fn should_create_subdir_named_after_network() {
         ProtocolVersion::from_parts(1, 0, 0),
         network_name,
         Ratio::new(1, 3),
-        None,
         EraId::from(0),
     )
     .unwrap();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1978,15 +1978,10 @@ impl<REv> EffectBuilder<REv> {
     where
         REv: From<StorageRequest> + From<ChainspecLoaderRequest>,
     {
-        // If there was an emergency restart at `era_id`, the switch block at this era will be the
-        // immediate switch block created after the emergency restart. Check for such a case, as we
-        // can't return the correct validator set then.
-        let maybe_block_header = self
-            .get_switch_block_header_at_era_id_from_storage(era_id)
-            .await;
-        if maybe_block_header.map_or(false, |header| header.is_first_after_emergency_restart()) {
-            return None;
-        }
+        // TODO (#3233): If there was an upgrade changing the validator set at `era_id`, the switch
+        // block at this era will be the immediate switch block created after the upgrade. We should
+        // check for such a case and return the validators from the switch block itself then.
+
         // Era 0 contains no blocks other than the genesis immediate switch block which can be used
         // to get the validators for era 0.  For any other era `n`, we need the switch block from
         // era `n-1` to get the validators for `n`.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -133,7 +133,7 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
-        chainspec_loader::{CurrentRunInfo, NextUpgrade},
+        chainspec_loader::NextUpgrade,
         consensus::{BlockContext, ClContext, EraDump, ValidatorChange},
         contract_runtime::{
             BlockAndExecutionEffects, BlockExecutionError, EraValidatorsRequest, ExecutionPreState,
@@ -1749,18 +1749,6 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Gets the information about the current run of the node software.
-    pub(crate) async fn get_current_run_info(self) -> CurrentRunInfo
-    where
-        REv: From<ChainspecLoaderRequest>,
-    {
-        self.make_request(
-            ChainspecLoaderRequest::GetCurrentRunInfo,
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     pub(crate) async fn get_node_state(self) -> NodeState
     where
         REv: From<NodeStateRequest> + Send,
@@ -1984,18 +1972,19 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the correct era validators set for the given era.
-    /// Takes emergency restarts into account based on the information from the chainspec loader.
+    /// Takes emergency restarts into account based on the information in the immediate switch
+    /// block after a restart.
     pub(crate) async fn get_era_validators(self, era_id: EraId) -> Option<BTreeMap<PublicKey, U512>>
     where
         REv: From<StorageRequest> + From<ChainspecLoaderRequest>,
     {
-        let CurrentRunInfo {
-            last_emergency_restart,
-            ..
-        } = self.get_current_run_info().await;
-        let cutoff_era_id = last_emergency_restart.unwrap_or_else(|| EraId::new(0));
-        if era_id < cutoff_era_id {
-            // we don't support getting the validators from before the last emergency restart
+        // If there was an emergency restart at `era_id`, the switch block at this era will be the
+        // immediate switch block created after the emergency restart. Check for such a case, as we
+        // can't return the correct validator set then.
+        let maybe_block_header = self
+            .get_switch_block_header_at_era_id_from_storage(era_id)
+            .await;
+        if maybe_block_header.map_or(false, |header| header.is_first_after_emergency_restart()) {
             return None;
         }
         // Era 0 contains no blocks other than the genesis immediate switch block which can be used

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -37,7 +37,6 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
-        chainspec_loader::CurrentRunInfo,
         consensus::{BlockContext, ClContext, ValidatorChange},
         contract_runtime::{
             BlockAndExecutionEffects, BlockExecutionError, EraValidatorsRequest, ExecutionPreState,
@@ -1212,8 +1211,6 @@ pub(crate) enum ConsensusRequest {
 pub(crate) enum ChainspecLoaderRequest {
     /// Chainspec info request.
     GetChainspecInfo(Responder<ChainspecInfo>),
-    /// Request for information about the current run.
-    GetCurrentRunInfo(Responder<CurrentRunInfo>),
     /// Request for the chainspec file bytes with the genesis_accounts and global_state bytes, if
     /// they are present.
     GetChainspecRawBytes(Responder<Arc<ChainspecRawBytes>>),
@@ -1223,7 +1220,6 @@ impl Display for ChainspecLoaderRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
-            ChainspecLoaderRequest::GetCurrentRunInfo(_) => write!(f, "get current run info"),
             ChainspecLoaderRequest::GetChainspecRawBytes(_) => write!(f, "get chainspec raw bytes"),
         }
     }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -208,10 +208,6 @@ impl Reactor {
             chainspec_loader
                 .chainspec()
                 .protocol_config
-                .last_emergency_restart,
-            chainspec_loader
-                .chainspec()
-                .protocol_config
                 .verifiable_chunked_hash_activation,
         )?;
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -997,6 +997,12 @@ impl BlockHeader {
         self.era_id().is_genesis() && self.height() == 0
     }
 
+    /// Returns true if the block is the first block after an emergency restart.
+    /// Such blocks are marked by having their accumulated seed set to be equal to the parent hash.
+    pub(crate) fn is_first_after_emergency_restart(&self) -> bool {
+        self.parent_hash.0 == self.accumulated_seed
+    }
+
     // Serialize the block header.
     fn serialize(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.to_bytes()

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -997,12 +997,6 @@ impl BlockHeader {
         self.era_id().is_genesis() && self.height() == 0
     }
 
-    /// Returns true if the block is the first block after an emergency restart.
-    /// Such blocks are marked by having their accumulated seed set to be equal to the parent hash.
-    pub(crate) fn is_first_after_emergency_restart(&self) -> bool {
-        self.parent_hash.0 == self.accumulated_seed
-    }
-
     // Serialize the block header.
     fn serialize(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.to_bytes()

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -329,7 +329,6 @@ mod tests {
                     Motes::new(U512::from((index as u64 + 1) * 10))
                 );
             }
-            assert!(spec.protocol_config.last_emergency_restart.is_none());
         } else {
             assert_eq!(
                 spec.protocol_config.version,
@@ -344,10 +343,6 @@ mod tests {
             for value in spec.protocol_config.global_state_update.unwrap().0.values() {
                 assert!(StoredValue::from_bytes(value).is_ok());
             }
-            assert_eq!(
-                spec.protocol_config.last_emergency_restart,
-                Some(EraId::new(99))
-            );
         }
 
         assert_eq!(spec.network_config.name, "test-chain");

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -34,7 +34,6 @@ struct TomlProtocol {
     version: ProtocolVersion,
     hard_reset: bool,
     activation_point: ActivationPoint,
-    last_emergency_restart: Option<EraId>,
     verifiable_chunked_hash_activation: EraId,
 }
 
@@ -58,7 +57,6 @@ impl From<&Chainspec> for TomlChainspec {
             version: chainspec.protocol_config.version,
             hard_reset: chainspec.protocol_config.hard_reset,
             activation_point: chainspec.protocol_config.activation_point,
-            last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
             verifiable_chunked_hash_activation: chainspec
                 .protocol_config
                 .verifiable_chunked_hash_activation,
@@ -118,7 +116,6 @@ pub(super) fn parse_toml<P: AsRef<Path>>(
         hard_reset: toml_chainspec.protocol.hard_reset,
         activation_point: toml_chainspec.protocol.activation_point,
         global_state_update,
-        last_emergency_restart: toml_chainspec.protocol.last_emergency_restart,
         verifiable_chunked_hash_activation: toml_chainspec
             .protocol
             .verifiable_chunked_hash_activation,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -12,8 +12,6 @@ hard_reset = false
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
-# Optional era ID in which the last emergency restart happened.
-#last_emergency_restart = 0
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
 verifiable_chunked_hash_activation = 2
 

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -12,8 +12,6 @@ hard_reset = true
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = 3000
-# Optional era ID in which the last emergency restart happened.
-#last_emergency_restart = 0
 
 # The era ID starting at which the new Merkle tree-based hashing scheme is applied.
 # TODO: Set this to the same value as the upgrade to the first version supporting Merkle tree-based hashing.

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -2,7 +2,6 @@
 version = '1.0.0'
 hard_reset = false
 activation_point = 1
-last_emergency_restart = 99
 verifiable_chunked_hash_activation = 0
 
 [network]

--- a/utils/nctl/sh/assets/upgrade.sh
+++ b/utils/nctl/sh/assets/upgrade.sh
@@ -134,7 +134,6 @@ function _emergency_upgrade_node() {
         "import toml;"
         "cfg=toml.load('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml');"
         "cfg['protocol']['hard_reset']=True;"
-        "cfg['protocol']['last_emergency_restart']=$ACTIVATE_ERA;"
         "toml.dump(cfg, open('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml', 'w'));"
     )
     python3 -c "${SCRIPT[*]}"
@@ -221,7 +220,6 @@ function _emergency_upgrade_node_balances() {
         "import toml;"
         "cfg=toml.load('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml');"
         "cfg['protocol']['hard_reset']=True;"
-        "cfg['protocol']['last_emergency_restart']=$ACTIVATE_ERA;"
         "toml.dump(cfg, open('$PATH_TO_NODE/config/$PROTOCOL_VERSION/chainspec.toml', 'w'));"
     )
     python3 -c "${SCRIPT[*]}"

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -141,7 +141,6 @@ pub fn create_storage(
         ProtocolVersion::from_parts(0, 0, 0),
         "test",
         Ratio::new(1, 3),
-        None,
         verifiable_chunked_hash_activation,
     )?)
 }


### PR DESCRIPTION
Closes #3211 

Note that this removes any notion of an emergency upgrade (or an upgrade editing the global state) from the chain synchronizer. This could cause issues for validating finality signatures around such an upgrade during sync to genesis, but this is going to be addressed in #3233 .