### PR TITLE
Update to fix new lint warnings since Rust 1.63.0

### DIFF
--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -19,7 +19,7 @@ use crate::{
 
 /// A target mode indicates if a native transfer's arguments will resolve to an existing purse, or
 /// will have to create a new account first.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TransferTargetMode {
     /// Unknown target mode.
     Unknown,
@@ -100,7 +100,7 @@ impl TryFrom<TransferArgs> for RuntimeArgs {
 ///
 /// Purpose of this builder is to resolve native tranfer args into [`TransferTargetMode`] and a
 /// [`TransferArgs`] instance to execute actual token transfer on the mint contract.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransferRuntimeArgsBuilder {
     inner: RuntimeArgs,
     transfer_target_mode: TransferTargetMode,

--- a/execution_engine/src/shared/newtypes/mod.rs
+++ b/execution_engine/src/shared/newtypes/mod.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 /// A correlation id is a unique identifier which can be used to track the progress of a given
 /// execution engine operation.
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize)]
 pub struct CorrelationId(Uuid);
 
 impl CorrelationId {

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -126,7 +126,7 @@ pub fn run_blocks_with_transfers_and_step(
 
         let existing_keys = cursor
             .iter()
-            .map(|(key, _)| Digest::try_from(&*key).expect("should be a digest"));
+            .map(|(key, _)| Digest::try_from(key).expect("should be a digest"));
         necessary_tries.extend(existing_keys);
     }
     writeln!(
@@ -238,7 +238,7 @@ fn find_necessary_tries<S>(
             TrieOrChunk::ChunkWithProof(_) => continue,
         };
 
-        if let Some(0) = trie_bytes.get(0) {
+        if let Some(0) = trie_bytes.first() {
             continue;
         }
 

--- a/execution_engine_testing/test_support/src/utils.rs
+++ b/execution_engine_testing/test_support/src/utils.rs
@@ -190,7 +190,7 @@ pub fn get_exec_costs<T: AsRef<ExecutionResult>, I: IntoIterator<Item = T>>(
 /// # Panics
 /// Panics if `response` is `None`.
 pub fn get_success_result(response: &[Rc<ExecutionResult>]) -> &ExecutionResult {
-    &*response.get(0).expect("should have a result")
+    response.get(0).expect("should have a result")
 }
 
 /// Returns an error if the `ExecutionResult` has an error.

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -125,7 +125,7 @@ impl Error {
     pub fn new<C: ErrorCodeT, T: Serialize>(error_code: C, additional_info: T) -> Self {
         let (code, message): (i64, &'static str) = error_code.into();
 
-        if !C::is_reserved() && code >= -32768 && code <= -32100 {
+        if !C::is_reserved() && (-32768..=-32100).contains(&code) {
             warn!(%code, "provided json-rpc error code is reserved; returning internal error");
             let (code, message) = ReservedErrorCode::InternalError.into();
             return Error {

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -190,11 +190,8 @@ mod tests {
             cannot_propose: &Default::default(),
         };
 
-        let expected_change = vec![(
-            seen_as_faulty_in_new_era.clone(),
-            ValidatorChange::SeenAsFaulty,
-        )];
         let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        let expected_change = vec![(seen_as_faulty_in_new_era, ValidatorChange::SeenAsFaulty)];
         assert_eq!(expected_change, actual_change.0)
     }
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -435,7 +435,7 @@ impl DocExample for ListRpcsResult {
 }
 
 /// "rpc.discover" RPC.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct ListRpcs {}
 
 #[async_trait]

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -594,7 +594,7 @@ impl reactor::Reactor for Reactor {
 
         let trie_or_chunk_fetcher = fetcher_builder.build("trie_or_chunk")?;
 
-        let deploy_acceptor = DeployAcceptor::new(&*chainspec_loader.chainspec(), registry)?;
+        let deploy_acceptor = DeployAcceptor::new(chainspec_loader.chainspec(), registry)?;
 
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",

--- a/node/src/testing/condition_check_reactor.rs
+++ b/node/src/testing/condition_check_reactor.rs
@@ -11,6 +11,8 @@ use crate::{
     NodeRng,
 };
 
+type ConditionChecker<R> = Box<dyn Fn(&<R as Reactor>::Event) -> bool + Send>;
+
 /// A reactor wrapping an inner reactor, and which has an optional hook into
 /// `Reactor::dispatch_event()`.
 ///
@@ -21,16 +23,13 @@ use crate::{
 /// Once the condition is met, the hook is reset to `None`.
 pub(crate) struct ConditionCheckReactor<R: Reactor> {
     reactor: R,
-    condition_checker: Option<Box<dyn Fn(&R::Event) -> bool + Send>>,
+    condition_checker: Option<ConditionChecker<R>>,
     condition_result: bool,
 }
 
 impl<R: Reactor> ConditionCheckReactor<R> {
     /// Sets the condition checker hook.
-    pub(crate) fn set_condition_checker(
-        &mut self,
-        condition_checker: Box<dyn Fn(&R::Event) -> bool + Send>,
-    ) {
+    pub(crate) fn set_condition_checker(&mut self, condition_checker: ConditionChecker<R>) {
         self.condition_checker = Some(condition_checker);
     }
 

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -1656,7 +1656,7 @@ impl From<Deploy> for DeployItem {
 ///
 /// Currently a stop-gap measure to associate an immutable deploy with additional metadata. Holds
 /// execution results.
-#[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct DeployMetadata {
     /// The block hashes of blocks containing the related deploy, along with the results of
     /// executing the related deploy in the context of one or more blocks.
@@ -1664,7 +1664,7 @@ pub struct DeployMetadata {
 }
 
 /// Additional information describing a deploy.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum DeployMetadataExt {
     /// Holds the execution results of a deploy.
     Metadata(DeployMetadata),

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -25,8 +25,8 @@ impl<T> Deref for SharedObject<T> {
     #[inline]
     fn deref(&self) -> &Self::Target {
         match self {
-            SharedObject::Owned(obj) => &*obj,
-            SharedObject::Shared(shared) => &*shared,
+            SharedObject::Owned(obj) => obj,
+            SharedObject::Shared(shared) => shared,
         }
     }
 }

--- a/utils/retrieve-state/src/lib.rs
+++ b/utils/retrieve-state/src/lib.rs
@@ -399,18 +399,15 @@ pub async fn download_trie_channels(
     for peer in peers {
         let base_send = base_send.clone();
         let peer_future = async move {
-            let maybe_peer =
-                match maybe_construct_peer(base_send.clone(), *peer, client, state_root_hash).await
-                {
-                    Ok(peer) => Some(peer),
-                    Err(_err) => {
-                        // just skip those that can't be communicated with
-                        // info!("error constructing peer with address {:?} {:?}", peer,
-                        // err);
-                        None
-                    }
-                };
-            maybe_peer
+            match maybe_construct_peer(base_send.clone(), *peer, client, state_root_hash).await {
+                Ok(peer) => Some(peer),
+                Err(_err) => {
+                    // just skip those that can't be communicated with
+                    // info!("error constructing peer with address {:?} {:?}", peer,
+                    // err);
+                    None
+                }
+            }
         };
         peer_futures.push(peer_future);
     }


### PR DESCRIPTION
This PR fixes new lints warnings introduced by Rust 1.63.0.
