### PR TITLE
Rate limit block acceptor creation per peer.

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -112,7 +112,7 @@ pub(crate) struct BlockAccumulator {
     /// created the block acceptor, from oldest to newest.
     peer_block_timestamps: BTreeMap<NodeId, VecDeque<(BlockHash, Timestamp)>>,
     /// The minimum time between a block and its child.
-    block_time: TimeDiff,
+    min_block_time: TimeDiff,
 }
 
 impl BlockAccumulator {
@@ -121,7 +121,7 @@ impl BlockAccumulator {
         validator_matrix: ValidatorMatrix,
         local_tip_height_and_era_id: Option<(u64, EraId)>,
         recent_era_interval: u64,
-        block_time: TimeDiff,
+        min_block_time: TimeDiff,
     ) -> Self {
         Self {
             validator_matrix,
@@ -135,7 +135,7 @@ impl BlockAccumulator {
                 .map(|(height, era_id)| LocalTipIdentifier::new(height, era_id)),
             recent_era_interval,
             peer_block_timestamps: Default::default(),
-            block_time,
+            min_block_time,
         }
     }
 
@@ -289,8 +289,8 @@ impl BlockAccumulator {
             }
 
             // Assume a block time of at least 1 millisecond, so we don't divide by zero.
-            let block_time = self.block_time.max(TimeDiff::from(1));
-            let expected_blocks = (purge_interval / block_time) as usize;
+            let min_block_time = self.min_block_time.max(TimeDiff::from(1));
+            let expected_blocks = (purge_interval / min_block_time) as usize;
             let max_block_count = PEER_RATE_LIMIT_MULTIPLIER.saturating_mul(expected_blocks);
             if block_timestamps.len() >= max_block_count {
                 warn!(

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -4,6 +4,8 @@ mod error;
 mod event;
 mod starting_with;
 mod sync_instruction;
+#[cfg(test)]
+mod tests;
 
 use std::{
     cmp::Ordering,

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -5,7 +5,11 @@ mod event;
 mod starting_with;
 mod sync_instruction;
 
-use std::{cmp::Ordering, collections::BTreeMap, iter};
+use std::{
+    cmp::Ordering,
+    collections::{btree_map, BTreeMap, VecDeque},
+    iter,
+};
 
 use datasize::DataSize;
 use futures::FutureExt;
@@ -35,6 +39,10 @@ pub use error::Error;
 pub(crate) use event::Event;
 pub(crate) use starting_with::StartingWith;
 pub(crate) use sync_instruction::SyncInstruction;
+
+/// If a peer "informs" us about more than the expected number of new blocks times this factor,
+/// they are probably spamming, and we refuse to create new block acceptors for them.
+const PEER_RATE_LIMIT_MULTIPLIER: usize = 2;
 
 #[derive(Clone, Copy, DataSize, Debug, Eq, PartialEq)]
 struct LocalTipIdentifier {
@@ -98,6 +106,11 @@ pub(crate) struct BlockAccumulator {
     recent_era_interval: u64,
     /// Tracks activity and assists with perceived tip determination.
     last_progress: Timestamp,
+    /// For each peer, a list of block hashes we first heard from them, and the timestamp when we
+    /// created the block acceptor, from oldest to newest.
+    peer_block_timestamps: BTreeMap<NodeId, VecDeque<(BlockHash, Timestamp)>>,
+    /// The minimum time between a block and its child.
+    block_time: TimeDiff,
 }
 
 impl BlockAccumulator {
@@ -106,6 +119,7 @@ impl BlockAccumulator {
         validator_matrix: ValidatorMatrix,
         local_tip_height_and_era_id: Option<(u64, EraId)>,
         recent_era_interval: u64,
+        block_time: TimeDiff,
     ) -> Self {
         Self {
             validator_matrix,
@@ -118,6 +132,8 @@ impl BlockAccumulator {
             local_tip: local_tip_height_and_era_id
                 .map(|(height, era_id)| LocalTipIdentifier::new(height, era_id)),
             recent_era_interval,
+            peer_block_timestamps: Default::default(),
+            block_time,
         }
     }
 
@@ -227,37 +243,63 @@ impl BlockAccumulator {
             .max();
     }
 
-    fn register_peer(
+    /// Registers a peer with an existing acceptor, or creates a new one.
+    ///
+    /// If the era is outdated or the peer has already caused us to create more acceptors than
+    /// expected, no new acceptor will be created.
+    fn upsert_acceptor(
         &mut self,
         block_hash: BlockHash,
         maybe_era_id: Option<EraId>,
-        sender: NodeId,
+        maybe_sender: Option<NodeId>,
     ) {
-        let maybe_local_tip_era_id = self.local_tip.map(|local_tip| local_tip.era_id);
-        match (maybe_era_id, maybe_local_tip_era_id) {
-            // When the era of the item sent by this peer is known, we check it
-            // against our local tip era. If it is recent (within a number of
-            // eras of our local tip), we create an acceptor for it along with
-            // registering the peer.
-            (Some(era_id), Some(local_tip_era_id))
-                if era_id >= local_tip_era_id.saturating_sub(self.recent_era_interval) =>
-            {
-                let acceptor = self
-                    .block_acceptors
-                    .entry(block_hash)
-                    .or_insert_with(|| BlockAcceptor::new(block_hash, None));
-                acceptor.register_peer(sender);
-            }
-            // In all other cases (i.e. the item's era is not provided, the
-            // local tip doesn't have an era or the item's era is older than
-            // the local tip era by more than `recent_era_interval`), we only
-            // register the peer if there is an acceptor for the item already.
-            _ => {
-                if let Some(acceptor) = self.block_acceptors.get_mut(&block_hash) {
-                    acceptor.register_peer(sender)
+        // If the acceptor already exists, just register the peer, if applicable.
+        let entry = match self.block_acceptors.entry(block_hash) {
+            btree_map::Entry::Occupied(entry) => {
+                if let Some(sender) = maybe_sender {
+                    entry.into_mut().register_peer(sender);
                 }
+                return;
             }
+            btree_map::Entry::Vacant(entry) => entry,
+        };
+
+        // The acceptor doesn't exist. Don't create it if the item's era is not provided, the local
+        // tip doesn't have an era or the item's era is older than the local tip era by more than
+        // `recent_era_interval`.
+        match (maybe_era_id, self.local_tip) {
+            (Some(era_id), Some(local_tip))
+                if era_id >= local_tip.era_id.saturating_sub(self.recent_era_interval) => {}
+            _ => return,
         }
+
+        // Check that the sender isn't telling us about more blocks than expected.
+        if let Some(sender) = maybe_sender {
+            let block_timestamps = self.peer_block_timestamps.entry(sender).or_default();
+
+            // Prune the timestamps, so the count reflects only the most recently added acceptors.
+            let purge_interval = self.purge_interval;
+            let is_expired = |(_, timestamp): &(_, Timestamp)| timestamp.elapsed() > purge_interval;
+            while block_timestamps.front().map_or(false, is_expired) {
+                block_timestamps.pop_front();
+            }
+
+            // Assume a block time of at least 1 millisecond, so we don't divide by zero.
+            let block_time = self.block_time.max(TimeDiff::from(1));
+            let expected_blocks = (purge_interval / block_time) as usize;
+            let max_block_count = PEER_RATE_LIMIT_MULTIPLIER.saturating_mul(expected_blocks);
+            if block_timestamps.len() >= max_block_count {
+                warn!(
+                    ?sender, %block_hash,
+                    "rejecting block hash from peer who sent us more than {} within {}",
+                    max_block_count, self.purge_interval,
+                );
+                return;
+            }
+            block_timestamps.push_back((block_hash, Timestamp::now()));
+        }
+
+        entry.insert(BlockAcceptor::new(block_hash, maybe_sender));
     }
 
     fn register_block<REv>(
@@ -280,11 +322,12 @@ impl BlockAccumulator {
             debug!(%block_hash, "ignoring outdated block");
             return Effects::new();
         }
+        self.upsert_acceptor(*block_hash, Some(era_id), sender);
 
-        let acceptor = self
-            .block_acceptors
-            .entry(*block_hash)
-            .or_insert_with(|| BlockAcceptor::new(*block_hash, None));
+        let acceptor = match self.block_acceptors.get_mut(block_hash) {
+            None => return Effects::new(),
+            Some(acceptor) => acceptor,
+        };
 
         match acceptor.register_block(block, sender) {
             Ok(_) => match self.validator_matrix.validator_weights(era_id) {
@@ -357,30 +400,13 @@ impl BlockAccumulator {
     {
         let block_hash = finality_signature.block_hash;
         let era_id = finality_signature.era_id;
-        let maybe_local_tip_era_id = self.local_tip.map(|local_tip| local_tip.era_id);
-        let acceptor = match maybe_local_tip_era_id {
-            // When the era of the finality signature being registered is
-            // known, we check it against our local tip era. If it is recent
-            // (within a number of eras of our local tip), we create an
-            // acceptor for it if one is not already present before registering
-            // the finality signature.
-            Some(local_tip_era_id)
-                if era_id >= local_tip_era_id.saturating_sub(self.recent_era_interval) =>
-            {
-                self.block_acceptors
-                    .entry(block_hash)
-                    .or_insert_with(|| BlockAcceptor::new(block_hash, sender))
-            }
-            // In all other cases (i.e. the local tip doesn't have an era or
-            // the signature's era is older than the local tip era by more than
-            // `recent_era_interval`), we only register the signature if there
-            // is an acceptor for it already.
-            _ => match self.block_acceptors.get_mut(&block_hash) {
-                Some(acceptor) => acceptor,
-                // When there is no acceptor for it, this function returns
-                // early, ignoring the signature.
-                None => return Effects::new(),
-            },
+        self.upsert_acceptor(block_hash, Some(era_id), sender);
+
+        let acceptor = match self.block_acceptors.get_mut(&block_hash) {
+            Some(acceptor) => acceptor,
+            // When there is no acceptor for it, this function returns
+            // early, ignoring the signature.
+            None => return Effects::new(),
         };
 
         match acceptor.register_finality_signature(finality_signature, sender) {
@@ -540,6 +566,15 @@ impl BlockAccumulator {
         });
         self.block_children
             .retain(|_parent, child| false == purged.contains(child));
+        self.peer_block_timestamps.retain(|_, block_timestamps| {
+            while block_timestamps
+                .front()
+                .map_or(false, |(_, timestamp)| timestamp.elapsed() > purge_interval)
+            {
+                block_timestamps.pop_front();
+            }
+            !block_timestamps.is_empty()
+        });
     }
 
     fn store_block_and_finality_signatures<REv, I>(
@@ -633,7 +668,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 era_id,
                 sender,
             } => {
-                self.register_peer(block_hash, era_id, sender);
+                self.upsert_acceptor(block_hash, era_id, Some(sender));
                 Effects::new()
             }
             Event::ReceivedBlock { block, sender } => {

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -281,8 +281,10 @@ impl BlockAccumulator {
 
             // Prune the timestamps, so the count reflects only the most recently added acceptors.
             let purge_interval = self.purge_interval;
-            let is_expired = |(_, timestamp): &(_, Timestamp)| timestamp.elapsed() > purge_interval;
-            while block_timestamps.front().map_or(false, is_expired) {
+            while block_timestamps
+                .front()
+                .map_or(false, |(_, timestamp)| timestamp.elapsed() > purge_interval)
+            {
                 block_timestamps.pop_front();
             }
 

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1,0 +1,62 @@
+use casper_types::testing::TestRng;
+
+use crate::components::consensus::tests::utils::{
+    ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID,
+};
+
+use super::*;
+
+#[test]
+fn upsert_acceptor() {
+    let mut rng = TestRng::new();
+    let config = Config::default();
+    let era0 = EraId::from(0);
+    let validator_matrix =
+        ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone(), ALICE_PUBLIC_KEY.clone());
+    let local_tip = (0, era0);
+    let recent_era_interval = 1;
+    let block_time = config.purge_interval() / 2;
+    let mut accumulator = BlockAccumulator::new(
+        config,
+        validator_matrix,
+        Some(local_tip),
+        recent_era_interval,
+        block_time,
+    );
+
+    let max_block_count =
+        PEER_RATE_LIMIT_MULTIPLIER * ((config.purge_interval() / block_time) as usize);
+
+    for _ in 0..max_block_count {
+        accumulator.upsert_acceptor(
+            BlockHash::random(&mut rng),
+            Some(era0),
+            Some(*ALICE_NODE_ID),
+        );
+    }
+
+    assert_eq!(accumulator.block_acceptors.len(), max_block_count);
+
+    let block_hash = BlockHash::random(&mut rng);
+
+    // Alice has sent us too many blocks; we don't register this one.
+    accumulator.upsert_acceptor(block_hash, Some(era0), Some(*ALICE_NODE_ID));
+    assert_eq!(accumulator.block_acceptors.len(), max_block_count);
+    assert!(!accumulator.block_acceptors.contains_key(&block_hash));
+
+    // Bob hasn't sent us anything yet. But we don't insert without an era ID.
+    accumulator.upsert_acceptor(block_hash, None, Some(*BOB_NODE_ID));
+    assert_eq!(accumulator.block_acceptors.len(), max_block_count);
+    assert!(!accumulator.block_acceptors.contains_key(&block_hash));
+
+    // With an era ID he's allowed to tell us about this one.
+    accumulator.upsert_acceptor(block_hash, Some(era0), Some(*BOB_NODE_ID));
+    assert_eq!(accumulator.block_acceptors.len(), max_block_count + 1);
+    assert!(accumulator.block_acceptors.contains_key(&block_hash));
+
+    // And if Alice tells us about it _now_, we'll register her as a peer.
+    accumulator.upsert_acceptor(block_hash, None, Some(*ALICE_NODE_ID));
+    assert!(accumulator.block_acceptors[&block_hash]
+        .peers()
+        .contains(&ALICE_NODE_ID));
+}

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -12,7 +12,7 @@ pub(crate) mod error;
 mod metrics;
 mod protocols;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 mod traits;
 mod validator_change;
 

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -27,6 +27,12 @@ pub static ALICE_NODE_ID: Lazy<NodeId> = Lazy::new(|| {
 pub static BOB_PRIVATE_KEY: Lazy<SecretKey> =
     Lazy::new(|| SecretKey::ed25519_from_bytes([1; SecretKey::ED25519_LENGTH]).unwrap());
 pub static BOB_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&*BOB_PRIVATE_KEY));
+pub static BOB_NODE_ID: Lazy<NodeId> = Lazy::new(|| {
+    NodeId::from(KeyFingerprint::from(Sha512::new(match *BOB_PUBLIC_KEY {
+        PublicKey::Ed25519(pub_key) => pub_key,
+        _ => panic!("BOB_PUBLIC_KEY is Ed25519"),
+    })))
+});
 
 /// Loads the local chainspec and overrides timestamp and genesis account with the given stakes.
 /// The test `Chainspec` returned has eras with exactly two blocks.

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -276,6 +276,7 @@ impl reactor::Reactor for MainReactor {
             validator_matrix.clone(),
             highest_block_height_and_era_id,
             chainspec.core_config.unbonding_delay,
+            chainspec.highway_config.min_round_length(),
         );
         let block_synchronizer =
             BlockSynchronizer::new(config.block_synchronizer, validator_matrix.clone());


### PR DESCRIPTION
This limits the number of new `BlockAcceptor` instances we create, per peer informing us about the block.

The rate is computed based on the `purge_interval` and the minimum block time.

Closes #3344.