### PR TITLE
Block synchronizer metrics

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer and `block_accumulator_block_acceptors`,  `block_accumulator_known_child_blocks` to track status of the block accumulator component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`,  `block_accumulator_known_child_blocks` to track status of the block accumulator component and `{forward|historical}_block_sync_time` histogram metric to track the progress of block synchronization.
 
 ### Changed
 

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -8,6 +8,7 @@ mod error;
 mod event;
 mod execution_results_acquisition;
 mod global_state_synchronizer;
+mod metrics;
 mod need_next;
 mod peer_list;
 mod signature_acquisition;
@@ -16,6 +17,7 @@ mod trie_accumulator;
 use datasize::DataSize;
 use either::Either;
 use once_cell::sync::Lazy;
+use prometheus::Registry;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, trace, warn};
@@ -88,6 +90,7 @@ static BLOCK_SYNCHRONIZER_STATUS: Lazy<BlockSynchronizerStatus> = Lazy::new(|| {
         }),
     )
 });
+use metrics::Metrics;
 
 pub(crate) trait ReactorEvent:
     From<FetcherRequest<ApprovalsHashes>>
@@ -184,11 +187,17 @@ pub(crate) struct BlockSynchronizer {
     historical: Option<BlockBuilder>,
     // deals with global state acquisition for historical blocks
     global_sync: GlobalStateSynchronizer,
+    #[data_size(skip)]
+    metrics: Metrics,
 }
 
 impl BlockSynchronizer {
-    pub(crate) fn new(config: Config, validator_matrix: ValidatorMatrix) -> Self {
-        BlockSynchronizer {
+    pub(crate) fn new(
+        config: Config,
+        validator_matrix: ValidatorMatrix,
+        registry: &Registry,
+    ) -> Result<Self, prometheus::Error> {
+        Ok(BlockSynchronizer {
             status: ComponentStatus::Uninitialized,
             status_before_pause: ComponentStatus::Uninitialized,
             validator_matrix,
@@ -199,7 +208,8 @@ impl BlockSynchronizer {
             forward: None,
             historical: None,
             global_sync: GlobalStateSynchronizer::new(config.max_parallel_trie_fetches() as usize),
-        }
+            metrics: Metrics::new(registry)?,
+        })
     }
 
     /// Returns the progress being made on the historical syncing.
@@ -385,6 +395,9 @@ impl BlockSynchronizer {
         match &mut self.forward {
             Some(builder) if builder.block_hash() == *block_hash => {
                 builder.register_block_execution_enqueued();
+                self.metrics
+                    .forward_block_sync_time
+                    .observe(builder.get_sync_start_time().elapsed().as_secs_f64());
             }
             _ => {
                 trace!(%block_hash, "BlockSynchronizer: not currently synchronizing forward block");
@@ -402,6 +415,9 @@ impl BlockSynchronizer {
         match &mut self.historical {
             Some(builder) if builder.block_hash() == *block_hash => {
                 builder.register_marked_complete();
+                self.metrics
+                    .historical_block_sync_time
+                    .observe(builder.get_sync_start_time().elapsed().as_secs_f64());
             }
             _ => {
                 trace!(%block_hash, "BlockSynchronizer: not currently synchronizing historical block");

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -397,7 +397,7 @@ impl BlockSynchronizer {
                 builder.register_block_execution_enqueued();
                 self.metrics
                     .forward_block_sync_time
-                    .observe(builder.get_sync_start_time().elapsed().as_secs_f64());
+                    .observe(builder.sync_start_time().elapsed().as_secs_f64());
             }
             _ => {
                 trace!(%block_hash, "BlockSynchronizer: not currently synchronizing forward block");
@@ -417,7 +417,7 @@ impl BlockSynchronizer {
                 builder.register_marked_complete();
                 self.metrics
                     .historical_block_sync_time
-                    .observe(builder.get_sync_start_time().elapsed().as_secs_f64());
+                    .observe(builder.sync_start_time().elapsed().as_secs_f64());
             }
             _ => {
                 trace!(%block_hash, "BlockSynchronizer: not currently synchronizing historical block");

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
+    time::Instant,
 };
 
 use datasize::DataSize;
@@ -52,6 +53,7 @@ pub(super) struct BlockBuilder {
     peer_list: PeerList,
 
     // progress tracking
+    sync_start: Instant,
     last_progress: Timestamp,
     in_flight_latch: Option<Timestamp>,
 
@@ -92,6 +94,7 @@ impl BlockBuilder {
             peer_list: PeerList::new(max_simultaneous_peers, peer_refresh_interval),
             should_fetch_execution_state,
             requires_strict_finality,
+            sync_start: Instant::now(),
             last_progress: Timestamp::now(),
             in_flight_latch: None,
         }
@@ -134,6 +137,7 @@ impl BlockBuilder {
             peer_list,
             should_fetch_execution_state,
             requires_strict_finality,
+            sync_start: Instant::now(),
             last_progress: Timestamp::now(),
             in_flight_latch: None,
         }
@@ -169,6 +173,10 @@ impl BlockBuilder {
 
     pub(super) fn should_fetch_execution_state(&self) -> bool {
         self.should_fetch_execution_state
+    }
+
+    pub(super) fn get_sync_start_time(&self) -> Instant {
+        self.sync_start
     }
 
     pub(super) fn last_progress_time(&self) -> Timestamp {

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -175,7 +175,7 @@ impl BlockBuilder {
         self.should_fetch_execution_state
     }
 
-    pub(super) fn get_sync_start_time(&self) -> Instant {
+    pub(super) fn sync_start_time(&self) -> Instant {
         self.sync_start
     }
 

--- a/node/src/components/block_synchronizer/metrics.rs
+++ b/node/src/components/block_synchronizer/metrics.rs
@@ -1,0 +1,58 @@
+use prometheus::{Histogram, Registry};
+
+use crate::{unregister_metric, utils};
+
+const HIST_SYNC_TIME_NAME: &str = "historical_block_sync_time";
+const HIST_SYNC_TIME_HELP: &str = "Time duration (in sec) to synchronize a historical block";
+const FWD_SYNC_TIME_NAME: &str = "forward_block_sync_time";
+const FWD_SYNC_TIME_HELP: &str = "Time duration (in sec) to synchronize a forward block";
+
+// We use linear buckets to observe the time it takes to synchonize blocks.
+// Buckets have 50 milisec widths and cover up to 500 milisec durations with this granularity.
+const LINEAR_BUCKET_START: f64 = 0.05;
+const LINEAR_BUCKET_WIDTH: f64 = 0.05;
+const LINEAR_BUCKET_COUNT: usize = 10;
+
+/// Metrics for the block synchronizer component.
+#[derive(Debug)]
+pub(super) struct Metrics {
+    /// Time duration for the historical synchronizer to get a block.
+    pub(super) historical_block_sync_time: Histogram,
+    /// Time duration for the forward synchronizer to get a block.
+    pub(super) forward_block_sync_time: Histogram,
+    registry: Registry,
+}
+
+impl Metrics {
+    /// Creates a new instance of the block synchronizer metrics.
+    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let buckets = prometheus::linear_buckets(
+            LINEAR_BUCKET_START,
+            LINEAR_BUCKET_WIDTH,
+            LINEAR_BUCKET_COUNT,
+        )?;
+
+        Ok(Metrics {
+            historical_block_sync_time: utils::register_histogram_metric(
+                registry,
+                HIST_SYNC_TIME_NAME,
+                HIST_SYNC_TIME_HELP,
+                buckets.clone(),
+            )?,
+            forward_block_sync_time: utils::register_histogram_metric(
+                registry,
+                FWD_SYNC_TIME_NAME,
+                FWD_SYNC_TIME_HELP,
+                buckets,
+            )?,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.historical_block_sync_time);
+        unregister_metric!(self.registry, self.forward_block_sync_time);
+    }
+}

--- a/node/src/components/block_synchronizer/metrics.rs
+++ b/node/src/components/block_synchronizer/metrics.rs
@@ -3,15 +3,15 @@ use prometheus::{Histogram, Registry};
 use crate::{unregister_metric, utils};
 
 const HIST_SYNC_TIME_NAME: &str = "historical_block_sync_time";
-const HIST_SYNC_TIME_HELP: &str = "Time duration (in sec) to synchronize a historical block";
+const HIST_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a historical block";
 const FWD_SYNC_TIME_NAME: &str = "forward_block_sync_time";
-const FWD_SYNC_TIME_HELP: &str = "Time duration (in sec) to synchronize a forward block";
+const FWD_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a forward block";
 
-// We use linear buckets to observe the time it takes to synchonize blocks.
-// Buckets have 50 milisec widths and cover up to 500 milisec durations with this granularity.
-const LINEAR_BUCKET_START: f64 = 0.05;
-const LINEAR_BUCKET_WIDTH: f64 = 0.05;
-const LINEAR_BUCKET_COUNT: usize = 10;
+// We use exponential buckets to observe the time it takes to synchronize blocks.
+// Coverage is ~7.7s with higher resolution in the first buckets.
+const EXPONENTIAL_BUCKET_START: f64 = 0.05;
+const EXPONENTIAL_BUCKET_FACTOR: f64 = 1.75;
+const EXPONENTIAL_BUCKET_COUNT: usize = 10;
 
 /// Metrics for the block synchronizer component.
 #[derive(Debug)]
@@ -26,10 +26,10 @@ pub(super) struct Metrics {
 impl Metrics {
     /// Creates a new instance of the block synchronizer metrics.
     pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let buckets = prometheus::linear_buckets(
-            LINEAR_BUCKET_START,
-            LINEAR_BUCKET_WIDTH,
-            LINEAR_BUCKET_COUNT,
+        let buckets = prometheus::exponential_buckets(
+            EXPONENTIAL_BUCKET_START,
+            EXPONENTIAL_BUCKET_FACTOR,
+            EXPONENTIAL_BUCKET_COUNT,
         )?;
 
         Ok(Metrics {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -276,8 +276,11 @@ impl reactor::Reactor for MainReactor {
             chainspec.highway_config.min_round_length(),
             registry,
         )?;
-        let block_synchronizer =
-            BlockSynchronizer::new(config.block_synchronizer, validator_matrix.clone());
+        let block_synchronizer = BlockSynchronizer::new(
+            config.block_synchronizer,
+            validator_matrix.clone(),
+            registry,
+        )?;
         let block_validator = BlockValidator::new(Arc::clone(&chainspec));
         let upgrade_watcher =
             UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;


### PR DESCRIPTION
Add block synchronizer time progress metrics.
Addresses https://github.com/casper-network/casper-node/issues/3422
