### PR TITLE
Log blocklisting reason

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased (next)]
 
+### Changed
+
+* Log messages for blocked nodes have been unified and reasons for blocking peers are better tracked.
 
 ## [Unreleased]
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -2179,7 +2179,7 @@ where
                     .announce_block_peer_with_justification(
                         peer,
                         BlocklistJustification::SentBlockThatExecutedIncorrectly {
-                            block_hash: block.hash().clone(),
+                            block_hash: *block.hash(),
                         },
                     )
                     .await;

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -35,6 +35,7 @@ use crate::{
         contract_runtime::{BlockAndExecutionEffects, ExecutionPreState},
         fetcher::{FetchedData, FetcherError},
         linear_chain::{self, BlockSignatureError},
+        small_network::blocklist::BlocklistJustification,
     },
     effect::{
         announcements::{
@@ -899,13 +900,15 @@ where
             }
             Ok(FetchedData::FromPeer { item, .. }) => {
                 if *item.header().parent_hash() != parent_header.hash() {
-                    warn!(
-                        ?peer,
-                        fetched_header = ?item.header(),
-                        ?parent_header,
-                        "received block with wrong parent from peer",
-                    );
-                    ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                    ctx.effect_builder
+                        .announce_block_peer_with_justification(
+                            peer,
+                            BlocklistJustification::SentBlockWithWrongParent {
+                                received_header: item.header().clone(),
+                                expected_parent_header: parent_header.clone(),
+                            },
+                        )
+                        .await;
                     continue;
                 }
 
@@ -918,8 +921,14 @@ where
                 }
 
                 if item.block_signatures().proofs.is_empty() {
-                    warn!(?peer, ?item, "no block signatures from peer");
-                    ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                    ctx.effect_builder
+                        .announce_block_peer_with_justification(
+                            peer,
+                            BlocklistJustification::MissingBlockSignatures {
+                                received_header: item.header().clone(),
+                            },
+                        )
+                        .await;
                     continue;
                 }
 
@@ -933,8 +942,12 @@ where
                         continue;
                     }
                     Err(error @ BlockSignatureError::BogusValidator { .. }) => {
-                        warn!(?error, ?peer, "bogus validator block signature from peer");
-                        ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                        ctx.effect_builder
+                            .announce_block_peer_with_justification(
+                                peer,
+                                BlocklistJustification::SentSignatureWithBogusValidator { error },
+                            )
+                            .await;
                         continue;
                     }
                     // TODO - make this an error condition once we start using
@@ -946,12 +959,12 @@ where
                 }
 
                 if let Err(error) = item.block_signatures().verify() {
-                    warn!(
-                        ?error,
-                        ?peer,
-                        "error validating finality signatures from peer"
-                    );
-                    ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                    ctx.effect_builder
+                        .announce_block_peer_with_justification(
+                            peer,
+                            BlocklistJustification::SentBadFinalitySignature { error },
+                        )
+                        .await;
                     continue;
                 }
 
@@ -1512,13 +1525,15 @@ where
                         return Ok(new_lowest);
                     }
                     Err(err) => {
-                        error!(
-                            ?err,
-                            ?peer,
-                            ?batch_id,
-                            "block headers batch failed validation. Trying next peer..."
-                        );
-                        ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                        ctx.effect_builder
+                            .announce_block_peer_with_justification(
+                                peer,
+                                BlocklistJustification::SentInvalidHeaderBatch {
+                                    batch_id,
+                                    error: err,
+                                },
+                            )
+                            .await;
                     }
                 }
             }
