### PR TITLE
[private chain] Backport 1.4.8 fixes and support for CA signed client certificates 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
 dependencies = [
  "brotli",
  "flate2",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -572,7 +572,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-serde",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "toml",
  "tower",
  "tracing",
@@ -2019,7 +2019,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -2165,14 +2165,14 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -2212,7 +2212,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2308,9 +2308,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jemalloc-ctl"
@@ -2404,9 +2404,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
@@ -2456,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2527,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -2596,25 +2596,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2694,15 +2683,6 @@ name = "new-named-uref"
 version = "0.1.0"
 dependencies = [
  "casper-contract",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2809,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -2834,18 +2814,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -2861,16 +2841,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2890,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.72"
+version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
  "autocfg",
  "cc",
@@ -3213,11 +3205,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3455,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque 0.8.1",
@@ -3467,14 +3459,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel 0.5.4",
  "crossbeam-deque 0.8.1",
  "crossbeam-utils 0.8.8",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -3497,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3517,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "regression-20210707"
@@ -3696,7 +3687,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3787,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safemem"
@@ -3808,12 +3799,12 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3878,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
@@ -3943,20 +3934,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21675ba6f9d97711cc00eee79d8dd7d0a31e571c350fb4d8a7c78f70c0e7b0e9"
+checksum = "fe196827aea34242c314d2f0dd49ed00a129225e80dda71b0dbf65d54d25628d"
 dependencies = [
  "serde",
 ]
@@ -3979,7 +3970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -4032,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4173,13 +4164,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4329,9 +4320,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.0"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f48b6d60512a392e34dbf7fd456249fd2de3c83669ab642e021903f4015185b"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",
@@ -4402,7 +4393,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -4420,9 +4411,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4434,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4464,7 +4455,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4528,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -4779,6 +4770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,9 +4798,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "untrusted"
@@ -4847,9 +4844,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check",
@@ -4978,7 +4975,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-service",
  "tracing",
 ]
@@ -5191,6 +5188,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "tempfile",
  "wabt",
  "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -2394,6 +2395,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -5073,6 +5080,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8905fd25fdadeb0e7e8bf43a9f46f9f972d6291ad0c7a32573b88dd13a6cfa6b"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5094,6 +5110,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "wast"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186c474c4f9bb92756b566d592a16591b4526b1a4841171caa3f31d7fe330d96"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d4bc4724b4f02a482c8cab053dac5ef26410f264c06ce914958f9a42813556"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,9 +2841,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2873,18 +2873,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.18.0+1.1.1n"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Security
 * Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
-
+* Implement checks before preprocessing Wasm to avoid references to undeclared functions or globals.
 
 
 ## 2.0.0

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 2.0.1
+
+### Security
+* Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
+
+
+
 ## 2.0.0
 
 ### Changed

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."

--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -19,7 +19,7 @@ use crate::{
 
 /// A target mode indicates if a native transfer's arguments will resolve to an existing purse, or
 /// will have to create a new account first.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TransferTargetMode {
     /// Unknown target mode.
     Unknown,
@@ -100,7 +100,7 @@ impl TryFrom<TransferArgs> for RuntimeArgs {
 ///
 /// Purpose of this builder is to resolve native tranfer args into [`TransferTargetMode`] and a
 /// [`TransferArgs`] instance to execute actual token transfer on the mint contract.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransferRuntimeArgsBuilder {
     inner: RuntimeArgs,
     transfer_target_mode: TransferTargetMode,

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/newtypes/mod.rs
+++ b/execution_engine/src/shared/newtypes/mod.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 /// A correlation id is a unique identifier which can be used to track the progress of a given
 /// execution engine operation.
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize)]
 pub struct CorrelationId(Uuid);
 
 impl CorrelationId {

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -131,6 +131,17 @@ impl Display for PreprocessingError {
     }
 }
 
+/// Ensures that all the references to functions and global variables in the wasm bytecode are
+/// properly declared.
+///
+/// This validates that:
+///
+/// - Start function points to a function declared in the Wasm bytecode
+/// - All exported functions are pointing to functions declared in the Wasm bytecode
+/// - `call` instructions reference a function declared in the Wasm bytecode.
+/// - `global.set`, `global.get` instructions are referencing an existing global declared in the
+///   Wasm bytecode.
+/// - All members of the "elem" section point at functions declared in the Wasm bytecode.
 fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
     let function_types_count = module
         .type_section()
@@ -208,6 +219,13 @@ fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
         }
     }
 
+    Ok(())
+}
+
+fn ensure_valid_function_index(index: u32, function_count: u32) -> Result<(), WasmValidationError> {
+    if index >= function_count {
+        return Err(WasmValidationError::MissingFunctionIndex { index });
+    }
     Ok(())
 }
 
@@ -391,13 +409,6 @@ pub fn preprocess(
     let module = stack_height::inject_limiter(module, wasm_config.max_stack_height)
         .map_err(|_| PreprocessingError::StackLimiter)?;
     Ok(module)
-}
-
-fn ensure_valid_function_index(index: u32, function_count: u32) -> Result<(), WasmValidationError> {
-    if index >= function_count {
-        return Err(WasmValidationError::MissingFunctionIndex { index });
-    }
-    Ok(())
 }
 
 /// Returns a parity Module from the given bytes without making modifications or checking limits.

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,7 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, MemorySection, Module, Section};
+use parity_wasm::elements::{self, MemorySection, Module, Section, TableSection, TableType};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -22,6 +22,8 @@ pub enum PreprocessingError {
     MissingMemorySection,
     /// The module is missing.
     MissingModule,
+    /// Wasm validation did not pass.
+    InvalidWasm(String),
 }
 
 impl From<elements::Error> for PreprocessingError {
@@ -37,7 +39,9 @@ impl Display for PreprocessingError {
             PreprocessingError::OperationForbiddenByGasRules => write!(f, "Encountered operation forbidden by gas rules. Consult instruction -> metering config map"),
             PreprocessingError::StackLimiter => write!(f, "Stack limiter error"),
             PreprocessingError::MissingMemorySection => write!(f, "Memory section should exist"),
-            PreprocessingError::MissingModule => write!(f, "Missing module")
+            PreprocessingError::MissingModule => write!(f, "Missing module"),
+            PreprocessingError::InvalidWasm(msg) => write!(f, "Invalid wasm: {msg}."),
+
         }
     }
 }
@@ -54,6 +58,51 @@ fn memory_section(module: &Module) -> Option<&MemorySection> {
         }
     }
     None
+}
+
+fn table_section(module: &mut Module) -> Option<&mut TableSection> {
+    for section in module.sections_mut() {
+        if let Section::Table(sect) = section {
+            return Some(sect);
+        }
+    }
+    None
+}
+
+/// Ensures (table) section has at most one table entry, and initial, and maximum values are
+/// normalized.
+///
+/// If a maximum value is not specified it will be defaulted to 65k to prevent OOM.
+fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
+    const TABLE_MAX: u32 = 65536;
+
+    if let Some(sect) = table_section(&mut module) {
+        for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
+            if i > 1 {
+                return Err("the number of tables must be at most one");
+            }
+
+            let initial = table_entry.limits().initial();
+            if initial > TABLE_MAX {
+                return Err("initial table size exceeds allowed bounds");
+            }
+
+            match table_entry.limits().maximum() {
+                Some(max) if max > TABLE_MAX => {
+                    return Err("maximum table size outside allowed bounds")
+                }
+                Some(_) => {
+                    // maximum within the limit
+                }
+                None => {
+                    // rewrite wasm and provide a maximum limit for a table section
+                    *table_entry = TableType::new(initial, Some(TABLE_MAX))
+                }
+            }
+        }
+    }
+
+    Ok(module)
 }
 
 /// Preprocesses Wasm bytes and returns a module.
@@ -78,6 +127,9 @@ pub fn preprocess(
         // and panics otherwise.
         return Err(PreprocessingError::MissingMemorySection);
     }
+
+    let module = validate_table_section(module)
+        .map_err(|error| PreprocessingError::InvalidWasm(error.to_owned()))?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -12,6 +12,8 @@ const DEFAULT_GAS_MODULE_NAME: &str = "env";
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
 /// Maximum number of elements that can appear as immediate value to the br_table instruction.
 pub const DEFAULT_BR_TABLE_MAX_SIZE: u32 = 256;
+/// Maximum number of global a module is allowed to declare.
+pub const DEFAULT_MAX_GLOBALS: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -41,6 +43,14 @@ pub enum WasmValidationError {
         /// Maximum allowed br_table length.
         max: u32,
         /// Actual size of the largest br_table in the code.
+        actual: usize,
+    },
+    /// Declares number of globals exceeds allowed size.
+    #[error("declared number of globals exceeds allowed size")]
+    TooManyGlobals {
+        /// Maximum allowed globals.
+        max: u32,
+        /// Actual number of globals declares in the Wasm.
         actual: usize,
     },
 }
@@ -137,6 +147,25 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
     Ok(module)
 }
 
