### PR TITLE
Add unit suffix for newly added metrics

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_time` histogram metric to track the progress of block synchronization, `chain_low_seq_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration`, `sync_leap_fetched_from_peer`, `sync_leap_rejected_by_peer`, `sync_leap_cant_fetch` to track progress of the sync leaper component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_time_seconds` histogram metric to track the progress of block synchronization, `chain_low_seq_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
 
 ### Changed
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_time_seconds` histogram metric to track the progress of block synchronization, `chain_low_seq_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_duration_seconds` histogram metric to track the progress of block synchronization, `chain_low_seq_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
 
 ### Changed
 

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -398,7 +398,7 @@ impl BlockSynchronizer {
             Some(builder) if builder.block_hash() == *block_hash => {
                 builder.register_block_execution_enqueued();
                 self.metrics
-                    .forward_block_sync_time
+                    .forward_block_sync_duration
                     .observe(builder.sync_start_time().elapsed().as_secs_f64());
             }
             _ => {
@@ -431,7 +431,7 @@ impl BlockSynchronizer {
                     effects.extend(effect_builder.announce_completed_block(block).ignore());
                 }
                 self.metrics
-                    .historical_block_sync_time
+                    .historical_block_sync_duration
                     .observe(builder.sync_start_time().elapsed().as_secs_f64());
             }
             _ => {

--- a/node/src/components/block_synchronizer/metrics.rs
+++ b/node/src/components/block_synchronizer/metrics.rs
@@ -2,9 +2,9 @@ use prometheus::{Histogram, Registry};
 
 use crate::{unregister_metric, utils};
 
-const HIST_SYNC_TIME_NAME: &str = "historical_block_sync_time";
+const HIST_SYNC_TIME_NAME: &str = "historical_block_sync_time_seconds";
 const HIST_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a historical block";
-const FWD_SYNC_TIME_NAME: &str = "forward_block_sync_time";
+const FWD_SYNC_TIME_NAME: &str = "forward_block_sync_time_seconds";
 const FWD_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a forward block";
 
 // We use exponential buckets to observe the time it takes to synchronize blocks.

--- a/node/src/components/block_synchronizer/metrics.rs
+++ b/node/src/components/block_synchronizer/metrics.rs
@@ -2,10 +2,10 @@ use prometheus::{Histogram, Registry};
 
 use crate::{unregister_metric, utils};
 
-const HIST_SYNC_TIME_NAME: &str = "historical_block_sync_time_seconds";
-const HIST_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a historical block";
-const FWD_SYNC_TIME_NAME: &str = "forward_block_sync_time_seconds";
-const FWD_SYNC_TIME_HELP: &str = "duration (in sec) to synchronize a forward block";
+const HIST_SYNC_DURATION_NAME: &str = "historical_block_sync_duration_seconds";
+const HIST_SYNC_DURATION_HELP: &str = "duration (in sec) to synchronize a historical block";
+const FWD_SYNC_DURATION_NAME: &str = "forward_block_sync_duration_seconds";
+const FWD_SYNC_DURATION_HELP: &str = "duration (in sec) to synchronize a forward block";
 
 // We use exponential buckets to observe the time it takes to synchronize blocks.
 // Coverage is ~7.7s with higher resolution in the first buckets.
@@ -17,9 +17,9 @@ const EXPONENTIAL_BUCKET_COUNT: usize = 10;
 #[derive(Debug)]
 pub(super) struct Metrics {
     /// Time duration for the historical synchronizer to get a block.
-    pub(super) historical_block_sync_time: Histogram,
+    pub(super) historical_block_sync_duration: Histogram,
     /// Time duration for the forward synchronizer to get a block.
-    pub(super) forward_block_sync_time: Histogram,
+    pub(super) forward_block_sync_duration: Histogram,
     registry: Registry,
 }
 
@@ -33,16 +33,16 @@ impl Metrics {
         )?;
 
         Ok(Metrics {
-            historical_block_sync_time: utils::register_histogram_metric(
+            historical_block_sync_duration: utils::register_histogram_metric(
                 registry,
-                HIST_SYNC_TIME_NAME,
-                HIST_SYNC_TIME_HELP,
+                HIST_SYNC_DURATION_NAME,
+                HIST_SYNC_DURATION_HELP,
                 buckets.clone(),
             )?,
-            forward_block_sync_time: utils::register_histogram_metric(
+            forward_block_sync_duration: utils::register_histogram_metric(
                 registry,
-                FWD_SYNC_TIME_NAME,
-                FWD_SYNC_TIME_HELP,
+                FWD_SYNC_DURATION_NAME,
+                FWD_SYNC_DURATION_HELP,
                 buckets,
             )?,
             registry: registry.clone(),
@@ -52,7 +52,7 @@ impl Metrics {
 
 impl Drop for Metrics {
     fn drop(&mut self) {
-        unregister_metric!(self.registry, self.historical_block_sync_time);
-        unregister_metric!(self.registry, self.forward_block_sync_time);
+        unregister_metric!(self.registry, self.historical_block_sync_duration);
+        unregister_metric!(self.registry, self.forward_block_sync_duration);
     }
 }

--- a/node/src/components/sync_leaper/metrics.rs
+++ b/node/src/components/sync_leaper/metrics.rs
@@ -2,7 +2,7 @@ use prometheus::{Histogram, IntCounter, Registry};
 
 use crate::{unregister_metric, utils};
 
-const SYNC_LEAP_DURATION_NAME: &str = "sync_leap_duration";
+const SYNC_LEAP_DURATION_NAME: &str = "sync_leap_duration_seconds";
 const SYNC_LEAP_DURATION_HELP: &str = "duration (in sec) to perform a successful sync leap";
 
 // We use linear buckets to observe the time it takes to do a sync leap.
@@ -36,15 +36,15 @@ impl Metrics {
         )?;
 
         let sync_leap_fetched_from_peer = IntCounter::new(
-            "sync_leap_fetched_from_peer".to_string(),
+            "sync_leap_fetched_from_peer_total".to_string(),
             "number of successful sync leap responses that were received from peers".to_string(),
         )?;
         let sync_leap_rejected_by_peer = IntCounter::new(
-            "sync_leap_rejected_by_peer".to_string(),
+            "sync_leap_rejected_by_peer_total".to_string(),
             "number of sync leap requests that were rejected by peers".to_string(),
         )?;
         let sync_leap_cant_fetch = IntCounter::new(
-            "sync_leap_cant_fetch".to_string(),
+            "sync_leap_cant_fetch_total".to_string(),
             "number of sync leap requests that couldn't be fetched from peers".to_string(),
         )?;
 


### PR DESCRIPTION
Since we're adding new metrics, use the suggested unit suffix as described in https://prometheus.io/docs/practices/naming/
