### PR TITLE
Update status endpoint

### DIFF
--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -132,6 +132,10 @@ impl BlockBuilder {
         self.touch();
     }
 
+    pub(crate) fn block_acquisition_state(&self) -> &BlockAcquisitionState {
+        &self.acquisition_state
+    }
+
     pub(super) fn block_hash(&self) -> BlockHash {
         self.block_hash
     }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -45,12 +45,13 @@ use crate::{
     effect::{
         announcements::RpcServerAnnouncement,
         requests::{
-            ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest, MetricsRequest,
-            NetworkInfoRequest, RpcRequest, StorageRequest, UpgradeWatcherRequest,
+            BlockSynchronizerRequest, ChainspecRawBytesRequest, ConsensusRequest,
+            ContractRuntimeRequest, MetricsRequest, NetworkInfoRequest, ReactorStatusRequest,
+            RpcRequest, StorageRequest, UpgradeWatcherRequest,
         },
         EffectBuilder, EffectExt, Effects, Responder,
     },
-    types::{BlockHeader, ChainspecInfo, Deploy, NodeState, StatusFeed},
+    types::{BlockHeader, ChainspecInfo, Deploy, StatusFeed},
     utils::{self, ListeningError},
     NodeRng,
 };
@@ -70,6 +71,8 @@ pub(crate) trait ReactorEventT:
     + From<MetricsRequest>
     + From<NetworkInfoRequest>
     + From<StorageRequest>
+    + From<ReactorStatusRequest>
+    + From<BlockSynchronizerRequest>
     + Send
 {
 }
@@ -85,6 +88,8 @@ impl<REv> ReactorEventT for REv where
         + From<MetricsRequest>
         + From<NetworkInfoRequest>
         + From<StorageRequest>
