### PR TITLE
GH-3412: Fix costs for some system entry points

### DIFF
--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -670,7 +670,7 @@ where
                 CLValue::from_t(result).map_err(Self::reverter)
             })(),
             mint::METHOD_MINT_INTO_EXISTING_PURSE => (|| {
-                mint_runtime.charge_system_contract_call(mint_costs.mint)?;
+                mint_runtime.charge_system_contract_call(mint_costs.mint_into_existing_purse)?;
 
                 let amount: U512 = Self::get_named_argument(runtime_args, mint::ARG_AMOUNT)?;
                 let existing_purse: URef = Self::get_named_argument(runtime_args, mint::ARG_PURSE)?;

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -905,7 +905,7 @@ where
             })(),
 
             auction::METHOD_REDELEGATE => (|| {
-                runtime.charge_system_contract_call(auction_costs.undelegate)?;
+                runtime.charge_system_contract_call(auction_costs.redelegate)?;
 
                 let delegator = Self::get_named_argument(runtime_args, auction::ARG_DELEGATOR)?;
                 let validator = Self::get_named_argument(runtime_args, auction::ARG_VALIDATOR)?;

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -974,7 +974,7 @@ where
             })(),
 
             auction::METHOD_ACTIVATE_BID => (|| {
-                runtime.charge_system_contract_call(auction_costs.read_era_id)?;
+                runtime.charge_system_contract_call(auction_costs.activate_bid)?;
 
                 let validator_public_key: PublicKey =
                     Self::get_named_argument(runtime_args, auction::ARG_VALIDATOR_PUBLIC_KEY)?;

--- a/execution_engine/src/shared/system_config/auction_costs.rs
+++ b/execution_engine/src/shared/system_config/auction_costs.rs
@@ -14,6 +14,8 @@ pub const DEFAULT_ADD_BID_COST: u32 = 10_000;
 pub const DEFAULT_WITHDRAW_BID_COST: u32 = 10_000;
 /// Default cost of the `delegate` auction entry point.
 pub const DEFAULT_DELEGATE_COST: u32 = 10_000;
+/// Default cost of the `redelegate` auction entry point.
+pub const DEFAULT_REDELEGATE_COST: u32 = 10_000;
 /// Default cost of the `undelegate` auction entry point.
 pub const DEFAULT_UNDELEGATE_COST: u32 = 10_000;
 /// Default cost of the `run_auction` auction entry point.
@@ -60,6 +62,8 @@ pub struct AuctionCosts {
     pub read_era_id: u32,
     /// Cost of calling the `activate_bid` entry point.
     pub activate_bid: u32,
+    /// Cost of calling the `redelegate` entry point.
+    pub redelegate: u32,
 }
 
 impl Default for AuctionCosts {
@@ -78,6 +82,7 @@ impl Default for AuctionCosts {
             withdraw_validator_reward: DEFAULT_WITHDRAW_VALIDATOR_REWARD_COST,
             read_era_id: DEFAULT_READ_ERA_ID_COST,
             activate_bid: DEFAULT_ACTIVATE_BID_COST,
+            redelegate: DEFAULT_REDELEGATE_COST,
         }
     }
 }
@@ -86,37 +91,73 @@ impl ToBytes for AuctionCosts {
     fn to_bytes(&self) -> Result<Vec<u8>, casper_types::bytesrepr::Error> {
         let mut ret = bytesrepr::unchecked_allocate_buffer(self);
 
-        ret.append(&mut self.get_era_validators.to_bytes()?);
-        ret.append(&mut self.read_seigniorage_recipients.to_bytes()?);
-        ret.append(&mut self.add_bid.to_bytes()?);
-        ret.append(&mut self.withdraw_bid.to_bytes()?);
-        ret.append(&mut self.delegate.to_bytes()?);
-        ret.append(&mut self.undelegate.to_bytes()?);
-        ret.append(&mut self.run_auction.to_bytes()?);
-        ret.append(&mut self.slash.to_bytes()?);
-        ret.append(&mut self.distribute.to_bytes()?);
-        ret.append(&mut self.withdraw_delegator_reward.to_bytes()?);
-        ret.append(&mut self.withdraw_validator_reward.to_bytes()?);
-        ret.append(&mut self.read_era_id.to_bytes()?);
-        ret.append(&mut self.activate_bid.to_bytes()?);
+        let Self {
+            get_era_validators,
+            read_seigniorage_recipients,
+            add_bid,
+            withdraw_bid,
+            delegate,
+            undelegate,
+            run_auction,
+            slash,
+            distribute,
+            withdraw_delegator_reward,
+            withdraw_validator_reward,
+            read_era_id,
+            activate_bid,
+            redelegate,
+        } = self;
+
+        ret.append(&mut get_era_validators.to_bytes()?);
+        ret.append(&mut read_seigniorage_recipients.to_bytes()?);
+        ret.append(&mut add_bid.to_bytes()?);
+        ret.append(&mut withdraw_bid.to_bytes()?);
+        ret.append(&mut delegate.to_bytes()?);
+        ret.append(&mut undelegate.to_bytes()?);
+        ret.append(&mut run_auction.to_bytes()?);
+        ret.append(&mut slash.to_bytes()?);
+        ret.append(&mut distribute.to_bytes()?);
+        ret.append(&mut withdraw_delegator_reward.to_bytes()?);
+        ret.append(&mut withdraw_validator_reward.to_bytes()?);
+        ret.append(&mut read_era_id.to_bytes()?);
+        ret.append(&mut activate_bid.to_bytes()?);
+        ret.append(&mut redelegate.to_bytes()?);
 
         Ok(ret)
     }
 
     fn serialized_length(&self) -> usize {
-        self.get_era_validators.serialized_length()
-            + self.read_seigniorage_recipients.serialized_length()
-            + self.add_bid.serialized_length()
-            + self.withdraw_bid.serialized_length()
-            + self.delegate.serialized_length()
-            + self.undelegate.serialized_length()
-            + self.run_auction.serialized_length()
-            + self.slash.serialized_length()
-            + self.distribute.serialized_length()
-            + self.withdraw_delegator_reward.serialized_length()
-            + self.withdraw_validator_reward.serialized_length()
-            + self.read_era_id.serialized_length()
-            + self.activate_bid.serialized_length()
+        let Self {
+            get_era_validators,
+            read_seigniorage_recipients,
+            add_bid,
+            withdraw_bid,
+            delegate,
+            undelegate,
+            run_auction,
+            slash,
+            distribute,
+            withdraw_delegator_reward,
+            withdraw_validator_reward,
+            read_era_id,
+            activate_bid,
+            redelegate,
+        } = self;
+
+        get_era_validators.serialized_length()
+            + read_seigniorage_recipients.serialized_length()
+            + add_bid.serialized_length()
+            + withdraw_bid.serialized_length()
+            + delegate.serialized_length()
+            + undelegate.serialized_length()
+            + run_auction.serialized_length()
+            + slash.serialized_length()
+            + distribute.serialized_length()
+            + withdraw_delegator_reward.serialized_length()
+            + withdraw_validator_reward.serialized_length()
+            + read_era_id.serialized_length()
+            + activate_bid.serialized_length()
+            + redelegate.serialized_length()
     }
 }
 
@@ -135,6 +176,7 @@ impl FromBytes for AuctionCosts {
         let (withdraw_validator_reward, rem) = FromBytes::from_bytes(rem)?;
         let (read_era_id, rem) = FromBytes::from_bytes(rem)?;
         let (activate_bid, rem) = FromBytes::from_bytes(rem)?;
+        let (redelegate, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             Self {
                 get_era_validators,
@@ -150,6 +192,7 @@ impl FromBytes for AuctionCosts {
                 withdraw_validator_reward,
                 read_era_id,
                 activate_bid,
+                redelegate,
             },
             rem,
         ))
@@ -172,6 +215,7 @@ impl Distribution<AuctionCosts> for Standard {
             withdraw_validator_reward: rng.gen(),
             read_era_id: rng.gen(),
             activate_bid: rng.gen(),
+            redelegate: rng.gen(),
         }
     }
 }
