### PR TITLE
Preserve the order of fields when encoding to json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
+ "indexmap",
  "itoa 1.0.3",
  "ryu",
  "serde",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -39,7 +39,7 @@ rand_chacha = "0.3.0"
 schemars = { version = "=0.8.5", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11.5"
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.18"
 tracing = "0.1.18"
 uint = "0.9.0"

--- a/json_rpc/Cargo.toml
+++ b/json_rpc/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.21"
 http = "0.2.7"
 itertools = "0.10.3"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 tracing = "0.1.34"
 warp = "0.3.2"
 

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn should_construct_reserved_error() {
         const EXPECTED_WITH_DATA: &str =
-            r#"{"code":-32700,"message":"Parse error","data":{"context":"TEST","id":1314}}"#;
+            r#"{"code":-32700,"message":"Parse error","data":{"id":1314,"context":"TEST"}}"#;
         const EXPECTED_WITHOUT_DATA: &str = r#"{"code":-32601,"message":"Method not found"}"#;
         const EXPECTED_WITH_BAD_DATA: &str = r#"{"code":-32603,"message":"Internal error","data":"failed to json-encode additional info in json-rpc error: won't encode"}"#;
 
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn should_construct_custom_error() {
         const EXPECTED_WITH_DATA: &str =
-            r#"{"code":-123,"message":"Valid test error","data":{"context":"TEST","id":1314}}"#;
+            r#"{"code":-123,"message":"Valid test error","data":{"id":1314,"context":"TEST"}}"#;
         const EXPECTED_WITHOUT_DATA: &str = r#"{"code":-123,"message":"Valid test error"}"#;
         const EXPECTED_WITH_BAD_DATA: &str = r#"{"code":-32603,"message":"Internal error","data":"failed to json-encode additional info in json-rpc error: won't encode"}"#;
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -63,7 +63,7 @@ schemars = { version = "=0.8.5", features = ["preserve_order", "impl_json_schema
 serde = { version = "1", features = ["derive", "rc"] }
 serde-big-array = "0.3.0"
 serde_bytes = "0.11.5"
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_repr = "0.1.6"
 shlex = "1.0.0"
 signal-hook = "0.3.4"

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -140,18 +140,25 @@ impl<REv> ReactorEvent for REv where
 {
 }
 
+/// The status of syncing an individual block.
 #[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BlockSyncStatus {
+    /// The block hash.
     block_hash: BlockHash,
+    /// The height of the block, if known.
     block_height: Option<u64>,
+    /// The state of acquisition of the data associated with the block.
     acquisition_state: String,
 }
 
+/// The status of the block synchronizer.
 #[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BlockSynchronizerStatus {
+    /// The status of syncing a historical block, if any.
     historical: Option<BlockSyncStatus>,
+    /// The status of syncing a forward block, if any.
     forward: Option<BlockSyncStatus>,
 }
 
@@ -1021,7 +1028,7 @@ impl BlockSynchronizer {
         )
     }
 
-    pub fn status(&self) -> BlockSynchronizerStatus {
+    fn status(&self) -> BlockSynchronizerStatus {
         BlockSynchronizerStatus::new(
             self.historical.as_ref().map(|builder| BlockSyncStatus {
                 block_hash: builder.block_hash(),

--- a/node/src/reactor/main_reactor/reactor_state.rs
+++ b/node/src/reactor/main_reactor/reactor_state.rs
@@ -1,33 +1,23 @@
 use datasize::DataSize;
+use derive_more::Display;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
 
-#[derive(Copy, Clone, PartialEq, Eq, DataSize, Debug, Deserialize, JsonSchema, Serialize)]
+/// The state of the reactor.
+#[derive(
+    Copy, Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Display, JsonSchema,
+)]
 pub enum ReactorState {
-    // get all components and reactor state set up on start
+    /// Get all components and reactor state set up on start.
     Initialize,
-    // orient to the network and attempt to catch up to tip
+    /// Orient to the network and attempt to catch up to tip.
     CatchUp,
-    // running commit upgrade and creating immediate switch block
+    /// Running commit upgrade and creating immediate switch block.
     Upgrading,
-    // stay caught up with tip
+    /// Stay caught up with tip.
     KeepUp,
-    // node is currently caught up and is an active validator
+    /// Node is currently caught up and is an active validator.
     Validate,
-    // node should be shut down for upgrade
+    /// Node should be shut down for upgrade.
     ShutdownForUpgrade,
-}
-
-impl Display for ReactorState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReactorState::Initialize => write!(f, "Initialize"),
-            ReactorState::CatchUp => write!(f, "CatchUp"),
-            ReactorState::Upgrading => write!(f, "Upgrading"),
-            ReactorState::KeepUp => write!(f, "KeepUp"),
-            ReactorState::Validate => write!(f, "Validate"),
-            ReactorState::ShutdownForUpgrade => write!(f, "ShutdownForUpgrade"),
-        }
-    }
 }

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -256,6 +256,7 @@
       ]
     },
     "ReactorState": {
+      "description": "The state of the reactor.",
       "type": "string",
       "enum": [
         "Initialize",
@@ -290,9 +291,11 @@
       "additionalProperties": false
     },
     "BlockSynchronizerStatus": {
+      "description": "The status of the block synchronizer.",
       "type": "object",
       "properties": {
         "historical": {
+          "description": "The status of syncing a historical block, if any.",
           "anyOf": [
             {
               "$ref": "#/definitions/BlockSyncStatus"
@@ -303,6 +306,7 @@
           ]
         },
         "forward": {
+          "description": "The status of syncing a forward block, if any.",
           "anyOf": [
             {
               "$ref": "#/definitions/BlockSyncStatus"
@@ -316,6 +320,7 @@
       "additionalProperties": false
     },
     "BlockSyncStatus": {
+      "description": "The status of syncing an individual block.",
       "type": "object",
       "required": [
         "acquisition_state",
@@ -323,9 +328,15 @@
       ],
       "properties": {
         "block_hash": {
-          "$ref": "#/definitions/BlockHash"
+          "description": "The block hash.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BlockHash"
+            }
+          ]
         },
         "block_height": {
+          "description": "The height of the block, if known.",
           "type": [
             "integer",
             "null"
@@ -334,6 +345,7 @@
           "minimum": 0.0
         },
         "acquisition_state": {
+          "description": "The state of acquisition of the data associated with the block.",
           "type": "string"
         }
       },

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3,2973 +3,62 @@
   "title": "OpenRpcSchema",
   "examples": [
     {
-      "components": {
-        "schemas": {
-          "Account": {
-            "additionalProperties": false,
-            "description": "Structure representing a user's account, stored in global state.",
-            "properties": {
-              "account_hash": {
-                "$ref": "#/components/schemas/AccountHash"
-              },
-              "action_thresholds": {
-                "$ref": "#/components/schemas/ActionThresholds"
-              },
-              "associated_keys": {
-                "items": {
-                  "$ref": "#/components/schemas/AssociatedKey"
-                },
-                "type": "array"
-              },
-              "main_purse": {
-                "$ref": "#/components/schemas/URef"
-              },
-              "named_keys": {
-                "items": {
-                  "$ref": "#/components/schemas/NamedKey"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "account_hash",
-              "action_thresholds",
-              "associated_keys",
-              "main_purse",
-              "named_keys"
-            ],
-            "type": "object"
-          },
-          "AccountHash": {
-            "description": "Hex-encoded account hash.",
-            "type": "string"
-          },
-          "ActionThresholds": {
-            "additionalProperties": false,
-            "description": "Thresholds that have to be met when executing an action of a certain type.",
-            "properties": {
-              "deployment": {
-                "format": "uint8",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "key_management": {
-                "format": "uint8",
-                "minimum": 0.0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "deployment",
-              "key_management"
-            ],
-            "type": "object"
-          },
-          "ActivationPoint": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/EraId"
-              },
-              {
-                "$ref": "#/components/schemas/Timestamp"
-              }
-            ],
-            "description": "The first era to which the associated protocol version applies."
-          },
-          "Approval": {
-            "additionalProperties": false,
-            "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
-            "properties": {
-              "signature": {
-                "$ref": "#/components/schemas/Signature"
-              },
-              "signer": {
-                "$ref": "#/components/schemas/PublicKey"
-              }
-            },
-            "required": [
-              "signature",
-              "signer"
-            ],
-            "type": "object"
-          },
-          "AssociatedKey": {
-            "additionalProperties": false,
-            "properties": {
-              "account_hash": {
-                "$ref": "#/components/schemas/AccountHash"
-              },
-              "weight": {
-                "format": "uint8",
-                "minimum": 0.0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "account_hash",
-              "weight"
-            ],
-            "type": "object"
-          },
-          "AuctionState": {
-            "additionalProperties": false,
-            "description": "Data structure summarizing auction contract data.",
-            "properties": {
-              "bids": {
-                "description": "All bids contained within a vector.",
-                "items": {
-                  "$ref": "#/components/schemas/JsonBids"
-                },
-                "type": "array"
-              },
-              "block_height": {
-                "description": "Block height.",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "era_validators": {
-                "description": "Era validators.",
-                "items": {
-                  "$ref": "#/components/schemas/JsonEraValidators"
-                },
-                "type": "array"
-              },
-              "state_root_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                ],
-                "description": "Global state hash."
-              }
-            },
-            "required": [
-              "bids",
-              "block_height",
-              "era_validators",
-              "state_root_hash"
-            ],
-            "type": "object"
-          },
-          "AvailableBlockRange": {
-            "additionalProperties": false,
-            "description": "An unbroken, inclusive range of blocks.",
-            "properties": {
-              "high": {
-                "description": "The inclusive upper bound of the range.",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "low": {
-                "description": "The inclusive lower bound of the range.",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "high",
-              "low"
-            ],
-            "type": "object"
-          },
-          "Bid": {
-            "additionalProperties": false,
-            "description": "An entry in the validator map.",
-            "properties": {
-              "bonding_purse": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "The purse that was used for bonding."
-              },
-              "delegation_rate": {
-                "description": "Delegation rate",
-                "format": "uint8",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "delegators": {
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/Delegator"
-                },
-                "description": "This validator's delegators, indexed by their public keys",
-                "type": "object"
-              },
-              "inactive": {
-                "description": "`true` if validator has been \"evicted\"",
-                "type": "boolean"
-              },
-              "staked_amount": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "The amount of tokens staked by a validator (not including delegators)."
-              },
-              "validator_public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "Validator public key"
-              },
-              "vesting_schedule": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/VestingSchedule"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Vesting schedule for a genesis validator. `None` if non-genesis validator."
-              }
-            },
-            "required": [
-              "bonding_purse",
-              "delegation_rate",
-              "delegators",
-              "inactive",
-              "staked_amount",
-              "validator_public_key"
-            ],
-            "type": "object"
-          },
-          "BlockHash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Digest"
-              }
-            ],
-            "description": "A cryptographic hash identifying a [`Block`](struct.Block.html)."
-          },
-          "BlockIdentifier": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Identify and retrieve the block with its hash.",
-                "properties": {
-                  "Hash": {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                },
-                "required": [
-                  "Hash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Identify and retrieve the block with its height.",
-                "properties": {
-                  "Height": {
-                    "format": "uint64",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "Height"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Identifier for possible ways to retrieve a block."
-          },
-          "BlockSyncStatus": {
-            "additionalProperties": false,
-            "properties": {
-              "acquisition_state": {
-                "type": "string"
-              },
-              "block_hash": {
-                "$ref": "#/components/schemas/BlockHash"
-              },
-              "block_height": {
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "acquisition_state",
-              "block_hash"
-            ],
-            "type": "object"
-          },
-          "BlockSynchronizerStatus": {
-            "additionalProperties": false,
-            "properties": {
-              "forward": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockSyncStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "historical": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockSyncStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "CLType": {
-            "anyOf": [
-              {
-                "enum": [
-                  "Bool",
-                  "I32",
-                  "I64",
-                  "U8",
-                  "U32",
-                  "U64",
-                  "U128",
-                  "U256",
-                  "U512",
-                  "Unit",
-                  "String",
-                  "Key",
-                  "URef",
-                  "PublicKey",
-                  "Any"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "`Option` of a `CLType`.",
-                "properties": {
-                  "Option": {
-                    "$ref": "#/components/schemas/CLType"
-                  }
-                },
-                "required": [
-                  "Option"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Variable-length list of a single `CLType` (comparable to a `Vec`).",
-                "properties": {
-                  "List": {
-                    "$ref": "#/components/schemas/CLType"
-                  }
-                },
-                "required": [
-                  "List"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Fixed-length list of a single `CLType` (comparable to a Rust array).",
-                "properties": {
-                  "ByteArray": {
-                    "format": "uint32",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "ByteArray"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "`Result` with `Ok` and `Err` variants of `CLType`s.",
-                "properties": {
-                  "Result": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "err": {
-                        "$ref": "#/components/schemas/CLType"
-                      },
-                      "ok": {
-                        "$ref": "#/components/schemas/CLType"
-                      }
-                    },
-                    "required": [
-                      "err",
-                      "ok"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Result"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Map with keys of a single `CLType` and values of a single `CLType`.",
-                "properties": {
-                  "Map": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "key": {
-                        "$ref": "#/components/schemas/CLType"
-                      },
-                      "value": {
-                        "$ref": "#/components/schemas/CLType"
-                      }
-                    },
-                    "required": [
-                      "key",
-                      "value"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Map"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "1-ary tuple of a `CLType`.",
-                "properties": {
-                  "Tuple1": {
-                    "items": {
-                      "$ref": "#/components/schemas/CLType"
-                    },
-                    "maxItems": 1,
-                    "minItems": 1,
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Tuple1"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "2-ary tuple of `CLType`s.",
-                "properties": {
-                  "Tuple2": {
-                    "items": {
-                      "$ref": "#/components/schemas/CLType"
-                    },
-                    "maxItems": 2,
-                    "minItems": 2,
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Tuple2"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "3-ary tuple of `CLType`s.",
-                "properties": {
-                  "Tuple3": {
-                    "items": {
-                      "$ref": "#/components/schemas/CLType"
-                    },
-                    "maxItems": 3,
-                    "minItems": 3,
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Tuple3"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue)."
-          },
-          "CLValue": {
-            "additionalProperties": false,
-            "description": "A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
-            "properties": {
-              "bytes": {
-                "type": "string"
-              },
-              "cl_type": {
-                "$ref": "#/components/schemas/CLType"
-              },
-              "parsed": true
-            },
-            "required": [
-              "bytes",
-              "cl_type"
-            ],
-            "type": "object"
-          },
-          "ChainspecRawBytes": {
-            "description": "The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.",
-            "properties": {
-              "chainspec_bytes": {
-                "description": "Hex-encoded raw bytes of the current chainspec.toml file.",
-                "type": "string"
-              },
-              "maybe_genesis_accounts_bytes": {
-                "description": "Hex-encoded raw bytes of the current genesis accounts.toml file.",
-                "type": "string"
-              },
-              "maybe_global_state_bytes": {
-                "description": "Hex-encoded raw bytes of the current global_state.toml file.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "chainspec_bytes",
-              "maybe_genesis_accounts_bytes",
-              "maybe_global_state_bytes"
-            ],
-            "type": "object"
-          },
-          "Contract": {
-            "additionalProperties": false,
-            "description": "A contract struct that can be serialized as  JSON object.",
-            "properties": {
-              "contract_package_hash": {
-                "$ref": "#/components/schemas/ContractPackageHash"
-              },
-              "contract_wasm_hash": {
-                "$ref": "#/components/schemas/ContractWasmHash"
-              },
-              "entry_points": {
-                "items": {
-                  "$ref": "#/components/schemas/EntryPoint"
-                },
-                "type": "array"
-              },
-              "named_keys": {
-                "items": {
-                  "$ref": "#/components/schemas/NamedKey"
-                },
-                "type": "array"
-              },
-              "protocol_version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contract_package_hash",
-              "contract_wasm_hash",
-              "entry_points",
-              "named_keys",
-              "protocol_version"
-            ],
-            "type": "object"
-          },
-          "ContractHash": {
-            "description": "The hash address of the contract",
-            "type": "string"
-          },
-          "ContractPackage": {
-            "additionalProperties": false,
-            "description": "Contract definition, metadata, and security container.",
-            "properties": {
-              "access_key": {
-                "$ref": "#/components/schemas/URef"
-              },
-              "disabled_versions": {
-                "items": {
-                  "$ref": "#/components/schemas/DisabledVersion"
-                },
-                "type": "array"
-              },
-              "groups": {
-                "items": {
-                  "$ref": "#/components/schemas/Groups"
-                },
-                "type": "array"
-              },
-              "versions": {
-                "items": {
-                  "$ref": "#/components/schemas/ContractVersion"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "access_key",
-              "disabled_versions",
-              "groups",
-              "versions"
-            ],
-            "type": "object"
-          },
-          "ContractPackageHash": {
-            "description": "The hash address of the contract package",
-            "type": "string"
-          },
-          "ContractVersion": {
-            "properties": {
-              "contract_hash": {
-                "$ref": "#/components/schemas/ContractHash"
-              },
-              "contract_version": {
-                "format": "uint32",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "protocol_version_major": {
-                "format": "uint32",
-                "minimum": 0.0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "contract_hash",
-              "contract_version",
-              "protocol_version_major"
-            ],
-            "type": "object"
-          },
-          "ContractWasmHash": {
-            "description": "The hash address of the contract wasm",
-            "type": "string"
-          },
-          "Delegator": {
-            "additionalProperties": false,
-            "description": "Represents a party delegating their stake to a validator (or \"delegatee\")",
-            "properties": {
-              "bonding_purse": {
-                "$ref": "#/components/schemas/URef"
-              },
-              "delegator_public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "staked_amount": {
-                "$ref": "#/components/schemas/U512"
-              },
-              "validator_public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "vesting_schedule": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/VestingSchedule"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "bonding_purse",
-              "delegator_public_key",
-              "staked_amount",
-              "validator_public_key"
-            ],
-            "type": "object"
-          },
-          "Deploy": {
-            "additionalProperties": false,
-            "description": "A deploy; an item containing a smart contract along with the requester's signature(s).",
-            "properties": {
-              "approvals": {
-                "items": {
-                  "$ref": "#/components/schemas/Approval"
-                },
-                "type": "array",
-                "uniqueItems": true
-              },
-              "hash": {
-                "$ref": "#/components/schemas/DeployHash"
-              },
-              "header": {
-                "$ref": "#/components/schemas/DeployHeader"
-              },
-              "payment": {
-                "$ref": "#/components/schemas/ExecutableDeployItem"
-              },
-              "session": {
-                "$ref": "#/components/schemas/ExecutableDeployItem"
-              }
-            },
-            "required": [
-              "approvals",
-              "hash",
-              "header",
-              "payment",
-              "session"
-            ],
-            "type": "object"
-          },
-          "DeployHash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Digest"
-              }
-            ],
-            "description": "Hex-encoded deploy hash."
-          },
-          "DeployHeader": {
-            "additionalProperties": false,
-            "description": "The header portion of a [`Deploy`].",
-            "properties": {
-              "account": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "body_hash": {
-                "$ref": "#/components/schemas/Digest"
-              },
-              "chain_name": {
-                "type": "string"
-              },
-              "dependencies": {
-                "items": {
-                  "$ref": "#/components/schemas/DeployHash"
-                },
-                "type": "array"
-              },
-              "gas_price": {
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "timestamp": {
-                "$ref": "#/components/schemas/Timestamp"
-              },
-              "ttl": {
-                "$ref": "#/components/schemas/TimeDiff"
-              }
-            },
-            "required": [
-              "account",
-              "body_hash",
-              "chain_name",
-              "dependencies",
-              "gas_price",
-              "timestamp",
-              "ttl"
-            ],
-            "type": "object"
-          },
-          "DeployInfo": {
-            "additionalProperties": false,
-            "description": "Information relating to the given Deploy.",
-            "properties": {
-              "deploy_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/DeployHash"
-                  }
-                ],
-                "description": "The relevant Deploy."
-              },
-              "from": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/AccountHash"
-                  }
-                ],
-                "description": "Account identifier of the creator of the Deploy."
-              },
-              "gas": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "Gas cost of executing the Deploy."
-              },
-              "source": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "Source purse used for payment of the Deploy."
-              },
-              "transfers": {
-                "description": "Transfers performed by the Deploy.",
-                "items": {
-                  "$ref": "#/components/schemas/TransferAddr"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "deploy_hash",
-              "from",
-              "gas",
-              "source",
-              "transfers"
-            ],
-            "type": "object"
-          },
-          "DictionaryIdentifier": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Lookup a dictionary item via an Account's named keys.",
-                "properties": {
-                  "AccountNamedKey": {
-                    "properties": {
-                      "dictionary_item_key": {
-                        "description": "The dictionary item key formatted as a string.",
-                        "type": "string"
-                      },
-                      "dictionary_name": {
-                        "description": "The named key under which the dictionary seed URef is stored.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "The account key as a formatted string whose named keys contains dictionary_name.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "dictionary_item_key",
-                      "dictionary_name",
-                      "key"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "AccountNamedKey"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Lookup a dictionary item via a Contract's named keys.",
-                "properties": {
-                  "ContractNamedKey": {
-                    "properties": {
-                      "dictionary_item_key": {
-                        "description": "The dictionary item key formatted as a string.",
-                        "type": "string"
-                      },
-                      "dictionary_name": {
-                        "description": "The named key under which the dictionary seed URef is stored.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "The contract key as a formatted string whose named keys contains dictionary_name.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "dictionary_item_key",
-                      "dictionary_name",
-                      "key"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "ContractNamedKey"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Lookup a dictionary item via its seed URef.",
-                "properties": {
-                  "URef": {
-                    "properties": {
-                      "dictionary_item_key": {
-                        "description": "The dictionary item key formatted as a string.",
-                        "type": "string"
-                      },
-                      "seed_uref": {
-                        "description": "The dictionary's seed URef.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "dictionary_item_key",
-                      "seed_uref"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "URef"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Lookup a dictionary item via its unique key.",
-                "properties": {
-                  "Dictionary": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "Dictionary"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Options for dictionary item lookups."
-          },
-          "Digest": {
-            "description": "Hex-encoded hash digest.",
-            "type": "string"
-          },
-          "DisabledVersion": {
-            "properties": {
-              "contract_version": {
-                "format": "uint32",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "protocol_version_major": {
-                "format": "uint32",
-                "minimum": 0.0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "contract_version",
-              "protocol_version_major"
-            ],
-            "type": "object"
-          },
-          "EntryPoint": {
-            "description": "Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
-            "properties": {
-              "access": {
-                "$ref": "#/components/schemas/EntryPointAccess"
-              },
-              "args": {
-                "items": {
-                  "$ref": "#/components/schemas/Parameter"
-                },
-                "type": "array"
-              },
-              "entry_point_type": {
-                "$ref": "#/components/schemas/EntryPointType"
-              },
-              "name": {
-                "type": "string"
-              },
-              "ret": {
-                "$ref": "#/components/schemas/CLType"
-              }
-            },
-            "required": [
-              "access",
-              "args",
-              "entry_point_type",
-              "name",
-              "ret"
-            ],
-            "type": "object"
-          },
-          "EntryPointAccess": {
-            "anyOf": [
-              {
-                "enum": [
-                  "Public"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
-                "properties": {
-                  "Groups": {
-                    "items": {
-                      "$ref": "#/components/schemas/Group"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Groups"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Enum describing the possible access control options for a contract entry point (method)."
-          },
-          "EntryPointType": {
-            "description": "Context of method execution",
-            "enum": [
-              "Session",
-              "Contract"
-            ],
-            "type": "string"
-          },
-          "EraId": {
-            "description": "Era ID newtype.",
-            "format": "uint64",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "EraInfo": {
-            "additionalProperties": false,
-            "description": "Auction metadata.  Intended to be recorded at each era.",
-            "properties": {
-              "seigniorage_allocations": {
-                "items": {
-                  "$ref": "#/components/schemas/SeigniorageAllocation"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "seigniorage_allocations"
-            ],
-            "type": "object"
-          },
-          "EraSummary": {
-            "additionalProperties": false,
-            "description": "The summary of an era",
-            "properties": {
-              "block_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                ],
-                "description": "The block hash"
-              },
-              "era_id": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ],
-                "description": "The era id"
-              },
-              "merkle_proof": {
-                "description": "The Merkle proof",
-                "type": "string"
-              },
-              "state_root_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                ],
-                "description": "Hex-encoded hash of the state root"
-              },
-              "stored_value": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/StoredValue"
-                  }
-                ],
-                "description": "The StoredValue containing era information"
-              }
-            },
-            "required": [
-              "block_hash",
-              "era_id",
-              "merkle_proof",
-              "state_root_hash",
-              "stored_value"
-            ],
-            "type": "object"
-          },
-          "ExecutableDeployItem": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Executable specified as raw bytes that represent WASM code and an instance of [`RuntimeArgs`].",
-                "properties": {
-                  "ModuleBytes": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      },
-                      "module_bytes": {
-                        "description": "Hex-encoded raw Wasm bytes.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "args",
-                      "module_bytes"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "ModuleBytes"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Stored contract referenced by its [`ContractHash`], entry point and an instance of [`RuntimeArgs`].",
-                "properties": {
-                  "StoredContractByHash": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      },
-                      "entry_point": {
-                        "description": "Name of an entry point.",
-                        "type": "string"
-                      },
-                      "hash": {
-                        "description": "Hex-encoded hash.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "args",
-                      "entry_point",
-                      "hash"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "StoredContractByHash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Stored contract referenced by a named key existing in the signer's account context, entry point and an instance of [`RuntimeArgs`].",
-                "properties": {
-                  "StoredContractByName": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      },
-                      "entry_point": {
-                        "description": "Name of an entry point.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Named key.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "args",
-                      "entry_point",
-                      "name"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "StoredContractByName"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Stored versioned contract referenced by its [`ContractPackageHash`], entry point and an instance of [`RuntimeArgs`].",
-                "properties": {
-                  "StoredVersionedContractByHash": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      },
-                      "entry_point": {
-                        "description": "Entry point name.",
-                        "type": "string"
-                      },
-                      "hash": {
-                        "description": "Hex-encoded hash.",
-                        "type": "string"
-                      },
-                      "version": {
-                        "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
-                        "format": "uint32",
-                        "minimum": 0.0,
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "args",
-                      "entry_point",
-                      "hash"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "StoredVersionedContractByHash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Stored versioned contract referenced by a named key existing in the signer's account context, entry point and an instance of [`RuntimeArgs`].",
-                "properties": {
-                  "StoredVersionedContractByName": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      },
-                      "entry_point": {
-                        "description": "Entry point name.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Named key.",
-                        "type": "string"
-                      },
-                      "version": {
-                        "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
-                        "format": "uint32",
-                        "minimum": 0.0,
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "args",
-                      "entry_point",
-                      "name"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "StoredVersionedContractByName"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A native transfer which does not contain or reference a WASM code.",
-                "properties": {
-                  "Transfer": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/RuntimeArgs"
-                          }
-                        ],
-                        "description": "Runtime arguments."
-                      }
-                    },
-                    "required": [
-                      "args"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Transfer"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Represents possible variants of an executable deploy."
-          },
-          "ExecutionEffect": {
-            "additionalProperties": false,
-            "description": "The journal of execution transforms from a single deploy.",
-            "properties": {
-              "operations": {
-                "description": "The resulting operations.",
-                "items": {
-                  "$ref": "#/components/schemas/Operation"
-                },
-                "type": "array"
-              },
-              "transforms": {
-                "description": "The journal of execution transforms.",
-                "items": {
-                  "$ref": "#/components/schemas/TransformEntry"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "operations",
-              "transforms"
-            ],
-            "type": "object"
-          },
-          "ExecutionResult": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "The result of a failed execution.",
-                "properties": {
-                  "Failure": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "cost": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/U512"
-                          }
-                        ],
-                        "description": "The cost of executing the deploy."
-                      },
-                      "effect": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ExecutionEffect"
-                          }
-                        ],
-                        "description": "The effect of executing the deploy."
-                      },
-                      "error_message": {
-                        "description": "The error message associated with executing the deploy.",
-                        "type": "string"
-                      },
-                      "transfers": {
-                        "description": "A record of Transfers performed while executing the deploy.",
-                        "items": {
-                          "$ref": "#/components/schemas/TransferAddr"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "required": [
-                      "cost",
-                      "effect",
-                      "error_message",
-                      "transfers"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Failure"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "The result of a successful execution.",
-                "properties": {
-                  "Success": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "cost": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/U512"
-                          }
-                        ],
-                        "description": "The cost of executing the deploy."
-                      },
-                      "effect": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ExecutionEffect"
-                          }
-                        ],
-                        "description": "The effect of executing the deploy."
-                      },
-                      "transfers": {
-                        "description": "A record of Transfers performed while executing the deploy.",
-                        "items": {
-                          "$ref": "#/components/schemas/TransferAddr"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "required": [
-                      "cost",
-                      "effect",
-                      "transfers"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Success"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The result of executing a single deploy."
-          },
-          "GlobalStateIdentifier": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Query using a block hash.",
-                "properties": {
-                  "BlockHash": {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                },
-                "required": [
-                  "BlockHash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Query using a block height.",
-                "properties": {
-                  "BlockHeight": {
-                    "format": "uint64",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "BlockHeight"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Query using the state root hash.",
-                "properties": {
-                  "StateRootHash": {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                },
-                "required": [
-                  "StateRootHash"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Identifier for possible ways to query Global State"
-          },
-          "Group": {
-            "description": "A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
-            "type": "string"
-          },
-          "Groups": {
-            "properties": {
-              "group": {
-                "type": "string"
-              },
-              "keys": {
-                "items": {
-                  "$ref": "#/components/schemas/URef"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "group",
-              "keys"
-            ],
-            "type": "object"
-          },
-          "JsonBid": {
-            "additionalProperties": false,
-            "description": "An entry in a founding validator map representing a bid.",
-            "properties": {
-              "bonding_purse": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "The purse that was used for bonding."
-              },
-              "delegation_rate": {
-                "description": "The delegation rate.",
-                "format": "uint8",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "delegators": {
-                "description": "The delegators.",
-                "items": {
-                  "$ref": "#/components/schemas/JsonDelegator"
-                },
-                "type": "array"
-              },
-              "inactive": {
-                "description": "Is this an inactive validator.",
-                "type": "boolean"
-              },
-              "staked_amount": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "The amount of tokens staked by a validator (not including delegators)."
-              }
-            },
-            "required": [
-              "bonding_purse",
-              "delegation_rate",
-              "delegators",
-              "inactive",
-              "staked_amount"
-            ],
-            "type": "object"
-          },
-          "JsonBids": {
-            "additionalProperties": false,
-            "description": "A Json representation of a single bid.",
-            "properties": {
-              "bid": {
-                "$ref": "#/components/schemas/JsonBid"
-              },
-              "public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              }
-            },
-            "required": [
-              "bid",
-              "public_key"
-            ],
-            "type": "object"
-          },
-          "JsonBlock": {
-            "additionalProperties": false,
-            "description": "A JSON-friendly representation of `Block`.",
-            "properties": {
-              "body": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/JsonBlockBody"
-                  }
-                ],
-                "description": "JSON-friendly block body."
-              },
-              "hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                ],
-                "description": "`BlockHash`"
-              },
-              "header": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/JsonBlockHeader"
-                  }
-                ],
-                "description": "JSON-friendly block header."
-              },
-              "proofs": {
-                "description": "JSON-friendly list of proofs for this block.",
-                "items": {
-                  "$ref": "#/components/schemas/JsonProof"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "body",
-              "hash",
-              "header",
-              "proofs"
-            ],
-            "type": "object"
-          },
-          "JsonBlockBody": {
-            "additionalProperties": false,
-            "description": "A JSON-friendly representation of `Body`",
-            "properties": {
-              "deploy_hashes": {
-                "items": {
-                  "$ref": "#/components/schemas/DeployHash"
-                },
-                "type": "array"
-              },
-              "proposer": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "transfer_hashes": {
-                "items": {
-                  "$ref": "#/components/schemas/DeployHash"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "deploy_hashes",
-              "proposer",
-              "transfer_hashes"
-            ],
-            "type": "object"
-          },
-          "JsonBlockHeader": {
-            "additionalProperties": false,
-            "description": "JSON representation of a block header.",
-            "properties": {
-              "accumulated_seed": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                ],
-                "description": "Accumulated seed."
-              },
-              "body_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                ],
-                "description": "The body hash."
-              },
-              "era_end": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/JsonEraEnd"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The era end."
-              },
-              "era_id": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ],
-                "description": "The block era id."
-              },
-              "height": {
-                "description": "The block height.",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "parent_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                ],
-                "description": "The parent hash."
-              },
-              "protocol_version": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ProtocolVersion"
-                  }
-                ],
-                "description": "The protocol version."
-              },
-              "random_bit": {
-                "description": "Randomness bit.",
-                "type": "boolean"
-              },
-              "state_root_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Digest"
-                  }
-                ],
-                "description": "The state root hash."
-              },
-              "timestamp": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Timestamp"
-                  }
-                ],
-                "description": "The block timestamp."
-              }
-            },
-            "required": [
-              "accumulated_seed",
-              "body_hash",
-              "era_id",
-              "height",
-              "parent_hash",
-              "protocol_version",
-              "random_bit",
-              "state_root_hash",
-              "timestamp"
-            ],
-            "type": "object"
-          },
-          "JsonDelegator": {
-            "additionalProperties": false,
-            "description": "A delegator associated with the given validator.",
-            "properties": {
-              "bonding_purse": {
-                "$ref": "#/components/schemas/URef"
-              },
-              "delegatee": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "staked_amount": {
-                "$ref": "#/components/schemas/U512"
-              }
-            },
-            "required": [
-              "bonding_purse",
-              "delegatee",
-              "public_key",
-              "staked_amount"
-            ],
-            "type": "object"
-          },
-          "JsonEraEnd": {
-            "additionalProperties": false,
-            "properties": {
-              "era_report": {
-                "$ref": "#/components/schemas/JsonEraReport"
-              },
-              "next_era_validator_weights": {
-                "items": {
-                  "$ref": "#/components/schemas/ValidatorWeight"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "era_report",
-              "next_era_validator_weights"
-            ],
-            "type": "object"
-          },
-          "JsonEraReport": {
-            "additionalProperties": false,
-            "description": "Equivocation and reward information to be included in the terminal block.",
-            "properties": {
-              "equivocators": {
-                "items": {
-                  "$ref": "#/components/schemas/PublicKey"
-                },
-                "type": "array"
-              },
-              "inactive_validators": {
-                "items": {
-                  "$ref": "#/components/schemas/PublicKey"
-                },
-                "type": "array"
-              },
-              "rewards": {
-                "items": {
-                  "$ref": "#/components/schemas/Reward"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "equivocators",
-              "inactive_validators",
-              "rewards"
-            ],
-            "type": "object"
-          },
-          "JsonEraValidators": {
-            "additionalProperties": false,
-            "description": "The validators for the given era.",
-            "properties": {
-              "era_id": {
-                "$ref": "#/components/schemas/EraId"
-              },
-              "validator_weights": {
-                "items": {
-                  "$ref": "#/components/schemas/JsonValidatorWeights"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "era_id",
-              "validator_weights"
-            ],
-            "type": "object"
-          },
-          "JsonExecutionResult": {
-            "additionalProperties": false,
-            "description": "The execution result of a single deploy.",
-            "properties": {
-              "block_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BlockHash"
-                  }
-                ],
-                "description": "The block hash."
-              },
-              "result": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExecutionResult"
-                  }
-                ],
-                "description": "Execution result."
-              }
-            },
-            "required": [
-              "block_hash",
-              "result"
-            ],
-            "type": "object"
-          },
-          "JsonProof": {
-            "additionalProperties": false,
-            "description": "A JSON-friendly representation of a proof, i.e. a block's finality signature.",
-            "properties": {
-              "public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "signature": {
-                "$ref": "#/components/schemas/Signature"
-              }
-            },
-            "required": [
-              "public_key",
-              "signature"
-            ],
-            "type": "object"
-          },
-          "JsonValidatorChanges": {
-            "additionalProperties": false,
-            "description": "The changes in a validator's status.",
-            "properties": {
-              "public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "The public key of the validator."
-              },
-              "status_changes": {
-                "description": "The set of changes to the validator's status.",
-                "items": {
-                  "$ref": "#/components/schemas/JsonValidatorStatusChange"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "public_key",
-              "status_changes"
-            ],
-            "type": "object"
-          },
-          "JsonValidatorStatusChange": {
-            "additionalProperties": false,
-            "description": "A single change to a validator's status in the given era.",
-            "properties": {
-              "era_id": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ],
-                "description": "The era in which the change occurred."
-              },
-              "validator_change": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ValidatorChange"
-                  }
-                ],
-                "description": "The change in validator status."
-              }
-            },
-            "required": [
-              "era_id",
-              "validator_change"
-            ],
-            "type": "object"
-          },
-          "JsonValidatorWeights": {
-            "additionalProperties": false,
-            "description": "A validator's weight.",
-            "properties": {
-              "public_key": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "weight": {
-                "$ref": "#/components/schemas/U512"
-              }
-            },
-            "required": [
-              "public_key",
-              "weight"
-            ],
-            "type": "object"
-          },
-          "MinimalBlockInfo": {
-            "additionalProperties": false,
-            "description": "Minimal info of a `Block`.",
-            "properties": {
-              "creator": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "era_id": {
-                "$ref": "#/components/schemas/EraId"
-              },
-              "hash": {
-                "$ref": "#/components/schemas/BlockHash"
-              },
-              "height": {
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "state_root_hash": {
-                "$ref": "#/components/schemas/Digest"
-              },
-              "timestamp": {
-                "$ref": "#/components/schemas/Timestamp"
-              }
-            },
-            "required": [
-              "creator",
-              "era_id",
-              "hash",
-              "height",
-              "state_root_hash",
-              "timestamp"
-            ],
-            "type": "object"
-          },
-          "NamedArg": {
-            "description": "Named arguments to a contract.",
-            "items": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/CLValue"
-              }
-            ],
-            "maxItems": 2,
-            "minItems": 2,
-            "type": "array"
-          },
-          "NamedKey": {
-            "additionalProperties": false,
-            "description": "A named key.",
-            "properties": {
-              "key": {
-                "description": "The value of the entry: a casper `Key` type.",
-                "type": "string"
-              },
-              "name": {
-                "description": "The name of the entry.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "key",
-              "name"
-            ],
-            "type": "object"
-          },
-          "NextUpgrade": {
-            "description": "Information about the next protocol upgrade.",
-            "properties": {
-              "activation_point": {
-                "$ref": "#/components/schemas/ActivationPoint"
-              },
-              "protocol_version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "activation_point",
-              "protocol_version"
-            ],
-            "type": "object"
-          },
-          "OpKind": {
-            "description": "The type of operation performed while executing a deploy.",
-            "enum": [
-              "Read",
-              "Write",
-              "Add",
-              "NoOp"
-            ],
-            "type": "string"
-          },
-          "Operation": {
-            "additionalProperties": false,
-            "description": "An operation performed while executing a deploy.",
-            "properties": {
-              "key": {
-                "description": "The formatted string of the `Key`.",
-                "type": "string"
-              },
-              "kind": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/OpKind"
-                  }
-                ],
-                "description": "The type of operation."
-              }
-            },
-            "required": [
-              "key",
-              "kind"
-            ],
-            "type": "object"
-          },
-          "Parameter": {
-            "description": "Parameter to a method",
-            "properties": {
-              "cl_type": {
-                "$ref": "#/components/schemas/CLType"
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "cl_type",
-              "name"
-            ],
-            "type": "object"
-          },
-          "PeerEntry": {
-            "additionalProperties": false,
-            "description": "Node peer entry.",
-            "properties": {
-              "address": {
-                "description": "Node address.",
-                "type": "string"
-              },
-              "node_id": {
-                "description": "Node id.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "address",
-              "node_id"
-            ],
-            "type": "object"
-          },
-          "PeersMap": {
-            "description": "Map of peer IDs to network addresses.",
-            "items": {
-              "$ref": "#/components/schemas/PeerEntry"
-            },
-            "type": "array"
-          },
-          "ProtocolVersion": {
-            "description": "Casper Platform protocol version",
-            "type": "string"
-          },
-          "PublicKey": {
-            "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
-            "type": "string"
-          },
-          "PurseIdentifier": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "The main purse of the account identified by this public key.",
-                "properties": {
-                  "main_purse_under_public_key": {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                },
-                "required": [
-                  "main_purse_under_public_key"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "The main purse of the account identified by this account hash.",
-                "properties": {
-                  "main_purse_under_account_hash": {
-                    "$ref": "#/components/schemas/AccountHash"
-                  }
-                },
-                "required": [
-                  "main_purse_under_account_hash"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "The purse identified by this URef.",
-                "properties": {
-                  "purse_uref": {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                },
-                "required": [
-                  "purse_uref"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Identifier of a purse."
-          },
-          "ReactorState": {
-            "enum": [
-              "Initialize",
-              "CatchUp",
-              "Upgrading",
-              "KeepUp",
-              "Validate",
-              "ShutdownForUpgrade"
-            ],
-            "type": "string"
-          },
-          "Reward": {
-            "additionalProperties": false,
-            "properties": {
-              "amount": {
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "validator": {
-                "$ref": "#/components/schemas/PublicKey"
-              }
-            },
-            "required": [
-              "amount",
-              "validator"
-            ],
-            "type": "object"
-          },
-          "RuntimeArgs": {
-            "description": "Represents a collection of arguments passed to a smart contract.",
-            "items": {
-              "$ref": "#/components/schemas/NamedArg"
-            },
-            "type": "array"
-          },
-          "SeigniorageAllocation": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "Info about a seigniorage allocation for a validator",
-                "properties": {
-                  "Validator": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "amount": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/U512"
-                          }
-                        ],
-                        "description": "Allocated amount"
-                      },
-                      "validator_public_key": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/PublicKey"
-                          }
-                        ],
-                        "description": "Validator's public key"
-                      }
-                    },
-                    "required": [
-                      "amount",
-                      "validator_public_key"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Validator"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Info about a seigniorage allocation for a delegator",
-                "properties": {
-                  "Delegator": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "amount": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/U512"
-                          }
-                        ],
-                        "description": "Allocated amount"
-                      },
-                      "delegator_public_key": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/PublicKey"
-                          }
-                        ],
-                        "description": "Delegator's public key"
-                      },
-                      "validator_public_key": {
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/PublicKey"
-                          }
-                        ],
-                        "description": "Validator's public key"
-                      }
-                    },
-                    "required": [
-                      "amount",
-                      "delegator_public_key",
-                      "validator_public_key"
-                    ],
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "Delegator"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Information about a seigniorage allocation"
-          },
-          "Signature": {
-            "description": "Hex-encoded cryptographic signature, including the algorithm tag prefix.",
-            "type": "string"
-          },
-          "StoredValue": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "description": "A CasperLabs value.",
-                "properties": {
-                  "CLValue": {
-                    "$ref": "#/components/schemas/CLValue"
-                  }
-                },
-                "required": [
-                  "CLValue"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "An account.",
-                "properties": {
-                  "Account": {
-                    "$ref": "#/components/schemas/Account"
-                  }
-                },
-                "required": [
-                  "Account"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A contract's Wasm",
-                "properties": {
-                  "ContractWasm": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "ContractWasm"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Methods and type signatures supported by a contract.",
-                "properties": {
-                  "Contract": {
-                    "$ref": "#/components/schemas/Contract"
-                  }
-                },
-                "required": [
-                  "Contract"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A contract definition, metadata, and security container.",
-                "properties": {
-                  "ContractPackage": {
-                    "$ref": "#/components/schemas/ContractPackage"
-                  }
-                },
-                "required": [
-                  "ContractPackage"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A record of a transfer",
-                "properties": {
-                  "Transfer": {
-                    "$ref": "#/components/schemas/Transfer"
-                  }
-                },
-                "required": [
-                  "Transfer"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A record of a deploy",
-                "properties": {
-                  "DeployInfo": {
-                    "$ref": "#/components/schemas/DeployInfo"
-                  }
-                },
-                "required": [
-                  "DeployInfo"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Auction metadata",
-                "properties": {
-                  "EraInfo": {
-                    "$ref": "#/components/schemas/EraInfo"
-                  }
-                },
-                "required": [
-                  "EraInfo"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A bid",
-                "properties": {
-                  "Bid": {
-                    "$ref": "#/components/schemas/Bid"
-                  }
-                },
-                "required": [
-                  "Bid"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A withdraw",
-                "properties": {
-                  "Withdraw": {
-                    "items": {
-                      "$ref": "#/components/schemas/WithdrawPurse"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Withdraw"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A collection of unbonding purses",
-                "properties": {
-                  "Unbonding": {
-                    "items": {
-                      "$ref": "#/components/schemas/UnbondingPurse"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "Unbonding"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
-          },
-          "TimeDiff": {
-            "description": "Human-readable duration.",
-            "format": "uint64",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "Timestamp": {
-            "description": "Timestamp formatted as per RFC 3339",
-            "format": "uint64",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "Transfer": {
-            "additionalProperties": false,
-            "description": "Represents a transfer from one purse to another",
-            "properties": {
-              "amount": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "Transfer amount"
-              },
-              "deploy_hash": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/DeployHash"
-                  }
-                ],
-                "description": "Deploy that created the transfer"
-              },
-              "from": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/AccountHash"
-                  }
-                ],
-                "description": "Account from which transfer was executed"
-              },
-              "gas": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "Gas"
-              },
-              "id": {
-                "description": "User-defined id",
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "source": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "Source purse"
-              },
-              "target": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "Target purse"
-              },
-              "to": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/AccountHash"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Account to which funds are transferred"
-              }
-            },
-            "required": [
-              "amount",
-              "deploy_hash",
-              "from",
-              "gas",
-              "source",
-              "target"
-            ],
-            "type": "object"
-          },
-          "TransferAddr": {
-            "description": "Hex-encoded transfer address.",
-            "type": "string"
-          },
-          "Transform": {
-            "anyOf": [
-              {
-                "enum": [
-                  "Identity",
-                  "WriteContractWasm",
-                  "WriteContract",
-                  "WriteContractPackage"
-                ],
-                "type": "string"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given CLValue to global state.",
-                "properties": {
-                  "WriteCLValue": {
-                    "$ref": "#/components/schemas/CLValue"
-                  }
-                },
-                "required": [
-                  "WriteCLValue"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given Account to global state.",
-                "properties": {
-                  "WriteAccount": {
-                    "$ref": "#/components/schemas/AccountHash"
-                  }
-                },
-                "required": [
-                  "WriteAccount"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given DeployInfo to global state.",
-                "properties": {
-                  "WriteDeployInfo": {
-                    "$ref": "#/components/schemas/DeployInfo"
-                  }
-                },
-                "required": [
-                  "WriteDeployInfo"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given EraInfo to global state.",
-                "properties": {
-                  "WriteEraInfo": {
-                    "$ref": "#/components/schemas/EraInfo"
-                  }
-                },
-                "required": [
-                  "WriteEraInfo"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given Transfer to global state.",
-                "properties": {
-                  "WriteTransfer": {
-                    "$ref": "#/components/schemas/Transfer"
-                  }
-                },
-                "required": [
-                  "WriteTransfer"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given Bid to global state.",
-                "properties": {
-                  "WriteBid": {
-                    "$ref": "#/components/schemas/Bid"
-                  }
-                },
-                "required": [
-                  "WriteBid"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Writes the given Withdraw to global state.",
-                "properties": {
-                  "WriteWithdraw": {
-                    "items": {
-                      "$ref": "#/components/schemas/UnbondingPurse"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "WriteWithdraw"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given `i32`.",
-                "properties": {
-                  "AddInt32": {
-                    "format": "int32",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "AddInt32"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given `u64`.",
-                "properties": {
-                  "AddUInt64": {
-                    "format": "uint64",
-                    "minimum": 0.0,
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "AddUInt64"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given `U128`.",
-                "properties": {
-                  "AddUInt128": {
-                    "$ref": "#/components/schemas/U128"
-                  }
-                },
-                "required": [
-                  "AddUInt128"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given `U256`.",
-                "properties": {
-                  "AddUInt256": {
-                    "$ref": "#/components/schemas/U256"
-                  }
-                },
-                "required": [
-                  "AddUInt256"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given `U512`.",
-                "properties": {
-                  "AddUInt512": {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                },
-                "required": [
-                  "AddUInt512"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "Adds the given collection of named keys.",
-                "properties": {
-                  "AddKeys": {
-                    "items": {
-                      "$ref": "#/components/schemas/NamedKey"
-                    },
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "AddKeys"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "description": "A failed transformation, containing an error message.",
-                "properties": {
-                  "Failure": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "Failure"
-                ],
-                "type": "object"
-              }
-            ],
-            "description": "The actual transformation performed while executing a deploy."
-          },
-          "TransformEntry": {
-            "additionalProperties": false,
-            "description": "A transformation performed while executing a deploy.",
-            "properties": {
-              "key": {
-                "description": "The formatted string of the `Key`.",
-                "type": "string"
-              },
-              "transform": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Transform"
-                  }
-                ],
-                "description": "The transformation."
-              }
-            },
-            "required": [
-              "key",
-              "transform"
-            ],
-            "type": "object"
-          },
-          "U128": {
-            "description": "Decimal representation of a 128-bit integer.",
-            "type": "string"
-          },
-          "U256": {
-            "description": "Decimal representation of a 256-bit integer.",
-            "type": "string"
-          },
-          "U512": {
-            "description": "Decimal representation of a 512-bit integer.",
-            "type": "string"
-          },
-          "URef": {
-            "description": "Hex-encoded, formatted URef.",
-            "type": "string"
-          },
-          "UnbondingPurse": {
-            "additionalProperties": false,
-            "description": "Unbonding purse.",
-            "properties": {
-              "amount": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "Unbonding Amount."
-              },
-              "bonding_purse": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "Bonding Purse"
-              },
-              "era_of_creation": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ],
-                "description": "Era in which this unbonding request was created."
-              },
-              "new_validator": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The validator public key to re-delegate to."
-              },
-              "unbonder_public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "Unbonders public key."
-              },
-              "validator_public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "Validators public key."
-              }
-            },
-            "required": [
-              "amount",
-              "bonding_purse",
-              "era_of_creation",
-              "unbonder_public_key",
-              "validator_public_key"
-            ],
-            "type": "object"
-          },
-          "ValidatorChange": {
-            "description": "A change to a validator's status between two eras.",
-            "enum": [
-              "Added",
-              "Removed",
-              "Banned",
-              "CannotPropose",
-              "SeenAsFaulty"
-            ],
-            "type": "string"
-          },
-          "ValidatorWeight": {
-            "additionalProperties": false,
-            "properties": {
-              "validator": {
-                "$ref": "#/components/schemas/PublicKey"
-              },
-              "weight": {
-                "$ref": "#/components/schemas/U512"
-              }
-            },
-            "required": [
-              "validator",
-              "weight"
-            ],
-            "type": "object"
-          },
-          "VestingSchedule": {
-            "additionalProperties": false,
-            "properties": {
-              "initial_release_timestamp_millis": {
-                "format": "uint64",
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              "locked_amounts": {
-                "items": {
-                  "$ref": "#/components/schemas/U512"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "initial_release_timestamp_millis"
-            ],
-            "type": "object"
-          },
-          "WithdrawPurse": {
-            "additionalProperties": false,
-            "description": "A withdraw purse, a legacy structure.",
-            "properties": {
-              "amount": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ],
-                "description": "Unbonding Amount."
-              },
-              "bonding_purse": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ],
-                "description": "Bonding Purse"
-              },
-              "era_of_creation": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ],
-                "description": "Era in which this unbonding request was created."
-              },
-              "unbonder_public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "Unbonders public key."
-              },
-              "validator_public_key": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ],
-                "description": "Validators public key."
-              }
-            },
-            "required": [
-              "amount",
-              "bonding_purse",
-              "era_of_creation",
-              "unbonder_public_key",
-              "validator_public_key"
-            ],
-            "type": "object"
-          }
-        }
-      },
+      "openrpc": "1.0.0-rc1",
       "info": {
+        "version": "1.4.8",
+        "title": "Client API of Casper Node",
+        "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
         "contact": {
           "name": "CasperLabs",
           "url": "https://casperlabs.io"
         },
-        "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
         "license": {
           "name": "CasperLabs Open Source License Version 1.0",
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
-        },
-        "title": "Client API of Casper Node",
-        "version": "1.4.8"
+        }
       },
+      "servers": [
+        {
+          "name": "any Casper Network node",
+          "url": "http://IP:PORT/rpc/"
+        }
+      ],
       "methods": [
         {
+          "name": "account_put_deploy",
+          "summary": "receives a Deploy to be executed by the network",
+          "params": [
+            {
+              "name": "deploy",
+              "schema": {
+                "description": "The `Deploy`.",
+                "$ref": "#/components/schemas/Deploy"
+              },
+              "required": true
+            }
+          ],
+          "result": {
+            "name": "account_put_deploy_result",
+            "schema": {
+              "description": "Result for \"account_put_deploy\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "deploy_hash"
+              ],
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
+                },
+                "deploy_hash": {
+                  "description": "The deploy hash.",
+                  "$ref": "#/components/schemas/DeployHash"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
           "examples": [
             {
               "name": "account_put_deploy_example",
@@ -2977,38 +66,32 @@
                 {
                   "name": "deploy",
                   "value": {
-                    "approvals": [
-                      {
-                        "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007",
-                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-                      }
-                    ],
                     "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                     "header": {
                       "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h",
+                      "gas_price": 1,
                       "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name": "casper-example",
                       "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price": 1,
-                      "timestamp": "2020-11-17T00:39:24.072Z",
-                      "ttl": "1h"
+                      "chain_name": "casper-example"
                     },
                     "payment": {
                       "StoredContractByName": {
+                        "name": "casper-example",
+                        "entry_point": "example-entry-point",
                         "args": [
                           [
                             "amount",
                             {
-                              "bytes": "e8030000",
                               "cl_type": "I32",
+                              "bytes": "e8030000",
                               "parsed": 1000
                             }
                           ]
-                        ],
-                        "entry_point": "example-entry-point",
-                        "name": "casper-example"
+                        ]
                       }
                     },
                     "session": {
@@ -3017,14 +100,20 @@
                           [
                             "amount",
                             {
-                              "bytes": "e8030000",
                               "cl_type": "I32",
+                              "bytes": "e8030000",
                               "parsed": 1000
                             }
                           ]
                         ]
                       }
-                    }
+                    },
+                    "approvals": [
+                      {
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                        "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007"
+                      }
+                    ]
                   }
                 }
               ],
@@ -3036,43 +125,70 @@
                 }
               }
             }
-          ],
-          "name": "account_put_deploy",
+          ]
+        },
+        {
+          "name": "info_get_deploy",
+          "summary": "returns a Deploy from the network",
           "params": [
             {
-              "name": "deploy",
-              "required": true,
+              "name": "deploy_hash",
               "schema": {
-                "$ref": "#/components/schemas/Deploy",
-                "description": "The `Deploy`."
-              }
+                "description": "The deploy hash.",
+                "$ref": "#/components/schemas/DeployHash"
+              },
+              "required": true
+            },
+            {
+              "name": "finalized_approvals",
+              "schema": {
+                "description": "Whether to return the deploy with the finalized approvals substituted. If `false` or omitted, returns the deploy with the approvals that were originally received by the node.",
+                "default": false,
+                "type": "boolean"
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "account_put_deploy_result",
+            "name": "info_get_deploy_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"account_put_deploy\" RPC response.",
+              "description": "Result for \"info_get_deploy\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "deploy",
+                "execution_results"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "deploy_hash": {
-                  "$ref": "#/components/schemas/DeployHash",
-                  "description": "The deploy hash."
+                "deploy": {
+                  "description": "The deploy.",
+                  "$ref": "#/components/schemas/Deploy"
+                },
+                "execution_results": {
+                  "description": "The map of block hash to execution result.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonExecutionResult"
+                  }
+                },
+                "block_hash": {
+                  "description": "The hash of this deploy's block.",
+                  "$ref": "#/components/schemas/BlockHash"
+                },
+                "block_height": {
+                  "description": "The height of this deploy's block.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               },
-              "required": [
-                "api_version",
-                "deploy_hash"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "receives a Deploy to be executed by the network"
-        },
-        {
           "examples": [
             {
               "name": "info_get_deploy_example",
@@ -3091,38 +207,32 @@
                 "value": {
                   "api_version": "1.4.8",
                   "deploy": {
-                    "approvals": [
-                      {
-                        "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007",
-                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-                      }
-                    ],
                     "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                     "header": {
                       "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h",
+                      "gas_price": 1,
                       "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name": "casper-example",
                       "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price": 1,
-                      "timestamp": "2020-11-17T00:39:24.072Z",
-                      "ttl": "1h"
+                      "chain_name": "casper-example"
                     },
                     "payment": {
                       "StoredContractByName": {
+                        "name": "casper-example",
+                        "entry_point": "example-entry-point",
                         "args": [
                           [
                             "amount",
                             {
-                              "bytes": "e8030000",
                               "cl_type": "I32",
+                              "bytes": "e8030000",
                               "parsed": 1000
                             }
                           ]
-                        ],
-                        "entry_point": "example-entry-point",
-                        "name": "casper-example"
+                        ]
                       }
                     },
                     "session": {
@@ -3131,21 +241,26 @@
                           [
                             "amount",
                             {
-                              "bytes": "e8030000",
                               "cl_type": "I32",
+                              "bytes": "e8030000",
                               "parsed": 1000
                             }
                           ]
                         ]
                       }
-                    }
+                    },
+                    "approvals": [
+                      {
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                        "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007"
+                      }
+                    ]
                   },
                   "execution_results": [
                     {
                       "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                       "result": {
                         "Success": {
-                          "cost": "123456",
                           "effect": {
                             "operations": [
                               {
@@ -3173,7 +288,8 @@
                           "transfers": [
                             "transfer-5959595959595959595959595959595959595959595959595959595959595959",
                             "transfer-8282828282828282828282828282828282828282828282828282828282828282"
-                          ]
+                          ],
+                          "cost": "123456"
                         }
                       }
                     }
@@ -3181,123 +297,24 @@
                 }
               }
             }
-          ],
-          "name": "info_get_deploy",
-          "params": [
-            {
-              "name": "deploy_hash",
-              "required": true,
-              "schema": {
-                "$ref": "#/components/schemas/DeployHash",
-                "description": "The deploy hash."
-              }
-            },
-            {
-              "name": "finalized_approvals",
-              "required": false,
-              "schema": {
-                "default": false,
-                "description": "Whether to return the deploy with the finalized approvals substituted. If `false` or omitted, returns the deploy with the approvals that were originally received by the node.",
-                "type": "boolean"
-              }
-            }
-          ],
-          "result": {
-            "name": "info_get_deploy_result",
-            "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"info_get_deploy\" RPC response.",
-              "properties": {
-                "api_version": {
-                  "description": "The RPC API version.",
-                  "type": "string"
-                },
-                "block_hash": {
-                  "$ref": "#/components/schemas/BlockHash",
-                  "description": "The hash of this deploy's block."
-                },
-                "block_height": {
-                  "description": "The height of this deploy's block.",
-                  "format": "uint64",
-                  "minimum": 0.0,
-                  "type": "integer"
-                },
-                "deploy": {
-                  "$ref": "#/components/schemas/Deploy",
-                  "description": "The deploy."
-                },
-                "execution_results": {
-                  "description": "The map of block hash to execution result.",
-                  "items": {
-                    "$ref": "#/components/schemas/JsonExecutionResult"
-                  },
-                  "type": "array"
-                }
-              },
-              "required": [
-                "api_version",
-                "deploy",
-                "execution_results"
-              ],
-              "type": "object"
-            }
-          },
-          "summary": "returns a Deploy from the network"
+          ]
         },
         {
-          "examples": [
-            {
-              "name": "state_get_account_info_example",
-              "params": [
-                {
-                  "name": "block_identifier",
-                  "value": {
-                    "Hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
-                  }
-                },
-                {
-                  "name": "public_key",
-                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
-                }
-              ],
-              "result": {
-                "name": "state_get_account_info_example_result",
-                "value": {
-                  "account": {
-                    "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                    "action_thresholds": {
-                      "deployment": 1,
-                      "key_management": 1
-                    },
-                    "associated_keys": [
-                      {
-                        "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                        "weight": 1
-                      }
-                    ],
-                    "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                    "named_keys": []
-                  },
-                  "api_version": "1.4.8",
-                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
-                }
-              }
-            }
-          ],
           "name": "state_get_account_info",
+          "summary": "returns an Account from the network",
           "params": [
             {
               "name": "public_key",
-              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/PublicKey",
-                "description": "The public key of the Account."
-              }
+                "description": "The public key of the Account.",
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "required": true
             },
             {
               "name": "block_identifier",
-              "required": false,
               "schema": {
+                "description": "The block identifier.",
                 "anyOf": [
                   {
                     "$ref": "#/components/schemas/BlockIdentifier"
@@ -3305,100 +322,110 @@
                   {
                     "type": "null"
                   }
-                ],
-                "description": "The block identifier."
-              }
+                ]
+              },
+              "required": false
             }
           ],
           "result": {
             "name": "state_get_account_info_result",
             "schema": {
-              "additionalProperties": false,
               "description": "Result for \"state_get_account_info\" RPC response.",
+              "type": "object",
+              "required": [
+                "account",
+                "api_version",
+                "merkle_proof"
+              ],
               "properties": {
-                "account": {
-                  "$ref": "#/components/schemas/Account",
-                  "description": "The account."
-                },
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
+                },
+                "account": {
+                  "description": "The account.",
+                  "$ref": "#/components/schemas/Account"
                 },
                 "merkle_proof": {
                   "description": "The Merkle proof.",
                   "type": "string"
                 }
               },
-              "required": [
-                "account",
-                "api_version",
-                "merkle_proof"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns an Account from the network"
-        },
-        {
           "examples": [
             {
-              "name": "state_get_dictionary_item_example",
+              "name": "state_get_account_info_example",
               "params": [
                 {
-                  "name": "dictionary_identifier",
-                  "value": {
-                    "URef": {
-                      "dictionary_item_key": "a_unique_entry_identifier",
-                      "seed_uref": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
-                    }
-                  }
+                  "name": "public_key",
+                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                 },
                 {
-                  "name": "state_root_hash",
-                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+                  }
                 }
               ],
               "result": {
-                "name": "state_get_dictionary_item_example_result",
+                "name": "state_get_account_info_example_result",
                 "value": {
                   "api_version": "1.4.8",
-                  "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
-                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value": {
-                    "CLValue": {
-                      "bytes": "0100000000000000",
-                      "cl_type": "U64",
-                      "parsed": 1
+                  "account": {
+                    "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                    "named_keys": [],
+                    "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                    "associated_keys": [
+                      {
+                        "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                        "weight": 1
+                      }
+                    ],
+                    "action_thresholds": {
+                      "deployment": 1,
+                      "key_management": 1
                     }
-                  }
+                  },
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
-          ],
+          ]
+        },
+        {
           "name": "state_get_dictionary_item",
+          "summary": "returns an item from a Dictionary",
           "params": [
             {
               "name": "state_root_hash",
-              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Digest",
-                "description": "Hash of the state root"
-              }
+                "description": "Hash of the state root",
+                "$ref": "#/components/schemas/Digest"
+              },
+              "required": true
             },
             {
               "name": "dictionary_identifier",
-              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/DictionaryIdentifier",
-                "description": "The Dictionary query identifier."
-              }
+                "description": "The Dictionary query identifier.",
+                "$ref": "#/components/schemas/DictionaryIdentifier"
+              },
+              "required": true
             }
           ],
           "result": {
             "name": "state_get_dictionary_item_result",
             "schema": {
-              "additionalProperties": false,
               "description": "Result for \"state_get_dictionary_item\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "dictionary_key",
+                "merkle_proof",
+                "stored_value"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
@@ -3408,31 +435,135 @@
                   "description": "The key under which the value is stored.",
                   "type": "string"
                 },
+                "stored_value": {
+                  "description": "The stored value.",
+                  "$ref": "#/components/schemas/StoredValue"
+                },
                 "merkle_proof": {
                   "description": "The Merkle proof.",
                   "type": "string"
-                },
-                "stored_value": {
-                  "$ref": "#/components/schemas/StoredValue",
-                  "description": "The stored value."
                 }
               },
+              "additionalProperties": false
+            }
+          },
+          "examples": [
+            {
+              "name": "state_get_dictionary_item_example",
+              "params": [
+                {
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
+                },
+                {
+                  "name": "dictionary_identifier",
+                  "value": {
+                    "URef": {
+                      "seed_uref": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                      "dictionary_item_key": "a_unique_entry_identifier"
+                    }
+                  }
+                }
+              ],
+              "result": {
+                "name": "state_get_dictionary_item_example_result",
+                "value": {
+                  "api_version": "1.4.8",
+                  "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
+                  "stored_value": {
+                    "CLValue": {
+                      "cl_type": "U64",
+                      "bytes": "0100000000000000",
+                      "parsed": 1
+                    }
+                  },
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "query_global_state",
+          "summary": "a query to global state using either a Block hash or state root hash",
+          "params": [
+            {
+              "name": "state_identifier",
+              "schema": {
+                "description": "The identifier used for the query.",
+                "$ref": "#/components/schemas/GlobalStateIdentifier"
+              },
+              "required": true
+            },
+            {
+              "name": "key",
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
+              },
+              "required": true
+            },
+            {
+              "name": "path",
+              "schema": {
+                "description": "The path components starting from the key as base.",
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "required": false
+            }
+          ],
+          "result": {
+            "name": "query_global_state_result",
+            "schema": {
+              "description": "Result for \"query_global_state\" RPC response.",
+              "type": "object",
               "required": [
                 "api_version",
-                "dictionary_key",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type": "object"
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
+                },
+                "block_header": {
+                  "description": "The block header if a Block hash was provided.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/JsonBlockHeader"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "stored_value": {
+                  "description": "The stored value.",
+                  "$ref": "#/components/schemas/StoredValue"
+                },
+                "merkle_proof": {
+                  "description": "The Merkle proof.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "summary": "returns an item from a Dictionary"
-        },
-        {
           "examples": [
             {
               "name": "query_global_state_example",
               "params": [
+                {
+                  "name": "state_identifier",
+                  "value": {
+                    "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+                  }
+                },
                 {
                   "name": "key",
                   "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
@@ -3440,12 +571,6 @@
                 {
                   "name": "path",
                   "value": []
-                },
-                {
-                  "name": "state_identifier",
-                  "value": {
-                    "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
-                  }
                 }
               ],
               "result": {
@@ -3453,21 +578,24 @@
                 "value": {
                   "api_version": "1.4.8",
                   "block_header": {
-                    "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                    "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
+                    "random_bit": true,
+                    "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "era_end": {
                       "era_report": {
                         "equivocators": [
                           "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                         ],
-                        "inactive_validators": [
-                          "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
-                        ],
                         "rewards": [
                           {
-                            "amount": 1000,
-                            "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                            "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+                            "amount": 1000
                           }
+                        ],
+                        "inactive_validators": [
+                          "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                         ]
                       },
                       "next_era_validator_weights": [
@@ -3485,122 +613,97 @@
                         }
                       ]
                     },
+                    "timestamp": "2020-11-17T00:39:24.072Z",
                     "era_id": 1,
                     "height": 10,
-                    "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
-                    "protocol_version": "1.0.0",
-                    "random_bit": true,
-                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp": "2020-11-17T00:39:24.072Z"
+                    "protocol_version": "1.0.0"
                   },
-                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "Account": {
                       "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                      "action_thresholds": {
-                        "deployment": 1,
-                        "key_management": 1
-                      },
+                      "named_keys": [],
+                      "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                       "associated_keys": [
                         {
                           "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                           "weight": 1
                         }
                       ],
-                      "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                      "named_keys": []
+                      "action_thresholds": {
+                        "deployment": 1,
+                        "key_management": 1
+                      }
                     }
-                  }
+                  },
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
-          ],
-          "name": "query_global_state",
+          ]
+        },
+        {
+          "name": "query_balance",
+          "summary": "query for a balance using a purse identifier and a state identifier",
           "params": [
             {
+              "name": "purse_identifier",
+              "schema": {
+                "description": "The identifier to obtain the purse corresponding to balance query.",
+                "$ref": "#/components/schemas/PurseIdentifier"
+              },
+              "required": true
+            },
+            {
               "name": "state_identifier",
-              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/GlobalStateIdentifier",
-                "description": "The identifier used for the query."
-              }
-            },
-            {
-              "name": "key",
-              "required": true,
-              "schema": {
-                "description": "`casper_types::Key` as formatted string.",
-                "type": "string"
-              }
-            },
-            {
-              "name": "path",
-              "required": false,
-              "schema": {
-                "default": [],
-                "description": "The path components starting from the key as base.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
+                "description": "The state identifier used for the query, if none is passed the tip of the chain will be used.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/GlobalStateIdentifier"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "query_global_state_result",
+            "name": "query_balance_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"query_global_state\" RPC response.",
+              "description": "Result for \"query_balance\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "balance"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "block_header": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/JsonBlockHeader"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The block header if a Block hash was provided."
-                },
-                "merkle_proof": {
-                  "description": "The Merkle proof.",
-                  "type": "string"
-                },
-                "stored_value": {
-                  "$ref": "#/components/schemas/StoredValue",
-                  "description": "The stored value."
+                "balance": {
+                  "description": "The balance represented in motes.",
+                  "$ref": "#/components/schemas/U512"
                 }
-              },
-              "required": [
-                "api_version",
-                "merkle_proof",
-                "stored_value"
-              ],
-              "type": "object"
+              }
             }
           },
-          "summary": "a query to global state using either a Block hash or state root hash"
-        },
-        {
           "examples": [
             {
               "name": "query_balance_example",
               "params": [
                 {
-                  "name": "purse_identifier",
-                  "value": {
-                    "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
-                  }
-                },
-                {
                   "name": "state_identifier",
                   "value": {
                     "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+                  }
+                },
+                {
+                  "name": "purse_identifier",
+                  "value": {
+                    "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
                   }
                 }
               ],
@@ -3612,57 +715,34 @@
                 }
               }
             }
-          ],
-          "name": "query_balance",
-          "params": [
-            {
-              "name": "purse_identifier",
-              "required": true,
-              "schema": {
-                "$ref": "#/components/schemas/PurseIdentifier",
-                "description": "The identifier to obtain the purse corresponding to balance query."
-              }
-            },
-            {
-              "name": "state_identifier",
-              "required": false,
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/GlobalStateIdentifier"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The state identifier used for the query, if none is passed the tip of the chain will be used."
-              }
-            }
-          ],
+          ]
+        },
+        {
+          "name": "info_get_peers",
+          "summary": "returns a list of peers connected to the node",
+          "params": [],
           "result": {
-            "name": "query_balance_result",
+            "name": "info_get_peers_result",
             "schema": {
-              "description": "Result for \"query_balance\" RPC response.",
+              "description": "Result for \"info_get_peers\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "peers"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "balance": {
-                  "$ref": "#/components/schemas/U512",
-                  "description": "The balance represented in motes."
+                "peers": {
+                  "description": "The node ID and network address of each connected peer.",
+                  "$ref": "#/components/schemas/PeersMap"
                 }
               },
-              "required": [
-                "api_version",
-                "balance"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "query for a balance using a purse identifier and a state identifier"
-        },
-        {
           "examples": [
             {
               "name": "info_get_peers_example",
@@ -3673,195 +753,24 @@
                   "api_version": "1.4.8",
                   "peers": [
                     {
-                      "address": "127.0.0.1:54321",
-                      "node_id": "tls:0101..0101"
+                      "node_id": "tls:0101..0101",
+                      "address": "127.0.0.1:54321"
                     }
                   ]
                 }
               }
             }
-          ],
-          "name": "info_get_peers",
-          "params": [],
-          "result": {
-            "name": "info_get_peers_result",
-            "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"info_get_peers\" RPC response.",
-              "properties": {
-                "api_version": {
-                  "description": "The RPC API version.",
-                  "type": "string"
-                },
-                "peers": {
-                  "$ref": "#/components/schemas/PeersMap",
-                  "description": "The node ID and network address of each connected peer."
-                }
-              },
-              "required": [
-                "api_version",
-                "peers"
-              ],
-              "type": "object"
-            }
-          },
-          "summary": "returns a list of peers connected to the node"
+          ]
         },
         {
-          "examples": [
-            {
-              "name": "info_get_status_example",
-              "params": [],
-              "result": {
-                "name": "info_get_status_example_result",
-                "value": {
-                  "api_version": "1.4.8",
-                  "available_block_range": {
-                    "high": 0,
-                    "low": 0
-                  },
-                  "block_sync": {
-                    "forward": {
-                      "acquisition_state": "have block body(6701) for: block hash 5990..4983",
-                      "block_hash": "59907b1e32a9158169c4d89d9ce5ac9164fc31240bfcfb0969227ece06d74983",
-                      "block_height": 6701
-                    },
-                    "historical": {
-                      "acquisition_state": "have strict finality(40) for: block hash 16dd..c55e",
-                      "block_hash": "16ddf28e2b3d2e17f4cef36f8b58827eca917af225d139b0c77df3b4a67dc55e",
-                      "block_height": 40
-                    }
-                  },
-                  "build_version": "1.0.0-xxxxxxxxx@DEBUG",
-                  "chainspec_name": "casper-example",
-                  "last_added_block_info": {
-                    "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                    "era_id": 1,
-                    "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
-                    "height": 10,
-                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp": "2020-11-17T00:39:24.072Z"
-                  },
-                  "last_progress": "1970-01-01T00:00:00.000Z",
-                  "next_upgrade": {
-                    "activation_point": 42,
-                    "protocol_version": "2.0.1"
-                  },
-                  "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                  "peers": [
-                    {
-                      "address": "127.0.0.1:54321",
-                      "node_id": "tls:0101..0101"
-                    }
-                  ],
-                  "reactor_state": "Initialize",
-                  "round_length": "1m 5s 536ms",
-                  "starting_state_root_hash": null,
-                  "uptime": "13s"
-                }
-              }
-            }
-          ],
           "name": "info_get_status",
+          "summary": "returns the current status of the node",
           "params": [],
           "result": {
             "name": "info_get_status_result",
             "schema": {
-              "additionalProperties": false,
               "description": "Result for \"info_get_status\" RPC response.",
-              "properties": {
-                "api_version": {
-                  "description": "The RPC API version.",
-                  "type": "string"
-                },
-                "available_block_range": {
-                  "$ref": "#/components/schemas/AvailableBlockRange",
-                  "description": "The available block range in storage."
-                },
-                "block_sync": {
-                  "$ref": "#/components/schemas/BlockSynchronizerStatus",
-                  "description": "The status of the block synchronizer builders."
-                },
-                "build_version": {
-                  "description": "The compiled node version.",
-                  "type": "string"
-                },
-                "chainspec_name": {
-                  "description": "The chainspec name.",
-                  "type": "string"
-                },
-                "last_added_block_info": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/MinimalBlockInfo"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The minimal info of the last block from the linear chain."
-                },
-                "last_progress": {
-                  "$ref": "#/components/schemas/Timestamp",
-                  "description": "Timestamp of the last recorded progress in the reactor."
-                },
-                "next_upgrade": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/NextUpgrade"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Information about the next scheduled upgrade."
-                },
-                "our_public_signing_key": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/PublicKey"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Our public signing key."
-                },
-                "peers": {
-                  "$ref": "#/components/schemas/PeersMap",
-                  "description": "The node ID and network address of each connected peer."
-                },
-                "reactor_state": {
-                  "$ref": "#/components/schemas/ReactorState",
-                  "description": "The current state of node reactor."
-                },
-                "round_length": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TimeDiff"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The next round length if this node is a validator."
-                },
-                "starting_state_root_hash": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/Digest"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The state root hash of the lowest block in the available block range."
-                },
-                "uptime": {
-                  "$ref": "#/components/schemas/TimeDiff",
-                  "description": "Time that passed since the node has started."
-                }
-              },
+              "type": "object",
               "required": [
                 "api_version",
                 "available_block_range",
@@ -3873,12 +782,186 @@
                 "reactor_state",
                 "uptime"
               ],
