### PR TITLE
Network bootstrap completion indication

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -161,7 +161,7 @@ where
 
     /// An indicator whether or not the networking component considers itself bootstrapped.
     ///
-    /// Indented to be used by other components (which can request it) that rely on the state of
+    /// Intended to be used by other components (which can request it) that rely on the state of
     /// the network connectivity to make decisions.
     bootstrap_completed: bool,
 
@@ -910,7 +910,7 @@ where
             return;
         }
 
-        // Check if we have reached the critical of known nodes connected.
+        // Check if we have reached the critical number of known nodes connected.
         let known_nodes_target = (self.cfg.known_addresses.len() as f32
             * self
                 .cfg

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -930,7 +930,6 @@ where
                 actual = known_nodes_connected_count,
                 "networking bootstrap completed after known node connection threshold was met"
             );
-            return;
         }
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -393,6 +393,13 @@ where
                 .event(|_| Event::SweepOutgoing),
         );
 
+        // We set a limit on when to consider bootstrap complete, so start a timer for this.
+        effects.extend(
+            effect_builder
+                .set_timeout(component.cfg.bootstrap_threshold.timeout.into())
+                .event(|_| Event::BootstrapTimerElapsed),
+        );
+
         Ok((component, effects))
     }
 
@@ -1001,6 +1008,12 @@ where
 
             Event::OutgoingDropped { peer_id, peer_addr } => {
                 self.handle_outgoing_dropped(*peer_id, peer_addr)
+            }
+
+            Event::BootstrapTimerElapsed => {
+                self.bootstrap_completed = true;
+                info!("networking bootstrap completed per set timeout");
+                Effects::new()
             }
 
             Event::NetworkRequest { req } => {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -900,7 +900,7 @@ where
             .filter_map(|(node_id, cs)| cs.is_symmetric().then_some(*node_id))
             .collect();
 
-        if symmetric_connections.len() > self.cfg.bootstrap_threshold.connection_count as usize {
+        if symmetric_connections.len() >= self.cfg.bootstrap_threshold.connection_count as usize {
             self.bootstrap_completed = true;
             info!(
                 target = self.cfg.bootstrap_threshold.connection_count,
@@ -923,7 +923,7 @@ where
 
         let known_nodes_connected_count = known_nodes_connected.into_iter().count();
 
-        if known_nodes_connected_count > known_nodes_target {
+        if known_nodes_connected_count >= known_nodes_target {
             self.bootstrap_completed = true;
             info!(
                 target = known_nodes_target,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -911,12 +911,8 @@ where
         }
 
         // Check if we have reached the critical number of known nodes connected.
-        let known_nodes_target = (self.cfg.known_addresses.len() as f32
-            * self
-                .cfg
-                .bootstrap_thresholds
-                .known_address_connection_percentage)
-            .round() as usize;
+        let known_nodes_target = self.cfg.known_addresses.len() * 100
+            / self.cfg.bootstrap_thresholds.known_address_connection_perc as usize;
 
         let known_node_ids: HashSet<_> = self.known_node_ids.values().cloned().collect();
         let known_nodes_connected = symmetric_connections.intersection(&known_node_ids);

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -396,7 +396,7 @@ where
         // We set a limit on when to consider bootstrap complete, so start a timer for this.
         effects.extend(
             effect_builder
-                .set_timeout(component.cfg.bootstrap_threshold.timeout.into())
+                .set_timeout(component.cfg.bootstrap_thresholds.timeout.into())
                 .event(|_| Event::BootstrapTimerElapsed),
         );
 
@@ -900,10 +900,10 @@ where
             .filter_map(|(node_id, cs)| cs.is_symmetric().then_some(*node_id))
             .collect();
 
-        if symmetric_connections.len() >= self.cfg.bootstrap_threshold.connection_count as usize {
+        if symmetric_connections.len() >= self.cfg.bootstrap_thresholds.connection_count as usize {
             self.bootstrap_completed = true;
             info!(
-                target = self.cfg.bootstrap_threshold.connection_count,
+                target = self.cfg.bootstrap_thresholds.connection_count,
                 actual = symmetric_connections.len(),
                 "networking bootstrap completed after connection threshold was met"
             );
@@ -914,7 +914,7 @@ where
         let known_nodes_target = (self.cfg.known_addresses.len() as f32
             * self
                 .cfg
-                .bootstrap_threshold
+                .bootstrap_thresholds
                 .known_address_connection_percentage)
             .round() as usize;
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -161,8 +161,8 @@ where
 
     /// An indicator whether or not the networking component considers itself bootstrapped.
     ///
-    /// Indented to be used by other components (which can request it) that rely on the state of the
-    /// network connectivity to make decisions.
+    /// Indented to be used by other components (which can request it) that rely on the state of
+    /// the network connectivity to make decisions.
     bootstrap_completed: bool,
 
     /// Tracks nodes that have announced themselves as nodes that are syncing.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -157,6 +157,12 @@ where
     /// Tracks whether a connection is symmetric or not.
     connection_symmetries: HashMap<NodeId, ConnectionSymmetry>,
 
+    /// An indicator whether or not the networking component considers itself bootstrapped.
+    ///
+    /// Indented to be used by other components (which can request it) that rely on the state of the
+    /// network connectivity to make decisions.
+    bootstrap_completed: bool,
+
     /// Tracks nodes that have announced themselves as nodes that are syncing.
     syncing_nodes: HashSet<NodeId>,
 
@@ -346,6 +352,7 @@ where
             context,
             outgoing_manager,
             connection_symmetries: HashMap::new(),
+            bootstrap_completed: false,
             syncing_nodes: HashSet::new(),
             shutdown_sender: Some(server_shutdown_sender),
             close_incoming_sender: Some(close_incoming_sender),
@@ -1004,6 +1011,9 @@ where
                     symmetric_validator_peers.shuffle(rng);
 
                     responder.respond(symmetric_validator_peers).ignore()
+                }
+                NetworkInfoRequest::BootstrapState { responder } => {
+                    responder.respond(self.bootstrap_completed).ignore()
                 }
             },
             Event::PeerAddressReceived(gossiped_address) => {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1011,8 +1011,12 @@ where
             }
 
             Event::BootstrapTimerElapsed => {
-                self.bootstrap_completed = true;
-                info!("networking bootstrap completed per set timeout");
+                if !self.bootstrap_completed {
+                    self.bootstrap_completed = true;
+                    info!("networking bootstrap completed per set timeout");
+                } else {
+                    debug!("networking bootstrap timer ignored, already complete");
+                }
                 Effects::new()
             }
 

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -108,7 +108,7 @@ pub struct Config {
 }
 
 /// Thresholds for bootstrap completion.
-#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Clone, Copy, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BootstrapThresholds {
     /// Percentage of known addresses that, when fully established, trigger bootstrap completion.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -49,6 +49,17 @@ impl Default for Config {
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
             blocklist_retain_duration: TimeDiff::from_seconds(600),
+            bootstrap_threshold: Default::default(),
+        }
+    }
+}
+
+impl Default for BootstrapThreshold {
+    fn default() -> Self {
+        Self {
+            known_address_connection_percentage: 0.5,
+            connection_count: 20,
+            timeout: TimeDiff::from_seconds(60),
         }
     }
 }
@@ -92,6 +103,20 @@ pub struct Config {
     pub max_in_flight_demands: u32,
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
+    /// Thresholds that indicate when bootstrapping is considered complete.
+    pub bootstrap_threshold: BootstrapThreshold,
+}
+
+/// Thresholds for bootstrap completion.
+#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapThreshold {
+    /// Percentage of known addresses that, when fully established, trigger bootstrap completion.
+    pub known_address_connection_percentage: f32,
+    /// Number of symmetric connections that trigger bootstrap completion.
+    pub connection_count: u32,
+    /// Timeout that triggers finishing of the bootstrap process if neither condition is reached.
+    pub timeout: TimeDiff,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -49,12 +49,12 @@ impl Default for Config {
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
             blocklist_retain_duration: TimeDiff::from_seconds(600),
-            bootstrap_threshold: Default::default(),
+            bootstrap_thresholds: Default::default(),
         }
     }
 }
 
-impl Default for BootstrapThreshold {
+impl Default for BootstrapThresholds {
     fn default() -> Self {
         Self {
             known_address_connection_percentage: 0.5,
@@ -104,13 +104,13 @@ pub struct Config {
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
     /// Thresholds that indicate when bootstrapping is considered complete.
-    pub bootstrap_threshold: BootstrapThreshold,
+    pub bootstrap_thresholds: BootstrapThresholds,
 }
 
 /// Thresholds for bootstrap completion.
 #[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct BootstrapThreshold {
+pub struct BootstrapThresholds {
     /// Percentage of known addresses that, when fully established, trigger bootstrap completion.
     pub known_address_connection_percentage: f32,
     /// Number of symmetric connections that trigger bootstrap completion.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -57,7 +57,7 @@ impl Default for Config {
 impl Default for BootstrapThresholds {
     fn default() -> Self {
         Self {
-            known_address_connection_percentage: 0.5,
+            known_address_connection_perc: 50,
             connection_count: 20,
             timeout: TimeDiff::from_seconds(60),
         }
@@ -112,7 +112,7 @@ pub struct Config {
 #[serde(deny_unknown_fields)]
 pub struct BootstrapThresholds {
     /// Percentage of known addresses that, when fully established, trigger bootstrap completion.
-    pub known_address_connection_percentage: f32,
+    pub known_address_connection_perc: u8,
     /// Number of symmetric connections that trigger bootstrap completion.
     pub connection_count: u32,
     /// Timeout that triggers finishing of the bootstrap process if neither condition is reached.

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -67,6 +67,9 @@ pub(crate) enum Event<P> {
         peer_addr: SocketAddr,
     },
 
+    /// The bootstrapping timer elapsed.
+    BootstrapTimerElapsed,
+
     /// Incoming network request.
     #[from]
     NetworkRequest {
@@ -134,6 +137,9 @@ impl<P: Display> Display for Event<P> {
             }
             Event::OutgoingDropped { peer_id, peer_addr } => {
                 write!(f, "dropped outgoing {} {}", peer_id, peer_addr)
+            }
+            Event::BootstrapTimerElapsed => {
+                write!(f, "bootstrap timer elapsed")
             }
             Event::NetworkRequest { req } => write!(f, "request: {}", req),
             Event::NetworkInfoRequest { req } => write!(f, "request: {}", req),

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -580,6 +580,13 @@ where
             })
     }
 
+    /// Look up whether a given address is known and marked as unforgettable.
+    ///
+    /// Returns `None` if the address has not been learned (or was forgotten).
+    pub(crate) fn is_unforgettable(&self, addr: SocketAddr) -> Option<bool> {
+        self.outgoing.get(&addr).map(|o| o.is_unforgettable)
+    }
+
     /// Checks if an address is blocked.
     #[cfg(test)]
     pub(crate) fn is_blocked(&self, addr: SocketAddr) -> bool {

--- a/node/src/components/small_network/symmetry.rs
+++ b/node/src/components/small_network/symmetry.rs
@@ -199,6 +199,11 @@ impl ConnectionSymmetry {
             ConnectionSymmetry::OutgoingOnly { .. } | ConnectionSymmetry::Gone => None,
         }
     }
+
+    /// Checks whether the given `ConnectionSymmetric` is in the symmetric state.
+    pub(super) fn is_symmetric(&self) -> bool {
+        matches!(self, ConnectionSymmetry::Symmetric { .. })
+    }
 }
 
 #[cfg(test)]

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -778,6 +778,21 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets the networks current bootstrapping state.
+    ///
+    /// Returns `true` if the networking component considers the network to have moved past initial
+    /// delays connecting.
+    pub async fn get_networking_bootstrap_state(self) -> bool
+    where
+        REv: From<NetworkInfoRequest>,
+    {
+        self.make_request(
+            |responder| NetworkInfoRequest::BootstrapState { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Announces which deploys have expired.
     pub(crate) async fn announce_expired_deploys(self, hashes: Vec<DeployHash>)
     where

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -782,6 +782,7 @@ impl<REv> EffectBuilder<REv> {
     ///
     /// Returns `true` if the networking component considers the network to have moved past initial
     /// delays connecting.
+    #[allow(dead_code)] // TODO: Remove once this code is used in fast sync.
     pub async fn get_networking_bootstrap_state(self) -> bool
     where
         REv: From<NetworkInfoRequest>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -778,7 +778,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the networks current bootstrapping state.
+    /// Gets the network's current bootstrapping state.
     ///
     /// Returns `true` if the networking component considers the network to have moved past initial
     /// delays connecting.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -205,6 +205,11 @@ pub(crate) enum NetworkInfoRequest {
         /// Responder to be called with all connected non-syncing peers in random order.
         responder: Responder<Vec<NodeId>>,
     },
+    /// Get the current bootstrapping state of the network.
+    BootstrapState {
+        /// Responder to be called with the current networking bootstrap state.
+        responder: Responder<bool>,
+    },
 }
 
 impl Display for NetworkInfoRequest {
@@ -218,6 +223,9 @@ impl Display for NetworkInfoRequest {
             }
             NetworkInfoRequest::FullyConnectedNonSyncingPeers { responder: _ } => {
                 write!(formatter, "get fully connected non-syncing peers")
+            }
+            NetworkInfoRequest::BootstrapState { responder: _ } => {
+                write!(formatter, "get bootstrapping state")
             }
         }
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -206,11 +206,12 @@ trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
 
-# Threshold for when the networking considers itself sufficiently connected.
-#
-# Some processes will not begin (or fail) unless this threshold is reached.
-[network.bootstrap_threshold]
-# A percentage of known addresses has been reached.
+# Thresholds for considering bootstrapping to the network to be finished.
+# 
+# When any one of the conditions is met, bootstrapping is considered finished.
+# Some processes will not begin (or fail) until bootstrapping is finished.
+[network.bootstrap_thresholds]
+# Symmetric connections to the given percentage of known addresses have been established.
 known_address_connection_percentage = 0.5
 # A number of symmetric connections have been established.
 connection_count = 20

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -206,6 +206,16 @@ trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
 
+# Threshold for when the networking considers itself sufficiently connected.
+#
+# Some processes will not begin (or fail) unless this threshold is reached.
+[network.bootstrap_threshold]
+# A percentage of known addresses has been reached.
+known_address_connection_percentage = 0.5
+# A number of symmetric connections have been established.
+connection_count = 20
+# Unconditional timeout.
+timeout = '1min'
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -212,7 +212,7 @@ finalized_approvals_responses = 0
 # Some processes will not begin (or fail) until bootstrapping is finished.
 [network.bootstrap_thresholds]
 # Symmetric connections to the given percentage of known addresses have been established.
-known_address_connection_percentage = 0.5
+known_address_connection_perc = 50
 # A number of symmetric connections have been established.
 connection_count = 20
 # Unconditional timeout.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -211,7 +211,7 @@ finalized_approvals_responses = 0
 # Some processes will not begin (or fail) unless this threshold is reached.
 [network.bootstrap_thresholds]
 # A percentage of known addresses has been reached.
-known_address_connection_percentage = 0.5
+known_address_connection_perc = 50
 # A number of symmetric connections have been established.
 connection_count = 20
 # Unconditional timeout.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -206,6 +206,16 @@ trie_responses = 0
 finalized_approvals_requests = 1
 finalized_approvals_responses = 0
 
+# Threshold for when the networking considers itself sufficiently connected.
+#
+# Some processes will not begin (or fail) unless this threshold is reached.
+[network.bootstrap_threshold]
+# A percentage of known addresses has been reached.
+known_address_connection_percentage = 0.5
+# A number of symmetric connections have been established.
+connection_count = 20
+# Unconditional timeout.
+timeout = '1min'
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -209,7 +209,7 @@ finalized_approvals_responses = 0
 # Threshold for when the networking considers itself sufficiently connected.
 #
 # Some processes will not begin (or fail) unless this threshold is reached.
-[network.bootstrap_threshold]
+[network.bootstrap_thresholds]
 # A percentage of known addresses has been reached.
 known_address_connection_percentage = 0.5
 # A number of symmetric connections have been established.


### PR DESCRIPTION
Closes #3274.

Adds the following features to the networking component:

* A mapping of known addresses to the last seen `NodeId` seen when connecting to said known address is kept (`known_node_ids`).
* A variable `bootstrap_completed` is introduced, which tracks whether the network considers itself "started up". Once set, it can never be cleared.
* The state of `bootstrap_completed` can be queried through a request (`EffectBuilder::get_networking_bootstrap_state`), this is intended to be used with fast sync code.
* Three conditions are introduced, and checked in the networking component (see `update_bootstrapping_state`) to keep the bootstrapping state up to date.

No changelog entry, as this behavior is only visible (sans a log message) with fast sync, which is not present in earlier versions.