@@ -198,6 +242,7 @@ pub mod gens {
             withdraw_validator_reward in num::u32::ANY,
             read_era_id in num::u32::ANY,
             activate_bid in num::u32::ANY,
+            redelegate in num::u32::ANY,
         ) -> AuctionCosts {
             AuctionCosts {
                 get_era_validators,
@@ -213,6 +258,7 @@ pub mod gens {
                 withdraw_validator_reward,
                 read_era_id,
                 activate_bid,
+                redelegate,
             }
         }
     }

--- a/execution_engine/src/shared/system_config/mint_costs.rs
+++ b/execution_engine/src/shared/system_config/mint_costs.rs
@@ -16,6 +16,8 @@ pub const DEFAULT_BALANCE_COST: u32 = 10_000;
 pub const DEFAULT_TRANSFER_COST: u32 = 10_000;
 /// Default cost of the `read_base_round_reward` mint entry point.
 pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
+/// Default cost of the `mint_into_existing_purse` mint entry point.
+pub const DEFAULT_MINT_INTO_EXISTING_PURSE_COST: u32 = 2_500_000_000;
 
 /// Description of the costs of calling mint entry points.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
@@ -32,6 +34,8 @@ pub struct MintCosts {
     pub transfer: u32,
     /// Cost of calling the `read_base_round_reward` entry point.
     pub read_base_round_reward: u32,
+    /// Cost of calling the `mint_into_existing_purse` entry point.
+    pub mint_into_existing_purse: u32,
 }
 
 impl Default for MintCosts {
@@ -43,6 +47,7 @@ impl Default for MintCosts {
             balance: DEFAULT_BALANCE_COST,
             transfer: DEFAULT_TRANSFER_COST,
             read_base_round_reward: DEFAULT_READ_BASE_ROUND_REWARD_COST,
+            mint_into_existing_purse: DEFAULT_MINT_INTO_EXISTING_PURSE_COST,
         }
     }
 }
