### PR TITLE
Muxink load testing binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ lto = true
 [profile.bench]
 codegen-units = 1
 lto = true
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/muxink/Cargo.toml
+++ b/muxink/Cargo.toml
@@ -9,7 +9,6 @@ testing = ["tokio-stream", "rand"]
 
 [[bin]]
 name = "load_testing"
-src = "bin/load_testing.rs"
 test = false
 bench = false
 required-features = ["testing"]

--- a/muxink/Cargo.toml
+++ b/muxink/Cargo.toml
@@ -3,6 +3,17 @@ name = "muxink"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+testing = ["tokio-stream"]
+
+[[bin]]
+name = "load_testing"
+src = "bin/load_testing.rs"
+test = false
+bench = false
+required-features = ["testing"]
+
 [dependencies]
 bytes = "1.1.0"
 futures = "0.3.21"
@@ -10,6 +21,7 @@ thiserror = "1.0.31"
 tokio = { version = "1" }
 tokio-util = "0.7.2"
 tracing = "0.1.18"
+tokio-stream = { version = "0.1.8", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "io-util", "macros", "net", "rt" ] }

--- a/muxink/Cargo.toml
+++ b/muxink/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = []
-testing = ["tokio-stream"]
+testing = ["tokio-stream", "rand"]
 
 [[bin]]
 name = "load_testing"
@@ -22,6 +22,7 @@ tokio = { version = "1" }
 tokio-util = "0.7.2"
 tracing = "0.1.18"
 tokio-stream = { version = "0.1.8", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "io-util", "macros", "net", "rt" ] }

--- a/muxink/src/bin/load_testing.rs
+++ b/muxink/src/bin/load_testing.rs
@@ -1,0 +1,5 @@
+use muxink;
+
+fn main() {
+    println!("hello world");
+}

--- a/muxink/src/bin/load_testing.rs
+++ b/muxink/src/bin/load_testing.rs
@@ -1,5 +1,94 @@
-use muxink;
+use std::time::{Duration, Instant};
+
+use futures::{FutureExt, SinkExt, StreamExt};
+use rand::{distributions::Standard, thread_rng, Rng};
+
+use muxink::{self, testing::fixtures::TwoWayFixtures};
+
+macro_rules! p {
+    ($start:expr, $($arg:tt)*) => {{
+        let time = $start.elapsed().as_millis();
+        print!("{time} - ");
+        println!($($arg)*);
+    }};
+}
+
+// This binary is useful for probing memory consumption of muxink.
+// Probably you want `heaptrack` installed to run this. https://github.com/KDE/heaptrack
+//
+// Test with:
+// ```
+// cargo build --profile release-with-debug --bin load_testing --features testing && \
+// heaptrack -o ~/heap ../target/release-with-debug/load_testing
+// ```
 
 fn main() {
-    println!("hello world");
+    let s = Instant::now();
+    p!(s, "started load_testing binary");
+
+    let message_size = 1024 * 1024 * 8;
+    let rand_bytes: Vec<u8> = thread_rng()
+        .sample_iter(Standard)
+        .take(message_size)
+        .collect();
+
+    futures::executor::block_on(async move {
+        test_ever_larger_buffers_matching_window_size(&s, rand_bytes.clone()).await;
+        test_cycling_full_buffer(&s, rand_bytes.clone(), 1, 1000).await;
+        test_cycling_full_buffer(&s, rand_bytes.clone(), 10, 100).await;
+        test_cycling_full_buffer(&s, rand_bytes.clone(), 100, 10).await;
+    });
+    p!(s, "load_testing binary finished");
+}
+
+async fn test_ever_larger_buffers_matching_window_size(s: &Instant, rand_bytes: Vec<u8>) {
+    p!(s, "testing buffers (filled to window size)");
+    for buffer_size in 1..100 {
+        let window_size = buffer_size as u64;
+        p!(
+            s,
+            "buffer size = {buffer_size}, expected mem consumption ~= {}",
+            rand_bytes.len() * buffer_size
+        );
+        let TwoWayFixtures {
+            mut client,
+            mut server,
+        } = TwoWayFixtures::new_with_window(buffer_size, window_size);
+        for _message_sequence in 0..buffer_size {
+            client.send(rand_bytes.clone().into()).await.unwrap();
+        }
+        for _message_sequence in 0..buffer_size {
+            server.next().now_or_never().unwrap();
+        }
+    }
+}
+
+async fn test_cycling_full_buffer(
+    s: &Instant,
+    rand_bytes: Vec<u8>,
+    buffer_size: usize,
+    cycles: u32,
+) {
+    p!(
+        s,
+        "testing cycling buffers (fill to window size, then empty)"
+    );
+    let window_size = buffer_size as u64;
+    p!(
+        s,
+        "buffer size = {buffer_size}, expected mem consumption ~= {}",
+        rand_bytes.len() * buffer_size
+    );
+    let TwoWayFixtures {
+        mut client,
+        mut server,
+    } = TwoWayFixtures::new_with_window(buffer_size, window_size);
+    for cycles in 0..cycles {
+        for _message_sequence in 0..buffer_size {
+            client.send(rand_bytes.clone().into()).await.unwrap();
+        }
+        for _message_sequence in 0..buffer_size {
+            server.next().now_or_never().unwrap();
+        }
+    }
 }

