### PR TITLE
Fix handling of delegators in `global-state-update-gen`

### DIFF
--- a/utils/global-state-update-gen/README.md
+++ b/utils/global-state-update-gen/README.md
@@ -26,8 +26,18 @@ The config file should be a TOML file, which can contain the following values:
 # multiple [[accounts]] definitions are possible
 [[accounts]]
 public_key = "..." # the public key of the account owner
-stake = "..."      # the staked amount for this account, in motes (optional)
 balance = "..."    # account balance, in motes (optional)
+
+# if the account is supposed to be validator, define the section below
+[accounts.validator]
+bonded_amount = "..."      # the staked amount for this account, in motes
+delegation_rate = ...      # the delegation rate for this validator (optional)
+
+# define delegators as entries in accounts.validator.delegators
+# multiple definitions per validator are possible
+[[accounts.validator.delegators]]
+public_key = "..."         # the delegator's public key
+delegated_amount = "..."   # the amount delegated to the validator, in motes
 
 # multiple [[transfers]] definitions are possible
 [[transfers]]
@@ -42,7 +52,7 @@ The `[[accounts]]` definitions control the balances and stakes of accounts on th
 
 For every such definition, if the `balance` key is present, the balance of the account will be updated. The account will be created if it didn't exist previously. If the `balance` key is not present, the pre-existing balance (if any) will be left untouched.
 
-Updating the stakes behaves differently based on the value of `only_listed_validators`. If it is false, the existing list of validators is treated as a base, and stakes are modified based on the entries in the config. If the `stake` key is present, the stake is set to the configured value. If it is not present, the pre-existing stake is left untouched.
+Updating the validator properties (stake, delegators) behaves differently based on the value of `only_listed_validators`. If it is false, the existing list of validators is treated as a base, and validator properties are modified based on the entries in the config. If the `validator` key is present, the stake and delegators are set to the configured values. If it is not present, the pre-existing properties are left untouched.
 
 If `only_listed_validators` is true, pre-existing validators are discarded, and only the accounts with non-zero stakes configured in the config file will be validators after the update. This option exists to match the behavior of the legacy `validators` subcommand and to cater to some use cases in testing.
 
@@ -78,8 +88,10 @@ Every `-v` instance configures a single validator to be included in the set afte
 ```toml
 [[accounts]]
 public_key = "KEY"
-stake = "STAKE"
 balance = "BALANCE"
+
+[accounts.validator]
+bonded_amount = "STAKE"
 ```
 
 The command as a whole works just like a config file with only `[[accounts]]` entries and `only_listed_validators` set to `true`.

--- a/utils/global-state-update-gen/src/balances.rs
+++ b/utils/global-state-update-gen/src/balances.rs
@@ -27,6 +27,7 @@ pub(crate) fn generate_balances_update(matches: &ArgMatches<'_>) {
             amount,
         }],
         only_listed_validators: false,
+        slash_instead_of_unbonding: false,
     };
 
     let builder = LmdbWasmTestBuilder::open_raw(data_dir, Default::default(), state_hash);

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -255,7 +255,7 @@ pub fn add_and_remove_bids<T: StateReader>(
         validators_diff.removed.clone()
     };
 
