### PR TITLE
Use complete block headers in `deploy_acceptor` and `query_balance`

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -214,7 +214,7 @@ impl DeployAcceptor {
         }
 
         effect_builder
-            .get_highest_block_header_from_storage()
+            .get_highest_complete_block_header_from_storage()
             .event(move |maybe_block_header| Event::GetBlockHeaderResult {
                 event_metadata: EventMetadata::new(deploy, source, maybe_responder),
                 maybe_block_header: Box::new(maybe_block_header),

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -910,7 +910,10 @@ impl RpcWithParams for QueryBalance {
         params: Self::RequestParams,
     ) -> Result<Self::ResponseResult, Error> {
         let state_root_hash = match params.state_identifier {
-            None => match effect_builder.get_highest_block_header_from_storage().await {
+            None => match effect_builder
+                .get_highest_complete_block_header_from_storage()
+                .await
+            {
                 None => {
                     return Err(Error::new(
                         ErrorCode::NoSuchBlock,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -745,12 +745,6 @@ impl Storage {
             StorageRequest::GetHighestBlock { responder } => {
                 responder.respond(self.read_highest_block()?).ignore()
             }
-            StorageRequest::GetHighestBlockHeader { responder } => {
-                let mut txn = self.env.begin_ro_txn()?;
-                responder
-                    .respond(self.get_highest_block_header(&mut txn)?)
-                    .ignore()
-            }
             StorageRequest::GetHighestCompleteBlockHeader { responder } => {
                 let mut txn = self.env.begin_ro_txn()?;
                 responder
@@ -1715,21 +1709,6 @@ impl Storage {
             .keys()
             .last()
             .and_then(|&height| self.get_block_by_height(txn, height).transpose())
-            .transpose()
-    }
-
-    /// Retrieves the highest block header from storage, if one exists. May return an LMDB error.
-    fn get_highest_block_header<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        self.block_height_index
-            .iter()
-            .last()
-            .and_then(|(_, hash_of_highest_block)| {
-                self.get_single_block_header(txn, hash_of_highest_block)
-                    .transpose()
-            })
             .transpose()
     }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1388,7 +1388,7 @@ fn should_get_signed_block_headers() {
         let mut txn = storage.env.begin_ro_txn().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().header();
         let highest_block_header_with_sufficient_signatures = storage
-            .get_header_of_highest_complete_block(&mut txn)
+            .get_header_with_metadata_of_highest_complete_block(&mut txn)
             .unwrap()
             .unwrap();
         let previous_switch_block_header = storage
@@ -1437,7 +1437,7 @@ fn should_get_signed_block_headers_when_no_sufficient_finality_in_most_recent_bl
         let mut txn = storage.env.begin_ro_txn().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().header();
         let highest_block_header_with_sufficient_signatures = storage
-            .get_header_of_highest_complete_block(&mut txn)
+            .get_header_with_metadata_of_highest_complete_block(&mut txn)
             .unwrap()
             .unwrap();
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -387,13 +387,13 @@ fn get_highest_block(
     response
 }
 
-/// Requests the highest block header from a storage component.
-fn get_highest_block_header(
+/// Requests the highest complete block header from a storage component.
+fn get_highest_complete_block_header(
     harness: &mut ComponentHarness<UnitTestEvent>,
     storage: &mut Storage,
 ) -> Option<BlockHeader> {
     let response = harness.send_request(storage, |responder| {
-        StorageRequest::GetHighestBlockHeader { responder }.into()
+        StorageRequest::GetHighestCompleteBlockHeader { responder }.into()
     });
     assert!(harness.is_idle());
     response
@@ -519,7 +519,7 @@ fn can_retrieve_block_by_height() {
     assert!(get_block_at_height(&mut storage, 0).is_none());
     assert!(get_block_header_at_height(&mut storage, 0).is_none());
     assert!(get_highest_block(&mut harness, &mut storage).is_none());
-    assert!(get_highest_block_header(&mut harness, &mut storage).is_none());
+    assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
     assert!(get_block_at_height(&mut storage, 14).is_none());
     assert!(get_block_header_at_height(&mut storage, 14).is_none());
     assert!(get_block_at_height(&mut storage, 33).is_none());
@@ -535,10 +535,7 @@ fn can_retrieve_block_by_height() {
         get_highest_block(&mut harness, &mut storage).as_ref(),
         Some(&*block_33)
     );
-    assert_eq!(
-        get_highest_block_header(&mut harness, &mut storage).as_ref(),
-        Some(block_33.header())
-    );
+    assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
     assert!(get_block_at_height(&mut storage, 0).is_none());
     assert!(get_block_header_at_height(&mut storage, 0).is_none());
     assert!(get_block_at_height(&mut storage, 14).is_none());
@@ -562,10 +559,7 @@ fn can_retrieve_block_by_height() {
         get_highest_block(&mut harness, &mut storage).as_ref(),
         Some(&*block_33)
     );
-    assert_eq!(
-        get_highest_block_header(&mut harness, &mut storage).as_ref(),
-        Some(block_33.header())
-    );
+    assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
     assert!(get_block_at_height(&mut storage, 0).is_none());
     assert!(get_block_header_at_height(&mut storage, 0).is_none());
     assert_eq!(
@@ -589,6 +583,8 @@ fn can_retrieve_block_by_height() {
 
     // Inserting block with height 99, changes highest.
     let was_new = put_block(&mut harness, &mut storage, block_99.clone());
+    // Mark block 99 as complete.
+    storage.completed_blocks.insert(99);
     assert!(was_new);
 
     assert_eq!(
@@ -596,7 +592,7 @@ fn can_retrieve_block_by_height() {
         Some(&*block_99)
     );
     assert_eq!(
-        get_highest_block_header(&mut harness, &mut storage).as_ref(),
+        get_highest_complete_block_header(&mut harness, &mut storage).as_ref(),
         Some(block_99.header())
     );
     assert!(get_block_at_height(&mut storage, 0).is_none());

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1377,18 +1377,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Requests the highest block header.
-    pub(crate) async fn get_highest_block_header_from_storage(self) -> Option<BlockHeader>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetHighestBlockHeader { responder },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Requests the highest complete block header.
     pub(crate) async fn get_highest_complete_block_header_from_storage(self) -> Option<BlockHeader>
     where

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1389,6 +1389,18 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Requests the highest complete block header.
+    pub(crate) async fn get_highest_complete_block_header_from_storage(self) -> Option<BlockHeader>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetHighestCompleteBlockHeader { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Requests the header of the switch block at the given era ID.
     pub(crate) async fn get_switch_block_header_at_era_id_from_storage(
         self,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -351,6 +351,11 @@ pub(crate) enum StorageRequest {
         /// Responder.
         responder: Responder<Option<BlockHeader>>,
     },
+    /// Retrieve highest complete block header.
+    GetHighestCompleteBlockHeader {
+        /// Responder.
+        responder: Responder<Option<BlockHeader>>,
+    },
     /// Retrieve switch block header with given era ID.
     GetSwitchBlockHeaderAtEraId {
         /// Era ID of the switch block.
@@ -586,6 +591,9 @@ impl Display for StorageRequest {
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
             StorageRequest::GetHighestBlockHeader { .. } => {
                 write!(formatter, "get highest block header")
+            }
+            StorageRequest::GetHighestCompleteBlockHeader { .. } => {
+                write!(formatter, "get highest complete block header")
             }
             StorageRequest::GetSwitchBlockHeaderAtEraId { era_id, .. } => {
                 write!(formatter, "get switch block header at era id {}", era_id)

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -346,11 +346,6 @@ pub(crate) enum StorageRequest {
         /// Responder.
         responder: Responder<Option<Block>>,
     },
-    /// Retrieve highest block header.
-    GetHighestBlockHeader {
-        /// Responder.
-        responder: Responder<Option<BlockHeader>>,
-    },
     /// Retrieve highest complete block header.
     GetHighestCompleteBlockHeader {
         /// Responder.
@@ -589,9 +584,6 @@ impl Display for StorageRequest {
                 write!(formatter, "get block and finalized deploys {}", block_hash)
             }
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
-            StorageRequest::GetHighestBlockHeader { .. } => {
-                write!(formatter, "get highest block header")
-            }
             StorageRequest::GetHighestCompleteBlockHeader { .. } => {
                 write!(formatter, "get highest complete block header")
             }


### PR DESCRIPTION
Fixes https://github.com/casper-network/casper-node/issues/3347

This PR replaces `get_highest_block_header` calls with `get_highest_complete_block_header`. Additionally, it removes the unused `get_highest_block_header` along with related functionality.
