### PR TITLE
Parametrize `check_network_sync()`

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -18,7 +18,7 @@ function main() {
     # 1. Allow the chain to progress
     do_await_era_change 1
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 3. Submit bid for node 6
     do_submit_auction_bids "6"
     do_read_lfb_hash "5"

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -140,15 +140,37 @@ function do_stop_node() {
 
 function check_network_sync() {
     local WAIT_TIME_SEC=0
-    log_step "check all node's LFBs are in sync"
+    local FIRST_NODE=${1:-1}
+    local LAST_NODE=${2:-10}
+
+    log_step "checking nodes' $FIRST_NODE to $LAST_NODE LFBs are in sync"
     while [ "$WAIT_TIME_SEC" != "$SYNC_TIMEOUT_SEC" ]; do
-        if [ "$(do_read_lfb_hash '5')" = "$(do_read_lfb_hash '1')" ] && \
-        [ "$(do_read_lfb_hash '4')" = "$(do_read_lfb_hash '1')" ] && \
-        [ "$(do_read_lfb_hash '3')" = "$(do_read_lfb_hash '1')" ] && \
-        [ "$(do_read_lfb_hash '2')" = "$(do_read_lfb_hash '1')" ]; then
-        log "all nodes in sync, proceeding..."
-        break
+
+        declare -a ALL_LFBS
+
+        index=0
+        for i in $(eval echo "{$FIRST_NODE..$LAST_NODE}")
+        do
+            ALL_LFBS[$index]=$(do_read_lfb_hash $i)
+            index=$((index + 1))
+        done
+
+        LFB_COUNT=${#ALL_LFBS[@]}
+        BASE_LFB=${ALL_LFBS[0]}
+        ALL_EQUAL=1
+        for i in $(eval echo "{0..$((LFB_COUNT - 1))}")
+        do
+            if [[ "$BASE_LFB" != "${ALL_LFBS[$i]}" ]]; then
+                ALL_EQUAL=0
+                break
+            fi
+        done
+
+        if [ "$ALL_EQUAL" -eq 1 ]; then
+            log "nodes $FIRST_NODE to $LAST_NODE in sync, proceeding..."
+            break
         fi
+
         WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
         if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
             log "ERROR: Failed to confirm network sync"

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -27,7 +27,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 3-6. Stop four nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -46,11 +46,11 @@ function main() {
     do_start_node "3" "$STALLED_LFB"
     do_start_node "2" "$STALLED_LFB"
     # 13. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 14. Ensure era proceeds after restart
     do_await_era_change "2"
     # 15. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 16-17. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst01.sh
+++ b/utils/nctl/sh/scenarios/itst01.sh
@@ -36,9 +36,9 @@ function main() {
     # wait 1 era, and then check they are still in sync.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    check_network_sync
+    check_network_sync 1 5
     do_await_era_change
-    check_network_sync
+    check_network_sync 1 5
     # 9. Run Closing Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -24,7 +24,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 3-5. Stop three nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -36,11 +36,11 @@ function main() {
     do_start_node "4" "$STALLED_LFB"
     do_start_node "3" "$STALLED_LFB"
     # 10. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 11. Ensure era proceeds after restart
     do_await_era_change "2"
     # 12. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 13-15. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -20,7 +20,7 @@ function main() {
     # 0. Verify network is creating blocks
     do_await_n_blocks '5'
     # 1. Verify network is in sync
-    check_network_sync
+    check_network_sync 1 5
     # 2. Background transfers so we can stop the node mid-stream
     do_background_wasmless_transfers '5'
     # 3. Stop node being sent transfers
@@ -32,7 +32,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 6. Verify network is in sync
-    check_network_sync
+    check_network_sync 1 5
     # 7. Give the tranfers a chance to be included
     do_await_n_blocks '30'
     # 8. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -19,7 +19,7 @@ function main() {
     # 0. Verify network is creating blocks
     do_await_n_blocks '5'
     # 1. Verify network is in sync
-    check_network_sync
+    check_network_sync 1 5
     # 2. Background transfers so we can stop the node mid-stream
     do_background_wasm_transfers '5'
     # 3. Stop node being sent transfers
@@ -31,7 +31,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 6. Verify network is in sync
-    check_network_sync
+    check_network_sync 1 5
     # 7. Give the tranfers a chance to be included
     do_await_n_blocks '30'
     # 8. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 3. Create the doppelganger
     create_doppelganger '5' '6'
     # 4. Get LFB Hash

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1  5
     # 3. Stop the node
     do_stop_node '5'
     # 4. Wait until N+1

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -20,7 +20,7 @@ function main() {
     # 0. Verify network is creating blocks
     do_await_n_blocks "5"
     # 1. Verify network is in sync
-    check_network_sync
+    check_network_sync 1 5
     # 2a. Get era
     STOPPED_ERA=$(check_current_era)
     # 2b. Stop node
@@ -32,11 +32,11 @@ function main() {
     do_read_lfb_hash 1
     do_start_node "5" "$LFB_HASH"
     # 5. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 6. Verify network is creating blocks post-restart
     do_await_n_blocks "5"
     # 7. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 8. Verify node proposed a block
     assert_node_proposed '5' '180'
     # 9. Verify we are in the same era
@@ -44,7 +44,7 @@ function main() {
     # 10. Wait an era
     do_await_era_change
     # 11. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
     # 12. Run Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -22,7 +22,7 @@ function main() {
     PRE_SWAP_HASH=$(do_read_lfb_hash 1)
 
     # 2. Verify all nodes are in sync
-    check_network_sync
+    check_network_sync 1 5
 
     # 3. Send some wasm to all running nodes
     log_step "sending wasm trandfers to validators"
@@ -81,7 +81,7 @@ function main() {
     nctl-await-n-eras offset='3' sleep_interval='10.0' timeout='300' node='6'
 
     # 22. Check network is in sync
-    check_network_sync
+    check_network_sync 1 10
 
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='0' \


### PR DESCRIPTION
This PR adds parameters to the `check_network_sync()` NCTL function to allow defining a range of nodes whose sync should be asserted. It also updates the test scenarios to provide relevant parameters at the call sites.