### PR TITLE
CI: package up global-state-update-gen

### DIFF
--- a/.github/workflows/publish-global-state-update-gen.yml
+++ b/.github/workflows/publish-global-state-update-gen.yml
@@ -1,0 +1,69 @@
+---
+name: publish-global-state-update-gen
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish_deb:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            code_name: bionic
+          - os: ubuntu-20.04
+            code_name: focal
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Install deps
+        run: |
+          echo "deb http://repo.aptly.info/ squeeze main" | sudo tee -a /etc/apt/sources.list.d/aptly.list
+          wget -qO - https://www.aptly.info/pubkey.txt | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y awscli aptly=1.2.0
+          aptly config show
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@c8bb57c57e8df1be8c73ff3d59deab1dbc00e0d1 #v5.1.0
+        with:
+          gpg_private_key: ${{ secrets.APTLY_GPG_KEY }}
+          passphrase: ${{ secrets.APTLY_GPG_PASS }}
+
+      - name: Install cargo deb
+        run: cargo install cargo-deb
+
+      - name: Cargo build
+        run: cargo build -p global-state-update-gen --release
+
+      - name: Cargo deb
+        run: cargo deb -p global-state-update-gen --no-build --variant ${{ matrix.code_name }}
+
+      - name: Upload binaries to repo
+        env:
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
+          PLUGIN_REPO_NAME: ${{ secrets.APTLY_REPO }}
+          PLUGIN_REGION: ${{ secrets.APTLY_REGION }}
+          PLUGIN_GPG_KEY: ${{ secrets.APTLY_GPG_KEY }}
+          PLUGIN_GPG_PASS: ${{ secrets.APTLY_GPG_PASS }}
+          PLUGIN_ACL: 'public-read'
+          PLUGIN_PREFIX: 'releases'
+          PLUGIN_DEB_PATH: './target/debian'
+          PLUGIN_OS_CODENAME: ${{ matrix.code_name }}
+        run: ./ci/publish_deb_to_repo.sh
+
+      - name: Invalidate cloudfront
+        uses: chetan/invalidate-cloudfront-action@c384d5f09592318a77b1e5c0c8d4772317e48b25 #v2.4
+        env:
+          DISTRIBUTION: ${{ secrets.APTLY_DIST_ID }}
+          PATHS: "/*"
+          AWS_REGION: ${{ secrets.APTLY_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}

--- a/ci/publish_deb_to_repo.sh
+++ b/ci/publish_deb_to_repo.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+# DEFAULTS
+PLUGIN_OS_CODENAME="${PLUGIN_OS_CODENAME:-bionic}"
+
+# Verify all variables are present
+if [[ -z $PLUGIN_GPG_KEY || -z $PLUGIN_GPG_PASS || -z $PLUGIN_REGION \
+        || -z $PLUGIN_REPO_NAME || -z $PLUGIN_ACL || -z $PLUGIN_PREFIX \
+        || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID \
+        || -z $PLUGIN_DEB_PATH || -z $PLUGIN_OS_CODENAME ]]; then
+    echo "ERROR: Environment Variable Missing!"
+    exit 1
+fi
+
+# Verify if its the first time publishing. Will need to know later.
+# Probably an easier way to do this check :)
+EXISTS=$(aws s3 ls s3://"$PLUGIN_REPO_NAME"/releases/dists/ --region "$PLUGIN_REGION" | grep "$PLUGIN_OS_CODENAME") || EXISTS_RET="false"
+
+# Sanity Check for later
+if [ "$EXISTS_RET" = "false" ]; then
+    echo "First time uploading repo!"
+else
+    echo "Repo Exists! Defaulting to publish update..."
+fi
+
+### APTLY SECTION
+
+# Move old config file to use in jq query
+mv ~/.aptly.conf ~/.aptly.conf.orig
+
+# Inject ENV Variables and save as .aptly.conf
+jq --arg region "$PLUGIN_REGION" --arg bucket "$PLUGIN_REPO_NAME" --arg acl "$PLUGIN_ACL" --arg prefix "$PLUGIN_PREFIX"   '.S3PublishEndpoints[$bucket] = {"region":$region, "bucket":$bucket, "acl": $acl, "prefix": $prefix}' ~/.aptly.conf.orig > ~/.aptly.conf
+
+# If aptly repo DOESNT exist locally already
+if [ ! "$(aptly repo list | grep $PLUGIN_OS_CODENAME)" ]; then
+    aptly repo create -distribution="$PLUGIN_OS_CODENAME" -component=main "release-$PLUGIN_OS_CODENAME"
+fi
+
+# If aptly mirror DOESNT exist locally already
+if [ ! "$(aptly mirror list | grep $PLUGIN_OS_CODENAME)" ] && [ ! "$EXISTS_RET" = "false" ] ; then
+    aptly mirror create -ignore-signatures "local-repo-$PLUGIN_OS_CODENAME" https://"${PLUGIN_REPO_NAME}"/"${PLUGIN_PREFIX}"/ "${PLUGIN_OS_CODENAME}" main
+fi
+
+# When it's not the first time uploading.
+if [ ! "$EXISTS_RET" = "false" ]; then
+    aptly mirror update -ignore-signatures "local-repo-$PLUGIN_OS_CODENAME"
+    # Found an article that said using 'Name' will select all packages for us
+    aptly repo import "local-repo-$PLUGIN_OS_CODENAME" "release-$PLUGIN_OS_CODENAME" Name
+fi
+
+# Add .debs to the local repo
+aptly repo add -force-replace "release-$PLUGIN_OS_CODENAME" "$PLUGIN_DEB_PATH"/*.deb
+
+# Publish to S3
+if [ ! "$(aptly publish list | grep $PLUGIN_REPO_NAME | grep $PLUGIN_OS_CODENAME)" ]; then
+    # If the repo is new
+    aptly publish repo -batch -force-overwrite -passphrase="$PLUGIN_GPG_PASS" "release-$PLUGIN_OS_CODENAME" s3:"${PLUGIN_REPO_NAME}":
+else
+    # If the repo exists
+    aptly publish update -batch -force-overwrite -passphrase="$PLUGIN_GPG_PASS" "$PLUGIN_OS_CODENAME" s3:"${PLUGIN_REPO_NAME}":
+fi

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -26,9 +26,9 @@ assets = [
 ]
 
 [package.metadata.deb.variants.bionic]
-name = "casper-client"
+name = "global-state-update-gen"
 revision = "0+bionic"
 
 [package.metadata.deb.variants.focal]
-name = "casper-client"
+name = "global-state-update-gen"
 revision = "0+focal"

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -3,6 +3,9 @@ name = "global-state-update-gen"
 version = "0.2.0"
 authors = ["Bartłomiej Kamiński <bart@casperlabs.io>"]
 edition = "2018"
+license-file = "../../LICENSE"
+description = "A tool used to make changes to casper-node's global state"
+readme = "README.md"
 
 [dependencies]
 base16 = "0.2.1"

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -16,3 +16,19 @@ lmdb = "0.8"
 rand = "0.8"
 serde = "1"
 toml = "0.5"
+
+[package.metadata.deb]
+revision = "0"
+depends = "$auto"
+assets = [
+    # binary
+    ["../../target/release/global-state-update-gen", "/usr/bin/", "755"],
+]
+
+[package.metadata.deb.variants.bionic]
+name = "casper-client"
+revision = "0+bionic"
+
+[package.metadata.deb.variants.focal]
+name = "casper-client"
+revision = "0+focal"


### PR DESCRIPTION
### Adds:
- `.github/workflows/publish-global-state-update-gen.yml`
    - gha workflow that will publish the `global-state-update-gen tool` on any `v*` tag to our `apt` repos
    - built on both `focal` and `bionic` runners
- `ci/publish_deb_to_repo.sh`
    - handles the juggling of the `aptly` commands
- `utils/global-state-update-gen/Cargo.toml`
    - adds fields use by `cargo-deb`
    
### Ticket:
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/541