### PR TITLE
Make swap_validator_set test reuse a different set of nodes

### DIFF
--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -64,18 +64,18 @@ function main() {
         assert_eviction "$i"
     done
 
-    # 17. Reuse nodes 1-3
+    # 17. Reuse nodes 1, 4, 5
     reuse_original_validators_as_new_nodes
 
     # 18. Start node 1 with pre validator swap block hash
     do_node_start '1' "$PRE_SWAP_HASH"
 
-    # 19. Start node 2 with post validator swap block hash
+    # 19. Start node 4 with post validator swap block hash
     POST_SWAP_HASH=$(do_read_lfb_hash 6)
-    do_node_start '2' "$POST_SWAP_HASH"
+    do_node_start '4' "$POST_SWAP_HASH"
 
-    # 20. Start node 3 with switch block hash
-    do_node_start '3' "$SWICHBLOCK_HASH"
+    # 20. Start node 5 with switch block hash
+    do_node_start '5' "$SWICHBLOCK_HASH"
 
     # 21. Lets some time pass
     nctl-await-n-eras offset='3' sleep_interval='10.0' timeout='300' node='6'
@@ -122,7 +122,7 @@ function reuse_original_validators_as_new_nodes() {
     mkdir -p "$DUMP_PATH"
 
     # loop thru the 3 nodes
-    for i in $(seq 1 3); do
+    for i in 1 4 5; do
         # stop the three nodes that will become make shift
         # joining nodes 11, 12, 13
         log "...stopping node-$i"

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -108,7 +108,7 @@ function reuse_original_validators_as_new_nodes() {
     local NODE_KEYS_PATH
     local USER_KEYS_PATH
 
-    log_step "Converting nodes 1 thru 3 to 'new' joiners"
+    log_step "Converting nodes 1, 4, 5 to 'new' joiners"
 
     # place to move old node stuff
     DUMP_PATH="/tmp/swap_validator_set"


### PR DESCRIPTION
The `swap_validator_set` test used to reset and reuse nodes 1-3. However, these also happen to be all the known peers of node 1. So when nodes 1-3 is restarted, node 1 has no known peer that would have the full knowledge of the chain, which might prevent it from syncing properly. This is an edge case that isn't very realistic, which is why this PR makes the test reuse nodes 1, 4 and 5 instead. This way nodes 2 and 3 won't be reset and node 1 will have 2 known peers from which it will be able to sync.
