### PR TITLE
Merge 1.4.8 to dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "tempfile",
  "wabt",
  "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -2549,6 +2550,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -5314,6 +5321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5351,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "wast"
+version = "46.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 2.0.1
+
+### Security
+* Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
+
+
+
 ## 2.0.0 - 2022-05-11
 
 ### Changed

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Security
 * Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
-
+* Implement checks before preprocessing Wasm to avoid references to undeclared functions or globals.
 
 
 ## 2.0.0 - 2022-05-11

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Security
 * Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
 * Implement checks before preprocessing Wasm to avoid references to undeclared functions or globals.
+* Implement checks before preprocessing Wasm to avoid possibility to import internal host functions.
 
 
 ## 2.0.0 - 2022-05-11

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -70,6 +70,12 @@ enum WasmValidationError {
     /// Module tries to import a function that the host does not provide.
     #[error("module imports a non-existent function")]
     MissingHostFunction,
+    /// Opcode for a global access refers to a non-existing global
+    #[error("opcode for a global access refers to non-existing global index {index}")]
+    IncorrectGlobalOperation {
+        /// Provided index.
+        index: u32,
+    },
 }
 
 /// An error emitted by the Wasm preprocessor.
@@ -268,6 +274,8 @@ pub fn preprocess(
 ) -> Result<Module, PreprocessingError> {
     let module = deserialize(module_bytes)?;
 
+    ensure_valid_access(&module)?;
+
     if memory_section(&module).is_none() {
         // `pwasm_utils::externalize_mem` expects a non-empty memory section to exist in the module,
         // and panics otherwise.
@@ -290,6 +298,35 @@ pub fn preprocess(
     let module = stack_height::inject_limiter(module, wasm_config.max_stack_height)
         .map_err(|_| PreprocessingError::StackLimiter)?;
     Ok(module)
+}
+
+fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
+    let code_section = if let Some(type_section) = module.code_section() {
+        type_section
+    } else {
+        return Ok(());
+    };
+
+    let global_len = module
+        .global_section()
+        .map(|global_section| global_section.entries().len())
+        .unwrap_or(0);
+
+    for instr in code_section
+        .bodies()
+        .iter()
+        .flat_map(|body| body.code().elements())
+    {
+        match instr {
+            Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
+                if *idx as usize >= global_len =>
+            {
+                return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Returns a parity Module from the given bytes without making modifications or checking limits.

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -79,7 +79,7 @@ fn table_section(module: &mut Module) -> Option<&mut TableSection> {
 fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
     if let Some(sect) = table_section(&mut module) {
         for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
-            if i > 1 {
+            if i >= 1 {
                 return Err("the number of tables must be at most one");
             }
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 use super::wasm_config::WasmConfig;
 
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
+/// Name of the internal gas function injected by [`pwasm_utils::inject_gas_counter`].
+const INTERNAL_GAS_FUNCTION_NAME: &str = "gas";
+
 /// We only allow maximum of 4k function pointers in a table section.
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
 /// Maximum number of elements that can appear as immediate value to the br_table instruction.
@@ -19,7 +22,8 @@ pub const DEFAULT_MAX_PARAMETER_COUNT: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
-pub enum WasmValidationError {
+#[non_exhaustive]
+enum WasmValidationError {
     /// Initial table size outside allowed bounds.
     #[error("initial table size of {actual} exceeds allowed limit of {max}")]
     InitialTableSizeExceeded {
@@ -82,13 +86,17 @@ pub enum PreprocessingError {
     MissingMemorySection,
     /// The module is missing.
     MissingModule,
-    /// Wasm validation did not pass.
-    InvalidWasm(#[from] WasmValidationError),
 }
 
 impl From<elements::Error> for PreprocessingError {
     fn from(error: elements::Error) -> Self {
         PreprocessingError::Deserialize(error.to_string())
+    }
+}
+
+impl From<WasmValidationError> for PreprocessingError {
+    fn from(wasm_validation_error: WasmValidationError) -> Self {
+        Self::Deserialize(wasm_validation_error.to_string())
     }
 }
 
@@ -100,7 +108,6 @@ impl Display for PreprocessingError {
             PreprocessingError::StackLimiter => write!(f, "Stack limiter error"),
             PreprocessingError::MissingMemorySection => write!(f, "Memory section should exist"),
             PreprocessingError::MissingModule => write!(f, "Missing module"),
-            PreprocessingError::InvalidWasm(msg) => write!(f, "Invalid wasm: {msg}."),
         }
     }
 }
@@ -222,14 +229,6 @@ fn ensure_parameter_limit(module: &Module, limit: u32) -> Result<(), WasmValidat
     Ok(())
 }
 
-/// List of invalid wasm imports considered non-existing.
-const WASM_INVALID_IMPORTS: &[(&str, &str)] = &[
-    // Gas counter is currently considered an implementation detail.
-    //
-    // If a wasm module tries to import it will be rejected.
-    (DEFAULT_GAS_MODULE_NAME, "gas"),
-];
-
 /// Ensures that Wasm module has valid imports.
 fn ensure_valid_imports(module: &Module) -> Result<(), WasmValidationError> {
     let import_entries = module
@@ -237,14 +236,14 @@ fn ensure_valid_imports(module: &Module) -> Result<(), WasmValidationError> {
         .map(|is| is.entries())
         .unwrap_or(&[]);
 
+    // Gas counter is currently considered an implementation detail.
+    //
+    // If a wasm module tries to import it will be rejected.
+
     for import in import_entries {
-        if WASM_INVALID_IMPORTS
-            .iter()
-            .any(|(module, func_name)| (import.module(), import.field()) == (*module, *func_name))
+        if import.module() == DEFAULT_GAS_MODULE_NAME
+            && import.field() == INTERNAL_GAS_FUNCTION_NAME
         {
-            // Currently we're checking the imports against the list of invalid imports such as
-            // special "gas" function, but this should be extended to also check if the provided
-            // imports are on the list of host functions.
             return Err(WasmValidationError::MissingHostFunction);
         }
     }

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,10 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType, Type};
+use parity_wasm::elements::{
+    self, External, FunctionType, Instruction, Internal, MemorySection, Module, Section, TableType,
+    Type,
+};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -73,6 +76,18 @@ enum WasmValidationError {
     /// Opcode for a global access refers to a non-existing global
     #[error("opcode for a global access refers to non-existing global index {index}")]
     IncorrectGlobalOperation {
+        /// Provided index.
+        index: u32,
+    },
+    /// Missing function index.
+    #[error("missing function index {index}")]
+    MissingFunctionIndex {
+        /// Provided index.
+        index: u32,
+    },
+    /// Missing function type.
+    #[error("missing type index {index}")]
+    MissingFunctionType {
         /// Provided index.
         index: u32,
     },
@@ -301,31 +316,104 @@ pub fn preprocess(
 }
 
 fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
-    let code_section = if let Some(type_section) = module.code_section() {
-        type_section
-    } else {
-        return Ok(());
-    };
+    // Copy types from module as is.
+    let types: Vec<FunctionType> = module
+        .type_section()
+        .map(|ts| {
+            ts.types()
+                .iter()
+                .map(|&Type::Function(ref ty)| ty)
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
 
-    let global_len = module
-        .global_section()
-        .map(|global_section| global_section.entries().len())
-        .unwrap_or(0);
+    // Function space that contains indexes of imported functions from import section and indexes
+    // from function section.
+    //
+    // It is an indirection from the i-th element of the index space into a type section as created
+    // in the `types` variable above.
+    let mut func_type_indices = Vec::new();
 
-    for instr in code_section
-        .bodies()
-        .iter()
-        .flat_map(|body| body.code().elements())
-    {
-        match instr {
-            Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
-                if *idx as usize >= global_len =>
-            {
-                return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+    if let Some(import_section) = module.import_section() {
+        for import_entry in import_section.entries() {
+            if let External::Function(idx) = import_entry.external() {
+                func_type_indices.push((*idx, false));
             }
-            _ => {}
         }
     }
+
+    if let Some(function_section) = module.function_section() {
+        for function_entry in function_section.entries() {
+            let idx = function_entry.type_ref();
+            func_type_indices.push((idx, false));
+        }
+    }
+
+    if let Some(idx) = module.start_section() {
+        ensure_function_exists(&idx, &mut func_type_indices, &types)?;
+    }
+
+    if let Some(export_section) = module.export_section() {
+        for export_entry in export_section.entries() {
+            if let Internal::Function(idx) = export_entry.internal() {
+                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+            }
+        }
+    }
+
+    if let Some(code_section) = module.code_section() {
+        let global_len = module
+            .global_section()
+            .map(|global_section| global_section.entries().len())
+            .unwrap_or(0);
+
+        for instr in code_section
+            .bodies()
+            .iter()
+            .flat_map(|body| body.code().elements())
+        {
+            match instr {
+                Instruction::Call(idx) => {
+                    ensure_function_exists(idx, &mut func_type_indices, &types)?
+                }
+                Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
+                    if *idx as usize >= global_len =>
+                {
+                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(element_section) = module.elements_section() {
+        for element_segment in element_section.entries() {
+            for idx in element_segment.members() {
+                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensures a function exists in a types table.
+fn ensure_function_exists(
+    idx: &u32,
+    func_type_indices: &mut [(u32, bool)],
+    types: &[FunctionType],
+) -> Result<(), WasmValidationError> {
+    let (ty_idx, is_validated) = func_type_indices
+        .get_mut(*idx as usize)
+        .ok_or(WasmValidationError::MissingFunctionIndex { index: *idx })?;
+    if *is_validated {
+        return Ok(());
+    }
+    let _ty = types
+        .get(*ty_idx as usize)
+        .ok_or(WasmValidationError::MissingFunctionType { index: *ty_idx })?;
+    *is_validated = true;
     Ok(())
 }
 
@@ -337,7 +425,10 @@ pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
 #[cfg(test)]
 mod tests {
     use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
-    use parity_wasm::{builder, elements::Instructions};
+    use parity_wasm::{
+        builder,
+        elements::{CodeSection, Instructions},
+    };
 
     use super::*;
 
@@ -449,16 +540,37 @@ mod tests {
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
-            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
             "{:?}",
             error,
         );
     }
 
     #[test]
-    fn should_not_overflow_in_start_section() {
+    fn should_not_overflow_in_start_section_without_code_section() {
         let module = builder::module()
             .with_section(Section::Start(u32::MAX))
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_start_section_with_code() {
+        let module = builder::module()
+            .with_section(Section::Start(u32::MAX))
+            .with_section(Section::Code(CodeSection::with_bodies(Vec::new())))
             .memory()
             .build()
             .build();
@@ -466,7 +578,8 @@ mod tests {
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
-            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
             "{:?}",
             error,
         );

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,7 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, MemorySection, Module, Section, TableType};
+use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -10,6 +10,8 @@ use super::wasm_config::WasmConfig;
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
 /// We only allow maximum of 4k function pointers in a table section.
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
+/// Maximum number of elements that can appear as immediate value to the br_table instruction.
+pub const DEFAULT_BR_TABLE_MAX_SIZE: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -33,6 +35,14 @@ pub enum WasmValidationError {
     /// Number of the tables in a Wasm must be at most one.
     #[error("the number of tables must be at most one")]
     MoreThanOneTable,
+    /// Length of a br_table exceeded the maximum allowed size.
+    #[error("maximum br_table size exceeds allowed bounds (expected {max} but found {actual})")]
+    BrTableSizeExceeded {
+        /// Maximum allowed br_table length.
+        max: u32,
+        /// Actual size of the largest br_table in the code.
+        actual: usize,
+    },
 }
 
 /// An error emitted by the Wasm preprocessor.
@@ -128,6 +138,30 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
     Ok(module)
 }
 
+/// Ensure that any `br_table` instruction adheres to its immediate value limit.
+fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError> {
+    let code_section = if let Some(type_section) = module.code_section() {
+        type_section
+    } else {
+        return Ok(());
+    };
+    for instr in code_section
+        .bodies()
+        .iter()
+        .flat_map(|body| body.code().elements())
+    {
+        if let Instruction::BrTable(br_table_data) = instr {
+            if br_table_data.table.len() > DEFAULT_BR_TABLE_MAX_SIZE as usize {
+                return Err(WasmValidationError::BrTableSizeExceeded {
+                    max: DEFAULT_BR_TABLE_MAX_SIZE,
+                    actual: br_table_data.table.len(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Preprocesses Wasm bytes and returns a module.
 ///
 /// This process consists of a few steps:
@@ -152,6 +186,7 @@ pub fn preprocess(
     }
 
     let module = ensure_table_size_limit(module)?;
+    ensure_br_table_size_limit(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -336,6 +336,9 @@ pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
 
 #[cfg(test)]
 mod tests {
+    use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
+    use parity_wasm::{builder, elements::Instructions};
+
     use super::*;
 
     #[test]
@@ -354,5 +357,118 @@ mod tests {
             PreprocessingError::MissingMemorySection => (),
             error => panic!("expected MissingMemorySection, got {:?}", error),
         }
+    }
+
+    #[test]
+    fn should_not_overflow_in_export_section() {
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+            .build()
+            .build()
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .internal()
+            .func(u32::MAX)
+            .build()
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_element_section() {
+        const CALL_FN_IDX: u32 = 0;
+
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+            .build()
+            .build()
+            // Export above function
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .internal()
+            .func(CALL_FN_IDX)
+            .build()
+            .table()
+            .with_element(u32::MAX, vec![u32::MAX])
+            .build()
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_call_opcode() {
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![
+                Instruction::Call(u32::MAX),
+                Instruction::End,
+            ]))
+            .build()
+            .build()
+            // Export above function
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .build()
+            // .with_sections(vec![Section::Start(u32::MAX)])
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_start_section() {
+        let module = builder::module()
+            .with_section(Section::Start(u32::MAX))
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
     }
 }

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -124,7 +124,7 @@ fn memory_section(module: &Module) -> Option<&MemorySection> {
 /// normalized.
 ///
 /// If a maximum value is not specified it will be defaulted to 4k to prevent OOM.
-fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationError> {
+fn ensure_table_size_limit(mut module: Module, limit: u32) -> Result<Module, WasmValidationError> {
     if let Some(sect) = module.table_section_mut() {
         // Table section is optional and there can be at most one.
         if sect.entries().len() > 1 {
@@ -133,26 +133,25 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
 
         if let Some(table_entry) = sect.entries_mut().iter_mut().next() {
             let initial = table_entry.limits().initial();
-            if initial > DEFAULT_MAX_TABLE_SIZE {
+            if initial > limit {
                 return Err(WasmValidationError::InitialTableSizeExceeded {
-                    max: DEFAULT_MAX_TABLE_SIZE,
+                    max: limit,
                     actual: initial,
                 });
             }
 
             match table_entry.limits().maximum() {
-                Some(max) if max > DEFAULT_MAX_TABLE_SIZE => {
-                    return Err(WasmValidationError::MaxTableSizeExceeded {
-                        max: DEFAULT_MAX_TABLE_SIZE,
-                        actual: max,
-                    })
-                }
-                Some(_) => {
-                    // maximum within the limit
+                Some(max) => {
+                    if max > limit {
+                        return Err(WasmValidationError::MaxTableSizeExceeded {
+                            max: limit,
+                            actual: max,
+                        });
+                    }
                 }
                 None => {
                     // rewrite wasm and provide a maximum limit for a table section
-                    *table_entry = TableType::new(initial, Some(DEFAULT_MAX_TABLE_SIZE))
+                    *table_entry = TableType::new(initial, Some(limit))
                 }
             }
         }
@@ -167,21 +166,18 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
 /// the linear memory limit `memory_pages` applies to them.
 ///
 /// There is potential to
-fn ensure_global_variable_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_global_variable_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     if let Some(global_section) = module.global_section() {
         let actual = global_section.entries().len();
-        if actual > DEFAULT_MAX_GLOBALS as usize {
-            return Err(WasmValidationError::TooManyGlobals {
-                max: DEFAULT_MAX_GLOBALS,
-                actual,
-            });
+        if actual > limit as usize {
+            return Err(WasmValidationError::TooManyGlobals { max: limit, actual });
         }
     }
     Ok(())
 }
 
 /// Ensure that any `br_table` instruction adheres to its immediate value limit.
-fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_br_table_size_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     let code_section = if let Some(type_section) = module.code_section() {
         type_section
     } else {
@@ -193,9 +189,9 @@ fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError
         .flat_map(|body| body.code().elements())
     {
         if let Instruction::BrTable(br_table_data) = instr {
-            if br_table_data.table.len() > DEFAULT_BR_TABLE_MAX_SIZE as usize {
+            if br_table_data.table.len() > limit as usize {
                 return Err(WasmValidationError::BrTableSizeExceeded {
-                    max: DEFAULT_BR_TABLE_MAX_SIZE,
+                    max: limit,
                     actual: br_table_data.table.len(),
                 });
             }
@@ -212,7 +208,7 @@ fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError
 /// of parameters of this function. Because the stack height instrumentation itself is
 /// is not weight metered its costs must be static (via this limit) and included in
 /// the costs of the instructions that cause them (call, call_indirect).
-fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_parameter_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     let type_section = if let Some(type_section) = module.type_section() {
         type_section
     } else {
@@ -221,11 +217,8 @@ fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
 
     for Type::Function(func) in type_section.types() {
         let actual = func.params().len();
-        if actual > DEFAULT_MAX_PARAMETER_COUNT as usize {
-            return Err(WasmValidationError::TooManyParameters {
-                max: DEFAULT_MAX_PARAMETER_COUNT,
-                actual,
-            });
+        if actual > limit as usize {
+            return Err(WasmValidationError::TooManyParameters { max: limit, actual });
         }
     }
 
@@ -285,10 +278,10 @@ pub fn preprocess(
         return Err(PreprocessingError::MissingMemorySection);
     }
 
-    let module = ensure_table_size_limit(module)?;
-    ensure_br_table_size_limit(&module)?;
-    ensure_global_variable_limit(&module)?;
-    ensure_parameter_limit(&module)?;
+    let module = ensure_table_size_limit(module, DEFAULT_MAX_TABLE_SIZE)?;
+    ensure_br_table_size_limit(&module, DEFAULT_BR_TABLE_MAX_SIZE)?;
+    ensure_global_variable_limit(&module, DEFAULT_MAX_GLOBALS)?;
+    ensure_parameter_limit(&module, DEFAULT_MAX_PARAMETER_COUNT)?;
     ensure_valid_imports(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license = "Apache-2.0"
 
 [dependencies]
-casper-execution-engine = { version = "2.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "2.0.1", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
 humantime = "2"

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3"
 wabt = "0.10.0"
 wasmi = "0.8.0"
 regex = "1.5.4"
+wat = "1.0.47"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -17,12 +15,21 @@ use casper_execution_engine::{
         },
         execution::Error as ExecError,
     },
-    shared::wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+    shared::{
+        wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+        wasm_prep::DEFAULT_MAX_PARAMETER_COUNT,
+    },
 };
 use casper_types::{EraId, ProtocolVersion, RuntimeArgs};
 
-const I32_WASM_SIZE_BYTES: usize = 8;
-const ARITY_INTERPRETER_LIMIT: usize = wasmi::DEFAULT_CALL_STACK_LIMIT / I32_WASM_SIZE_BYTES;
+use crate::wasm_utils;
+
+// Previously this value was derived from `wasmi::DEFAULT_CALL_STACK_LIMIT` as we haven't a check
+// for argument count declared in wasm functions. We have very restrictive stack height which also
+// means the maximum allowed function count still fails at runtime inside the stack limiter.
+//
+// Max parameter count - 1 will exercise the height limiter while passing the preprocessing stage.
+const ARITY_INTERPRETER_LIMIT: usize = DEFAULT_MAX_PARAMETER_COUNT as usize - 1;
 const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 const I32_WAT_TYPE: &str = "i64";
 const NEW_WASM_STACK_HEIGHT: u32 = 16;
@@ -36,32 +43,6 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
     )
 });
 
-fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
-    let mut call_args = String::new();
-    for i in 0..arity {
-        write!(call_args, "({}.const {}) ", arg_type, i).unwrap();
-    }
-
-    let mut func_params = String::new();
-    for i in 0..arity {
-        write!(func_params, "(param $arg{} {}) ", i, arg_type).unwrap();
-    }
-
-    // This wasm module contains a function with a specified amount of arguments in it.
-    let wat = format!(
-        r#"(module
-        (func $call (call $func {call_args}) (return))
-        (func $func {func_params} (return))
-        (export "func" (func $func))
-        (export "call" (func $call))
-        (memory $memory 1)
-      )"#,
-        call_args = call_args,
-        func_params = func_params
-    );
-    wabt::wat2wasm(wat).expect("should parse wat")
-}
-
 fn initialize_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
@@ -74,7 +55,9 @@ fn should_verify_interpreter_stack_limit() {
     let mut builder = initialize_builder();
 
     // This runs out of the interpreter stack limit
-    let module_bytes = make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE);
+    let module_bytes = wasm_utils::make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE)
+        .expect("should make wasm bytes");
+
     let exec = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -105,7 +88,9 @@ fn should_observe_stack_height_limit() {
 
     // This runs out of the interpreter stack limit
     let exec_request_1 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -149,7 +134,9 @@ fn should_observe_stack_height_limit() {
     // An amount of args equal to the new limit fails because there's overhead of `fn call` that
     // adds 1 to the height.
     let exec_request_2 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -171,7 +158,9 @@ fn should_observe_stack_height_limit() {
 
     // But new limit minus one runs fine
     let exec_request_3 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -57,5 +57,6 @@ mod regression_20220222;
 mod regression_20220223;
 mod regression_20220224;
 mod regression_20220303;
+mod regression_20220727;
 pub(crate) mod test_utils;
 mod transforms_must_be_ordered;

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,0 +1,261 @@
+use std::fmt::Write;
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::{
+    core::{engine_state, execution},
+    shared::wasm_prep::PreprocessingError,
+};
+use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
+fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
+    let mut bounds = initial.to_string();
+    if let Some(max) = maximum {
+        bounds += " ";
+        bounds += &max.to_string();
+    }
+
+    let wat = format!(
+        r#"(module
+            (table (;0;) {} funcref)
+            (memory (;0;) 0)
+            (export "call" (func $call))
+            (func $call))
+            "#,
+        bounds
+    );
+    wabt::wat2wasm(wat).expect("should parse wat")
+}
+
+const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+
+#[ignore]
+#[test]
+fn should_not_oom() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let test_cases = vec![
+        OOM_INIT,
+        FAILURE_ONE_ABOVE_LIMIT,
+        FAILURE_MAX_ABOVE_LIMIT,
+        FAILURE_INIT_ABOVE_LIMIT,
+    ];
+
+    for (initial, maximum) in test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_failure().commit();
+
+        let error = builder.get_error().unwrap();
+
+        assert!(matches!(
+            error,
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(ref _msg))
+        ))
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_table_validation() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
+
+    for (initial, maximum) in passing_test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_success().commit();
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_elem_section() {
+    // more functions than elements - wasmi doesn't allocate
+    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    assert!(
+        matches!(
+            elem_does_not_fit_err,
+            Some(engine_state::Error::Exec(execution::Error::Interpreter(ref msg)))
+            if msg == "elements segment does not fit"
+        ),
+        "{:?}",
+        elem_does_not_fit_err
+    );
+
+    // wasmi assumes table size and function pointers are equal
+    assert!(matches!(
+        test_element_section(65536, Some(65536), 65536),
+        None
+    ));
+}
+
+fn test_element_section(
+    table_init: u32,
+    table_max: Option<u32>,
+    function_count: u32,
+) -> Option<engine_state::Error> {
+    // Ensures proper initialization of table elements for different number of function pointers
+    //
+    // This should ensure there's no hidden lazy allocation and initialization that might still
+    // overallocate memory, burn cpu cycles allocating etc.
+
+    // (module
+    //     (table 0 1 anyfunc)
+    //     (memory $0 1)
+    //     (export "memory" (memory $0))
+    //     (export "foo1" (func $foo1))
+    //     (export "foo2" (func $foo2))
+    //     (export "foo3" (func $foo3))
+    //     (export "main" (func $main))
+    //     (func $foo1 (; 0 ;)
+    //     )
+    //     (func $foo2 (; 1 ;)
+    //     )
+    //     (func $foo3 (; 2 ;)
+    //     )
+    //     (func $main (; 3 ;) (result i32)
+    //      (i32.const 0)
+    //     )
+    //     (elem (i32.const 0) $foo1 $foo2 $foo3)
+    // )
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let mut wat = String::new();
+
+    if let Some(max) = table_max {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} {max} anyfunc)"#
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} anyfunc)"#
+        )
+        .unwrap();
+    }
+
+    wat += "(memory $0 1)\n";
+    wat += r#"(export "memory" (memory $0))"#;
+    wat += "\n";
+    wat += r#"(export "call" (func $call))"#;
+    wat += "\n";
+    for i in 0..function_count {
+        writeln!(wat, r#"(export "foo{i}" (func $foo{i}))"#).unwrap();
+    }
+    for i in 0..function_count {
+        writeln!(wat, "(func $foo{i} (; 0 ;))").unwrap();
+    }
+    wat += "(func $call)\n";
+    wat += "\n";
+    wat += "(elem (i32.const 0) ";
+    for i in 0..function_count {
+        write!(wat, "$foo{i} ").unwrap();
+    }
+    wat += ")\n";
+    wat += ")";
+
+    let module_bytes = wabt::wat2wasm(wat).unwrap();
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).commit();
+
+    builder.get_error()
+}
+
+#[ignore]
+#[test]
+fn should_not_allow_more_than_one_table() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
+
+    let module = builder::module()
+        // table 1
+        .table()
+        .with_min(0)
+        .build()
+        // table 2
+        .table()
+        .with_min(1)
+        .build()
+        .function()
+        // A signature with 0 params and no return type
+        .signature()
+        .build()
+        .body()
+        // Generated instructions for our entrypoint
+        .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+        .build()
+        .build()
+        // Export above function
+        .export()
+        .field(DEFAULT_ENTRY_POINT_NAME)
+        .build()
+        // Memory section is mandatory
+        .memory()
+        .build()
+        .build();
+    let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).expect_failure().commit();
+
+    let error = builder.get_error().unwrap();
+
+    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
+    // than 1 table.
+    assert!(
+        matches!(
+            error,
+            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
+            if msg == "too many tables in index space: 2"
+        ),
+        "{:?}",
+        error
+    );
+}

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -6,7 +6,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::PreprocessingError,
+    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 use parity_wasm::{
@@ -34,11 +34,11 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 }
 
 const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
-const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
-const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE + 1, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(u32::MAX));
 const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
-const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
-const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(DEFAULT_MAX_TABLE_SIZE));
 
 #[ignore]
 #[test]
@@ -98,7 +98,7 @@ fn should_pass_table_validation() {
 #[test]
 fn should_pass_elem_section() {
     // more functions than elements - wasmi doesn't allocate
-    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    let elem_does_not_fit_err = test_element_section(0, None, DEFAULT_MAX_TABLE_SIZE);
     assert!(
         matches!(
             elem_does_not_fit_err,
@@ -111,7 +111,11 @@ fn should_pass_elem_section() {
 
     // wasmi assumes table size and function pointers are equal
     assert!(matches!(
-        test_element_section(65536, Some(65536), 65536),
+        test_element_section(
+            DEFAULT_MAX_TABLE_SIZE,
+            Some(DEFAULT_MAX_TABLE_SIZE),
+            DEFAULT_MAX_TABLE_SIZE
+        ),
         None
     ));
 }

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -11,7 +11,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
+    shared::wasm_prep::{PreprocessingError, WasmValidationError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 
@@ -252,13 +252,12 @@ fn should_not_allow_more_than_one_table() {
 
     let error = builder.get_error().unwrap();
 
-    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
-    // than 1 table.
     assert!(
         matches!(
             error,
-            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
-            if msg == "too many tables in index space: 2"
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(
+                WasmValidationError::MoreThanOneTable
+            ))
         ),
         "{:?}",
         error

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -512,7 +512,7 @@ fn should_verify_max_param_count() {
 
     let error = builder.get_error().expect("should have error");
 
-    // Here we pass the preprocess stage, but we wail at stack height limiter as we do have very
+    // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
     // restrictive default stack height.
     assert!(
         matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,5 +1,10 @@
 use std::fmt::Write;
 
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_RUN_GENESIS_REQUEST,
@@ -9,10 +14,6 @@ use casper_execution_engine::{
     shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
-use parity_wasm::{
-    builder,
-    elements::{Instruction, Instructions},
-};
 
 fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
     let mut bounds = initial.to_string();

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -7,7 +7,7 @@ use parity_wasm::{
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -58,7 +58,7 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 #[test]
 fn should_not_oom() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let test_cases = vec![
         OOM_INIT,
@@ -91,7 +91,7 @@ fn should_not_oom() {
 #[test]
 fn should_pass_table_validation() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
 
@@ -165,7 +165,7 @@ fn test_element_section(
     // )
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut wat = String::new();
 
@@ -222,7 +222,7 @@ fn test_element_section(
 #[test]
 fn should_not_allow_more_than_one_table() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
 
@@ -354,7 +354,7 @@ fn should_allow_large_br_table() {
         .expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -373,7 +373,7 @@ fn should_not_allow_large_br_table() {
         make_arbitrary_br_table(FAILING_BR_TABLE_SIZE).expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -445,7 +445,7 @@ fn should_allow_multiple_globals() {
         make_arbitrary_global(DEFAULT_MAX_GLOBALS as usize).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -464,7 +464,7 @@ fn should_not_allow_too_many_globals() {
         make_arbitrary_global(FAILING_GLOBALS_SIZE).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -496,7 +496,7 @@ fn should_verify_max_param_count() {
             .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -521,7 +521,7 @@ fn should_verify_max_param_count() {
         wasm_utils::make_n_arg_call_bytes(100, "i32").expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -540,7 +540,7 @@ fn should_not_allow_too_many_params() {
         .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -576,7 +576,7 @@ fn should_not_allow_to_import_gas_function() {
     .unwrap();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -710,7 +710,7 @@ fn should_not_set_non_existing_global_above_declared_range() {
 fn test_non_existing_global(module_wat: &str, index: u32) {
     let module_bytes = wat::parse_str(module_wat).unwrap();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,

--- a/execution_engine_testing/tests/src/wasm_utils.rs
+++ b/execution_engine_testing/tests/src/wasm_utils.rs
@@ -1,4 +1,6 @@
 //! Wasm helpers.
+use std::fmt::Write;
+
 use parity_wasm::builder;
 
 use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
@@ -22,4 +24,33 @@ pub fn do_nothing_bytes() -> Vec<u8> {
         .build()
         .build();
     parity_wasm::serialize(module).expect("should serialize")
+}
+
+/// Creates minimal session code that contains a function with arbitrary number of parameters.
+pub fn make_n_arg_call_bytes(
+    arity: usize,
+    arg_type: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut call_args = String::new();
+    for i in 0..arity {
+        write!(call_args, "({}.const {}) ", arg_type, i)?;
+    }
+
+    let mut func_params = String::new();
+    for i in 0..arity {
+        write!(func_params, "(param $arg{} {}) ", i, arg_type)?;
+    }
+
+    // This wasm module contains a function with a specified amount of arguments in it.
+    let wat = format!(
+        r#"(module
+        (func $call (call $func {call_args}) (return))
+        (func $func {func_params} (return))
+        (export "func" (func $func))
+        (export "call" (func $call))
+        (memory $memory 1)
+      )"#
+    );
+    let module_bytes = wabt::wat2wasm(wat)?;
+    Ok(module_bytes)
 }

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -85,6 +85,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.7
+
+### Changed
+* Update `casper-execution-engine` and three `openssl` crates to latest versions.
+
+
+
 ## 1.4.6
 
 ### Changed

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -85,6 +85,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.8
+
+### Changed
+* Update `casper-execution-engine`.
+
+
+
 ## 1.4.7
 
 ### Changed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.6" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,7 +20,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "2.0.0", path = "../execution_engine" }
+casper-execution-engine = { version = "2.0.1", path = "../execution_engine" }
 casper-hashing = { version = "1.4.3", path = "../hashing" }
 casper-json-rpc = { version = "0.1.0", path = "../json_rpc" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.8" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 6);
+    ProtocolVersion::from_parts(1, 4, 7);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 7);
+    ProtocolVersion::from_parts(1, 4, 8);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.6")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.8")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.6'
+version = '1.4.7'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.7'
+version = '1.4.8'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3861,7 +3861,7 @@
               "result": {
                 "name": "query_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.8",
                   "balance": "123456"
                 }
               }
@@ -4156,7 +4156,7 @@
               "result": {
                 "name": "info_get_chainspec_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.8",
                   "chainspec_bytes": {
                     "chainspec_bytes": "2a2a",
                     "maybe_genesis_accounts_bytes": null,

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3220,7 +3220,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.6"
+        "version": "1.4.7"
       },
       "methods": [
         {
@@ -3285,7 +3285,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -3343,7 +3343,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy": {
                     "approvals": [
                       {
@@ -3532,7 +3532,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3615,7 +3615,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3705,7 +3705,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3924,7 +3924,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3969,7 +3969,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -4103,7 +4103,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -4206,7 +4206,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -4324,7 +4324,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -4408,7 +4408,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -4478,7 +4478,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -4568,7 +4568,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4638,7 +4638,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4724,7 +4724,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3220,7 +3220,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.7"
+        "version": "1.4.8"
       },
       "methods": [
         {
@@ -3285,7 +3285,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -3343,7 +3343,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy": {
                     "approvals": [
                       {
@@ -3532,7 +3532,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3615,7 +3615,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3705,7 +3705,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3924,7 +3924,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3969,7 +3969,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -4103,7 +4103,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -4206,7 +4206,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -4324,7 +4324,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -4408,7 +4408,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -4478,7 +4478,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -4568,7 +4568,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4638,7 +4638,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4724,7 +4724,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "auction_state": {
                     "bids": [
                       {

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
+++ b/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
@@ -10,33 +10,33 @@ use casper_contract::contract_api::{runtime, storage};
 
 use casper_types::{
     runtime_args, ApiError, CLType, ContractHash, ContractVersion, EntryPoint, EntryPointAccess,
-    EntryPointType, EntryPoints, Parameter, RuntimeArgs,
+    EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs,
 };
 
-// This is making use of the undocumented "FFI" function `gas()` which is used by the Wasm
-// interpreter to charge gas for upcoming interpreted instructions.  For further info on this, see
-// https://docs.rs/pwasm-utils/0.12.0/pwasm_utils/fn.inject_gas_counter.html
-mod unsafe_ffi {
-    extern "C" {
-        pub fn gas(amount: i32);
-    }
-}
-
-fn safe_gas(amount: i32) {
-    unsafe { unsafe_ffi::gas(amount) }
-}
-
 const SUBCALL_NAME: &str = "add_gas";
+const DATA_KEY: &str = "data";
 const ADD_GAS_FROM_SESSION: &str = "add-gas-from-session";
 const ADD_GAS_VIA_SUBCALL: &str = "add-gas-via-subcall";
 
 const ARG_GAS_AMOUNT: &str = "gas_amount";
 const ARG_METHOD_NAME: &str = "method_name";
 
+fn consume_gas(amount: i32) {
+    if amount > 0 {
+        let data = vec![0u8; amount as usize];
+        let data_uref = runtime::get_key(DATA_KEY)
+            .and_then(Key::into_uref)
+            .unwrap_or_else(|| storage::new_uref(()));
+
+        storage::write(data_uref, data);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn add_gas() {
     let amount: i32 = runtime::get_named_arg(ARG_GAS_AMOUNT);
-    safe_gas(amount);
+
+    consume_gas(amount);
 }
 
 fn store() -> (ContractHash, ContractVersion) {
@@ -63,7 +63,7 @@ pub extern "C" fn call() {
     let method_name: String = runtime::get_named_arg(ARG_METHOD_NAME);
 
     match method_name.as_str() {
-        ADD_GAS_FROM_SESSION => safe_gas(amount),
+        ADD_GAS_FROM_SESSION => consume_gas(amount),
         ADD_GAS_VIA_SUBCALL => {
             let (contract_hash, _contract_version) = store();
             runtime::call_contract(


### PR DESCRIPTION
This PR merges the 1.4.8 bugfix release into dev by cherry-picking relevant fixes from the history of the v1.4.8 release.

A complete history of v1.4.8 release as compared to dev: https://github.com/casper-network/casper-node/compare/dev...v1.4.8

Commits cherry-picked in order starting from `Clippy fixes with recent stable` (a369e37b6).

| Message | Git SHA on v1.4.8 | Cherry-picked |
| --- | --- | --- |
`(Merge #115, 2022-08-14)` | b94c4f79a | merge commit |
`(version bump casper-node and assembly script, 2022-08-12)` | 389dddc91 | 696206e999db6960e0d3613f03dfa6ebb62affc9 |
`(Merge pull request #114 from casper-network/regression-20220727-part2, 2022-08-12)` | 281061f22 | merge commit |
`(Add changelog and docs., 2022-08-12)` | 01999db7d | a301241ac91b80ffce47bcdb9f1de0136946cac5 |
`(Shuffle ensure_* functions in order, 2022-08-12)` | 3677f9d88 | 99bfdd9e9e8b53848c2ba3d3bd01bca076bdd43e |
`(Simplify checking algorithm, 2022-08-12)` | 6658738f3 | 5a7d1bd380123cba30a590ae8a656d97e122e244 |
`(Fix clippy issues., 2022-08-12)` | 0ee97fcab | empty commit |
`(Add checks to avoid panics in the gas accounting, 2022-08-11)` | 43402044a | 38818206c159efa828ecd59de8e847977f245772 |
`(Add regression tests for gas counter injector., 2022-08-11)` | e710b8e46 | 09f023a6765bd528cda9b20593eb7b54f8ec3012 |
`(Restrict access to non-declared globals., 2022-08-10)` | 794488154 | a2ca3dc1b177f24da420ee66e9c2dd915e54725e |
`(Regression tests for global set/get access., 2022-08-10)` | 843cf53a8 | 5432145d67cc20baf8b30d3083dcf403fa780823 |
`(Merge #113, 2022-08-03)` | 298dfaa3b | merge commit |
`(further updates required for version bumps, 2022-08-03)` | 9129165e2 | 5c07b4ec5506785652e4423a44aa0e76ddd0262f |
`(Bumping EE, casper-node and assembly script (to keep from erroring on publish)., 2022-08-02)` | 55a413d98 | 6823aa647a2de743a94dff2760590a2effdc1f32 |
`(Merge pull request #110 from casper-network/regression-20220727, 2022-08-02)` | 17a39d8ea |  |
`(Fix backwards compatibility, 2022-08-02)` | 476a2369d | 1ac4e8ce2d8d6d8e2c945a46c3f6c2a6d8633e47 |
`(Apply suggestions from code review, 2022-08-02)` | 7ae3f1db8 | 11c0f95b3b739dbc71c180cf3b569e3f08b978fa |
`(Rewrite for clarity as @goral09 suggested, 2022-08-01)` | 7b84dfa43 | 1de2f6284719f4303e24b7cb7fd40d0364d080ea |
`(Ensure internal gas function cannot be imported., 2022-07-29)` | 31fe6b3f3 | 822bea093d2bc8f72c354eaad99f466460e10964 |
`(Ensure functions max param size., 2022-07-29)` | ea0f05cbf | 8f2dff488b2521699762c1847b32a01277be1f39 |
`(Ensure module doesnt declare more than 256 globals, 2022-07-29)` | 20a667a10 | 496f5a8243fb3985d4ff8b00aae943603aab7073 |
`(Limit the size of a br_table to 256 elements., 2022-07-29)` | 3d519978a | 83023e15ba8f4362e7bcbfe5d0cd32cf20688389 |
`(Apply review comments, 2022-07-29)` | e562a5c2b | 5ec9af7d553442f2ca679c4cd211df5de144e5dc |
`(Apply review comments, 2022-07-28)` | 223d86154 | f064a36e38437e1b075042588ccf74c3f28b0e76 |
`(Lower the table size to 4k, 2022-07-28)` | 438f56ed9 | 66b3e9c5b91eac400bf70cfc153ac671b0ecb9ac |
`(Fix the issue by imposing a limit for table size., 2022-07-27)` | 7dc6dcbfe | bec2292201e89519ebd1301ed757adca836be811 |
`(Add regression test to trigger the issue., 2022-07-27)` | 1eafe744f | c31d448e66e6e35a07ac4773303d943b5ac4ecd8 |
`(Clippy fixes with recent stable, 2022-07-27)` | a369e37b6 | effectively empty commit |


