### PR TITLE
Fix network rate-limiter tests

### DIFF
--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1,9 +1,7 @@
 use casper_types::testing::TestRng;
 use prometheus::Registry;
 
-use crate::components::consensus::tests::utils::{
-    ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID,
-};
+use crate::components::consensus::tests::utils::{ALICE_NODE_ID, ALICE_SECRET_KEY, BOB_NODE_ID};
 
 use super::*;
 
@@ -12,8 +10,7 @@ fn upsert_acceptor() {
     let mut rng = TestRng::new();
     let config = Config::default();
     let era0 = EraId::from(0);
-    let validator_matrix =
-        ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone(), ALICE_PUBLIC_KEY.clone());
+    let validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let local_tip = (0, era0);
     let recent_era_interval = 1;
     let block_time = config.purge_interval() / 2;

--- a/node/src/components/network/limiter.rs
+++ b/node/src/components/network/limiter.rs
@@ -312,7 +312,27 @@ mod tests {
 
     #[tokio::test]
     async fn unlimited_limiter_is_unlimited() {
-        panic!("ensure behaviour of setting limit to 0 is maintained");
+        let mut rng = crate::new_rng();
+
+        // We insert one unrelated active validator to avoid triggering the automatic disabling of
+        // the limiter in case there are no active validators.
+        let validator_matrix =
+            ValidatorMatrix::new_with_validator(Arc::new(SecretKey::random(&mut rng)));
+        let limiter = Limiter::new(0, new_wait_time_sec(), validator_matrix);
+
+        // Try with non-validators or unknown nodes.
+        let handles = vec![
+            limiter.create_handle(NodeId::random(&mut rng), Some(PublicKey::random(&mut rng))),
+            limiter.create_handle(NodeId::random(&mut rng), None),
+        ];
+
+        for handle in handles {
+            let start = Instant::now();
+            handle.request_allowance(0).await;
+            handle.request_allowance(u32::MAX).await;
+            handle.request_allowance(1).await;
+            assert!(start.elapsed() < SHORT_TIME);
+        }
     }
 
     #[tokio::test]
@@ -321,10 +341,7 @@ mod tests {
 
         let secret_key = SecretKey::random(&mut rng);
         let consensus_key = PublicKey::from(&secret_key);
-        // We insert one unrelated active validator to avoid triggering the automatic disabling of
-        // the limiter in case there are no active validators.
-        let validator_matrix =
-            ValidatorMatrix::new_with_validator(Arc::new(secret_key), consensus_key.clone());
+        let validator_matrix = ValidatorMatrix::new_with_validator(Arc::new(secret_key));
         let limiter = Limiter::new(1_000, new_wait_time_sec(), validator_matrix);
 
         let handle = limiter.create_handle(NodeId::random(&mut rng), Some(consensus_key));
@@ -333,26 +350,22 @@ mod tests {
         handle.request_allowance(0).await;
         handle.request_allowance(u32::MAX).await;
         handle.request_allowance(1).await;
-        let end = Instant::now();
-
-        assert!(end - start < SHORT_TIME);
+        assert!(start.elapsed() < SHORT_TIME);
     }
 
     #[tokio::test]
     async fn inactive_validator_limited() {
         let mut rng = crate::new_rng();
 
-        let secret_key = SecretKey::random(&mut rng);
-        let consensus_key = PublicKey::from(&secret_key);
         // We insert one unrelated active validator to avoid triggering the automatic disabling of
         // the limiter in case there are no active validators.
         let validator_matrix =
-            ValidatorMatrix::new_with_validator(Arc::new(secret_key), consensus_key.clone());
+            ValidatorMatrix::new_with_validator(Arc::new(SecretKey::random(&mut rng)));
         let limiter = Limiter::new(1_000, new_wait_time_sec(), validator_matrix);
 
         // Try with non-validators or unknown nodes.
         let handles = vec![
-            limiter.create_handle(NodeId::random(&mut rng), Some(consensus_key)),
+            limiter.create_handle(NodeId::random(&mut rng), Some(PublicKey::random(&mut rng))),
             limiter.create_handle(NodeId::random(&mut rng), None),
         ];
 
@@ -366,11 +379,10 @@ mod tests {
             handle.request_allowance(2000).await;
             handle.request_allowance(4000).await;
             handle.request_allowance(1).await;
-            let end = Instant::now();
+            let elapsed = start.elapsed();
 
-            let diff = end - start;
-            assert!(diff >= Duration::from_secs(9));
-            assert!(diff <= Duration::from_secs(10));
+            assert!(elapsed >= Duration::from_secs(9));
+            assert!(elapsed <= Duration::from_secs(10));
         }
     }
 
@@ -378,22 +390,22 @@ mod tests {
     async fn nonvalidators_parallel_limited() {
         let mut rng = crate::new_rng();
 
-        let secret_key = SecretKey::random(&mut rng);
-        let consensus_key = PublicKey::from(&secret_key);
         let wait_metric = new_wait_time_sec();
-
-        let start = Instant::now();
 
         // We insert one unrelated active validator to avoid triggering the automatic disabling of
         // the limiter in case there are no active validators.
         let validator_matrix =
-            ValidatorMatrix::new_with_validator(Arc::new(secret_key), consensus_key.clone());
-        let limiter = Limiter::new(1_000, new_wait_time_sec(), validator_matrix);
+            ValidatorMatrix::new_with_validator(Arc::new(SecretKey::random(&mut rng)));
+        let limiter = Limiter::new(1_000, wait_metric.clone(), validator_matrix);
+
+        let start = Instant::now();
 
         // Parallel test, 5 non-validators sharing 1000 bytes per second. Each sends 1001 bytes, so
         // total time is expected to be just over 5 seconds.
         let join_handles = (0..5)
-            .map(|_| limiter.create_handle(NodeId::random(&mut rng), Some(consensus_key.clone())))
+            .map(|_| {
+                limiter.create_handle(NodeId::random(&mut rng), Some(PublicKey::random(&mut rng)))
+            })
             .map(|handle| {
                 tokio::spawn(async move {
                     handle.request_allowance(500).await;
@@ -407,10 +419,9 @@ mod tests {
             join_handle.await.expect("could not join task");
         }
 
-        let end = Instant::now();
-        let diff = end - start;
-        assert!(diff >= Duration::from_secs(5));
-        assert!(diff <= Duration::from_secs(6));
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_secs(5));
+        assert!(elapsed <= Duration::from_secs(6));
 
         // Ensure metrics recorded the correct number of seconds.
         assert!(
@@ -449,7 +460,7 @@ mod tests {
 
         // Try with non-validators or unknown nodes.
         let handles = vec![
-            limiter.create_handle(NodeId::random(&mut rng), Some(consensus_key)),
+            limiter.create_handle(NodeId::random(&mut rng), Some(PublicKey::random(&mut rng))),
             limiter.create_handle(NodeId::random(&mut rng), None),
         ];
 
@@ -463,10 +474,7 @@ mod tests {
             handle.request_allowance(2000).await;
             handle.request_allowance(4000).await;
             handle.request_allowance(1).await;
-            let end = Instant::now();
-
-            let diff = end - start;
-            assert!(diff <= SHORT_TIME);
+            assert!(start.elapsed() < SHORT_TIME);
         }
 
         // There should have been no time spent waiting.
@@ -486,8 +494,7 @@ mod tests {
 
         let secret_key = SecretKey::random(&mut rng);
         let consensus_key = PublicKey::from(&secret_key);
-        let validator_matrix =
-            ValidatorMatrix::new_with_validator(Arc::new(secret_key), consensus_key.clone());
+        let validator_matrix = ValidatorMatrix::new_with_validator(Arc::new(secret_key));
         let limiter = Limiter::new(1_000, new_wait_time_sec(), validator_matrix);
 
         let non_validator_handle = limiter.create_handle(NodeId::random(&mut rng), None);

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -10,7 +10,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use casper_types::{PublicKey, SecretKey};
 use derive_more::From;
 use futures::FutureExt;
 use prometheus::Registry;
@@ -18,6 +17,8 @@ use reactor::ReactorEvent;
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
 use tracing::{debug, info};
+
+use casper_types::SecretKey;
 
 use super::{
     chain_info::ChainInfo, Config, Event as NetworkEvent, FromIncoming, GossipedAddress, Identity,
@@ -194,14 +195,13 @@ impl Reactor for TestReactor {
         rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let secret_key = SecretKey::random(rng);
-        let public_key = PublicKey::from(&secret_key);
         let net = Network::new(
             cfg,
             our_identity,
             None,
             registry,
             ChainInfo::create_for_testing(),
-            ValidatorMatrix::new_with_validator(Arc::new(secret_key), public_key),
+            ValidatorMatrix::new_with_validator(Arc::new(secret_key)),
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();
         let address_gossiper =

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -54,10 +54,8 @@ impl ValidatorMatrix {
 
     /// Creates a new validator matrix with just a single validator.
     #[cfg(test)]
-    pub(crate) fn new_with_validator(
-        secret_signing_key: Arc<SecretKey>,
-        public_signing_key: PublicKey,
-    ) -> Self {
+    pub(crate) fn new_with_validator(secret_signing_key: Arc<SecretKey>) -> Self {
+        let public_signing_key = PublicKey::from(&*secret_signing_key);
         let finality_threshold_fraction = Ratio::new(1, 3);
         let era_id = EraId::new(0);
         let weights = EraValidatorWeights::new(


### PR DESCRIPTION
This PR fixes tests for the network rate-limiter which were either inadvertently broken or were deliberately broken as a reminder to update them.

Closes #3385.
