### PR TITLE
NCTL: swap out direct calls to await_n_eras for wrapper

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -94,7 +94,7 @@ function _step_04()
 {
     log_step_upgrades 4 "awaiting next era"
 
-    await_n_eras 1 'true' '2.0'
+    nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='180'
 }
 
 # Step 05: Upgrade network from stage.
@@ -187,7 +187,7 @@ function _step_07()
     done
 
     log "... awaiting auction bid acceptance (3 eras + 1 block)"
-    await_n_eras 3 'true'
+    nctl-await-n-eras offset='3' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 
     log "... starting nodes"
@@ -213,7 +213,7 @@ function _step_07()
         fi
     done
 
-    await_n_eras 1 'true'
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
     await_n_blocks 1
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -130,11 +130,11 @@ function _step_04()
             validator="$NODE_ID"
 }
 
-# Step 05: Await 3 eras
+# Step 05: Await 4 eras
 function _step_05()
 {
-    log_step_upgrades 5 "Awaiting Auction_Delay = 3"
-    await_n_eras '4' 'true' '5.0'
+    log_step_upgrades 5 "Awaiting Auction_Delay = 3 + 1"
+    nctl-await-n-eras offset='4' sleep_interval='5.0' timeout='300'
 }
 
 # Step 06: Assert NODE_ID is a validator
@@ -289,7 +289,7 @@ function _step_09()
 function _step_10()
 {
     log_step_upgrades 10 "awaiting next era"
-    await_n_eras '1' 'true' '5.0'
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
 }
 
 # Step 11: Unbond previously bonded validator
@@ -321,11 +321,11 @@ function _step_12()
             validator="$NODE_ID"
 }
 
-# Step 13: Await 3 eras
+# Step 13: Await 4 eras
 function _step_13()
 {
-    log_step_upgrades 13 "Awaiting Auction_Delay = 3"
-    await_n_eras '4' 'true' '5.0'
+    log_step_upgrades 13 "Awaiting Auction_Delay = 3 + 1"
+    nctl-await-n-eras offset='4' sleep_interval='5.0' timeout='300'
 }
 
 # Step 14: Assert NODE_ID is NOT a validator

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -238,7 +238,7 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "awaiting next era"
-    await_n_eras '1' 'true' '5.0' '2'
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180' node_id='2'
 }
 
 # Step 09: Stage nodes 1&10 and restart.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/Usr/bin/env bash
 # ----------------------------------------------------------------
 # Synopsis.
 # ----------------------------------------------------------------
@@ -238,7 +238,7 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "awaiting 10 eras"
-    await_n_eras '10' 'true' '5.0' '2'
+    nctl-await-n-eras offset='10' sleep_interval='5.0' timeout='600' node_id='2'
 }
 
 # Step 09: Stage nodes 1&10 and restart.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -218,7 +218,7 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "awaiting 1 eras"
-    await_n_eras '1' 'true' '5.0' '2'
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180' node_id='2'
 }
 
 # Step 09: Stage nodes 1&10 and restart.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -218,7 +218,7 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "awaiting 10 eras"
-    await_n_eras '10' 'true' '5.0' '2'
+    nctl-await-n-eras offset='10' sleep_interval='5.0' timeout='600' node_id='2'
 }
 
 # Step 09: Stage nodes 1&10 and restart.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -165,7 +165,7 @@ function _step_05()
 function _step_06()
 {
     log_step_upgrades 6 "awaiting next era"
-    await_n_eras '1' 'true' '5.0' '2'
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180' node_id='2'
 }
 
 # Step 07: Stage node 6 with old trusted hash.

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test.sh
@@ -151,7 +151,7 @@ function do_send_transfers() {
 function do_await_deploy_inclusion() {
     # Should be enough to await for one era.
     log_step "awaiting one era…"
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
 }
 
 function dispatch_native() {

--- a/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
+++ b/utils/nctl/sh/scenarios/emergency_upgrade_test_balances.sh
@@ -151,7 +151,7 @@ function do_await_network_upgrade() {
 function do_await_one_era() {
     # Should be enough to await for one era.
     log_step "awaiting one era…"
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
 }
 
 # ----------------------------------------------------------------

--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -103,7 +103,7 @@ function do_send_transfers() {
 function do_await_deploy_inclusion() {
     # Should be enough to await for one era.
     log_step "awaiting one era…"
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
 }
 
 function do_read_lfb_hash() {
@@ -146,7 +146,7 @@ function do_await_full_synchronization() {
     # Wait one more era and then test LFB again.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
     while [ "$(do_read_lfb_hash "$NODE_ID")" != "$(do_read_lfb_hash 1)" ]; do
         if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
             log "ERROR: Failed to keep up with the protocol state"

--- a/utils/nctl/sh/scenarios/sync_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/sync_upgrade_test.sh
@@ -150,7 +150,7 @@ function do_send_transfers() {
 function do_await_deploy_inclusion() {
     # Should be enough to await for one era.
     log_step "awaiting one era…"
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
 }
 
 function do_read_lfb_hash() {
@@ -182,7 +182,7 @@ function do_await_full_synchronization() {
     # Wait one more era and then test LFB again.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    await_n_eras 1
+    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
     while [ "$(do_read_lfb_hash "$NODE_ID")" != "$(do_read_lfb_hash 1)" ]; do
         if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
             log "ERROR: Failed to keep up with the protocol state"


### PR DESCRIPTION
Changes:
- moves over to `nctl-await-n-eras` alias to allow for clarity around args
