### PR TITLE
Register local tip before block.

### DIFF
--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -196,6 +196,11 @@ impl BlockAcceptor {
         }
 
         if self.block.is_none() || self.signatures.is_empty() {
+            debug!(
+                no_block = self.block.is_none(),
+                no_sigs = self.signatures.is_empty(),
+                "not storing block"
+            );
             return (ShouldStore::Nothing, Vec::new());
         }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1363,7 +1363,7 @@ fn should_get_trusted_ancestor_headers() {
         let mut txn = storage.env.begin_ro_txn().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().header();
         storage
-            .get_trusted_ancestor_headers(&mut txn, requested_block_header, 1)
+            .get_trusted_ancestor_headers(&mut txn, requested_block_header)
             .unwrap()
             .unwrap()
             .iter()


### PR DESCRIPTION
The block accumulator refuses to instantiate the acceptor if it doesn't have a local tip.
