### PR TITLE
Handle validator-change upgrades

### DIFF
--- a/hashing/src/indexed_merkle_proof.rs
+++ b/hashing/src/indexed_merkle_proof.rs
@@ -12,6 +12,7 @@ use crate::{
     Digest,
 };
 
+/// A Merkle proof of the given chunk.
 #[derive(DataSize, PartialEq, Eq, Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexedMerkleProof {
@@ -116,7 +117,7 @@ impl IndexedMerkleProof {
         self.count
     }
 
-    /// Returns the root hash of this proof (ie., the index hashed with the Merkle root hash).
+    /// Returns the root hash of this proof (i.e. the index hashed with the Merkle root hash).
     pub fn root_hash(&self) -> Digest {
         let IndexedMerkleProof {
             index: _,
@@ -162,6 +163,7 @@ impl IndexedMerkleProof {
         Digest::hash_merkle_root(*count, raw_root)
     }
 
+    /// Returns the full collection of hash digests of the proof.
     pub fn merkle_proof(&self) -> &[Digest] {
         &self.merkle_proof
     }

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -38,6 +38,7 @@ pub use chunk_with_proof::ChunkWithProof;
 pub use error::{
     ChunkWithProofVerificationError, Error, MerkleConstructionError, MerkleVerificationError,
 };
+pub use indexed_merkle_proof::IndexedMerkleProof;
 
 /// The output of the hash function.
 #[derive(Copy, Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Default, JsonSchema)]

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -110,6 +110,25 @@ pub(crate) enum Error {
         GetEraValidatorsError,
     ),
 
+    /// Expected entry in validator map not found.
+    #[error("stored block has no validator map entry for {missing_era_id}: {block_header:?}")]
+    MissingValidatorMapEntry {
+        block_header: Box<BlockHeader>,
+        missing_era_id: EraId,
+    },
+
+    /// Trusted block is earlier than a validator change upgrade.
+    #[error(
+        "joining with trusted hash before an upgrade that changed the validators - find a more \
+         recent hash from after the upgrade. \
+         first block after the upgrade: {upgrade_block_header:?}, \
+         trusted block header: {trusted_block_header:?}"
+    )]
+    TryingToJoinBeforeLastValidatorChangeUpgrade {
+        upgrade_block_header: Box<BlockHeader>,
+        trusted_block_header: Box<BlockHeader>,
+    },
+
     #[error("stored block has unexpected parent hash. parent: {parent:?}, child: {child:?}")]
     UnexpectedParentHash {
         parent: Box<BlockHeader>,

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -13,8 +13,8 @@ use casper_types::{EraId, ProtocolVersion};
 
 use crate::{
     components::{
-        consensus::error::FinalitySignatureError, contract_runtime::BlockExecutionError,
-        fetcher::FetcherError, linear_chain,
+        contract_runtime::BlockExecutionError, fetcher::FetcherError, linear_chain,
+        linear_chain::BlockSignatureError,
     },
     types::{
         Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
@@ -90,7 +90,7 @@ pub(crate) enum Error {
     FinalitySignatures(
         #[from]
         #[serde(skip_serializing)]
-        FinalitySignatureError,
+        BlockSignatureError,
     ),
 
     #[error(transparent)]

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1354,7 +1354,8 @@ where
         + From<ContractRuntimeRequest>
         + From<BlocklistAnnouncement>
         + From<MarkBlockCompletedRequest>
-        + From<ChainSynchronizerAnnouncement>,
+        + From<ChainSynchronizerAnnouncement>
+        + Send,
 {
     info!("starting chain sync to genesis");
     let _metric = ScopeTimer::new(&metrics.chain_sync_to_genesis_total_duration_seconds);
@@ -1480,7 +1481,8 @@ where
         + From<NetworkInfoRequest>
         + From<ContractRuntimeRequest>
         + From<BlocklistAnnouncement>
-        + From<MarkBlockCompletedRequest>,
+        + From<MarkBlockCompletedRequest>
+        + Send,
 {
     let _metric = ScopeTimer::new(&ctx.metrics.chain_sync_fetch_forward_duration_seconds);
     info!("syncing blocks and deploys and state since Genesis");
@@ -1522,7 +1524,8 @@ where
         + From<NetworkInfoRequest>
         + From<ContractRuntimeRequest>
         + From<BlocklistAnnouncement>
-        + From<MarkBlockCompletedRequest>,
+        + From<MarkBlockCompletedRequest>
+        + Send,
 {
     let trusted_block_height = ctx.trusted_block_header().height();
     loop {
@@ -1662,7 +1665,10 @@ impl BlockSignaturesCollector {
         ctx: &ChainSyncContext<'_, REv>,
     ) -> Result<HandleSignaturesResult, Error>
     where
-        REv: From<StorageRequest> + From<BlocklistAnnouncement> + From<ContractRuntimeRequest>,
+        REv: From<StorageRequest>
+            + From<BlocklistAnnouncement>
+            + From<ContractRuntimeRequest>
+            + Send,
     {
         if signatures.proofs.is_empty() {
             return Ok(HandleSignaturesResult::ContinueFetching);
@@ -1741,7 +1747,8 @@ where
         + From<NetworkInfoRequest>
         + From<FetcherRequest<BlockSignatures>>
         + From<BlocklistAnnouncement>
-        + From<ContractRuntimeRequest>,
+        + From<ContractRuntimeRequest>
+        + Send,
 {
     let start = Timestamp::now();
     let peer_list = get_filtered_fully_connected_peers(ctx).await;

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -689,7 +689,7 @@ impl BlockOrHeaderWithMetadata for BlockWithMetadata {
     }
 
     fn block_signatures(&self) -> &BlockSignatures {
-        &self.finality_signatures
+        &self.block_signatures
     }
 
     async fn store_block_or_header<REv>(&self, effect_builder: EffectBuilder<REv>)

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -14,7 +14,6 @@ mod protocols;
 #[cfg(test)]
 mod tests;
 mod traits;
-mod utils;
 mod validator_change;
 
 use std::{
@@ -56,11 +55,6 @@ pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor};
 pub(crate) use protocols::highway::HighwayProtocol;
-
-pub(crate) use utils::{
-    check_sufficient_finality_signatures, check_sufficient_finality_signatures_with_quorum_formula,
-    validate_finality_signatures,
-};
 pub(crate) use validator_change::ValidatorChange;
 
 #[derive(DataSize, Clone, Serialize, Deserialize)]

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -59,7 +59,7 @@ pub(crate) use protocols::highway::HighwayProtocol;
 
 pub(crate) use utils::{
     check_sufficient_finality_signatures, check_sufficient_finality_signatures_with_quorum_formula,
-    get_minimal_set_of_signatures, validate_finality_signatures,
+    validate_finality_signatures,
 };
 pub(crate) use validator_change::ValidatorChange;
 

--- a/node/src/components/consensus/error.rs
+++ b/node/src/components/consensus/error.rs
@@ -1,60 +1,8 @@
-use std::collections::BTreeMap;
-
-use num::rational::Ratio;
 use thiserror::Error;
 
-use casper_types::{EraId, PublicKey, U512};
+use casper_types::EraId;
 
-use crate::types::{BlockHeader, BlockSignatures};
-
-#[derive(Error, Debug)]
-pub enum FinalitySignatureError {
-    #[error(
-        "Block signatures contain bogus validator. \
-         trusted validator weights: {trusted_validator_weights:?}, \
-         block signatures: {block_signatures:?}, \
-         bogus validator public key: {bogus_validator_public_key:?}"
-    )]
-    BogusValidator {
-        trusted_validator_weights: BTreeMap<PublicKey, U512>,
-        block_signatures: Box<BlockSignatures>,
-        bogus_validator_public_key: Box<PublicKey>,
-    },
-
-    #[error(
-        "Insufficient weight for finality. \
-         trusted validator weights: {trusted_validator_weights:?}, \
-         block signatures: {block_signatures:?}, \
-         signature weight: {signature_weight:?}, \
-         total validator weight: {total_validator_weight}, \
-         finality threshold fraction: {finality_threshold_fraction}"
-    )]
-    InsufficientWeightForFinality {
-        trusted_validator_weights: BTreeMap<PublicKey, U512>,
-        block_signatures: Option<Box<BlockSignatures>>,
-        signature_weight: Option<Box<U512>>,
-        total_validator_weight: Box<U512>,
-        finality_threshold_fraction: Ratio<u64>,
-    },
-
-    #[error(
-        "Anti-spam: signature set not minimal. \
-         trusted validator weights: {trusted_validator_weights:?}, \
-         block signatures: {block_signatures:?}, \
-         signature weight: {signature_weight}, \
-         weight minus minimum: {weight_minus_minimum}, \
-         total validator weight: {total_validator_weight}, \
-         finality threshold fraction: {finality_threshold_fraction}"
-    )]
-    TooManySignatures {
-        trusted_validator_weights: BTreeMap<PublicKey, U512>,
-        block_signatures: Box<BlockSignatures>,
-        signature_weight: Box<U512>,
-        weight_minus_minimum: Box<U512>,
-        total_validator_weight: Box<U512>,
-        finality_threshold_fraction: Ratio<u64>,
-    },
-}
+use crate::types::BlockHeader;
 
 #[derive(Error, Debug)]
 pub enum CreateNewEraError {

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -139,6 +139,8 @@ pub(crate) fn check_sufficient_finality_signatures(
     )
 }
 
+// TODO - remove the `allow` below.
+#[allow(unused)]
 pub(crate) fn get_minimal_set_of_signatures(
     trusted_validator_weights: &BTreeMap<PublicKey, U512>,
     finality_threshold_fraction: Ratio<u64>,

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -180,7 +180,7 @@ pub(crate) fn get_minimal_set_of_signatures(
         .map(|(pub_key, _)| pub_key)
         .collect();
 
-    // Chack if we managed to collect sufficient weight (there might not have been enough
+    // Check if we managed to collect sufficient weight (there might not have been enough
     // signatures in the first place).
     if accumulated_weight * U512::from(*lower_bound.denom())
         > total_weight * U512::from(*lower_bound.numer())

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -143,7 +143,7 @@ pub(crate) fn check_sufficient_finality_signatures(
 #[allow(unused)]
 pub(crate) fn get_minimal_set_of_signatures(
     trusted_validator_weights: &BTreeMap<PublicKey, U512>,
-    finality_threshold_fraction: Ratio<u64>,
+    fault_tolerance_fraction: Ratio<u64>,
     mut block_signatures: BlockSignatures,
 ) -> Option<BlockSignatures> {
     // Calculate the values for comparison.
@@ -152,7 +152,7 @@ pub(crate) fn get_minimal_set_of_signatures(
         .map(|(_, weight)| *weight)
         .sum();
 
-    let lower_bound = quorum_fraction(finality_threshold_fraction);
+    let lower_bound = quorum_fraction(fault_tolerance_fraction);
 
     let mut sig_weights: Vec<_> = block_signatures
         .proofs

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -8,7 +8,6 @@ use std::{
 
 use derive_more::From;
 use futures::channel::oneshot;
-use num_rational::Ratio;
 use prometheus::Registry;
 use reactor::ReactorEvent;
 use serde::Serialize;
@@ -419,7 +418,6 @@ impl reactor::Reactor for Reactor {
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             "test",
-            Ratio::new(1, 3),
         )
         .unwrap();
 

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -509,19 +509,12 @@ impl ItemFetcher<BlockHeaderWithMetadata> for Fetcher<BlockHeaderWithMetadata> {
         responder: FetchResponder<BlockHeaderWithMetadata>,
     ) -> Effects<Event<BlockHeaderWithMetadata>> {
         async move {
-            // TODO: Only header needed.
-            let BlockWithMetadata {
-                block,
-                finality_signatures,
-            } = effect_builder
-                .get_block_with_metadata_from_storage_by_height(id, false)
+            let block_header_with_metadata = effect_builder
+                .get_block_header_with_metadata_from_storage_by_height(id, false)
                 .await?;
             // TODO: Check if sufficient, otherwise return None. Take validator change updates into
             // account! (See chain_synchronizer::operations::era_validator_weights_for_block.)
-            Some(BlockHeaderWithMetadata {
-                block_header: block.take_header(),
-                block_signatures: finality_signatures,
-            })
+            Some(block_header_with_metadata)
         }
         .event(move |result| Event::GetFromStorageResult {
             id,
@@ -557,16 +550,14 @@ impl ItemFetcher<BlockSignatures> for Fetcher<BlockSignatures> {
         responder: FetchResponder<BlockSignatures>,
     ) -> Effects<Event<BlockSignatures>> {
         async move {
-            // TODO: Only header needed.
-            let BlockWithMetadata {
-                finality_signatures,
-                ..
+            let BlockHeaderWithMetadata {
+                block_signatures, ..
             } = effect_builder
-                .get_block_with_metadata_from_storage(id, false)
+                .get_block_header_with_metadata_from_storage(id, false)
                 .await?;
             // TODO: Check if sufficient, otherwise return None. Take validator change updates into
             // account! (See chain_synchronizer::operations::era_validator_weights_for_block.)
-            Some(finality_signatures)
+            Some(block_signatures)
         }
         .event(move |result| Event::GetFromStorageResult {
             id,

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -559,8 +559,8 @@ impl ItemFetcher<BlockSignatures> for Fetcher<BlockSignatures> {
         async move {
             // TODO: Only header needed.
             let BlockWithMetadata {
-                block,
                 finality_signatures,
+                ..
             } = effect_builder
                 .get_block_with_metadata_from_storage(id, false)
                 .await?;

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -818,7 +818,7 @@ async fn has_enough_block_signatures<REv>(
     finality_threshold_fraction: Ratio<u64>,
 ) -> bool
 where
-    REv: From<StorageRequest> + From<ContractRuntimeRequest> + From<BlocklistAnnouncement>,
+    REv: From<StorageRequest> + From<ContractRuntimeRequest> + From<BlocklistAnnouncement> + Send,
 {
     let validator_weights =
         match linear_chain::era_validator_weights_for_block(block_header, effect_builder).await {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -15,9 +15,9 @@ use casper_execution_engine::storage::trie::{TrieOrChunk, TrieOrChunkId};
 
 use crate::{
     components::{
-        consensus::{self, error::FinalitySignatureError},
         fetcher::event::FetchResponder,
-        linear_chain, Component,
+        linear_chain::{self, BlockSignatureError},
+        Component,
     },
     effect::{
         requests::{ContractRuntimeRequest, FetcherRequest, NetworkRequest, StorageRequest},
@@ -834,21 +834,21 @@ where
             }
         };
 
-    match consensus::check_sufficient_finality_signatures(
+    match linear_chain::check_sufficient_block_signatures(
         &validator_weights,
         fault_tolerance_fraction,
         Some(block_signatures),
     ) {
-        Err(error @ FinalitySignatureError::InsufficientWeightForFinality { .. }) => {
+        Err(error @ BlockSignatureError::InsufficientWeightForFinality { .. }) => {
             info!(?error, "insufficient block signatures from storage");
             false
         }
-        Err(error @ FinalitySignatureError::BogusValidator { .. }) => {
+        Err(error @ BlockSignatureError::BogusValidator { .. }) => {
             error!(?error, "bogus validator block signature from storage");
             false
         }
         // TODO - make this an error condition once we start using `get_minimal_set_of_signatures`.
-        Err(FinalitySignatureError::TooManySignatures { .. }) => {
+        Err(BlockSignatureError::TooManySignatures { .. }) => {
             debug!("too many block signatures from storage");
             true
         }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -84,6 +84,7 @@ reactor!(Reactor {
         deploy_fetcher = Fetcher::<Deploy>(
             "deploy",
             cfg.fetcher_config,
+            chainspec_loader.chainspec().highway_config.finality_threshold_fraction,
             registry);
     }
 

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -79,10 +79,6 @@ reactor!(Reactor {
             chainspec_loader.hard_reset_to_start_of_era(),
             chainspec_loader.chainspec().protocol_config.version,
             &chainspec_loader.chainspec().network_config.name,
-            chainspec_loader
-                .chainspec()
-                .highway_config
-                .finality_threshold_fraction,
         );
         fake_deploy_acceptor = infallible FakeDeployAcceptor();
         deploy_fetcher = Fetcher::<Deploy>(

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use derive_more::From;
-use num_rational::Ratio;
 use prometheus::Registry;
 use rand::Rng;
 use reactor::ReactorEvent;
@@ -234,7 +233,6 @@ impl reactor::Reactor for Reactor {
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             "test",
-            Ratio::new(1, 3),
         )
         .unwrap();
 

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -529,13 +529,11 @@ mod tests {
             );
 
             let state_root_hash = Digest::hash(&[era.value() as u8]);
-            // If this is a switch block, update the validator weights to have entries for this era
-            // and the next two eras.  Otherwise, just copy the validator weights for the previous
-            // block.
+            // If this is a switch block, update the validator weights to have entries for the next
+            // two eras.  Otherwise, just copy the validator weights for the previous block.
             let validators_in_global_state = match next_two_eras_validator_weights.as_ref() {
                 Some((weights_1, weights_2)) => {
                     let mut validators = EraValidators::new();
-                    validators.insert(era, validators_for_this_block.clone());
                     validators.insert(era + 1, weights_1.clone());
                     validators.insert(era + 2, weights_2.clone());
                     validators

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -5,6 +5,7 @@ mod pending_signatures;
 mod signature;
 mod signature_cache;
 mod state;
+mod utils;
 
 use std::convert::Infallible;
 
@@ -38,8 +39,12 @@ use crate::{
     types::{ActivationPoint, BlockHeader},
     NodeRng,
 };
-pub(crate) use error::Error;
+pub(crate) use error::{BlockSignatureError, Error};
 pub(crate) use event::Event;
+pub(crate) use utils::{
+    check_sufficient_block_signatures, check_sufficient_block_signatures_with_quorum_formula,
+    validate_block_signatures,
+};
 
 #[derive(DataSize, Debug)]
 pub(crate) struct LinearChainComponent {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -6,15 +6,20 @@ mod signature;
 mod signature_cache;
 mod state;
 
-use std::{collections::BTreeMap, convert::Infallible};
+use std::convert::Infallible;
 
+use async_trait::async_trait;
 use datasize::DataSize;
 use itertools::Itertools;
 use num::rational::Ratio;
 use prometheus::Registry;
 use tracing::{error, info};
 
-use casper_types::{EraId, ProtocolVersion, PublicKey, U512};
+use casper_execution_engine::core::engine_state::GetEraValidatorsError;
+use casper_types::{
+    system::auction::{EraValidators, ValidatorWeights},
+    EraId, ProtocolVersion,
+};
 
 use self::{
     metrics::Metrics,
@@ -206,17 +211,49 @@ where
     }
 }
 
-/// Returns the validator weights that should be used to check the finality signatures for the given
-/// block.
-pub(crate) async fn era_validator_weights_for_block<REv>(
-    block_header: &BlockHeader,
-    effect_builder: EffectBuilder<REv>,
-) -> Result<(EraId, BTreeMap<PublicKey, U512>), Error>
+/// A trait to allow an `EffectBuilder` to be replaced in testing by a mock.
+#[async_trait]
+pub(crate) trait EraValidatorsGetter: Copy {
+    async fn get_switch_block_header_at_era_id_from_storage(
+        self,
+        era_id: EraId,
+    ) -> Option<BlockHeader>;
+
+    async fn get_era_validators_from_contract_runtime(
+        self,
+        request: EraValidatorsRequest,
+    ) -> Result<EraValidators, GetEraValidatorsError>;
+}
+
+#[async_trait]
+impl<REv> EraValidatorsGetter for EffectBuilder<REv>
 where
-    REv: From<StorageRequest> + From<ContractRuntimeRequest>,
+    REv: From<StorageRequest> + From<ContractRuntimeRequest> + Send,
 {
+    async fn get_switch_block_header_at_era_id_from_storage(
+        self,
+        era_id: EraId,
+    ) -> Option<BlockHeader> {
+        self.get_switch_block_header_at_era_id_from_storage(era_id)
+            .await
+    }
+
+    async fn get_era_validators_from_contract_runtime(
+        self,
+        request: EraValidatorsRequest,
+    ) -> Result<EraValidators, GetEraValidatorsError> {
+        self.get_era_validators_from_contract_runtime(request).await
+    }
+}
+
+/// Returns the validator weights that should be used to check the block signatures for the given
+/// block, taking into account validator-change upgrades.
+pub(crate) async fn era_validator_weights_for_block<T: EraValidatorsGetter>(
+    block_header: &BlockHeader,
+    era_validators_getter: T,
+) -> Result<(EraId, ValidatorWeights), Error> {
     let era_for_validators_retrieval = block_header.era_id().saturating_sub(1);
-    let switch_block_of_previous_era = effect_builder
+    let switch_block_of_previous_era = era_validators_getter
         .get_switch_block_header_at_era_id_from_storage(era_for_validators_retrieval)
         .await
         .ok_or(Error::NoSwitchBlockForEra {
@@ -228,7 +265,7 @@ where
                 *switch_block_of_previous_era.state_root_hash(),
                 switch_block_of_previous_era.protocol_version(),
             );
-            let validator_map = effect_builder
+            let validator_map = era_validators_getter
                 .get_era_validators_from_contract_runtime(request)
                 .await
                 .map_err(Error::GetEraValidators)?;
@@ -266,4 +303,352 @@ where
             era_id: era_for_validators_retrieval,
         })?;
     Ok((era_for_validators_retrieval, validator_weights.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use futures::FutureExt;
+
+    use casper_hashing::Digest;
+    use casper_types::{testing::TestRng, PublicKey, SemVer, Timestamp, U512};
+
+    use super::*;
+    use crate::{
+        components::consensus::EraReport,
+        types::{Block, BlockHash, BlockPayload, FinalizedBlock},
+    };
+
+    const ERA_0: EraId = EraId::new(0);
+    const ERA_1: EraId = EraId::new(1);
+    const ERA_2: EraId = EraId::new(2);
+    const ERA_3: EraId = EraId::new(3);
+    const ERA_4: EraId = EraId::new(4);
+    const ERA_5: EraId = EraId::new(5);
+    const ERA_6: EraId = EraId::new(6);
+    const VERSION_1: ProtocolVersion = ProtocolVersion::V1_0_0;
+    const VERSION_2: ProtocolVersion = ProtocolVersion::new(SemVer::new(2, 0, 0));
+    const VERSION_3: ProtocolVersion = ProtocolVersion::new(SemVer::new(3, 0, 0));
+
+    fn random_validators(rng: &mut TestRng, base_weight: u64) -> ValidatorWeights {
+        (0..10)
+            .map(|index| (PublicKey::random(rng), U512::from(base_weight + index)))
+            .collect()
+    }
+
+    #[derive(Default)]
+    struct Fixture {
+        // The validators and weights applicable for the given block height.
+        expected_validators_for_block_height: BTreeMap<u64, ValidatorWeights>,
+        // The blocks, keyed by block height.
+        blocks: BTreeMap<u64, Block>,
+        // The switch blocks, keyed by era ID.
+        switch_blocks: BTreeMap<EraId, Block>,
+        // The validators and weights as recorded at each global state root hash.
+        validators_in_global_state: BTreeMap<Digest, EraValidators>,
+    }
+
+    impl Fixture {
+        /// This constructs a fixture where we have a block chain as follows:
+        ///
+        /// Block  |     | Protocol | Next Era
+        /// Height | Era | Version  | Validators
+        /// ===========================================
+        ///    2   |  0  |  1.0.0   | Era 1 weights (switch block)
+        ///    3   |  1  |  1.0.0   | None
+        ///    4   |  1  |  1.0.0   | Era 2 weights (switch block)
+        ///    5   |  2  |  1.0.0   | None
+        ///    6   |  2  |  1.0.0   | Era 3 weights (switch block)
+        ///    7   |  3  |  2.0.0   | Era 4 weights (immediate switch block after upgrade)
+        ///    8   |  4  |  2.0.0   | None
+        ///    9   |  4  |  2.0.0   | Bad era 5 weights (switch block)
+        ///   10   |  5  |  3.0.0   | Era 6 weights (immediate switch block after validator-change
+        ///                                          upgrade where bad weights were replaced)
+        ///   11   |  6  |  3.0.0   | None
+        fn new() -> Self {
+            let mut rng = TestRng::new();
+            let era_1_validators = random_validators(&mut rng, 100);
+            let era_2_validators = random_validators(&mut rng, 200);
+            let era_3_validators = random_validators(&mut rng, 300);
+            let era_4_validators = random_validators(&mut rng, 400);
+            let original_era_5_validators = random_validators(&mut rng, 500);
+            let replacement_era_5_validators = random_validators(&mut rng, 550);
+            // The global_state_update_gen tool ensures we don't allow rotating validators while
+            // running commit_step during the creation of the immediate switch block after a
+            // validator-change upgrade.
+            let era_6_validators = replacement_era_5_validators.clone();
+            let era_7_validators = random_validators(&mut rng, 700);
+
+            let mut fixture = Fixture::default();
+
+            // Block 2: switch block at end of era 0.
+            let parent_hash = BlockHash::new(Digest::hash(b"parent state root hash"));
+            let parent_seed = Digest::hash(b"parent accumulated seed");
+            let state_root_hash = Digest::hash(&[2]);
+            let finalized_block = FinalizedBlock::new(
+                BlockPayload::default(),
+                Some(EraReport::default()),
+                Timestamp::now(),
+                ERA_0,
+                2,
+                era_1_validators.keys().next().unwrap().clone(),
+            );
+            let block_2 = Block::new(
+                parent_hash,
+                parent_seed,
+                state_root_hash,
+                finalized_block,
+                Some(era_1_validators.clone()),
+                VERSION_1,
+            )
+            .unwrap();
+            fixture
+                .expected_validators_for_block_height
+                .insert(block_2.height(), era_1_validators.clone());
+            fixture.blocks.insert(block_2.height(), block_2.clone());
+            fixture
+                .switch_blocks
+                .insert(block_2.header().era_id(), block_2.clone());
+            let validators_in_global_state: EraValidators = [
+                (ERA_0, &era_1_validators),
+                (ERA_1, &era_1_validators),
+                (ERA_2, &era_2_validators),
+            ]
+            .iter()
+            .map(|(era, validators)| (*era, (*validators).clone()))
+            .collect();
+            fixture
+                .validators_in_global_state
+                .insert(*block_2.state_root_hash(), validators_in_global_state);
+
+            // Block 3: non-switch block in era 1.
+            fixture.create_next_block(
+                ERA_1,
+                None,
+                era_1_validators.keys().next().unwrap().clone(),
+                VERSION_1,
+                era_1_validators.clone(),
+            );
+
+            // Block 4: switch block in era 1.
+            fixture.create_next_block(
+                ERA_1,
+                Some((era_2_validators.clone(), era_3_validators.clone())),
+                era_1_validators.keys().next().unwrap().clone(),
+                VERSION_1,
+                era_1_validators,
+            );
+
+            // Block 5: non-switch block in era 2.
+            fixture.create_next_block(
+                ERA_2,
+                None,
+                era_2_validators.keys().next().unwrap().clone(),
+                VERSION_1,
+                era_2_validators.clone(),
+            );
+
+            // Block 6: switch block in era 2.
+            fixture.create_next_block(
+                ERA_2,
+                Some((era_3_validators.clone(), era_4_validators.clone())),
+                era_2_validators.keys().next().unwrap().clone(),
+                VERSION_1,
+                era_2_validators,
+            );
+
+            // Block 7: immediate switch block in era 3 after upgrade to version 2.0.0.
+            fixture.create_next_block(
+                ERA_3,
+                Some((era_4_validators.clone(), original_era_5_validators.clone())),
+                PublicKey::System,
+                VERSION_2,
+                era_3_validators,
+            );
+
+            // Block 8: non-switch block in era 4.
+            fixture.create_next_block(
+                ERA_4,
+                None,
+                era_4_validators.keys().next().unwrap().clone(),
+                VERSION_2,
+                era_4_validators.clone(),
+            );
+
+            // Block 9: switch block in era 4.
+            fixture.create_next_block(
+                ERA_4,
+                Some((original_era_5_validators.clone(), original_era_5_validators)),
+                era_4_validators.keys().next().unwrap().clone(),
+                VERSION_2,
+                era_4_validators,
+            );
+
+            // Block 10: immediate switch block in era 5 after validator-change upgrade to version
+            // 3.0.0.
+            fixture.create_next_block(
+                ERA_5,
+                Some((era_6_validators.clone(), era_7_validators)),
+                PublicKey::System,
+                VERSION_3,
+                replacement_era_5_validators,
+            );
+
+            // Block 11: non-switch block in era 6.
+            fixture.create_next_block(
+                ERA_6,
+                None,
+                era_6_validators.keys().next().unwrap().clone(),
+                VERSION_3,
+                era_6_validators,
+            );
+
+            fixture
+        }
+
+        fn create_next_block(
+            &mut self,
+            era: EraId,
+            next_two_eras_validator_weights: Option<(ValidatorWeights, ValidatorWeights)>,
+            proposer: PublicKey,
+            protocol_version: ProtocolVersion,
+            validators_for_this_block: ValidatorWeights,
+        ) {
+            let last_block = self.blocks.values().last().unwrap();
+            let era_report = next_two_eras_validator_weights
+                .as_ref()
+                .map(|_| EraReport::default());
+            let finalized_block = FinalizedBlock::new(
+                BlockPayload::default(),
+                era_report,
+                Timestamp::now(),
+                era,
+                last_block.height() + 1,
+                proposer,
+            );
+
+            let state_root_hash = Digest::hash(&[era.value() as u8]);
+            // If this is a switch block, update the validator weights to have entries for this era
+            // and the next two eras.  Otherwise, just copy the validator weights for the previous
+            // block.
+            let validators_in_global_state = match next_two_eras_validator_weights.as_ref() {
+                Some((weights_1, weights_2)) => {
+                    let mut validators = EraValidators::new();
+                    validators.insert(era, validators_for_this_block.clone());
+                    validators.insert(era + 1, weights_1.clone());
+                    validators.insert(era + 2, weights_2.clone());
+                    validators
+                }
+                None => self
+                    .validators_in_global_state
+                    .get(last_block.state_root_hash())
+                    .unwrap()
+                    .clone(),
+            };
+            self.validators_in_global_state
+                .insert(state_root_hash, validators_in_global_state);
+
+            let block = Block::new(
+                *last_block.hash(),
+                last_block.header().accumulated_seed(),
+                state_root_hash,
+                finalized_block,
+                next_two_eras_validator_weights.map(|(weights_1, _)| weights_1),
+                protocol_version,
+            )
+            .unwrap();
+
+            assert!(self
+                .expected_validators_for_block_height
+                .insert(block.height(), validators_for_this_block)
+                .is_none());
+            assert!(self.blocks.insert(block.height(), block.clone()).is_none());
+            if block.header().is_switch_block() {
+                assert!(self
+                    .switch_blocks
+                    .insert(block.header().era_id(), block)
+                    .is_none());
+            }
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    struct TestEffectBuilder<'a> {
+        fixture: &'a Fixture,
+    }
+
+    #[async_trait]
+    impl<'a> EraValidatorsGetter for TestEffectBuilder<'a> {
+        async fn get_switch_block_header_at_era_id_from_storage(
+            self,
+            era_id: EraId,
+        ) -> Option<BlockHeader> {
+            self.fixture
+                .switch_blocks
+                .get(&era_id)
+                .map(|block| block.header().clone())
+        }
+
+        async fn get_era_validators_from_contract_runtime(
+            self,
+            request: EraValidatorsRequest,
+        ) -> Result<EraValidators, GetEraValidatorsError> {
+            self.fixture
+                .validators_in_global_state
+                .get(&request.state_hash())
+                .cloned()
+                .ok_or(GetEraValidatorsError::RootNotFound)
+        }
+    }
+
+    fn check_validators(fixture: &Fixture, block_height: u64, expected_era: EraId) {
+        let effect_builder = TestEffectBuilder { fixture };
+
+        let block_header = fixture
+            .blocks
+            .get(&block_height)
+            .unwrap_or_else(|| panic!("should have block {}", block_height))
+            .header();
+
+        let (era, validator_weights) =
+            era_validator_weights_for_block(block_header, effect_builder)
+                .now_or_never()
+                .expect("future should be ready")
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "era_validator_weights_for_block should succeed for block {}: {}",
+                        block_height, error
+                    )
+                });
+
+        assert_eq!(era, expected_era, "mismatch for block {}", block_height);
+        assert_eq!(
+            validator_weights,
+            *fixture
+                .expected_validators_for_block_height
+                .get(&block_height)
+                .unwrap_or_else(|| panic!(
+                    "should have expected validators for block {}",
+                    block_height
+                )),
+            "mismatch for block {}",
+            block_height
+        );
+    }
+
+    #[test]
+    fn should_get_validators() {
+        let fixture = Fixture::new();
+        check_validators(&fixture, 2, ERA_0);
+        check_validators(&fixture, 3, ERA_0);
+        check_validators(&fixture, 4, ERA_0);
+        check_validators(&fixture, 5, ERA_1);
+        check_validators(&fixture, 6, ERA_1);
+        check_validators(&fixture, 7, ERA_2);
+        check_validators(&fixture, 8, ERA_3);
+        check_validators(&fixture, 9, ERA_3);
+        check_validators(&fixture, 10, ERA_5);
+        check_validators(&fixture, 11, ERA_5);
+    }
 }

--- a/node/src/components/linear_chain/error.rs
+++ b/node/src/components/linear_chain/error.rs
@@ -1,0 +1,33 @@
+use std::fmt::Debug;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use casper_execution_engine::core::engine_state::GetEraValidatorsError;
+use casper_types::EraId;
+
+use crate::types::BlockHeader;
+
+#[derive(Error, Debug, Serialize)]
+pub(crate) enum Error {
+    #[error("cannot get switch block for era {era_id}")]
+    NoSwitchBlockForEra { era_id: EraId },
+
+    #[error("switch block at height {height} for era {era_id} contains no validator weights")]
+    MissingNextEraValidators { height: u64, era_id: EraId },
+
+    /// Error getting era validators from the execution engine.
+    #[error(transparent)]
+    GetEraValidators(
+        #[from]
+        #[serde(skip_serializing)]
+        GetEraValidatorsError,
+    ),
+
+    /// Expected entry in validator map not found.
+    #[error("stored block has no validator map entry for era {missing_era_id}: {block_header:?}")]
+    MissingValidatorMapEntry {
+        block_header: Box<BlockHeader>,
+        missing_era_id: EraId,
+    },
+}

--- a/node/src/components/linear_chain/error.rs
+++ b/node/src/components/linear_chain/error.rs
@@ -1,12 +1,13 @@
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 
+use num::rational::Ratio;
 use serde::Serialize;
 use thiserror::Error;
 
 use casper_execution_engine::core::engine_state::GetEraValidatorsError;
-use casper_types::EraId;
+use casper_types::{EraId, PublicKey, U512};
 
-use crate::types::BlockHeader;
+use crate::types::{BlockHeader, BlockSignatures};
 
 #[derive(Error, Debug, Serialize)]
 pub(crate) enum Error {
@@ -29,5 +30,54 @@ pub(crate) enum Error {
     MissingValidatorMapEntry {
         block_header: Box<BlockHeader>,
         missing_era_id: EraId,
+    },
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum BlockSignatureError {
+    #[error(
+        "Block signatures contain bogus validator. \
+         trusted validator weights: {trusted_validator_weights:?}, \
+         block signatures: {block_signatures:?}, \
+         bogus validator public key: {bogus_validator_public_key:?}"
+    )]
+    BogusValidator {
+        trusted_validator_weights: BTreeMap<PublicKey, U512>,
+        block_signatures: Box<BlockSignatures>,
+        bogus_validator_public_key: Box<PublicKey>,
+    },
+
+    #[error(
+        "Insufficient weight for finality. \
+         trusted validator weights: {trusted_validator_weights:?}, \
+         block signatures: {block_signatures:?}, \
+         signature weight: {signature_weight:?}, \
+         total validator weight: {total_validator_weight}, \
+         fault tolerance fraction: {fault_tolerance_fraction}"
+    )]
+    InsufficientWeightForFinality {
+        trusted_validator_weights: BTreeMap<PublicKey, U512>,
+        block_signatures: Option<Box<BlockSignatures>>,
+        signature_weight: Option<Box<U512>>,
+        total_validator_weight: Box<U512>,
+        fault_tolerance_fraction: Ratio<u64>,
+    },
+
+    #[error(
+        "Anti-spam: signature set not minimal. \
+         trusted validator weights: {trusted_validator_weights:?}, \
+         block signatures: {block_signatures:?}, \
+         signature weight: {signature_weight}, \
+         weight minus minimum: {weight_minus_minimum}, \
+         total validator weight: {total_validator_weight}, \
+         fault tolerance fraction: {fault_tolerance_fraction}"
+    )]
+    TooManySignatures {
+        trusted_validator_weights: BTreeMap<PublicKey, U512>,
+        block_signatures: Box<BlockSignatures>,
+        signature_weight: Box<U512>,
+        weight_minus_minimum: Box<U512>,
+        total_validator_weight: Box<U512>,
+        fault_tolerance_fraction: Ratio<u64>,
     },
 }

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::{
     components::{
         chain_synchronizer::KeyBlockInfo,
-        consensus::{self, error::FinalitySignatureError},
+        linear_chain::{self, BlockSignatureError},
     },
     types::{ActivationPoint, Block, BlockHash, BlockSignatures, DeployHash, FinalitySignature},
 };
@@ -300,12 +300,12 @@ impl LinearChain {
             Some(era_kb_info) => era_kb_info,
         };
         matches!(
-            consensus::check_sufficient_finality_signatures(
+            linear_chain::check_sufficient_block_signatures(
                 era_kb_info.validator_weights(),
                 self.finality_threshold_fraction,
                 Some(signatures),
             ),
-            Ok(()) | Err(FinalitySignatureError::TooManySignatures { .. })
+            Ok(()) | Err(BlockSignatureError::TooManySignatures { .. })
         )
     }
 

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -159,14 +159,14 @@ impl RpcWithOptionalParams for GetBlock {
         let maybe_block_id = maybe_params.map(|params| params.block_identifier);
         let BlockWithMetadata {
             block,
-            finality_signatures,
+            block_signatures,
         } = get_block_with_metadata(
             maybe_block_id,
             only_from_available_block_range,
             effect_builder,
         )
         .await?;
-        let json_block = JsonBlock::new(block, Some(finality_signatures));
+        let json_block = JsonBlock::new(block, Some(block_signatures));
 
         // Return the result.
         let result = Self::ResponseResult {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1288,7 +1288,7 @@ impl Storage {
             if let Some(block_signatures) = self.get_block_signatures(&mut txn, block.hash())? {
                 block_signatures
             } else {
-                info!(height, "no block signatures stored for block");
+                debug!(height, "no block signatures stored for block");
                 return Ok(None);
             };
         Ok(Some(BlockWithMetadata {
@@ -1320,7 +1320,7 @@ impl Storage {
         {
             block_signatures
         } else {
-            info!(height, "no block signatures stored for block header");
+            debug!(height, "no block signatures stored for block header");
             return Ok(None);
         };
         Ok(Some(BlockHeaderWithMetadata {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1231,8 +1231,7 @@ impl Storage {
     }
 
     /// Retrieves a block header by height.
-    /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
+    /// Returns `None` if they are less than the fault tolerance threshold.
     pub(crate) fn read_block_header_and_sufficient_finality_signatures_by_height(
         &self,
         height: u64,
@@ -1244,8 +1243,7 @@ impl Storage {
     }
 
     /// Retrieves a block by height.
-    /// Returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
+    /// Returns `None` if they are less than the fault tolerance threshold.
     fn read_block_and_sufficient_finality_signatures_by_height(
         &self,
         height: u64,
@@ -1632,8 +1630,7 @@ impl Storage {
     }
 
     /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
+    /// returns `None` if they are less than the fault tolerance threshold.
     fn get_block_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
         &self,
         txn: &mut Tx,
@@ -1711,8 +1708,7 @@ impl Storage {
     }
 
     /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold, or if the block is from
-    /// before the most recent emergency upgrade.
+    /// returns `None` if they are less than the fault tolerance threshold.
     fn get_block_header_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
         &self,
         txn: &mut Tx,
@@ -1737,8 +1733,7 @@ impl Storage {
     }
 
     /// Retrieves finality signatures for a block with a given header; returns `None` if they
-    /// are less than the fault tolerance threshold or if the block is from before the most recent
-    /// emergency upgrade.
+    /// are less than the fault tolerance threshold.
     fn get_sufficient_finality_signatures<Tx: Transaction>(
         &self,
         txn: &mut Tx,
@@ -1783,8 +1778,7 @@ impl Storage {
     }
 
     /// Retrieves finality signatures for a block with a given block hash; returns `None` if they
-    /// are less than the fault tolerance threshold or if the block is from before the most recent
-    /// emergency upgrade.
+    /// are less than the fault tolerance threshold.
     fn get_sufficient_finality_signatures_by_hash<Tx: Transaction>(
         &self,
         txn: &mut Tx,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -602,8 +602,14 @@ impl Storage {
                 let item_id = decode_item_id::<BlockWithMetadata>(serialized_id)?;
                 let opt_item = self
                     .read_block_and_metadata_by_height(item_id)
-                    .map_err(FatalStorageError::from)?;
-                // TODO: At least one signature?
+                    .map_err(FatalStorageError::from)?
+                    .and_then(|block_with_metadata| {
+                        if block_with_metadata.finality_signatures.proofs.is_empty() {
+                            None
+                        } else {
+                            Some(block_with_metadata)
+                        }
+                    });
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
@@ -631,8 +637,18 @@ impl Storage {
                 let item_id = decode_item_id::<BlockHeaderWithMetadata>(serialized_id)?;
                 let opt_item = self
                     .read_block_header_and_metadata_by_height(item_id)
-                    .map_err(FatalStorageError::from)?;
-                // TODO: At least one signature?
+                    .map_err(FatalStorageError::from)?
+                    .and_then(|block_header_with_metadata| {
+                        if block_header_with_metadata
+                            .block_signatures
+                            .proofs
+                            .is_empty()
+                        {
+                            None
+                        } else {
+                            Some(block_header_with_metadata)
+                        }
+                    });
 
                 Ok(self.update_pool_and_send(
                     effect_builder,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -55,7 +55,6 @@ use lmdb::{
     Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, RwTransaction, Transaction,
     WriteFlags,
 };
-use num_rational::Ratio;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use static_assertions::const_assert;
@@ -72,7 +71,7 @@ use casper_types::{
 // The reactor! macro needs this in the fetcher tests
 pub(crate) use crate::effect::requests::StorageRequest;
 use crate::{
-    components::{consensus, fetcher::FetchedOrNotFound, Component},
+    components::{fetcher::FetchedOrNotFound, Component},
     effect::{
         incoming::{NetRequest, NetRequestIncoming},
         requests::{MarkBlockCompletedRequest, NetworkRequest, StateStoreRequest},
@@ -185,9 +184,6 @@ pub struct Storage {
     ///
     /// Keyed by serialized item ID, contains the serialized item.
     serialized_item_pool: ObjectPool<Box<[u8]>>,
-    /// The fraction of validators, by weight, that have to sign a block to prove its finality.
-    #[data_size(skip)]
-    finality_threshold_fraction: Ratio<u64>,
 }
 
 /// A storage component event.
@@ -281,7 +277,6 @@ impl Storage {
         hard_reset_to_start_of_era: Option<EraId>,
         protocol_version: ProtocolVersion,
         network_name: &str,
-        finality_threshold_fraction: Ratio<u64>,
     ) -> Result<Self, FatalStorageError> {
         let config = cfg.value();
 
@@ -424,7 +419,6 @@ impl Storage {
             completed_blocks: Default::default(),
             enable_mem_deduplication: config.enable_mem_deduplication,
             serialized_item_pool: ObjectPool::new(config.mem_pool_prune_interval),
-            finality_threshold_fraction,
         };
 
         match component.read_state_store(&Cow::Borrowed(COMPLETED_BLOCKS_STORAGE_KEY))? {
@@ -607,8 +601,9 @@ impl Storage {
             NetRequest::BlockAndMetadataByHeight(ref serialized_id) => {
                 let item_id = decode_item_id::<BlockWithMetadata>(serialized_id)?;
                 let opt_item = self
-                    .read_block_and_sufficient_finality_signatures_by_height(item_id)
+                    .read_block_and_metadata_by_height(item_id)
                     .map_err(FatalStorageError::from)?;
+                // TODO: At least one signature?
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
@@ -635,8 +630,9 @@ impl Storage {
             NetRequest::BlockHeaderAndFinalitySignaturesByHeight(ref serialized_id) => {
                 let item_id = decode_item_id::<BlockHeaderWithMetadata>(serialized_id)?;
                 let opt_item = self
-                    .read_block_header_and_sufficient_finality_signatures_by_height(item_id)
+                    .read_block_header_and_metadata_by_height(item_id)
                     .map_err(FatalStorageError::from)?;
+                // TODO: At least one signature?
 
                 Ok(self.update_pool_and_send(
                     effect_builder,
@@ -910,14 +906,6 @@ impl Storage {
                     }))
                     .ignore()
             }
-            StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            } => responder
-                .respond(
-                    self.read_block_and_sufficient_finality_signatures_by_height(block_height)?,
-                )
-                .ignore(),
             StorageRequest::GetBlockAndMetadataByHeight {
                 block_height,
                 only_from_available_block_range,
@@ -1011,16 +999,6 @@ impl Storage {
                     .respond(self.get_finality_signatures(&mut txn, &block_hash)?)
                     .ignore()
             }
-            StorageRequest::GetSufficientBlockSignatures {
-                block_hash,
-                responder,
-            } => {
-                let result = self.get_sufficient_finality_signatures_by_hash(
-                    &mut self.env.begin_ro_txn()?,
-                    &block_hash,
-                )?;
-                responder.respond(result).ignore()
-            }
             StorageRequest::GetFinalizedBlocks { ttl, responder } => {
                 responder.respond(self.get_finalized_blocks(ttl)?).ignore()
             }
@@ -1034,17 +1012,6 @@ impl Storage {
                     &mut txn,
                     block_height,
                     only_from_available_block_range,
-                )?;
-                responder.respond(result).ignore()
-            }
-            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            } => {
-                let mut txn = self.env.begin_ro_txn()?;
-                let result = self.get_block_header_and_sufficient_finality_signatures_by_height(
-                    &mut txn,
-                    block_height,
                 )?;
                 responder.respond(result).ignore()
             }
@@ -1230,33 +1197,65 @@ impl Storage {
         self.get_switch_block_header_by_era_id(&mut txn, switch_block_era_id)
     }
 
-    /// Retrieves a block header by height.
-    /// Returns `None` if they are less than the fault tolerance threshold.
-    pub(crate) fn read_block_header_and_sufficient_finality_signatures_by_height(
-        &self,
-        height: u64,
-    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        let maybe_block_header_and_finality_signatures =
-            self.get_block_header_and_sufficient_finality_signatures_by_height(&mut txn, height)?;
-        Ok(maybe_block_header_and_finality_signatures)
-    }
-
-    /// Retrieves a block by height.
-    /// Returns `None` if they are less than the fault tolerance threshold.
-    fn read_block_and_sufficient_finality_signatures_by_height(
-        &self,
-        height: u64,
-    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        let maybe_block_and_finality_signatures =
-            self.get_block_and_sufficient_finality_signatures_by_height(&mut txn, height)?;
-        Ok(maybe_block_and_finality_signatures)
-    }
-
     /// Retrieves single block by height by looking it up in the index and returning it.
     pub fn read_block_by_height(&self, height: u64) -> Result<Option<Block>, FatalStorageError> {
         self.get_block_by_height(&mut self.env.begin_ro_txn()?, height)
+    }
+
+    /// Retrieves a block by height, together with all stored finality signatures.
+    pub fn read_block_and_metadata_by_height(
+        &self,
+        height: u64,
+    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
+        let mut txn = self
+            .env
+            .begin_ro_txn()
+            .expect("could not create RO transaction");
+        let block = if let Some(block) = self.get_block_by_height(&mut txn, height)? {
+            block
+        } else {
+            return Ok(None);
+        };
+        let finality_signatures = if let Some(finality_signatures) =
+            self.get_finality_signatures(&mut txn, block.hash())?
+        {
+            finality_signatures
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(BlockWithMetadata {
+            block,
+            finality_signatures,
+        }))
+    }
+
+    /// Retrieves a block header by height, together with all stored finality signatures.
+    pub fn read_block_header_and_metadata_by_height(
+        &self,
+        height: u64,
+    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
+        let mut txn = self
+            .env
+            .begin_ro_txn()
+            .expect("could not create RO transaction");
+        let block_header =
+            if let Some(block_header) = self.get_block_header_by_height(&mut txn, height)? {
+                block_header
+            } else {
+                return Ok(None);
+            };
+        let block_signatures = if let Some(block_signatures) = self.get_finality_signatures(
+            &mut txn,
+            &block_header.hash(),
+        )? {
+            block_signatures
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(BlockHeaderWithMetadata {
+            block_header,
+            block_signatures,
+        }))
     }
 
     /// Retrieves single block and all of its deploys.
@@ -1290,6 +1289,21 @@ impl Storage {
         self.block_height_index
             .get(&height)
             .and_then(|block_hash| self.get_single_block(txn, block_hash).transpose())
+            .transpose()
+    }
+
+    /// Retrieves single block header by height by looking it up in the index and returning it.
+    fn get_block_header_by_height<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        height: u64,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        self.block_height_index
+            .get(&height)
+            .and_then(|block_hash| {
+                self.get_single_block_header_restricted(txn, block_hash, false)
+                    .transpose()
+            })
             .transpose()
     }
 
@@ -1629,32 +1643,6 @@ impl Storage {
         self.get_finality_signatures(&mut txn, block_hash)
     }
 
-    /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold.
-    fn get_block_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        height: u64,
-    ) -> Result<Option<BlockWithMetadata>, FatalStorageError> {
-        let BlockHeaderWithMetadata {
-            block_header,
-            block_signatures,
-        } = match self.get_block_header_and_sufficient_finality_signatures_by_height(txn, height)? {
-            None => return Ok(None),
-            Some(block_header_with_metadata) => block_header_with_metadata,
-        };
-        let maybe_block_body = get_body_for_block_header(txn, &block_header, self.block_body_db);
-        if let Some(block_body) = maybe_block_body? {
-            Ok(Some(BlockWithMetadata {
-                block: Block::new_from_header_and_body(block_header, block_body)?,
-                finality_signatures: block_signatures,
-            }))
-        } else {
-            debug!(?block_header, "Missing block body for header");
-            Ok(None)
-        }
-    }
-
     /// Directly returns a deploy from internal store.
     pub fn read_deploy_by_hash(
         &self,
@@ -1705,93 +1693,6 @@ impl Storage {
             txn.commit()?;
         }
         Ok(())
-    }
-
-    /// Retrieves single block header by height by looking it up in the index and returning it;
-    /// returns `None` if they are less than the fault tolerance threshold.
-    fn get_block_header_and_sufficient_finality_signatures_by_height<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        height: u64,
-    ) -> Result<Option<BlockHeaderWithMetadata>, FatalStorageError> {
-        let block_hash = match self.block_height_index.get(&height) {
-            None => return Ok(None),
-            Some(block_hash) => block_hash,
-        };
-        let block_header = match self.get_single_block_header(txn, block_hash)? {
-            None => return Ok(None),
-            Some(block_header) => block_header,
-        };
-        let block_signatures = match self.get_sufficient_finality_signatures(txn, &block_header)? {
-            None => return Ok(None),
-            Some(signatures) => signatures,
-        };
-        Ok(Some(BlockHeaderWithMetadata {
-            block_header,
-            block_signatures,
-        }))
-    }
-
-    /// Retrieves finality signatures for a block with a given header; returns `None` if they
-    /// are less than the fault tolerance threshold.
-    fn get_sufficient_finality_signatures<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        block_header: &BlockHeader,
-    ) -> Result<Option<BlockSignatures>, FatalStorageError> {
-        let block_signatures = match self.get_finality_signatures(txn, &block_header.hash())? {
-            None => return Ok(None),
-            Some(block_signatures) => block_signatures,
-        };
-        // If `block_header` is from era 0, we can use the switch block from era 0 to ascertain the
-        // validators for that era.
-        let switch_block_hash = match self
-            .switch_block_era_id_index
-            .get(&(block_header.era_id().saturating_sub(1)))
-        {
-            None => return Ok(None),
-            Some(switch_block_hash) => switch_block_hash,
-        };
-        let switch_block_header = match self.get_single_block_header(txn, switch_block_hash)? {
-            None => return Ok(None),
-            Some(switch_block_header) => switch_block_header,
-        };
-
-        let validator_weights = match switch_block_header.next_era_validator_weights() {
-            None => {
-                return Err(FatalStorageError::InvalidSwitchBlock(Box::new(
-                    switch_block_header,
-                )))
-            }
-            Some(validator_weights) => validator_weights,
-        };
-
-        let block_signatures = consensus::get_minimal_set_of_signatures(
-            validator_weights,
-            self.finality_threshold_fraction,
-            block_signatures,
-        );
-
-        // `block_signatures` is already an `Option`, which is `None` if there weren't enough
-        // signatures to bring the total weight over the threshold.
-        Ok(block_signatures)
-    }
-
-    /// Retrieves finality signatures for a block with a given block hash; returns `None` if they
-    /// are less than the fault tolerance threshold.
-    fn get_sufficient_finality_signatures_by_hash<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        block_hash: &BlockHash,
-    ) -> Result<Option<BlockSignatures>, FatalStorageError> {
-        // Needed to know what era the block was in, so that we can check what the validators were
-        // and figure out if the signatures are sufficient.
-        let block_header = match self.get_single_block_header(txn, block_hash)? {
-            Some(header) => header,
-            None => return Ok(None),
-        };
-
-        self.get_sufficient_finality_signatures(txn, &block_header)
     }
 
     /// Retrieves a deploy from the deploy store.

--- a/node/src/components/storage/error.rs
+++ b/node/src/components/storage/error.rs
@@ -7,12 +7,8 @@ use casper_hashing::Digest;
 use casper_types::{bytesrepr, crypto, EraId};
 
 use super::lmdb_ext::LmdbExtError;
-use crate::{
-    components::consensus::error::FinalitySignatureError,
-    types::{
-        error::BlockValidationError, BlockBody, BlockHash, BlockHashAndHeight, BlockHeader,
-        DeployHash,
-    },
+use crate::types::{
+    error::BlockValidationError, BlockBody, BlockHash, BlockHashAndHeight, BlockHeader, DeployHash,
 };
 
 /// A fatal storage component error.
@@ -124,9 +120,6 @@ pub enum FatalStorageError {
     /// Switch block does not contain era end.
     #[error("switch block does not contain era end: {0:?}")]
     InvalidSwitchBlock(Box<BlockHeader>),
-    /// Insufficient or wrong finality signatures.
-    #[error(transparent)]
-    FinalitySignature(#[from] FinalitySignatureError),
     /// A block body was found to have more parts than expected.
     #[error(
         "Found an unexpected part of a block body in the database: \

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1117,26 +1117,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Retrieves finality signatures for a block with a given block hash; returns `None` if they
-    /// are less than the fault tolerance threshold or if the block is from before the most recent
-    /// emergency upgrade.
-    pub(crate) async fn get_sufficient_signatures_from_storage(
-        self,
-        block_hash: BlockHash,
-    ) -> Option<BlockSignatures>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetSufficientBlockSignatures {
-                block_hash,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Puts a block header to storage.
     pub(crate) async fn put_block_header_to_storage(self, block_header: Box<BlockHeader>) -> bool
     where
@@ -1417,42 +1397,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets a block and sufficient finality signatures from storage.
-    pub(crate) async fn get_block_and_sufficient_finality_signatures_by_height_from_storage(
-        self,
-        block_height: u64,
-    ) -> Option<BlockWithMetadata>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Gets the requested block and its associated metadata.
-    pub(crate) async fn get_block_header_and_sufficient_finality_signatures_by_height_from_storage(
-        self,
-        block_height: u64,
-    ) -> Option<BlockHeaderWithMetadata>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Gets the requested block by hash with its associated metadata.
     pub(crate) async fn get_block_with_metadata_from_storage(
         self,
@@ -1465,6 +1409,26 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHash {
                 block_hash,
+                only_from_available_block_range,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Gets the requested block by height with its associated metadata.
+    pub(crate) async fn get_block_with_metadata_from_storage_by_height(
+        self,
+        block_height: u64,
+        only_from_available_block_range: bool,
+    ) -> Option<BlockWithMetadata>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockAndMetadataByHeight {
+                block_height,
                 only_from_available_block_range,
                 responder,
             },

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -146,11 +146,11 @@ use crate::{
     effect::announcements::ChainSynchronizerAnnouncement,
     reactor::{EventQueueHandle, QueueKind},
     types::{
-        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeadersBatch,
-        BlockHeadersBatchId, BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec,
-        ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash, DeployHeader, DeployMetadataExt,
-        DeployWithFinalizedApprovals, FinalitySignature, FinalizedApprovals, FinalizedBlock, Item,
-        NodeId, NodeState,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
+        BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
+        BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
+        DeployHash, DeployHeader, DeployMetadataExt, DeployWithFinalizedApprovals,
+        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
     },
     utils::{SharedFlag, Source},
 };
@@ -1417,6 +1417,26 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets the requested block header by hash with its associated metadata.
+    pub(crate) async fn get_block_header_with_metadata_from_storage(
+        self,
+        block_hash: BlockHash,
+        only_from_available_block_range: bool,
+    ) -> Option<BlockHeaderWithMetadata>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockHeaderAndMetadataByHash {
+                block_hash,
+                only_from_available_block_range,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Gets the requested block by height with its associated metadata.
     pub(crate) async fn get_block_with_metadata_from_storage_by_height(
         self,
@@ -1428,6 +1448,26 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHeight {
+                block_height,
+                only_from_available_block_range,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Gets the requested block header by height with its associated metadata.
+    pub(crate) async fn get_block_header_with_metadata_from_storage_by_height(
+        self,
+        block_height: u64,
+        only_from_available_block_range: bool,
+    ) -> Option<BlockHeaderWithMetadata>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockHeaderAndMetadataByHeight {
                 block_height,
                 only_from_available_block_range,
                 responder,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -146,11 +146,11 @@ use crate::{
     effect::announcements::ChainSynchronizerAnnouncement,
     reactor::{EventQueueHandle, QueueKind},
     types::{
-        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
-        BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
-        BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
-        DeployHash, DeployHeader, DeployMetadataExt, DeployWithFinalizedApprovals,
-        FinalitySignature, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeadersBatch,
+        BlockHeadersBatchId, BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec,
+        ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash, DeployHeader, DeployMetadataExt,
+        DeployWithFinalizedApprovals, FinalitySignature, FinalizedApprovals, FinalizedBlock, Item,
+        NodeId, NodeState,
     },
     utils::{SharedFlag, Source},
 };

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -542,7 +542,7 @@ impl<REv> EffectBuilder<REv> {
     /// # Cancellation safety
     ///
     /// This future is cancellation safe: If it is dropped without being polled, it merely indicates
-    /// the original requestor is not longer interested in the result, which will be discarded.
+    /// the original requester is not longer interested in the result, which will be discarded.
     pub(crate) async fn make_request<T, Q, F>(self, f: F, queue_kind: QueueKind) -> T
     where
         T: Send + 'static,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -275,7 +275,7 @@ impl<T: Debug> Responder<T> {
     pub(crate) async fn respond(mut self, data: T) {
         if let Some(sender) = self.sender.take() {
             if let Err(data) = sender.send(data) {
-                // If we cannot send a response down the channel, it means the original requestor is
+                // If we cannot send a response down the channel, it means the original requester is
                 // no longer interested in our response. This typically happens during shutdowns, or
                 // in cases where an originating external request has been cancelled.
 
@@ -1132,7 +1132,10 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Puts the requested finality signatures into storage.
+    /// Puts the requested block signatures into storage.
+    ///
+    /// If `signatures.proofs` is empty, no attempt to store will be made, an error will be logged,
+    /// and this function will return `false`.
     pub(crate) async fn put_signatures_to_storage(self, signatures: BlockSignatures) -> bool
     where
         REv: From<StorageRequest>,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -48,11 +48,11 @@ use crate::{
     effect::{AutoClosingResponder, Responder},
     rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
-        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
-        BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
-        BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
-        DeployHash, DeployMetadataExt, DeployWithFinalizedApprovals, FinalizedApprovals,
-        FinalizedBlock, Item, NodeId, NodeState, StatusFeed,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeadersBatch,
+        BlockHeadersBatchId, BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec,
+        ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash, DeployMetadataExt,
+        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
+        StatusFeed,
     },
     utils::{DisplayIter, Source},
 };

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -48,11 +48,11 @@ use crate::{
     effect::{AutoClosingResponder, Responder},
     rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
-        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeadersBatch,
-        BlockHeadersBatchId, BlockPayload, BlockSignatures, BlockWithMetadata, Chainspec,
-        ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash, DeployMetadataExt,
-        DeployWithFinalizedApprovals, FinalizedApprovals, FinalizedBlock, Item, NodeId, NodeState,
-        StatusFeed,
+        AvailableBlockRange, Block, BlockAndDeploys, BlockHash, BlockHeader,
+        BlockHeaderWithMetadata, BlockHeadersBatch, BlockHeadersBatchId, BlockPayload,
+        BlockSignatures, BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy,
+        DeployHash, DeployMetadataExt, DeployWithFinalizedApprovals, FinalizedApprovals,
+        FinalizedBlock, Item, NodeId, NodeState, StatusFeed,
     },
     utils::{DisplayIter, Source},
 };
@@ -402,6 +402,16 @@ pub(crate) enum StorageRequest {
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
     },
+    /// Retrieve block header and its metadata by its hash.
+    GetBlockHeaderAndMetadataByHash {
+        /// The hash of the block.
+        block_hash: BlockHash,
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
+        only_from_available_block_range: bool,
+        /// The responder to call with the results.
+        responder: Responder<Option<BlockHeaderWithMetadata>>,
+    },
     /// Retrieve block and its metadata at a given height.
     GetBlockAndMetadataByHeight {
         /// The height of the block.
@@ -411,6 +421,16 @@ pub(crate) enum StorageRequest {
         only_from_available_block_range: bool,
         /// The responder to call with the results.
         responder: Responder<Option<BlockWithMetadata>>,
+    },
+    /// Retrieve block header and its metadata at a given height.
+    GetBlockHeaderAndMetadataByHeight {
+        /// The height of the block.
+        block_height: BlockHeight,
+        /// Flag indicating whether storage should check the block availability before trying to
+        /// retrieve it.
+        only_from_available_block_range: bool,
+        /// The responder to call with the results.
+        responder: Responder<Option<BlockHeaderWithMetadata>>,
     },
     /// Get the highest block and its metadata.
     GetHighestBlockWithMetadata {
@@ -527,10 +547,24 @@ impl Display for StorageRequest {
                     block_hash
                 )
             }
+            StorageRequest::GetBlockHeaderAndMetadataByHash { block_hash, .. } => {
+                write!(
+                    formatter,
+                    "get block header and metadata for block with hash: {}",
+                    block_hash
+                )
+            }
             StorageRequest::GetBlockAndMetadataByHeight { block_height, .. } => {
                 write!(
                     formatter,
                     "get block and metadata for block at height: {}",
+                    block_height
+                )
+            }
+            StorageRequest::GetBlockHeaderAndMetadataByHeight { block_height, .. } => {
+                write!(
+                    formatter,
+                    "get block header and metadata for block at height: {}",
                     block_height
                 )
             }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -339,22 +339,6 @@ pub(crate) enum StorageRequest {
         /// Responder to call with the result.
         responder: Responder<bool>,
     },
-    /// Retrieve block header with sufficient finality signatures by height.
-    GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
-        /// Height of block to get header of.
-        block_height: u64,
-        /// Responder to call with the result.  Returns `None` if the block header doesn't exist in
-        /// local storage.
-        responder: Responder<Option<BlockHeaderWithMetadata>>,
-    },
-    /// Retrieves a block header with sufficient finality signatures by height.
-    GetBlockAndSufficientFinalitySignaturesByHeight {
-        /// Height of block to get header of.
-        block_height: u64,
-        /// Responder to call with the result.  Returns `None` if the block header doesn't exist or
-        /// does not have sufficient finality signatures by height.
-        responder: Responder<Option<BlockWithMetadata>>,
-    },
     /// Retrieve all transfers in a block with given hash.
     GetBlockTransfers {
         /// Hash of block to get transfers of.
@@ -435,15 +419,6 @@ pub(crate) enum StorageRequest {
     },
     /// Get finality signatures for a Block hash.
     GetBlockSignatures {
-        /// The hash for the request.
-        block_hash: BlockHash,
-        /// Responder to call with the result.
-        responder: Responder<Option<BlockSignatures>>,
-    },
-    /// Gets finality signatures for a block with a given block hash; returns `None` if they
-    /// are less than the fault tolerance threshold or if the block is from before the most recent
-    /// emergency upgrade.
-    GetSufficientBlockSignatures {
         /// The hash for the request.
         block_hash: BlockHash,
         /// Responder to call with the result.
@@ -569,41 +544,14 @@ impl Display for StorageRequest {
                     block_hash
                 )
             }
-            StorageRequest::GetSufficientBlockSignatures { block_hash, .. } => {
-                write!(
-                    formatter,
-                    "get sufficient finality signatures for block hash {}",
-                    block_hash
-                )
-            }
             StorageRequest::PutBlockSignatures { .. } => {
                 write!(formatter, "put finality signatures")
             }
             StorageRequest::GetFinalizedBlocks { ttl, .. } => {
                 write!(formatter, "get finalized blocks, ttl: {:?}", ttl)
             }
-            StorageRequest::GetBlockHeaderAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                ..
-            } => {
-                write!(
-                    formatter,
-                    "get block and metadata for block by height: {}",
-                    block_height
-                )
-            }
             StorageRequest::PutBlockHeader { block_header, .. } => {
                 write!(formatter, "put block header: {}", block_header)
-            }
-            StorageRequest::GetBlockAndSufficientFinalitySignaturesByHeight {
-                block_height,
-                ..
-            } => {
-                write!(
-                    formatter,
-                    "get block and sufficient finality signatures by height: {}",
-                    block_height
-                )
             }
             StorageRequest::GetAvailableBlockRange { .. } => {
                 write!(formatter, "get available block range",)

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -201,10 +201,6 @@ impl Reactor {
             hard_reset_to_start_of_era,
             chainspec_loader.chainspec().protocol_config.version,
             &chainspec_loader.chainspec().network_config.name,
-            chainspec_loader
-                .chainspec()
-                .highway_config
-                .finality_threshold_fraction,
         )?;
 
         let contract_runtime = ContractRuntime::new(

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -579,7 +579,11 @@ impl reactor::Reactor for Reactor {
             *protocol_version,
         )?;
 
-        let fetcher_builder = FetcherBuilder::new(config.fetcher, registry);
+        let fetcher_builder = FetcherBuilder::new(
+            config.fetcher,
+            chainspec.highway_config.finality_threshold_fraction,
+            registry,
+        );
 
         let deploy_fetcher = fetcher_builder.build("deploy")?;
         let finalized_approvals_fetcher = fetcher_builder.build("finalized_approvals")?;

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -769,7 +769,11 @@ impl reactor::Reactor for Reactor {
             node_startup_instant,
         )?;
 
-        let fetcher_builder = FetcherBuilder::new(config.fetcher, registry);
+        let fetcher_builder = FetcherBuilder::new(
+            config.fetcher,
+            chainspec.highway_config.finality_threshold_fraction,
+            registry,
+        );
 
         let deploy_acceptor = DeployAcceptor::new(chainspec_loader.chainspec(), registry)?;
         let deploy_fetcher = fetcher_builder.build("deploy")?;

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -497,10 +497,10 @@ async fn dont_upgrade_without_switch_block() {
         let header = runner
             .participating()
             .storage()
-            .read_block_header_and_sufficient_finality_signatures_by_height(2)
+            .read_block_by_height(2)
             .expect("failed to read from storage")
             .expect("missing switch block")
-            .block_header;
+            .take_header();
         assert_eq!(EraId::from(1), header.era_id());
         assert!(header.is_switch_block());
         assert_eq!(

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1652,17 +1652,17 @@ impl Item for Block {
 #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BlockWithMetadata {
     pub block: Block,
-    pub finality_signatures: BlockSignatures,
+    pub block_signatures: BlockSignatures,
 }
 
 impl Display for BlockWithMetadata {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Block at {} with hash {} with {} finality signatures.",
+            "Block at {} with hash {} with {} block signatures.",
             self.block.height(),
             self.block.hash(),
-            self.finality_signatures.proofs.len()
+            self.block_signatures.proofs.len()
         )
     }
 }
@@ -1699,7 +1699,7 @@ impl Item for BlockWithMetadata {
 
     fn validate(&self) -> Result<(), Self::ValidationError> {
         self.block.verify()?;
-        validate_block_header_and_signature_hash(self.block.header(), &self.finality_signatures)?;
+        validate_block_header_and_signature_hash(self.block.header(), &self.block_signatures)?;
         Ok(())
     }
 

--- a/utils/retrieve-state/src/storage.rs
+++ b/utils/retrieve-state/src/storage.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use lmdb::DatabaseFlags;
-use num_rational::Ratio;
 use tracing::info;
 
 use casper_execution_engine::{
@@ -137,7 +136,6 @@ pub fn create_storage(chain_download_path: impl AsRef<Path>) -> Result<Storage, 
         None,
         ProtocolVersion::from_parts(0, 0, 0),
         "test",
-        Ratio::new(1, 3),
     )?)
 }
 


### PR DESCRIPTION
This PR includes the following changes:
* removes storage getters which calculated sufficient block signatures
* adds storage getters for block header and signatures
* storage returns `None` for `NetRequest`s of Block/BlockHeader with signatures if no signatures are stored locally
* provides new `linear_chain::era_validator_weights_for_block` function to retrieve validator weights while accounting for validator-change upgrades.

Closes #3233.