@@ -51,23 +56,45 @@ impl ToBytes for MintCosts {
     fn to_bytes(&self) -> Result<Vec<u8>, casper_types::bytesrepr::Error> {
         let mut ret = bytesrepr::unchecked_allocate_buffer(self);
 
-        ret.append(&mut self.mint.to_bytes()?);
-        ret.append(&mut self.reduce_total_supply.to_bytes()?);
-        ret.append(&mut self.create.to_bytes()?);
-        ret.append(&mut self.balance.to_bytes()?);
-        ret.append(&mut self.transfer.to_bytes()?);
-        ret.append(&mut self.read_base_round_reward.to_bytes()?);
+        let Self {
+            mint,
+            reduce_total_supply,
+            create,
+            balance,
+            transfer,
+            read_base_round_reward,
+            mint_into_existing_purse,
+        } = self;
+
+        ret.append(&mut mint.to_bytes()?);
+        ret.append(&mut reduce_total_supply.to_bytes()?);
+        ret.append(&mut create.to_bytes()?);
+        ret.append(&mut balance.to_bytes()?);
+        ret.append(&mut transfer.to_bytes()?);
+        ret.append(&mut read_base_round_reward.to_bytes()?);
+        ret.append(&mut mint_into_existing_purse.to_bytes()?);
 
         Ok(ret)
     }
 
     fn serialized_length(&self) -> usize {
-        self.mint.serialized_length()
-            + self.reduce_total_supply.serialized_length()
-            + self.create.serialized_length()
-            + self.balance.serialized_length()
-            + self.transfer.serialized_length()
-            + self.read_base_round_reward.serialized_length()
+        let Self {
+            mint,
+            reduce_total_supply,
+            create,
+            balance,
+            transfer,
+            read_base_round_reward,
+            mint_into_existing_purse,
+        } = self;
+
+        mint.serialized_length()
+            + reduce_total_supply.serialized_length()
+            + create.serialized_length()
+            + balance.serialized_length()
+            + transfer.serialized_length()
+            + read_base_round_reward.serialized_length()
+            + mint_into_existing_purse.serialized_length()
     }
 }
 
@@ -79,6 +106,7 @@ impl FromBytes for MintCosts {
         let (balance, rem) = FromBytes::from_bytes(rem)?;
         let (transfer, rem) = FromBytes::from_bytes(rem)?;
         let (read_base_round_reward, rem) = FromBytes::from_bytes(rem)?;
+        let (mint_into_existing_purse, rem) = FromBytes::from_bytes(rem)?;
 
         Ok((
             Self {
@@ -88,6 +116,7 @@ impl FromBytes for MintCosts {
                 balance,
                 transfer,
                 read_base_round_reward,
+                mint_into_existing_purse,
             },
             rem,
         ))
@@ -103,6 +132,7 @@ impl Distribution<MintCosts> for Standard {
             balance: rng.gen(),
             transfer: rng.gen(),
             read_base_round_reward: rng.gen(),
+            mint_into_existing_purse: rng.gen(),
         }
     }
 }