@@ -1718,13 +1733,15 @@ impl BlockSignaturesCollector {
                 .await?;
 
         if let Err(err) = linear_chain::validate_block_signatures(&signatures, &validator_weights) {
-            warn!(
-                ?peer,
-                ?err,
-                height = block_header.height(),
-                "peer sent invalid finality signatures, banning peer"
-            );
-            ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+            ctx.effect_builder
+                .announce_block_peer_with_justification(
+                    peer,
+                    BlocklistJustification::SentBlockWithInvalidFinalitySignatures {
+                        block_header: block_header.clone(),
+                        error: err,
+                    },
+                )
+                .await;
 
             // Try with next peer.
             return Ok(HandleSignaturesResult::ContinueFetching);
@@ -2158,12 +2175,14 @@ where
                 if blocks_match {
                     break;
                 }
-                warn!(
-                    %peer,
-                    "block executed with approvals from this peer doesn't match the received \
-                    block; blocking peer"
-                );
-                ctx.effect_builder.announce_disconnect_from_peer(peer).await;
+                ctx.effect_builder
+                    .announce_block_peer_with_justification(
+                        peer,
+                        BlocklistJustification::SentBlockThatExecutedIncorrectly {
+                            block_hash: block.hash().clone(),
+                        },
+                    )
+                    .await;
             }
         }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -42,6 +42,7 @@ use crate::{
             ActionId, ChainspecConsensusExt, Config, ConsensusMessage, Event, NewBlockPayload,
             ReactorEventT, ResolveValidity, TimerId,
         },
