### PR TITLE
Make sure we do not propose deploys that have not been gossiped yet

### DIFF
--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -292,13 +292,7 @@ impl DeployBuffer {
                     current_deploy_details.already_gossiped,
                 );
             })
-            .or_insert_with(|| {
-                DeployDetails::new(
-                    deploy_details.expiry_time,
-                    deploy_details.footprint_and_approvals,
-                    deploy_details.already_gossiped,
-                )
-            });
+            .or_insert(deploy_details);
     }
 }
 

--- a/node/src/components/deploy_buffer/config.rs
+++ b/node/src/components/deploy_buffer/config.rs
@@ -3,40 +3,24 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::TimeDiff;
 
-const DEFAULT_DEPLOY_DELAY: &str = "15sec";
 const DEFAULT_EXPIRY_CHECK_INTERVAL: &str = "1min";
 
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
-    /// Deploys are only proposed in a new block if they have been received at least this long ago.
-    /// A longer delay makes it more likely that many proposed deploys are already known by the
-    /// other nodes, and don't have to be requested from the proposer afterwards.
-    deploy_delay: TimeDiff,
     /// The interval of checking for expired deploys.
     expiry_check_interval: TimeDiff,
 }
 
 impl Config {
-    // todo! - use this
-    // pub(crate) fn deploy_delay(&self) -> TimeDiff {
-    //     self.deploy_delay
-    // }
-
     pub(crate) fn expiry_check_interval(&self) -> TimeDiff {
         self.expiry_check_interval
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_deploy_delay(&mut self, deploy_delay: TimeDiff) {
-        self.deploy_delay = deploy_delay;
     }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            deploy_delay: DEFAULT_DEPLOY_DELAY.parse().unwrap(),
             expiry_check_interval: DEFAULT_EXPIRY_CHECK_INTERVAL.parse().unwrap(),
         }
     }

--- a/node/src/components/deploy_buffer/event.rs
+++ b/node/src/components/deploy_buffer/event.rs
@@ -6,7 +6,7 @@ use derive_more::From;
 use crate::{
     components::consensus::{ClContext, ProposedBlock},
     effect::requests::DeployBufferRequest,
-    types::{Block, Deploy, FinalizedBlock},
+    types::{Block, Deploy, DeployHash, FinalizedBlock},
 };
 
 #[derive(Debug, From, DataSize)]
@@ -18,6 +18,7 @@ pub(crate) enum Event {
     BlockProposed(Box<ProposedBlock<ClContext>>),
     Block(Box<Block>),
     BlockFinalized(Box<FinalizedBlock>),
+    DeployHashGossiped(DeployHash),
     Expire,
 }
 
@@ -49,6 +50,11 @@ impl Display for Event {
             Event::Expire => {
                 write!(formatter, "expire deploys")
             }
+            Event::DeployHashGossiped(deploy_hash) => write!(
+                formatter,
+                "got notified about gossiped deploy hash={}",
+                deploy_hash
+            ),
         }
     }
 }

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -924,15 +924,15 @@ impl reactor::Reactor for MainReactor {
                 ),
             ),
             MainEvent::DeployGossiperAnnouncement(GossiperAnnouncement::FinishedGossiping(
-                _gossiped_deploy_id,
-            )) => {
-                // [TODO][Fraser]: notify DeployBuffer the deploy can be proposed
-                // let reactor_event =
-                //     MainEvent::DeployBuffer(deploy_buffer::Event::
-                // BufferDeploy(gossiped_deploy_id));
-                // self.dispatch_event(effect_builder, rng, reactor_event)
-                Effects::new()
-            }
+                gossiped_deploy_id,
+            )) => reactor::wrap_effects(
+                MainEvent::DeployBuffer,
+                self.deploy_buffer.handle_event(
+                    effect_builder,
+                    rng,
+                    deploy_buffer::Event::DeployHashGossiped(*gossiped_deploy_id.deploy_hash()),
+                ),
+            ),
             MainEvent::DeployBuffer(event) => reactor::wrap_effects(
                 MainEvent::DeployBuffer,
                 self.deploy_buffer.handle_event(effect_builder, rng, event),

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -12,7 +12,7 @@ use casper_execution_engine::core::engine_state::GetBidsRequest;
 use casper_types::{
     system::auction::{Bids, DelegationRate},
     testing::TestRng,
-    EraId, Motes, ProtocolVersion, PublicKey, SecretKey, TimeDiff, Timestamp, U512,
+    EraId, Motes, ProtocolVersion, PublicKey, SecretKey, Timestamp, U512,
 };
 
 use crate::{
@@ -155,10 +155,6 @@ impl TestChain {
         }
         self.storages.push(temp_dir);
         cfg.storage = storage_cfg;
-
-        cfg.deploy_buffer
-            .set_deploy_delay(TimeDiff::from_seconds(5));
-
         cfg
     }
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -202,9 +202,6 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '1min'
 
-# Peer is considered a validator if it was a validator in this number of latest eras.
-eras_to_determine_if_validator = 3
-
 # Identity of a node
 #
 # When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
@@ -484,11 +481,6 @@ enable_manual_sync = true
 # Configuration options for the deploy buffer
 # ===========================================
 [deploy_buffer]
-
-# Deploys are only proposed in a new block if they have been received at least this long ago.
-# A longer delay makes it more likely that many proposed deploys are already known by the
-# other nodes, and don't have to be requested from the proposer afterwards.
-deploy_delay = '15sec'
 
 # The interval of checking for expired deploys.
 expiry_check_interval = '1min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -482,11 +482,6 @@ max_global_state_size = 2_089_072_132_096
 # ===========================================
 [deploy_buffer]
 
-# Deploys are only proposed in a new block if they have been received at least this long ago.
-# A longer delay makes it more likely that many proposed deploys are already known by the
-# other nodes, and don't have to be requested from the proposer afterwards.
-deploy_delay = '15sec'
-
 # The interval of checking for expired deploys.
 expiry_check_interval = '1min'
 

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml.override
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml.override
@@ -1,2 +1,0 @@
-[deploy_buffer]
-deploy_delay = '5sec'


### PR DESCRIPTION
Deploy buffer is tracking which deploy hashes have been gossiped and only proposes such deploys to the appendable block.

The `DEFAULT_DEPLOY_DELAY` has been removed.

Fixes #3349