--- a/muxink/src/lib.rs
+++ b/muxink/src/lib.rs
@@ -30,7 +30,7 @@ pub mod fragmented;
 pub mod framing;
 pub mod io;
 pub mod mux;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
 use bytes::Buf;

--- a/muxink/src/testing.rs
+++ b/muxink/src/testing.rs
@@ -71,7 +71,8 @@ pub(crate) struct TestStream<T> {
 }
 
 impl<T> TestStream<T> {
-    pub fn new(items: Vec<T>) -> Self {
+    #[cfg(test)]
+    pub(crate) fn new(items: Vec<T>) -> Self {
         TestStream {
             items: items.into(),
             finished: false,

--- a/muxink/src/testing.rs
+++ b/muxink/src/testing.rs
@@ -1,6 +1,7 @@
 //! Testing support utilities.
 
 pub mod encoding;
+pub mod fixtures;
 pub mod pipe;
 pub mod testing_sink;
 
@@ -70,7 +71,7 @@ pub(crate) struct TestStream<T> {
 }
 
 impl<T> TestStream<T> {
-    pub(crate) fn new(items: Vec<T>) -> Self {
+    pub fn new(items: Vec<T>) -> Self {
         TestStream {
             items: items.into(),
             finished: false,

--- a/muxink/src/testing/fixtures.rs
+++ b/muxink/src/testing/fixtures.rs
@@ -93,6 +93,10 @@ pub struct TwoWayFixtures {
 impl TwoWayFixtures {
     /// Creates a new set of two-way fixtures.
     pub fn new(size: usize) -> Self {
+        Self::new_with_window(size, WINDOW_SIZE)
+    }
+    /// Creates a new set of two-way fixtures with a specified window size.
+    pub fn new_with_window(size: usize, window_size: u64) -> Self {
         let (sink, stream) = setup_io_pipe::<Bytes>(size);
 
         let (ack_sink, ack_stream) = setup_io_pipe::<u64>(size);
@@ -102,13 +106,13 @@ impl TwoWayFixtures {
         let boxed_ack_stream: Box<dyn Stream<Item = Result<u64, Infallible>> + Send + Unpin> =
             Box::new(ack_stream);
 
-        let client = BackpressuredSink::new(boxed_sink, boxed_ack_stream, WINDOW_SIZE);
+        let client = BackpressuredSink::new(boxed_sink, boxed_ack_stream, window_size);
 
         let boxed_stream: Box<dyn Stream<Item = Result<Bytes, Infallible>> + Send + Unpin> =
             Box::new(stream);
         let boxed_ack_sink: Box<dyn Sink<u64, Error = Infallible> + Send + Unpin> =
             Box::new(ack_sink);
-        let server = BackpressuredStream::new(boxed_stream, boxed_ack_sink, WINDOW_SIZE);
+        let server = BackpressuredStream::new(boxed_stream, boxed_ack_sink, window_size);
 
         TwoWayFixtures { client, server }
     }

--- a/muxink/src/testing/fixtures.rs
+++ b/muxink/src/testing/fixtures.rs
@@ -1,0 +1,115 @@
+use std::{convert::Infallible, sync::Arc};
+
+use bytes::Bytes;
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::PollSender;
+
+use crate::{
+    backpressured::{BackpressuredSink, BackpressuredStream},
+    testing::testing_sink::{TestingSink, TestingSinkRef},
+};
+
+/// Window size used in tests.
+pub const WINDOW_SIZE: u64 = 3;
+
+/// Sets up a `Sink`/`Stream` pair that outputs infallible results.
+pub fn setup_io_pipe<T: Send + Sync + 'static>(
+    size: usize,
+) -> (
+    impl Sink<T, Error = Infallible> + Unpin + 'static,
+    impl Stream<Item = Result<T, Infallible>> + Unpin + 'static,
+) {
+    let (send, recv) = tokio::sync::mpsc::channel::<T>(size);
+
+    let stream = ReceiverStream::new(recv).map(Ok);
+
+    let sink =
+        PollSender::new(send).sink_map_err(|_err| panic!("did not expect a `PollSendError`"));
+
+    (sink, stream)
+}
+
+/// A common set of fixtures used in the backpressure tests.
+///
+/// The fixtures represent what a server holds when dealing with a backpressured client.
+pub struct OneWayFixtures {
+    /// A sender for ACKs back to the client.
+    pub ack_sink: Box<dyn Sink<u64, Error = Infallible> + Unpin>,
+    /// The clients sink for requests, with no backpressure wrapper. Used for retrieving the
+    /// test data in the end or setting plugged/clogged status.
+    pub sink: Arc<TestingSink>,
+    /// The properly set up backpressured sink.
+    pub bp: BackpressuredSink<
+        TestingSinkRef,
+        Box<dyn Stream<Item = Result<u64, Infallible>> + Unpin>,
+        Bytes,
+    >,
+}
+
+impl OneWayFixtures {
+    /// Creates a new set of fixtures.
+    pub fn new() -> Self {
+        let sink = Arc::new(TestingSink::new());
+
+        let (raw_ack_sink, raw_ack_stream) = setup_io_pipe::<u64>(1024);
+
+        // The ACK stream and sink need to be boxed to make their types named.
+        let ack_sink: Box<dyn Sink<u64, Error = Infallible> + Unpin> = Box::new(raw_ack_sink);
+        let ack_stream: Box<dyn Stream<Item = Result<u64, Infallible>> + Unpin> =
+            Box::new(raw_ack_stream);
+
+        let bp = BackpressuredSink::new(sink.clone().into_ref(), ack_stream, WINDOW_SIZE);
+
+        Self { ack_sink, sink, bp }
+    }
+}
+
+impl Default for OneWayFixtures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A more complicated setup for testing backpressure that allows accessing both sides of the
+/// connection.
+///
+/// The resulting `client` sends byte frames across to the `server`, with ACKs flowing through
+/// the associated ACK pipe.
+#[allow(clippy::type_complexity)]
+pub struct TwoWayFixtures {
+    pub client: BackpressuredSink<
+        Box<dyn Sink<Bytes, Error = Infallible> + Send + Unpin>,
+        Box<dyn Stream<Item = Result<u64, Infallible>> + Send + Unpin>,
+        Bytes,
+    >,
+    pub server: BackpressuredStream<
+        Box<dyn Stream<Item = Result<Bytes, Infallible>> + Send + Unpin>,
+        Box<dyn Sink<u64, Error = Infallible> + Send + Unpin>,
+        Bytes,
+    >,
+}
+
+impl TwoWayFixtures {
+    /// Creates a new set of two-way fixtures.
+    pub fn new(size: usize) -> Self {
+        let (sink, stream) = setup_io_pipe::<Bytes>(size);
+
+        let (ack_sink, ack_stream) = setup_io_pipe::<u64>(size);
+
+        let boxed_sink: Box<dyn Sink<Bytes, Error = Infallible> + Send + Unpin + 'static> =
+            Box::new(sink);
+        let boxed_ack_stream: Box<dyn Stream<Item = Result<u64, Infallible>> + Send + Unpin> =
+            Box::new(ack_stream);
+
+        let client = BackpressuredSink::new(boxed_sink, boxed_ack_stream, WINDOW_SIZE);
+
+        let boxed_stream: Box<dyn Stream<Item = Result<Bytes, Infallible>> + Send + Unpin> =
+            Box::new(stream);
+        let boxed_ack_sink: Box<dyn Sink<u64, Error = Infallible> + Send + Unpin> =
+            Box::new(ack_sink);
+        let server = BackpressuredStream::new(boxed_stream, boxed_ack_sink, WINDOW_SIZE);
+
+        TwoWayFixtures { client, server }
+    }
+}

--- a/muxink/src/testing/pipe.rs
+++ b/muxink/src/testing/pipe.rs
@@ -151,7 +151,7 @@ impl AsyncWrite for WriteEnd {
 ///
 /// Dropping either end of the pipe will close it, causing writes to return broken pipe errors and
 /// reads to return successful 0-byte reads.
-pub(crate) fn pipe() -> (WriteEnd, ReadEnd) {
+pub fn pipe() -> (WriteEnd, ReadEnd) {
     let inner: Arc<Mutex<_>> = Default::default();
     let read_end = ReadEnd {
         inner: inner.clone(),

--- a/muxink/src/testing/pipe.rs
+++ b/muxink/src/testing/pipe.rs
@@ -151,7 +151,8 @@ impl AsyncWrite for WriteEnd {
 ///
 /// Dropping either end of the pipe will close it, causing writes to return broken pipe errors and
 /// reads to return successful 0-byte reads.
-pub fn pipe() -> (WriteEnd, ReadEnd) {
+#[cfg(test)]
+pub(crate) fn pipe() -> (WriteEnd, ReadEnd) {
     let inner: Arc<Mutex<_>> = Default::default();
     let read_end = ReadEnd {
         inner: inner.clone(),

--- a/muxink/src/testing/testing_sink.rs
+++ b/muxink/src/testing/testing_sink.rs
@@ -12,7 +12,10 @@ use std::{
 };
 
 use bytes::Buf;
-use futures::{FutureExt, Sink, SinkExt};
+use futures::{Sink, SinkExt};
+
+#[cfg(test)]
+use futures::FutureExt;
 
 /// A sink for unit testing.
 ///


### PR DESCRIPTION
resolves #3331 - adds binary to make testing `muxink` crate with heaptrack in isolation easier.

This PR adds a new profile to the top-level Cargo.toml which enables the project (and subs) to be built with debug info enabled. This is essential for many profiling tools to resolve method names but shouldn't be a part of the release build.

Additionally, I moved some test fixtures to the testing module and added a feature to `muxink`'s Cargo.toml that conditionally compiles them for the binary and for unit testing where they are used.

I've included a sample of the heaptrack output here, but @marc-casperlabs `muxink` looks like it is performing as expected.

![image](https://user-images.githubusercontent.com/1497784/205366571-7a0d99aa-91be-4a1d-a4a3-cc775220aa1b.png)

