### PR TITLE
refactor upgrade shutdown instruction

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -209,7 +209,7 @@ impl BlockSynchronizer {
             &self.historical,
             &self.forward,
         ) {
-            if builder.block_hash() == block_hash && !builder.is_fatal() {
+            if builder.block_hash() == block_hash && !builder.is_failed() {
                 return false;
             }
         }

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -159,7 +159,7 @@ impl BlockBuilder {
         self.in_flight_latch = Some(Timestamp::now());
     }
 
-    pub(super) fn is_fatal(&self) -> bool {
+    pub(super) fn is_failed(&self) -> bool {
         matches!(self.acquisition_state, BlockAcquisitionState::Failed(_, _))
     }
 
@@ -386,7 +386,7 @@ impl BlockBuilder {
 
     pub(super) fn register_peers(&mut self, peers: Vec<NodeId>) {
         peers.into_iter().for_each(|peer| {
-            if !(self.is_finished() || self.is_fatal()) {
+            if !(self.is_finished() || self.is_failed()) {
                 self.peer_list.register_peer(peer)
             }
         });

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -13,6 +13,7 @@ mod keep_up_instruction;
 mod reactor_state;
 #[cfg(test)]
 mod tests;
+mod upgrade_shutdown_instruction;
 mod upgrading_instruction;
 mod validate_instruction;
 

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -126,6 +126,9 @@ impl MainReactor {
                 }
             },
             ReactorState::Upgrading => match self.upgrading_instruction() {
+                UpgradingInstruction::Fatal(msg) => {
+                    (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore())
+                }
                 UpgradingInstruction::CheckLater(msg, wait) => {
                     debug!("Upgrading: {}", msg);
                     (wait, Effects::new())
@@ -134,9 +137,6 @@ impl MainReactor {
                     info!("Upgrading: switch to CatchUp");
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())
-                }
-                UpgradingInstruction::Fatal(msg) => {
-                    (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore())
                 }
             },
             ReactorState::KeepUp => {

--- a/node/src/reactor/main_reactor/upgrade_shutdown_instruction.rs
+++ b/node/src/reactor/main_reactor/upgrade_shutdown_instruction.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+use crate::{effect::Effects, reactor::main_reactor::MainEvent};
+
+pub(super) enum UpgradeShutdownInstruction {
+    Do(Duration, Effects<MainEvent>),
+    CheckLater(String, Duration),
+    Fatal(String),
+}


### PR DESCRIPTION
also renamed is_fatal to is_failed on BlockSynchronizer for consistency