### PR TITLE
Move the creation of immediate switch blocks to the initializer reactor

### DIFF
--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -7,7 +7,7 @@ use casper_types::{EraId, ProtocolVersion, TimeDiff};
 
 use crate::{
     components::consensus::ChainspecConsensusExt,
-    types::{BlockHash, BlockHeader, Chainspec, NodeConfig},
+    types::{BlockHash, Chainspec, NodeConfig},
     SmallNetworkConfig,
 };
 
@@ -133,13 +133,6 @@ impl Config {
     /// Returns `ChainspecConsensusExt::earliest_switch_block_needed`.
     pub(super) fn earliest_switch_block_needed(&self, era_id: EraId) -> EraId {
         self.chainspec.earliest_switch_block_needed(era_id)
-    }
-
-    /// Returns `ProtocolConfig::is_last_block_before_activation`.
-    pub(super) fn is_last_block_before_activation(&self, block_header: &BlockHeader) -> bool {
-        self.chainspec
-            .protocol_config
-            .is_last_block_before_activation(block_header)
     }
 
     pub(super) fn chainspec(&self) -> Arc<Chainspec> {

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -47,6 +47,9 @@ pub(crate) enum Error {
     #[error("cannot get switch block for era: {era_id}")]
     NoSwitchBlockForEra { era_id: EraId },
 
+    #[error("no blocks have been found in storage (should have at least genesis switch block)")]
+    NoBlocksInStorage,
+
     #[error("switch block at height {height} for era {era_id} contains no validator weights")]
     MissingNextEraValidators { height: u64, era_id: EraId },
 

--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -47,7 +47,7 @@ pub(crate) enum Error {
         activation_point: EraId,
     },
 
-    #[error("no blocks have been found in storage (should have at least genesis switch block)")]
+    #[error("no blocks have been found in storage (should provide recent trusted hash)")]
     NoBlocksInStorage,
 
     #[error(

--- a/node/src/components/chain_synchronizer/event.rs
+++ b/node/src/components/chain_synchronizer/event.rs
@@ -4,10 +4,7 @@ use derive_more::From;
 use serde::Serialize;
 
 use super::Error;
-use crate::{
-    components::chainspec_loader::ImmediateSwitchBlockData, effect::requests::NodeStateRequest,
-    types::BlockHeader,
-};
+use crate::{effect::requests::NodeStateRequest, types::BlockHeader};
 
 #[derive(Debug, Serialize, From)]
 #[allow(clippy::enum_variant_names)]
@@ -15,8 +12,6 @@ pub(crate) enum Event {
     /// The result of running the fast sync task.
     FastSyncResult {
         result: Box<Result<BlockHeader, Error>>,
-        #[serde(skip_serializing)]
-        maybe_immediate_switch_block_data: Option<Box<ImmediateSwitchBlockData>>,
     },
     /// A request to provide the node state.
     #[from]
@@ -26,15 +21,8 @@ pub(crate) enum Event {
 impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Event::FastSyncResult {
-                result,
-                maybe_immediate_switch_block_data,
-            } => {
-                write!(
-                    formatter,
-                    "fast sync result: {:?}; immediate switch block data: {:?}",
-                    result, maybe_immediate_switch_block_data
-                )
+            Event::FastSyncResult { result } => {
+                write!(formatter, "fast sync result: {:?}", result)
             }
             Event::GetNodeState(_) => write!(formatter, "get node state"),
         }

--- a/node/src/components/chain_synchronizer/progress.rs
+++ b/node/src/components/chain_synchronizer/progress.rs
@@ -187,20 +187,6 @@ impl ProgressHolder {
         });
     }
 
-    pub(super) fn start_fetching_tries_for_upgrade(
-        &self,
-        block_height: u64,
-        state_root_hash: Digest,
-    ) {
-        let mut inner = self.get_inner_while_fast_syncing("fetching_tries_for_upgrade");
-        *inner = Progress::FastSync(FastSync::FetchingTries {
-            block_height,
-            state_root_hash,
-            reason: FetchingTriesReason::Upgrade,
-            num_tries_to_fetch: 0,
-        });
-    }
-
     pub(super) fn start_fetching_block_and_deploys_to_execute(&self, block_height: u64) {
         let mut inner = self.get_inner_while_fast_syncing("fetching_block_and_deploys_to_execute");
         *inner = Progress::FastSync(FastSync::FetchingBlockAndDeploysToExecute(block_height));

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -321,7 +321,7 @@ impl ChainspecLoader {
             {
                 // This is a valid run immediately after upgrading the node version, we'll need to
                 // create an immediate switch block.
-                trace!("valid run immediately after upgrade");
+                info!("valid run immediately after upgrade");
                 let upgrade_config_result =
                     self.new_upgrade_config(&header, Arc::clone(&self.chainspec_raw_bytes));
                 async move {
@@ -351,7 +351,7 @@ impl ChainspecLoader {
                         .genesis_timestamp()
                         .unwrap()
                 {
-                    trace!("creating genesis immediate switch block");
+                    info!("creating genesis immediate switch block");
                     effect_builder
                         .commit_genesis(
                             Arc::clone(&self.chainspec),
@@ -359,14 +359,14 @@ impl ChainspecLoader {
                         )
                         .event(Event::CommitGenesisResult)
                 } else {
-                    trace!("started after genesis; not creating the switch block");
+                    info!("started after genesis; not creating the switch block");
                     self.reactor_exit = Some(ReactorExit::ProcessShouldContinue);
                     Effects::new()
                 }
             }
             _ => {
                 // We're neither at genesis nor right after an upgrade - proceed to fast sync
-                trace!("valid run ready to be passed to the joiner reactor");
+                info!("valid run ready to be passed to the joiner reactor");
                 self.reactor_exit = Some(ReactorExit::ProcessShouldContinue);
                 Effects::new()
             }

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -84,7 +84,7 @@ impl From<EraValidatorsRequest> for GetEraValidatorsRequest {
 }
 
 /// Effects from running step and the next era validators that are gathered when an era ends.
-#[derive(Debug, DataSize)]
+#[derive(Clone, Debug, DataSize)]
 pub struct StepEffectAndUpcomingEraValidators {
     /// Validator sets for all upcoming eras that have already been determined.
     pub upcoming_era_validators: BTreeMap<EraId, BTreeMap<PublicKey, U512>>,
@@ -94,7 +94,7 @@ pub struct StepEffectAndUpcomingEraValidators {
 
 /// A [`Block`] that was the result of execution in the `ContractRuntime` along with any execution
 /// effects it may have.
-#[derive(Debug, DataSize)]
+#[derive(Clone, Debug, DataSize)]
 pub struct BlockAndExecutionEffects {
     /// The [`Block`] the contract runtime executed.
     pub block: Box<Block>,

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -100,6 +100,7 @@ reactor!(Reactor {
         // This test contains no linear chain requests, so we panic if we receive any.
         NetworkRequest<Message> -> network;
         StorageRequest -> storage;
+        MarkBlockCompletedRequest -> storage;
         StateStoreRequest -> storage;
         FetcherRequest<Deploy> -> deploy_fetcher;
         TrieDemand -> !;

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -552,12 +552,9 @@ impl reactor::Reactor for Reactor {
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
         let effect_builder = EffectBuilder::new(event_queue);
-        let maybe_immediate_switch_block_data =
-            chainspec_loader.maybe_immediate_switch_block_data();
         let (chain_synchronizer, sync_effects) =
             ChainSynchronizer::<JoinerEvent>::new_for_fast_sync(
                 Arc::clone(chainspec_loader.chainspec()),
-                maybe_immediate_switch_block_data,
                 config.node.clone(),
                 config.network.clone(),
                 effect_builder,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -552,9 +552,12 @@ impl reactor::Reactor for Reactor {
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
         let effect_builder = EffectBuilder::new(event_queue);
+        let maybe_immediate_switch_block_data =
+            chainspec_loader.maybe_immediate_switch_block_data();
         let (chain_synchronizer, sync_effects) =
             ChainSynchronizer::<JoinerEvent>::new_for_fast_sync(
                 Arc::clone(chainspec_loader.chainspec()),
+                maybe_immediate_switch_block_data,
                 config.node.clone(),
                 config.network.clone(),
                 effect_builder,
@@ -1018,9 +1021,7 @@ impl reactor::Reactor for Reactor {
                 JoiningOutcome::ShouldExitForUpgrade => {
                     ReactorExit::ProcessShouldExit(ExitCode::Success)
                 }
-                JoiningOutcome::Synced { .. } | JoiningOutcome::RanUpgradeOrGenesis { .. } => {
-                    ReactorExit::ProcessShouldContinue
-                }
+                JoiningOutcome::Synced { .. } => ReactorExit::ProcessShouldContinue,
             })
     }
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -664,7 +664,6 @@ impl reactor::Reactor for Reactor {
             }
             JoiningOutcome::Synced {
                 highest_block_header,
-                maybe_immediate_switch_block_data,
             } => {
                 if let Some(ImmediateSwitchBlockData {
                     block_and_execution_effects:
@@ -674,7 +673,9 @@ impl reactor::Reactor for Reactor {
                             maybe_step_effect_and_upcoming_era_validators,
                         },
                     validators_to_sign_immediate_switch_block,
-                }) = maybe_immediate_switch_block_data.map(|data| *data)
+                }) = chainspec_loader
+                    .maybe_immediate_switch_block_data()
+                    .cloned()
                 {
                     // The outcome of joining in this case caused a new switch block to be created,
                     // so we need to emit the effects which would have been created by that

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -729,7 +729,8 @@ impl reactor::Reactor for Reactor {
                                     }
                                 };
 
-                            // We're responsible for signing the new block if we're in the provided list.
+                            // We're responsible for signing the new block if we're in the provided
+                            // list.
                             if validator_weights.contains_key(&public_key) {
                                 let signature = FinalitySignature::new(
                                     block_hash,

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -29,7 +29,7 @@ use crate::{
         block_proposer::{self, BlockProposer},
         block_validator::{self, BlockValidator},
         chain_synchronizer::{self, ChainSynchronizer, JoiningOutcome},
-        chainspec_loader::{self, ChainspecLoader},
+        chainspec_loader::{self, ChainspecLoader, ImmediateSwitchBlockData},
         consensus::{self, EraSupervisor, HighwayProtocol},
         contract_runtime::{BlockAndExecutionEffects, ContractRuntime, ExecutionPreState},
         deploy_acceptor::{self, DeployAcceptor},
@@ -664,75 +664,77 @@ impl reactor::Reactor for Reactor {
             }
             JoiningOutcome::Synced {
                 highest_block_header,
-            } => highest_block_header,
-            JoiningOutcome::RanUpgradeOrGenesis {
-                block_and_execution_effects:
-                    BlockAndExecutionEffects {
-                        block,
-                        execution_results,
-                        maybe_step_effect_and_upcoming_era_validators,
-                    },
-                validators_to_sign_immediate_switch_block,
-                highest_block_header,
+                maybe_immediate_switch_block_data,
             } => {
-                // The outcome of joining in this case caused a new switch block to be created, so
-                // we need to emit the effects which would have been created by that execution, but
-                // add them to the participating reactor's event queues so they don't get dropped as
-                // the joining reactor shuts down.
-                effects.extend(
-                    effect_builder
-                        .announce_new_linear_chain_block(block.clone(), execution_results)
-                        .ignore(),
-                );
-
-                let current_era_id = block.header().era_id();
-                if let Some(step_effect_and_upcoming_era_validators) =
-                    maybe_step_effect_and_upcoming_era_validators
+                if let Some(ImmediateSwitchBlockData {
+                    block_and_execution_effects:
+                        BlockAndExecutionEffects {
+                            block,
+                            execution_results,
+                            maybe_step_effect_and_upcoming_era_validators,
+                        },
+                    validators_to_sign_immediate_switch_block,
+                }) = maybe_immediate_switch_block_data.map(|data| *data)
                 {
+                    // The outcome of joining in this case caused a new switch block to be created,
+                    // so we need to emit the effects which would have been created by that
+                    // execution, but add them to the participating reactor's event queues so they
+                    // don't get dropped as the joining reactor shuts down.
                     effects.extend(
                         effect_builder
-                            .announce_commit_step_success(
-                                current_era_id,
-                                step_effect_and_upcoming_era_validators.step_execution_journal,
-                            )
+                            .announce_new_linear_chain_block(block.clone(), execution_results)
                             .ignore(),
                     );
-                    effects.extend(
-                        effect_builder
-                            .announce_upcoming_era_validators(
-                                current_era_id,
-                                step_effect_and_upcoming_era_validators.upcoming_era_validators,
-                            )
+
+                    let current_era_id = block.header().era_id();
+                    if let Some(step_effect_and_upcoming_era_validators) =
+                        maybe_step_effect_and_upcoming_era_validators
+                    {
+                        effects.extend(
+                            effect_builder
+                                .announce_commit_step_success(
+                                    current_era_id,
+                                    step_effect_and_upcoming_era_validators.step_execution_journal,
+                                )
+                                .ignore(),
+                        );
+                        effects.extend(
+                            effect_builder
+                                .announce_upcoming_era_validators(
+                                    current_era_id,
+                                    step_effect_and_upcoming_era_validators.upcoming_era_validators,
+                                )
+                                .ignore(),
+                        );
+                    }
+
+                    // We're responsible for signing the new block if we're in the provided list.
+                    if validators_to_sign_immediate_switch_block.contains(&our_public_key) {
+                        let signature = FinalitySignature::new(
+                            *block.hash(),
+                            current_era_id,
+                            &our_secret_key,
+                            our_public_key.clone(),
+                        );
+                        effects.extend(
+                            async move {
+                                effect_builder
+                                    .announce_created_finality_signature(signature.clone())
+                                    .await;
+                                // Allow a short period for peers to establish connections. This
+                                // delay can be removed once we move to a single reactor model.
+                                effect_builder
+                                    .set_timeout(DELAY_FOR_SIGNING_IMMEDIATE_SWITCH_BLOCK)
+                                    .await;
+                                let message = Message::FinalitySignature(Box::new(signature));
+                                effect_builder.broadcast_message(message).await
+                            }
                             .ignore(),
-                    );
+                        );
+                    }
                 }
 
-                // We're responsible for signing the new block if we're in the provided list.
-                if validators_to_sign_immediate_switch_block.contains(&our_public_key) {
-                    let signature = FinalitySignature::new(
-                        *block.hash(),
-                        current_era_id,
-                        &our_secret_key,
-                        our_public_key.clone(),
-                    );
-                    effects.extend(
-                        async move {
-                            effect_builder
-                                .announce_created_finality_signature(signature.clone())
-                                .await;
-                            // Allow a short period for peers to establish connections.  This delay
-                            // can be removed once we move to a single reactor model.
-                            effect_builder
-                                .set_timeout(DELAY_FOR_SIGNING_IMMEDIATE_SWITCH_BLOCK)
-                                .await;
-                            let message = Message::FinalitySignature(Box::new(signature));
-                            effect_builder.broadcast_message(message).await
-                        }
-                        .ignore(),
-                    );
-                }
-
-                highest_block_header
+                *highest_block_header
             }
         };
 

--- a/node/src/reactor/participating/tests.rs
+++ b/node/src/reactor/participating/tests.rs
@@ -103,8 +103,8 @@ impl TestChain {
         let delegators = vec![];
         chainspec.network_config.accounts_config = AccountsConfig::new(accounts, delegators);
 
-        // Make the genesis timestamp 45 seconds from now, to allow for all validators to start up.
-        let genesis_time = Timestamp::now() + 45000.into();
+        // Make the genesis timestamp 60 seconds from now, to allow for all validators to start up.
+        let genesis_time = Timestamp::now() + 60000.into();
         info!(
             "creating test chain configuration, genesis: {}",
             genesis_time

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -110,6 +110,11 @@ impl Chainspec {
         Digest::hash(&serialized_chainspec)
     }
 
+    /// Returns true if this chainspec has an activation_point specifying era ID 0.
+    pub(crate) fn is_genesis(&self) -> bool {
+        self.protocol_config.activation_point.is_genesis()
+    }
+
     /// Returns the protocol version of the chainspec.
     pub(crate) fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_config.version

--- a/node/src/types/chainspec/activation_point.rs
+++ b/node/src/types/chainspec/activation_point.rs
@@ -52,6 +52,14 @@ impl ActivationPoint {
             ActivationPoint::Genesis(timestamp) => Some(*timestamp),
         }
     }
+
+    /// Returns true if `self` is `Genesis`.
+    pub(crate) fn is_genesis(&self) -> bool {
+        match self {
+            ActivationPoint::EraId(_) => false,
+            ActivationPoint::Genesis(_) => true,
+        }
+    }
 }
 
 impl Display for ActivationPoint {


### PR DESCRIPTION
This PR moves the code creating and storing immediate switch blocks to `ChainspecLoader`, which does its work in the `initializer` reactor.

Closes #3212 