### PR TITLE
GH-3268: Add support for CA signed client certificates

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
 * Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
 * The network handshake now contains the hash of the chainspec used and will be successful only if they match.
+* Add an `identity` option to load existing network identity certificates signed by a CA.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 
 use casper_types::{ProtocolVersion, TimeDiff};
 use datasize::DataSize;
@@ -49,8 +50,22 @@ impl Default for Config {
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
             blocklist_retain_duration: TimeDiff::from_seconds(600),
+            identity: None,
         }
     }
+}
+
+/// Small network identity configuration.
+#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    /// Path to a signed certificate
+    pub tls_certificate: PathBuf,
+    /// Path to a secret key.
+    pub secret_key: PathBuf,
+    /// Path to a certificate authority certificate
+    pub ca_certificate: PathBuf,
 }
 
 /// Small network configuration.
@@ -92,6 +107,11 @@ pub struct Config {
     pub max_in_flight_demands: u32,
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
+    /// Small network identity configuration option.
+    ///
+    /// An identity will be automatically generated when starting up a node if this option is
+    /// unspecified.
+    pub identity: Option<IdentityConfig>,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::{
-    tls::ValidationError,
+    tls::{LoadCertError, ValidationError},
     utils::{LoadError, Loadable, ResolveAddressError},
 };
 
@@ -63,13 +63,26 @@ pub enum Error {
         #[source]
         ResolveAddressError,
     ),
-
     /// Instantiating metrics failed.
     #[error(transparent)]
     Metrics(
         #[serde(skip_serializing)]
         #[from]
         prometheus::Error,
+    ),
+    /// Failed to load a certificate.
+    #[error("failed to load a certificate: {0}")]
+    LoadCertificate(
+        #[serde(skip_serializing)]
+        #[from]
+        LoadCertError,
+    ),
+    /// Failed to validate a network CA certificate.
+    #[error("failed to validate a cert against network CA: {0:?}")]
+    CertValidationError(
+        #[serde(skip_serializing)]
+        #[source]
+        ValidationError,
     ),
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -206,7 +206,7 @@ where
     /// TLS certificate associated with this node's identity.
     pub(super) our_cert: Arc<TlsCert>,
     /// TLS certificate authority associated with this node's identity.
-    pub(super) our_ca: Option<Arc<X509>>,
+    pub(super) network_ca: Option<Arc<X509>>,
     /// Secret key associated with `our_cert`.
     pub(super) secret_key: Arc<PKey<Private>>,
     /// Weak reference to the networking metrics shared by all sender/receiver tasks.
@@ -235,7 +235,7 @@ where
 
 impl<REv> NetworkContext<REv> {
     pub(crate) fn validate_peer_cert(&self, peer_cert: X509) -> Result<TlsCert, ValidationError> {
-        match &self.our_ca {
+        match &self.network_ca {
             Some(ca_cert) => tls::validate_cert_with_authority(peer_cert, ca_cert),
             None => tls::validate_self_signed_cert(peer_cert),
         }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -185,7 +185,7 @@ impl Reactor for TestReactor {
         event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let small_network_identity = SmallNetworkIdentity::with_generated_certs()?;
         let (net, effects) = SmallNetwork::new(
             event_queue,
             cfg,

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -236,8 +236,8 @@ impl Reactor {
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 
-        let network_config = config.map_ref(|cfg| cfg.network.clone());
-        let small_network_identity = SmallNetworkIdentity::from_config(&network_config)?;
+        let network_config = config.map_ref(|config| config.network.clone());
+        let small_network_identity = SmallNetworkIdentity::from_config(network_config)?;
 
         let reactor = Reactor {
             config,

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -236,7 +236,8 @@ impl Reactor {
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let network_config = config.map_ref(|cfg| cfg.network.clone());
+        let small_network_identity = SmallNetworkIdentity::from_config(&network_config)?;
 
         let reactor = Reactor {
             config,

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -287,8 +287,6 @@ pub(crate) enum LoadSecretKeyError {
 
 pub(crate) fn load_secret_key<P: AsRef<Path>>(src: P) -> Result<PKey<Private>, LoadSecretKeyError> {
     let pem = read_file(src.as_ref()).map_err(LoadSecretKeyError::ReadFile)?;
-
-    // TODO: It might be that we need to call `PKey::private_key_from_pkcs8` instead.
     PKey::private_key_from_pem(&pem).map_err(LoadSecretKeyError::PrivateKeyFromPem)
 }
 

--- a/node/src/utils/external.rs
+++ b/node/src/utils/external.rs
@@ -142,7 +142,7 @@ impl Loadable for X509 {
             Err(LoadCertError::ReadFile(error)) => {
                 anyhow::Error::new(error).context("failed to load certificate")
             }
-            Err(LoadCertError::X509(error)) => {
+            Err(LoadCertError::X509CertFromPem(error)) => {
                 anyhow::Error::new(error).context("parsing certificate")
             }
         };

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -189,6 +189,15 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '1min'
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "local_node_cert.pem"
+# secret_key = "local_node.pem"
+# ca_certificate = "ca_cert.pem"
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -189,6 +189,15 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '10min'
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "node_cert.pem"
+# secret_key = "node.pem"
+# ca_certificate = "ca_cert.pem"
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #


### PR DESCRIPTION
Closes #3268

This commit introduces an option to load a node's identity from existing certificates signed by a CA authority. This is optional and is helpful for some private chains, where joining new nodes to an existing private network is a restricted process.

# Config

There is a new configuration option in `config.toml.`

```toml
[network.identity]
tls_certificate = "node_cert.pem"
secret_key = "node.pem"
ca_certificate = "ca_cert.pem"
```

The node will load the existing secret key, certificate, and CA cert at startup if specified.

When new peer nodes are connecting, the node process will validate peer client certificates against provided CA certificates and rejects those not signed by provided CA.

# Testing

Script that generates `ca_key.pem` `ca_cert.pem` and bunch of `local_node*.pem` certificates signed by CA

https://gist.github.com/mpapierski/bd80f7519f697daa0337e27f44d81b89

Connecting with a `openssl s_client` with client key signed by a different CA cert to a nctl network using shared ca_cert.pem:

```
2022-08-25T14:39:34.127048Z DEBUG init:incoming{; peer_addr=127.0.0.1:55958}: [casper_node::components::small_network small_network.rs:478] incoming connection failed early; err=TLS validation error of peer certificate: the certificate is not signed by provided certificate authority
```

Otherwise, a network reaches consensus if every node in the network is set up with shared CA with certificates signed by said CA.