### PR TITLE
Always consider highest stored block as trusted block.

### DIFF
--- a/node/src/components/chain_synchronizer/error.rs
+++ b/node/src/components/chain_synchronizer/error.rs
@@ -48,6 +48,16 @@ pub(crate) enum Error {
     },
 
     #[error(
+        "configured trusted block is different from the stored block at the same height \
+         configured block header: {config_header:?}, \
+         stored block header: {stored_header_at_same_height:?}"
+    )]
+    TrustedHeaderOnDifferentFork {
+        config_header: Box<BlockHeader>,
+        stored_header_at_same_height: Box<BlockHeader>,
+    },
+
+    #[error(
         "current version is {current_version}, but retrieved block header with future version: \
          {block_header_with_future_version:?}"
     )]

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -146,17 +146,29 @@ where
             trie_fetch_limit: Semaphore::new(config.max_parallel_trie_fetches()),
         };
 
-        let trusted_block_header = match config.trusted_hash() {
-            Some(trusted_hash) => {
-                *fetch_and_store_initial_trusted_block_header(&ctx, metrics, trusted_hash).await?
+        // The config may contain the hash of a block that is known to be on the correct chain. We
+        // Also assume that all blocks in storage are correct. Fast sync will use whichever is more
+        // recent as a trusted starting point.
+        let maybe_stored_header = effect_builder.get_highest_block_header_from_storage().await;
+        let maybe_config_header = if let Some(trusted_hash) = config.trusted_hash() {
+            Some(*fetch_and_store_initial_trusted_block_header(&ctx, metrics, trusted_hash).await?)
+        } else {
+            None
+        };
+        let trusted_block_header = match (maybe_config_header, maybe_stored_header) {
+            (Some(config_header), None) => config_header,
+            (None, Some(stored_header)) => stored_header,
+            (None, None) => {
+                debug!("no highest block header found in storage, no trusted header configured");
+                return Ok(None);
             }
-            None => match effect_builder.get_highest_block_header_from_storage().await {
-                Some(block_header) => block_header,
-                None => {
-                    debug!("no highest block header found in storage");
-                    return Ok(None);
+            (Some(config_header), Some(highest_header)) => {
+                if config_header.height() > highest_header.height() {
+                    config_header
+                } else {
+                    highest_header
                 }
-            },
+            }
         };
 
         if trusted_block_header.protocol_version() != config.protocol_version()

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -162,11 +162,16 @@ where
                 debug!("no highest block header found in storage, no trusted header configured");
                 return Ok(None);
             }
-            (Some(config_header), Some(highest_header)) => {
-                if config_header.height() > highest_header.height() {
+            (Some(config_header), Some(stored_header)) => {
+                if config_header.height() > stored_header.height() {
                     config_header
                 } else {
-                    highest_header
+                    info!(
+                        %config_header,
+                        %stored_header,
+                        "using stored block that is more recent than configured trusted hash"
+                    );
+                    stored_header
                 }
             }
         };

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -166,6 +166,19 @@ where
                 if config_header.height() > stored_header.height() {
                     config_header
                 } else {
+                    if let Some(stored_header_at_same_height) = effect_builder
+                        .get_block_header_at_height_from_storage(config_header.height(), false)
+                        .await
+                    {
+                        if stored_header_at_same_height != config_header {
+                            return Err(Error::TrustedHeaderOnDifferentFork {
+                                config_header: Box::new(config_header),
+                                stored_header_at_same_height: Box::new(
+                                    stored_header_at_same_height,
+                                ),
+                            });
+                        }
+                    }
                     info!(
                         %config_header,
                         %stored_header,


### PR DESCRIPTION
Even if a trusted hash is specified in the config file, fast sync will now use the highest block from storage as a starting point if that is more recent.

So e.g. a node that started originally with block 1000 as a trusted block, and was then restarted after block 2000, with the same config file, will now start syncing from block 2000 forward, not 1000, without loading the intermediate 1000 headers from storage first.

Closes #3288.