### PR TITLE
Move `hash_bytes_into_chunks` from execution-engine to `Digest` type.

### DIFF
--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -551,7 +551,7 @@ impl<K, V> Trie<K, V> {
         Self: ToBytes,
     {
         self.to_bytes()
-            .map(|bytes| hash_bytes_into_chunks_if_necessary(&bytes))
+            .map(|bytes| Digest::hash_bytes_into_chunks_if_necessary(&bytes))
     }
 
     /// Returns a pointer block, if possible.
@@ -598,19 +598,6 @@ impl<'a> Iterator for DescendantsIterator<'a> {
                 iter.next().map(|pointer| *pointer.hash())
             }
         }
-    }
-}
-
-/// Hash bytes into chunks if necessary.
-pub(crate) fn hash_bytes_into_chunks_if_necessary(bytes: &[u8]) -> Digest {
-    if bytes.len() <= ChunkWithProof::CHUNK_SIZE_BYTES {
-        Digest::hash(bytes)
-    } else {
-        Digest::hash_merkle_tree(
-            bytes
-                .chunks(ChunkWithProof::CHUNK_SIZE_BYTES)
-                .map(Digest::hash),
-        )
     }
 }
 

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     storage::{
         transaction_source::{Readable, Writable},
         trie::{
-            hash_bytes_into_chunks_if_necessary,
             merkle_proof::{TrieMerkleProof, TrieMerkleProofStep},
             Parents, Pointer, PointerBlock, Trie, RADIX, USIZE_EXCEEDS_U8,
         },
@@ -1048,7 +1047,7 @@ where
     S::Error: From<T::Error>,
     E: From<S::Error> + From<bytesrepr::Error>,
 {
-    let trie_hash = hash_bytes_into_chunks_if_necessary(trie_bytes);
+    let trie_hash = Digest::hash_bytes_into_chunks_if_necessary(trie_bytes);
     store.put_raw(txn, &trie_hash, trie_bytes)?;
     Ok(trie_hash)
 }

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -221,6 +221,19 @@ impl Digest {
             .map_err(|_| Error::IncorrectDigestLength(hex_input.as_ref().len()))?;
         Ok(Digest(slice))
     }
+
+    /// Hash bytes into chunks if necessary.
+    pub fn hash_bytes_into_chunks_if_necessary(bytes: &[u8]) -> Digest {
+        if bytes.len() <= ChunkWithProof::CHUNK_SIZE_BYTES {
+            Digest::hash(bytes)
+        } else {
+            Digest::hash_merkle_tree(
+                bytes
+                    .chunks(ChunkWithProof::CHUNK_SIZE_BYTES)
+                    .map(Digest::hash),
+            )
+        }
+    }
 }
 
 impl CLTyped for Digest {

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -408,12 +408,9 @@ where
 fn compute_execution_results_root_hash<'a>(
     results: &mut impl Iterator<Item = &'a ExecutionResult>,
 ) -> Result<Digest, BlockCreationError> {
-    let mut execution_results_serialized = vec![];
-    for result in results {
-        execution_results_serialized
-            .push(result.to_bytes().map_err(BlockCreationError::BytesRepr)?);
-    }
-    let execution_results_bytes = execution_results_serialized
+    let execution_results_bytes = results
+        .cloned()
+        .collect::<Vec<_>>()
         .to_bytes()
         .map_err(BlockCreationError::BytesRepr)?;
     Ok(Digest::hash_bytes_into_chunks_if_necessary(


### PR DESCRIPTION
We want to reuse the chunking logic in more places, to chunk other data types that just trie, and they all have to follow the same scheme:
* be chunked before storing
* have chunks' IDs being computed (in the fetcher) in a way that is aligned with how the data is stored

By moving this method from execution engine to `Digest` type we're making it easier for developers to use the correct logic instead of writing a new version of it.

Closes https://github.com/casper-network/casper-node/issues/3265 and https://github.com/casper-network/casper-node/issues/3264