### PR TITLE
update global-state-update-gen tool to print validators

### DIFF
--- a/utils/global-state-update-gen/README.md
+++ b/utils/global-state-update-gen/README.md
@@ -1,6 +1,6 @@
 # global-state-update-gen
 
-If the network experiences a catastrophic failure, it might become impossible to make changes to the global state required for fixing the situation via normal channels (ie., executing deploys on the network), and we might instead need to resort to social consensus outside of the blockchain and applying the changes manually. This tool facilitates generating files specifying such changes, which can then be applied during an emergency upgrade.
+If the network experiences a catastrophic failure, it might become impossible to make changes to the global state required for fixing the situation via normal channels (i.e. executing deploys on the network), and we might instead need to resort to social consensus outside the blockchain and applying the changes manually. This tool facilitates generating files specifying such changes, which can then be applied during an emergency upgrade.
 
 The tool consists of 1 main subcommand and 3 legacy subcommands:
 - `generic` - a generic update based on a config file,
@@ -18,11 +18,15 @@ All subcommands share 3 parameters:
 
 ### `generic`
 
-Usage: `global-state-update-gen -d DATA-DIRECTORY -s STATE-ROOT-HASH CONFIG-FILE`
+Usage: `global-state-update-gen generic -d DATA-DIRECTORY -s STATE-ROOT-HASH CONFIG-FILE`
 
 The config file should be a TOML file, which can contain the following values:
 
 ```toml
+# can be true or false, optional, false if not present; more detailed description below
+# *must* be listed before all [[accounts]] and [[transfers]] entries
+only_listed_validators = false
+
 # multiple [[accounts]] definitions are possible
 [[accounts]]
 public_key = "..." # the public key of the account owner
@@ -34,8 +38,6 @@ balance = "..."    # account balance, in motes (optional)
 from = "account-hash-..." # the account hash to transfer funds from
 to = "account-hash-..."   # the account hash to transfer funds to
 amount = "..."            # the amount to be transferred, in motes
-
-only_listed_validators = false # can be true or false, optional, false if not present; more detailed description below
 ```
 
 The `[[accounts]]` definitions control the balances and stakes of accounts on the network. It is possible to change the set of validators using these definitions, by changing the staked amounts.

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -17,13 +17,18 @@ use casper_types::{
 
 use clap::ArgMatches;
 
-use crate::utils::{hash_from_str, print_entry, validators_diff, ValidatorsDiff};
+use crate::utils::{hash_from_str, print_entry, print_validators, validators_diff, ValidatorsDiff};
 
 use self::{
     config::{AccountConfig, Config, Transfer},
     state_reader::StateReader,
     state_tracker::StateTracker,
 };
+
+struct Update {
+    validators: Vec<PublicKey>,
+    entries: BTreeMap<Key, StoredValue>,
+}
 
 pub(crate) fn generate_generic_update(matches: &ArgMatches<'_>) {
     let data_dir = matches.value_of("data_dir").unwrap_or(".");
@@ -38,25 +43,30 @@ pub(crate) fn generate_generic_update(matches: &ArgMatches<'_>) {
     update_from_config(builder, config);
 }
 
-pub(crate) fn get_update<T: StateReader>(reader: T, config: Config) -> BTreeMap<Key, StoredValue> {
+fn get_update<T: StateReader>(reader: T, config: Config) -> Update {
     let mut state_tracker = StateTracker::new(reader);
 
     process_transfers(&mut state_tracker, &config.transfers);
 
     update_account_balances(&mut state_tracker, &config.accounts);
 
-    update_auction_state(
+    let validators = update_auction_state(
         &mut state_tracker,
         &config.accounts,
         config.only_listed_validators,
     );
 
-    state_tracker.get_entries()
+    let entries = state_tracker.get_entries();
+    Update {
+        validators,
+        entries,
+    }
 }
 
 pub(crate) fn update_from_config<T: StateReader>(reader: T, config: Config) {
     let update = get_update(reader, config);
-    for (key, value) in update {
+    print_validators(&update.validators);
+    for (key, value) in update.entries {
         print_entry(&key, &value);
     }
 }
@@ -86,11 +96,12 @@ fn update_account_balances<T: StateReader>(
     }
 }
 
+/// Returns the complete set of validators immediately after the upgrade.
 fn update_auction_state<T: StateReader>(
     state: &mut StateTracker<T>,
     accounts: &[AccountConfig],
     only_listed_validators: bool,
-) {
+) -> Vec<PublicKey> {
     // Read the old SeigniorageRecipientsSnapshot
     let (validators_key, old_snapshot) = state.read_snapshot();
 
@@ -105,6 +116,7 @@ fn update_auction_state<T: StateReader>(
         gen_snapshot_from_old(old_snapshot.clone(), accounts)
     };
 
+    // take first value of new snapshot to get list of validators
     if new_snapshot != old_snapshot {
         // Save the write to the snapshot key.
         state.write_entry(
@@ -123,6 +135,15 @@ fn update_auction_state<T: StateReader>(
 
         state.remove_withdraws(&validators_diff.removed);
     }
+
+    // All entries in the new snapshot contain the same set of validators, just use the first entry.
+    new_snapshot
+        .values()
+        .next()
+        .expect("snapshot should have at least one entry")
+        .keys()
+        .cloned()
+        .collect()
 }
 
 /// Generates a new `SeigniorageRecipientsSnapshot` based on:
@@ -154,7 +175,7 @@ fn gen_snapshot_only_listed(
 }
 
 /// Generates a new `SeigniorageRecipientsSnapshot` by modifying the stakes listed in the old
-/// snaphot according to the supplied list of configured accounts.
+/// snapshot according to the supplied list of configured accounts.
 fn gen_snapshot_from_old(
     mut snapshot: SeigniorageRecipientsSnapshot,
     accounts: &[AccountConfig],

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -16,6 +16,7 @@ use super::{
     config::{AccountConfig, Config, Transfer},
     get_update,
     state_reader::StateReader,
+    Update,
 };
 
 const TOTAL_SUPPLY_KEY: URef = URef::new([1; 32], AccessRights::READ_ADD_WRITE);
@@ -136,12 +137,22 @@ impl StateReader for MockStateReader {
 fn should_transfer_funds() {
     let mut rng = TestRng::new();
 
-    let account1: AccountHash = rng.gen();
-    let account2: AccountHash = rng.gen();
+    let public_key1 = PublicKey::random(&mut rng);
+    let public_key2 = PublicKey::random(&mut rng);
+    let account1 = public_key1.to_account_hash();
+    let account2 = public_key2.to_account_hash();
 
-    let mut reader = MockStateReader::new()
-        .with_account(account1, U512::from(1_000_000_000), &mut rng)
-        .with_account(account2, U512::zero(), &mut rng);
+    let mut reader = MockStateReader::new().with_validators(
+        vec![
+            (
+                public_key1.clone(),
+                U512::from(1),
+                U512::from(1_000_000_000),
+            ),
+            (public_key2.clone(), U512::zero(), U512::zero()),
+        ],
+        &mut rng,
+    );
 
     let config = Config {
         transfers: vec![Transfer {
@@ -152,14 +163,21 @@ fn should_transfer_funds() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
+
+    assert_eq!(validators.len(), 2);
+    assert!(validators.contains(&public_key1));
+    assert!(validators.contains(&public_key2));
 
     let account1 = reader.get_account(account1).unwrap();
     let account2 = reader.get_account(account2).unwrap();
 
     // should write decreased balance to the first purse
     assert_eq!(
-        result.get(&Key::Balance(account1.main_purse().addr())),
+        entries.get(&Key::Balance(account1.main_purse().addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(700_000_000)).expect("should convert U512 to CLValue")
         )),
@@ -167,7 +185,7 @@ fn should_transfer_funds() {
 
     // should write increased balance to the second purse
     assert_eq!(
-        result.get(&Key::Balance(account2.main_purse().addr())),
+        entries.get(&Key::Balance(account2.main_purse().addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(300_000_000)).expect("should convert U512 to CLValue")
         )),
@@ -176,25 +194,33 @@ fn should_transfer_funds() {
     // total supply is written on every purse balance change, so we'll have a write to this key
     // even though the changes cancel each other out
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
-            CLValue::from_t(U512::from(1_000_000_000)).expect("should convert U512 to CLValue")
+            CLValue::from_t(U512::from(1_000_000_001)).expect("should convert U512 to CLValue")
         ))
     );
 
     // 3 keys tested above should be all that would be written
-    assert_eq!(result.len(), 3);
+    assert_eq!(entries.len(), 3);
 }
 
 #[test]
 fn should_create_account_when_transferring_funds() {
     let mut rng = TestRng::new();
 
-    let account1: AccountHash = rng.gen();
-    let account2: AccountHash = rng.gen();
+    let public_key1 = PublicKey::random(&mut rng);
+    let public_key2 = PublicKey::random(&mut rng);
+    let account1 = public_key1.to_account_hash();
+    let account2 = public_key2.to_account_hash();
 
-    let mut reader =
-        MockStateReader::new().with_account(account1, U512::from(1_000_000_000), &mut rng);
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            public_key1.clone(),
+            U512::from(1),
+            U512::from(1_000_000_000),
+        )],
+        &mut rng,
+    );
 
     let config = Config {
         transfers: vec![Transfer {
@@ -205,21 +231,26 @@ fn should_create_account_when_transferring_funds() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
+
+    assert_eq!(validators, vec![public_key1]);
 
     let account1 = reader.get_account(account1).unwrap();
     assert!(reader.get_account(account2).is_none());
 
     // should write decreased balance to the first purse
     assert_eq!(
-        result.get(&Key::Balance(account1.main_purse().addr())),
+        entries.get(&Key::Balance(account1.main_purse().addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(700_000_000)).expect("should convert U512 to CLValue")
         )),
     );
 
     // the new account should be created
-    let account_write = result
+    let account_write = entries
         .get(&Key::Account(account2))
         .expect("should create account")
         .as_account()
@@ -229,13 +260,13 @@ fn should_create_account_when_transferring_funds() {
 
     // check that the main purse for the new account has been created with the correct amount
     assert_eq!(
-        result.get(&Key::URef(new_purse)),
+        entries.get(&Key::URef(new_purse)),
         Some(&StoredValue::from(
             CLValue::from_t(()).expect("should convert unit to CLValue")
         ))
     );
     assert_eq!(
-        result.get(&Key::Balance(new_purse.addr())),
+        entries.get(&Key::Balance(new_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(300_000_000)).expect("should convert U512 to CLValue")
         ))
@@ -244,14 +275,14 @@ fn should_create_account_when_transferring_funds() {
     // total supply is written on every purse balance change, so we'll have a write to this key
     // even though the changes cancel each other out
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
-            CLValue::from_t(U512::from(1_000_000_000)).expect("should convert U512 to CLValue")
+            CLValue::from_t(U512::from(1_000_000_001)).expect("should convert U512 to CLValue")
         ))
     );
 
     // 5 keys tested above should be all that would be written
-    assert_eq!(result.len(), 5);
+    assert_eq!(entries.len(), 5);
 }
 
 #[test]
@@ -264,8 +295,8 @@ fn should_change_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1, U512::from(101), U512::from(101)),
-            (validator2, U512::from(102), U512::from(102)),
+            (validator1.clone(), U512::from(101), U512::from(101)),
+            (validator2.clone(), U512::from(102), U512::from(102)),
             (validator3.clone(), U512::from(103), U512::from(103)),
         ],
         &mut rng,
@@ -281,11 +312,19 @@ fn should_change_one_validator() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
 
-    assert!(result.contains_key(&reader.get_seigniorage_recipients_key()));
+    assert_eq!(validators.len(), 3);
+    assert!(validators.contains(&validator1));
+    assert!(validators.contains(&validator2));
+    assert!(validators.contains(&validator3));
+
+    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(610)).expect("should convert U512 to CLValue")
         ))
@@ -304,13 +343,13 @@ fn should_change_one_validator() {
         .main_purse();
 
     assert_eq!(
-        result.get(&Key::Balance(bid_purse.addr())),
+        entries.get(&Key::Balance(bid_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
         ))
     );
     assert_eq!(
-        result.get(&Key::Balance(main_purse.addr())),
+        entries.get(&Key::Balance(main_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
         ))
@@ -319,12 +358,12 @@ fn should_change_one_validator() {
     // check bid overwrite
     let expected_bid = Bid::unlocked(validator3, bid_purse, U512::from(104), Default::default());
     assert_eq!(
-        result.get(&Key::Bid(account3)),
+        entries.get(&Key::Bid(account3)),
         Some(&StoredValue::from(expected_bid))
     );
 
     // 5 keys above should be all that was overwritten
-    assert_eq!(result.len(), 5);
+    assert_eq!(entries.len(), 5);
 }
 
 #[test]
@@ -337,8 +376,8 @@ fn should_change_only_stake_of_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1, U512::from(101), U512::from(101)),
-            (validator2, U512::from(102), U512::from(102)),
+            (validator1.clone(), U512::from(101), U512::from(101)),
+            (validator2.clone(), U512::from(102), U512::from(102)),
             (validator3.clone(), U512::from(103), U512::from(103)),
         ],
         &mut rng,
@@ -354,11 +393,19 @@ fn should_change_only_stake_of_one_validator() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
 
-    assert!(result.contains_key(&reader.get_seigniorage_recipients_key()));
+    assert_eq!(validators.len(), 3);
+    assert!(validators.contains(&validator1));
+    assert!(validators.contains(&validator2));
+    assert!(validators.contains(&validator3));
+
+    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(613)).expect("should convert U512 to CLValue")
         ))
