### PR TITLE
Add `max_sync_fetch_attempts` to node config and use if for fetches in chain synchronizer

### DIFF
--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -217,7 +217,7 @@ where
                 synchronizer.metrics.clone(),
                 progress,
             )
-            .event(Event::SyncResultToGenesisResult);
+            .event(Event::SyncToGenesisResult);
 
             return Ok((synchronizer, effects));
         }
@@ -291,7 +291,7 @@ where
     ) -> Effects<Self::Event> {
         debug!(?event, "handling event");
         match event {
-            Event::SyncResultToGenesisResult(result) => {
+            Event::SyncToGenesisResult(result) => {
                 // TODO[RC]: When all fetch operations are unified, rely on the single
                 // `Error::AttemptsExhausted` variant.
                 if matches!(result, Err(Error::AttemptsExhausted))

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -217,7 +217,7 @@ where
                 synchronizer.metrics.clone(),
                 progress,
             )
-            .event(Event::SyncToGenesisResult);
+            .event(|result| Event::SyncToGenesisResult(Box::new(result)));
 
             return Ok((synchronizer, effects));
         }
@@ -294,9 +294,9 @@ where
             Event::SyncToGenesisResult(result) => {
                 // TODO[RC]: When all fetch operations are unified, rely on the single
                 // `Error::AttemptsExhausted` variant.
-                if matches!(result, Err(Error::AttemptsExhausted))
-                    | matches!(result, Err(Error::FetchHeadersBatch(ref err)) if matches!(err, FetchBlockHeadersBatchError::AttemptsExhausted))
-                    | matches!(result, Err(Error::FetchTrie(err)) if matches!(err, FetchTrieError::AttemptsExhausted))
+                if matches!(*result, Err(Error::AttemptsExhausted))
+                    | matches!(*result, Err(Error::FetchHeadersBatch(ref err)) if matches!(err, FetchBlockHeadersBatchError::AttemptsExhausted))
+                    | matches!(*result, Err(Error::FetchTrie(err)) if matches!(err, FetchTrieError::AttemptsExhausted))
                 {
                     error!("sync to genesis failed due to fetch retries exhaustion; shutting down");
                     fatal!(

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -185,6 +185,10 @@ where
                 self.joining_outcome = Some(JoiningOutcome::ShouldExitForUpgrade);
                 Effects::new()
             }
+            Err(Error::RetriesExhausted) => {
+                // TODO[RC]: Trigger node exit here
+                todo!()
+            }
             Err(error) => {
                 error!(%error, "failed to sync linear chain");
                 fatal!(effect_builder, "{}", error).ignore()

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -640,10 +640,10 @@ where
             Event::FastSyncResult(result) => self.handle_fast_sync_result(effect_builder, result),
             Event::SyncResultToGenesisResult(result) => {
                 // TODO[RC]: When all fetch operations are unified, rely on the single
-                // `Error::RetriesExhausted` variant.
-                if matches!(result, Err(Error::RetriesExhausted))
-                    | matches!(result, Err(Error::FetchHeadersBatch(ref err)) if matches!(err, FetchBlockHeadersBatchError::RetriesExhausted))
-                    | matches!(result, Err(Error::FetchTrie(err)) if matches!(err, FetchTrieError::RetriesExhausted))
+                // `Error::AttemptsExhausted` variant.
+                if matches!(result, Err(Error::AttemptsExhausted))
+                    | matches!(result, Err(Error::FetchHeadersBatch(ref err)) if matches!(err, FetchBlockHeadersBatchError::AttemptsExhausted))
+                    | matches!(result, Err(Error::FetchTrie(err)) if matches!(err, FetchTrieError::AttemptsExhausted))
                 {
                     error!("sync to genesis failed due to fetch retries exhaustion; shutting down");
                     fatal!(

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -113,9 +113,7 @@ where
             metrics.clone(),
             progress.clone(),
         )
-        .event(|result| Event::FastSyncResult {
-            result: Box::new(result),
-        });
+        .event(|result| Event::FastSyncResult(Box::new(result)));
 
         let synchronizer = ChainSynchronizer {
             config,
@@ -308,9 +306,7 @@ where
                     Effects::new()
                 }
             }
-            Event::FastSyncResult { result } => {
-                self.handle_fast_sync_result(effect_builder, *result)
-            }
+            Event::FastSyncResult(result) => self.handle_fast_sync_result(effect_builder, *result),
             Event::GetNodeState(request) => self.handle_get_node_state_request(request),
         }
     }

--- a/node/src/components/chain_synchronizer.rs
+++ b/node/src/components/chain_synchronizer.rs
@@ -185,10 +185,6 @@ where
                 self.joining_outcome = Some(JoiningOutcome::ShouldExitForUpgrade);
                 Effects::new()
             }
-            Err(Error::RetriesExhausted) => {
-                // TODO[RC]: Trigger node exit here
-                todo!()
-            }
             Err(error) => {
                 error!(%error, "failed to sync linear chain");
                 fatal!(effect_builder, "{}", error).ignore()

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -128,6 +128,10 @@ impl Config {
         self.max_parallel_block_fetches as usize
     }
 
+    pub(super) fn max_sync_fetch_attempts(&self) -> usize {
+        self.max_sync_fetch_attempts as usize
+    }
+
     pub(super) fn retry_interval(&self) -> Duration {
         self.retry_interval
     }

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -23,6 +23,9 @@ pub(super) struct Config {
     max_parallel_trie_fetches: u32,
     /// Maximum number of blocks to fetch in parallel.
     max_parallel_block_fetches: u32,
+    /// The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
+    /// only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+    max_sync_fetch_attempts: u32,
     /// The duration for which to pause between retry attempts while synchronising.
     retry_interval: Duration,
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
@@ -54,6 +57,7 @@ impl Config {
             max_parallel_deploy_fetches: node_config.max_parallel_deploy_fetches,
             max_parallel_trie_fetches: node_config.max_parallel_trie_fetches,
             max_parallel_block_fetches: node_config.max_parallel_block_fetches,
+            max_sync_fetch_attempts: node_config.max_sync_fetch_attempts,
             retry_interval: Duration::from_millis(node_config.retry_interval.millis()),
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -23,8 +23,9 @@ pub(super) struct Config {
     max_parallel_trie_fetches: u32,
     /// Maximum number of blocks to fetch in parallel.
     max_parallel_block_fetches: u32,
-    /// The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
-    /// only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+    /// The maximum number of retries of fetch operations during the chain synchronization process.
+    /// The retry limit is in effect only when the network component reports that enough peers
+    /// are connected, until that happens, the retries are unbounded.
     max_sync_fetch_attempts: u32,
     /// The duration for which to pause between retry attempts while synchronising.
     retry_interval: Duration,

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -18,9 +18,11 @@ use crate::{
     },
     types::{
         Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
-        BlockWithMetadata, Deploy, FinalizedApprovalsWithId,
+        BlockWithMetadata, Deploy, FinalizedApprovalsWithId, Item,
     },
 };
+
+use super::operations::FetchWithRetryError;
 
 #[derive(Error, Debug, Serialize)]
 pub(crate) enum Error {
@@ -164,6 +166,9 @@ pub(crate) enum Error {
         #[serde(skip_serializing)]
         AcquireError,
     ),
+
+    #[error("Fetch retries exhausted")]
+    RetriesExhausted,
 }
 
 #[derive(Error, Debug)]
@@ -185,6 +190,9 @@ pub(crate) enum FetchTrieError {
          by a peer somehow. Trie digest: {digest:?}"
     )]
     TrieBeingFetchedByChunksSomehowFetchWholeFromPeer { digest: Digest },
+
+    #[error("Fetch retries exhausted")]
+    RetriesExhausted,
 }
 
 #[derive(Error, Debug)]
@@ -195,4 +203,7 @@ pub(crate) enum FetchBlockHeadersBatchError {
 
     #[error("Batch from storage was empty")]
     EmptyBatchFromStorage,
+
+    #[error("Fetch retries exhausted")]
+    RetriesExhausted,
 }

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -167,7 +167,7 @@ pub(crate) enum Error {
         AcquireError,
     ),
 
-    #[error("Fetch retries exhausted")]
+    #[error("fetch retries exhausted")]
     RetriesExhausted,
 }
 
@@ -191,7 +191,7 @@ pub(crate) enum FetchTrieError {
     )]
     TrieBeingFetchedByChunksSomehowFetchWholeFromPeer { digest: Digest },
 
-    #[error("Fetch retries exhausted")]
+    #[error("fetch retries exhausted")]
     RetriesExhausted,
 }
 
@@ -204,6 +204,6 @@ pub(crate) enum FetchBlockHeadersBatchError {
     #[error("Batch from storage was empty")]
     EmptyBatchFromStorage,
 
-    #[error("Fetch retries exhausted")]
+    #[error("fetch retries exhausted")]
     RetriesExhausted,
 }

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -165,8 +165,8 @@ pub(crate) enum Error {
         AcquireError,
     ),
 
-    #[error("fetch retries exhausted")]
-    RetriesExhausted,
+    #[error("fetch attempts exhausted")]
+    AttemptsExhausted,
 }
 
 #[derive(Error, Debug)]
