### PR TITLE
fix casper-types build when compiled with std feature

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -64,7 +64,7 @@ untrusted = "0.7.1"
 
 [features]
 json-schema = ["once_cell", "schemars"]
-std = ["derp", "getrandom", "humantime", "once_cell", "pem", "thiserror", "untrusted"]
+std = ["derp", "getrandom/std", "humantime", "once_cell", "pem", "thiserror", "untrusted"]
 testing = ["proptest", "rand_pcg"]
 # DEPRECATED - use "testing" instead of "gens".
 gens = ["testing"]


### PR DESCRIPTION
This PR fixes an issue where `casper-types` fails to compile if the `std` feature is enabled.