### PR TITLE
NCTL: Nightly Failure Fix 20220817

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_10.sh
@@ -89,6 +89,7 @@ function _step_04()
     log "... setting upgrade assets"
     source "$NCTL/sh/assets/upgrade_from_stage.sh" \
         stage="$STAGE_ID" \
+        chainspec_path="$NCTL_CASPER_HOME/resources/local/chainspec.toml.in" \
         verbose=false
 
     log "... awaiting 2 eras + 1 block"


### PR DESCRIPTION
Description:
Test failed after nodes failed to upgrade and exited. Issue was a missing value, `vesting_schedule_period`, in the post-upgrade `chainspec.toml` which caused the node to exit. 

This test is different then the others where it upgrades from an older build to `dev`, ie. `1.3.0` -> `dev`, and the test was using the `chainspec.toml.in` template from `1.3.0` still for `dev`.

Changes:
- use `./resources/local/chainspec.toml.in` when staging local code for upgrade

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/558

