### PR TITLE
Update nctl test to use pre- and post-upgrade trusted hashes

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -33,7 +33,8 @@ function _main()
     local STAGE_ID=${1}
     local INITIAL_PROTOCOL_VERSION
     local ACTIVATION_POINT
-    local UPGRADE_HASH
+    local PRE_UPGRADE_BLOCK_HASH
+    local POST_UPGRADE_BLOCK_HASH
 
     if [ ! -d "$(get_path_to_stage "$STAGE_ID")" ]; then
         log "ERROR :: stage $STAGE_ID has not been built - cannot run scenario"
@@ -47,13 +48,17 @@ function _main()
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
     ACTIVATION_POINT="$(get_chain_era)"
+    PRE_UPGRADE_BLOCK_HASH="$($(get_path_to_client) get-block --node-address "$(get_node_address_rpc '2')" | jq -r '.result.block.hash')"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
     _step_04 "$INITIAL_PROTOCOL_VERSION"
+
+    POST_UPGRADE_BLOCK_HASH="$($(get_path_to_client) get-block --node-address "$(get_node_address_rpc '2')" | jq -r '.result.block.hash')"
+
     _step_05
     _step_06
-    _step_07 "$STAGE_ID" "$ACTIVATION_POINT"
-    _step_08 '6'
+    _step_07 "$STAGE_ID" "$ACTIVATION_POINT" "$PRE_UPGRADE_BLOCK_HASH" "$POST_UPGRADE_BLOCK_HASH"
+    _step_08
     _step_09
     _step_10
 }
@@ -165,25 +170,21 @@ function _step_06()
     nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180' node_id='2'
 }
 
-# Step 07: Stage node 6 with old trusted hash.
+# Step 07: Stage node 6 with post-upgrade trusted hash and node 7 with pre-upgrade trusted hash
 function _step_07()
 {
     local STAGE_ID=${1}
     local ACTIVATION_POINT=${2}
-    local HASH
+    local PRE_UPGRADE_BLOCK_HASH=${3}
+    local POST_UPGRADE_BLOCK_HASH=${4}
     local PATH_TO_NODE_CONFIG_UPGRADE
     local N2_PROTO_VERSION
-
-    # Use trusted hash prior to upgrade point
-    # Block 31 should be in era 2 or 3 - so before the upgrade, but after era 0, which is important
-    # because a node can't get the validators set for a block in era 0.
-    HASH="$($(get_path_to_client) get-block -b 31 --node-address "$(get_node_address_rpc '2')" | jq -r '.result.block.hash')"
 
     # Node 2 would be running the upgrade if we made it this far in the test.
     # sed is for switching from: ie. 1.0.0 -> 1_0_0
     N2_PROTO_VERSION="$(get_node_protocol_version 2 | sed 's/\./_/g')"
 
-    log_step_upgrades 7 "upgrading node 6 from stage ($STAGE_ID)"
+    log_step_upgrades 7 "upgrading nodes 6 and 7 from stage ($STAGE_ID) - expecting node 7 to fail"
 
     log "... setting upgrade assets"
 
@@ -193,11 +194,15 @@ function _step_07()
         node="6" \
         era="$ACTIVATION_POINT"
     echo ""
-    # add hash to upgrades config
-    PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"
-    _update_node_config_on_start "$PATH_TO_NODE_CONFIG_UPGRADE" "$HASH"
+    source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" \
+        stage="$STAGE_ID" \
+        verbose=false \
+        node="7" \
+        era="$ACTIVATION_POINT"
+    echo ""
 
-    source "$NCTL/sh/node/start.sh" node='6' hash="$HASH"
+    source "$NCTL/sh/node/start.sh" node='6' hash="$POST_UPGRADE_BLOCK_HASH"
+    source "$NCTL/sh/node/start.sh" node='7' hash="$PRE_UPGRADE_BLOCK_HASH"
 }
 
 # Step 08: Assert nodes 1-6 didn't stall
@@ -236,13 +241,26 @@ function _step_08()
     done
 }
 
-# Step 09: Run NCTL health checks
+# Step 09: Assert node 7 is not running
 function _step_09()
 {
+    log_step_upgrades 8 "Asserting node 7 is not running"
+    if [ "$(get_node_is_up 7)" = true ]; then
+        log "ERROR :: upgrade failure :: node-7 is running using a pre-upgrade trusted hash"
+        exit 1
+    else
+        log " ... node-7 not running [expected]"
+    fi
+}
+
+# Step 10: Run NCTL health checks
+function _step_10()
+{
     # restarts=5 - Nodes that upgrade
-    log_step_upgrades 9 "running health checks"
+    # errors=2 - node 7: "failed to sync linear chain" and "fatal error via control announcement"
+    log_step_upgrades 10 "running health checks"
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='0' \
+            errors='2' \
             equivocators='0' \
             doppels='0' \
             crashes=0 \
@@ -250,10 +268,10 @@ function _step_09()
             ejections=0
 }
 
-# Step 10: Terminate.
-function _step_10()
+# Step 11: Terminate.
+function _step_11()
 {
-    log_step_upgrades 10 "upgrade_scenario_09 successful - tidying up"
+    log_step_upgrades 11 "upgrade_scenario_09 successful - tidying up"
 
     source "$NCTL/sh/assets/teardown.sh"
 


### PR DESCRIPTION
This PR fixes the nctl upgrade scenario 09 to expect failure when a trusted hash from before the upgrade is used and to expect success if a post-upgrade hash is used.

Closes #3259.