### PR TITLE
rejoin validator flow (WIP)

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -203,13 +203,18 @@ impl BlockAccumulator {
                 SyncInstruction::BlockSync { block_hash }
             }
             None => {
-                if !self.is_stalled() {
-                    SyncInstruction::CaughtUp { block_hash }
-                } else {
+                if self.is_stalled() {
                     SyncInstruction::Leap { block_hash }
+                } else {
+                    SyncInstruction::CaughtUp { block_hash }
                 }
             }
         }
+    }
+
+    /// Gets local tip block_height if available.
+    pub(crate) fn local_tip(&self) -> Option<u64> {
+        self.local_tip.map(|lti| lti.height)
     }
 
     /// Drops all old block acceptors and tracks new local block height;
@@ -480,7 +485,7 @@ impl BlockAccumulator {
     {
         let mut effects = Effects::new();
         if let Some(block) = block {
-            effects.extend(effect_builder.announce_block_accepted(block).ignore());
+            effects.extend(effect_builder.announce_block_added(block).ignore());
         };
         for finality_signature in finality_signatures {
             effects.extend(

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -154,6 +154,10 @@ impl BlockBuilder {
         self.block_hash
     }
 
+    pub(super) fn maybe_block(&self) -> Option<Box<Block>> {
+        self.acquisition_state.maybe_block()
+    }
+
     pub(super) fn block_height(&self) -> Option<u64> {
         self.acquisition_state.block_height()
     }

--- a/node/src/components/block_synchronizer/global_state_synchronizer.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer.rs
@@ -33,8 +33,8 @@ pub(crate) enum Error {
     PutTrie(engine_state::Error),
     #[error("no peers available to ask for a trie: {0}")]
     NoPeersAvailable(Digest),
-    #[error("request to fetch cancelled")]
-    Cancelled,
+    // #[error("request to fetch cancelled")]
+    // Cancelled,
 }
 
 #[derive(Debug, From, Serialize)]

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -756,7 +756,7 @@ impl ContractRuntime {
         }
 
         effect_builder
-            .announce_new_linear_chain_block(block, approvals_hashes, execution_results)
+            .announce_executed_block(block, approvals_hashes, execution_results)
             .await;
 
         // If the child is already finalized, start execution.

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -270,20 +270,20 @@ impl DeployBuffer {
 
     /// Update buffer and holds considering new added block.
     fn register_block(&mut self, block: &Block) {
+        let block_height = block.header().height();
+        let timestamp = block.timestamp();
         debug!(%timestamp, "DeployBuffer: register_block({}) timestamp finalized", block_height);
-        self.register_deploys(
-            block.header().height(),
-            block.timestamp(),
-            block.deploy_and_transfer_hashes(),
-        );
+        self.register_deploys(block_height, timestamp, block.deploy_and_transfer_hashes());
     }
 
     /// Update buffer and holds considering new finalized block.
     fn register_block_finalized(&mut self, finalized_block: &FinalizedBlock) {
+        let block_height = finalized_block.height();
+        let timestamp = finalized_block.timestamp();
         debug!(%timestamp, "DeployBuffer: register_block_finalized({}) timestamp finalized", block_height);
         self.register_deploys(
-            finalized_block.height(),
-            finalized_block.timestamp(),
+            block_height,
+            timestamp,
             finalized_block.deploy_and_transfer_hashes(),
         );
     }

--- a/node/src/components/network/tasks.rs
+++ b/node/src/components/network/tasks.rs
@@ -673,111 +673,110 @@ where
     let demands_in_flight = Arc::new(Semaphore::new(context.max_in_flight_demands));
     let event_queue = context.event_queue.expect("component not initialized");
 
-    let read_messages = async move {
-        while let Some(msg_result) = stream.next().await {
-            match msg_result {
-                Ok(msg) => {
-                    trace!(%msg, "message received");
+    let read_messages =
+        async move {
+            while let Some(msg_result) = stream.next().await {
+                match msg_result {
+                    Ok(msg) => {
+                        trace!(%msg, "message received");
 
-                    let effect_builder = EffectBuilder::new(event_queue);
+                        let effect_builder = EffectBuilder::new(event_queue);
 
-                    match msg.try_into_demand(effect_builder, peer_id) {
-                        Ok((event, wait_for_response)) => {
-                            // Note: For now, demands bypass the limiter, as we expect the
-                            //       backpressure to handle this instead.
+                        match msg.try_into_demand(effect_builder, peer_id) {
+                            Ok((event, wait_for_response)) => {
+                                // Note: For now, demands bypass the limiter, as we expect the
+                                //       backpressure to handle this instead.
 
-                            // Acquire a permit. If we are handling too many demands at this
-                            // time, this will block, halting the processing of new message,
-                            // thus letting the peer they have reached their maximum allowance.
-                            let in_flight = demands_in_flight
-                                .clone()
-                                .acquire_owned()
-                                .await
-                                // Note: Since the semaphore is reference counted, it must
-                                //       explicitly be closed for acquisition to fail, which we
-                                //       never do. If this happens, there is a bug in the code;
-                                //       we exit with an error and close the connection.
-                                .map_err(|_| {
-                                    io::Error::new(
-                                        io::ErrorKind::Other,
-                                        "demand limiter semaphore closed unexpectedly",
-                                    )
-                                })?;
+                                // Acquire a permit. If we are handling too many demands at this
+                                // time, this will block, halting the processing of new message,
+                                // thus letting the peer they have reached their maximum allowance.
+                                let in_flight = demands_in_flight
+                                    .clone()
+                                    .acquire_owned()
+                                    .await
+                                    // Note: Since the semaphore is reference counted, it must
+                                    //       explicitly be closed for acquisition to fail, which we
+                                    //       never do. If this happens, there is a bug in the code;
+                                    //       we exit with an error and close the connection.
+                                    .map_err(|_| {
+                                        io::Error::new(
+                                            io::ErrorKind::Other,
+                                            "demand limiter semaphore closed unexpectedly",
+                                        )
+                                    })?;
 
-                            Metrics::record_trie_request_start(&context.net_metrics);
+                                Metrics::record_trie_request_start(&context.net_metrics);
 
-                            let net_metrics = context.net_metrics.clone();
-                            // Spawn a future that will eventually send the returned message. It
-                            // will essentially buffer the response.
-                            tokio::spawn(async move {
-                                if let Some(payload) = wait_for_response.await {
-                                    // Send message and await its return. `send_message` should
-                                    // only return when the message has been buffered, if the
-                                    // peer is not accepting data, we will block here until the
-                                    // send buffer has sufficient room.
-                                    effect_builder.send_message(peer_id, payload).await;
+                                let net_metrics = context.net_metrics.clone();
+                                // Spawn a future that will eventually send the returned message. It
+                                // will essentially buffer the response.
+                                tokio::spawn(async move {
+                                    if let Some(payload) = wait_for_response.await {
+                                        // Send message and await its return. `send_message` should
+                                        // only return when the message has been buffered, if the
+                                        // peer is not accepting data, we will block here until the
+                                        // send buffer has sufficient room.
+                                        effect_builder.send_message(peer_id, payload).await;
 
-                                    // Note: We could short-circuit the event queue here and
-                                    //       directly insert into the outgoing message queue,
-                                    //       which may be potential performance improvement.
-                                }
+                                        // Note: We could short-circuit the event queue here and
+                                        //       directly insert into the outgoing message queue,
+                                        //       which may be potential performance improvement.
+                                    }
 
-                                // Missing else: The handler of the demand did not deem it
-                                // worthy a response. Just drop it.
+                                    // Missing else: The handler of the demand did not deem it
+                                    // worthy a response. Just drop it.
 
-                                // After we have either successfully buffered the message for
-                                // sending, failed to do so or did not have a message to send
-                                // out, we consider the request handled and free up the permit.
-                                Metrics::record_trie_request_end(&net_metrics);
-                                drop(in_flight);
-                            });
+                                    // After we have either successfully buffered the message for
+                                    // sending, failed to do so or did not have a message to send
+                                    // out, we consider the request handled and free up the permit.
+                                    Metrics::record_trie_request_end(&net_metrics);
+                                    drop(in_flight);
+                                });
 
-                            // Schedule the created event.
-                            event_queue
-                                .schedule::<REv>(event, QueueKind::NetworkDemand)
-                                .await;
-                        }
-                        Err(msg) => {
-                            // We've received a non-demand message. Ensure we have the proper amount
-                            // of resources, then push it to the reactor.
-                            limiter
-                                .request_allowance(
-                                    msg.payload_incoming_resource_estimate(
+                                // Schedule the created event.
+                                event_queue
+                                    .schedule::<REv>(event, QueueKind::NetworkDemand)
+                                    .await;
+                            }
+                            Err(msg) => {
+                                // We've received a non-demand message. Ensure we have the proper amount
+                                // of resources, then push it to the reactor.
+                                limiter
+                                    .request_allowance(msg.payload_incoming_resource_estimate(
                                         &context.payload_weights,
-                                    ),
-                                )
-                                .await;
+                                    ))
+                                    .await;
 
-                            let queue_kind = if msg.is_low_priority() {
-                                QueueKind::NetworkLowPriority
-                            } else {
-                                QueueKind::NetworkIncoming
-                            };
+                                let queue_kind = if msg.is_low_priority() {
+                                    QueueKind::NetworkLowPriority
+                                } else {
+                                    QueueKind::NetworkIncoming
+                                };
 
-                            event_queue
-                                .schedule(
-                                    Event::IncomingMessage {
-                                        peer_id: Box::new(peer_id),
-                                        msg: Box::new(msg),
-                                        span: span.clone(),
-                                    },
-                                    queue_kind,
-                                )
-                                .await;
+                                event_queue
+                                    .schedule(
+                                        Event::IncomingMessage {
+                                            peer_id: Box::new(peer_id),
+                                            msg: Box::new(msg),
+                                            span: span.clone(),
+                                        },
+                                        queue_kind,
+                                    )
+                                    .await;
+                            }
                         }
                     }
-                }
-                Err(err) => {
-                    warn!(
-                        err = display_error(&err),
-                        "receiving message failed, closing connection"
-                    );
-                    return Err(err);
+                    Err(err) => {
+                        warn!(
+                            err = display_error(&err),
+                            "receiving message failed, closing connection"
+                        );
+                        return Err(err);
+                    }
                 }
             }
-        }
-        Ok(())
-    };
+            Ok(())
+        };
 
     let shutdown_messages = async move { while close_incoming_receiver.changed().await.is_ok() {} };
 

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -154,7 +154,7 @@ impl DisjointSequences {
         self.sequences.first()
     }
 
-    /// Returns the highest sequence, or `None` if there are no sequences.
+    /// Returns all the sequences, if any.
     pub(super) fn sequences(&self) -> &Vec<Sequence> {
         &self.sequences
     }

--- a/node/src/components/storage/disjoint_sequences.rs
+++ b/node/src/components/storage/disjoint_sequences.rs
@@ -154,6 +154,11 @@ impl DisjointSequences {
         self.sequences.first()
     }
 
+    /// Returns the highest sequence, or `None` if there are no sequences.
+    pub(super) fn sequences(&self) -> &Vec<Sequence> {
+        &self.sequences
+    }
+
     /// Reduces the sequence(s), keeping all entries below and including `max_value`.  If
     /// `max_value` is not already included in a sequence, it will not be added.
     ///

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -856,7 +856,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that the block accumulator has received and stored a new block.
-    pub(crate) async fn announce_block_accepted(self, block: Box<Block>)
+    pub(crate) async fn announce_block_added(self, block: Box<Block>)
     where
         REv: From<BlockAccumulatorAnnouncement>,
     {
@@ -1032,7 +1032,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces a new block has been created.
-    pub(crate) async fn announce_new_linear_chain_block(
+    pub(crate) async fn announce_executed_block(
         self,
         block: Box<Block>,
         approvals_hashes: Box<ApprovalsHashes>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -142,7 +142,7 @@ use crate::{
         upgrade_watcher::NextUpgrade,
     },
     contract_runtime::SpeculativeExecutionState,
-    effect::requests::BlockAccumulatorRequest,
+    effect::{announcements::BlockSynchronizerAnnouncement, requests::BlockAccumulatorRequest},
     reactor::{main_reactor::ReactorState, EventQueueHandle, QueueKind},
     types::{
         appendable_block::AppendableBlock, ApprovalsHashes, AvailableBlockRange, Block,
@@ -851,6 +851,19 @@ impl<REv> EffectBuilder<REv> {
             .schedule(
                 GossiperAnnouncement::NewItemBody { item, sender },
                 QueueKind::Gossip,
+            )
+            .await;
+    }
+
+    /// The block synchronizer has ensured that all the parts of this block are stored
+    pub(crate) async fn announce_completed_block(self, block: Box<Block>)
+    where
+        REv: From<BlockSynchronizerAnnouncement>,
+    {
+        self.event_queue
+            .schedule(
+                BlockSynchronizerAnnouncement::CompletedBlock { block },
+                QueueKind::Validation,
             )
             .await;
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -110,6 +110,22 @@ impl Display for FatalAnnouncement {
     }
 }
 
+#[derive(Serialize, Debug)]
+#[must_use]
+pub(crate) enum ReactorAnnouncement {
+    CompletedBlock { block: Box<Block> },
+}
+
+impl Display for ReactorAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ReactorAnnouncement::CompletedBlock { block } => {
+                write!(f, "added complete block block_height: {}", block.height())
+            }
+        }
+    }
+}
+
 /// Queue dump format with handler.
 #[derive(Serialize)]
 pub(crate) enum QueueDumpFormat {
@@ -396,6 +412,22 @@ impl Display for BlockAccumulatorAnnouncement {
             }
             BlockAccumulatorAnnouncement::AcceptedNewFinalitySignature { finality_signature } => {
                 write!(f, "finality signature {} accepted", finality_signature.id())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) enum BlockSynchronizerAnnouncement {
+    /// A block which wasn't previously stored on this node has been accepted and stored.
+    CompletedBlock { block: Box<Block> },
+}
+
+impl Display for BlockSynchronizerAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockSynchronizerAnnouncement::CompletedBlock { block } => {
+                write!(f, "block {} completed", block.hash())
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1171,7 +1171,7 @@ impl Display for BlockAccumulatorRequest {
 pub(crate) enum BlockSynchronizerRequest {
     NeedNext,
     DishonestPeers,
-    BlockExecuted {
+    BlockAdded {
         block_hash: BlockHash,
         height: u64,
         state_root_hash: Digest,
@@ -1190,7 +1190,7 @@ impl Display for BlockSynchronizerRequest {
             BlockSynchronizerRequest::DishonestPeers => {
                 write!(f, "block synchronizer request: dishonest peers")
             }
-            BlockSynchronizerRequest::BlockExecuted {
+            BlockSynchronizerRequest::BlockAdded {
                 block_hash,
                 height,
                 state_root_hash,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1171,11 +1171,6 @@ impl Display for BlockAccumulatorRequest {
 pub(crate) enum BlockSynchronizerRequest {
     NeedNext,
     DishonestPeers,
-    BlockAdded {
-        block_hash: BlockHash,
-        height: u64,
-        state_root_hash: Digest,
-    },
     Status {
         responder: Responder<BlockSynchronizerStatus>,
     },
@@ -1189,18 +1184,6 @@ impl Display for BlockSynchronizerRequest {
             }
             BlockSynchronizerRequest::DishonestPeers => {
                 write!(f, "block synchronizer request: dishonest peers")
-            }
-            BlockSynchronizerRequest::BlockAdded {
-                block_hash,
-                height,
-                state_root_hash,
-            } => {
-                write!(
-                    f,
-                    "block synchronizer request: executed block {} at height {}, state root hash \
-                    {}",
-                    block_hash, height, state_root_hash
-                )
             }
             BlockSynchronizerRequest::Status { .. } => {
                 write!(f, "block synchronizer request: status")

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -49,13 +49,13 @@ use crate::{
     },
     effect::{
         announcements::{
-            BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
-            ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
-            GossiperAnnouncement, PeerBehaviorAnnouncement, RpcServerAnnouncement,
-            UpgradeWatcherAnnouncement,
+            BlockAccumulatorAnnouncement, BlockSynchronizerAnnouncement, ConsensusAnnouncement,
+            ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
+            DeployBufferAnnouncement, GossiperAnnouncement, PeerBehaviorAnnouncement,
+            ReactorAnnouncement, RpcServerAnnouncement, UpgradeWatcherAnnouncement,
         },
         incoming::{NetResponseIncoming, TrieResponseIncoming},
-        requests::{BlockSynchronizerRequest, ChainspecRawBytesRequest},
+        requests::ChainspecRawBytesRequest,
         EffectBuilder, EffectExt, Effects,
     },
     protocol::Message,
@@ -375,6 +375,34 @@ impl reactor::Reactor for MainReactor {
             // PRIMARY REACTOR STATE CONTROL LOGIC
             MainEvent::ReactorCrank => self.crank(effect_builder, rng),
 
+            MainEvent::MainReactorRequest(req) => {
+                req.0.respond((self.state, self.last_progress)).ignore()
+            }
+            MainEvent::MainReactorAnnouncement(ReactorAnnouncement::CompletedBlock { block }) => {
+                let mut effects = Effects::new();
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    MainEvent::EventStreamServer(event_stream_server::Event::BlockAdded(
+                        block.clone(),
+                    )),
+                ));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    MainEvent::DeployBuffer(deploy_buffer::Event::Block(block.clone())),
+                ));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    MainEvent::Consensus(consensus::Event::BlockAdded {
+                        header: Box::new(block.header().clone()),
+                        header_hash: *block.hash(),
+                    }),
+                ));
+                effects
+            }
+
             // LOCAL I/O BOUND COMPONENTS
             MainEvent::UpgradeWatcher(event) => reactor::wrap_effects(
                 MainEvent::UpgradeWatcher,
@@ -386,9 +414,6 @@ impl reactor::Reactor for MainReactor {
                 self.upgrade_watcher
                     .handle_event(effect_builder, rng, req.into()),
             ),
-            MainEvent::MainReactorRequest(req) => {
-                req.0.respond((self.state, self.last_progress)).ignore()
-            }
             MainEvent::UpgradeWatcherAnnouncement(
                 UpgradeWatcherAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => reactor::wrap_effects(
@@ -581,31 +606,21 @@ impl reactor::Reactor for MainReactor {
                 self.block_synchronizer
                     .handle_event(effect_builder, rng, req.into()),
             ),
+            MainEvent::BlockSynchronizerAnnouncement(
+                BlockSynchronizerAnnouncement::CompletedBlock { block },
+            ) => self.dispatch_event(
+                effect_builder,
+                rng,
+                MainEvent::MainReactorAnnouncement(ReactorAnnouncement::CompletedBlock { block }),
+            ),
+
             MainEvent::BlockAccumulatorAnnouncement(
                 BlockAccumulatorAnnouncement::AcceptedNewBlock { block },
             ) => {
                 let mut effects = Effects::new();
-
-                let reactor_event_es = MainEvent::EventStreamServer(
-                    event_stream_server::Event::BlockAdded(block.clone()),
-                );
-                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event_es));
-                let block_sync_event =
-                    MainEvent::BlockSynchronizerRequest(BlockSynchronizerRequest::BlockAdded {
-                        block_hash: *block.hash(),
-                        height: block.height(),
-                        state_root_hash: *block.header().state_root_hash(),
-                    });
-                effects.extend(self.dispatch_event(effect_builder, rng, block_sync_event));
                 let deploy_buffer_event =
                     MainEvent::DeployBuffer(deploy_buffer::Event::Block(block.clone()));
                 effects.extend(self.dispatch_event(effect_builder, rng, deploy_buffer_event));
-
-                let reactor_event_consensus = MainEvent::Consensus(consensus::Event::BlockAdded {
-                    header: Box::new(block.header().clone()),
-                    header_hash: *block.hash(),
-                });
-                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event_consensus));
 
                 // if it is a switch block, get validators
                 if let Some(validator_weights) = block.header().next_era_validator_weights() {
@@ -990,31 +1005,6 @@ impl reactor::Reactor for MainReactor {
                         .ignore(),
                 );
 
-                // this is a temporary measure...need to extricate
-                // accepted new block out of block accumulator
-                // and make it a more general announcement
-                effects.extend(self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    MainEvent::BlockAccumulatorAnnouncement(
-                        BlockAccumulatorAnnouncement::AcceptedNewBlock {
-                            block: block.clone(),
-                        },
-                    ),
-                ));
-
-                // notify the block accumulator
-                let event = block_accumulator::Event::ExecutedBlock {
-                    block: block.clone(),
-                };
-                effects.extend(reactor::wrap_effects(
-                    MainEvent::BlockAccumulator,
-                    self.block_accumulator
-                        .handle_event(effect_builder, rng, event),
-                ));
-
-                effects.extend(effect_builder.mark_block_completed(block.height()).ignore());
-
                 // When this node is a validator in this era, sign and announce.
                 if let Some(finality_signature) = self
                     .validator_matrix
@@ -1042,6 +1032,23 @@ impl reactor::Reactor for MainReactor {
                             .ignore(),
                     ));
                 }
+
+                effects.extend(effect_builder.mark_block_completed(block.height()).ignore());
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    MainEvent::MainReactorAnnouncement(ReactorAnnouncement::CompletedBlock {
+                        block: block.clone(),
+                    }),
+                ));
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::BlockAccumulator,
+                    self.block_accumulator.handle_event(
+                        effect_builder,
+                        rng,
+                        block_accumulator::Event::ExecutedBlock { block },
+                    ),
+                ));
 
                 // send deploy processed events to event stream
                 for (deploy_hash, deploy_header, execution_result) in execution_results {

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -462,16 +462,17 @@ impl MainReactor {
         effect_builder: EffectBuilder<MainEvent>,
         rng: &mut NodeRng,
     ) -> (bool, Option<Effects<MainEvent>>) {
-        // if on a switch block, check if we should go to Validate
         match self.create_required_eras(effect_builder, rng) {
             Err(msg) => {
                 return (false, Some(fatal!(effect_builder, "{}", msg).ignore()));
             }
             Ok(Some(effects)) => {
+                debug!("Validate: should validate");
                 return (true, Some(effects));
             }
             Ok(None) => (),
         }
+        debug!("Validate: should not validate");
         (false, None)
     }
 

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::time::Duration;
 use tracing::{debug, info, trace};
 
@@ -21,7 +22,7 @@ use crate::{
         upgrade_shutdown::UpgradeShutdownInstruction, upgrading_instruction::UpgradingInstruction,
         utils, validate::ValidateInstruction, MainEvent, MainReactor, ReactorState,
     },
-    types::{BlockHash, BlockPayload, FinalizedBlock},
+    types::{BlockHash, BlockPayload, FinalizedBlock, Item},
     NodeRng,
 };
 
@@ -63,6 +64,9 @@ impl MainReactor {
                     if false == self.net.has_sufficient_fully_connected_peers() {
                         info!("Initialize: awaiting sufficient fully-connected peers");
                         return (Duration::from_secs(2), Effects::new());
+                    }
+                    if let Err(msg) = self.refresh_contract_runtime() {
+                        return (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore());
                     }
                     info!("Initialize: switch to CatchUp");
                     self.state = ReactorState::CatchUp;
@@ -124,6 +128,9 @@ impl MainReactor {
                     (wait, effects)
                 }
                 CatchUpInstruction::CaughtUp => {
+                    if let Err(msg) = self.refresh_contract_runtime() {
+                        return (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore());
+                    }
                     info!("CatchUp: switch to KeepUp");
                     self.state = ReactorState::KeepUp;
                     (Duration::ZERO, Effects::new())
@@ -225,13 +232,6 @@ impl MainReactor {
         }
         if let Some(effects) = utils::initialize_component(
             effect_builder,
-            &mut self.net,
-            MainEvent::Network(network::Event::Initialize),
-        ) {
-            return Some(effects);
-        }
-        if let Some(effects) = utils::initialize_component(
-            effect_builder,
             &mut self.event_stream_server,
             MainEvent::EventStreamServer(event_stream_server::Event::Initialize),
         ) {
@@ -241,13 +241,6 @@ impl MainReactor {
             effect_builder,
             &mut self.rest_server,
             MainEvent::RestServer(rest_server::Event::Initialize),
-        ) {
-            return Some(effects);
-        }
-        if let Some(effects) = utils::initialize_component(
-            effect_builder,
-            &mut self.rpc_server,
-            MainEvent::RpcServer(rpc_server::Event::Initialize),
         ) {
             return Some(effects);
         }
@@ -281,6 +274,10 @@ impl MainReactor {
                     )
                 }
             };
+            debug!(
+                blocks = ?blocks.iter().map(|b| b.height()).collect_vec(),
+                "DeployBuffer: initialization"
+            );
             let event = deploy_buffer::Event::Initialize(blocks);
             if let Some(effects) = utils::initialize_component(
                 effect_builder,
@@ -289,6 +286,20 @@ impl MainReactor {
             ) {
                 return Some(effects);
             }
+        }
+        if let Some(effects) = utils::initialize_component(
+            effect_builder,
+            &mut self.rpc_server,
+            MainEvent::RpcServer(rpc_server::Event::Initialize),
+        ) {
+            return Some(effects);
+        }
+        if let Some(effects) = utils::initialize_component(
+            effect_builder,
+            &mut self.net,
+            MainEvent::Network(network::Event::Initialize),
+        ) {
+            return Some(effects);
         }
         None
     }
@@ -327,7 +338,7 @@ impl MainReactor {
         );
 
         let next_block_height = 0;
-        self.refresh_contract_runtime(
+        self.initialize_contract_runtime(
             next_block_height,
             post_state_hash,
             BlockHash::default(),
@@ -382,7 +393,7 @@ impl MainReactor {
                     );
 
                     let next_block_height = previous_block_header.height() + 1;
-                    self.refresh_contract_runtime(
+                    self.initialize_contract_runtime(
                         next_block_height,
                         post_state_hash,
                         previous_block_header.block_hash(),
@@ -452,27 +463,50 @@ impl MainReactor {
         rng: &mut NodeRng,
     ) -> (bool, Option<Effects<MainEvent>>) {
         // if on a switch block, check if we should go to Validate
-        if self.switch_block.is_some() {
-            match self.create_required_eras(effect_builder, rng) {
-                Err(msg) => {
-                    return (false, Some(fatal!(effect_builder, "{}", msg).ignore()));
-                }
-                Ok(Some(effects)) => {
-                    return (true, Some(effects));
-                }
-                Ok(None) => (),
+        match self.create_required_eras(effect_builder, rng) {
+            Err(msg) => {
+                return (false, Some(fatal!(effect_builder, "{}", msg).ignore()));
             }
+            Ok(Some(effects)) => {
+                return (true, Some(effects));
+            }
+            Ok(None) => (),
         }
         (false, None)
     }
 
-    pub(super) fn refresh_contract_runtime(
+    fn refresh_contract_runtime(&mut self) -> Result<(), String> {
+        match self.storage.read_highest_complete_block() {
+            Ok(Some(block)) => {
+                let block_height = block.height();
+                let state_root_hash = block.state_root_hash();
+                let block_hash = block.id();
+                let accumulated_seed = block.header().accumulated_seed();
+                self.initialize_contract_runtime(
+                    block_height + 1,
+                    *state_root_hash,
+                    block_hash,
+                    accumulated_seed,
+                )
+            }
+            Ok(None) => {
+                Ok(()) // noop
+            }
+            Err(error) => Err(format!("failed to read highest complete block: {}", error)),
+        }
+    }
+
+    fn initialize_contract_runtime(
         &mut self,
         next_block_height: u64,
         pre_state_root_hash: Digest,
         parent_hash: BlockHash,
         parent_seed: Digest,
     ) -> Result<(), String> {
+        // a better approach might be to have an announcement for immediate switch block
+        // creation, which the contract runtime handles and sets itself into
+        // the proper state to handle the unexpected block.
+        // in the meantime, this is expedient.
         let initial_pre_state = ExecutionPreState::new(
             next_block_height,
             pre_state_root_hash,

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -14,10 +14,11 @@ use crate::{
     },
     effect::{
         announcements::{
-            BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
-            ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
-            FatalAnnouncement, GossiperAnnouncement, PeerBehaviorAnnouncement,
-            RpcServerAnnouncement, UpgradeWatcherAnnouncement,
+            BlockAccumulatorAnnouncement, BlockSynchronizerAnnouncement, ConsensusAnnouncement,
+            ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
+            DeployBufferAnnouncement, FatalAnnouncement, GossiperAnnouncement,
+            PeerBehaviorAnnouncement, ReactorAnnouncement, RpcServerAnnouncement,
+            UpgradeWatcherAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
@@ -128,6 +129,8 @@ pub(crate) enum MainEvent {
     BlockSynchronizer(#[serde(skip_serializing)] block_synchronizer::Event),
     #[from]
     BlockSynchronizerRequest(#[serde(skip_serializing)] BlockSynchronizerRequest),
+    #[from]
+    BlockSynchronizerAnnouncement(#[serde(skip_serializing)] BlockSynchronizerAnnouncement),
 
     #[from]
     ApprovalsHashesFetcher(#[serde(skip_serializing)] fetcher::Event<ApprovalsHashes>),
@@ -216,6 +219,8 @@ pub(crate) enum MainEvent {
     StorageRequest(#[serde(skip_serializing)] StorageRequest),
     #[from]
     MainReactorRequest(#[serde(skip_serializing)] ReactorStatusRequest),
+    #[from]
+    MainReactorAnnouncement(#[serde(skip_serializing)] ReactorAnnouncement),
 }
 
 impl ReactorEvent for MainEvent {
@@ -316,12 +321,14 @@ impl ReactorEvent for MainEvent {
             MainEvent::BlockAccumulatorAnnouncement(_) => "BlockAccumulatorAnnouncement",
             MainEvent::BlockSynchronizer(_) => "BlockSynchronizer",
             MainEvent::BlockSynchronizerRequest(_) => "BlockSynchronizerRequest",
+            MainEvent::BlockSynchronizerAnnouncement(_) => "BlockSynchronizerAnnouncement",
             MainEvent::BlockGossiper(_) => "BlockGossiper",
             MainEvent::BlockGossiperIncoming(_) => "BlockGossiperIncoming",
             MainEvent::BlockGossiperAnnouncement(_) => "BlockGossiperAnnouncement",
             MainEvent::BlockFetcher(_) => "BlockFetcher",
             MainEvent::BlockFetcherRequest(_) => "BlockFetcherRequest",
             MainEvent::MainReactorRequest(_) => "MainReactorRequest",
+            MainEvent::MainReactorAnnouncement(_) => "MainReactorAnnouncement",
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
         }
     }
@@ -386,6 +393,9 @@ impl Display for MainEvent {
             }
             MainEvent::BlockSynchronizerRequest(req) => {
                 write!(f, "block synchronizer request: {}", req)
+            }
+            MainEvent::BlockSynchronizerAnnouncement(ann) => {
+                write!(f, "block synchronizer announcement: {}", ann)
             }
             MainEvent::DiagnosticsPort(event) => write!(f, "diagnostics port: {}", event),
             MainEvent::NetworkRequest(req) => write!(f, "network request: {}", req),
@@ -492,6 +502,7 @@ impl Display for MainEvent {
             MainEvent::BlockFetcher(inner) => Display::fmt(inner, f),
             MainEvent::BlockFetcherRequest(inner) => Display::fmt(inner, f),
             MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
+            MainEvent::MainReactorAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),
         }
     }

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -121,25 +121,11 @@ impl MainReactor {
 
     fn keep_up_idle(&mut self) -> Either<StartingWith, KeepUpInstruction> {
         match self.storage.read_highest_complete_block() {
-            Ok(Some(block)) => {
-                let block_height = block.height();
-                let state_root_hash = block.state_root_hash();
-                let block_hash = block.id();
-                let accumulated_seed = block.header().accumulated_seed();
-                match self.refresh_contract_runtime(
-                    block_height + 1,
-                    *state_root_hash,
-                    block_hash,
-                    accumulated_seed,
-                ) {
-                    Ok(_) => Either::Left(StartingWith::LocalTip(
-                        block.id(),
-                        block_height,
-                        block.header().era_id(),
-                    )),
-                    Err(msg) => Either::Right(KeepUpInstruction::Fatal(msg)),
-                }
-            }
+            Ok(Some(block)) => Either::Left(StartingWith::LocalTip(
+                block.id(),
+                block.height(),
+                block.header().era_id(),
+            )),
             Ok(None) => {
                 error!("KeepUp: block synchronizer idle, local storage has no complete blocks");
                 self.block_synchronizer.purge();

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -102,6 +102,7 @@ impl MainReactor {
         {
             return keep_up_instruction;
         }
+        // if there's no work to do to keep up, see if we should get a historical block
         self.sync_back_process(effect_builder, rng)
     }
 

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -91,10 +91,14 @@ impl MainReactor {
             return Ok(None);
         }
 
-        if !self
-            .deploy_buffer
-            .have_full_ttl_of_deploys(highest_switch_block_header.height())
-        {
+        // get local tip if we have it, otherwise
+        // highest switch block
+        let from_height = match self.block_accumulator.local_tip() {
+            Some(tip) => tip,
+            None => highest_switch_block_header.height(),
+        };
+
+        if !self.deploy_buffer.have_full_ttl_of_deploys(from_height) {
             info!("currently have insufficient deploy TTL awareness to safely participate in consensus");
             return Ok(None);
         }

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -59,19 +59,19 @@ impl MainReactor {
     ) -> Result<Option<Effects<MainEvent>>, String> {
         let highest_switch_block_header = match self.recent_switch_block_headers.last() {
             None => {
-                debug!("create_required_eras: recent_switch_block_headers is empty");
+                debug!("Validate: create_required_eras: recent_switch_block_headers is empty");
                 return Ok(None);
             }
             Some(header) => header,
         };
         debug!(
-            "highest_switch_block_header: {} - {}",
+            "Validate: highest_switch_block_header: {} - {}",
             highest_switch_block_header.era_id(),
             highest_switch_block_header.block_hash(),
         );
 
         if let Some(current_era) = self.consensus.current_era() {
-            debug!("consensus current_era: {}", current_era.value());
+            debug!("Validate: consensus current_era: {}", current_era.value());
             if highest_switch_block_header.next_block_era_id() <= current_era {
                 return Ok(Some(Effects::new()));
             }
@@ -80,32 +80,31 @@ impl MainReactor {
         let highest_era_weights = match highest_switch_block_header.next_era_validator_weights() {
             None => {
                 return Err(format!(
-                    "highest switch block has no era end: {}",
+                    "Validate: highest switch block has no era end: {}",
                     highest_switch_block_header
                 ));
             }
             Some(weights) => weights,
         };
         if !highest_era_weights.contains_key(self.consensus.public_key()) {
-            debug!("highest_era_weights does not contain signing_public_key");
+            debug!("Validate: highest_era_weights does not contain signing_public_key");
             return Ok(None);
         }
 
-        // get local tip if we have it, otherwise
-        // highest switch block
+        // use local tip if it is higher than highest switch block, otherwise highest switch block
         let from_height = match self.block_accumulator.local_tip() {
-            Some(tip) => tip,
+            Some(tip) => highest_switch_block_header.height().max(tip),
             None => highest_switch_block_header.height(),
         };
 
         if !self.deploy_buffer.have_full_ttl_of_deploys(from_height) {
-            info!("currently have insufficient deploy TTL awareness to safely participate in consensus");
+            info!("Validate: insufficient deploy TTL awareness to safely participate in consensus");
             return Ok(None);
         }
 
         let era_id = highest_switch_block_header.era_id();
         if self.upgrade_watcher.should_upgrade_after(era_id) {
-            debug!(%era_id, "upgrade required after given era");
+            debug!(%era_id, "Validate: upgrade required after given era");
             return Ok(None);
         }
 
@@ -114,10 +113,18 @@ impl MainReactor {
             rng,
             &self.recent_switch_block_headers,
         );
-        if create_required_eras.is_some() {
-            info!("will attempt to create required eras for consensus");
+        match &create_required_eras {
+            Some(effects) => {
+                if effects.is_empty() {
+                    info!("Validate: create_required_eras is empty");
+                } else {
+                    info!("Validate: will attempt to create required eras for consensus");
+                }
+            }
+            None => {
+                info!("Validate: create_required_eras is none");
+            }
         }
-
         Ok(
             create_required_eras
                 .map(|effects| reactor::wrap_effects(MainEvent::Consensus, effects)),


### PR DESCRIPTION
* allows a validator that restarts & immediately restarts to rapidly transition back to Validate mode
* however, still gets stuck (block execution enqueue glitch) if a block is missed in the interim
* a 2nd re-start will go to keep up, sync back corrects gap, and then can still switch back to validate and should work

Though there is still a glitch (as mentioned) this is pretty close and is a step forward from the current flow, so I'm throwing up to let the euro crowd whack at it a bit while I sleep