@@ -373,7 +420,7 @@ fn should_change_only_stake_of_one_validator() {
         .bonding_purse();
 
     assert_eq!(
-        result.get(&Key::Balance(bid_purse.addr())),
+        entries.get(&Key::Balance(bid_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
         ))
@@ -382,12 +429,12 @@ fn should_change_only_stake_of_one_validator() {
     // check bid overwrite
     let expected_bid = Bid::unlocked(validator3, bid_purse, U512::from(104), Default::default());
     assert_eq!(
-        result.get(&Key::Bid(account3)),
+        entries.get(&Key::Bid(account3)),
         Some(&StoredValue::from(expected_bid))
     );
 
     // 4 keys above should be all that was overwritten
-    assert_eq!(result.len(), 4);
+    assert_eq!(entries.len(), 4);
 }
 
 #[test]
@@ -400,8 +447,8 @@ fn should_change_only_balance_of_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1, U512::from(101), U512::from(101)),
-            (validator2, U512::from(102), U512::from(102)),
+            (validator1.clone(), U512::from(101), U512::from(101)),
+            (validator2.clone(), U512::from(102), U512::from(102)),
             (validator3.clone(), U512::from(103), U512::from(103)),
         ],
         &mut rng,
@@ -417,10 +464,18 @@ fn should_change_only_balance_of_one_validator() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
+
+    assert_eq!(validators.len(), 3);
+    assert!(validators.contains(&validator1));
+    assert!(validators.contains(&validator2));
+    assert!(validators.contains(&validator3));
 
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(609)).expect("should convert U512 to CLValue")
         ))
