### PR TITLE
Ensure synced deploys of a block are held in the correct order

### DIFF
--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use casper_execution_engine::{
     core::engine_state::{BalanceResult, GetBidsResult, QueryResult},
@@ -1048,7 +1048,7 @@ impl RpcWithParams for GetTrie {
                 Ok(result)
             }
             Err(error) => {
-                error!(?error, "failed to get trie");
+                warn!(?error, "failed to get trie");
                 Err(Error::new(
                     ErrorCode::FailedToGetTrie,
                     format!("{:?}", error),

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -32,7 +32,7 @@ pub(super) const TRANSFER_ADDR_FORMATTED_STRING_PREFIX: &str = "transfer-";
 
 /// A newtype wrapping a <code>[u8; [DEPLOY_HASH_LENGTH]]</code> which is the raw bytes of the
 /// deploy hash.
-#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct DeployHash([u8; DEPLOY_HASH_LENGTH]);
 
@@ -110,6 +110,12 @@ impl<'de> Deserialize<'de> for DeployHash {
             <[u8; DEPLOY_HASH_LENGTH]>::deserialize(deserializer)?
         };
         Ok(DeployHash(bytes))
+    }
+}
+
+impl Debug for DeployHash {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "DeployHash({})", base16::encode_lower(&self.0))
     }
 }
 


### PR DESCRIPTION
This PR ensures that during chain sync, deploys which are fetched in parallel are inserted into the block for execution in the correct order.

It also updates the `Debug` impl for the mirrored `DeployHash` type in casper-types to use hex-encoded notation as per other hash digests.

Finally, it downgrades an `error!` log in the RPC server to `warn!` as it could be triggered by an invalid client request and doesn't represent an actual internal node error.

Closes #3253.