### PR TITLE
Fix adding validators with `only_listed_validators = false`

### DIFF
--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -195,6 +195,20 @@ fn gen_snapshot_from_old(
             }
             None => true,
         });
+
+        // add the validators that weren't present in the old snapshot
+        for (public_key, stake) in &stakes_map {
+            if recipients.contains_key(public_key) {
+                continue;
+            }
+
+            if *stake != U512::zero() {
+                recipients.insert(
+                    public_key.clone(),
+                    SeigniorageRecipient::new(*stake, Default::default(), Default::default()),
+                );
+            }
+        }
     }
 
     snapshot

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -620,3 +620,112 @@ fn should_replace_one_validator() {
     // 10 keys above should be all that was overwritten
     assert_eq!(entries.len(), 10);
 }
+
+#[test]
+fn should_add_one_validator() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let validator2 = PublicKey::random(&mut rng);
+    let validator3 = PublicKey::random(&mut rng);
+    let validator4 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![
+            (validator1.clone(), U512::from(101), U512::from(101)),
+            (validator2.clone(), U512::from(102), U512::from(102)),
+            (validator3.clone(), U512::from(103), U512::from(103)),
+        ],
+        &mut rng,
+    );
+
+    // we'll be adding validator 4
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator4.clone(),
+            balance: Some(U512::from(100)),
+            stake: Some(U512::from(104)),
+        }],
+        only_listed_validators: false,
+        ..Default::default()
+    };
+
+    let Update {
+        validators,
+        entries,
+    } = get_update(&mut reader, config);
+
+    assert_eq!(validators.len(), 4);
+    assert!(validators.contains(&validator1));
+    assert!(validators.contains(&validator2));
+    assert!(validators.contains(&validator3));
+    assert!(validators.contains(&validator4));
+
+    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
+    assert_eq!(
+        entries.get(&reader.get_total_supply_key()),
+        Some(&StoredValue::from(
+            CLValue::from_t(U512::from(816)).expect("should convert U512 to CLValue")
+        ))
+    );
+
+    // check writes for validator4
+    let account4 = validator4.to_account_hash();
+
+    // the new account should be created
+    let account_write = entries
+        .get(&Key::Account(account4))
+        .expect("should create account")
+        .as_account()
+        .expect("should be account")
+        .clone();
+    let main_purse_4 = account_write.main_purse();
+
+    // check that the main purse for the new account has been created with the correct amount
+    assert_eq!(
+        entries.get(&Key::URef(main_purse_4)),
+        Some(&StoredValue::from(
+            CLValue::from_t(()).expect("should convert unit to CLValue")
+        ))
+    );
+    assert_eq!(
+        entries.get(&Key::Balance(main_purse_4.addr())),
+        Some(&StoredValue::from(
+            CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
+        ))
+    );
+
+    let bid_write = entries
+        .get(&Key::Bid(account4))
+        .expect("should create bid")
+        .as_bid()
+        .expect("should be bid")
+        .clone();
+    assert_eq!(bid_write.validator_public_key(), &validator4);
+    assert_eq!(
+        bid_write
+            .total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(104)
+    );
+    assert!(!bid_write.inactive());
+
+    let bid_purse_4 = *bid_write.bonding_purse();
+
+    // check that the bid purse for the new validator has been created with the correct amount
+    assert_eq!(
+        entries.get(&Key::URef(bid_purse_4)),
+        Some(&StoredValue::from(
+            CLValue::from_t(()).expect("should convert unit to CLValue")
+        ))
+    );
+    assert_eq!(
+        entries.get(&Key::Balance(bid_purse_4.addr())),
+        Some(&StoredValue::from(
+            CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
+        ))
+    );
+
+    // 8 keys above should be all that was written
+    assert_eq!(entries.len(), 8);
+}


### PR DESCRIPTION
This is a port of a bugfix from #3305 that fixes an issue with validators not being added in updates with `only_listed_validators = false`.