@@ -189,8 +189,8 @@ pub(crate) enum FetchTrieError {
     )]
     TrieBeingFetchedByChunksSomehowFetchWholeFromPeer { digest: Digest },
 
-    #[error("fetch retries exhausted")]
-    RetriesExhausted,
+    #[error("fetch attempts exhausted")]
+    AttemptsExhausted,
 }
 
 #[derive(Error, Debug)]
@@ -202,6 +202,6 @@ pub(crate) enum FetchBlockHeadersBatchError {
     #[error("Batch from storage was empty")]
     EmptyBatchFromStorage,
 
-    #[error("fetch retries exhausted")]
-    RetriesExhausted,
+    #[error("fetch attempts exhausted")]
+    AttemptsExhausted,
 }

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -18,11 +18,9 @@ use crate::{
     },
     types::{
         Block, BlockAndDeploys, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockHeadersBatch,
-        BlockWithMetadata, Deploy, FinalizedApprovalsWithId, Item,
+        BlockWithMetadata, Deploy, FinalizedApprovalsWithId,
     },
 };
-
-use super::operations::FetchWithRetryError;
 
 #[derive(Error, Debug, Serialize)]
 pub(crate) enum Error {

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -12,9 +12,7 @@ pub(crate) enum Event {
     /// The result of running the fast sync task.
     SyncToGenesisResult(Box<Result<(), Error>>),
     /// The result of running the fast sync task.
-    FastSyncResult {
-        result: Box<Result<BlockHeader, Error>>,
-    },
+    FastSyncResult(Box<Result<BlockHeader, Error>>),
     /// A request to provide the node state.
     #[from]
     GetNodeState(NodeStateRequest),
@@ -23,7 +21,7 @@ pub(crate) enum Event {
 impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Event::FastSyncResult { result } => {
+            Event::FastSyncResult(result) => {
                 write!(formatter, "fast sync result: {:?}", result)
             }
             Event::SyncToGenesisResult(result) => {

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -10,7 +10,7 @@ use crate::{effect::requests::NodeStateRequest, types::BlockHeader};
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Event {
     /// The result of running the fast sync task.
-    SyncResultToGenesisResult(Result<(), Error>),
+    SyncToGenesisResult(Result<(), Error>),
     /// The result of running the fast sync task.
     FastSyncResult {
         result: Box<Result<BlockHeader, Error>>,
@@ -26,7 +26,7 @@ impl Display for Event {
             Event::FastSyncResult { result } => {
                 write!(formatter, "fast sync result: {:?}", result)
             }
-            Event::SyncResultToGenesisResult(result) => {
+            Event::SyncToGenesisResult(result) => {
                 write!(formatter, "sync to genesis result: {:?}", result)
             }
             Event::GetNodeState(_) => write!(formatter, "get node state"),

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -10,7 +10,7 @@ use crate::{effect::requests::NodeStateRequest, types::BlockHeader};
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Event {
     /// The result of running the fast sync task.
-    SyncToGenesisResult(Result<(), Error>),
+    SyncToGenesisResult(Box<Result<(), Error>>),
     /// The result of running the fast sync task.
     FastSyncResult {
         result: Box<Result<BlockHeader, Error>>,

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -21,6 +21,8 @@ use crate::{
 pub(crate) enum Event {
     /// The result of running the fast sync task.
     FastSyncResult(Result<FastSyncOutcome, Error>),
+    /// The result of running the sync to genesis task.
+    SyncResultToGenesisResult(Result<(), Error>),
     /// The result of contract runtime running the genesis process.
     CommitGenesisResult(#[serde(skip_serializing)] Result<GenesisSuccess, engine_state::Error>),
     /// The result of contract runtime running the upgrade process.
@@ -54,6 +56,9 @@ impl Display for Event {
         match self {
             Event::FastSyncResult(result) => {
                 write!(formatter, "fast sync result: {:?}", result)
+            }
+            Event::SyncResultToGenesisResult(result) => {
+                write!(formatter, "sync to genesis result: {:?}", result)
             }
             Event::CommitGenesisResult(result) => {
                 write!(formatter, "commit genesis result: {:?}", result)

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -418,7 +418,7 @@ where
             return Err(FetchWithRetryError::RetriesExhausted {
                 id,
                 total_attempts,
-                retries_while_connected: retry_count,
+                retries_while_connected: retry_count - 1,
             });
         }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -503,7 +503,7 @@ enum TrieAlreadyPresentOrDownloaded {
     Downloaded(Bytes),
 }
 
-async fn fetch_trie<REv>(
+async fn fetch_trie_with_retries<REv>(
     id: Digest,
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Result<TrieAlreadyPresentOrDownloaded, FetchTrieError>
@@ -1025,7 +1025,7 @@ where
     REv:
         From<FetcherRequest<TrieOrChunk>> + From<NetworkInfoRequest> + From<ContractRuntimeRequest>,
 {
-    let fetched_trie = fetch_trie(trie_key, ctx).await?;
+    let fetched_trie = fetch_trie_with_retries(trie_key, ctx).await?;
     match fetched_trie {
         TrieAlreadyPresentOrDownloaded::AlreadyPresent => Ok(ctx
             .effect_builder

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -362,7 +362,6 @@ where
 }
 
 /// Fetching should stop only when the network is connected and all retries have been exhausted.
-// TODO[RC]: Add unit test.
 fn should_stop_fetching(
     retry_count: &mut usize,
     has_connected_to_network: bool,
@@ -514,7 +513,12 @@ where
             total_attempts,
             retries_while_connected,
         }) => {
-            // TODO[RC]: Log error
+            warn!(
+                total_attempts,
+                ?id,
+                retries_while_connected,
+                "fetch retries exhausted"
+            );
             return Err(FetchTrieError::RetriesExhausted);
         }
         Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
@@ -558,7 +562,12 @@ where
                     total_attempts,
                     retries_while_connected,
                 }) => {
-                    // TODO[RC]: Log error
+                    warn!(
+                        total_attempts,
+                        ?id,
+                        retries_while_connected,
+                        "fetch retries exhausted"
+                    );
                     return Err(FetchTrieError::RetriesExhausted);
                 }
                 Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
@@ -1354,7 +1363,12 @@ where
                 total_attempts,
                 retries_while_connected,
             }) => {
-                // TODO[RC]: Log error
+                warn!(
+                    total_attempts,
+                    ?id,
+                    retries_while_connected,
+                    "fetch retries exhausted"
+                );
                 return Err(Error::RetriesExhausted);
             }
             Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
@@ -1527,7 +1541,12 @@ where
                 total_attempts,
                 retries_while_connected,
             }) => {
-                // TODO[RC]: Log error
+                warn!(
+                    total_attempts,
+                    ?id,
+                    retries_while_connected,
+                    "fetch retries exhausted"
+                );
                 return Err(FetchBlockHeadersBatchError::RetriesExhausted);
             }
             Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
@@ -2362,7 +2381,12 @@ where
                 total_attempts,
                 retries_while_connected,
             }) => {
-                // TODO[RC]: Log error
+                warn!(
+                    total_attempts,
+                    ?id,
+                    retries_while_connected,
+                    "fetch retries exhausted"
+                );
                 return Err(Error::RetriesExhausted);
             }
             Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -431,12 +431,13 @@ where
 
         let new_peer_list = get_peers(T::can_use_syncing_nodes(), ctx).await;
         if new_peer_list.is_empty() && total_attempts % 100 == 0 {
-            error!(
+            warn!(
                 total_attempts,
+                retry_count,
+                has_connected_to_network,
                 item_type = ?T::TAG,
                 ?id,
                 can_use_syncing_nodes = %T::can_use_syncing_nodes(),
-                has_connected_to_network,
                 "failed to attempt to fetch item due to no fully-connected peers"
             );
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -566,9 +566,9 @@ where
                         ?id,
                         "fetch retries exhausted"
                     );
-                    return Err(FetchTrieError::RetriesExhausted);
+                    Err(FetchTrieError::RetriesExhausted)
                 }
-                Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
+                Err(FetchWithRetryError::FetcherError(err)) => Err(err.into()),
             }
         })
         // Do not try to fetch all of the trie chunks at once; only fetch at most
@@ -645,9 +645,9 @@ where
                 ?id,
                 "fetch retries exhausted"
             );
-            return Err(Error::RetriesExhausted);
+            Err(Error::RetriesExhausted)
         }
-        Err(FetchWithRetryError::FetcherError(err)) => return Err(err.into()),
+        Err(FetchWithRetryError::FetcherError(err)) => Err(err.into()),
     }
 }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -448,7 +448,7 @@ async fn fetch_from_peers<REv, T>(
     ctx: &ChainSyncContext<'_, REv>,
 ) -> Option<Result<FetchedData<T>, FetchWithRetryError<T>>>
 where
-    T: Item + CanUseSyncingNodes + 'static,
+    T: Item + 'static,
     REv: From<FetcherRequest<T>> + From<NetworkInfoRequest>,
 {
     for peer in new_peer_list {

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -410,9 +410,10 @@ where
     let mut total_attempts = 0_usize;
     let mut retry_count = 0_usize;
     loop {
+        let has_connected_to_network = has_connected_to_network();
         if should_stop_fetching(
             &mut retry_count,
-            has_connected_to_network(),
+            has_connected_to_network,
             ctx.config.max_sync_fetch_attempts(),
         ) {
             return Err(FetchWithRetryError::RetriesExhausted {
@@ -429,6 +430,7 @@ where
                 item_type = ?T::TAG,
                 ?id,
                 can_use_syncing_nodes = %T::can_use_syncing_nodes(),
+                has_connected_to_network,
                 "failed to attempt to fetch item due to no fully-connected peers"
             );
         }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -381,12 +381,16 @@ fn should_stop_fetching(
     true
 }
 
+/// Possible errors caused by fetch operation that uses the retry mechanism.
 #[derive(Error, Debug)]
 pub(crate) enum FetchWithRetryError<T>
 where
     T: Item,
 {
-    #[error("Fetch retries exhausted for item with id {id:?}. Total attempts: {total_attempts}, retries while network was connected: {retries_while_connected}")]
+    #[error(
+        "Fetch retries exhausted for item with id {id:?}. Total attempts: {total_attempts}, \
+        retries while network was connected: {retries_while_connected}"
+    )]
     RetriesExhausted {
         id: T::Id,
         total_attempts: usize,
@@ -397,8 +401,10 @@ where
     FetcherError(#[from] FetcherError<T>),
 }
 
-/// Fetches an item. Not suited to fetching a block header or block by height, which require
-/// verification with finality signatures.
+/// Fetches an item.
+///
+/// Not suited to fetching a block header or block by height, which require verification with
+/// finality signatures.
 async fn fetch_with_retries<REv, T>(
     ctx: &ChainSyncContext<'_, REv>,
     id: T::Id,

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -2695,7 +2695,7 @@ mod tests {
         let has_connected_to_network = true;
         let max_sync_fetch_attempts = 2;
 
-        // Start fetching.
+        // 1st allowed try.
         assert!(!should_stop_fetching(
             &mut retry_count,
             has_connected_to_network,
@@ -2703,7 +2703,7 @@ mod tests {
         ));
         assert_eq!(retry_count, 1);
 
-        // Don't give up after the first time failed.
+        // 2nd allowed try.
         assert!(!should_stop_fetching(
             &mut retry_count,
             has_connected_to_network,
@@ -2711,7 +2711,7 @@ mod tests {
         ));
         assert_eq!(retry_count, 2);
 
-        // Second attempt failed as well, give up.
+        // 3rd call should return false, as "max_sync_fetch_attempts == 2".
         assert!(should_stop_fetching(
             &mut retry_count,
             has_connected_to_network,

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -31,8 +31,9 @@ pub struct NodeConfig {
     /// Maximum number of trie nodes to fetch in parallel.
     pub max_parallel_trie_fetches: u32,
 
-    /// The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
-    /// only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+    /// The maximum number of retries of fetch operations during the chain synchronization process.
+    /// The retry limit is in effect only when the network component reports that enough peers
+    /// are connected, until that happens, the retries are unbounded.
     pub max_sync_fetch_attempts: u32,
 
     /// The duration for which to pause between retry attempts while synchronising during joining.

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -10,6 +10,7 @@ const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 5000;
 /// Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
 const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 5000;
 const DEFAULT_MAX_PARALLEL_BLOCK_FETCHES: u32 = 50;
+const DEFAULT_MAX_SYNC_FETCH_ATTEMPTS: u32 = 5;
 const DEFAULT_PEER_REDEMPTION_INTERVAL: u32 = 10_000;
 const DEFAULT_RETRY_INTERVAL: &str = "100ms";
 
@@ -30,6 +31,10 @@ pub struct NodeConfig {
     /// Maximum number of trie nodes to fetch in parallel.
     pub max_parallel_trie_fetches: u32,
 
+    /// The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
+    /// only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+    pub max_sync_fetch_attempts: u32,
+
     /// The duration for which to pause between retry attempts while synchronising during joining.
     pub retry_interval: TimeDiff,
 
@@ -48,6 +53,7 @@ impl Default for NodeConfig {
             max_parallel_deploy_fetches: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES,
             max_parallel_block_fetches: DEFAULT_MAX_PARALLEL_BLOCK_FETCHES,
             max_parallel_trie_fetches: DEFAULT_MAX_PARALLEL_TRIE_FETCHES,
+            max_sync_fetch_attempts: DEFAULT_MAX_SYNC_FETCH_ATTEMPTS,
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
             sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -18,6 +18,10 @@ max_parallel_block_fetches = 50
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
+# only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+max_sync_fetch_attempts = 5
+
 # How often between sync attempts to redeem a bad node.
 sync_peer_redemption_interval = 0
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -20,7 +20,8 @@ retry_interval = '100ms'
 
 # The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
 # only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
-max_sync_fetch_attempts = 5
+# TODO: Temporarily set to a high value, because `has_connected_to_network()` is not implemented yet.
+max_sync_fetch_attempts = 5000
 
 # How often between sync attempts to redeem a bad node.
 sync_peer_redemption_interval = 0

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -18,6 +18,10 @@ max_parallel_block_fetches = 50
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
+# only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
+max_sync_fetch_attempts = 5
+
 # How often between sync attempts to redeem a bad node.
 sync_peer_redemption_interval = 0
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -20,7 +20,8 @@ retry_interval = '100ms'
 
 # The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
 # only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
-max_sync_fetch_attempts = 5
+# TODO: Temporarily set to a high value, because `has_connected_to_network()` is not implemented yet.
+max_sync_fetch_attempts = 5000
 
 # How often between sync attempts to redeem a bad node.
 sync_peer_redemption_interval = 0


### PR DESCRIPTION
This PR changes the following:

1. Adds `max_sync_fetch_attempts` to the node config
```rust
    /// The maximum number of retries of fetch operations during the chain synchronization process.
    /// The retry limit is in effect only when the network component reports that enough peers
    /// are connected, until that happens, the retries are unbounded.
    pub max_sync_fetch_attempts: u32,
```

2. Temporarily sets the above parameter to `5000` to allow enough retries for the nodes to synchronize; the value will be reduced once https://github.com/casper-network/casper-node/issues/3274 is implemented and used in https://github.com/casper-network/casper-node/issues/3275

3. Implements the retry limit to fetch operations (fetch forever if network is not connected, respect retry limit once the network is connected). Currently the network is assumed to be always connected.

4. If the node fails to sync to genesis due to fetch retry exhaustion, it quits
```
{"message":"fetch retries exhausted","total_attempts":2,"retries_while_connected":2,"id":"BlockHeadersBatchId { highest: 12, lowest: 0 }"}
{"message":"failed to download block headers batch","err":"RetriesExhausted"}
{"message":"handling event","event":"SyncResultToGenesisResult(Err(FetchHeadersBatch(RetriesExhausted)))"}
{"message":"sync to genesis failed due to fetch retries exhaustion; shutting down"}
```

Closes https://github.com/casper-network/casper-node/issues/3273

It also partially covers https://github.com/casper-network/casper-node/issues/3275. In particular, it **does not** unify the fetch operations and they are left as described here: https://github.com/casper-network/casper-node/issues/3275#issuecomment-1220763505