+/// Ensures that module doesn't declare too many globals.
+///
+/// Globals are not limited through the `stack_height` as locals are. Neither does
+/// the linear memory limit `memory_pages` applies to them.
+///
+/// There is potential to
+fn ensure_global_variable_limit(module: &Module) -> Result<(), WasmValidationError> {
+    if let Some(global_section) = module.global_section() {
+        let actual = global_section.entries().len();
+        if actual > DEFAULT_MAX_GLOBALS as usize {
+            return Err(WasmValidationError::TooManyGlobals {
+                max: DEFAULT_MAX_GLOBALS,
+                actual,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Ensure that any `br_table` instruction adheres to its immediate value limit.
 fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError> {
     let code_section = if let Some(type_section) = module.code_section() {
@@ -186,6 +215,7 @@ pub fn preprocess(
 
     let module = ensure_table_size_limit(module)?;
     ensure_br_table_size_limit(&module)?;
+    ensure_global_variable_limit(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,7 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType};
+use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType, Type};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -14,6 +14,8 @@ pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
 pub const DEFAULT_BR_TABLE_MAX_SIZE: u32 = 256;
 /// Maximum number of global a module is allowed to declare.
 pub const DEFAULT_MAX_GLOBALS: u32 = 256;
+/// Maximum number of parameters a function can have.
+pub const DEFAULT_MAX_PARAMETER_COUNT: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -51,6 +53,14 @@ pub enum WasmValidationError {
         /// Maximum allowed globals.
         max: u32,
         /// Actual number of globals declares in the Wasm.
+        actual: usize,
+    },
+    /// Module declares a function type with too many parameters.
+    #[error("use of a function type with too many parameters (expected {max} but function declares {actual})")]
+    TooManyParameters {
+        /// Maximum allowed parameters.
+        max: u32,
+        /// Actual number of parameters a function has in the Wasm.
         actual: usize,
     },
 }
@@ -190,6 +200,33 @@ fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError
     Ok(())
 }
 
+/// Ensure maximum numbers of parameters a function can have.
+///
+/// Those need to be limited to prevent a potentially exploitable interaction with
+/// the stack height instrumentation: The costs of executing the stack height
+/// instrumentation for an indirectly called function scales linearly with the amount
+/// of parameters of this function. Because the stack height instrumentation itself is
+/// is not weight metered its costs must be static (via this limit) and included in
+/// the costs of the instructions that cause them (call, call_indirect).
+fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
+    let type_section = if let Some(type_section) = module.type_section() {
+        type_section
+    } else {
+        return Ok(());
+    };
+
+    for Type::Function(func) in type_section.types() {
+        let actual = func.params().len();
+        if actual > DEFAULT_MAX_PARAMETER_COUNT as usize {
+            return Err(WasmValidationError::TooManyParameters {
+                max: DEFAULT_MAX_PARAMETER_COUNT,
+                actual,
+            });
+        }
+    }
+
+    Ok(())
+}
 /// Preprocesses Wasm bytes and returns a module.
 ///
 /// This process consists of a few steps:
@@ -216,6 +253,7 @@ pub fn preprocess(
     let module = ensure_table_size_limit(module)?;
     ensure_br_table_size_limit(&module)?;
     ensure_global_variable_limit(&module)?;
+    ensure_parameter_limit(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -63,6 +63,9 @@ pub enum WasmValidationError {
         /// Actual number of parameters a function has in the Wasm.
         actual: usize,
     },
+    /// Module tries to import a function that the host does not provide.
+    #[error("module imports a non-existent function")]
+    MissingHostFunction,
 }
 
 /// An error emitted by the Wasm preprocessor.
@@ -227,6 +230,37 @@ fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
 
     Ok(())
 }
+
+/// List of invalid wasm imports considered non-existing.
+const WASM_INVALID_IMPORTS: &[(&str, &str)] = &[
+    // Gas counter is currently considered an implementation detail.
+    //
+    // If a wasm module tries to import it will be rejected.
+    (DEFAULT_GAS_MODULE_NAME, "gas"),
+];
+
+/// Ensures that Wasm module has valid imports.
+fn ensure_valid_imports(module: &Module) -> Result<(), WasmValidationError> {
+    let import_entries = module
+        .import_section()
+        .map(|is| is.entries())
+        .unwrap_or(&[]);
+
+    for import in import_entries {
+        if WASM_INVALID_IMPORTS
+            .iter()
+            .any(|(module, func_name)| (import.module(), import.field()) == (*module, *func_name))
+        {
+            // Currently we're checking the imports against the list of invalid imports such as
+            // special "gas" function, but this should be extended to also check if the provided
+            // imports are on the list of host functions.
+            return Err(WasmValidationError::MissingHostFunction);
+        }
+    }
+
+    Ok(())
+}
+
 /// Preprocesses Wasm bytes and returns a module.
 ///
 /// This process consists of a few steps:
@@ -254,6 +288,7 @@ pub fn preprocess(
     ensure_br_table_size_limit(&module)?;
     ensure_global_variable_limit(&module)?;
     ensure_parameter_limit(&module)?;
+    ensure_valid_imports(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -2,8 +2,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use parity_wasm::elements::{
-    self, External, FunctionType, Instruction, Internal, MemorySection, Module, Section, TableType,
-    Type,
+    self, External, Instruction, Internal, MemorySection, Module, Section, TableType, Type,
 };
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
@@ -315,48 +314,45 @@ pub fn preprocess(
 }
 
 fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
-    // Copy types from module as is.
-    let types: Vec<FunctionType> = module
+    let function_types_count = module
         .type_section()
-        .map(|ts| {
-            ts.types()
-                .iter()
-                .map(|&Type::Function(ref ty)| ty)
-                .cloned()
-                .collect()
-        })
+        .map(|ts| ts.types().len())
         .unwrap_or_default();
 
-    // Function space that contains indexes of imported functions from import section and indexes
-    // from function section.
-    //
-    // It is an indirection from the i-th element of the index space into a type section as created
-    // in the `types` variable above.
-    let mut func_type_indices = Vec::new();
-
+    let mut function_count = 0_u32;
     if let Some(import_section) = module.import_section() {
         for import_entry in import_section.entries() {
-            if let External::Function(idx) = import_entry.external() {
-                func_type_indices.push((*idx, false));
+            if let External::Function(function_type_index) = import_entry.external() {
+                if (*function_type_index as usize) < function_types_count {
+                    function_count = function_count.saturating_add(1);
+                } else {
+                    return Err(WasmValidationError::MissingFunctionType {
+                        index: *function_type_index,
+                    });
+                }
+            }
+        }
+    }
+    if let Some(function_section) = module.function_section() {
+        for function_entry in function_section.entries() {
+            let function_type_index = function_entry.type_ref();
+            if (function_type_index as usize) < function_types_count {
+                function_count = function_count.saturating_add(1);
+            } else {
+                return Err(WasmValidationError::MissingFunctionType {
+                    index: function_type_index,
+                });
             }
         }
     }
 
-    if let Some(function_section) = module.function_section() {
-        for function_entry in function_section.entries() {
-            let idx = function_entry.type_ref();
-            func_type_indices.push((idx, false));
-        }
+    if let Some(function_index) = module.start_section() {
+        ensure_valid_function_index(function_index, function_count)?;
     }
-
-    if let Some(idx) = module.start_section() {
-        ensure_function_exists(&idx, &mut func_type_indices, &types)?;
-    }
-
     if let Some(export_section) = module.export_section() {
         for export_entry in export_section.entries() {
-            if let Internal::Function(idx) = export_entry.internal() {
-                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+            if let Internal::Function(function_index) = export_entry.internal() {
+                ensure_valid_function_index(*function_index, function_count)?;
             }
         }
     }
@@ -374,12 +370,12 @@ fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
         {
             match instr {
                 Instruction::Call(idx) => {
-                    ensure_function_exists(idx, &mut func_type_indices, &types)?
+                    ensure_valid_function_index(*idx, function_count)?;
                 }
                 Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
                     if *idx as usize >= global_len =>
                 {
-                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx });
                 }
                 _ => {}
             }
@@ -389,7 +385,7 @@ fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
     if let Some(element_section) = module.elements_section() {
         for element_segment in element_section.entries() {
             for idx in element_segment.members() {
-                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+                ensure_valid_function_index(*idx, function_count)?;
             }
         }
     }
@@ -397,22 +393,10 @@ fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
     Ok(())
 }
 
-/// Ensures a function exists in a types table.
-fn ensure_function_exists(
-    idx: &u32,
-    func_type_indices: &mut [(u32, bool)],
-    types: &[FunctionType],
-) -> Result<(), WasmValidationError> {
-    let (ty_idx, is_validated) = func_type_indices
-        .get_mut(*idx as usize)
-        .ok_or(WasmValidationError::MissingFunctionIndex { index: *idx })?;
-    if *is_validated {
-        return Ok(());
+fn ensure_valid_function_index(index: u32, function_count: u32) -> Result<(), WasmValidationError> {
+    if index >= function_count {
+        return Err(WasmValidationError::MissingFunctionIndex { index });
     }
-    let _ty = types
-        .get(*ty_idx as usize)
-        .ok_or(WasmValidationError::MissingFunctionType { index: *ty_idx })?;
-    *is_validated = true;
     Ok(())
 }
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -21,42 +21,42 @@ pub const DEFAULT_MAX_PARAMETER_COUNT: u32 = 256;
 #[derive(Debug, Clone, Error)]
 pub enum WasmValidationError {
     /// Initial table size outside allowed bounds.
-    #[error("initial table size exceeds allowed bounds")]
+    #[error("initial table size of {actual} exceeds allowed limit of {max}")]
     InitialTableSizeExceeded {
         /// Allowed maximum table size.
         max: u32,
-        /// Actual maximum table size in the Wasm.
+        /// Actual initial table size specified in the Wasm.
         actual: u32,
     },
     /// Maximum table size outside allowed bounds.
-    #[error("maximum table size outside allowed bounds")]
+    #[error("maximum table size of {actual} exceeds allowed limit of {max}")]
     MaxTableSizeExceeded {
-        /// Allowed maximum initial table size.
+        /// Allowed maximum table size.
         max: u32,
-        /// Actual initial table szie in the Wasm.
+        /// Actual max table size specified in the Wasm.
         actual: u32,
     },
     /// Number of the tables in a Wasm must be at most one.
     #[error("the number of tables must be at most one")]
     MoreThanOneTable,
     /// Length of a br_table exceeded the maximum allowed size.
-    #[error("maximum br_table size exceeds allowed bounds (expected {max} but found {actual})")]
+    #[error("maximum br_table size of {actual} exceeds allowed limit of {max}")]
     BrTableSizeExceeded {
         /// Maximum allowed br_table length.
         max: u32,
-        /// Actual size of the largest br_table in the code.
+        /// Actual size of a br_table in the code.
         actual: usize,
     },
-    /// Declares number of globals exceeds allowed size.
-    #[error("declared number of globals exceeds allowed size")]
+    /// Declared number of globals exceeds allowed limit.
+    #[error("declared number of globals ({actual}) exceeds allowed limit of {max}")]
     TooManyGlobals {
         /// Maximum allowed globals.
         max: u32,
-        /// Actual number of globals declares in the Wasm.
+        /// Actual number of globals declared in the Wasm.
         actual: usize,
     },
     /// Module declares a function type with too many parameters.
-    #[error("use of a function type with too many parameters (expected {max} but function declares {actual})")]
+    #[error("use of a function type with too many parameters (limit of {max} but function declares {actual})")]
     TooManyParameters {
         /// Maximum allowed parameters.
         max: u32,
@@ -100,7 +100,6 @@ impl Display for PreprocessingError {
             PreprocessingError::MissingMemorySection => write!(f, "Memory section should exist"),
             PreprocessingError::MissingModule => write!(f, "Missing module"),
             PreprocessingError::InvalidWasm(msg) => write!(f, "Invalid wasm: {msg}."),
-
         }
     }
 }
@@ -130,7 +129,7 @@ fn ensure_table_size_limit(mut module: Module, limit: u32) -> Result<Module, Was
             return Err(WasmValidationError::MoreThanOneTable);
         }
 
-        if let Some(table_entry) = sect.entries_mut().iter_mut().next() {
+        if let Some(table_entry) = sect.entries_mut().first_mut() {
             let initial = table_entry.limits().initial();
             if initial > limit {
                 return Err(WasmValidationError::InitialTableSizeExceeded {
@@ -163,8 +162,6 @@ fn ensure_table_size_limit(mut module: Module, limit: u32) -> Result<Module, Was
 ///
 /// Globals are not limited through the `stack_height` as locals are. Neither does
 /// the linear memory limit `memory_pages` applies to them.
-///
-/// There is potential to
 fn ensure_global_variable_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     if let Some(global_section) = module.global_section() {
         let actual = global_section.entries().len();

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 use super::wasm_config::WasmConfig;
 
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
+/// We only allow maximum of 4k function pointers in a table section.
+pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -72,10 +74,8 @@ fn table_section(module: &mut Module) -> Option<&mut TableSection> {
 /// Ensures (table) section has at most one table entry, and initial, and maximum values are
 /// normalized.
 ///
-/// If a maximum value is not specified it will be defaulted to 65k to prevent OOM.
+/// If a maximum value is not specified it will be defaulted to 4k to prevent OOM.
 fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
-    const TABLE_MAX: u32 = 65536;
-
     if let Some(sect) = table_section(&mut module) {
         for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
             if i > 1 {
@@ -83,12 +83,12 @@ fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
             }
 
             let initial = table_entry.limits().initial();
-            if initial > TABLE_MAX {
+            if initial > DEFAULT_MAX_TABLE_SIZE {
                 return Err("initial table size exceeds allowed bounds");
             }
 
             match table_entry.limits().maximum() {
-                Some(max) if max > TABLE_MAX => {
+                Some(max) if max > DEFAULT_MAX_TABLE_SIZE => {
                     return Err("maximum table size outside allowed bounds")
                 }
                 Some(_) => {
@@ -96,7 +96,7 @@ fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
                 }
                 None => {
                     // rewrite wasm and provide a maximum limit for a table section
-                    *table_entry = TableType::new(initial, Some(TABLE_MAX))
+                    *table_entry = TableType::new(initial, Some(DEFAULT_MAX_TABLE_SIZE))
                 }
             }
         }

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -131,6 +131,86 @@ impl Display for PreprocessingError {
     }
 }
 
+fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
+    let function_types_count = module
+        .type_section()
+        .map(|ts| ts.types().len())
+        .unwrap_or_default();
+
+    let mut function_count = 0_u32;
+    if let Some(import_section) = module.import_section() {
+        for import_entry in import_section.entries() {
+            if let External::Function(function_type_index) = import_entry.external() {
+                if (*function_type_index as usize) < function_types_count {
+                    function_count = function_count.saturating_add(1);
+                } else {
+                    return Err(WasmValidationError::MissingFunctionType {
+                        index: *function_type_index,
+                    });
+                }
+            }
+        }
+    }
+    if let Some(function_section) = module.function_section() {
+        for function_entry in function_section.entries() {
+            let function_type_index = function_entry.type_ref();
+            if (function_type_index as usize) < function_types_count {
+                function_count = function_count.saturating_add(1);
+            } else {
+                return Err(WasmValidationError::MissingFunctionType {
+                    index: function_type_index,
+                });
+            }
+        }
+    }
+
+    if let Some(function_index) = module.start_section() {
+        ensure_valid_function_index(function_index, function_count)?;
+    }
+    if let Some(export_section) = module.export_section() {
+        for export_entry in export_section.entries() {
+            if let Internal::Function(function_index) = export_entry.internal() {
+                ensure_valid_function_index(*function_index, function_count)?;
+            }
+        }
+    }
+
+    if let Some(code_section) = module.code_section() {
+        let global_len = module
+            .global_section()
+            .map(|global_section| global_section.entries().len())
+            .unwrap_or(0);
+
+        for instr in code_section
+            .bodies()
+            .iter()
+            .flat_map(|body| body.code().elements())
+        {
+            match instr {
+                Instruction::Call(idx) => {
+                    ensure_valid_function_index(*idx, function_count)?;
+                }
+                Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
+                    if *idx as usize >= global_len =>
+                {
+                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(element_section) = module.elements_section() {
+        for element_segment in element_section.entries() {
+            for idx in element_segment.members() {
+                ensure_valid_function_index(*idx, function_count)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Checks if given wasm module contains a non-empty memory section.
 fn memory_section(module: &Module) -> Option<&MemorySection> {
     for section in module.sections() {
@@ -185,20 +265,6 @@ fn ensure_table_size_limit(mut module: Module, limit: u32) -> Result<Module, Was
     Ok(module)
 }
 
-/// Ensures that module doesn't declare too many globals.
-///
-/// Globals are not limited through the `stack_height` as locals are. Neither does
-/// the linear memory limit `memory_pages` applies to them.
-fn ensure_global_variable_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
-    if let Some(global_section) = module.global_section() {
-        let actual = global_section.entries().len();
-        if actual > limit as usize {
-            return Err(WasmValidationError::TooManyGlobals { max: limit, actual });
-        }
-    }
-    Ok(())
-}
-
 /// Ensure that any `br_table` instruction adheres to its immediate value limit.
 fn ensure_br_table_size_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     let code_section = if let Some(type_section) = module.code_section() {
@@ -218,6 +284,20 @@ fn ensure_br_table_size_limit(module: &Module, limit: u32) -> Result<(), WasmVal
                     actual: br_table_data.table.len(),
                 });
             }
+        }
+    }
+    Ok(())
+}
+
+/// Ensures that module doesn't declare too many globals.
+///
+/// Globals are not limited through the `stack_height` as locals are. Neither does
+/// the linear memory limit `memory_pages` applies to them.
+fn ensure_global_variable_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
+    if let Some(global_section) = module.global_section() {
+        let actual = global_section.entries().len();
+        if actual > limit as usize {
+            return Err(WasmValidationError::TooManyGlobals { max: limit, actual });
         }
     }
     Ok(())
@@ -311,86 +391,6 @@ pub fn preprocess(
     let module = stack_height::inject_limiter(module, wasm_config.max_stack_height)
         .map_err(|_| PreprocessingError::StackLimiter)?;
     Ok(module)
-}
-
-fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
-    let function_types_count = module
-        .type_section()
-        .map(|ts| ts.types().len())
-        .unwrap_or_default();
-
-    let mut function_count = 0_u32;
-    if let Some(import_section) = module.import_section() {
-        for import_entry in import_section.entries() {
-            if let External::Function(function_type_index) = import_entry.external() {
-                if (*function_type_index as usize) < function_types_count {
-                    function_count = function_count.saturating_add(1);
-                } else {
-                    return Err(WasmValidationError::MissingFunctionType {
-                        index: *function_type_index,
-                    });
-                }
-            }
-        }
-    }
-    if let Some(function_section) = module.function_section() {
-        for function_entry in function_section.entries() {
-            let function_type_index = function_entry.type_ref();
-            if (function_type_index as usize) < function_types_count {
-                function_count = function_count.saturating_add(1);
-            } else {
-                return Err(WasmValidationError::MissingFunctionType {
-                    index: function_type_index,
-                });
-            }
-        }
-    }
-
-    if let Some(function_index) = module.start_section() {
-        ensure_valid_function_index(function_index, function_count)?;
-    }
-    if let Some(export_section) = module.export_section() {
-        for export_entry in export_section.entries() {
-            if let Internal::Function(function_index) = export_entry.internal() {
-                ensure_valid_function_index(*function_index, function_count)?;
-            }
-        }
-    }
-
-    if let Some(code_section) = module.code_section() {
-        let global_len = module
-            .global_section()
-            .map(|global_section| global_section.entries().len())
-            .unwrap_or(0);
-
-        for instr in code_section
-            .bodies()
-            .iter()
-            .flat_map(|body| body.code().elements())
-        {
-            match instr {
-                Instruction::Call(idx) => {
-                    ensure_valid_function_index(*idx, function_count)?;
-                }
-                Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
-                    if *idx as usize >= global_len =>
-                {
-                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx });
-                }
-                _ => {}
-            }
-        }
-    }
-
-    if let Some(element_section) = module.elements_section() {
-        for element_segment in element_section.entries() {
-            for idx in element_segment.members() {
-                ensure_valid_function_index(*idx, function_count)?;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn ensure_valid_function_index(index: u32, function_count: u32) -> Result<(), WasmValidationError> {

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,7 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, MemorySection, Module, Section, TableSection, TableType};
+use parity_wasm::elements::{self, MemorySection, Module, Section, TableType};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -10,6 +10,30 @@ use super::wasm_config::WasmConfig;
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
 /// We only allow maximum of 4k function pointers in a table section.
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
+
+/// An error emitted by the Wasm preprocessor.
+#[derive(Debug, Clone, Error)]
+pub enum WasmValidationError {
+    /// Initial table size outside allowed bounds.
+    #[error("initial table size exceeds allowed bounds")]
+    InitialTableSizeExceeded {
+        /// Allowed maximum table size.
+        max: u32,
+        /// Actual maximum table size in the Wasm.
+        actual: u32,
+    },
+    /// Maximum table size outside allowed bounds.
+    #[error("maximum table size outside allowed bounds")]
+    MaxTableSizeExceeded {
+        /// Allowed maximum initial table size.
+        max: u32,
+        /// Actual initial table szie in the Wasm.
+        actual: u32,
+    },
+    /// Number of the tables in a Wasm must be at most one.
+    #[error("the number of tables must be at most one")]
+    MoreThanOneTable,
+}
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -25,7 +49,7 @@ pub enum PreprocessingError {
     /// The module is missing.
     MissingModule,
     /// Wasm validation did not pass.
-    InvalidWasm(String),
+    InvalidWasm(#[from] WasmValidationError),
 }
 
 impl From<elements::Error> for PreprocessingError {
@@ -62,34 +86,32 @@ fn memory_section(module: &Module) -> Option<&MemorySection> {
     None
 }
 
-fn table_section(module: &mut Module) -> Option<&mut TableSection> {
-    for section in module.sections_mut() {
-        if let Section::Table(sect) = section {
-            return Some(sect);
-        }
-    }
-    None
-}
-
 /// Ensures (table) section has at most one table entry, and initial, and maximum values are
 /// normalized.
 ///
 /// If a maximum value is not specified it will be defaulted to 4k to prevent OOM.
-fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
-    if let Some(sect) = table_section(&mut module) {
-        for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
-            if i >= 1 {
-                return Err("the number of tables must be at most one");
-            }
+fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationError> {
+    if let Some(sect) = module.table_section_mut() {
+        // Table section is optional and there can be at most one.
+        if sect.entries().len() > 1 {
+            return Err(WasmValidationError::MoreThanOneTable);
+        }
 
+        if let Some(table_entry) = sect.entries_mut().iter_mut().next() {
             let initial = table_entry.limits().initial();
             if initial > DEFAULT_MAX_TABLE_SIZE {
-                return Err("initial table size exceeds allowed bounds");
+                return Err(WasmValidationError::InitialTableSizeExceeded {
+                    max: DEFAULT_MAX_TABLE_SIZE,
+                    actual: initial,
+                });
             }
 
             match table_entry.limits().maximum() {
                 Some(max) if max > DEFAULT_MAX_TABLE_SIZE => {
-                    return Err("maximum table size outside allowed bounds")
+                    return Err(WasmValidationError::MaxTableSizeExceeded {
+                        max: DEFAULT_MAX_TABLE_SIZE,
+                        actual: max,
+                    })
                 }
                 Some(_) => {
                     // maximum within the limit
@@ -128,8 +150,7 @@ pub fn preprocess(
         return Err(PreprocessingError::MissingMemorySection);
     }
 
-    let module = validate_table_section(module)
-        .map_err(|error| PreprocessingError::InvalidWasm(error.to_owned()))?;
+    let module = ensure_table_size_limit(module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -78,7 +78,7 @@ fn table_section(module: &mut Module) -> Option<&mut TableSection> {
 fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
     if let Some(sect) = table_section(&mut module) {
         for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
-            if i > 1 {
+            if i >= 1 {
                 return Err("the number of tables must be at most one");
             }
 

--- a/execution_engine/src/storage/error/db.rs
+++ b/execution_engine/src/storage/error/db.rs
@@ -8,7 +8,7 @@ use casper_types::bytesrepr;
 use crate::storage::{error::in_memory, global_state::CommitError};
 
 /// Error enum representing possible errors from database internals.
-#[derive(Debug, Clone, Error, PartialEq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum DbError {
     /// LMDB error returned from underlying `lmdb` crate.
     #[error(transparent)]
@@ -16,7 +16,7 @@ pub enum DbError {
 }
 
 /// Error enum representing possible error states in DB interactions.
-#[derive(Debug, Clone, Error, PartialEq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
     /// Error from the underlying database.
     #[error(transparent)]

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -269,7 +269,7 @@ where
         // Optimization: Don't look for descendants of leaves.
         match maybe_retrieved_trie_bytes
             .as_ref()
-            .and_then(|bytes| bytes.get(0))
+            .and_then(|bytes| bytes.first())
         {
             // if this is a leaf don't parse (ie, the first byte is 0), just continue
             Some(0) => continue,

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-execution-engine = { version = "2.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "2.0.1", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
 filesize = "0.2.0"

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -126,7 +126,7 @@ pub fn run_blocks_with_transfers_and_step(
 
         let existing_keys = cursor
             .iter()
-            .map(|(key, _)| Digest::try_from(&*key).expect("should be a digest"));
+            .map(|(key, _)| Digest::try_from(key).expect("should be a digest"));
         necessary_tries.extend(existing_keys);
     }
     writeln!(

--- a/execution_engine_testing/test_support/src/utils.rs
+++ b/execution_engine_testing/test_support/src/utils.rs
@@ -188,7 +188,7 @@ pub fn get_exec_costs<T: AsRef<ExecutionResult>, I: IntoIterator<Item = T>>(
 /// # Panics
 /// Panics if `response` is `None`.
 pub fn get_success_result(response: &[Rc<ExecutionResult>]) -> &ExecutionResult {
-    &*response.get(0).expect("should have a result")
+    response.get(0).expect("should have a result")
 }
 
 /// Returns an error if the `ExecutionResult` has an error.

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3"
 wabt = "0.10.0"
 wasmi = "0.8.0"
 regex = "1.5.4"
+wat = "1.0.47"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,5 +1,6 @@
-use once_cell::sync::Lazy;
 use std::fmt::Write;
+
+use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -15,12 +13,21 @@ use casper_execution_engine::{
         },
         execution::Error as ExecError,
     },
-    shared::wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+    shared::{
+        wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+        wasm_prep::DEFAULT_MAX_PARAMETER_COUNT,
+    },
 };
 use casper_types::{EraId, ProtocolVersion, RuntimeArgs};
 
-const I32_WASM_SIZE_BYTES: usize = 8;
-const ARITY_INTERPRETER_LIMIT: usize = wasmi::DEFAULT_CALL_STACK_LIMIT / I32_WASM_SIZE_BYTES;
+use crate::wasm_utils;
+
+// Previously this value was derived from `wasmi::DEFAULT_CALL_STACK_LIMIT` as we haven't a check
+// for argument count declared in wasm functions. We have very restrictive stack height which also
+// means the maximum allowed function count still fails at runtime inside the stack limiter.
+//
+// Max parameter count - 1 will exercise the height limiter while passing the preprocessing stage.
+const ARITY_INTERPRETER_LIMIT: usize = DEFAULT_MAX_PARAMETER_COUNT as usize - 1;
 const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 const I32_WAT_TYPE: &str = "i64";
 const NEW_WASM_STACK_HEIGHT: u32 = 16;
@@ -34,32 +41,6 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
     )
 });
 
-fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
-    let mut call_args = String::new();
-    for i in 0..arity {
-        write!(call_args, "({}.const {}) ", arg_type, i).unwrap();
-    }
-
-    let mut func_params = String::new();
-    for i in 0..arity {
-        write!(func_params, "(param $arg{} {}) ", i, arg_type).unwrap();
-    }
-
-    // This wasm module contains a function with a specified amount of arguments in it.
-    let wat = format!(
-        r#"(module
-        (func $call (call $func {call_args}) (return))
-        (func $func {func_params} (return))
-        (export "func" (func $func))
-        (export "call" (func $call))
-        (memory $memory 1)
-      )"#,
-        call_args = call_args,
-        func_params = func_params
-    );
-    wabt::wat2wasm(wat).expect("should parse wat")
-}
-
 fn initialize_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
@@ -72,7 +53,9 @@ fn should_verify_interpreter_stack_limit() {
     let mut builder = initialize_builder();
 
     // This runs out of the interpreter stack limit
-    let module_bytes = make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE);
+    let module_bytes = wasm_utils::make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE)
+        .expect("should make wasm bytes");
+
     let exec = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -103,7 +86,9 @@ fn should_observe_stack_height_limit() {
 
     // This runs out of the interpreter stack limit
     let exec_request_1 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -147,7 +132,9 @@ fn should_observe_stack_height_limit() {
     // An amount of args equal to the new limit fails because there's overhead of `fn call` that
     // adds 1 to the height.
     let exec_request_2 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -169,7 +156,9 @@ fn should_observe_stack_height_limit() {
 
     // But new limit minus one runs fine
     let exec_request_3 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use std::fmt::Write;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
@@ -35,12 +36,12 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
 fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
     let mut call_args = String::new();
     for i in 0..arity {
-        call_args.push_str(&format!("({}.const {}) ", arg_type, i));
+        write!(call_args, "({}.const {}) ", arg_type, i).unwrap();
     }
 
     let mut func_params = String::new();
     for i in 0..arity {
-        func_params.push_str(&format!("(param $arg{} {}) ", i, arg_type));
+        write!(func_params, "(param $arg{} {}) ", i, arg_type).unwrap();
     }
 
     // This wasm module contains a function with a specified amount of arguments in it.

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -54,4 +54,5 @@ mod regression_20220222;
 mod regression_20220223;
 mod regression_20220224;
 mod regression_20220303;
+mod regression_20220727;
 mod transforms_must_be_ordered;

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,0 +1,261 @@
+use std::fmt::Write;
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::{
+    core::{engine_state, execution},
+    shared::wasm_prep::PreprocessingError,
+};
+use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
+fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
+    let mut bounds = initial.to_string();
+    if let Some(max) = maximum {
+        bounds += " ";
+        bounds += &max.to_string();
+    }
+
+    let wat = format!(
+        r#"(module
+            (table (;0;) {} funcref)
+            (memory (;0;) 0)
+            (export "call" (func $call))
+            (func $call))
+            "#,
+        bounds
+    );
+    wabt::wat2wasm(wat).expect("should parse wat")
+}
+
+const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+
+#[ignore]
+#[test]
+fn should_not_oom() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let test_cases = vec![
+        OOM_INIT,
+        FAILURE_ONE_ABOVE_LIMIT,
+        FAILURE_MAX_ABOVE_LIMIT,
+        FAILURE_INIT_ABOVE_LIMIT,
+    ];
+
+    for (initial, maximum) in test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_failure().commit();
+
+        let error = builder.get_error().unwrap();
+
+        assert!(matches!(
+            error,
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(ref _msg))
+        ))
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_table_validation() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
+
+    for (initial, maximum) in passing_test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_success().commit();
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_elem_section() {
+    // more functions than elements - wasmi doesn't allocate
+    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    assert!(
+        matches!(
+            elem_does_not_fit_err,
+            Some(engine_state::Error::Exec(execution::Error::Interpreter(ref msg)))
+            if msg == "elements segment does not fit"
+        ),
+        "{:?}",
+        elem_does_not_fit_err
+    );
+
+    // wasmi assumes table size and function pointers are equal
+    assert!(matches!(
+        test_element_section(65536, Some(65536), 65536),
+        None
+    ));
+}
+
+fn test_element_section(
+    table_init: u32,
+    table_max: Option<u32>,
+    function_count: u32,
+) -> Option<engine_state::Error> {
+    // Ensures proper initialization of table elements for different number of function pointers
+    //
+    // This should ensure there's no hidden lazy allocation and initialization that might still
+    // overallocate memory, burn cpu cycles allocating etc.
+
+    // (module
+    //     (table 0 1 anyfunc)
+    //     (memory $0 1)
+    //     (export "memory" (memory $0))
+    //     (export "foo1" (func $foo1))
+    //     (export "foo2" (func $foo2))
+    //     (export "foo3" (func $foo3))
+    //     (export "main" (func $main))
+    //     (func $foo1 (; 0 ;)
+    //     )
+    //     (func $foo2 (; 1 ;)
+    //     )
+    //     (func $foo3 (; 2 ;)
+    //     )
+    //     (func $main (; 3 ;) (result i32)
+    //      (i32.const 0)
+    //     )
+    //     (elem (i32.const 0) $foo1 $foo2 $foo3)
+    // )
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let mut wat = String::new();
+
+    if let Some(max) = table_max {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} {max} anyfunc)"#
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} anyfunc)"#
+        )
+        .unwrap();
+    }
+
+    wat += "(memory $0 1)\n";
+    wat += r#"(export "memory" (memory $0))"#;
+    wat += "\n";
+    wat += r#"(export "call" (func $call))"#;
+    wat += "\n";
+    for i in 0..function_count {
+        writeln!(wat, r#"(export "foo{i}" (func $foo{i}))"#).unwrap();
+    }
+    for i in 0..function_count {
+        writeln!(wat, "(func $foo{i} (; 0 ;))").unwrap();
+    }
+    wat += "(func $call)\n";
+    wat += "\n";
+    wat += "(elem (i32.const 0) ";
+    for i in 0..function_count {
+        write!(wat, "$foo{i} ").unwrap();
+    }
+    wat += ")\n";
+    wat += ")";
+
+    let module_bytes = wabt::wat2wasm(wat).unwrap();
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).commit();
+
+    builder.get_error()
+}
+
+#[ignore]
+#[test]
+fn should_not_allow_more_than_one_table() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
+
+    let module = builder::module()
+        // table 1
+        .table()
+        .with_min(0)
+        .build()
+        // table 2
+        .table()
+        .with_min(1)
+        .build()
+        .function()
+        // A signature with 0 params and no return type
+        .signature()
+        .build()
+        .body()
+        // Generated instructions for our entrypoint
+        .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+        .build()
+        .build()
+        // Export above function
+        .export()
+        .field(DEFAULT_ENTRY_POINT_NAME)
+        .build()
+        // Memory section is mandatory
+        .memory()
+        .build()
+        .build();
+    let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).expect_failure().commit();
+
+    let error = builder.get_error().unwrap();
+
+    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
+    // than 1 table.
+    assert!(
+        matches!(
+            error,
+            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
+            if msg == "too many tables in index space: 2"
+        ),
+        "{:?}",
+        error
+    );
+}

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -6,7 +6,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::PreprocessingError,
+    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 use parity_wasm::{
@@ -34,11 +34,11 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 }
 
 const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
-const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
-const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE + 1, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(u32::MAX));
 const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
-const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
-const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(DEFAULT_MAX_TABLE_SIZE));
 
 #[ignore]
 #[test]
@@ -98,7 +98,7 @@ fn should_pass_table_validation() {
 #[test]
 fn should_pass_elem_section() {
     // more functions than elements - wasmi doesn't allocate
-    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    let elem_does_not_fit_err = test_element_section(0, None, DEFAULT_MAX_TABLE_SIZE);
     assert!(
         matches!(
             elem_does_not_fit_err,
@@ -111,7 +111,11 @@ fn should_pass_elem_section() {
 
     // wasmi assumes table size and function pointers are equal
     assert!(matches!(
-        test_element_section(65536, Some(65536), 65536),
+        test_element_section(
+            DEFAULT_MAX_TABLE_SIZE,
+            Some(DEFAULT_MAX_TABLE_SIZE),
+            DEFAULT_MAX_TABLE_SIZE
+        ),
         None
     ));
 }

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -11,7 +11,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
+    shared::wasm_prep::{PreprocessingError, WasmValidationError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 
@@ -252,13 +252,12 @@ fn should_not_allow_more_than_one_table() {
 
     let error = builder.get_error().unwrap();
 
-    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
-    // than 1 table.
     assert!(
         matches!(
             error,
-            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
-            if msg == "too many tables in index space: 2"
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(
+                WasmValidationError::MoreThanOneTable
+            ))
         ),
         "{:?}",
         error

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -512,7 +512,7 @@ fn should_verify_max_param_count() {
 
     let error = builder.get_error().expect("should have error");
 
-    // Here we pass the preprocess stage, but we wail at stack height limiter as we do have very
+    // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
     // restrictive default stack height.
     assert!(
         matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,5 +1,10 @@
 use std::fmt::Write;
 
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_RUN_GENESIS_REQUEST,
@@ -9,10 +14,6 @@ use casper_execution_engine::{
     shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
-use parity_wasm::{
-    builder,
-    elements::{Instruction, Instructions},
-};
 
 fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
     let mut bounds = initial.to_string();

--- a/execution_engine_testing/tests/src/wasm_utils.rs
+++ b/execution_engine_testing/tests/src/wasm_utils.rs
@@ -1,4 +1,6 @@
 //! Wasm helpers.
+use std::fmt::Write;
+
 use parity_wasm::builder;
 
 use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
@@ -22,4 +24,33 @@ pub fn do_nothing_bytes() -> Vec<u8> {
         .build()
         .build();
     parity_wasm::serialize(module).expect("should serialize")
+}
+
+/// Creates minimal session code that contains a function with arbitrary number of parameters.
+pub fn make_n_arg_call_bytes(
+    arity: usize,
+    arg_type: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut call_args = String::new();
+    for i in 0..arity {
+        write!(call_args, "({}.const {}) ", arg_type, i)?;
+    }
+
+    let mut func_params = String::new();
+    for i in 0..arity {
+        write!(func_params, "(param $arg{} {}) ", i, arg_type)?;
+    }
+
+    // This wasm module contains a function with a specified amount of arguments in it.
+    let wat = format!(
+        r#"(module
+        (func $call (call $func {call_args}) (return))
+        (func $func {func_params} (return))
+        (export "func" (func $func))
+        (export "call" (func $call))
+        (memory $memory 1)
+      )"#
+    );
+    let module_bytes = wabt::wat2wasm(wat)?;
+    Ok(module_bytes)
 }

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.  The format
 
 ## 1.4.8
 
+### Added
+* Add an `identity` option to load existing network identity certificates signed by a CA.
+
+
+
 ### Changed
 * Update `casper-execution-engine`.
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.8
+
+### Changed
+* Update `casper-execution-engine`.
+
+
+
 ## 1.4.7
 
 ### Changed

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+
+## 1.4.7
+
+### Changed
+* Update `casper-execution-engine` and three `openssl` crates to latest versions.
+
+
+
 ## 1.4.6
 
 ### Changed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.6" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,7 +20,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "2.0.0", path = "../execution_engine" }
+casper-execution-engine = { version = "2.0.1", path = "../execution_engine" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }
 casper-hashing = { version = "1.4.3", path = "../hashing" }
 casper-types = { version = "1.5.0", path = "../types", features = ["datasize", "gens", "json-schema"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.8" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -866,7 +866,7 @@ mod tests {
             match *new_units {
                 [] => (),
                 [unit] => {
-                    let _ = self.state.add_unit(unit.clone()).unwrap();
+                    self.state.add_unit(unit.clone()).unwrap();
                 }
                 _ => panic!(
                     "Expected at most one timer to be scheduled: {:?}",

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -189,11 +189,8 @@ mod tests {
             cannot_propose: &Default::default(),
         };
 
-        let expected_change = vec![(
-            seen_as_faulty_in_new_era.clone(),
-            ValidatorChange::SeenAsFaulty,
-        )];
         let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        let expected_change = vec![(seen_as_faulty_in_new_era, ValidatorChange::SeenAsFaulty)];
         assert_eq!(expected_change, actual_change.0)
     }
 

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -79,7 +79,7 @@ reactor!(Reactor {
             false,
             "test"
         );
-        deploy_acceptor = DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec(), registry);
+        deploy_acceptor = DeployAcceptor(cfg.deploy_acceptor_config, chainspec_loader.chainspec(), registry);
         deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);
     }
 

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -456,7 +456,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     fn insert_to_finished(&mut self, data_id: &T) {
         let timeout = Instant::now() + self.finished_entry_duration;
         let _ = self.finished.insert(*data_id);
-        let _ = self.timeouts.push(timeout, *data_id);
+        self.timeouts.push(timeout, *data_id);
     }
 
     /// Retains only those finished entries which still haven't timed out.

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -567,8 +567,8 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
     pub(crate) fn latest_block(&self) -> Option<&Block> {
         match &self.state {
-            State::SyncingTrustedHash { latest_block, .. } => Option::as_ref(&*latest_block),
-            State::SyncingDescendants { latest_block, .. } => Some(&*latest_block),
+            State::SyncingTrustedHash { latest_block, .. } => Option::as_ref(latest_block),
+            State::SyncingDescendants { latest_block, .. } => Some(latest_block),
             State::Done(latest_block) => latest_block.as_deref(),
             State::None => None,
         }

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display};
 
 use datasize::DataSize;
 
-#[derive(DataSize, Debug, PartialEq)]
+#[derive(DataSize, Debug, PartialEq, Eq)]
 pub enum StopReason {
     ForUpgrade,
     ForDowngrade,

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 7);
+    ProtocolVersion::from_parts(1, 4, 8);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 6);
+    ProtocolVersion::from_parts(1, 4, 7);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -73,6 +73,7 @@ use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
 use self::{
     chain_info::ChainInfo,
+    config::IdentityConfig,
     counting_format::{ConnectionId, CountingFormat, Role},
     error::{ConnectionError, Result},
     event::{IncomingConnection, OutgoingConnection},
@@ -100,7 +101,10 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     reactor::{EventQueueHandle, Finalize, ReactorEvent},
-    tls::{self, TlsCert, ValidationError},
+    tls::{
+        self, validate_cert_with_authority, LoadCertError, LoadSecretKeyError, TlsCert,
+        ValidationError,
+    },
     types::NodeId,
     utils::{self, display_error, WithDir},
     NodeRng,
@@ -275,10 +279,31 @@ where
             .map_err(Error::LoadConsensusKeys)?
             .map(|(secret_key, public_key)| ConsensusKeyPair::new(secret_key, public_key));
 
+        // Load a ca certificate (if present)
+        let ca_certificate = match &cfg.identity {
+            Some(identity) => {
+                let ca_cert = tls::load_cert(&identity.ca_certificate)?;
+
+                // A quick sanity check for the loaded cert against supplied CA.
+                validate_cert_with_authority(
+                    small_network_identity.tls_certificate.as_x509().clone(),
+                    &ca_cert,
+                )
+                .map_err(|error| {
+                    warn!(%error, "the given node certificate is not signed by the network CA");
+                    Error::CertValidationError(error)
+                })?;
+
+                Some(ca_cert)
+            }
+            None => None,
+        };
+
         let context = Arc::new(NetworkContext {
             event_queue,
             our_id: NodeId::from(&small_network_identity),
             our_cert: small_network_identity.tls_certificate,
+            network_ca: ca_certificate.map(Arc::new),
             secret_key: small_network_identity.secret_key,
             net_metrics: Arc::downgrade(&net_metrics),
             chain_info: chain_info_source.into(),
@@ -967,6 +992,10 @@ pub(crate) enum SmallNetworkIdentityError {
     CouldNotGenerateTlsCertificate(OpenSslErrorStack),
     #[error(transparent)]
     ValidationError(#[from] ValidationError),
+    #[error(transparent)]
+    LoadCertError(#[from] LoadCertError),
+    #[error(transparent)]
+    LoadSecretKeyError(#[from] LoadSecretKeyError),
 }
 
 /// An ephemeral [PKey<Private>] and [TlsCert] that identifies this node
@@ -977,14 +1006,37 @@ pub(crate) struct SmallNetworkIdentity {
 }
 
 impl SmallNetworkIdentity {
-    pub(crate) fn new() -> result::Result<Self, SmallNetworkIdentityError> {
-        let (not_yet_validated_x509_cert, secret_key) = tls::generate_node_cert()
-            .map_err(SmallNetworkIdentityError::CouldNotGenerateTlsCertificate)?;
-        let tls_certificate = tls::validate_cert(not_yet_validated_x509_cert)?;
-        Ok(SmallNetworkIdentity {
+    fn new(secret_key: PKey<Private>, tls_certificate: TlsCert) -> Self {
+        Self {
             secret_key: Arc::new(secret_key),
             tls_certificate: Arc::new(tls_certificate),
-        })
+        }
+    }
+
+    pub(crate) fn from_config(
+        config: WithDir<Config>,
+    ) -> result::Result<Self, SmallNetworkIdentityError> {
+        match &config.value().identity {
+            Some(identity) => Self::from_identity_config(identity),
+            None => Self::with_generated_certs(),
+        }
+    }
+
+    fn from_identity_config(
+        identity: &IdentityConfig,
+    ) -> result::Result<Self, SmallNetworkIdentityError> {
+        let not_yet_validated_x509_cert = tls::load_cert(&identity.tls_certificate)?;
+        let secret_key = tls::load_secret_key(&identity.secret_key)?;
+        let x509_cert = tls::tls_cert_from_x509(not_yet_validated_x509_cert)?;
+
+        Ok(SmallNetworkIdentity::new(secret_key, x509_cert))
+    }
+
+    pub(crate) fn with_generated_certs() -> result::Result<Self, SmallNetworkIdentityError> {
+        let (not_yet_validated_x509_cert, secret_key) = tls::generate_node_cert()
+            .map_err(SmallNetworkIdentityError::CouldNotGenerateTlsCertificate)?;
+        let tls_certificate = tls::validate_self_signed_cert(not_yet_validated_x509_cert)?;
+        Ok(SmallNetworkIdentity::new(secret_key, tls_certificate))
     }
 }
 

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
@@ -35,8 +35,22 @@ impl Default for Config {
             max_outgoing_byte_rate_non_validators: 0,
             max_incoming_message_rate_non_validators: 0,
             estimator_weights: Default::default(),
+            identity: None,
         }
     }
+}
+
+/// Small network identity configuration.
+#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    /// Path to a signed certificate
+    pub tls_certificate: PathBuf,
+    /// Path to a secret key.
+    pub secret_key: PathBuf,
+    /// Path to a certificate authority certificate
+    pub ca_certificate: PathBuf,
 }
 
 /// Small network configuration.
@@ -64,6 +78,11 @@ pub struct Config {
     pub max_incoming_message_rate_non_validators: u32,
     /// Weight distribution for the payload impact estimator.
     pub estimator_weights: PayloadWeights,
+    /// Small network identity configuration option.
+    ///
+    /// An identity will be automatically generated when starting up a node if this option is
+    /// unspecified.
+    pub identity: Option<IdentityConfig>,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::{
     crypto,
-    tls::ValidationError,
+    tls::{LoadCertError, ValidationError},
     utils::{LoadError, Loadable, ResolveAddressError},
 };
 
@@ -63,13 +63,26 @@ pub enum Error {
         #[source]
         ResolveAddressError,
     ),
-
     /// Instantiating metrics failed.
     #[error(transparent)]
     Metrics(
         #[serde(skip_serializing)]
         #[from]
         prometheus::Error,
+    ),
+    /// Failed to load a certificate.
+    #[error("failed to load a certificate: {0}")]
+    LoadCertificate(
+        #[serde(skip_serializing)]
+        #[from]
+        LoadCertError,
+    ),
+    /// Failed to validate a network CA certificate.
+    #[error("failed to validate a cert against network CA: {0:?}")]
+    CertValidationError(
+        #[serde(skip_serializing)]
+        #[source]
+        ValidationError,
     ),
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -19,6 +19,7 @@ use futures::{
 use openssl::{
     pkey::{PKey, Private},
     ssl::Ssl,
+    x509::X509,
 };
 use prometheus::IntGauge;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -45,7 +46,7 @@ use super::{
 };
 use crate::{
     reactor::{EventQueueHandle, QueueKind},
-    tls::{self, TlsCert},
+    tls::{self, TlsCert, ValidationError},
     types::NodeId,
     utils::display_error,
 };
@@ -87,11 +88,11 @@ where
         .peer_certificate()
         .ok_or(ConnectionError::NoPeerCertificate)?;
 
-    let peer_id = NodeId::from(
-        tls::validate_cert(peer_cert)
-            .map_err(ConnectionError::PeerCertificateInvalid)?
-            .public_key_fingerprint(),
-    );
+    let validated_peer_cert = context
+        .validate_peer_cert(peer_cert)
+        .map_err(ConnectionError::PeerCertificateInvalid)?;
+
+    let peer_id = NodeId::from(validated_peer_cert.public_key_fingerprint());
 
     Ok((peer_id, transport))
 }
@@ -171,6 +172,8 @@ where
     pub(super) our_id: NodeId,
     /// TLS certificate associated with this node's identity.
     pub(super) our_cert: Arc<TlsCert>,
+    /// TLS certificate authority associated with this node's identity.
+    pub(super) network_ca: Option<Arc<X509>>,
     /// Secret key associated with `our_cert`.
     pub(super) secret_key: Arc<PKey<Private>>,
     /// Weak reference to the networking metrics shared by all sender/receiver tasks.
@@ -183,6 +186,15 @@ where
     pub(super) consensus_keys: Option<ConsensusKeyPair>,
     /// Weights to estimate payloads with.
     pub(super) payload_weights: PayloadWeights,
+}
+
+impl<REv> NetworkContext<REv> {
+    pub(crate) fn validate_peer_cert(&self, peer_cert: X509) -> Result<TlsCert, ValidationError> {
+        match &self.network_ca {
+            Some(ca_cert) => tls::validate_cert_with_authority(peer_cert, ca_cert),
+            None => tls::validate_self_signed_cert(peer_cert),
+        }
+    }
 }
 
 /// Handles an incoming connection.
@@ -199,13 +211,12 @@ where
     for<'de> P: Serialize + Deserialize<'de>,
     for<'de> Message<P>: Serialize + Deserialize<'de>,
 {
-    let (peer_id, transport) =
-        match server_setup_tls(stream, &context.our_cert, &context.secret_key).await {
-            Ok(value) => value,
-            Err(error) => {
-                return IncomingConnection::FailedEarly { peer_addr, error };
-            }
-        };
+    let (peer_id, transport) = match server_setup_tls(&context, stream).await {
+        Ok(value) => value,
+        Err(error) => {
+            return IncomingConnection::FailedEarly { peer_addr, error };
+        }
+    };
 
     // Register the `peer_id` on the [`Span`] for logging the ID from here on out.
     Span::current().record("peer_id", &field::display(peer_id));
@@ -256,15 +267,17 @@ where
 /// Server-side TLS setup.
 ///
 /// This function groups the TLS setup into a convenient function, enabling the `?` operator.
-pub(super) async fn server_setup_tls(
+pub(super) async fn server_setup_tls<REv>(
+    context: &NetworkContext<REv>,
     stream: TcpStream,
-    cert: &TlsCert,
-    secret_key: &PKey<Private>,
 ) -> Result<(NodeId, Transport), ConnectionError> {
-    let mut tls_stream = tls::create_tls_acceptor(cert.as_x509().as_ref(), secret_key.as_ref())
-        .and_then(|ssl_acceptor| Ssl::new(ssl_acceptor.context()))
-        .and_then(|ssl| SslStream::new(ssl, stream))
-        .map_err(ConnectionError::TlsInitialization)?;
+    let mut tls_stream = tls::create_tls_acceptor(
+        context.our_cert.as_x509().as_ref(),
+        context.secret_key.as_ref(),
+    )
+    .and_then(|ssl_acceptor| Ssl::new(ssl_acceptor.context()))
+    .and_then(|ssl| SslStream::new(ssl, stream))
+    .map_err(ConnectionError::TlsInitialization)?;
 
     SslStream::accept(Pin::new(&mut tls_stream))
         .await
@@ -276,12 +289,12 @@ pub(super) async fn server_setup_tls(
         .peer_certificate()
         .ok_or(ConnectionError::NoPeerCertificate)?;
 
+    let validated_peer_cert = context
+        .validate_peer_cert(peer_cert)
+        .map_err(ConnectionError::PeerCertificateInvalid)?;
+
     Ok((
-        NodeId::from(
-            tls::validate_cert(peer_cert)
-                .map_err(ConnectionError::PeerCertificateInvalid)?
-                .public_key_fingerprint(),
-        ),
+        NodeId::from(validated_peer_cert.public_key_fingerprint()),
         tls_stream,
     ))
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -143,7 +143,7 @@ impl Reactor for TestReactor {
         event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let small_network_identity = SmallNetworkIdentity::with_generated_certs()?;
         let (net, effects) = SmallNetwork::new(
             event_queue,
             cfg,

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -323,7 +323,7 @@ fn put_execution_results(
     block_hash: BlockHash,
     execution_results: HashMap<DeployHash, ExecutionResult>,
 ) {
-    let response = harness.send_request(storage, move |responder| {
+    harness.send_request(storage, move |responder| {
         StorageRequest::PutExecutionResults {
             block_hash: Box::new(block_hash),
             execution_results,
@@ -332,7 +332,6 @@ fn put_execution_results(
         .into()
     });
     assert!(harness.is_idle());
-    response
 }
 
 /// Saves state from the storage component.

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.6")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.8")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -70,8 +70,7 @@ impl EventQueueMetrics {
             .iter()
             .sorted_by_key(|k| k.0)
             .map(|(queue, event_count)| {
-                let _ = self
-                    .event_queue_gauges
+                self.event_queue_gauges
                     .get(queue)
                     .map(|gauge| gauge.set(*event_count as i64))
                     .expect("queue exists.");

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -311,7 +311,8 @@ impl Reactor {
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let network_config = config.map_ref(|config| config.network.clone());
+        let small_network_identity = SmallNetworkIdentity::from_config(network_config)?;
 
         let reactor = Reactor {
             config,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -483,7 +483,7 @@ impl reactor::Reactor for Reactor {
 
         let deploy_acceptor = DeployAcceptor::new(
             config.deploy_acceptor,
-            &*chainspec_loader.chainspec(),
+            chainspec_loader.chainspec(),
             registry,
         )?;
 

--- a/node/src/reactor/participating.rs
+++ b/node/src/reactor/participating.rs
@@ -495,7 +495,7 @@ impl reactor::Reactor for Reactor {
 
         let deploy_acceptor = DeployAcceptor::new(
             config.deploy_acceptor,
-            &*chainspec_loader.chainspec(),
+            chainspec_loader.chainspec(),
             registry,
         )?;
 

--- a/node/src/testing/condition_check_reactor.rs
+++ b/node/src/testing/condition_check_reactor.rs
@@ -10,6 +10,8 @@ use crate::{
     NodeRng,
 };
 
+type ConditionChecker<R> = Box<dyn Fn(&<R as Reactor>::Event) -> bool + Send>;
+
 /// A reactor wrapping an inner reactor, and which has an optional hook into
 /// `Reactor::dispatch_event()`.
 ///
@@ -20,16 +22,13 @@ use crate::{
 /// Once the condition is met, the hook is reset to `None`.
 pub(crate) struct ConditionCheckReactor<R: Reactor> {
     reactor: R,
-    condition_checker: Option<Box<dyn Fn(&R::Event) -> bool + Send>>,
+    condition_checker: Option<ConditionChecker<R>>,
     condition_result: bool,
 }
 
 impl<R: Reactor> ConditionCheckReactor<R> {
     /// Sets the condition checker hook.
-    pub(crate) fn set_condition_checker(
-        &mut self,
-        condition_checker: Box<dyn Fn(&R::Event) -> bool + Send>,
-    ) {
+    pub(crate) fn set_condition_checker(&mut self, condition_checker: ConditionChecker<R>) {
         self.condition_checker = Some(condition_checker);
     }
 

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -1462,7 +1462,7 @@ impl From<Deploy> for DeployItem {
 ///
 /// Currently a stop-gap measure to associate an immutable deploy with additional metadata. Holds
 /// execution results.
-#[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct DeployMetadata {
     /// The block hashes of blocks containing the related deploy, along with the results of
     /// executing the related deploy in the context of one or more blocks.

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -70,7 +70,7 @@ static AUCTION_INFO: Lazy<AuctionState> = Lazy::new(|| {
 });
 
 /// A validator's weight.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonValidatorWeights {
     public_key: PublicKey,
@@ -78,7 +78,7 @@ pub struct JsonValidatorWeights {
 }
 
 /// The validators for the given era.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonEraValidators {
     era_id: EraId,
@@ -86,7 +86,7 @@ pub struct JsonEraValidators {
 }
 
 /// A delegator associated with the given validator.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonDelegator {
     public_key: PublicKey,
@@ -96,7 +96,7 @@ pub struct JsonDelegator {
 }
 
 /// An entry in a founding validator map representing a bid.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonBid {
     /// The purse that was used for bonding.
@@ -133,7 +133,7 @@ impl From<Bid> for JsonBid {
 }
 
 /// A Json representation of a single bid.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonBids {
     public_key: PublicKey,
@@ -141,7 +141,7 @@ pub struct JsonBids {
 }
 
 /// Data structure summarizing auction contract data.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AuctionState {
     /// Global state hash.

--- a/node/src/types/shared_object.rs
+++ b/node/src/types/shared_object.rs
@@ -25,8 +25,8 @@ impl<T> Deref for SharedObject<T> {
     #[inline]
     fn deref(&self) -> &Self::Target {
         match self {
-            SharedObject::Owned(obj) => &*obj,
-            SharedObject::Shared(shared) => &*shared,
+            SharedObject::Owned(obj) => obj,
+            SharedObject::Shared(shared) => shared,
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -139,6 +139,14 @@ max_incoming_message_rate_non_validators = 0
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "local_node_cert.pem"
+# secret_key = "local_node.pem"
+# ca_certificate = "ca_cert.pem"
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.7'
+version = '1.4.8'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.6'
+version = '1.4.7'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.
@@ -11,7 +11,7 @@ hard_reset = true
 # in contract-runtime for computing genesis post-state hash.
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
-activation_point = 3000
+activation_point = 5900
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -139,6 +139,14 @@ max_incoming_message_rate_non_validators = 3000
 # Any weight set to 0 means that the category of traffic is exempt from throttling.
 estimator_weights = { consensus=0, deploy_requests=1 }
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "local_node_cert.pem"
+# secret_key = "local_node.pem"
+# ca_certificate = "ca_cert.pem"
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -2718,7 +2718,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.6"
+        "version": "1.4.7"
       },
       "methods": [
         {
@@ -2783,7 +2783,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2841,7 +2841,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy": {
                     "approvals": [
                       {
@@ -3020,7 +3020,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3103,7 +3103,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3193,7 +3193,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3336,7 +3336,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3381,7 +3381,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3508,7 +3508,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3568,7 +3568,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -3686,7 +3686,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -3770,7 +3770,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3840,7 +3840,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3930,7 +3930,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4000,7 +4000,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4086,7 +4086,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -2718,7 +2718,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.7"
+        "version": "1.4.8"
       },
       "methods": [
         {
@@ -2783,7 +2783,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2841,7 +2841,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy": {
                     "approvals": [
                       {
@@ -3020,7 +3020,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3103,7 +3103,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3193,7 +3193,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3336,7 +3336,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3381,7 +3381,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3508,7 +3508,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3568,7 +3568,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -3686,7 +3686,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -3770,7 +3770,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3840,7 +3840,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3930,7 +3930,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4000,7 +4000,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4086,7 +4086,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.6"
+        "version": "1.4.7"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.7"
+        "version": "1.4.8"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "auction_state": {
                     "bids": [
                       {

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
+++ b/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
@@ -10,33 +10,33 @@ use casper_contract::contract_api::{runtime, storage};
 
 use casper_types::{
     runtime_args, ApiError, CLType, ContractHash, ContractVersion, EntryPoint, EntryPointAccess,
-    EntryPointType, EntryPoints, Parameter, RuntimeArgs,
+    EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs,
 };
 
-// This is making use of the undocumented "FFI" function `gas()` which is used by the Wasm
-// interpreter to charge gas for upcoming interpreted instructions.  For further info on this, see
-// https://docs.rs/pwasm-utils/0.12.0/pwasm_utils/fn.inject_gas_counter.html
-mod unsafe_ffi {
-    extern "C" {
-        pub fn gas(amount: i32);
-    }
-}
-
-fn safe_gas(amount: i32) {
-    unsafe { unsafe_ffi::gas(amount) }
-}
-
 const SUBCALL_NAME: &str = "add_gas";
+const DATA_KEY: &str = "data";
 const ADD_GAS_FROM_SESSION: &str = "add-gas-from-session";
 const ADD_GAS_VIA_SUBCALL: &str = "add-gas-via-subcall";
 
 const ARG_GAS_AMOUNT: &str = "gas_amount";
 const ARG_METHOD_NAME: &str = "method_name";
 
+fn consume_gas(amount: i32) {
+    if amount > 0 {
+        let data = vec![0u8; amount as usize];
+        let data_uref = runtime::get_key(DATA_KEY)
+            .and_then(Key::into_uref)
+            .unwrap_or_else(|| storage::new_uref(()));
+
+        storage::write(data_uref, data);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn add_gas() {
     let amount: i32 = runtime::get_named_arg(ARG_GAS_AMOUNT);
-    safe_gas(amount);
+
+    consume_gas(amount);
 }
 
 fn store() -> (ContractHash, ContractVersion) {
@@ -63,7 +63,7 @@ pub extern "C" fn call() {
     let method_name: String = runtime::get_named_arg(ARG_METHOD_NAME);
 
     match method_name.as_str() {
-        ADD_GAS_FROM_SESSION => safe_gas(amount),
+        ADD_GAS_FROM_SESSION => consume_gas(amount),
         ADD_GAS_VIA_SUBCALL => {
             let (contract_hash, _contract_version) = store();
             runtime::call_contract(

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -137,7 +137,7 @@ impl Distribution<AccessRights> for Standard {
 }
 
 /// Used to indicate if a granted [`URef`] was already held by the context.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum GrantedAccess {
     /// No new set of access rights were granted.
     PreExisting,
@@ -151,7 +151,7 @@ pub enum GrantedAccess {
 }
 
 /// Access rights for a given runtime context.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ContextAccessRights {
     context_key: Key,
     access_rights: BTreeMap<URefAddr, AccessRights>,

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -40,7 +40,7 @@ const CONTRACT_STRING_PREFIX: &str = "contract-";
 const PACKAGE_STRING_PREFIX: &str = "contract-package-wasm";
 
 /// Set of errors which may happen when working with contract headers.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Error {
     /// Attempt to override an existing or previously existing version with a

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -657,7 +657,7 @@ impl Distribution<Transform> for Standard {
             11 => {
                 let mut named_keys = Vec::new();
                 for _ in 0..rng.gen_range(1..6) {
-                    let _ = named_keys.push(NamedKey {
+                    named_keys.push(NamedKey {
                         name: rng.gen::<u64>().to_string(),
                         key: rng.gen::<u64>().to_string(),
                     });

--- a/types/src/system/auction/seigniorage_recipient.rs
+++ b/types/src/system/auction/seigniorage_recipient.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// The seigniorage recipient details.
-#[derive(Default, PartialEq, Clone, Debug)]
+#[derive(Default, PartialEq, Eq, Clone, Debug)]
 pub struct SeigniorageRecipient {
     /// Validator stake (not including delegators)
     stake: U512,

--- a/types/src/system/mod.rs
+++ b/types/src/system/mod.rs
@@ -87,7 +87,7 @@ mod system_contract_type {
     ///
     /// Used by converting to a `u32` and passing as the `system_contract_index` argument of
     /// `ext_ffi::casper_get_system_contract()`.
-    #[derive(Debug, Copy, Clone, PartialEq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum SystemContractType {
         /// Mint contract.
         Mint,


### PR DESCRIPTION
This PR contains updates `feat-private-chain` for a new private chain release independent of 1.5.0:

- Merge of v1.4.8 security release
- Backport of #3291

After this PR is merged, it should be possible to release `private-1.4.8`.