+        small_network::blocklist::BlocklistJustification,
         storage::Storage,
     },
     effect::{
@@ -758,12 +759,11 @@ impl EraSupervisor {
         self.metrics.proposed_block();
         let mut effects = Effects::new();
         if !valid {
-            warn!(
-                peer_id = %sender,
-                era = %era_id.value(),
-                "invalid consensus value; disconnecting from the sender"
-            );
-            effects.extend(self.disconnect(effect_builder, sender));
+            effects.extend(self.disconnect(
+                effect_builder,
+                sender,
+                BlocklistJustification::SentInvalidConsensusValue { era: era_id },
+            ));
         }
         if self
             .open_eras
@@ -821,20 +821,21 @@ impl EraSupervisor {
         consensus_result: ProtocolOutcome<ClContext>,
     ) -> Effects<Event> {
         match consensus_result {
-            ProtocolOutcome::InvalidIncomingMessage(_, sender, error) => {
-                warn!(
-                    %sender,
-                    %error,
-                    "invalid incoming message to consensus instance; disconnecting from the sender"
-                );
-                self.disconnect(effect_builder, sender)
-            }
+            ProtocolOutcome::InvalidIncomingMessage(_, sender, error) => self.disconnect(
+                effect_builder,
+                sender,
+                BlocklistJustification::SentInvalidConsensusMessage { error },
+            ),
             ProtocolOutcome::Disconnect(sender) => {
                 warn!(
                     %sender,
                     "disconnecting from the sender of invalid data"
                 );
-                self.disconnect(effect_builder, sender)
+                self.disconnect(
+                    effect_builder,
+                    sender,
+                    BlocklistJustification::BadConsensusBehavior,
+                )
             }
             ProtocolOutcome::CreatedGossipMessage(payload) => {
                 let message = ConsensusMessage::Protocol { era_id, payload };
@@ -1082,9 +1083,10 @@ impl EraSupervisor {
         &self,
         effect_builder: EffectBuilder<REv>,
         sender: NodeId,
+        justification: BlocklistJustification,
     ) -> Effects<Event> {
         effect_builder
-            .announce_block_peer_with_justification(sender, todo!())
+            .announce_block_peer_with_justification(sender, justification)
             .ignore()
     }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1084,7 +1084,7 @@ impl EraSupervisor {
         sender: NodeId,
     ) -> Effects<Event> {
         effect_builder
-            .announce_disconnect_from_peer(sender)
+            .announce_block_peer_with_justification(sender, todo!())
             .ignore()
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1039,12 +1039,12 @@ where
                 );
                 self.process_dial_requests(requests)
             }
-            Event::BlocklistAnnouncement(BlocklistAnnouncement::OffenseCommitted(peer_id)) => {
+            Event::BlocklistAnnouncement(BlocklistAnnouncement::OffenseCommitted { offender }) => {
                 // TODO: We do not have a proper by-node-ID blocklist, but rather only block the
                 // current outgoing address of a peer.
-                warn!(%peer_id, "adding peer to blocklist after transgression");
+                warn!(%offender, "adding peer to blocklist after transgression");
 
-                if let Some(addr) = self.outgoing_manager.get_addr(*peer_id) {
+                if let Some(addr) = self.outgoing_manager.get_addr(*offender) {
                     let requests = self.outgoing_manager.block_addr(addr, Instant::now());
                     self.process_dial_requests(requests)
                 } else {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1040,10 +1040,13 @@ where
                 );
                 self.process_dial_requests(requests)
             }
-            Event::BlocklistAnnouncement(BlocklistAnnouncement::OffenseCommitted { offender }) => {
+            Event::BlocklistAnnouncement(BlocklistAnnouncement::OffenseCommitted {
+                offender,
+                justification,
+            }) => {
                 // TODO: We do not have a proper by-node-ID blocklist, but rather only block the
                 // current outgoing address of a peer.
-                warn!(%offender, "adding peer to blocklist after transgression");
+                info!(%offender, %justification, "adding peer to blocklist after transgression");
 
                 if let Some(addr) = self.outgoing_manager.get_addr(*offender) {
                     let requests = self.outgoing_manager.block_addr(addr, Instant::now());

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -24,6 +24,7 @@
 //! maintain an outgoing connection to any new address learned.
 
 mod bincode_format;
+pub(crate) mod blocklist;
 mod chain_info;
 mod config;
 mod counting_format;

--- a/node/src/components/small_network/blocklist.rs
+++ b/node/src/components/small_network/blocklist.rs
@@ -8,7 +8,10 @@ use serde::Serialize;
 
 /// Reasons why a peer was blocked.
 #[derive(Copy, Clone, Debug, Serialize)]
-pub(crate) enum BlocklistJustification {}
+pub(crate) enum BlocklistJustification {
+    /// No reason given for blocking. TODO: Remove this entirely.
+    Unspecified,
+}
 
 impl Display for BlocklistJustification {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/node/src/components/small_network/blocklist.rs
+++ b/node/src/components/small_network/blocklist.rs
@@ -1,0 +1,19 @@
+//! Blocklisting support.
+//!
+//! Blocked peers are prevent from interacting with the node through a variety of means.
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::Serialize;
+
+/// Reasons why a peer was blocked.
+#[derive(Copy, Clone, Debug, Serialize)]
+pub(crate) enum BlocklistJustification {}
+
+impl Display for BlocklistJustification {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            _ => f.write_str("BlocklistJustification"),
+        }
+    }
+}

--- a/node/src/components/small_network/blocklist.rs
+++ b/node/src/components/small_network/blocklist.rs
@@ -4,19 +4,145 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use casper_types::crypto;
 use serde::Serialize;
 
+use crate::{
+    components::linear_chain::BlockSignatureError,
+    types::{
+        error::BlockHeadersBatchValidationError, BlockHash, BlockHeader, BlockHeadersBatchId, Tag,
+    },
+};
+
 /// Reasons why a peer was blocked.
-#[derive(Copy, Clone, Debug, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) enum BlocklistJustification {
-    /// No reason given for blocking. TODO: Remove this entirely.
-    Unspecified,
+    /// Peer sent an item that was not parseable at all.
+    SentBadItem { tag: Tag },
+    /// Received a block with incorrect parent, which was specified beforehand.
+    SentBlockWithWrongParent {
+        /// The header that was received.
+        received_header: BlockHeader,
+        /// The parent that was expected.
+        expected_parent_header: BlockHeader,
+    },
+    /// A block header or block was received without the appropriate finality signatures.
+    MissingBlockSignatures {
+        /// Received header/header of block.
+        received_header: BlockHeader,
+    },
+    /// A peer sent a bogus block signature
+    SentSignatureWithBogusValidator {
+        /// The actual validation error.
+        #[serde(skip_serializing)]
+        error: BlockSignatureError,
+    },
+    /// A finality signature that was sent is cryptographically invalid.
+    SentBadFinalitySignature {
+        /// The actual cryptographic validation error.
+        #[serde(skip_serializing)]
+        error: crypto::Error,
+    },
+    /// A received batch of block headers was not valid.
+    SentInvalidHeaderBatch {
+        /// The ID of the received batch that did not validate.
+        batch_id: BlockHeadersBatchId,
+        /// The actual validation error.
+        #[serde(skip_serializing)]
+        error: BlockHeadersBatchValidationError,
+    },
+    /// A received block with signatures failed validation.
+    SentBlockWithInvalidFinalitySignatures {
+        /// The block header for which invalid signatures were received.
+        block_header: BlockHeader,
+        /// The block signature error.
+        #[serde(skip_serializing)]
+        error: BlockSignatureError,
+    },
+    /// A received block did not yield the expected execution results.
+    SentBlockThatExecutedIncorrectly {
+        /// The hash of the received block.
+        block_hash: BlockHash,
+    },
+    /// An item received failed to validation.
+    SentInvalidItem {
+        /// The tag of the item received.
+        tag: Tag,
+        /// The ID of item, as a human-readable string.
+        item_id: String,
+        /// The validation error, as a human-readable string.
+        error: String,
+    },
+    /// A serialized deploy was received that failed to deserialize.
+    SentBadDeploy {
+        /// The deserialization error.
+        #[serde(skip_serializing)]
+        error: bincode::Error,
+    },
+    /// A network address was received that should only be received via direct gossip.
+    SentGossipedAddress,
 }
 
 impl Display for BlocklistJustification {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            _ => f.write_str("BlocklistJustification"),
+            BlocklistJustification::SentBadItem { tag } => {
+                write!(f, "sent a {:?} item we couldn't parse", tag)
+            }
+            BlocklistJustification::SentBlockWithWrongParent {
+                received_header,
+                expected_parent_header,
+            } => write!(
+                f,
+                "sent block (header: {:?}) with wrong parent ({:?})",
+                received_header, expected_parent_header,
+            ),
+            BlocklistJustification::MissingBlockSignatures { received_header } => write!(
+                f,
+                "sent no block signatures along with header {:?}",
+                received_header
+            ),
+            BlocklistJustification::SentSignatureWithBogusValidator { error } => {
+                write!(f, "sent signature with bogus validator ({})", error)
+            }
+            BlocklistJustification::SentBadFinalitySignature { error } => write!(
+                f,
+                "sent cryptographically invalid finality signature: {}",
+                error
+            ),
+            BlocklistJustification::SentInvalidHeaderBatch { batch_id, error } => write!(
+                f,
+                "sent block headers batch {} that failed validation: {}",
+                batch_id, error
+            ),
+            BlocklistJustification::SentBlockWithInvalidFinalitySignatures {
+                block_header,
+                error,
+            } => write!(
+                f,
+                "sent sent invalid finality signatures for block {:?}: {}",
+                block_header, error
+            ),
+            BlocklistJustification::SentBlockThatExecutedIncorrectly { block_hash } => write!(
+                f,
+                "sent block {}, but the execution of the block did not yield the expected results",
+                block_hash
+            ),
+            BlocklistJustification::SentInvalidItem {
+                tag,
+                item_id,
+                error,
+            } => write!(
+                f,
+                "sent item {} of type {:?} that was invalid: {}",
+                item_id, tag, error
+            ),
+            BlocklistJustification::SentBadDeploy { error } => {
+                write!(f, "sent a deploy that could not be deserialized: {}", error)
+            }
+            BlocklistJustification::SentGossipedAddress => {
+                f.write_str("sent a network address via response, which is only ever gossiped")
+            }
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -140,7 +140,7 @@ use crate::{
         },
         deploy_acceptor,
         fetcher::FetchResult,
-        small_network::FromIncoming,
+        small_network::{blocklist::BlocklistJustification, FromIncoming},
     },
     contract_runtime::SpeculativeExecutionState,
     effect::announcements::ChainSynchronizerAnnouncement,
@@ -1657,7 +1657,7 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Announce the intent to disconnect from a specific peer, which consensus thinks is faulty.
+    /// Blocks a specific peer due to a transgression.
     pub(crate) async fn announce_disconnect_from_peer(self, peer: NodeId)
     where
         REv: From<BlocklistAnnouncement>,
@@ -1666,6 +1666,7 @@ impl<REv> EffectBuilder<REv> {
             .schedule(
                 BlocklistAnnouncement::OffenseCommitted {
                     offender: Box::new(peer),
+                    justification: BlocklistJustification::Unspecified,
                 },
                 QueueKind::Regular,
             )

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1658,15 +1658,21 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Blocks a specific peer due to a transgression.
-    pub(crate) async fn announce_disconnect_from_peer(self, peer: NodeId)
-    where
+    ///
+    /// This function will also emit a log message for the block.
+    pub(crate) async fn announce_block_peer_with_justification(
+        self,
+        offender: NodeId,
+        justification: BlocklistJustification,
+    ) where
         REv: From<BlocklistAnnouncement>,
     {
+        warn!(%offender, %justification, "peer will be blocked");
         self.event_queue
             .schedule(
                 BlocklistAnnouncement::OffenseCommitted {
-                    offender: Box::new(peer),
-                    justification: BlocklistJustification::Unspecified,
+                    offender: Box::new(offender),
+                    justification: Box::new(justification),
                 },
                 QueueKind::Regular,
             )

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1664,7 +1664,9 @@ impl<REv> EffectBuilder<REv> {
     {
         self.event_queue
             .schedule(
-                BlocklistAnnouncement::OffenseCommitted(Box::new(peer)),
+                BlocklistAnnouncement::OffenseCommitted {
+                    offender: Box::new(peer),
+                },
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -17,6 +17,7 @@ use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey, Timestamp
 use crate::{
     components::{
         chainspec_loader::NextUpgrade, deploy_acceptor::Error, diagnostics_port::FileSerializer,
+        small_network::blocklist::BlocklistJustification,
     },
     effect::Responder,
     types::{
@@ -228,14 +229,19 @@ pub(crate) enum BlocklistAnnouncement {
     OffenseCommitted {
         /// The peer ID of the offending node.
         offender: Box<NodeId>,
+        /// Justification for blocking the peer.
+        justification: BlocklistJustification,
     },
 }
 
 impl Display for BlocklistAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BlocklistAnnouncement::OffenseCommitted { offender } => {
-                write!(f, "peer {} committed offense", offender)
+            BlocklistAnnouncement::OffenseCommitted {
+                offender,
+                justification,
+            } => {
+                write!(f, "peer {} committed offense: {}", offender, justification)
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -225,14 +225,17 @@ impl Display for ConsensusAnnouncement {
 #[derive(Debug, Serialize)]
 pub(crate) enum BlocklistAnnouncement {
     /// A given peer committed a blockable offense.
-    OffenseCommitted(Box<NodeId>),
+    OffenseCommitted {
+        /// The peer ID of the offending node.
+        offender: Box<NodeId>,
+    },
 }
 
 impl Display for BlocklistAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BlocklistAnnouncement::OffenseCommitted(peer) => {
-                write!(f, "peer {} committed offense", peer)
+            BlocklistAnnouncement::OffenseCommitted { offender } => {
+                write!(f, "peer {} committed offense", offender)
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -230,7 +230,7 @@ pub(crate) enum BlocklistAnnouncement {
         /// The peer ID of the offending node.
         offender: Box<NodeId>,
         /// Justification for blocking the peer.
-        justification: BlocklistJustification,
+        justification: Box<BlocklistJustification>,
     },
 }
 


### PR DESCRIPTION
Closes #3321.

This PR is part of a larger push to improve integration with OS-level block lists. It unifies handling of giving reasons for blocking a peer by creating an appropriate `enum` with a list of reasons.

It is a little coarse grained on the consensus side, but overall I feel it is an improvement. The log levels have been standardized as well - a warning is emitted every time a request is made to block a peer, while a mere `info`-level message is written to the log when the actual blocking takes effect.

The one thing this does affect negatively is the loss of line and file numbers in the logs when a ban happens, as these messages would be direct logging macros before, reducing the level of indirection. However in many cases (e.g. consensus) these were hidden behind another indirection anyway, and since there is a 1:1 mapping between former log lines and unique variants of the `BlocklistJustification` variants, this is still easily reconstructed. I favored this over the alternative of introducing a macro instead.