-              "type": "object"
+              "properties": {
+                "peers": {
+                  "description": "The node ID and network address of each connected peer.",
+                  "$ref": "#/components/schemas/PeersMap"
+                },
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
+                },
+                "build_version": {
+                  "description": "The compiled node version.",
+                  "type": "string"
+                },
+                "chainspec_name": {
+                  "description": "The chainspec name.",
+                  "type": "string"
+                },
+                "starting_state_root_hash": {
+                  "description": "The state root hash of the lowest block in the available block range.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/Digest"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "last_added_block_info": {
+                  "description": "The minimal info of the last block from the linear chain.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MinimalBlockInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "our_public_signing_key": {
+                  "description": "Our public signing key.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/PublicKey"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "round_length": {
+                  "description": "The next round length if this node is a validator.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimeDiff"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "next_upgrade": {
+                  "description": "Information about the next scheduled upgrade.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NextUpgrade"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "uptime": {
+                  "description": "Time that passed since the node has started.",
+                  "$ref": "#/components/schemas/TimeDiff"
+                },
+                "reactor_state": {
+                  "description": "The current state of node reactor.",
+                  "$ref": "#/components/schemas/ReactorState"
+                },
+                "last_progress": {
+                  "description": "Timestamp of the last recorded progress in the reactor.",
+                  "$ref": "#/components/schemas/Timestamp"
+                },
+                "available_block_range": {
+                  "description": "The available block range in storage.",
+                  "$ref": "#/components/schemas/AvailableBlockRange"
+                },
+                "block_sync": {
+                  "description": "The status of the block synchronizer builders.",
+                  "$ref": "#/components/schemas/BlockSynchronizerStatus"
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "summary": "returns the current status of the node"
+          "examples": [
+            {
+              "name": "info_get_status_example",
+              "params": [],
+              "result": {
+                "name": "info_get_status_example_result",
+                "value": {
+                  "peers": [
+                    {
+                      "node_id": "tls:0101..0101",
+                      "address": "127.0.0.1:54321"
+                    }
+                  ],
+                  "api_version": "1.4.8",
+                  "build_version": "1.0.0-xxxxxxxxx@DEBUG",
+                  "chainspec_name": "casper-example",
+                  "starting_state_root_hash": null,
+                  "last_added_block_info": {
+                    "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
+                    "timestamp": "2020-11-17T00:39:24.072Z",
+                    "era_id": 1,
+                    "height": 10,
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+                  },
+                  "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                  "round_length": "1m 5s 536ms",
+                  "next_upgrade": {
+                    "activation_point": 42,
+                    "protocol_version": "2.0.1"
+                  },
+                  "uptime": "13s",
+                  "reactor_state": "Initialize",
+                  "last_progress": "1970-01-01T00:00:00.000Z",
+                  "available_block_range": {
+                    "low": 0,
+                    "high": 0
+                  },
+                  "block_sync": {
+                    "historical": {
+                      "block_hash": "16ddf28e2b3d2e17f4cef36f8b58827eca917af225d139b0c77df3b4a67dc55e",
+                      "block_height": 40,
+                      "acquisition_state": "have strict finality(40) for: block hash 16dd..c55e"
+                    },
+                    "forward": {
+                      "block_hash": "59907b1e32a9158169c4d89d9ce5ac9164fc31240bfcfb0969227ece06d74983",
+                      "block_height": 6701,
+                      "acquisition_state": "have block body(6701) for: block hash 5990..4983"
+                    }
+                  }
+                }
+              }
+            }
+          ]
         },
         {
+          "name": "info_get_validator_changes",
+          "summary": "returns status changes of active validators",
+          "params": [],
+          "result": {
+            "name": "info_get_validator_changes_result",
+            "schema": {
+              "description": "Result for the \"info_get_validator_changes\" RPC.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "changes"
+              ],
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
+                },
+                "changes": {
+                  "description": "The validators' status changes.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonValidatorChanges"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
           "examples": [
             {
               "name": "info_get_validator_changes_example",
@@ -3901,37 +984,33 @@
                 }
               }
             }
-          ],
-          "name": "info_get_validator_changes",
+          ]
+        },
+        {
+          "name": "info_get_chainspec",
+          "summary": "returns the raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files",
           "params": [],
           "result": {
-            "name": "info_get_validator_changes_result",
+            "name": "info_get_chainspec_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for the \"info_get_validator_changes\" RPC.",
+              "description": "Result for the \"info_get_chainspec\" RPC.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "chainspec_bytes"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "changes": {
-                  "description": "The validators' status changes.",
-                  "items": {
-                    "$ref": "#/components/schemas/JsonValidatorChanges"
-                  },
-                  "type": "array"
+                "chainspec_bytes": {
+                  "description": "The chainspec file bytes.",
+                  "$ref": "#/components/schemas/ChainspecRawBytes"
                 }
-              },
-              "required": [
-                "api_version",
-                "changes"
-              ],
-              "type": "object"
+              }
             }
           },
