### PR TITLE
Remove `eras_to_determine_if_validator` which is no longer desirable

### DIFF
--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -202,9 +202,6 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '1min'
 
-# Peer is considered a validator if it was a validator in this number of latest eras.
-eras_to_determine_if_validator = 3
-
 # Identity of a node
 #
 # When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.


### PR DESCRIPTION
This PR removes the `eras_to_determine_if_validator` parameter from the config, as it is no longer desirable.