### PR TITLE
Fix marking blocks complete in storage

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -446,11 +446,16 @@ impl BlockSynchronizer {
                 }
                 NeedNext::BlockMarkedComplete(block_hash, block_height) => {
                     builder.set_in_flight_latch();
-                    results.extend(
-                        effect_builder
-                            .mark_block_completed(block_height)
-                            .event(move |_| Event::MarkBlockCompleted(block_hash)),
-                    )
+                    // Only mark the block complete if we're syncing historical
+                    // because we have global state and execution effects (if
+                    // any).
+                    if builder.should_fetch_execution_state() {
+                        results.extend(
+                            effect_builder
+                                .mark_block_completed(block_height)
+                                .event(move |_| Event::MarkBlockCompleted(block_hash)),
+                        )
+                    }
                 }
                 NeedNext::Peers(block_hash) => {
                     builder.set_in_flight_latch();

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -42,7 +42,7 @@ use crate::{
     effect::{
         announcements::{ContractRuntimeAnnouncement, FatalAnnouncement},
         incoming::{TrieDemand, TrieRequest, TrieRequestIncoming},
-        requests::{BlockCompleteConfirmationRequest, ContractRuntimeRequest, NetworkRequest},
+        requests::{ContractRuntimeRequest, NetworkRequest},
         EffectBuilder, EffectExt, Effects,
     },
     fatal,
@@ -211,7 +211,6 @@ where
     REv: From<ContractRuntimeRequest>
         + From<ContractRuntimeAnnouncement>
         + From<NetworkRequest<Message>>
-        + From<BlockCompleteConfirmationRequest>
         + From<FatalAnnouncement>
         + Send,
 {
@@ -303,7 +302,6 @@ impl ContractRuntime {
     where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
             + From<FatalAnnouncement>
             + Send,
     {
@@ -670,7 +668,6 @@ impl ContractRuntime {
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
             + From<FatalAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
             + Send,
     {
         let current_execution_pre_state = execution_pre_state.lock().unwrap().clone();

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -179,7 +179,7 @@ where
                         available_block_range,
                         block_sync,
                     ) = join!(
-                        effect_builder.get_highest_block_from_storage(),
+                        effect_builder.get_highest_complete_block_from_storage(),
                         effect_builder.network_peers(),
                         effect_builder.get_next_upgrade(),
                         effect_builder.consensus_status(),

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -402,7 +402,7 @@ where
                         available_block_range,
                         block_sync,
                     ) = join!(
-                        effect_builder.get_highest_block_from_storage(),
+                        effect_builder.get_highest_complete_block_from_storage(),
                         effect_builder.network_peers(),
                         effect_builder.get_next_upgrade(),
                         effect_builder.consensus_status(),

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -657,6 +657,13 @@ impl Storage {
             StorageRequest::PutBlock { block, responder } => {
                 responder.respond(self.write_block(&*block)?).ignore()
             }
+            StorageRequest::PutCompleteBlock { block, responder } => {
+                let wrote = self.write_block(&*block)?;
+                if wrote {
+                    self.mark_block_complete(block.height())?;
+                }
+                responder.respond(wrote).ignore()
+            }
             StorageRequest::PutApprovalsHashes {
                 approvals_hashes,
                 responder,
@@ -1042,6 +1049,13 @@ impl Storage {
             responder,
         }: BlockCompleteConfirmationRequest,
     ) -> Result<Effects<Event>, FatalStorageError> {
+        self.mark_block_complete(block_height)?;
+        Ok(responder.respond(()).ignore())
+    }
+
+    /// Marks the block at height `block_height` as complete by inserting it
+    /// into the `completed_blocks` index and storing it to disk.
+    fn mark_block_complete(&mut self, block_height: u64) -> Result<(), FatalStorageError> {
         self.completed_blocks.insert(block_height);
         self.persist_completed_blocks()?;
         info!(
@@ -1049,7 +1063,7 @@ impl Storage {
             block_height,
             self.get_available_block_range()
         );
-        Ok(responder.respond(()).ignore())
+        Ok(())
     }
 
     /// Persists the completed blocks disjoint sequences state to the database.
@@ -1196,6 +1210,26 @@ impl Storage {
         let mut txn = env.begin_rw_txn()?;
         let wrote = self.write_validated_block(&mut txn, block)?;
         if wrote {
+            txn.commit()?;
+        }
+        Ok(wrote)
+    }
+
+    /// Writes a block to storage and marks it as complete, updating indices as necessary.
+    ///
+    /// Returns `Ok(true)` if the block has been successfully written, `Ok(false)` if a part of it
+    /// couldn't be written because it already existed, and `Err(_)` if there was an error.
+    /// This function guarantees that either both the block storing and the `completed_blocks` index
+    /// update were successful or that the entire operation was reverted.
+    pub fn write_complete_block(&mut self, block: &Block) -> Result<bool, FatalStorageError> {
+        // Validate the block prior to inserting it into the database
+        block.verify()?;
+        let env = Rc::clone(&self.env);
+        let mut txn = env.begin_rw_txn()?;
+        let wrote = self.write_validated_block(&mut txn, block)?;
+        if wrote {
+            // Update the `completed_blocks` index only if the block was actually stored.
+            self.mark_block_complete(block.height())?;
             txn.commit()?;
         }
         Ok(wrote)

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -684,9 +684,9 @@ impl Storage {
             } => responder
                 .respond(self.read_approvals_hashes(&block_hash)?)
                 .ignore(),
-            StorageRequest::GetHighestBlock { responder } => {
-                responder.respond(self.read_highest_block()?).ignore()
-            }
+            StorageRequest::GetHighestCompleteBlock { responder } => responder
+                .respond(self.read_highest_complete_block()?)
+                .ignore(),
             StorageRequest::GetHighestCompleteBlockHeader { responder } => {
                 let mut txn = self.env.begin_ro_txn()?;
                 responder

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -364,13 +364,13 @@ fn get_naive_deploy_and_metadata(
     })
 }
 
-/// Requests the highest block from a storage component.
-fn get_highest_block(
+/// Requests the highest complete block from a storage component.
+fn get_highest_complete_block(
     harness: &mut ComponentHarness<UnitTestEvent>,
     storage: &mut Storage,
 ) -> Option<Block> {
     let response = harness.send_request(storage, |responder| {
-        StorageRequest::GetHighestBlock { responder }.into()
+        StorageRequest::GetHighestCompleteBlock { responder }.into()
     });
     assert!(harness.is_idle());
     response
@@ -507,7 +507,7 @@ fn can_retrieve_block_by_height() {
     // Both block at ID and highest block should return `None` initially.
     assert!(get_block_at_height(&mut storage, 0).is_none());
     assert!(get_block_header_at_height(&mut storage, 0).is_none());
-    assert!(get_highest_block(&mut harness, &mut storage).is_none());
+    assert!(get_highest_complete_block(&mut harness, &mut storage).is_none());
     assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
     assert!(get_block_at_height(&mut storage, 14).is_none());
     assert!(get_block_header_at_height(&mut storage, 14).is_none());
@@ -521,7 +521,7 @@ fn can_retrieve_block_by_height() {
     assert!(was_new);
 
     assert_eq!(
-        get_highest_block(&mut harness, &mut storage).as_ref(),
+        get_highest_complete_block(&mut harness, &mut storage).as_ref(),
         Some(&*block_33)
     );
     assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
@@ -545,7 +545,7 @@ fn can_retrieve_block_by_height() {
     assert!(was_new);
 
     assert_eq!(
-        get_highest_block(&mut harness, &mut storage).as_ref(),
+        get_highest_complete_block(&mut harness, &mut storage).as_ref(),
         Some(&*block_33)
     );
     assert!(get_highest_complete_block_header(&mut harness, &mut storage).is_none());
@@ -577,7 +577,7 @@ fn can_retrieve_block_by_height() {
     assert!(was_new);
 
     assert_eq!(
-        get_highest_block(&mut harness, &mut storage).as_ref(),
+        get_highest_complete_block(&mut harness, &mut storage).as_ref(),
         Some(&*block_99)
     );
     assert_eq!(
@@ -1137,7 +1137,7 @@ fn should_hard_reset() {
     // Check the highest block is #7.
     assert_eq!(
         Some(blocks[blocks_count - 1].clone()),
-        get_highest_block(&mut harness, &mut storage)
+        get_highest_complete_block(&mut harness, &mut storage)
     );
 
     // The closure doing the actual checks.
@@ -1147,7 +1147,7 @@ fn should_hard_reset() {
         let mut storage = storage_fixture_with_hard_reset(&harness, EraId::from(reset_era as u64));
 
         // Check highest block is the last from the previous era, or `None` if resetting to era 0.
-        let highest_block = get_highest_block(&mut harness, &mut storage);
+        let highest_block = get_highest_complete_block(&mut harness, &mut storage);
         if reset_era > 0 {
             assert_eq!(
                 blocks[blocks_per_era * reset_era - 1],

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1321,13 +1321,13 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Requests the highest block.
-    pub(crate) async fn get_highest_block_from_storage(self) -> Option<Block>
+    /// Requests the highest complete block.
+    pub(crate) async fn get_highest_complete_block_from_storage(self) -> Option<Block>
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::GetHighestBlock { responder },
+            |responder| StorageRequest::GetHighestCompleteBlock { responder },
             QueueKind::FromStorage,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1076,6 +1076,18 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Puts the given complete block into the linear block store.
+    pub(crate) async fn put_complete_block_to_storage(self, block: Box<Block>) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::PutCompleteBlock { block, responder },
+            QueueKind::ToStorage,
+        )
+        .await
+    }
+
     /// Puts the given approvals hashes into the linear block store.
     pub(crate) async fn put_approvals_hashes_to_storage(
         self,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -310,8 +310,8 @@ pub(crate) enum StorageRequest {
         /// in local storage.
         responder: Responder<Option<ApprovalsHashes>>,
     },
-    /// Retrieve highest block.
-    GetHighestBlock {
+    /// Retrieve highest complete block.
+    GetHighestCompleteBlock {
         /// Responder.
         responder: Responder<Option<Block>>,
     },
@@ -511,7 +511,9 @@ impl Display for StorageRequest {
             StorageRequest::GetApprovalsHashes { block_hash, .. } => {
                 write!(formatter, "get approvals hashes {}", block_hash)
             }
-            StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
+            StorageRequest::GetHighestCompleteBlock { .. } => {
+                write!(formatter, "get highest complete block")
+            }
             StorageRequest::GetHighestCompleteBlockHeader { .. } => {
                 write!(formatter, "get highest complete block header")
             }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -270,6 +270,15 @@ pub(crate) enum StorageRequest {
         /// attempt or false if it was previously stored.
         responder: Responder<bool>,
     },
+    /// Store given block and mark it complete.
+    PutCompleteBlock {
+        /// Block to be stored.
+        block: Box<Block>,
+        /// Responder to call with the result.  Returns true if the block was stored and it
+        /// was inserted into the completed blocks index on this attempt or false if it was
+        /// previously stored.
+        responder: Responder<bool>,
+    },
     /// Store the approvals hashes.
     PutApprovalsHashes {
         /// Approvals hashes to store.
@@ -488,6 +497,9 @@ impl Display for StorageRequest {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             StorageRequest::PutBlock { block, .. } => write!(formatter, "put {}", block),
+            StorageRequest::PutCompleteBlock { block, .. } => {
+                write!(formatter, "put complete {}", block)
+            }
             StorageRequest::PutApprovalsHashes {
                 approvals_hashes, ..
             } => {


### PR DESCRIPTION
Fixes #3388 

The logic in the block synchronizer and block accumulator was mistakenly marking blocks as complete before they were known to be executed and have the necessary global state. This led to `put-deploy` calls failing when they would request the global state associated with the highest complete block, which sometimes didn't have it.

Additionally, this PR changes `last_added_block_info` in the status RPC call to use the highest complete block rather than the highest block.