-          "summary": "returns status changes of active validators"
-        },
-        {
           "examples": [
             {
               "name": "info_get_chainspec_example",
@@ -3948,33 +1027,49 @@
                 }
               }
             }
+          ]
+        },
+        {
+          "name": "chain_get_block",
+          "summary": "returns a Block from the network",
+          "params": [
+            {
+              "name": "block_identifier",
+              "schema": {
+                "description": "The block identifier.",
+                "$ref": "#/components/schemas/BlockIdentifier"
+              },
+              "required": false
+            }
           ],
-          "name": "info_get_chainspec",
-          "params": [],
           "result": {
-            "name": "info_get_chainspec_result",
+            "name": "chain_get_block_result",
             "schema": {
-              "description": "Result for the \"info_get_chainspec\" RPC.",
+              "description": "Result for \"chain_get_block\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "chainspec_bytes": {
-                  "$ref": "#/components/schemas/ChainspecRawBytes",
-                  "description": "The chainspec file bytes."
+                "block": {
+                  "description": "The block, if found.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/JsonBlock"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
-              "required": [
-                "api_version",
-                "chainspec_bytes"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns the raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files"
-        },
-        {
           "examples": [
             {
               "name": "chain_get_block_example",
@@ -3991,30 +1086,26 @@
                 "value": {
                   "api_version": "1.4.8",
                   "block": {
-                    "body": {
-                      "deploy_hashes": [],
-                      "proposer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "transfer_hashes": [
-                        "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
-                      ]
-                    },
                     "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "header": {
-                      "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                      "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                      "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
                       "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
+                      "random_bit": true,
+                      "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                       "era_end": {
                         "era_report": {
                           "equivocators": [
                             "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                           ],
-                          "inactive_validators": [
-                            "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
-                          ],
                           "rewards": [
                             {
-                              "amount": 1000,
-                              "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                              "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+                              "amount": 1000
                             }
+                          ],
+                          "inactive_validators": [
+                            "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                           ]
                         },
                         "next_era_validator_weights": [
@@ -4032,13 +1123,17 @@
                           }
                         ]
                       },
+                      "timestamp": "2020-11-17T00:39:24.072Z",
                       "era_id": 1,
                       "height": 10,
-                      "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
-                      "protocol_version": "1.0.0",
-                      "random_bit": true,
-                      "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
-                      "timestamp": "2020-11-17T00:39:24.072Z"
+                      "protocol_version": "1.0.0"
+                    },
+                    "body": {
+                      "proposer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "deploy_hashes": [],
+                      "transfer_hashes": [
+                        "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
+                      ]
                     },
                     "proofs": [
                       {
@@ -4050,49 +1145,59 @@
                 }
               }
             }
-          ],
-          "name": "chain_get_block",
+          ]
+        },
+        {
+          "name": "chain_get_block_transfers",
+          "summary": "returns all transfers for a Block from the network",
           "params": [
             {
               "name": "block_identifier",
-              "required": false,
               "schema": {
-                "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block identifier."
-              }
+                "description": "The block hash.",
+                "$ref": "#/components/schemas/BlockIdentifier"
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "chain_get_block_result",
+            "name": "chain_get_block_transfers_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"chain_get_block\" RPC response.",
+              "description": "Result for \"chain_get_block_transfers\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "block": {
+                "block_hash": {
+                  "description": "The block hash, if found.",
                   "anyOf": [
                     {
-                      "$ref": "#/components/schemas/JsonBlock"
+                      "$ref": "#/components/schemas/BlockHash"
                     },
                     {
                       "type": "null"
                     }
+                  ]
+                },
+                "transfers": {
+                  "description": "The block's transfers, if found.",
+                  "type": [
+                    "array",
+                    "null"
                   ],
-                  "description": "The block, if found."
+                  "items": {
+                    "$ref": "#/components/schemas/Transfer"
+                  }
                 }
               },
-              "required": [
-                "api_version"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns a Block from the network"
-        },
-        {
           "examples": [
             {
               "name": "chain_get_block_transfers_example",
@@ -4111,72 +1216,62 @@
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
-                      "amount": "0",
                       "deploy_hash": "0000000000000000000000000000000000000000000000000000000000000000",
                       "from": "account-hash-0000000000000000000000000000000000000000000000000000000000000000",
-                      "gas": "0",
-                      "id": null,
+                      "to": null,
                       "source": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
                       "target": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
-                      "to": null
+                      "amount": "0",
+                      "gas": "0",
+                      "id": null
                     }
                   ]
                 }
               }
             }
-          ],
-          "name": "chain_get_block_transfers",
+          ]
+        },
+        {
+          "name": "chain_get_state_root_hash",
+          "summary": "returns a state root hash at a given Block",
           "params": [
             {
               "name": "block_identifier",
-              "required": false,
               "schema": {
-                "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block hash."
-              }
+                "description": "The block hash.",
+                "$ref": "#/components/schemas/BlockIdentifier"
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "chain_get_block_transfers_result",
+            "name": "chain_get_state_root_hash_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"chain_get_block_transfers\" RPC response.",
+              "description": "Result for \"chain_get_state_root_hash\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "block_hash": {
+                "state_root_hash": {
+                  "description": "Hex-encoded hash of the state root.",
                   "anyOf": [
                     {
-                      "$ref": "#/components/schemas/BlockHash"
+                      "$ref": "#/components/schemas/Digest"
                     },
                     {
                       "type": "null"
                     }
-                  ],
-                  "description": "The block hash, if found."
-                },
-                "transfers": {
-                  "description": "The block's transfers, if found.",
-                  "items": {
-                    "$ref": "#/components/schemas/Transfer"
-                  },
-                  "type": [
-                    "array",
-                    "null"
                   ]
                 }
               },
-              "required": [
-                "api_version"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns all transfers for a Block from the network"
-        },
-        {
           "examples": [
             {
               "name": "chain_get_state_root_hash_example",
@@ -4196,53 +1291,76 @@
                 }
               }
             }
-          ],
-          "name": "chain_get_state_root_hash",
+          ]
+        },
+        {
+          "name": "state_get_item",
+          "summary": "returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead.",
           "params": [
             {
-              "name": "block_identifier",
-              "required": false,
+              "name": "state_root_hash",
               "schema": {
-                "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block hash."
-              }
+                "description": "Hash of the state root.",
+                "$ref": "#/components/schemas/Digest"
+              },
+              "required": true
+            },
+            {
+              "name": "key",
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
+              },
+              "required": true
+            },
+            {
+              "name": "path",
+              "schema": {
+                "description": "The path components starting from the key as base.",
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "chain_get_state_root_hash_result",
+            "name": "state_get_item_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"chain_get_state_root_hash\" RPC response.",
+              "description": "Result for \"state_get_item\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "merkle_proof",
+                "stored_value"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "state_root_hash": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/Digest"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Hex-encoded hash of the state root."
+                "stored_value": {
+                  "description": "The stored value.",
+                  "$ref": "#/components/schemas/StoredValue"
+                },
+                "merkle_proof": {
+                  "description": "The Merkle proof.",
+                  "type": "string"
                 }
               },
-              "required": [
-                "api_version"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns a state root hash at a given Block"
-        },
-        {
           "examples": [
             {
               "name": "state_get_item_example",
               "params": [
+                {
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
+                },
                 {
                   "name": "key",
                   "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
@@ -4252,100 +1370,84 @@
                   "value": [
                     "inner"
                   ]
-                },
-                {
-                  "name": "state_root_hash",
-                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
                   "api_version": "1.4.8",
-                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
-                      "bytes": "0100000000000000",
                       "cl_type": "U64",
+                      "bytes": "0100000000000000",
                       "parsed": 1
                     }
-                  }
+                  },
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
-          ],
-          "name": "state_get_item",
+          ]
+        },
+        {
+          "name": "state_get_balance",
+          "summary": "returns a purse's balance from the network",
           "params": [
             {
               "name": "state_root_hash",
-              "required": true,
               "schema": {
-                "$ref": "#/components/schemas/Digest",
-                "description": "Hash of the state root."
-              }
+                "description": "The hash of state root.",
+                "$ref": "#/components/schemas/Digest"
+              },
+              "required": true
             },
             {
-              "name": "key",
-              "required": true,
+              "name": "purse_uref",
               "schema": {
-                "description": "`casper_types::Key` as formatted string.",
+                "description": "Formatted URef.",
                 "type": "string"
-              }
-            },
-            {
-              "name": "path",
-              "required": false,
-              "schema": {
-                "default": [],
-                "description": "The path components starting from the key as base.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
+              },
+              "required": true
             }
           ],
           "result": {
-            "name": "state_get_item_result",
+            "name": "state_get_balance_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"state_get_item\" RPC response.",
+              "description": "Result for \"state_get_balance\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "balance_value",
+                "merkle_proof"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
+                "balance_value": {
+                  "description": "The balance value.",
+                  "$ref": "#/components/schemas/U512"
+                },
                 "merkle_proof": {
                   "description": "The Merkle proof.",
                   "type": "string"
-                },
-                "stored_value": {
-                  "$ref": "#/components/schemas/StoredValue",
-                  "description": "The stored value."
                 }
               },
