### PR TITLE
Make `TrackingCopy` public

### DIFF
--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -4,7 +4,7 @@ pub mod execution;
 pub mod resolvers;
 pub mod runtime;
 pub mod runtime_context;
-pub(crate) mod tracking_copy;
+pub mod tracking_copy;
 
 pub use tracking_copy::{validate_balance_proof, validate_query_proof, ValidationError};
 

--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -12,17 +12,19 @@ use crate::{
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
+/// Higher-level operations on the state via a `TrackingCopy`.
 pub trait TrackingCopyExt<R> {
+    /// The type for the returned errors.
     type Error;
 
-    /// Gets the account at a given account address
+    /// Gets the account at a given account address.
     fn get_account(
         &mut self,
         correlation_id: CorrelationId,
         account_hash: AccountHash,
     ) -> Result<Account, Self::Error>;
 
-    /// Reads the account at a given account address
+    /// Reads the account at a given account address.
     fn read_account(
         &mut self,
         correlation_id: CorrelationId,
@@ -30,55 +32,56 @@ pub trait TrackingCopyExt<R> {
     ) -> Result<Account, Self::Error>;
 
     // TODO: make this a static method
-    /// Gets the purse balance key for a given purse id
+    /// Gets the purse balance key for a given purse id.
     fn get_purse_balance_key(
         &self,
         correlation_id: CorrelationId,
         purse_key: Key,
     ) -> Result<Key, Self::Error>;
 
-    /// Gets the balance at a given balance key
+    /// Gets the balance at a given balance key.
     fn get_purse_balance(
         &self,
         correlation_id: CorrelationId,
         balance_key: Key,
     ) -> Result<Motes, Self::Error>;
 
-    /// Gets the purse balance key for a given purse id and provides a Merkle proof
+    /// Gets the purse balance key for a given purse id and provides a Merkle proof.
     fn get_purse_balance_key_with_proof(
         &self,
         correlation_id: CorrelationId,
         purse_key: Key,
     ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error>;
 
-    /// Gets the balance at a given balance key and provides a Merkle proof
+    /// Gets the balance at a given balance key and provides a Merkle proof.
     fn get_purse_balance_with_proof(
         &self,
         correlation_id: CorrelationId,
         balance_key: Key,
     ) -> Result<(Motes, TrieMerkleProof<Key, StoredValue>), Self::Error>;
 
-    /// Gets a contract by Key
+    /// Gets a contract by Key.
     fn get_contract_wasm(
         &mut self,
         correlation_id: CorrelationId,
         contract_wasm_hash: ContractWasmHash,
     ) -> Result<ContractWasm, Self::Error>;
 
-    /// Gets a contract header by Key
+    /// Gets a contract header by Key.
     fn get_contract(
         &mut self,
         correlation_id: CorrelationId,
         contract_hash: ContractHash,
     ) -> Result<Contract, Self::Error>;
 
-    /// Gets a contract package by Key
+    /// Gets a contract package by Key.
     fn get_contract_package(
         &mut self,
         correlation_id: CorrelationId,
         contract_package_hash: ContractPackageHash,
     ) -> Result<ContractPackage, Self::Error>;
 
+    /// Gets the system contract registry.
     fn get_system_contracts(
         &mut self,
         correlation_id: CorrelationId,

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -1,3 +1,6 @@
+//! This module defines the `TrackingCopy` - a utility that caches operations on the state, so that
+//! the underlying state remains unmodified, but it can be interacted with as if the modifications
+//! were applied on it.
 mod byte_size;
 mod ext;
 pub(self) mod meter;
@@ -32,16 +35,24 @@ use crate::{
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
+/// Result of a query on a `TrackingCopy`.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum TrackingCopyQueryResult {
+    /// The query was successful.
     Success {
+        /// The value read from the state.
         value: StoredValue,
+        /// Merkle proofs for the value.
         proofs: Vec<TrieMerkleProof<Key, StoredValue>>,
     },
+    /// The value wasn't found.
     ValueNotFound(String),
+    /// A circular reference was found in the state while traversing it.
     CircularReference(String),
+    /// The query reached the depth limit.
     DepthLimit {
+        /// The depth reached.
         depth: u64,
     },
 }
@@ -199,26 +210,36 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
         self.reads_cached.get_refresh(key).map(|v| &*v)
     }
 
+    /// Gets the set of mutated keys in the cache by `KeyTag`.
     pub fn get_key_tag_muts_cached(&mut self, key_tag: &KeyTag) -> Option<&BTreeSet<Key>> {
         self.key_tag_muts_cached.get(key_tag)
     }
 
+    /// Gets the set of read keys in the cache by `KeyTag`.
     pub fn get_key_tag_reads_cached(&mut self, key_tag: &KeyTag) -> Option<&BTreeSet<Key>> {
         self.key_tag_reads_cached.get_refresh(key_tag).map(|v| &*v)
     }
 }
 
+/// An interface for the global state that caches all operations (reads and writes) instead of
+/// applying them directly to the state. This way the state remains unmodified, while the user can
+/// interact with it as if it was being modified in real time.
 pub struct TrackingCopy<R> {
     reader: R,
     cache: TrackingCopyCache<HeapSize>,
     journal: ExecutionJournal,
 }
 
+/// Result of executing an "add" operation on a value in the state.
 #[derive(Debug)]
 pub enum AddResult {
+    /// The operation was successful.
     Success,
+    /// The key was not found.
     KeyNotFound(Key),
+    /// There was a type mismatch between the stored value and the value being added.
     TypeMismatch(StoredValueTypeMismatch),
+    /// Serialization error.
     Serialization(bytesrepr::Error),
 }
 
@@ -236,7 +257,8 @@ impl From<CLValueError> for AddResult {
 }
 
 impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
-    pub(super) fn new(reader: R) -> TrackingCopy<R> {
+    /// Creates a new `TrackingCopy` using the `reader` as the interface to the state.
+    pub fn new(reader: R) -> TrackingCopy<R> {
         TrackingCopy {
             reader,
             cache: TrackingCopyCache::new(1024 * 16, HeapSize),
@@ -247,6 +269,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
+    /// Returns the `reader` used to access the state.
     pub fn reader(&self) -> &R {
         &self.reader
     }
@@ -263,7 +286,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// `TrackingCopy`. this means the current usage requires repeated
     /// forking, however we recognize this is sub-optimal and will revisit
     /// in the future.
-    pub(super) fn fork(&self) -> TrackingCopy<&TrackingCopy<R>> {
+    pub fn fork(&self) -> TrackingCopy<&TrackingCopy<R>> {
         TrackingCopy::new(self)
     }
 
@@ -283,7 +306,8 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn get_keys(
+    /// Gets the set of keys in the state whose tag is `key_tag`.
+    pub fn get_keys(
         &mut self,
         correlation_id: CorrelationId,
         key_tag: &KeyTag,
@@ -306,7 +330,8 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         Ok(ret)
     }
 
-    pub(super) fn read(
+    /// Reads the value stored under `key`.
+    pub fn read(
         &mut self,
         correlation_id: CorrelationId,
         key: &Key,
@@ -320,7 +345,9 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn write(&mut self, key: Key, value: StoredValue) {
+    /// Writes `value` under `key`. Note that the write is only cached, and the global state itself
+    /// remains unmodified.
+    pub fn write(&mut self, key: Key, value: StoredValue) {
         let normalized_key = key.normalize();
         self.cache.insert_write(normalized_key, value.clone());
         self.journal.push((normalized_key, Transform::Write(value)));
@@ -330,7 +357,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// Ok(Some(unit)) represents successful operation.
     /// Err(error) is reserved for unexpected errors when accessing global
     /// state.
-    pub(super) fn add(
+    pub fn add(
         &mut self,
         correlation_id: CorrelationId,
         key: Key,
@@ -402,11 +429,13 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn effect(&self) -> ExecutionEffect {
+    /// Returns the execution effects cached by this instance.
+    pub fn effect(&self) -> ExecutionEffect {
         ExecutionEffect::from(self.journal.clone())
     }
 
-    pub(super) fn execution_journal(&self) -> ExecutionJournal {
+    /// Returns the journal of operations executed on this instance.
+    pub fn execution_journal(&self) -> ExecutionJournal {
         self.journal.clone()
     }
 
@@ -417,7 +446,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// The intent is that `query()` is only used to satisfy `QueryRequest`s made to the server.
     /// Other EE internal use cases should call `read()` or `get()` in order to retrieve cached
     /// values.
-    pub(super) fn query(
+    pub fn query(
         &self,
         correlation_id: CorrelationId,
         config: &EngineConfig,


### PR DESCRIPTION
This fixes an oversight due to which the `TrackingCopy` was not a part of the public API of the Execution Engine.

Addresses a part of #3235 (but not all of it).