@@ -434,14 +489,14 @@ fn should_change_only_balance_of_one_validator() {
         .main_purse();
 
     assert_eq!(
-        result.get(&Key::Balance(main_purse.addr())),
+        entries.get(&Key::Balance(main_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
         ))
     );
 
     // 2 keys above should be all that was overwritten
-    assert_eq!(result.len(), 2);
+    assert_eq!(entries.len(), 2);
 }
 
 #[test]
@@ -467,11 +522,16 @@ fn should_replace_one_validator() {
         ..Default::default()
     };
 
-    let result = get_update(&mut reader, config);
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
 
-    assert!(result.contains_key(&reader.get_seigniorage_recipients_key()));
+    assert_eq!(validators, vec![validator2.clone()]);
+
+    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
     assert_eq!(
-        result.get(&reader.get_total_supply_key()),
+        entries.get(&reader.get_total_supply_key()),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(305)).expect("should convert U512 to CLValue")
         ))
@@ -485,7 +545,7 @@ fn should_replace_one_validator() {
         .bonding_purse();
 
     assert_eq!(
-        result.get(&Key::Balance(bid_purse.addr())),
+        entries.get(&Key::Balance(bid_purse.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::zero()).expect("should convert U512 to CLValue")
         ))
@@ -496,7 +556,7 @@ fn should_replace_one_validator() {
     let mut expected_bid_1 = Bid::unlocked(validator1, bid_purse, U512::zero(), Default::default());
     expected_bid_1.deactivate();
     assert_eq!(
-        result.get(&Key::Bid(account1)),
+        entries.get(&Key::Bid(account1)),
         Some(&StoredValue::from(expected_bid_1))
     );
 
@@ -504,7 +564,7 @@ fn should_replace_one_validator() {
     let account2 = validator2.to_account_hash();
 
     // the new account should be created
-    let account_write = result
+    let account_write = entries
         .get(&Key::Account(account2))
         .expect("should create account")
         .as_account()
@@ -514,19 +574,19 @@ fn should_replace_one_validator() {
 
     // check that the main purse for the new account has been created with the correct amount
     assert_eq!(
-        result.get(&Key::URef(main_purse_2)),
+        entries.get(&Key::URef(main_purse_2)),
         Some(&StoredValue::from(
             CLValue::from_t(()).expect("should convert unit to CLValue")
         ))
     );
     assert_eq!(
-        result.get(&Key::Balance(main_purse_2.addr())),
+        entries.get(&Key::Balance(main_purse_2.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(102)).expect("should convert U512 to CLValue")
         ))
     );
 
-    let bid_write = result
+    let bid_write = entries
         .get(&Key::Bid(account2))
         .expect("should create bid")
         .as_bid()
@@ -545,18 +605,18 @@ fn should_replace_one_validator() {
 
     // check that the bid purse for the new validator has been created with the correct amount
     assert_eq!(
-        result.get(&Key::URef(bid_purse_2)),
+        entries.get(&Key::URef(bid_purse_2)),
         Some(&StoredValue::from(
             CLValue::from_t(()).expect("should convert unit to CLValue")
         ))
     );
     assert_eq!(
-        result.get(&Key::Balance(bid_purse_2.addr())),
+        entries.get(&Key::Balance(bid_purse_2.addr())),
         Some(&StoredValue::from(
             CLValue::from_t(U512::from(102)).expect("should convert U512 to CLValue")
         ))
     );
 
     // 10 keys above should be all that was overwritten
-    assert_eq!(result.len(), 10);
+    assert_eq!(entries.len(), 10);
 }

--- a/utils/global-state-update-gen/src/utils.rs
+++ b/utils/global-state-update-gen/src/utils.rs
@@ -5,8 +5,8 @@ use std::{
 
 use casper_hashing::Digest;
 use casper_types::{
-    bytesrepr::ToBytes, checksummed_hex, system::auction::SeigniorageRecipientsSnapshot, Key,
-    PublicKey, StoredValue,
+    bytesrepr::ToBytes, checksummed_hex, system::auction::SeigniorageRecipientsSnapshot,
+    AsymmetricType, Key, PublicKey, StoredValue,
 };
 
 /// Parses a Digest from a string. Panics if parsing fails.
@@ -14,6 +14,19 @@ pub fn hash_from_str(hex_str: &str) -> Digest {
     (&checksummed_hex::decode(hex_str).unwrap()[..])
         .try_into()
         .unwrap()
+}
+
+pub(crate) fn print_validators(validators: &[PublicKey]) {
+    println!("validators = [");
+    for (index, validator) in validators.iter().enumerate() {
+        if index + 1 == validators.len() {
+            println!("    \"{}\"", validator.to_hex());
+        } else {
+            println!("    \"{}\",", validator.to_hex());
+        }
+    }
+    println!("]");
+    println!();
 }
 
 /// Prints a global state update entry in a format ready for inclusion in a TOML file.


### PR DESCRIPTION
This changes the global-state-update-gen tool to output the set of post-upgrade validators, in line with changes related to #3339 to support network upgrades.