-              "required": [
-                "api_version",
-                "merkle_proof",
-                "stored_value"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead."
-        },
-        {
           "examples": [
             {
               "name": "state_get_balance_example",
               "params": [
                 {
-                  "name": "purse_uref",
-                  "value": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
-                },
-                {
                   "name": "state_root_hash",
                   "value": "0808080808080808080808080808080808080808080808080808080808080808"
+                },
+                {
+                  "name": "purse_uref",
+                  "value": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
                 }
               ],
               "result": {
@@ -4357,56 +1459,49 @@
                 }
               }
             }
-          ],
-          "name": "state_get_balance",
+          ]
+        },
+        {
+          "name": "chain_get_era_info_by_switch_block",
+          "summary": "returns an EraInfo from the network",
           "params": [
             {
-              "name": "state_root_hash",
-              "required": true,
+              "name": "block_identifier",
               "schema": {
-                "$ref": "#/components/schemas/Digest",
-                "description": "The hash of state root."
-              }
-            },
-            {
-              "name": "purse_uref",
-              "required": true,
-              "schema": {
-                "description": "Formatted URef.",
-                "type": "string"
-              }
+                "description": "The block identifier.",
+                "$ref": "#/components/schemas/BlockIdentifier"
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "state_get_balance_result",
+            "name": "chain_get_era_info_by_switch_block_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"state_get_balance\" RPC response.",
+              "description": "Result for \"chain_get_era_info\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "balance_value": {
-                  "$ref": "#/components/schemas/U512",
-                  "description": "The balance value."
-                },
-                "merkle_proof": {
-                  "description": "The Merkle proof.",
-                  "type": "string"
+                "era_summary": {
+                  "description": "The era summary.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/EraSummary"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
-              "required": [
-                "api_version",
-                "balance_value",
-                "merkle_proof"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns a purse's balance from the network"
-        },
-        {
           "examples": [
             {
               "name": "chain_get_era_info_by_switch_block_example",
@@ -4425,74 +1520,68 @@
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
-                    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
                     "stored_value": {
                       "EraInfo": {
                         "seigniorage_allocations": [
                           {
                             "Delegator": {
-                              "amount": "1000",
                               "delegator_public_key": "01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18",
-                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876",
+                              "amount": "1000"
                             }
                           },
                           {
                             "Validator": {
-                              "amount": "2000",
-                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876",
+                              "amount": "2000"
                             }
                           }
                         ]
                       }
-                    }
+                    },
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                   }
                 }
               }
             }
-          ],
-          "name": "chain_get_era_info_by_switch_block",
+          ]
+        },
+        {
+          "name": "state_get_auction_info",
+          "summary": "returns the bids and validators as of either a specific block (by height or hash), or the most recently added block",
           "params": [
             {
               "name": "block_identifier",
-              "required": false,
               "schema": {
-                "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block identifier."
-              }
+                "description": "The block identifier.",
+                "$ref": "#/components/schemas/BlockIdentifier"
+              },
+              "required": false
             }
           ],
           "result": {
-            "name": "chain_get_era_info_by_switch_block_result",
+            "name": "state_get_auction_info_result",
             "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"chain_get_era_info\" RPC response.",
+              "description": "Result for \"state_get_auction_info\" RPC response.",
+              "type": "object",
+              "required": [
+                "api_version",
+                "auction_state"
+              ],
               "properties": {
                 "api_version": {
                   "description": "The RPC API version.",
                   "type": "string"
                 },
-                "era_summary": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/EraSummary"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The era summary."
+                "auction_state": {
+                  "description": "The auction state.",
+                  "$ref": "#/components/schemas/AuctionState"
                 }
               },
-              "required": [
-                "api_version"
-              ],
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "summary": "returns an EraInfo from the network"
-        },
-        {
           "examples": [
             {
               "name": "state_get_auction_info_example",
@@ -4509,18 +1598,7 @@
                 "value": {
                   "api_version": "1.4.8",
                   "auction_state": {
-                    "bids": [
-                      {
-                        "bid": {
-                          "bonding_purse": "uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
-                          "delegation_rate": 0,
-                          "delegators": [],
-                          "inactive": false,
-                          "staked_amount": "10"
-                        },
-                        "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
-                      }
-                    ],
+                    "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                     "block_height": 10,
                     "era_validators": [
                       {
@@ -4533,55 +1611,2989 @@
                         ]
                       }
                     ],
-                    "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+                    "bids": [
+                      {
+                        "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+                        "bid": {
+                          "bonding_purse": "uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
+                          "staked_amount": "10",
+                          "delegation_rate": 0,
+                          "delegators": [],
+                          "inactive": false
+                        }
+                      }
+                    ]
                   }
                 }
               }
             }
