### PR TITLE
Remove superfluous `Arc` from limiter resources

### DIFF
--- a/node/src/components/network/limiter.rs
+++ b/node/src/components/network/limiter.rs
@@ -144,7 +144,7 @@ struct LimiterData {
     /// connection.
     connected_validators: RwLock<HashMap<NodeId, PublicKey>>,
     /// Information about available resources.
-    resources: Arc<Mutex<ResourceData>>,
+    resources: Mutex<ResourceData>,
     /// Total time spent waiting.
     wait_time_sec: Counter,
 }
@@ -168,10 +168,10 @@ impl LimiterData {
         LimiterData {
             resources_per_second,
             connected_validators: Default::default(),
-            resources: Arc::new(Mutex::new(ResourceData {
+            resources: Mutex::new(ResourceData {
                 available: 0,
                 last_refill: Instant::now(),
-            })),
+            }),
             wait_time_sec,
         }
     }


### PR DESCRIPTION
This PR removes the superfluous `Arc` that was a leftover from previous implementation of `debug_inspect_unspent_allowance()` when we used a separate thread.