### PR TITLE
Fix fatal macro usage

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -137,6 +137,8 @@ pub(crate) trait InitializedComponent<REv>: Component<REv> {
     fn is_fatal(&self) -> bool {
         matches!(self.status(), ComponentStatus::Fatal(_))
     }
+
+    fn name(&self) -> &str;
 }
 
 pub(crate) trait PortBoundComponent<REv>: InitializedComponent<REv> {

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -17,7 +17,7 @@ use crate::{
     components::{small_network::blocklist::BlocklistJustification, Component},
     effect::{
         announcements::{
-            BlockAccumulatorAnnouncement, ControlAnnouncement, PeerBehaviorAnnouncement,
+            BlockAccumulatorAnnouncement, FatalAnnouncement, PeerBehaviorAnnouncement,
         },
         requests::{BlockAccumulatorRequest, BlockCompleteConfirmationRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
@@ -266,10 +266,7 @@ impl BlockAccumulator {
         sender: Option<NodeId>,
     ) -> Effects<Event>
     where
-        REv: From<StorageRequest>
-            + From<PeerBehaviorAnnouncement>
-            + From<ControlAnnouncement>
-            + Send,
+        REv: From<StorageRequest> + From<PeerBehaviorAnnouncement> + From<FatalAnnouncement> + Send,
     {
         let block_hash = block.hash();
         let era_id = block.header().era_id();
@@ -354,10 +351,7 @@ impl BlockAccumulator {
         sender: Option<NodeId>,
     ) -> Effects<Event>
     where
-        REv: From<StorageRequest>
-            + From<PeerBehaviorAnnouncement>
-            + From<ControlAnnouncement>
-            + Send,
+        REv: From<StorageRequest> + From<PeerBehaviorAnnouncement> + From<FatalAnnouncement> + Send,
     {
         let block_hash = finality_signature.block_hash;
         let era_id = finality_signature.era_id;
@@ -547,7 +541,7 @@ pub(crate) trait ReactorEvent:
     + From<PeerBehaviorAnnouncement>
     + From<BlockAccumulatorAnnouncement>
     + From<BlockCompleteConfirmationRequest>
-    + From<ControlAnnouncement>
+    + From<FatalAnnouncement>
     + Send
     + 'static
 {
@@ -558,7 +552,7 @@ impl<REv> ReactorEvent for REv where
         + From<PeerBehaviorAnnouncement>
         + From<BlockAccumulatorAnnouncement>
         + From<BlockCompleteConfirmationRequest>
-        + From<ControlAnnouncement>
+        + From<FatalAnnouncement>
         + Send
         + 'static
 {

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -822,6 +822,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "block_synchronizer"
+    }
 }
 
 impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -34,7 +34,7 @@ use casper_types::{EraId, PublicKey, Timestamp};
 use crate::{
     components::Component,
     effect::{
-        announcements::{ConsensusAnnouncement, PeerBehaviorAnnouncement},
+        announcements::{ConsensusAnnouncement, FatalAnnouncement, PeerBehaviorAnnouncement},
         diagnostics_port::DumpConsensusStateRequest,
         incoming::ConsensusMessageIncoming,
         requests::{
@@ -237,6 +237,7 @@ pub(crate) trait ReactorEventT:
     + From<ContractRuntimeRequest>
     + From<ChainspecRawBytesRequest>
     + From<PeerBehaviorAnnouncement>
+    + From<FatalAnnouncement>
 {
 }
 
@@ -253,6 +254,7 @@ impl<REv> ReactorEventT for REv where
         + From<ContractRuntimeRequest>
         + From<ChainspecRawBytesRequest>
         + From<PeerBehaviorAnnouncement>
+        + From<FatalAnnouncement>
 {
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -45,7 +45,7 @@ use crate::{
         small_network::blocklist::BlocklistJustification,
     },
     effect::{
-        announcements::ControlAnnouncement,
+        announcements::FatalAnnouncement,
         requests::{BlockValidationRequest, ContractRuntimeRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects, Responder,
     },
@@ -1120,7 +1120,7 @@ async fn execute_finalized_block<REv>(
     finalized_approvals: HashMap<DeployHash, FinalizedApprovals>,
     finalized_block: FinalizedBlock,
 ) where
-    REv: From<StorageRequest> + From<ControlAnnouncement> + From<ContractRuntimeRequest>,
+    REv: From<StorageRequest> + From<FatalAnnouncement> + From<ContractRuntimeRequest>,
 {
     // if the block exists in storage, it either has been executed before, or we fast synced to a
     // higher block - skip execution

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -41,7 +41,7 @@ use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion, Timestamp};
 use crate::{
     components::{fetcher::FetchResponse, Component, ComponentStatus},
     effect::{
-        announcements::{ContractRuntimeAnnouncement, ControlAnnouncement},
+        announcements::{ContractRuntimeAnnouncement, FatalAnnouncement},
         incoming::{TrieDemand, TrieRequest, TrieRequestIncoming},
         requests::{BlockCompleteConfirmationRequest, ContractRuntimeRequest, NetworkRequest},
         EffectBuilder, EffectExt, Effects,
@@ -211,9 +211,9 @@ impl<REv> Component<REv> for ContractRuntime
 where
     REv: From<ContractRuntimeRequest>
         + From<ContractRuntimeAnnouncement>
-        + From<ControlAnnouncement>
         + From<NetworkRequest<Message>>
         + From<BlockCompleteConfirmationRequest>
+        + From<FatalAnnouncement>
         + Send,
 {
     type Event = Event;
@@ -304,8 +304,8 @@ impl ContractRuntime {
     where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
-            + From<ControlAnnouncement>
             + From<BlockCompleteConfirmationRequest>
+            + From<FatalAnnouncement>
             + Send,
     {
         match request {
@@ -752,7 +752,7 @@ impl ContractRuntime {
     ) where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
-            + From<ControlAnnouncement>
+            + From<FatalAnnouncement>
             + From<BlockCompleteConfirmationRequest>
             + Send,
     {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -27,7 +27,7 @@ use casper_types::{
 use crate::{
     components::Component,
     effect::{
-        announcements::{ControlAnnouncement, DeployAcceptorAnnouncement},
+        announcements::{DeployAcceptorAnnouncement, FatalAnnouncement},
         requests::{ContractRuntimeRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects, Responder,
     },
@@ -123,7 +123,7 @@ pub(crate) trait ReactorEventT:
     + From<DeployAcceptorAnnouncement>
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
-    + From<ControlAnnouncement>
+    + From<FatalAnnouncement>
     + Send
 {
 }
@@ -133,7 +133,7 @@ impl<REv> ReactorEventT for REv where
         + From<DeployAcceptorAnnouncement>
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
-        + From<ControlAnnouncement>
+        + From<FatalAnnouncement>
         + Send
 {
 }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -61,6 +61,8 @@ enum Event {
     #[from]
     ControlAnnouncement(ControlAnnouncement),
     #[from]
+    FatalAnnouncement(FatalAnnouncement),
+    #[from]
     DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     #[from]
     ContractRuntime(#[serde(skip_serializing)] ContractRuntimeRequest),
@@ -94,6 +96,7 @@ impl Display for Event {
             Event::Storage(event) => write!(formatter, "storage: {}", event),
             Event::DeployAcceptor(event) => write!(formatter, "deploy acceptor: {}", event),
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
+            Event::FatalAnnouncement(fatal_ann) => write!(formatter, "fatal: {}", fatal_ann),
             Event::DeployAcceptorAnnouncement(ann) => {
                 write!(formatter, "deploy-acceptor announcement: {}", ann)
             }
@@ -464,6 +467,9 @@ impl reactor::Reactor for Reactor {
             ),
             Event::ControlAnnouncement(ctrl_ann) => {
                 panic!("unhandled control announcement: {}", ctrl_ann)
+            }
+            Event::FatalAnnouncement(fatal_ann) => {
+                panic!("unhandled fatal announcement: {}", fatal_ann)
             }
             Event::DeployAcceptorAnnouncement(_) => {
                 // We do not care about deploy acceptor announcements in the acceptor tests.

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -248,6 +248,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "deploy_buffer"
+    }
 }
 
 impl<REv> Component<REv> for DeployBuffer

--- a/node/src/components/diagnostics_port.rs
+++ b/node/src/components/diagnostics_port.rs
@@ -135,6 +135,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "diagnostics"
+    }
 }
 
 impl<REv> PortBoundComponent<REv> for DiagnosticsPort

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -217,6 +217,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "event_stream_server"
+    }
 }
 
 impl<REv> PortBoundComponent<REv> for EventStreamServer

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -22,7 +22,10 @@ use crate::{
         storage::{self, Storage},
     },
     effect::{
-        announcements::{ControlAnnouncement, DeployAcceptorAnnouncement, RpcServerAnnouncement},
+        announcements::{
+            ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement,
+            RpcServerAnnouncement,
+        },
         incoming::{
             ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming,
             NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
@@ -82,6 +85,10 @@ impl Default for FetcherTestConfig {
 #[derive(Debug, From, Serialize)]
 enum Event {
     #[from]
+    ControlAnnouncement(ControlAnnouncement),
+    #[from]
+    FatalAnnouncement(FatalAnnouncement),
+    #[from]
     Network(in_memory_network::Event<Message>),
     #[from]
     Storage(storage::Event),
@@ -129,8 +136,6 @@ enum Event {
     ConsensusMessageIncoming(ConsensusMessageIncoming),
     #[from]
     FinalitySignatureIncoming(FinalitySignatureIncoming),
-    #[from]
-    ControlAnnouncement(ControlAnnouncement),
 }
 
 impl Display for Event {
@@ -249,7 +254,8 @@ impl ReactorTrait for Reactor {
             | Event::TrieResponseIncoming(_)
             | Event::ConsensusMessageIncoming(_)
             | Event::FinalitySignatureIncoming(_)
-            | Event::ControlAnnouncement(_) => panic!("unexpected: {}", event),
+            | Event::ControlAnnouncement(_)
+            | Event::FatalAnnouncement(_) => panic!("unexpected: {}", event),
         }
     }
 

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -43,7 +43,7 @@ use crate::{
     effect::{
         announcements::{
             ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
-            GossiperAnnouncement, RpcServerAnnouncement,
+            FatalAnnouncement, GossiperAnnouncement, RpcServerAnnouncement,
         },
         incoming::{
             ConsensusMessageIncoming, FinalitySignatureIncoming, NetRequestIncoming, NetResponse,
@@ -74,6 +74,10 @@ const MAX_TTL: TimeDiff = TimeDiff::from_seconds(86400);
 #[must_use]
 enum Event {
     #[from]
+    ControlAnnouncement(ControlAnnouncement),
+    #[from]
+    FatalAnnouncement(FatalAnnouncement),
+    #[from]
     Network(in_memory_network::Event<NodeMessage>),
     #[from]
     Storage(storage::Event),
@@ -87,8 +91,6 @@ enum Event {
     StorageRequest(StorageRequest),
     #[from]
     MarkBlockCompletedRequest(BlockCompleteConfirmationRequest),
-    #[from]
-    ControlAnnouncement(ControlAnnouncement),
     #[from]
     RpcServerAnnouncement(#[serde(skip_serializing)] RpcServerAnnouncement),
     #[from]
@@ -177,6 +179,7 @@ impl Display for Event {
             Event::NetworkRequest(req) => write!(formatter, "network request: {}", req),
             Event::ContractRuntimeRequest(req) => write!(formatter, "incoming: {}", req),
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
+            Event::FatalAnnouncement(fatal_ann) => write!(formatter, "fatal: {}", fatal_ann),
             Event::RpcServerAnnouncement(ann) => {
                 write!(formatter, "api server announcement: {}", ann)
             }
@@ -338,6 +341,9 @@ impl reactor::Reactor for Reactor {
             }
             Event::ControlAnnouncement(ctrl_ann) => {
                 unreachable!("unhandled control announcement: {}", ctrl_ann)
+            }
+            Event::FatalAnnouncement(fatal_ann) => {
+                unreachable!("unhandled fatal announcement: {}", fatal_ann)
             }
             Event::RpcServerAnnouncement(RpcServerAnnouncement::DeployReceived {
                 deploy,

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -218,6 +218,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "rest_server"
+    }
 }
 
 impl<REv> PortBoundComponent<REv> for RestServer

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -502,6 +502,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "rpc_server"
+    }
 }
 
 impl<REv> PortBoundComponent<REv> for RpcServer

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1170,6 +1170,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "small_network"
+    }
 }
 
 /// Transport type alias for base encrypted connections.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -78,6 +78,7 @@ use object_pool::ObjectPool;
 use crate::{
     components::{fetcher::FetchResponse, Component},
     effect::{
+        announcements::FatalAnnouncement,
         incoming::{NetRequest, NetRequestIncoming},
         requests::{
             AppStateRequest, BlockCompleteConfirmationRequest, NetworkRequest, StorageRequest,
@@ -86,7 +87,6 @@ use crate::{
     },
     fatal,
     protocol::Message,
-    reactor::ReactorEvent,
     types::{
         ApprovalsHash, ApprovalsHashes, AvailableBlockRange, Block, BlockAndDeploys, BlockBody,
         BlockExecutionResultsOrChunk, BlockExecutionResultsOrChunkId, BlockHash,
@@ -262,7 +262,7 @@ impl From<AppStateRequest> for Event {
 
 impl<REv> Component<REv> for Storage
 where
-    REv: ReactorEvent + From<NetworkRequest<Message>>,
+    REv: From<FatalAnnouncement> + From<NetworkRequest<Message>> + Send,
 {
     type Event = Event;
 

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -294,6 +294,10 @@ where
     fn status(&self) -> ComponentStatus {
         self.status.clone()
     }
+
+    fn name(&self) -> &str {
+        "upgrade_watcher"
+    }
 }
 
 /// This struct can be parsed from a TOML-encoded chainspec file.  It means that as the

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -158,7 +158,7 @@ use crate::{
 };
 use announcements::{
     BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
-    ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
+    ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement, FatalAnnouncement,
     GossiperAnnouncement, PeerBehaviorAnnouncement, QueueDumpFormat, RpcServerAnnouncement,
     UpgradeWatcherAnnouncement,
 };
@@ -636,18 +636,12 @@ impl<REv> EffectBuilder<REv> {
     /// Reports a fatal error.  Normally called via the `crate::fatal!()` macro.
     ///
     /// Usually causes the node to cease operations quickly and exit/crash.
-    //
-    // Note: This function is implemented manually without `async` sugar because the `Send`
-    // inference seems to not work in all cases otherwise.
     pub(crate) async fn fatal(self, file: &'static str, line: u32, msg: String)
     where
-        REv: From<ControlAnnouncement>,
+        REv: From<FatalAnnouncement>,
     {
         self.event_queue
-            .schedule(
-                ControlAnnouncement::FatalError { file, line, msg },
-                QueueKind::Control,
-            )
+            .schedule(FatalAnnouncement { file, line, msg }, QueueKind::Control)
             .await
     }
 

--- a/node/src/reactor/main_reactor/catch_up_instruction.rs
+++ b/node/src/reactor/main_reactor/catch_up_instruction.rs
@@ -5,7 +5,7 @@ use crate::{effect::Effects, reactor::main_reactor::MainEvent};
 pub(super) enum CatchUpInstruction {
     Do(Duration, Effects<MainEvent>),
     CheckLater(String, Duration),
-    Shutdown(String),
+    Fatal(String),
     ShutdownForUpgrade,
     CaughtUp,
     CommitGenesis,

--- a/node/src/reactor/main_reactor/keep_up_instruction.rs
+++ b/node/src/reactor/main_reactor/keep_up_instruction.rs
@@ -8,4 +8,5 @@ pub(super) enum KeepUpInstruction {
     CheckLater(String, Duration),
     CatchUp,
     ShutdownForUpgrade,
+    Fatal(String),
 }

--- a/node/src/reactor/main_reactor/upgrading_instruction.rs
+++ b/node/src/reactor/main_reactor/upgrading_instruction.rs
@@ -3,5 +3,5 @@ use std::time::Duration;
 pub(super) enum UpgradingInstruction {
     CheckLater(String, Duration),
     CatchUp,
-    Shutdown(String),
+    Fatal(String),
 }

--- a/node/src/reactor/main_reactor/utils.rs
+++ b/node/src/reactor/main_reactor/utils.rs
@@ -1,25 +1,23 @@
 use futures::FutureExt;
 use smallvec::smallvec;
 
-use crate::{components::InitializedComponent, effect::Effects, reactor::main_reactor::MainEvent};
-
-pub(super) fn new_shutdown_effect<T: ToString + Send + 'static>(message: T) -> Effects<MainEvent> {
-    smallvec![async move { smallvec![MainEvent::Shutdown(message.to_string())] }.boxed()]
-}
+use crate::{
+    components::InitializedComponent,
+    effect::{EffectBuilder, EffectExt, Effects},
+    fatal,
+    reactor::main_reactor::MainEvent,
+};
 
 pub(super) fn initialize_component(
+    effect_builder: EffectBuilder<MainEvent>,
     component: &mut impl InitializedComponent<MainEvent>,
-    component_name: &str,
     initiating_event: MainEvent,
 ) -> Option<Effects<MainEvent>> {
     if component.is_uninitialized() {
         return Some(smallvec![async { smallvec![initiating_event] }.boxed()]);
     }
     if component.is_fatal() {
-        return Some(new_shutdown_effect(format!(
-            "{} failed to initialize",
-            component_name
-        )));
+        return Some(fatal!(effect_builder, "{} failed to initialize", component.name()).ignore());
     }
     None
 }

--- a/node/src/reactor/main_reactor/validate_instruction.rs
+++ b/node/src/reactor/main_reactor/validate_instruction.rs
@@ -8,4 +8,5 @@ pub(super) enum ValidateInstruction {
     NonSwitchBlock,
     KeepUp,
     ShutdownForUpgrade,
+    Fatal(String),
 }

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -38,8 +38,9 @@ use casper_types::{testing::TestRng, TimeDiff, Timestamp};
 use crate::{
     components::Component,
     effect::{
-        announcements::ControlAnnouncement, requests::NetworkRequest, EffectBuilder, Effects,
-        Responder,
+        announcements::{ControlAnnouncement, FatalAnnouncement},
+        requests::NetworkRequest,
+        EffectBuilder, Effects, Responder,
     },
     logging,
     protocol::Message,
@@ -326,6 +327,8 @@ pub(crate) enum UnitTestEvent {
     /// A preserved control announcement.
     #[from]
     ControlAnnouncement(ControlAnnouncement),
+    #[from]
+    FatalAnnouncement(FatalAnnouncement),
     /// A network request made by the component under test.
     #[from]
     NetworkRequest(NetworkRequest<Message>),
@@ -342,7 +345,7 @@ impl ReactorEvent for UnitTestEvent {
     fn try_into_control(self) -> Option<ControlAnnouncement> {
         match self {
             UnitTestEvent::ControlAnnouncement(ctrl_ann) => Some(ctrl_ann),
-            UnitTestEvent::NetworkRequest(_) => None,
+            UnitTestEvent::FatalAnnouncement(_) | UnitTestEvent::NetworkRequest(_) => None,
         }
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -1048,8 +1048,6 @@ mod tests {
         AccessRights, URef,
     };
 
-    const BLOCK_HEIGHT: u64 = 245125;
-
     const ACCOUNT_KEY: Key = Key::Account(AccountHash::new([42; 32]));
     const HASH_KEY: Key = Key::Hash([42; 32]);
     const UREF_KEY: Key = Key::URef(URef::new([42; 32], AccessRights::READ));
@@ -1061,9 +1059,9 @@ mod tests {
     const WITHDRAW_KEY: Key = Key::Withdraw(AccountHash::new([42; 32]));
     const DICTIONARY_KEY: Key = Key::Dictionary([42; 32]);
     const SYSTEM_CONTRACT_REGISTRY_KEY: Key = Key::SystemContractRegistry;
+    const UNBOND_KEY: Key = Key::Unbond(AccountHash::new([42; 32]));
     const CHAINSPEC_REGISTRY_KEY: Key = Key::ChainspecRegistry;
     const CHECKSUM_REGISTRY_KEY: Key = Key::ChecksumRegistry;
-    const UNBOND_KEY: Key = Key::Unbond(AccountHash::new([42; 32]));
     const KEYS: [Key; 14] = [
         ACCOUNT_KEY,
         HASH_KEY,
@@ -1076,9 +1074,9 @@ mod tests {
         WITHDRAW_KEY,
         DICTIONARY_KEY,
         SYSTEM_CONTRACT_REGISTRY_KEY,
+        UNBOND_KEY,
         CHAINSPEC_REGISTRY_KEY,
         CHECKSUM_REGISTRY_KEY,
-        UNBOND_KEY,
     ];
     const HEX_STRING: &str = "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a";
 
@@ -1361,18 +1359,14 @@ mod tests {
                 r#"{{"SystemContractRegistry":"system-contract-registry-{}"}}"#,
                 base16::encode_lower(&SYSTEM_CONTRACT_REGISTRY_KEY_BYTES)
             ),
+            format!(r#"{{"Unbond":"unbond-{}"}}"#, HEX_STRING),
             format!(
                 r#"{{"ChainspecRegistry":"chainspec-registry-{}"}}"#,
                 base16::encode_lower(&CHAINSPEC_REGISTRY_KEY_BYTES)
             ),
-            format!(r#"{{"Unbond":"unbond-{}"}}"#, HEX_STRING),
             format!(
-                r#"{{"BlockExecutionResultsChecksum":"block-effects-checksum-{}"}}"#,
-                BLOCK_HEIGHT
-            ),
-            format!(
-                r#"{{"DeployApprovalsChecksum":"deploy-approvals-checksum-{}"}}"#,
-                BLOCK_HEIGHT
+                r#"{{"ChecksumRegistry":"checksum-registry-{}"}}"#,
+                base16::encode_lower(&CHECKSUM_REGISTRY_KEY_BYTES)
             ),
         ];
 


### PR DESCRIPTION
This PR updates the `fatal!` macro to produce a new announcement type: `FatalAnnouncement`.  This new announcement is converted to a `ControlAnnouncement::FatalError` (causing the node to shut down) in the main reactor's `dispatch_event`.