### PR TITLE
Retry fetch block and block header forever when not enough peers

### DIFF
--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -33,10 +33,10 @@ pub(super) struct Config {
     max_retries_while_not_connected: u64,
     /// How many fetches in between attempting to redeem one bad node.
     pub(crate) redemption_interval: u32,
-    /// Block and block header fetch operations are retried *once* when at the initial trial there
-    /// were fewer peers than `minimum_peer_count_threshold_for_fetch_retry` available. By default,
-    /// this is the number of items on the `known_addresses` list in the node config.
-    pub(crate) minimum_peer_count_threshold_for_fetch_retry: usize,
+    /// Block and block header fetch operations are retried forever until we have enough connected
+    /// peers. If the operation fails while there are enough peers, the process gives up. By
+    /// default, this is the number of items on the `known_addresses` list in the node config.
+    pub(crate) minimum_peer_count_threshold_for_block_fetch_retry: usize,
 }
 
 impl Config {
@@ -58,7 +58,7 @@ impl Config {
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
             redemption_interval: node_config.sync_peer_redemption_interval,
-            minimum_peer_count_threshold_for_fetch_retry: small_network_config
+            minimum_peer_count_threshold_for_block_fetch_retry: small_network_config
                 .known_addresses
                 .len(),
         }


### PR DESCRIPTION
This PR changes how the blocks and block headers are fetched during the fast sync process. Fetch operations are now retried forever until we have enough connected peers. If the operation fails while there are enough peers, the process gives up.

It also adds a wait interval between consecutive fetch retries.

Closes https://github.com/casper-network/casper-node/issues/3260