-    for (pub_key, seigniorage_recipient) in new_snapshot.values().next().unwrap() {
+    for (pub_key, seigniorage_recipient) in new_snapshot.values().rev().next().unwrap() {
         create_or_update_bid(state, pub_key, seigniorage_recipient, slash);
     }
 

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -183,7 +183,7 @@ fn gen_snapshot_from_old(
             |public_key, recipient| match validators_map.get(public_key) {
                 // If the validator's stake is configured to be zero, we drop them from the
                 // snapshot.
-                Some(validator) if validator.bonded_amount == U512::zero() => false,
+                Some(validator) if validator.bonded_amount.is_zero() => false,
                 // Otherwise, we keep them, but modify the properties.
                 Some(validator) => {
                     *recipient = SeigniorageRecipient::new(

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -144,8 +144,8 @@ fn gen_snapshot_only_listed(
         };
         let seigniorage_recipient = SeigniorageRecipient::new(
             validator_cfg.bonded_amount,
-            validator_cfg.delegation_rate,
-            validator_cfg.delegators_map(),
+            validator_cfg.delegation_rate.unwrap_or_default(),
+            validator_cfg.delegators_map().unwrap_or_default(),
         );
         let _ = era_validators.insert(account.public_key.clone(), seigniorage_recipient);
     }
@@ -177,8 +177,12 @@ fn gen_snapshot_from_old(
             Some(validator) => {
                 *recipient = SeigniorageRecipient::new(
                     validator.bonded_amount,
-                    validator.delegation_rate,
-                    validator.delegators_map(),
+                    validator
+                        .delegation_rate
+                        .unwrap_or(*recipient.delegation_rate()),
+                    validator
+                        .delegators_map()
+                        .unwrap_or_else(|| recipient.delegator_stake().clone()),
                 );
                 true
             }

--- a/utils/global-state-update-gen/src/generic/config.rs
+++ b/utils/global-state-update-gen/src/generic/config.rs
@@ -31,16 +31,18 @@ pub struct AccountConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidatorConfig {
     pub bonded_amount: U512,
-    pub delegation_rate: u8,
-    pub delegators: Vec<DelegatorConfig>,
+    pub delegation_rate: Option<u8>,
+    pub delegators: Option<Vec<DelegatorConfig>>,
 }
 
 impl ValidatorConfig {
-    pub fn delegators_map(&self) -> BTreeMap<PublicKey, U512> {
-        self.delegators
-            .iter()
-            .map(|delegator| (delegator.public_key.clone(), delegator.delegated_amount))
-            .collect()
+    pub fn delegators_map(&self) -> Option<BTreeMap<PublicKey, U512>> {
+        self.delegators.as_ref().map(|delegators| {
+            delegators
+                .iter()
+                .map(|delegator| (delegator.public_key.clone(), delegator.delegated_amount))
+                .collect()
+        })
     }
 }
 

--- a/utils/global-state-update-gen/src/generic/config.rs
+++ b/utils/global-state-update-gen/src/generic/config.rs
@@ -1,6 +1,8 @@
-use casper_types::{account::AccountHash, PublicKey, U512};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+
+use casper_types::{account::AccountHash, PublicKey, U512};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -23,5 +25,27 @@ pub struct Transfer {
 pub struct AccountConfig {
     pub public_key: PublicKey,
     pub balance: Option<U512>,
-    pub stake: Option<U512>,
+    pub validator: Option<ValidatorConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorConfig {
+    pub bonded_amount: U512,
+    pub delegation_rate: u8,
+    pub delegators: Vec<DelegatorConfig>,
+}
+
+impl ValidatorConfig {
+    pub fn delegators_map(&self) -> BTreeMap<PublicKey, U512> {
+        self.delegators
+            .iter()
+            .map(|delegator| (delegator.public_key.clone(), delegator.delegated_amount))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegatorConfig {
+    pub public_key: PublicKey,
+    pub delegated_amount: U512,
 }

--- a/utils/global-state-update-gen/src/generic/config.rs
+++ b/utils/global-state-update-gen/src/generic/config.rs
@@ -28,7 +28,7 @@ pub struct AccountConfig {
     pub validator: Option<ValidatorConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ValidatorConfig {
     pub bonded_amount: U512,
     pub delegation_rate: Option<u8>,

--- a/utils/global-state-update-gen/src/generic/config.rs
+++ b/utils/global-state-update-gen/src/generic/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub accounts: Vec<AccountConfig>,
     #[serde(default)]
     pub only_listed_validators: bool,
+    #[serde(default)]
+    pub slash_instead_of_unbonding: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -241,7 +241,8 @@ impl<T: StateReader> StateTracker<T> {
             }
             //
             for (delegator_pub_key, delegator) in old_bid.delegators() {
-                // skip zeroing purses of delegators that will be handled later
+                // skip zeroing purses of delegators whose purses don't change - that will be
+                // handled later
                 if bid
                     .delegators()
                     .get(delegator_pub_key)
@@ -272,9 +273,9 @@ impl<T: StateReader> StateTracker<T> {
             }
         }
 
-        if slash || new_amount >= old_amount {
+        if slash || new_amount > old_amount {
             self.set_purse_balance(*bid.bonding_purse(), new_amount);
-        } else {
+        } else if new_amount < old_amount {
             self.create_unbonding_purse(
                 *bid.bonding_purse(),
                 &public_key,
@@ -286,9 +287,9 @@ impl<T: StateReader> StateTracker<T> {
         for (delegator_public_key, delegator) in bid.delegators() {
             let old_amount = self.get_purse_balance(*delegator.bonding_purse());
             let new_amount = *delegator.staked_amount();
-            if slash || new_amount >= old_amount {
+            if slash || new_amount > old_amount {
                 self.set_purse_balance(*delegator.bonding_purse(), *delegator.staked_amount());
-            } else {
+            } else if new_amount < old_amount {
                 self.create_unbonding_purse(
                     *delegator.bonding_purse(),
                     &public_key,

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -273,7 +273,7 @@ impl<T: StateReader> StateTracker<T> {
             }
         }
 
-        if slash || new_amount > old_amount {
+        if (slash && new_amount != old_amount) || new_amount > old_amount {
             self.set_purse_balance(*bid.bonding_purse(), new_amount);
         } else if new_amount < old_amount {
             self.create_unbonding_purse(
@@ -287,7 +287,7 @@ impl<T: StateReader> StateTracker<T> {
         for (delegator_public_key, delegator) in bid.delegators() {
             let old_amount = self.get_purse_balance(*delegator.bonding_purse());
             let new_amount = *delegator.staked_amount();
-            if slash || new_amount > old_amount {
+            if (slash && new_amount != old_amount) || new_amount > old_amount {
                 self.set_purse_balance(*delegator.bonding_purse(), *delegator.staked_amount());
             } else if new_amount < old_amount {
                 self.create_unbonding_purse(

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 
 use casper_types::{
     account::{Account, AccountHash},
-    system::auction::{Bid, Bids, SeigniorageRecipientsSnapshot},
+    system::auction::{Bid, Bids, SeigniorageRecipientsSnapshot, UnbondingPurse},
     AccessRights, CLValue, Key, PublicKey, StoredValue, URef, U512,
 };
 
@@ -21,6 +21,7 @@ pub struct StateTracker<T> {
     total_supply: U512,
     total_supply_key: Key,
     accounts_cache: BTreeMap<AccountHash, Account>,
+    unbonds_cache: BTreeMap<AccountHash, Vec<UnbondingPurse>>,
     purses_cache: BTreeMap<URef, U512>,
     bids_cache: Option<Bids>,
 }
@@ -44,6 +45,7 @@ impl<T: StateReader> StateTracker<T> {
             total_supply_key,
             total_supply: total_supply.into_t().expect("should be U512"),
             accounts_cache: BTreeMap::new(),
+            unbonds_cache: BTreeMap::new(),
             purses_cache: BTreeMap::new(),
             bids_cache: None,
         }
@@ -209,10 +211,14 @@ impl<T: StateReader> StateTracker<T> {
     }
 
     /// Sets the bid for the given account.
-    pub fn set_bid(&mut self, public_key: PublicKey, bid: Bid) {
+    pub fn set_bid(&mut self, public_key: PublicKey, bid: Bid, slash: bool) {
         let maybe_current_bid = self.get_bids().get(&public_key).cloned();
 
         let new_amount = *bid.staked_amount();
+        let old_amount = maybe_current_bid
+            .as_ref()
+            .map(|bid| self.get_purse_balance(*bid.bonding_purse()))
+            .unwrap_or_else(U512::zero);
 
         // we called `get_bids` above, so `bids_cache` will be `Some`
         self.bids_cache
@@ -227,11 +233,13 @@ impl<T: StateReader> StateTracker<T> {
 
         // Update the bonding purses - this will also take care of the total supply changes.
         if let Some(old_bid) = maybe_current_bid {
-            // only zero the bonding purse if the new one is different (just to save unnecessary
-            // writes)
+            // only zero the bonding purse and write the balance to the new purse if the new one is
+            // different (just to save unnecessary writes)
             if old_bid.bonding_purse() != bid.bonding_purse() {
                 self.set_purse_balance(*old_bid.bonding_purse(), U512::zero());
+                self.set_purse_balance(*bid.bonding_purse(), old_amount);
             }
+            //
             for (delegator_pub_key, delegator) in old_bid.delegators() {
                 // skip zeroing purses of delegators that will be handled later
                 if bid
@@ -242,13 +250,52 @@ impl<T: StateReader> StateTracker<T> {
                 {
                     continue;
                 }
-                self.set_purse_balance(*delegator.bonding_purse(), U512::zero());
+                // zero the old purse if we are going to transfer the funds to a new purse, or if
+                // we're supposed to slash the delegator
+                if slash || bid.delegators().contains_key(delegator_pub_key) {
+                    // if we're transferring funds to a new purse, set the new purse balance to the
+                    // old amount
+                    let old_amount = self.get_purse_balance(*delegator.bonding_purse());
+                    if let Some(new_delegator) = bid.delegators().get(delegator_pub_key) {
+                        self.set_purse_balance(*new_delegator.bonding_purse(), old_amount);
+                    }
+                    self.set_purse_balance(*delegator.bonding_purse(), U512::zero());
+                } else {
+                    let amount = self.get_purse_balance(*delegator.bonding_purse());
+                    self.create_unbonding_purse(
+                        *delegator.bonding_purse(),
+                        &public_key,
+                        delegator_pub_key,
+                        amount,
+                    );
+                }
             }
         }
 
-        self.set_purse_balance(*bid.bonding_purse(), new_amount);
-        for delegator in bid.delegators().values() {
-            self.set_purse_balance(*delegator.bonding_purse(), *delegator.staked_amount());
+        if slash || new_amount >= old_amount {
+            self.set_purse_balance(*bid.bonding_purse(), new_amount);
+        } else {
+            self.create_unbonding_purse(
+                *bid.bonding_purse(),
+                &public_key,
+                &public_key,
+                old_amount - new_amount,
+            );
+        }
+
+        for (delegator_public_key, delegator) in bid.delegators() {
+            let old_amount = self.get_purse_balance(*delegator.bonding_purse());
+            let new_amount = *delegator.staked_amount();
+            if slash || new_amount >= old_amount {
+                self.set_purse_balance(*delegator.bonding_purse(), *delegator.staked_amount());
+            } else {
+                self.create_unbonding_purse(
+                    *delegator.bonding_purse(),
+                    &public_key,
+                    delegator_public_key,
+                    old_amount - new_amount,
+                );
+            }
         }
     }
 
@@ -265,5 +312,45 @@ impl<T: StateReader> StateTracker<T> {
         {
             self.write_entry(key, value);
         }
+    }
+
+    pub fn create_unbonding_purse(
+        &mut self,
+        bonding_purse: URef,
+        validator_key: &PublicKey,
+        unbonder_key: &PublicKey,
+        amount: U512,
+    ) {
+        let account_hash = validator_key.to_account_hash();
+        let unbonding_era = self.read_snapshot().1.keys().next().copied().unwrap();
+        let unbonding_purses = match self.unbonds_cache.entry(account_hash) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let existing_purses = self
+                    .reader
+                    .query(Key::Unbond(account_hash))
+                    .and_then(|stored_val| stored_val.as_unbonding().cloned())
+                    .unwrap_or_default();
+                entry.insert(existing_purses)
+            }
+        };
+        // Take the first era from the snapshot as the unbonding era.
+        let new_purse = UnbondingPurse::new(
+            bonding_purse,
+            validator_key.clone(),
+            unbonder_key.clone(),
+            unbonding_era,
+            amount,
+            None,
+        );
+
+        // This doesn't actually transfer or create any funds - the funds will be transferred from
+        // the bonding purse to the unbonder's main purse later by the auction contract.
+        unbonding_purses.push(new_purse);
+        let unbonding_purses = unbonding_purses.clone();
+        self.write_entry(
+            Key::Unbond(account_hash),
+            StoredValue::Unbonding(unbonding_purses),
+        );
     }
 }

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -13,7 +13,7 @@ use casper_types::{
 };
 
 use super::{
-    config::{AccountConfig, Config, Transfer},
+    config::{AccountConfig, Config, Transfer, ValidatorConfig},
     get_update,
     state_reader::StateReader,
 };
@@ -275,8 +275,12 @@ fn should_change_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: Some(U512::from(104)),
             balance: Some(U512::from(100)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(104),
+                delegation_rate: 5,
+                delegators: vec![],
+            }),
         }],
         ..Default::default()
     };
@@ -348,8 +352,12 @@ fn should_change_only_stake_of_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: Some(U512::from(104)),
             balance: None,
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(104),
+                delegation_rate: 5,
+                delegators: vec![],
+            }),
         }],
         ..Default::default()
     };
@@ -411,8 +419,8 @@ fn should_change_only_balance_of_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: None,
             balance: Some(U512::from(100)),
+            validator: None,
         }],
         ..Default::default()
     };
@@ -460,8 +468,12 @@ fn should_replace_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator2.clone(),
-            stake: Some(U512::from(102)),
             balance: Some(U512::from(102)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(102),
+                delegation_rate: 5,
+                delegators: vec![],
+            }),
         }],
         only_listed_validators: true,
         ..Default::default()

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -278,8 +278,8 @@ fn should_change_one_validator() {
             balance: Some(U512::from(100)),
             validator: Some(ValidatorConfig {
                 bonded_amount: U512::from(104),
-                delegation_rate: 5,
-                delegators: vec![],
+                delegation_rate: None,
+                delegators: None,
             }),
         }],
         ..Default::default()
@@ -355,8 +355,8 @@ fn should_change_only_stake_of_one_validator() {
             balance: None,
             validator: Some(ValidatorConfig {
                 bonded_amount: U512::from(104),
-                delegation_rate: 5,
-                delegators: vec![],
+                delegation_rate: None,
+                delegators: None,
             }),
         }],
         ..Default::default()
@@ -471,8 +471,8 @@ fn should_replace_one_validator() {
             balance: Some(U512::from(102)),
             validator: Some(ValidatorConfig {
                 bonded_amount: U512::from(102),
-                delegation_rate: 5,
-                delegators: vec![],
+                delegation_rate: None,
+                delegators: None,
             }),
         }],
         only_listed_validators: true,

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -571,6 +571,7 @@ fn should_replace_one_validator() {
             }),
         }],
         only_listed_validators: true,
+        slash_instead_of_unbonding: true,
         ..Default::default()
     };
 
@@ -962,6 +963,7 @@ fn should_replace_a_delegator() {
             }),
         }],
         only_listed_validators: false,
+        slash_instead_of_unbonding: true,
         ..Default::default()
     };
 
@@ -1149,6 +1151,7 @@ fn should_remove_the_delegator() {
             }),
         }],
         only_listed_validators: false,