+        + From<ReactorStatusRequest>
+        + From<BlockSynchronizerRequest>
         + Send
         + 'static
 {
@@ -388,19 +393,38 @@ where
                 let node_uptime = self.node_startup_instant.elapsed();
                 let network_name = self.network_name.clone();
                 async move {
-                    let (last_added_block, peers, next_upgrade, consensus_status) = join!(
+                    let (
+                        last_added_block,
+                        peers,
+                        next_upgrade,
+                        consensus_status,
+                        (reactor_state, last_progress),
+                        available_block_range,
+                        block_sync,
+                    ) = join!(
                         effect_builder.get_highest_block_from_storage(),
                         effect_builder.network_peers(),
                         effect_builder.get_next_upgrade(),
                         effect_builder.consensus_status(),
+                        effect_builder.get_reactor_status(),
+                        effect_builder.get_available_block_range_from_storage(),
+                        effect_builder.get_block_synchronizer_status(),
                     );
+                    let starting_state_root_hash = effect_builder
+                        .get_block_header_at_height_from_storage(available_block_range.low(), true)
+                        .await
+                        .map(|header| *header.state_root_hash());
                     let status_feed = StatusFeed::new(
                         last_added_block,
                         peers,
                         ChainspecInfo::new(network_name, next_upgrade),
                         consensus_status,
                         node_uptime,
-                        NodeState::Participating,
+                        reactor_state,
+                        last_progress,
+                        available_block_range,
+                        block_sync,
+                        starting_state_root_hash,
                     );
                     responder.respond(status_feed).await;
                 }
@@ -571,7 +595,6 @@ mod tests {
             "{}/../resources/test/rpc_schema_hashing.json",
             env!("CARGO_MANIFEST_DIR")
         );
-
         assert_schema(schema_path, schema_for_value!(OPEN_RPC_SCHEMA.clone()));
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -134,7 +134,7 @@ use casper_types::{
 
 use crate::{
     components::{
-        block_synchronizer::{GlobalStateSynchronizerError, TrieAccumulatorError},
+        block_synchronizer::{BlockSyncStatus, GlobalStateSynchronizerError, TrieAccumulatorError},
         consensus::{ClContext, EraDump, ProposedBlock, ValidatorChange},
         contract_runtime::{ContractRuntimeError, EraValidatorsRequest},
         deploy_acceptor,
@@ -144,7 +144,7 @@ use crate::{
     },
     contract_runtime::SpeculativeExecutionState,
     effect::requests::BlockAccumulatorRequest,
-    reactor::{EventQueueHandle, QueueKind},
+    reactor::{main_reactor::ReactorState, EventQueueHandle, QueueKind},
     types::{
         appendable_block::AppendableBlock, ApprovalsHashes, AvailableBlockRange, Block,
         BlockAndDeploys, BlockExecutionResultsOrChunk, BlockExecutionResultsOrChunkId, BlockHash,
@@ -164,9 +164,10 @@ use announcements::{
 };
 use diagnostics_port::DumpConsensusStateRequest;
 use requests::{
-    AppStateRequest, BeginGossipRequest, BlockCompleteConfirmationRequest, BlockValidationRequest,
-    ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest, DeployBufferRequest,
-    FetcherRequest, MetricsRequest, NetworkInfoRequest, NetworkRequest, StorageRequest,
+    AppStateRequest, BeginGossipRequest, BlockCompleteConfirmationRequest,
+    BlockSynchronizerRequest, BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest,
+    ContractRuntimeRequest, DeployBufferRequest, FetcherRequest, MetricsRequest,
+    NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, StorageRequest,
     SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
 };
 
@@ -1446,6 +1447,25 @@ impl<REv> EffectBuilder<REv> {
                 responder,
             },
             QueueKind::ContractRuntime,
+        )
+        .await
+    }
+
+    pub(crate) async fn get_reactor_status(self) -> (ReactorState, Timestamp)
+    where
+        REv: From<ReactorStatusRequest>,
+    {
+        self.make_request(ReactorStatusRequest, QueueKind::Regular)
+            .await
+    }
+
+    pub(crate) async fn get_block_synchronizer_status(self) -> Vec<BlockSyncStatus>
+    where
+        REv: From<BlockSynchronizerRequest>,
+    {
+        self.make_request(
+            |responder| BlockSynchronizerRequest::Status { responder },
+            QueueKind::Regular,
         )
         .await
     }

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -388,6 +388,9 @@ impl reactor::Reactor for MainReactor {
                 self.upgrade_watcher
                     .handle_event(effect_builder, rng, req.into()),
             ),
+            MainEvent::MainReactorRequest(req) => {
+                req.0.respond((self.state, self.last_progress)).ignore()
+            }
             MainEvent::UpgradeWatcherAnnouncement(
                 UpgradeWatcherAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => reactor::wrap_effects(

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -30,8 +30,8 @@ use crate::{
             BlockCompleteConfirmationRequest, BlockSynchronizerRequest, BlockValidationRequest,
             ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest,
             DeployBufferRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,
-            NetworkRequest, RestRequest, RpcRequest, StorageRequest, SyncGlobalStateRequest,
-            TrieAccumulatorRequest, UpgradeWatcherRequest,
+            NetworkRequest, ReactorStatusRequest, RestRequest, RpcRequest, StorageRequest,
+            SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
         },
     },
     protocol::Message,
@@ -215,6 +215,8 @@ pub(crate) enum MainEvent {
     StorageRequest(#[serde(skip_serializing)] StorageRequest),
     #[from]
     AppStateRequest(AppStateRequest),
+    #[from]
+    MainReactorRequest(#[serde(skip_serializing)] ReactorStatusRequest),
 }
 
 impl ReactorEvent for MainEvent {
@@ -321,6 +323,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::BlockGossiperAnnouncement(_) => "BlockGossiperAnnouncement",
             MainEvent::BlockFetcher(_) => "BlockFetcher",
             MainEvent::BlockFetcherRequest(_) => "BlockFetcherRequest",
+            MainEvent::MainReactorRequest(_) => "MainReactorRequest",
         }
     }
 }
@@ -490,6 +493,7 @@ impl Display for MainEvent {
             MainEvent::BlockGossiperAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::BlockFetcher(inner) => Display::fmt(inner, f),
             MainEvent::BlockFetcherRequest(inner) => Display::fmt(inner, f),
+            MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
         }
     }
 }

--- a/node/src/reactor/main_reactor/reactor_state.rs
+++ b/node/src/reactor/main_reactor/reactor_state.rs
@@ -1,7 +1,9 @@
 use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, PartialEq, Eq, DataSize, Debug)]
-pub(crate) enum ReactorState {
+#[derive(Copy, Clone, PartialEq, Eq, DataSize, Debug, Deserialize, JsonSchema, Serialize)]
+pub enum ReactorState {
     // get all components and reactor state set up on start
     Initialize,
     // orient to the network and attempt to catch up to tip

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -53,7 +53,7 @@ pub(crate) use item::{EmptyValidationMetadata, FetcherItem, GossiperItem, Item, 
 pub use node_config::NodeConfig;
 pub(crate) use node_id::NodeId;
 pub use peers_map::PeersMap;
-pub use status_feed::{ChainspecInfo, GetStatusResult, NodeState, StatusFeed};
+pub use status_feed::{ChainspecInfo, GetStatusResult, StatusFeed};
 pub(crate) use sync_leap::{SyncLeap, SyncLeapIdentifier};
 pub(crate) use validator_matrix::{EraValidatorWeights, SignatureWeight, ValidatorMatrix};
 pub use value_or_chunk::{

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -7,7 +7,6 @@ use std::{
     time::Duration,
 };
 
-use datasize::DataSize;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -17,11 +16,15 @@ use casper_types::{EraId, ProtocolVersion, PublicKey, TimeDiff, Timestamp};
 
 use crate::{
     components::{
+        block_synchronizer::BlockSyncStatus,
         rpc_server::rpcs::docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
         upgrade_watcher::NextUpgrade,
     },
+    reactor::main_reactor::ReactorState,
     types::{ActivationPoint, Block, BlockHash, NodeId, PeersMap},
 };
+
+use super::AvailableBlockRange;
 
 static CHAINSPEC_INFO: Lazy<ChainspecInfo> = Lazy::new(|| {
     let next_upgrade = NextUpgrade::new(
@@ -47,7 +50,11 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         round_length: Some(TimeDiff::from(1 << 16)),
         version: crate::VERSION_STRING.as_str(),
         node_uptime: Duration::from_secs(13),
-        node_state: NodeState::Participating,
+        reactor_state: ReactorState::Initialize,
+        last_progress: Timestamp::from(0),
+        available_block_range: AvailableBlockRange::RANGE_0_0,
+        block_sync: vec![],
+        starting_state_root_hash: None,
     };
     GetStatusResult::new(status_feed, DOCS_EXAMPLE_PROTOCOL_VERSION)
 });
@@ -75,22 +82,6 @@ impl ChainspecInfo {
     }
 }
 
-/// The various possible states of operation for the node.
-#[derive(Clone, PartialEq, Eq, DataSize, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum NodeState {
-    // /// The node is currently in joining mode.
-    // Joining(Progress),
-    // /// The node is currently in participating mode, but also syncing to genesis in the
-    // background.
-    // ParticipatingAndSyncingToGenesis {
-    //     /// The progress of the chain sync-to-genesis task.
-    //     sync_progress: Progress,
-    // },
-    /// The node is currently in the participating state.
-    Participating,
-}
-
 /// Data feed for client "info_get_status" endpoint.
 #[derive(Debug, Serialize)]
 pub struct StatusFeed {
@@ -108,18 +99,31 @@ pub struct StatusFeed {
     pub version: &'static str,
     /// Time that passed since the node has started.
     pub node_uptime: Duration,
-    /// The current state of node.
-    pub node_state: NodeState,
+    /// The current state of node reactor.
+    pub reactor_state: ReactorState,
+    /// Timestamp of the last recorded progress in the reactor.
+    pub last_progress: Timestamp,
+    /// The available block range in storage.
+    pub available_block_range: AvailableBlockRange,
+    /// The status of the block synchronizer builders.
+    pub block_sync: Vec<BlockSyncStatus>,
+    /// The state root hash of the lowest block in the available block range.
+    pub starting_state_root_hash: Option<Digest>,
 }
 
 impl StatusFeed {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         last_added_block: Option<Block>,
         peers: BTreeMap<NodeId, String>,
         chainspec_info: ChainspecInfo,
         consensus_status: Option<(PublicKey, Option<TimeDiff>)>,
         node_uptime: Duration,
-        node_state: NodeState,
+        reactor_state: ReactorState,
+        last_progress: Timestamp,
+        available_block_range: AvailableBlockRange,
+        block_sync: Vec<BlockSyncStatus>,
+        starting_state_root_hash: Option<Digest>,
     ) -> Self {
         let (our_public_signing_key, round_length) = match consensus_status {
             Some((public_key, round_length)) => (Some(public_key), round_length),
@@ -133,7 +137,11 @@ impl StatusFeed {
             round_length,
             version: crate::VERSION_STRING.as_str(),
             node_uptime,
-            node_state,
+            reactor_state,
+            last_progress,
+            available_block_range,
+            block_sync,
+            starting_state_root_hash,
         }
     }
 }
@@ -167,16 +175,17 @@ impl From<Block> for MinimalBlockInfo {
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GetStatusResult {
+    /// The node ID and network address of each connected peer.
+    pub peers: PeersMap,
     /// The RPC API version.
     #[schemars(with = "String")]
     pub api_version: ProtocolVersion,
+    /// The compiled node version.
+    pub build_version: String,
     /// The chainspec name.
     pub chainspec_name: String,
-    /// The state root hash used at the start of the current session.
-    #[deprecated(since = "1.5.0")]
-    pub starting_state_root_hash: Digest,
-    /// The node ID and network address of each connected peer.
-    pub peers: PeersMap,
+    /// The state root hash of the lowest block in the available block range.
+    pub starting_state_root_hash: Option<Digest>,
     /// The minimal info of the last block from the linear chain.
     pub last_added_block_info: Option<MinimalBlockInfo>,
     /// Our public signing key.
@@ -185,28 +194,35 @@ pub struct GetStatusResult {
     pub round_length: Option<TimeDiff>,
     /// Information about the next scheduled upgrade.
     pub next_upgrade: Option<NextUpgrade>,
-    /// The compiled node version.
-    pub build_version: String,
     /// Time that passed since the node has started.
     pub uptime: TimeDiff,
-    /// The current state of node.
-    pub node_state: NodeState,
+    /// The current state of node reactor.
+    pub reactor_state: ReactorState,
+    /// Timestamp of the last recorded progress in the reactor.
+    pub last_progress: Timestamp,
+    /// The available block range in storage.
+    pub available_block_range: AvailableBlockRange,
+    /// The status of the block synchronizer builders.
+    pub block_sync: Vec<BlockSyncStatus>,
 }
 
 impl GetStatusResult {
     #[allow(deprecated)]
     pub(crate) fn new(status_feed: StatusFeed, api_version: ProtocolVersion) -> Self {
         GetStatusResult {
+            peers: PeersMap::from(status_feed.peers),
             api_version,
             chainspec_name: status_feed.chainspec_info.name,
-            starting_state_root_hash: Digest::from([0u8; 32]),
-            peers: PeersMap::from(status_feed.peers),
+            starting_state_root_hash: status_feed.starting_state_root_hash,
             last_added_block_info: status_feed.last_added_block.map(Into::into),
             our_public_signing_key: status_feed.our_public_signing_key,
             round_length: status_feed.round_length,
             next_upgrade: status_feed.chainspec_info.next_upgrade,
             uptime: status_feed.node_uptime.into(),
-            node_state: status_feed.node_state,
+            reactor_state: status_feed.reactor_state,
+            last_progress: status_feed.last_progress,
+            available_block_range: status_feed.available_block_range,
+            block_sync: status_feed.block_sync,
             #[cfg(not(test))]
             build_version: crate::VERSION_STRING.clone(),
 

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -5,16 +5,30 @@
   "type": "object",
   "required": [
     "api_version",
+    "available_block_range",
+    "block_sync",
     "build_version",
     "chainspec_name",
-    "node_state",
+    "last_progress",
     "peers",
-    "starting_state_root_hash",
+    "reactor_state",
     "uptime"
   ],
   "properties": {
+    "peers": {
+      "description": "The node ID and network address of each connected peer.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PeersMap"
+        }
+      ]
+    },
     "api_version": {
       "description": "The RPC API version.",
+      "type": "string"
+    },
+    "build_version": {
+      "description": "The compiled node version.",
       "type": "string"
     },
     "chainspec_name": {
@@ -22,19 +36,13 @@
       "type": "string"
     },
     "starting_state_root_hash": {
-      "description": "The state root hash used at the start of the current session.",
-      "deprecated": true,
-      "allOf": [
+      "description": "The state root hash of the lowest block in the available block range.",
+      "anyOf": [
         {
           "$ref": "#/definitions/Digest"
-        }
-      ]
-    },
-    "peers": {
-      "description": "The node ID and network address of each connected peer.",
-      "allOf": [
+        },
         {
-          "$ref": "#/definitions/PeersMap"
+          "type": "null"
         }
       ]
     },
@@ -82,10 +90,6 @@
         }
       ]
     },
-    "build_version": {
-      "description": "The compiled node version.",
-      "type": "string"
-    },
     "uptime": {
       "description": "Time that passed since the node has started.",
       "allOf": [
@@ -94,21 +98,40 @@
         }
       ]
     },
-    "node_state": {
-      "description": "The current state of node.",
+    "reactor_state": {
+      "description": "The current state of node reactor.",
       "allOf": [
         {
-          "$ref": "#/definitions/NodeState"
+          "$ref": "#/definitions/ReactorState"
         }
       ]
+    },
+    "last_progress": {
+      "description": "Timestamp of the last recorded progress in the reactor.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Timestamp"
+        }
+      ]
+    },
+    "available_block_range": {
+      "description": "The available block range in storage.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AvailableBlockRange"
+        }
+      ]
+    },
+    "block_sync": {
+      "description": "The status of the block synchronizer builders.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/BlockSyncStatus"
+      }
     }
   },
   "additionalProperties": false,
   "definitions": {
-    "Digest": {
-      "description": "Hex-encoded hash digest.",
-      "type": "string"
-    },
     "PeersMap": {
       "description": "Map of peer IDs to network addresses.",
       "type": "array",
@@ -134,6 +157,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "Digest": {
+      "description": "Hex-encoded hash digest.",
+      "type": "string"
     },
     "MinimalBlockInfo": {
       "description": "Minimal info of a `Block`.",
@@ -227,343 +254,63 @@
         }
       ]
     },
