### PR TITLE
Remove panic in trie when "No trie value at key" - supports fast-sync

### DIFF
--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -9,7 +9,7 @@ use std::{
     time::Instant,
 };
 
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 use casper_hashing::Digest;
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
@@ -96,11 +96,12 @@ where
                             current = next;
                         }
                         None => {
-                            panic!(
+                            warn!(
                                 "No trie value at key: {:?} (reading from key: {:?})",
                                 pointer.hash(),
                                 key
                             );
+                            return Ok(ReadResult::NotFound);
                         }
                     },
                     None => {
@@ -117,11 +118,12 @@ where
                             current = next;
                         }
                         None => {
-                            panic!(
+                            warn!(
                                 "No trie value at key: {:?} (reading from key: {:?})",
                                 pointer.hash(),
                                 key
                             );
+                            return Ok(ReadResult::NotFound);
                         }
                     }
                 } else {
@@ -192,11 +194,12 @@ where
                 let next = match store.get(txn, pointer.hash())? {
                     Some(next) => next,
                     None => {
-                        panic!(
-                            "No trie value at key: {:?} (reading from key: {:?})",
+                        warn!(
+                            "No trie value at key: {:?} (reading from path: {:?})",
                             pointer.hash(),
-                            key
+                            path
                         );
+                        return Ok(ReadResult::NotFound);
                     }
                 };
                 depth += 1;
@@ -216,11 +219,12 @@ where
                 let next = match store.get(txn, pointer.hash())? {
                     Some(next) => next,
                     None => {
-                        panic!(
-                            "No trie value at key: {:?} (reading from key: {:?})",
+                        warn!(
+                            "No trie value at key: {:?} (reading from path: {:?})",
                             pointer.hash(),
-                            key
+                            path
                         );
+                        return Ok(ReadResult::NotFound);
                     }
                 };
                 depth += affix.len();
@@ -453,11 +457,12 @@ where
                         acc.push((index, Trie::Node { pointer_block }))
                     }
                     None => {
-                        panic!(
+                        warn!(
                             "No trie value at key: {:?} (reading from path: {:?})",
                             pointer.hash(),
                             path
                         );
+                        return Ok(ReadResult::NotFound);
                     }
                 }
             }
@@ -477,11 +482,12 @@ where
                         acc.push((index, Trie::Extension { affix, pointer }))
                     }
                     None => {
-                        panic!(
+                        warn!(
                             "No trie value at key: {:?} (reading from path: {:?})",
                             pointer.hash(),
                             path
                         );
+                        return Ok(ReadResult::NotFound);
                     }
                 }
             }

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -414,7 +414,7 @@ fn scan<K, V, T, S, E>(
     store: &S,
     key_bytes: &[u8],
     root: &Trie<K, V>,
-) -> Result<TrieScan<K, V>, E>
+) -> Result<Option<TrieScan<K, V>>, E>
 where
     K: ToBytes + FromBytes + Clone,
     V: ToBytes + FromBytes + Clone,
@@ -432,7 +432,7 @@ where
     loop {
         match current {
             leaf @ Trie::Leaf { .. } => {
-                return Ok(TrieScan::new(leaf, acc));
+                return Ok(Some(TrieScan::new(leaf, acc)));
             }
             Trie::Node { pointer_block } => {
                 let index = {
@@ -447,7 +447,7 @@ where
                 let pointer = match maybe_pointer {
                     Some(pointer) => pointer,
                     None => {
-                        return Ok(TrieScan::new(Trie::Node { pointer_block }, acc));
+                        return Ok(Some(TrieScan::new(Trie::Node { pointer_block }, acc)));
                     }
                 };
                 match store.get(txn, pointer.hash())? {
@@ -462,14 +462,14 @@ where
                             pointer.hash(),
                             path
                         );
-                        return Ok(ReadResult::NotFound);
+                        return Ok(None);
                     }
                 }
             }
             Trie::Extension { affix, pointer } => {
                 let sub_path = &path[depth..depth + affix.len()];
                 if sub_path != affix.as_slice() {
-                    return Ok(TrieScan::new(Trie::Extension { affix, pointer }, acc));
+                    return Ok(Some(TrieScan::new(Trie::Extension { affix, pointer }, acc)));
                 }
                 match store.get(txn, pointer.hash())? {
                     Some(next) => {
@@ -487,7 +487,7 @@ where
                             pointer.hash(),
                             path
                         );
-                        return Ok(ReadResult::NotFound);
+                        return Ok(None);
                     }
                 }
             }
@@ -525,7 +525,10 @@ where
 
     let key_bytes = key_to_delete.to_bytes()?;
     let TrieScan { tip, mut parents } =
-        scan::<_, _, _, _, E>(correlation_id, txn, store, &key_bytes, &root_trie)?;
+        match scan::<_, _, _, _, E>(correlation_id, txn, store, &key_bytes, &root_trie)? {
+            Some(trie_scan) => trie_scan,
+            None => return Ok(DeleteResult::DoesNotExist),
+        };
 
     // Check that tip is a leaf
     match tip {
@@ -973,7 +976,13 @@ where
             };
             let path: Vec<u8> = key.to_bytes()?;
             let TrieScan { tip, parents } =
-                scan::<K, V, T, S, E>(correlation_id, txn, store, &path, &current_root)?;
+                match scan::<K, V, T, S, E>(correlation_id, txn, store, &path, &current_root)? {
+                    Some(trie_scan) => trie_scan,
+                    // If we are scanning the trie and it's not complete under the given root, then
+                    // in the context of a write we must consider this root to "not exist".
+                    // This can happen when a trie is being sync'd or is incomplete.
+                    None => return Ok(WriteResult::RootNotFound),
+                };
             let new_elements: Vec<(Digest, Trie<K, V>)> = match tip {
                 // If the "tip" is the same as the new leaf, then the leaf
                 // is already in the Trie.

--- a/execution_engine/src/storage/trie_store/operations/tests/scan.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/scan.rs
@@ -32,7 +32,8 @@ where
         store,
         key,
         &root,
-    )?;
+    )?
+    .expect("trie scan returned no leaf");
 
     for (index, parent) in parents.into_iter().rev() {
         let expected_tip_hash = {


### PR DESCRIPTION
Resolves #3293 

fast-sync can be in-progress while other requests come into the trie, and currently the trie can panic! when a PointerBlock has a pointer that has not been written yet. This PR removes the panic and instead:

1. logs with `warn!`
2. returns Ok(ReadResult::NotFound) for the offending trie.