+        slash_instead_of_unbonding: true,
         ..Default::default()
     };
 

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -596,8 +596,7 @@ fn should_replace_one_validator_with_unbonding() {
             balance: Some(U512::from(102)),
             validator: Some(ValidatorConfig {
                 bonded_amount: U512::from(102),
-                delegation_rate: None,
-                delegators: None,
+                ..Default::default()
             }),
         }],
         only_listed_validators: true,

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -49,7 +49,9 @@ impl MockStateReader {
         let main_purse = URef::new(rng.gen(), AccessRights::READ_ADD_WRITE);
         let account = Account::create(account_hash, Default::default(), main_purse);
         self.purses.insert(main_purse.addr(), balance);
-        self.accounts.insert(account_hash, account);
+        // If `insert` returns `Some()`, it means we used the same account hash twice, which is
+        // a programmer error and the function will panic.
+        assert!(self.accounts.insert(account_hash, account).is_none());
         self.total_supply += balance;
         self
     }

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -1,0 +1,93 @@
+use std::collections::BTreeMap;
+
+use casper_types::{
+    account::{Account, AccountHash},
+    system::auction::Bid,
+    CLValue, Key, StoredValue, URef, U512,
+};
+
+#[cfg(test)]
+use super::state_reader::StateReader;
+
+use crate::utils::print_entry;
+
+pub(crate) struct Update {
+    entries: BTreeMap<Key, StoredValue>,
+}
+
+impl Update {
+    pub(crate) fn new(entries: BTreeMap<Key, StoredValue>) -> Self {
+        Self { entries }
+    }
+
+    pub(crate) fn print_entries(&self) {
+        for (key, value) in &self.entries {
+            print_entry(key, value);
+        }
+    }
+}
+
+#[cfg(test)]
+impl Update {
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn get_written_account(&self, account: AccountHash) -> Account {
+        self.entries
+            .get(&Key::Account(account))
+            .expect("account should exist")
+            .as_account()
+            .expect("should be an account")
+            .clone()
+    }
+
+    pub(crate) fn get_written_bid(&self, account: AccountHash) -> Bid {
+        self.entries
+            .get(&Key::Bid(account))
+            .expect("should create bid")
+            .as_bid()
+            .expect("should be bid")
+            .clone()
+    }
+
+    pub(crate) fn assert_written_balance(&self, purse: URef, balance: u64) {
+        assert_eq!(
+            self.entries.get(&Key::Balance(purse.addr())),
+            Some(&StoredValue::from(
+                CLValue::from_t(U512::from(balance)).expect("should convert U512 to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_total_supply<R: StateReader>(&self, reader: &mut R, supply: u64) {
+        assert_eq!(
+            self.entries.get(&reader.get_total_supply_key()),
+            Some(&StoredValue::from(
+                CLValue::from_t(U512::from(supply)).expect("should convert U512 to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_written_purse_is_unit(&self, purse: URef) {
+        assert_eq!(
+            self.entries.get(&Key::URef(purse)),
+            Some(&StoredValue::from(
+                CLValue::from_t(()).expect("should convert unit to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_seigniorage_recipients_written<R: StateReader>(&self, reader: &mut R) {
+        assert!(self
+            .entries
+            .contains_key(&reader.get_seigniorage_recipients_key()));
+    }
+
+    pub(crate) fn assert_written_bid(&self, account: AccountHash, bid: Bid) {
+        assert_eq!(
+            self.entries.get(&Key::Bid(account)),
+            Some(&StoredValue::from(bid))
+        );
+    }
+}

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
 
+#[cfg(test)]
 use casper_types::{
     account::{Account, AccountHash},
     system::auction::Bid,
-    CLValue, Key, StoredValue, URef, U512,
+    CLValue, URef, U512,
 };
+use casper_types::{Key, StoredValue};
 
 #[cfg(test)]
 use super::state_reader::StateReader;

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -1,12 +1,14 @@
 use std::collections::BTreeMap;
 
 #[cfg(test)]
+use casper_types::PublicKey;
+#[cfg(test)]
 use casper_types::{
     account::{Account, AccountHash},
     system::auction::Bid,
     CLValue, URef, U512,
 };
-use casper_types::{Key, PublicKey, StoredValue};
+use casper_types::{Key, StoredValue};
 
 #[cfg(test)]
 use super::state_reader::StateReader;
@@ -107,15 +109,12 @@ impl Update {
             .expect("should have unbonds for the account")
             .as_unbonding()
             .expect("should be unbonding purses");
-        assert!(unbonds
-            .iter()
-            .find(
-                |unbonding_purse| unbonding_purse.bonding_purse() == &bid_purse
-                    && unbonding_purse.validator_public_key() == validator_key
-                    && unbonding_purse.unbonder_public_key() == unbonder_key
-                    && unbonding_purse.amount() == &U512::from(amount)
-            )
-            .is_some())
+        assert!(unbonds.iter().any(
+            |unbonding_purse| unbonding_purse.bonding_purse() == &bid_purse
+                && unbonding_purse.validator_public_key() == validator_key
+                && unbonding_purse.unbonder_public_key() == unbonder_key
+                && unbonding_purse.amount() == &U512::from(amount)
+        ))
     }
 
     pub(crate) fn assert_key_absent(&self, key: &Key) {

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -43,8 +43,8 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
                     balance: maybe_new_balance,
                     validator: Some(ValidatorConfig {
                         bonded_amount: stake,
-                        delegation_rate: 5,
-                        delegators: vec![],
+                        delegation_rate: None,
+                        delegators: None,
                     }),
                 }
             })

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -5,7 +5,7 @@ use casper_types::{AsymmetricType, PublicKey, U512};
 
 use crate::{
     generic::{
-        config::{AccountConfig, Config},
+        config::{AccountConfig, Config, ValidatorConfig},
         update_from_config,
     },
     utils::hash_from_str,
@@ -40,8 +40,12 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
 
                 AccountConfig {
                     public_key,
-                    stake: Some(stake),
                     balance: maybe_new_balance,
+                    validator: Some(ValidatorConfig {
+                        bonded_amount: stake,
+                        delegation_rate: 5,
+                        delegators: vec![],
+                    }),
                 }
             })
             .collect(),

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -55,6 +55,7 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
         accounts,
         transfers: vec![],
         only_listed_validators: true,
+        slash_instead_of_unbonding: true, // for consistency with the old behavior
     };
 
     let builder = LmdbWasmTestBuilder::open_raw(data_dir, Default::default(), state_hash);


### PR DESCRIPTION
It is now possible to specify the delegators for new validators, and to leave delegators of old validators untouched.

The PR also fixes a couple of bugs, most notably that validators weren't being added in updates with `only_listed_validators = false`.

Closes #3213 
