### PR TITLE
Minor small network changes/improvements

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -556,11 +556,8 @@ where
                     tasks::message_reader(
                         self.context.clone(),
                         stream,
-                        self.incoming_limiter.create_handle(
-                            peer_id,
-                            peer_consensus_public_key,
-                            self.cfg.eras_to_determine_if_validator,
-                        ),
+                        self.incoming_limiter
+                            .create_handle(peer_id, peer_consensus_public_key),
                         self.channel_management().close_incoming_receiver.clone(),
                         peer_id,
                         span.clone(),
@@ -743,11 +740,8 @@ where
                     tasks::message_sender(
                         receiver,
                         sink,
-                        self.outgoing_limiter.create_handle(
-                            peer_id,
-                            peer_consensus_public_key,
-                            self.cfg.eras_to_determine_if_validator,
-                        ),
+                        self.outgoing_limiter
+                            .create_handle(peer_id, peer_consensus_public_key),
                         self.net_metrics.queued_messages.clone(),
                     )
                     .instrument(span)

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -32,9 +32,6 @@ const DEFAULT_MAX_ADDR_PENDING_TIME: TimeDiff = TimeDiff::from_seconds(60);
 /// Default timeout during which the handshake needs to be completed.
 const DEFAULT_HANDSHAKE_TIMEOUT: TimeDiff = TimeDiff::from_seconds(20);
 
-/// Default value for the parameter used for determining if peer is to be considered a validator.
-const DEFAULT_ERAS_TO_DETERMINE_IF_VALIDATOR: usize = 3;
-
 impl Default for Config {
     fn default() -> Self {
         Config {
@@ -55,7 +52,6 @@ impl Default for Config {
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
             blocklist_retain_duration: TimeDiff::from_seconds(600),
-            eras_to_determine_if_validator: DEFAULT_ERAS_TO_DETERMINE_IF_VALIDATOR,
             identity: None,
         }
     }
@@ -115,8 +111,6 @@ pub struct Config {
     pub max_in_flight_demands: u32,
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
-    /// Peer is considered a validator if it was a validator in this number of latest eras.
-    pub eras_to_determine_if_validator: usize,
     /// Small network identity configuration option.
     ///
     /// An identity will be automatically generated when starting up a node if this option is

--- a/node/src/components/small_network/limiter.rs
+++ b/node/src/components/small_network/limiter.rs
@@ -463,6 +463,7 @@ mod tests {
                 Ratio::new(1, 3),
                 Arc::new(secret_key),
                 consensus_key.clone(),
+                2,
             ),
         );
 

--- a/node/src/components/small_network/outgoing.rs
+++ b/node/src/components/small_network/outgoing.rs
@@ -392,10 +392,10 @@ where
     if let Some(outgoing) = outgoing {
         match outgoing.state {
             OutgoingState::Connected { peer_id, .. } => {
-                error_span!("outgoing", %addr, state=%outgoing.state, %peer_id, validator_id=Empty)
+                error_span!("outgoing", %addr, state=%outgoing.state, %peer_id, consensus_key=Empty)
             }
             _ => {
-                error_span!("outgoing", %addr, state=%outgoing.state, peer_id=Empty, validator_id=Empty)
+                error_span!("outgoing", %addr, state=%outgoing.state, peer_id=Empty, consensus_key=Empty)
             }
         }
     } else {

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -165,7 +165,7 @@ where
             is_peer_syncing: is_syncing,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
-                Span::current().record("validator_id", &field::display(public_key));
+                Span::current().record("consensus_key", &field::display(public_key));
             }
 
             if public_addr != peer_addr {
@@ -364,7 +364,7 @@ where
             is_peer_syncing: _,
         }) => {
             if let Some(ref public_key) = peer_consensus_public_key {
-                Span::current().record("validator_id", &field::display(public_key));
+                Span::current().record("consensus_key", &field::display(public_key));
             }
 
             // Establish full transport and close the receiving end.
@@ -602,7 +602,7 @@ pub(super) async fn server<P, REv>(
                 Ok((stream, peer_addr)) => {
                     // The span setup here is used throughout the entire lifetime of the connection.
                     let span =
-                        error_span!("incoming", %peer_addr, peer_id=Empty, validator_id=Empty);
+                        error_span!("incoming", %peer_addr, peer_id=Empty, consensus_key=Empty);
 
                     let context = context.clone();
                     let handler_span = span.clone();

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -168,6 +168,7 @@ impl reactor::Reactor for MainReactor {
             chainspec.highway_config.finality_threshold_fraction,
             our_secret_key.clone(),
             our_public_key.clone(),
+            chainspec.core_config.auction_delay,
         );
 
         let storage_config = WithDir::new(&root_dir, config.storage.clone());

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -32,7 +32,7 @@ pub(crate) struct ValidatorMatrix {
     finality_threshold_fraction: Ratio<u64>,
     secret_signing_key: Arc<SecretKey>,
     public_signing_key: PublicKey,
-    auction_delay: i64,
+    auction_delay: u64,
 }
 
 impl ValidatorMatrix {
@@ -40,6 +40,7 @@ impl ValidatorMatrix {
         finality_threshold_fraction: Ratio<u64>,
         secret_signing_key: Arc<SecretKey>,
         public_signing_key: PublicKey,
+        auction_delay: u64,
     ) -> Self {
         let inner = Arc::new(RwLock::new(BTreeMap::new()));
         ValidatorMatrix {
@@ -47,7 +48,7 @@ impl ValidatorMatrix {
             finality_threshold_fraction,
             secret_signing_key,
             public_signing_key,
-            auction_delay: todo!("add parameter to ::new"),
+            auction_delay,
         }
     }
 

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -32,6 +32,7 @@ pub(crate) struct ValidatorMatrix {
     finality_threshold_fraction: Ratio<u64>,
     secret_signing_key: Arc<SecretKey>,
     public_signing_key: PublicKey,
+    auction_delay: i64,
 }
 
 impl ValidatorMatrix {
@@ -46,6 +47,7 @@ impl ValidatorMatrix {
             finality_threshold_fraction,
             secret_signing_key,
             public_signing_key,
+            auction_delay: todo!("add parameter to ::new"),
         }
     }
 
@@ -67,6 +69,7 @@ impl ValidatorMatrix {
             finality_threshold_fraction,
             public_signing_key,
             secret_signing_key,
+            auction_delay: 2,
         }
     }
 
@@ -137,15 +140,15 @@ impl ValidatorMatrix {
             .map(|validator_weights| validator_weights.is_validator(public_key))
     }
 
-    pub(crate) fn is_validator_in_any_of_latest_n_eras(
-        &self,
-        n: usize,
-        public_key: &PublicKey,
-    ) -> bool {
+    /// Determine if the active validator is in a current or upcoming set of active validators.
+    #[inline]
+    pub(crate) fn is_active_or_upcoming_validator(&self, public_key: &PublicKey) -> bool {
+        // This function is potentially expensive and could be memoized, with the cache being
+        // invalidated when the max value of the `BTreeMap` changes.
         self.read_inner()
             .values()
             .rev()
-            .take(n)
+            .take(self.auction_delay as usize + 1)
             .any(|validator_weights| validator_weights.is_validator(public_key))
     }
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -202,9 +202,6 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '10min'
 
-# Peer is considered a validator if it was a validator in this number of latest eras.
-eras_to_determine_if_validator = 3
-
 # Identity of a node
 #
 # When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.


### PR DESCRIPTION
Closes #3345.

* Removes the notion of a `validator_id` from the limiter (as the presence of an ID is not enough to conclude a peer is a validator).
* The number of eras to consider when determining if a peer is an active/upcoming validator is now calculated from the auction delay.