### PR TITLE
bug fix for complete block index

### DIFF
--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -30,14 +30,6 @@ pub(crate) struct Sequence {
 }
 
 impl Sequence {
-    /// Constructs a new sequence using the bounds of `a` and `b`.
-    ///
-    /// `low` and `high` will be automatically determined.
-    pub(super) fn new(a: u64, b: u64) -> Self {
-        let (low, high) = if a <= b { (a, b) } else { (b, a) };
-        Sequence { low, high }
-    }
-
     /// Constructs a new sequence containing only `value`.
     fn single(value: u64) -> Self {
         Sequence {
@@ -96,15 +88,6 @@ pub(super) struct DisjointSequences {
 }
 
 impl DisjointSequences {
-    /// Constructs disjoint sequences from one initial sequence.
-    ///
-    /// Note: Use [`Default::default()`] to create an empty set of sequences.
-    pub(super) fn new(initial_sequence: Sequence) -> Self {
-        DisjointSequences {
-            sequences: vec![initial_sequence],
-        }
-    }
-
     /// Inserts `value` into the appropriate sequence and merges sequences if required.
     ///
     /// Note, this method is efficient where `value` is one greater than the current highest value.


### PR DESCRIPTION
A core assumption of the complete block index creation was incorrect; it assumed that a node would only hit a particular execution path directly after an upgrade. However, a node could also hit that code path if it started to join a network and restarted after it had stored at least one block header but before its first complete block was stored. 

I've removed the offending logic necessary to prevent an erroneous index record from being written. 

The current fast sync process will naturally fill in the affected index if sync to genesis is on. However, it would not do so on nodes with sync to genesis off, and also that approach may be sub-optimal for networks with a lot of blocks as it would take an indeterminate amount of time to get eventually consistent. 

We can discuss a better way to solve for how we want to handle populating this index when upgrading a pre-1.5 network. In the meantime however, this PR solves the immediate problem interfering w/ our testing efforts.
