### PR TITLE
Add `ComponentStatus::Paused`

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -80,6 +80,7 @@ pub(crate) enum ComponentStatus {
     #[default]
     Uninitialized,
     Initialized,
+    Paused,
     Fatal(String),
 }
 

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -374,6 +374,10 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match &self.status {
+            ComponentStatus::Paused => {
+                warn!("component paused - ignoring event");
+                Effects::new()
+            }
             ComponentStatus::Fatal(msg) => {
                 warn!(
                     msg,

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -189,6 +189,10 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match (self.status.clone(), event) {
+            (ComponentStatus::Paused, _) => {
+                warn!("component paused - ignoring event");
+                Effects::new()
+            }
             (ComponentStatus::Fatal(msg), _) => {
                 error!(
                     msg,

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -959,6 +959,10 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match (self.status.clone(), event) {
+            (ComponentStatus::Paused, _) => {
+                warn!("component paused - ignoring event");
+                Effects::new()
+            }
             (ComponentStatus::Fatal(msg), _) => {
                 error!(
                     msg,

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -143,6 +143,10 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match (self.status.clone(), event) {
+            (ComponentStatus::Paused, _) => {
+                warn!("component paused - ignoring event");
+                Effects::new()
+            }
             (ComponentStatus::Fatal(msg), _) => {
                 error!(
                     msg,

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -222,6 +222,10 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match (self.status.clone(), event) {
+            (ComponentStatus::Paused, _) => {
+                warn!("component paused - ignoring event");
+                Effects::new()
+            }
             (ComponentStatus::Fatal(msg), _) => {
                 error!(
                     msg,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -131,7 +131,9 @@ use casper_types::{
 
 use crate::{
     components::{
-        block_synchronizer::{BlockSyncStatus, GlobalStateSynchronizerError, TrieAccumulatorError},
+        block_synchronizer::{
+            BlockSynchronizerStatus, GlobalStateSynchronizerError, TrieAccumulatorError,
+        },
         consensus::{ClContext, EraDump, ProposedBlock, ValidatorChange},
         contract_runtime::{ContractRuntimeError, EraValidatorsRequest},
         deploy_acceptor,
@@ -1405,7 +1407,7 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    pub(crate) async fn get_block_synchronizer_status(self) -> Vec<BlockSyncStatus>
+    pub(crate) async fn get_block_synchronizer_status(self) -> BlockSynchronizerStatus
     where
         REv: From<BlockSynchronizerRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -33,7 +33,9 @@ use casper_types::{
 
 use crate::{
     components::{
-        block_synchronizer::{BlockSyncStatus, GlobalStateSynchronizerError, TrieAccumulatorError},
+        block_synchronizer::{
+            BlockSynchronizerStatus, GlobalStateSynchronizerError, TrieAccumulatorError,
+        },
         consensus::{BlockContext, ClContext, ProposedBlock, ValidatorChange},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor::Error,
@@ -1161,7 +1163,7 @@ pub(crate) enum BlockSynchronizerRequest {
         state_root_hash: Digest,
     },
     Status {
-        responder: Responder<Vec<BlockSyncStatus>>,
+        responder: Responder<BlockSynchronizerStatus>,
     },
 }
 

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -93,6 +93,7 @@ impl MainReactor {
                     Ok(effects) => {
                         info!("CatchUp: switch to Validate at genesis");
                         self.state = ReactorState::Validate;
+                        self.block_synchronizer.pause();
                         (Duration::ZERO, effects)
                     }
                     Err(msg) => (

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -16,7 +16,7 @@ use casper_types::{EraId, ProtocolVersion, PublicKey, TimeDiff, Timestamp};
 
 use crate::{
     components::{
-        block_synchronizer::BlockSyncStatus,
+        block_synchronizer::BlockSynchronizerStatus,
         rpc_server::rpcs::docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
         upgrade_watcher::NextUpgrade,
     },
@@ -53,7 +53,7 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         reactor_state: ReactorState::Initialize,
         last_progress: Timestamp::from(0),
         available_block_range: AvailableBlockRange::RANGE_0_0,
-        block_sync: vec![],
+        block_sync: BlockSynchronizerStatus::doc_example().clone(),
         starting_state_root_hash: None,
     };
     GetStatusResult::new(status_feed, DOCS_EXAMPLE_PROTOCOL_VERSION)
@@ -106,7 +106,7 @@ pub struct StatusFeed {
     /// The available block range in storage.
     pub available_block_range: AvailableBlockRange,
     /// The status of the block synchronizer builders.
-    pub block_sync: Vec<BlockSyncStatus>,
+    pub block_sync: BlockSynchronizerStatus,
     /// The state root hash of the lowest block in the available block range.
     pub starting_state_root_hash: Option<Digest>,
 }
@@ -122,7 +122,7 @@ impl StatusFeed {
         reactor_state: ReactorState,
         last_progress: Timestamp,
         available_block_range: AvailableBlockRange,
-        block_sync: Vec<BlockSyncStatus>,
+        block_sync: BlockSynchronizerStatus,
         starting_state_root_hash: Option<Digest>,
     ) -> Self {
         let (our_public_signing_key, round_length) = match consensus_status {
@@ -203,7 +203,7 @@ pub struct GetStatusResult {
     /// The available block range in storage.
     pub available_block_range: AvailableBlockRange,
     /// The status of the block synchronizer builders.
-    pub block_sync: Vec<BlockSyncStatus>,
+    pub block_sync: BlockSynchronizerStatus,
 }
 
 impl GetStatusResult {


### PR DESCRIPTION
This PR adds the new component status: `Paused`. Currently it is used by `BlockSynchronizer` only. When resuming, the previous component state is correctly restored.

It also makes the `BlockSynchronizer` responsive to `BlockSynchronizerRequest::Status` even when paused

Additionally, this PR changes the format of the `block_sync` part of the `/status` response. It is now possible to distinguish between `forward` and `historical` synchronizers, like so:
```json
{
  "peers": [
    {
      "node_id": "tls:4a77..f652",
      "address": "127.0.0.1:22101"
    },
  ],
  "api_version": "1.0.0",
   ... other fields omitted ...
  "block_sync": {
    "historical": {
      "block_hash": "c390ebc5bc747a962fff6609ce4328ee92b682b4e87a7969fa8d38c513a5c940",
      "block_height": 31,
      "acquisition_state": "have strict finality(31) for: block hash c390..c940"
    },
    "forward": {
      "block_hash": "e3480dd433d24b22043992dde4f3a7e365fc7cd0510935c07c1fe10322a13d1f",
      "block_height": 37,
      "acquisition_state": "have block body(37) for: block hash e348..3d1f"
    }
  }
}

```
