### PR TITLE
Add metrics for block accumulator

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,8 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys` and `deploy_buffer_dead_deploys` to report status of the node deploy buffer.
-* Add metrics `block_accumulator_block_acceptors` and `block_accumulator_known_child_blocks` to track status of the block accumulator component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer and `block_accumulator_block_acceptors`,  `block_accumulator_known_child_blocks` to track status of the block accumulator component.
 
 ### Changed
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
 * Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys` and `deploy_buffer_dead_deploys` to report status of the node deploy buffer.
+* Add metrics `block_accumulator_block_acceptors` and `block_accumulator_known_child_blocks` to track status of the block accumulator component.
 
 ### Changed
 

--- a/node/src/components/block_accumulator/metrics.rs
+++ b/node/src/components/block_accumulator/metrics.rs
@@ -1,0 +1,44 @@
+use prometheus::{IntGauge, Registry};
+
+use crate::unregister_metric;
+
+/// Metrics for the block accumulator component.
+#[derive(Debug)]
+pub(super) struct Metrics {
+    /// Total number of BlockAcceptors contained in the BlockAccumulator.
+    pub(super) block_acceptors: IntGauge,
+    /// Number of child block hashes that we know of and that will be used in order to request next
+    /// blocks.
+    pub(super) known_child_blocks: IntGauge,
+    registry: Registry,
+}
+
+impl Metrics {
+    /// Creates a new instance of the block accumulator metrics, using the given prefix.
+    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let block_acceptors = IntGauge::new(
+            "block_accumulator_block_acceptors".to_string(),
+            "number of block acceptors in the Block Accumulator".to_string(),
+        )?;
+        let known_child_blocks = IntGauge::new(
+            "block_accumulator_known_child_blocks".to_string(),
+            "number of blocks received by the Block Accumulator for which we know the hash of the child block".to_string(),
+        )?;
+
+        registry.register(Box::new(block_acceptors.clone()))?;
+        registry.register(Box::new(known_child_blocks.clone()))?;
+
+        Ok(Metrics {
+            block_acceptors,
+            known_child_blocks,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.block_acceptors);
+        unregister_metric!(self.registry, self.known_child_blocks);
+    }
+}

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1,4 +1,5 @@
 use casper_types::testing::TestRng;
+use prometheus::Registry;
 
 use crate::components::consensus::tests::utils::{
     ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID,
@@ -16,13 +17,16 @@ fn upsert_acceptor() {
     let local_tip = (0, era0);
     let recent_era_interval = 1;
     let block_time = config.purge_interval() / 2;
+    let metrics_registry = Registry::new();
     let mut accumulator = BlockAccumulator::new(
         config,
         validator_matrix,
         Some(local_tip),
         recent_era_interval,
         block_time,
-    );
+        &metrics_registry,
+    )
+    .unwrap();
 
     let max_block_count =
         PEER_RATE_LIMIT_MULTIPLIER * ((config.purge_interval() / block_time) as usize);

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -278,7 +278,8 @@ impl reactor::Reactor for MainReactor {
             highest_block_height_and_era_id,
             chainspec.core_config.unbonding_delay,
             chainspec.highway_config.min_round_length(),
-        );
+            registry,
+        )?;
         let block_synchronizer =
             BlockSynchronizer::new(config.block_synchronizer, validator_matrix.clone());
         let block_validator = BlockValidator::new(Arc::clone(&chainspec));


### PR DESCRIPTION
- Simplify metrics collection for the `deploy_buffer`.
- Add basic metrics for the `block_accumulator` component.
Changes related to https://github.com/casper-network/casper-node/issues/3392.