-          ],
-          "name": "state_get_auction_info",
-          "params": [
-            {
-              "name": "block_identifier",
-              "required": false,
-              "schema": {
-                "$ref": "#/components/schemas/BlockIdentifier",
-                "description": "The block identifier."
-              }
-            }
-          ],
-          "result": {
-            "name": "state_get_auction_info_result",
-            "schema": {
-              "additionalProperties": false,
-              "description": "Result for \"state_get_auction_info\" RPC response.",
-              "properties": {
-                "api_version": {
-                  "description": "The RPC API version.",
-                  "type": "string"
-                },
-                "auction_state": {
-                  "$ref": "#/components/schemas/AuctionState",
-                  "description": "The auction state."
-                }
-              },
-              "required": [
-                "api_version",
-                "auction_state"
-              ],
-              "type": "object"
-            }
-          },
-          "summary": "returns the bids and validators as of either a specific block (by height or hash), or the most recently added block"
+          ]
         }
       ],
-      "openrpc": "1.0.0-rc1",
-      "servers": [
-        {
-          "name": "any Casper Network node",
-          "url": "http://IP:PORT/rpc/"
+      "components": {
+        "schemas": {
+          "Deploy": {
+            "description": "A deploy; an item containing a smart contract along with the requester's signature(s).",
+            "type": "object",
+            "required": [
+              "approvals",
+              "hash",
+              "header",
+              "payment",
+              "session"
+            ],
+            "properties": {
+              "hash": {
+                "$ref": "#/components/schemas/DeployHash"
+              },
+              "header": {
+                "$ref": "#/components/schemas/DeployHeader"
+              },
+              "payment": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
+              },
+              "session": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
+              },
+              "approvals": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Approval"
+                },
+                "uniqueItems": true
+              }
+            },
+            "additionalProperties": false
+          },
+          "DeployHash": {
+            "description": "Hex-encoded deploy hash.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Digest"
+              }
+            ]
+          },
+          "Digest": {
+            "description": "Hex-encoded hash digest.",
+            "type": "string"
+          },
+          "DeployHeader": {
+            "description": "The header portion of a [`Deploy`].",
+            "type": "object",
+            "required": [
+              "account",
+              "body_hash",
+              "chain_name",
+              "dependencies",
+              "gas_price",
+              "timestamp",
+              "ttl"
+            ],
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
+              },
+              "ttl": {
+                "$ref": "#/components/schemas/TimeDiff"
+              },
+              "gas_price": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "body_hash": {
+                "$ref": "#/components/schemas/Digest"
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
+                }
+              },
+              "chain_name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "PublicKey": {
+            "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+            "type": "string"
+          },
+          "Timestamp": {
+            "description": "Timestamp formatted as per RFC 3339",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "TimeDiff": {
+            "description": "Human-readable duration.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "ExecutableDeployItem": {
+            "description": "Represents possible variants of an executable deploy.",
+            "anyOf": [
+              {
+                "description": "Executable specified as raw bytes that represent WASM code and an instance of [`RuntimeArgs`].",
+                "type": "object",
+                "required": [
+                  "ModuleBytes"
+                ],
+                "properties": {
+                  "ModuleBytes": {
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "module_bytes"
+                    ],
+                    "properties": {
+                      "module_bytes": {
+                        "description": "Hex-encoded raw Wasm bytes.",
+                        "type": "string"
+                      },
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Stored contract referenced by its [`ContractHash`], entry point and an instance of [`RuntimeArgs`].",
+                "type": "object",
+                "required": [
+                  "StoredContractByHash"
+                ],
+                "properties": {
+                  "StoredContractByHash": {
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "entry_point",
+                      "hash"
+                    ],
+                    "properties": {
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
+                      },
+                      "entry_point": {
+                        "description": "Name of an entry point.",
+                        "type": "string"
+                      },
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Stored contract referenced by a named key existing in the signer's account context, entry point and an instance of [`RuntimeArgs`].",
+                "type": "object",
+                "required": [
+                  "StoredContractByName"
+                ],
+                "properties": {
+                  "StoredContractByName": {
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "entry_point",
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Named key.",
+                        "type": "string"
+                      },
+                      "entry_point": {
+                        "description": "Name of an entry point.",
+                        "type": "string"
+                      },
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Stored versioned contract referenced by its [`ContractPackageHash`], entry point and an instance of [`RuntimeArgs`].",
+                "type": "object",
+                "required": [
+                  "StoredVersionedContractByHash"
+                ],
+                "properties": {
+                  "StoredVersionedContractByHash": {
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "entry_point",
+                      "hash"
+                    ],
+                    "properties": {
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
+                        "type": [
+                          "integer",
+                          "null"
+                        ],
+                        "format": "uint32",
+                        "minimum": 0.0
+                      },
+                      "entry_point": {
+                        "description": "Entry point name.",
+                        "type": "string"
+                      },
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Stored versioned contract referenced by a named key existing in the signer's account context, entry point and an instance of [`RuntimeArgs`].",
+                "type": "object",
+                "required": [
+                  "StoredVersionedContractByName"
+                ],
+                "properties": {
+                  "StoredVersionedContractByName": {
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "entry_point",
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Named key.",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
+                        "type": [
+                          "integer",
+                          "null"
+                        ],
+                        "format": "uint32",
+                        "minimum": 0.0
+                      },
+                      "entry_point": {
+                        "description": "Entry point name.",
+                        "type": "string"
+                      },
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A native transfer which does not contain or reference a WASM code.",
+                "type": "object",
+                "required": [
+                  "Transfer"
+                ],
+                "properties": {
+                  "Transfer": {
+                    "type": "object",
+                    "required": [
+                      "args"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "Runtime arguments.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/RuntimeArgs"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "RuntimeArgs": {
+            "description": "Represents a collection of arguments passed to a smart contract.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NamedArg"
+            }
+          },
+          "NamedArg": {
+            "description": "Named arguments to a contract.",
+            "type": "array",
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/CLValue"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          },
+          "CLValue": {
+            "description": "A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
+            "type": "object",
+            "required": [
+              "bytes",
+              "cl_type"
+            ],
+            "properties": {
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
+              },
+              "bytes": {
+                "type": "string"
+              },
+              "parsed": true
+            },
+            "additionalProperties": false
+          },
+          "CLType": {
+            "description": "Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue).",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Bool",
+                  "I32",
+                  "I64",
+                  "U8",
+                  "U32",
+                  "U64",
+                  "U128",
+                  "U256",
+                  "U512",
+                  "Unit",
+                  "String",
+                  "Key",
+                  "URef",
+                  "PublicKey",
+                  "Any"
+                ]
+              },
+              {
+                "description": "`Option` of a `CLType`.",
+                "type": "object",
+                "required": [
+                  "Option"
+                ],
+                "properties": {
+                  "Option": {
+                    "$ref": "#/components/schemas/CLType"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Variable-length list of a single `CLType` (comparable to a `Vec`).",
+                "type": "object",
+                "required": [
+                  "List"
+                ],
+                "properties": {
+                  "List": {
+                    "$ref": "#/components/schemas/CLType"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Fixed-length list of a single `CLType` (comparable to a Rust array).",
+                "type": "object",
+                "required": [
+                  "ByteArray"
+                ],
+                "properties": {
+                  "ByteArray": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "`Result` with `Ok` and `Err` variants of `CLType`s.",
+                "type": "object",
+                "required": [
+                  "Result"
+                ],
+                "properties": {
+                  "Result": {
+                    "type": "object",
+                    "required": [
+                      "err",
+                      "ok"
+                    ],
+                    "properties": {
+                      "ok": {
+                        "$ref": "#/components/schemas/CLType"
+                      },
+                      "err": {
+                        "$ref": "#/components/schemas/CLType"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Map with keys of a single `CLType` and values of a single `CLType`.",
+                "type": "object",
+                "required": [
+                  "Map"
+                ],
+                "properties": {
+                  "Map": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "$ref": "#/components/schemas/CLType"
+                      },
+                      "value": {
+                        "$ref": "#/components/schemas/CLType"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "1-ary tuple of a `CLType`.",
+                "type": "object",
+                "required": [
+                  "Tuple1"
+                ],
+                "properties": {
+                  "Tuple1": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
+                    },
+                    "maxItems": 1,
+                    "minItems": 1
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "2-ary tuple of `CLType`s.",
+                "type": "object",
+                "required": [
+                  "Tuple2"
+                ],
+                "properties": {
+                  "Tuple2": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
+                    },
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "3-ary tuple of `CLType`s.",
+                "type": "object",
+                "required": [
+                  "Tuple3"
+                ],
+                "properties": {
+                  "Tuple3": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
+                    },
+                    "maxItems": 3,
+                    "minItems": 3
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "Approval": {
+            "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
+            "type": "object",
+            "required": [
+              "signature",
+              "signer"
+            ],
+            "properties": {
+              "signer": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
+              }
+            },
+            "additionalProperties": false
+          },
+          "Signature": {
+            "description": "Hex-encoded cryptographic signature, including the algorithm tag prefix.",
+            "type": "string"
+          },
+          "JsonExecutionResult": {
+            "description": "The execution result of a single deploy.",
+            "type": "object",
+            "required": [
+              "block_hash",
+              "result"
+            ],
+            "properties": {
+              "block_hash": {
+                "description": "The block hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                ]
+              },
+              "result": {
+                "description": "Execution result.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExecutionResult"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "BlockHash": {
+            "description": "A cryptographic hash identifying a [`Block`](struct.Block.html).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Digest"
+              }
+            ]
+          },
+          "ExecutionResult": {
+            "description": "The result of executing a single deploy.",
+            "anyOf": [
+              {
+                "description": "The result of a failed execution.",
+                "type": "object",
+                "required": [
+                  "Failure"
+                ],
+                "properties": {
+                  "Failure": {
+                    "type": "object",
+                    "required": [
+                      "cost",
+                      "effect",
+                      "error_message",
+                      "transfers"
+                    ],
+                    "properties": {
+                      "effect": {
+                        "description": "The effect of executing the deploy.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/ExecutionEffect"
+                          }
+                        ]
+                      },
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
+                        }
+                      },
+                      "cost": {
+                        "description": "The cost of executing the deploy.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/U512"
+                          }
+                        ]
+                      },
+                      "error_message": {
+                        "description": "The error message associated with executing the deploy.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "The result of a successful execution.",
+                "type": "object",
+                "required": [
+                  "Success"
+                ],
+                "properties": {
+                  "Success": {
+                    "type": "object",
+                    "required": [
+                      "cost",
+                      "effect",
+                      "transfers"
+                    ],
+                    "properties": {
+                      "effect": {
+                        "description": "The effect of executing the deploy.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/ExecutionEffect"
+                          }
+                        ]
+                      },
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
+                        }
+                      },
+                      "cost": {
+                        "description": "The cost of executing the deploy.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/U512"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "ExecutionEffect": {
+            "description": "The journal of execution transforms from a single deploy.",
+            "type": "object",
+            "required": [
+              "operations",
+              "transforms"
+            ],
+            "properties": {
+              "operations": {
+                "description": "The resulting operations.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              },
+              "transforms": {
+                "description": "The journal of execution transforms.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TransformEntry"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "Operation": {
+            "description": "An operation performed while executing a deploy.",
+            "type": "object",
+            "required": [
+              "key",
+              "kind"
+            ],
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The type of operation.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpKind"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "OpKind": {
+            "description": "The type of operation performed while executing a deploy.",
+            "type": "string",
+            "enum": [
+              "Read",
+              "Write",
+              "Add",
+              "NoOp"
+            ]
+          },
+          "TransformEntry": {
+            "description": "A transformation performed while executing a deploy.",
+            "type": "object",
+            "required": [
+              "key",
+              "transform"
+            ],
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
+              },
+              "transform": {
+                "description": "The transformation.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Transform"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "Transform": {
+            "description": "The actual transformation performed while executing a deploy.",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Identity",
+                  "WriteContractWasm",
+                  "WriteContract",
+                  "WriteContractPackage"
+                ]
+              },
+              {
+                "description": "Writes the given CLValue to global state.",
+                "type": "object",
+                "required": [
+                  "WriteCLValue"
+                ],
+                "properties": {
+                  "WriteCLValue": {
+                    "$ref": "#/components/schemas/CLValue"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given Account to global state.",
+                "type": "object",
+                "required": [
+                  "WriteAccount"
+                ],
+                "properties": {
+                  "WriteAccount": {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given DeployInfo to global state.",
+                "type": "object",
+                "required": [
+                  "WriteDeployInfo"
+                ],
+                "properties": {
+                  "WriteDeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given EraInfo to global state.",
+                "type": "object",
+                "required": [
+                  "WriteEraInfo"
+                ],
+                "properties": {
+                  "WriteEraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given Transfer to global state.",
+                "type": "object",
+                "required": [
+                  "WriteTransfer"
+                ],
+                "properties": {
+                  "WriteTransfer": {
+                    "$ref": "#/components/schemas/Transfer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given Bid to global state.",
+                "type": "object",
+                "required": [
+                  "WriteBid"
+                ],
+                "properties": {
+                  "WriteBid": {
+                    "$ref": "#/components/schemas/Bid"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given Withdraw to global state.",
+                "type": "object",
+                "required": [
+                  "WriteWithdraw"
+                ],
+                "properties": {
+                  "WriteWithdraw": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given `i32`.",
+                "type": "object",
+                "required": [
+                  "AddInt32"
+                ],
+                "properties": {
+                  "AddInt32": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given `u64`.",
+                "type": "object",
+                "required": [
+                  "AddUInt64"
+                ],
+                "properties": {
+                  "AddUInt64": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given `U128`.",
+                "type": "object",
+                "required": [
+                  "AddUInt128"
+                ],
+                "properties": {
+                  "AddUInt128": {
+                    "$ref": "#/components/schemas/U128"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given `U256`.",
+                "type": "object",
+                "required": [
+                  "AddUInt256"
+                ],
+                "properties": {
+                  "AddUInt256": {
+                    "$ref": "#/components/schemas/U256"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given `U512`.",
+                "type": "object",
+                "required": [
+                  "AddUInt512"
+                ],
+                "properties": {
+                  "AddUInt512": {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Adds the given collection of named keys.",
+                "type": "object",
+                "required": [
+                  "AddKeys"
+                ],
+                "properties": {
+                  "AddKeys": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/NamedKey"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A failed transformation, containing an error message.",
+                "type": "object",
+                "required": [
+                  "Failure"
+                ],
+                "properties": {
+                  "Failure": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "AccountHash": {
+            "description": "Hex-encoded account hash.",
+            "type": "string"
+          },
+          "DeployInfo": {
+            "description": "Information relating to the given Deploy.",
+            "type": "object",
+            "required": [
+              "deploy_hash",
+              "from",
+              "gas",
+              "source",
+              "transfers"
+            ],
+            "properties": {
+              "deploy_hash": {
+                "description": "The relevant Deploy.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeployHash"
+                  }
+                ]
+              },
+              "transfers": {
+                "description": "Transfers performed by the Deploy.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TransferAddr"
+                }
+              },
+              "from": {
+                "description": "Account identifier of the creator of the Deploy.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                ]
+              },
+              "source": {
+                "description": "Source purse used for payment of the Deploy.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "gas": {
+                "description": "Gas cost of executing the Deploy.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "TransferAddr": {
+            "description": "Hex-encoded transfer address.",
+            "type": "string"
+          },
+          "URef": {
+            "description": "Hex-encoded, formatted URef.",
+            "type": "string"
+          },
+          "U512": {
+            "description": "Decimal representation of a 512-bit integer.",
+            "type": "string"
+          },
+          "EraInfo": {
+            "description": "Auction metadata.  Intended to be recorded at each era.",
+            "type": "object",
+            "required": [
+              "seigniorage_allocations"
+            ],
+            "properties": {
+              "seigniorage_allocations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SeigniorageAllocation"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "SeigniorageAllocation": {
+            "description": "Information about a seigniorage allocation",
+            "anyOf": [
+              {
+                "description": "Info about a seigniorage allocation for a validator",
+                "type": "object",
+                "required": [
+                  "Validator"
+                ],
+                "properties": {
+                  "Validator": {
+                    "type": "object",
+                    "required": [
+                      "amount",
+                      "validator_public_key"
+                    ],
+                    "properties": {
+                      "validator_public_key": {
+                        "description": "Validator's public key",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/PublicKey"
+                          }
+                        ]
+                      },
+                      "amount": {
+                        "description": "Allocated amount",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/U512"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Info about a seigniorage allocation for a delegator",
+                "type": "object",
+                "required": [
+                  "Delegator"
+                ],
+                "properties": {
+                  "Delegator": {
+                    "type": "object",
+                    "required": [
+                      "amount",
+                      "delegator_public_key",
+                      "validator_public_key"
+                    ],
+                    "properties": {
+                      "delegator_public_key": {
+                        "description": "Delegator's public key",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/PublicKey"
+                          }
+                        ]
+                      },
+                      "validator_public_key": {
+                        "description": "Validator's public key",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/PublicKey"
+                          }
+                        ]
+                      },
+                      "amount": {
+                        "description": "Allocated amount",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/U512"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "Transfer": {
+            "description": "Represents a transfer from one purse to another",
+            "type": "object",
+            "required": [
+              "amount",
+              "deploy_hash",
+              "from",
+              "gas",
+              "source",
+              "target"
+            ],
+            "properties": {
+              "deploy_hash": {
+                "description": "Deploy that created the transfer",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeployHash"
+                  }
+                ]
+              },
+              "from": {
+                "description": "Account from which transfer was executed",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                ]
+              },
+              "to": {
+                "description": "Account to which funds are transferred",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/AccountHash"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "source": {
+                "description": "Source purse",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "target": {
+                "description": "Target purse",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "amount": {
+                "description": "Transfer amount",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              },
+              "gas": {
+                "description": "Gas",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              },
+              "id": {
+                "description": "User-defined id",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          "Bid": {
+            "description": "An entry in the validator map.",
+            "type": "object",
+            "required": [
+              "bonding_purse",
+              "delegation_rate",
+              "delegators",
+              "inactive",
+              "staked_amount",
+              "validator_public_key"
+            ],
+            "properties": {
+              "validator_public_key": {
+                "description": "Validator public key",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "bonding_purse": {
+                "description": "The purse that was used for bonding.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "staked_amount": {
+                "description": "The amount of tokens staked by a validator (not including delegators).",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              },
+              "delegation_rate": {
+                "description": "Delegation rate",
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              },
+              "vesting_schedule": {
+                "description": "Vesting schedule for a genesis validator. `None` if non-genesis validator.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/VestingSchedule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "delegators": {
+                "description": "This validator's delegators, indexed by their public keys",
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Delegator"
+                }
+              },
+              "inactive": {
+                "description": "`true` if validator has been \"evicted\"",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "VestingSchedule": {
+            "type": "object",
+            "required": [
+              "initial_release_timestamp_millis"
+            ],
+            "properties": {
+              "initial_release_timestamp_millis": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "locked_amounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/U512"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "Delegator": {
+            "description": "Represents a party delegating their stake to a validator (or \"delegatee\")",
+            "type": "object",
+            "required": [
+              "bonding_purse",
+              "delegator_public_key",
+              "staked_amount",
+              "validator_public_key"
+            ],
+            "properties": {
+              "delegator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
+              },
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
+              },
+              "validator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "vesting_schedule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/VestingSchedule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "UnbondingPurse": {
+            "description": "Unbonding purse.",
+            "type": "object",
+            "required": [
+              "amount",
+              "bonding_purse",
+              "era_of_creation",
+              "unbonder_public_key",
+              "validator_public_key"
+            ],
+            "properties": {
+              "bonding_purse": {
+                "description": "Bonding Purse",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "validator_public_key": {
+                "description": "Validators public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "unbonder_public_key": {
+                "description": "Unbonders public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "era_of_creation": {
+                "description": "Era in which this unbonding request was created.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "amount": {
+                "description": "Unbonding Amount.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              },
+              "new_validator": {
+                "description": "The validator public key to re-delegate to.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "EraId": {
+            "description": "Era ID newtype.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "U128": {
+            "description": "Decimal representation of a 128-bit integer.",
+            "type": "string"
+          },
+          "U256": {
+            "description": "Decimal representation of a 256-bit integer.",
+            "type": "string"
+          },
+          "NamedKey": {
+            "description": "A named key.",
+            "type": "object",
+            "required": [
+              "key",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "description": "The name of the entry.",
+                "type": "string"
+              },
+              "key": {
+                "description": "The value of the entry: a casper `Key` type.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "BlockIdentifier": {
+            "description": "Identifier for possible ways to retrieve a block.",
+            "anyOf": [
+              {
+                "description": "Identify and retrieve the block with its hash.",
+                "type": "object",
+                "required": [
+                  "Hash"
+                ],
+                "properties": {
+                  "Hash": {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Identify and retrieve the block with its height.",
+                "type": "object",
+                "required": [
+                  "Height"
+                ],
+                "properties": {
+                  "Height": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "Account": {
+            "description": "Structure representing a user's account, stored in global state.",
+            "type": "object",
+            "required": [
+              "account_hash",
+              "action_thresholds",
+              "associated_keys",
+              "main_purse",
+              "named_keys"
+            ],
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
+              },
+              "named_keys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
+                }
+              },
+              "main_purse": {
+                "$ref": "#/components/schemas/URef"
+              },
+              "associated_keys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AssociatedKey"
+                }
+              },
+              "action_thresholds": {
+                "$ref": "#/components/schemas/ActionThresholds"
+              }
+            },
+            "additionalProperties": false
+          },
+          "AssociatedKey": {
+            "type": "object",
+            "required": [
+              "account_hash",
+              "weight"
+            ],
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
+              },
+              "weight": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          "ActionThresholds": {
+            "description": "Thresholds that have to be met when executing an action of a certain type.",
+            "type": "object",
+            "required": [
+              "deployment",
+              "key_management"
+            ],
+            "properties": {
+              "deployment": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              },
+              "key_management": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          "DictionaryIdentifier": {
+            "description": "Options for dictionary item lookups.",
+            "anyOf": [
+              {
+                "description": "Lookup a dictionary item via an Account's named keys.",
+                "type": "object",
+                "required": [
+                  "AccountNamedKey"
+                ],
+                "properties": {
+                  "AccountNamedKey": {
+                    "type": "object",
+                    "required": [
+                      "dictionary_item_key",
+                      "dictionary_name",
+                      "key"
+                    ],
+                    "properties": {
+                      "key": {
+                        "description": "The account key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
+                      },
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
+                      },
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Lookup a dictionary item via a Contract's named keys.",
+                "type": "object",
+                "required": [
+                  "ContractNamedKey"
+                ],
+                "properties": {
+                  "ContractNamedKey": {
+                    "type": "object",
+                    "required": [
+                      "dictionary_item_key",
+                      "dictionary_name",
+                      "key"
+                    ],
+                    "properties": {
+                      "key": {
+                        "description": "The contract key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
+                      },
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
+                      },
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Lookup a dictionary item via its seed URef.",
+                "type": "object",
+                "required": [
+                  "URef"
+                ],
+                "properties": {
+                  "URef": {
+                    "type": "object",
+                    "required": [
+                      "dictionary_item_key",
+                      "seed_uref"
+                    ],
+                    "properties": {
+                      "seed_uref": {
+                        "description": "The dictionary's seed URef.",
+                        "type": "string"
+                      },
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Lookup a dictionary item via its unique key.",
+                "type": "object",
+                "required": [
+                  "Dictionary"
+                ],
+                "properties": {
+                  "Dictionary": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "StoredValue": {
+            "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info).",
+            "anyOf": [
+              {
+                "description": "A CasperLabs value.",
+                "type": "object",
+                "required": [
+                  "CLValue"
+                ],
+                "properties": {
+                  "CLValue": {
+                    "$ref": "#/components/schemas/CLValue"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "An account.",
+                "type": "object",
+                "required": [
+                  "Account"
+                ],
+                "properties": {
+                  "Account": {
+                    "$ref": "#/components/schemas/Account"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A contract's Wasm",
+                "type": "object",
+                "required": [
+                  "ContractWasm"
+                ],
+                "properties": {
+                  "ContractWasm": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Methods and type signatures supported by a contract.",
+                "type": "object",
+                "required": [
+                  "Contract"
+                ],
+                "properties": {
+                  "Contract": {
+                    "$ref": "#/components/schemas/Contract"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A contract definition, metadata, and security container.",
+                "type": "object",
+                "required": [
+                  "ContractPackage"
+                ],
+                "properties": {
+                  "ContractPackage": {
+                    "$ref": "#/components/schemas/ContractPackage"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A record of a transfer",
+                "type": "object",
+                "required": [
+                  "Transfer"
+                ],
+                "properties": {
+                  "Transfer": {
+                    "$ref": "#/components/schemas/Transfer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A record of a deploy",
+                "type": "object",
+                "required": [
+                  "DeployInfo"
+                ],
+                "properties": {
+                  "DeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Auction metadata",
+                "type": "object",
+                "required": [
+                  "EraInfo"
+                ],
+                "properties": {
+                  "EraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A bid",
+                "type": "object",
+                "required": [
+                  "Bid"
+                ],
+                "properties": {
+                  "Bid": {
+                    "$ref": "#/components/schemas/Bid"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A withdraw",
+                "type": "object",
+                "required": [
+                  "Withdraw"
+                ],
+                "properties": {
+                  "Withdraw": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WithdrawPurse"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "A collection of unbonding purses",
+                "type": "object",
+                "required": [
+                  "Unbonding"
+                ],
+                "properties": {
+                  "Unbonding": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "Contract": {
+            "description": "A contract struct that can be serialized as  JSON object.",
+            "type": "object",
+            "required": [
+              "contract_package_hash",
+              "contract_wasm_hash",
+              "entry_points",
+              "named_keys",
+              "protocol_version"
+            ],
+            "properties": {
+              "contract_package_hash": {
+                "$ref": "#/components/schemas/ContractPackageHash"
+              },
+              "contract_wasm_hash": {
+                "$ref": "#/components/schemas/ContractWasmHash"
+              },
+              "named_keys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
+                }
+              },
+              "entry_points": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryPoint"
+                }
+              },
+              "protocol_version": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "ContractPackageHash": {
+            "description": "The hash address of the contract package",
+            "type": "string"
+          },
+          "ContractWasmHash": {
+            "description": "The hash address of the contract wasm",
+            "type": "string"
+          },
+          "EntryPoint": {
+            "description": "Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
+            "type": "object",
+            "required": [
+              "access",
+              "args",
+              "entry_point_type",
+              "name",
+              "ret"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Parameter"
+                }
+              },
+              "ret": {
+                "$ref": "#/components/schemas/CLType"
+              },
+              "access": {
+                "$ref": "#/components/schemas/EntryPointAccess"
+              },
+              "entry_point_type": {
+                "$ref": "#/components/schemas/EntryPointType"
+              }
+            }
+          },
+          "Parameter": {
+            "description": "Parameter to a method",
+            "type": "object",
+            "required": [
+              "cl_type",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
+              }
+            }
+          },
+          "EntryPointAccess": {
+            "description": "Enum describing the possible access control options for a contract entry point (method).",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Public"
+                ]
+              },
+              {
+                "description": "Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
+                "type": "object",
+                "required": [
+                  "Groups"
+                ],
+                "properties": {
+                  "Groups": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Group"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "Group": {
+            "description": "A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
+            "type": "string"
+          },
+          "EntryPointType": {
+            "description": "Context of method execution",
+            "type": "string",
+            "enum": [
+              "Session",
+              "Contract"
+            ]
+          },
+          "ContractPackage": {
+            "description": "Contract definition, metadata, and security container.",
+            "type": "object",
+            "required": [
+              "access_key",
+              "disabled_versions",
+              "groups",
+              "versions"
+            ],
+            "properties": {
+              "access_key": {
+                "$ref": "#/components/schemas/URef"
+              },
+              "versions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ContractVersion"
+                }
+              },
+              "disabled_versions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DisabledVersion"
+                }
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Groups"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "ContractVersion": {
+            "type": "object",
+            "required": [
+              "contract_hash",
+              "contract_version",
+              "protocol_version_major"
+            ],
+            "properties": {
+              "protocol_version_major": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "contract_version": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "contract_hash": {
+                "$ref": "#/components/schemas/ContractHash"
+              }
+            }
+          },
+          "ContractHash": {
+            "description": "The hash address of the contract",
+            "type": "string"
+          },
+          "DisabledVersion": {
+            "type": "object",
+            "required": [
+              "contract_version",
+              "protocol_version_major"
+            ],
+            "properties": {
+              "protocol_version_major": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "contract_version": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          },
+          "Groups": {
+            "type": "object",
+            "required": [
+              "group",
+              "keys"
+            ],
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "keys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/URef"
+                }
+              }
+            }
+          },
+          "WithdrawPurse": {
+            "description": "A withdraw purse, a legacy structure.",
+            "type": "object",
+            "required": [
+              "amount",
+              "bonding_purse",
+              "era_of_creation",
+              "unbonder_public_key",
+              "validator_public_key"
+            ],
+            "properties": {
+              "bonding_purse": {
+                "description": "Bonding Purse",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "validator_public_key": {
+                "description": "Validators public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "unbonder_public_key": {
+                "description": "Unbonders public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "era_of_creation": {
+                "description": "Era in which this unbonding request was created.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "amount": {
+                "description": "Unbonding Amount.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "GlobalStateIdentifier": {
+            "description": "Identifier for possible ways to query Global State",
+            "anyOf": [
+              {
+                "description": "Query using a block hash.",
+                "type": "object",
+                "required": [
+                  "BlockHash"
+                ],
+                "properties": {
+                  "BlockHash": {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Query using a block height.",
+                "type": "object",
+                "required": [
+                  "BlockHeight"
+                ],
+                "properties": {
+                  "BlockHeight": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Query using the state root hash.",
+                "type": "object",
+                "required": [
+                  "StateRootHash"
+                ],
+                "properties": {
+                  "StateRootHash": {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "JsonBlockHeader": {
+            "description": "JSON representation of a block header.",
+            "type": "object",
+            "required": [
+              "accumulated_seed",
+              "body_hash",
+              "era_id",
+              "height",
+              "parent_hash",
+              "protocol_version",
+              "random_bit",
+              "state_root_hash",
+              "timestamp"
+            ],
+            "properties": {
+              "parent_hash": {
+                "description": "The parent hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                ]
+              },
+              "state_root_hash": {
+                "description": "The state root hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                ]
+              },
+              "body_hash": {
+                "description": "The body hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                ]
+              },
+              "random_bit": {
+                "description": "Randomness bit.",
+                "type": "boolean"
+              },
+              "accumulated_seed": {
+                "description": "Accumulated seed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                ]
+              },
+              "era_end": {
+                "description": "The era end.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/JsonEraEnd"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "timestamp": {
+                "description": "The block timestamp.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Timestamp"
+                  }
+                ]
+              },
+              "era_id": {
+                "description": "The block era id.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "height": {
+                "description": "The block height.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "protocol_version": {
+                "description": "The protocol version.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProtocolVersion"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonEraEnd": {
+            "type": "object",
+            "required": [
+              "era_report",
+              "next_era_validator_weights"
+            ],
+            "properties": {
+              "era_report": {
+                "$ref": "#/components/schemas/JsonEraReport"
+              },
+              "next_era_validator_weights": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ValidatorWeight"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonEraReport": {
+            "description": "Equivocation and reward information to be included in the terminal block.",
+            "type": "object",
+            "required": [
+              "equivocators",
+              "inactive_validators",
+              "rewards"
+            ],
+            "properties": {
+              "equivocators": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
+                }
+              },
+              "rewards": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Reward"
+                }
+              },
+              "inactive_validators": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "Reward": {
+            "type": "object",
+            "required": [
+              "amount",
+              "validator"
+            ],
+            "properties": {
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "amount": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          "ValidatorWeight": {
+            "type": "object",
+            "required": [
+              "validator",
+              "weight"
+            ],
+            "properties": {
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "weight": {
+                "$ref": "#/components/schemas/U512"
+              }
+            },
+            "additionalProperties": false
+          },
+          "ProtocolVersion": {
+            "description": "Casper Platform protocol version",
+            "type": "string"
+          },
+          "PurseIdentifier": {
+            "description": "Identifier of a purse.",
+            "anyOf": [
+              {
+                "description": "The main purse of the account identified by this public key.",
+                "type": "object",
+                "required": [
+                  "main_purse_under_public_key"
+                ],
+                "properties": {
+                  "main_purse_under_public_key": {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "The main purse of the account identified by this account hash.",
+                "type": "object",
+                "required": [
+                  "main_purse_under_account_hash"
+                ],
+                "properties": {
+                  "main_purse_under_account_hash": {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "The purse identified by this URef.",
+                "type": "object",
+                "required": [
+                  "purse_uref"
+                ],
+                "properties": {
+                  "purse_uref": {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "PeersMap": {
+            "description": "Map of peer IDs to network addresses.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PeerEntry"
+            }
+          },
+          "PeerEntry": {
+            "description": "Node peer entry.",
+            "type": "object",
+            "required": [
+              "address",
+              "node_id"
+            ],
+            "properties": {
+              "node_id": {
+                "description": "Node id.",
+                "type": "string"
+              },
+              "address": {
+                "description": "Node address.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "MinimalBlockInfo": {
+            "description": "Minimal info of a `Block`.",
+            "type": "object",
+            "required": [
+              "creator",
+              "era_id",
+              "hash",
+              "height",
+              "state_root_hash",
+              "timestamp"
+            ],
+            "properties": {
+              "hash": {
+                "$ref": "#/components/schemas/BlockHash"
+              },
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
+              },
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
+              },
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "state_root_hash": {
+                "$ref": "#/components/schemas/Digest"
+              },
+              "creator": {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            },
+            "additionalProperties": false
+          },
+          "NextUpgrade": {
+            "description": "Information about the next protocol upgrade.",
+            "type": "object",
+            "required": [
+              "activation_point",
+              "protocol_version"
+            ],
+            "properties": {
+              "activation_point": {
+                "$ref": "#/components/schemas/ActivationPoint"
+              },
+              "protocol_version": {
+                "type": "string"
+              }
+            }
+          },
+          "ActivationPoint": {
+            "description": "The first era to which the associated protocol version applies.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              },
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "ReactorState": {
+            "description": "The state of the reactor.",
+            "type": "string",
+            "enum": [
+              "Initialize",
+              "CatchUp",
+              "Upgrading",
+              "KeepUp",
+              "Validate",
+              "ShutdownForUpgrade"
+            ]
+          },
+          "AvailableBlockRange": {
+            "description": "An unbroken, inclusive range of blocks.",
+            "type": "object",
+            "required": [
+              "high",
+              "low"
+            ],
+            "properties": {
+              "low": {
+                "description": "The inclusive lower bound of the range.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "high": {
+                "description": "The inclusive upper bound of the range.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          "BlockSynchronizerStatus": {
+            "description": "The status of the block synchronizer.",
+            "type": "object",
+            "properties": {
+              "historical": {
+                "description": "The status of syncing a historical block, if any.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockSyncStatus"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "forward": {
+                "description": "The status of syncing a forward block, if any.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockSyncStatus"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "BlockSyncStatus": {
+            "description": "The status of syncing an individual block.",
+            "type": "object",
+            "required": [
+              "acquisition_state",
+              "block_hash"
+            ],
+            "properties": {
+              "block_hash": {
+                "description": "The block hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                ]
+              },
+              "block_height": {
+                "description": "The height of the block, if known.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "acquisition_state": {
+                "description": "The state of acquisition of the data associated with the block.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonValidatorChanges": {
+            "description": "The changes in a validator's status.",
+            "type": "object",
+            "required": [
+              "public_key",
+              "status_changes"
+            ],
+            "properties": {
+              "public_key": {
+                "description": "The public key of the validator.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "status_changes": {
+                "description": "The set of changes to the validator's status.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonValidatorStatusChange"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonValidatorStatusChange": {
+            "description": "A single change to a validator's status in the given era.",
+            "type": "object",
+            "required": [
+              "era_id",
+              "validator_change"
+            ],
+            "properties": {
+              "era_id": {
+                "description": "The era in which the change occurred.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "validator_change": {
+                "description": "The change in validator status.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ValidatorChange"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "ValidatorChange": {
+            "description": "A change to a validator's status between two eras.",
+            "type": "string",
+            "enum": [
+              "Added",
+              "Removed",
+              "Banned",
+              "CannotPropose",
+              "SeenAsFaulty"
+            ]
+          },
+          "ChainspecRawBytes": {
+            "description": "The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.",
+            "type": "object",
+            "required": [
+              "chainspec_bytes",
+              "maybe_genesis_accounts_bytes",
+              "maybe_global_state_bytes"
+            ],
+            "properties": {
+              "chainspec_bytes": {
+                "description": "Hex-encoded raw bytes of the current chainspec.toml file.",
+                "type": "string"
+              },
+              "maybe_genesis_accounts_bytes": {
+                "description": "Hex-encoded raw bytes of the current genesis accounts.toml file.",
+                "type": "string"
+              },
+              "maybe_global_state_bytes": {
+                "description": "Hex-encoded raw bytes of the current global_state.toml file.",
+                "type": "string"
+              }
+            }
+          },
+          "JsonBlock": {
+            "description": "A JSON-friendly representation of `Block`.",
+            "type": "object",
+            "required": [
+              "body",
+              "hash",
+              "header",
+              "proofs"
+            ],
+            "properties": {
+              "hash": {
+                "description": "`BlockHash`",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                ]
+              },
+              "header": {
+                "description": "JSON-friendly block header.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/JsonBlockHeader"
+                  }
+                ]
+              },
+              "body": {
+                "description": "JSON-friendly block body.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/JsonBlockBody"
+                  }
+                ]
+              },
+              "proofs": {
+                "description": "JSON-friendly list of proofs for this block.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonProof"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonBlockBody": {
+            "description": "A JSON-friendly representation of `Body`",
+            "type": "object",
+            "required": [
+              "deploy_hashes",
+              "proposer",
+              "transfer_hashes"
+            ],
+            "properties": {
+              "proposer": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "deploy_hashes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
+                }
+              },
+              "transfer_hashes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonProof": {
+            "description": "A JSON-friendly representation of a proof, i.e. a block's finality signature.",
+            "type": "object",
+            "required": [
+              "public_key",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
+              }
+            },
+            "additionalProperties": false
+          },
+          "EraSummary": {
+            "description": "The summary of an era",
+            "type": "object",
+            "required": [
+              "block_hash",
+              "era_id",
+              "merkle_proof",
+              "state_root_hash",
+              "stored_value"
+            ],
+            "properties": {
+              "block_hash": {
+                "description": "The block hash",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockHash"
+                  }
+                ]
+              },
+              "era_id": {
+                "description": "The era id",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "stored_value": {
+                "description": "The StoredValue containing era information",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/StoredValue"
+                  }
+                ]
+              },
+              "state_root_hash": {
+                "description": "Hex-encoded hash of the state root",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                ]
+              },
+              "merkle_proof": {
+                "description": "The Merkle proof",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "AuctionState": {
+            "description": "Data structure summarizing auction contract data.",
+            "type": "object",
+            "required": [
+              "bids",
+              "block_height",
+              "era_validators",
+              "state_root_hash"
+            ],
+            "properties": {
+              "state_root_hash": {
+                "description": "Global state hash.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Digest"
+                  }
+                ]
+              },
+              "block_height": {
+                "description": "Block height.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "era_validators": {
+                "description": "Era validators.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonEraValidators"
+                }
+              },
+              "bids": {
+                "description": "All bids contained within a vector.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonBids"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonEraValidators": {
+            "description": "The validators for the given era.",
+            "type": "object",
+            "required": [
+              "era_id",
+              "validator_weights"
+            ],
+            "properties": {
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
+              },
+              "validator_weights": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonValidatorWeights"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonValidatorWeights": {
+            "description": "A validator's weight.",
+            "type": "object",
+            "required": [
+              "public_key",
+              "weight"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "weight": {
+                "$ref": "#/components/schemas/U512"
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonBids": {
+            "description": "A Json representation of a single bid.",
+            "type": "object",
+            "required": [
+              "bid",
+              "public_key"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "bid": {
+                "$ref": "#/components/schemas/JsonBid"
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonBid": {
+            "description": "An entry in a founding validator map representing a bid.",
+            "type": "object",
+            "required": [
+              "bonding_purse",
+              "delegation_rate",
+              "delegators",
+              "inactive",
+              "staked_amount"
+            ],
+            "properties": {
+              "bonding_purse": {
+                "description": "The purse that was used for bonding.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "staked_amount": {
+                "description": "The amount of tokens staked by a validator (not including delegators).",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              },
+              "delegation_rate": {
+                "description": "The delegation rate.",
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              },
+              "delegators": {
+                "description": "The delegators.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/JsonDelegator"
+                }
+              },
+              "inactive": {
+                "description": "Is this an inactive validator.",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "JsonDelegator": {
+            "description": "A delegator associated with the given validator.",
+            "type": "object",
+            "required": [
+              "bonding_purse",
+              "delegatee",
+              "public_key",
+              "staked_amount"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
+              },
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
+              },
+              "delegatee": {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            },
+            "additionalProperties": false
+          }
         }
-      ]
+      }
     }
   ],
   "type": "object",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -55,8 +55,8 @@ proptest = "1.0.0"
 proptest-attr-macro = "1.0.0"
 rand = "0.8.3"
 rand_pcg = "0.3.0"
-serde_json = "1.0.55"
-serde_test = "1.0.117"
+serde_json = "1"
+serde_test = "1"
 strum = { version = "0.21", features = ["derive"] }
 tempfile = "3"
 thiserror = "1"
@@ -64,7 +64,7 @@ untrusted = "0.7.1"
 
 [features]
 json-schema = ["once_cell", "schemars"]
-std = ["derp", "getrandom", "humantime", "once_cell", "pem", "thiserror", "untrusted"]
+std = ["derp", "getrandom", "humantime", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
 testing = ["proptest", "rand_pcg"]
 # DEPRECATED - use "testing" instead of "gens".
 gens = ["testing"]


### PR DESCRIPTION
This PR enable the `preserve_order` feature of `serde_json`, which causes structs (such as the `GetStatusResult`) to retain the order of the fields when encoding to JSON.