@@ -122,6 +152,7 @@ pub mod gens {
             balance in num::u32::ANY,
             transfer in num::u32::ANY,
             read_base_round_reward in num::u32::ANY,
+            mint_into_existing_purse in num::u32::ANY,
         ) -> MintCosts {
             MintCosts {
                 mint,
@@ -130,6 +161,7 @@ pub mod gens {
                 balance,
                 transfer,
                 read_base_round_reward,
+                mint_into_existing_purse,
             }
         }
     }

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -65,6 +65,7 @@ const NEW_ADD_BID_COST: u32 = DEFAULT_ADD_BID_COST * 2;
 const NEW_WITHDRAW_BID_COST: u32 = DEFAULT_WITHDRAW_BID_COST * 3;
 const NEW_DELEGATE_COST: u32 = DEFAULT_DELEGATE_COST * 4;
 const NEW_UNDELEGATE_COST: u32 = DEFAULT_UNDELEGATE_COST * 5;
+const NEW_REDELEGATE_COST: u32 = DEFAULT_UNDELEGATE_COST * 6;
 const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 
 static OLD_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| *DEFAULT_PROTOCOL_VERSION);
@@ -490,6 +491,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
     let new_auction_costs = AuctionCosts {
         delegate: NEW_DELEGATE_COST,
         undelegate: NEW_UNDELEGATE_COST,
+        redelegate: NEW_REDELEGATE_COST,
         ..Default::default()
     };
     let new_mint_costs = MintCosts::default();
@@ -605,6 +607,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
     );
     assert_eq!(builder.last_exec_gas_cost().value(), call_cost);
 
+    // Redelegate bid
     let redelegate_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         account
@@ -627,10 +630,10 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
 
     builder.exec(redelegate_request).expect_success().commit();
 
-    let expected_call_cost = U512::from(NEW_UNDELEGATE_COST);
+    let expected_call_cost = U512::from(NEW_REDELEGATE_COST);
     assert_eq!(builder.last_exec_gas_cost().value(), expected_call_cost);
 
-    // Withdraw bid
+    // Withdraw bid (undelegate)
     let undelegate_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         account

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -217,6 +217,7 @@ create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000
+mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -208,6 +208,7 @@ withdraw_delegator_reward = 10_000
 withdraw_validator_reward = 10_000
 read_era_id = 10_000
 activate_bid = 10_000
+redelegate = 10_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -211,6 +211,7 @@ withdraw_delegator_reward = 10_000
 withdraw_validator_reward = 10_000
 read_era_id = 10_000
 activate_bid = 10_000
+redelegate = 10_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -220,6 +220,7 @@ create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000
+mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -137,6 +137,7 @@ create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000
+mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -128,6 +128,7 @@ withdraw_delegator_reward = 10_000
 withdraw_validator_reward = 10_000
 read_era_id = 10_000
 activate_bid = 10_000
+redelegate = 10_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -137,6 +137,7 @@ create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000
+mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -128,6 +128,7 @@ withdraw_delegator_reward = 10_000
 withdraw_validator_reward = 10_000
 read_era_id = 10_000
 activate_bid = 10_000
+redelegate = 10_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -137,6 +137,7 @@ create = 2_500_000_000
 balance = 10_000
 transfer = 10_000
 read_base_round_reward = 10_000
+mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -128,6 +128,7 @@ withdraw_delegator_reward = 10_000
 withdraw_validator_reward = 10_000
 read_era_id = 10_000
 activate_bid = 10_000
+redelegate = 10_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000


### PR DESCRIPTION
Closes #3412 

This PR fixes `activate_bid` to actually charge for the correct cost from the cost table - currently it was charging for `read_era_id` but coincidentally the cost is currently the same.

This also adds separate entries for the `redelegate` entry point that was charging for `undelegate`, and `mint_into_existing_purse` that charged for `mint` for the same reasons.