### PR TITLE
Update the Highway tests.

### DIFF
--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -85,13 +85,12 @@ where
         0,
         start_timestamp,
     );
-    // We expect four messages:
+    // We expect three messages:
     // * log participation timer,
     // * log synchronizer queue length timer,
-    // * purge synchronizer queue timer,
-    // * latest state request timer
+    // * purge synchronizer queue timer
     // If there are more, the tests might need to handle them.
-    assert_eq!(4, outcomes.len());
+    assert_eq!(3, outcomes.len());
     hw_proto
 }
 
@@ -211,7 +210,9 @@ fn send_a_valid_wire_unit() {
     let mut outcomes = highway_protocol.handle_message(&mut rng, sender, msg, now);
     while let Some(outcome) = outcomes.pop() {
         match outcome {
-            ProtocolOutcome::CreatedGossipMessage(_) | ProtocolOutcome::FinalizedBlock(_) => (),
+            ProtocolOutcome::CreatedGossipMessage(_)
+            | ProtocolOutcome::FinalizedBlock(_)
+            | ProtocolOutcome::HandledProposedBlock(_) => (),
             ProtocolOutcome::QueueAction(ACTION_ID_VERTEX) => {
                 outcomes.extend(highway_protocol.handle_action(ACTION_ID_VERTEX, now))
             }


### PR DESCRIPTION
This updates the Highway tests to take into account the new `ProtocolOutcome::HandledProposedBlock` and the removed standstill alert.

Closes https://github.com/casper-network/casper-node/issues/3384.