-    "NodeState": {
-      "description": "The various possible states of operation for the node.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "participating"
-          ]
-        },
-        {
-          "description": "The node is currently in joining mode.",
-          "type": "object",
-          "required": [
-            "joining"
-          ],
-          "properties": {
-            "joining": {
-              "$ref": "#/definitions/Progress"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
-          "type": "object",
-          "required": [
-            "participating_and_syncing_to_genesis"
-          ],
-          "properties": {
-            "participating_and_syncing_to_genesis": {
-              "type": "object",
-              "required": [
-                "sync_progress"
-              ],
-              "properties": {
-                "sync_progress": {
-                  "description": "The progress of the chain sync-to-genesis task.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/Progress"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Progress": {
-      "description": "The progress of the chain-synchronizer task.",
-      "anyOf": [
-        {
-          "description": "The chain-synchronizer is performing the fast-sync task.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FastSync"
-            }
-          ]
-        },
-        {
-          "description": "The chain-synchronizer is performing the sync-to-genesis task.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/SyncToGenesis"
-            }
-          ]
-        }
-      ]
-    },
-    "FastSync": {
-      "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "not yet started",
-            "starting",
-            "finished"
-          ]
-        },
-        {
-          "description": "Currently fetching the trusted block header.",
-          "type": "object",
-          "required": [
-            "fetching_trusted_block_header"
-          ],
-          "properties": {
-            "fetching_trusted_block_header": {
-              "$ref": "#/definitions/BlockHash"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Currently syncing the trie-store under the given state root hash.",
-          "type": "object",
-          "required": [
-            "fetching_global_state_under_given_block"
-          ],
-          "properties": {
-            "fetching_global_state_under_given_block": {
-              "type": "object",
-              "required": [
-                "block_height",
-                "number_of_remaining_tries_to_fetch",
-                "reason",
-                "state_root_hash"
-              ],
-              "properties": {
-                "block_height": {
-                  "description": "The height of the block containing the given state root hash.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "state_root_hash": {
-                  "description": "The global state root hash.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/Digest"
-                    }
-                  ]
-                },
-                "reason": {
-                  "description": "The reason for syncing the trie-store.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/FetchingTriesReason"
-                    }
-                  ]
-                },
-                "number_of_remaining_tries_to_fetch": {
-                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
-          "type": "object",
-          "required": [
-            "fetching_block_and_deploys_at_given_block_height_before_execution"
-          ],
-          "properties": {
-            "fetching_block_and_deploys_at_given_block_height_before_execution": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Currently executing the block at the given height.",
-          "type": "object",
-          "required": [
-            "executing_block_at_height"
-          ],
-          "properties": {
-            "executing_block_at_height": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
-          "type": "object",
-          "required": [
-            "retrying_block_execution"
-          ],
-          "properties": {
-            "retrying_block_execution": {
-              "type": "object",
-              "required": [
-                "attempt",
-                "block_height"
-              ],
-              "properties": {
-                "block_height": {
-                  "description": "The height of the block being executed.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "attempt": {
-                  "description": "The retry attempt number.",
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "FetchingTriesReason": {
-      "description": "The reason for syncing the trie store under a given state root hash.",
+    "ReactorState": {
       "type": "string",
       "enum": [
-        "for fast sync",
-        "preparing for emergency upgrade",
-        "preparing for upgrade"
+        "Initialize",
+        "CatchUp",
+        "Upgrading",
+        "KeepUp",
+        "Validate",
+        "ShutdownForUpgrade"
       ]
     },
-    "SyncToGenesis": {
-      "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "not yet started",
-            "starting",
-            "finished"
-          ]
-        },
-        {
-          "description": "Currently fetching block headers in batches back towards the genesis block.",
-          "type": "object",
-          "required": [
-            "fetching_headers_back_to_genesis"
-          ],
-          "properties": {
-            "fetching_headers_back_to_genesis": {
-              "type": "object",
-              "required": [
-                "lowest_block_height"
-              ],
-              "properties": {
-                "lowest_block_height": {
-                  "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
-          "type": "object",
-          "required": [
-            "syncing_forward_from_genesis"
-          ],
-          "properties": {
-            "syncing_forward_from_genesis": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SyncBlock"
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "SyncBlock": {
-      "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
+    "AvailableBlockRange": {
+      "description": "An unbroken, inclusive range of blocks.",
       "type": "object",
       "required": [
-        "block_height",
-        "fetching"
+        "high",
+        "low"
       ],
       "properties": {
-        "block_height": {
-          "description": "The height of the block being synced.",
+        "low": {
+          "description": "The inclusive lower bound of the range.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
-        "fetching": {
-          "description": "The progress of the sync-block task.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/SyncBlockFetching"
-            }
-          ]
+        "high": {
+          "description": "The inclusive upper bound of the range.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
-      }
+      },
+      "additionalProperties": false
     },
-    "SyncBlockFetching": {
-      "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "block and deploys",
-            "block signatures"
-          ]
+    "BlockSyncStatus": {
+      "type": "object",
+      "required": [
+        "acquisition_state",
+        "block_hash"
+      ],
+      "properties": {
+        "block_hash": {
+          "$ref": "#/definitions/BlockHash"
         },
-        {
-          "description": "Currently syncing the trie-store under the state root hash held in the block.",
-          "type": "object",
-          "required": [
-            "global_state_under_given_block"
+        "block_height": {
+          "type": [
+            "integer",
+            "null"
           ],
-          "properties": {
-            "global_state_under_given_block": {
-              "type": "object",
-              "required": [
-                "number_of_remaining_tries_to_fetch",
-                "state_root_hash"
-              ],
-              "properties": {
-                "state_root_hash": {
-                  "description": "The global state root hash.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/Digest"
-                    }
-                  ]
-                },
-                "number_of_remaining_tries_to_fetch": {
-                  "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "acquisition_state": {
+          "type": "string"
         }
-      ]
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -78,7 +78,7 @@
           },
           "Approval": {
             "additionalProperties": false,
-            "description": "A struct containing a signature and the public key of the signer.",
+            "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
             "properties": {
               "signature": {
                 "$ref": "#/components/schemas/Signature"
@@ -149,6 +149,29 @@
               "block_height",
               "era_validators",
               "state_root_hash"
+            ],
+            "type": "object"
+          },
+          "AvailableBlockRange": {
+            "additionalProperties": false,
+            "description": "An unbroken, inclusive range of blocks.",
+            "properties": {
+              "high": {
+                "description": "The inclusive upper bound of the range.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "low": {
+                "description": "The inclusive lower bound of the range.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "high",
+              "low"
             ],
             "type": "object"
           },
@@ -259,6 +282,30 @@
               }
             ],
             "description": "Identifier for possible ways to retrieve a block."
+          },
+          "BlockSyncStatus": {
+            "additionalProperties": false,
+            "properties": {
+              "acquisition_state": {
+                "type": "string"
+              },
+              "block_hash": {
+                "$ref": "#/components/schemas/BlockHash"
+              },
+              "block_height": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "acquisition_state",
+              "block_hash"
+            ],
+            "type": "object"
           },
           "CLType": {
             "anyOf": [
@@ -655,7 +702,7 @@
           },
           "DeployHeader": {
             "additionalProperties": false,
-            "description": "The header portion of a [`Deploy`](struct.Deploy.html).",
+            "description": "The header portion of a [`Deploy`].",
             "properties": {
               "account": {
                 "$ref": "#/components/schemas/PublicKey"
@@ -1371,151 +1418,6 @@
             ],
             "description": "The result of executing a single deploy."
           },
-          "FastSync": {
-            "anyOf": [
-              {
-                "enum": [
-                  "not yet started",
-                  "starting",
-                  "finished"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently fetching the trusted block header.",
-                "properties": {
-                  "fetching_trusted_block_header": {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                },
-                "required": [
-                  "fetching_trusted_block_header"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently syncing the trie-store under the given state root hash.",
-                "properties": {
-                  "fetching_global_state_under_given_block": {
-                    "properties": {
-                      "block_height": {
-                        "description": "The height of the block containing the given state root hash.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      },
-                      "number_of_remaining_tries_to_fetch": {
-                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
-                        "format": "uint",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      },
-                      "reason": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/FetchingTriesReason"
-                          }
-                        ],
-                        "description": "The reason for syncing the trie-store."
-                      },
-                      "state_root_hash": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/Digest"
-                          }
-                        ],
-                        "description": "The global state root hash."
-                      }
-                    },
-                    "required": [
-                      "block_height",
-                      "number_of_remaining_tries_to_fetch",
-                      "reason",
-                      "state_root_hash"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "fetching_global_state_under_given_block"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently fetching the block at the given height and its deploys in preparation for executing it.",
-                "properties": {
-                  "fetching_block_and_deploys_at_given_block_height_before_execution": {
-                    "format": "uint64",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "fetching_block_and_deploys_at_given_block_height_before_execution"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently executing the block at the given height.",
-                "properties": {
-                  "executing_block_at_height": {
-                    "format": "uint64",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "executing_block_at_height"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently retrying the execution of the block at the given height, due to an unexpected mismatch in the previous execution result (due to a mismatch in the deploys' approvals).",
-                "properties": {
-                  "retrying_block_execution": {
-                    "properties": {
-                      "attempt": {
-                        "description": "The retry attempt number.",
-                        "format": "uint",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      },
-                      "block_height": {
-                        "description": "The height of the block being executed.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "attempt",
-                      "block_height"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "retrying_block_execution"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The progress of the fast-sync task, performed by all nodes while in joining mode.\n\nThe fast-sync task generally progresses from each variant to the next linearly.  An exception is that it will cycle repeatedly from `FetchingBlockAndDeploysToExecute` to `ExecutingBlock` (and possibly to `RetryingBlockExecution`) as it iterates forwards one block at a time, fetching then executing."
-          },
-          "FetchingTriesReason": {
-            "description": "The reason for syncing the trie store under a given state root hash.",
-            "enum": [
-              "for fast sync",
-              "preparing for emergency upgrade",
-              "preparing for upgrade"
-            ],
-            "type": "string"
-          },
           "GlobalStateIdentifier": {
             "anyOf": [
               {
@@ -2106,56 +2008,6 @@
             ],
             "type": "object"
           },
-          "NodeState": {
-            "anyOf": [
-              {
-                "enum": [
-                  "participating"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "The node is currently in joining mode.",
-                "properties": {
-                  "joining": {
-                    "$ref": "#/components/schemas/Progress"
-                  }
-                },
-                "required": [
-                  "joining"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "The node is currently in participating mode, but also syncing to genesis in the background.",
-                "properties": {
-                  "participating_and_syncing_to_genesis": {
-                    "properties": {
-                      "sync_progress": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/Progress"
-                          }
-                        ],
-                        "description": "The progress of the chain sync-to-genesis task."
-                      }
-                    },
-                    "required": [
-                      "sync_progress"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "participating_and_syncing_to_genesis"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The various possible states of operation for the node."
-          },
           "OpKind": {
             "description": "The type of operation performed while executing a deploy.",
             "enum": [
@@ -2231,27 +2083,6 @@
             },
             "type": "array"
           },
-          "Progress": {
-            "anyOf": [
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/FastSync"
-                  }
-                ],
-                "description": "The chain-synchronizer is performing the fast-sync task."
-              },
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SyncToGenesis"
-                  }
-                ],
-                "description": "The chain-synchronizer is performing the sync-to-genesis task."
-              }
-            ],
-            "description": "The progress of the chain-synchronizer task."
-          },
           "ProtocolVersion": {
             "description": "Casper Platform protocol version",
             "type": "string"
@@ -2303,6 +2134,17 @@
               }
             ],
             "description": "Identifier of a purse."
+          },
+          "ReactorState": {
+            "enum": [
+              "Initialize",
+              "CatchUp",
+              "Upgrading",
+              "KeepUp",
+              "Validate",
+              "ShutdownForUpgrade"
+            ],
+            "type": "string"
           },
           "Reward": {
             "additionalProperties": false,
@@ -2572,128 +2414,6 @@
               }
             ],
             "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
-          },
-          "SyncBlock": {
-            "description": "Container pairing the given [`SyncBlockFetching`] progress indicator with the height of the relative block.",
-            "properties": {
-              "block_height": {
-                "description": "The height of the block being synced.",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "fetching": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SyncBlockFetching"
-                  }
-                ],
-                "description": "The progress of the sync-block task."
-              }
-            },
-            "required": [
-              "block_height",
-              "fetching"
-            ],
-            "type": "object"
-          },
-          "SyncBlockFetching": {
-            "anyOf": [
-              {
-                "enum": [
-                  "block and deploys",
-                  "block signatures"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently syncing the trie-store under the state root hash held in the block.",
-                "properties": {
-                  "global_state_under_given_block": {
-                    "properties": {
-                      "number_of_remaining_tries_to_fetch": {
-                        "description": "The number of remaining tries to fetch (this value can rise and fall as the task proceeds).",
-                        "format": "uint",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      },
-                      "state_root_hash": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/Digest"
-                          }
-                        ],
-                        "description": "The global state root hash."
-                      }
-                    },
-                    "required": [
-                      "number_of_remaining_tries_to_fetch",
-                      "state_root_hash"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "global_state_under_given_block"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The progress of a single sync-block task, many of which are performed in parallel during sync-to-genesis.\n\nThe task progresses from each variant to the next linearly."
-          },
-          "SyncToGenesis": {
-            "anyOf": [
-              {
-                "enum": [
-                  "not yet started",
-                  "starting",
-                  "finished"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently fetching block headers in batches back towards the genesis block.",
-                "properties": {
-                  "fetching_headers_back_to_genesis": {
-                    "properties": {
-                      "lowest_block_height": {
-                        "description": "The current lowest block header retrieved by this fetch-headers-to-genesis task.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "lowest_block_height"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "fetching_headers_back_to_genesis"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Currently syncing all blocks from genesis towards the tip of the chain.\n\nThis is done via many parallel sync-block tasks, with each such ongoing task being represented by an entry in the wrapped `Vec`.  The set is sorted ascending by block height.",
-                "properties": {
-                  "syncing_forward_from_genesis": {
-                    "items": {
-                      "$ref": "#/components/schemas/SyncBlock"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "syncing_forward_from_genesis"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The progress of the sync-to-genesis task, only performed by nodes configured to do this, and performed by them while in participating mode.\n\nThe sync-to-genesis task progresses from each variant to the next linearly."
           },
           "TimeDiff": {
             "description": "Human-readable duration.",
@@ -3970,6 +3690,11 @@
                 "name": "info_get_status_example_result",
                 "value": {
                   "api_version": "1.4.8",
+                  "available_block_range": {
+                    "high": 0,
+                    "low": 0
+                  },
+                  "block_sync": [],
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3980,11 +3705,11 @@
                     "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
                     "timestamp": "2020-11-17T00:39:24.072Z"
                   },
+                  "last_progress": "1970-01-01T00:00:00.000Z",
                   "next_upgrade": {
                     "activation_point": 42,
                     "protocol_version": "2.0.1"
                   },
-                  "node_state": "participating",
                   "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
                   "peers": [
                     {
@@ -3992,8 +3717,9 @@
                       "node_id": "tls:0101..0101"
                     }
                   ],
+                  "reactor_state": "Initialize",
                   "round_length": "1m 5s 536ms",
-                  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                  "starting_state_root_hash": null,
                   "uptime": "13s"
                 }
               }
@@ -4010,6 +3736,17 @@
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
+                },
+                "available_block_range": {
+                  "$ref": "#/components/schemas/AvailableBlockRange",
+                  "description": "The available block range in storage."
+                },
+                "block_sync": {
+                  "description": "The status of the block synchronizer builders.",
+                  "items": {
+                    "$ref": "#/components/schemas/BlockSyncStatus"
+                  },
+                  "type": "array"
                 },
                 "build_version": {
                   "description": "The compiled node version.",
@@ -4030,6 +3767,10 @@
                   ],
                   "description": "The minimal info of the last block from the linear chain."
                 },
+                "last_progress": {
+                  "$ref": "#/components/schemas/Timestamp",
+                  "description": "Timestamp of the last recorded progress in the reactor."
+                },
                 "next_upgrade": {
                   "anyOf": [
                     {
@@ -4040,10 +3781,6 @@
                     }
                   ],
                   "description": "Information about the next scheduled upgrade."
-                },
-                "node_state": {
-                  "$ref": "#/components/schemas/NodeState",
-                  "description": "The current state of node."
                 },
                 "our_public_signing_key": {
                   "anyOf": [
@@ -4060,6 +3797,10 @@
                   "$ref": "#/components/schemas/PeersMap",
                   "description": "The node ID and network address of each connected peer."
                 },
+                "reactor_state": {
+                  "$ref": "#/components/schemas/ReactorState",
+                  "description": "The current state of node reactor."
+                },
                 "round_length": {
                   "anyOf": [
                     {
@@ -4072,9 +3813,15 @@
                   "description": "The next round length if this node is a validator."
                 },
                 "starting_state_root_hash": {
-                  "$ref": "#/components/schemas/Digest",
-                  "deprecated": true,
-                  "description": "The state root hash used at the start of the current session."
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/Digest"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The state root hash of the lowest block in the available block range."
                 },
                 "uptime": {
                   "$ref": "#/components/schemas/TimeDiff",
@@ -4083,11 +3830,13 @@
               },
               "required": [
                 "api_version",
+                "available_block_range",
+                "block_sync",
                 "build_version",
                 "chainspec_name",
-                "node_state",
+                "last_progress",
                 "peers",
-                "starting_state_root_hash",
+                "reactor_state",
                 "uptime"
               ],
               "type": "object"


### PR DESCRIPTION
Fixes #3374 

This PR brings all the changes mentioned in the issue above to the status endpoint.

> Update `GetStatusResult` as follows:
>     - move `pub peers: PeersMap`, to be the first field
>     - move `pub build_version: String`, to immediately follow `api_version`
>     - `starting_state_root_hash` should be changed to be set to the state root hash of the lowest block of the available block range (comment needs updated and remove deprecation)
>     - `node_state` should be replaced with pub `reactor_state: ReactorState`,
>     - add `pub last_progress: Timestamp`,
>     - add `pub blocks_sync: Vec<BlockSyncStatus>` (see below)
>     - add `pub available_block_range: AvailableBlockRange`,

