### PR TITLE
Port changes in `global-state-update-gen` from `dev`

### DIFF
--- a/utils/global-state-update-gen/README.md
+++ b/utils/global-state-update-gen/README.md
@@ -30,8 +30,18 @@ only_listed_validators = false
 # multiple [[accounts]] definitions are possible
 [[accounts]]
 public_key = "..." # the public key of the account owner
-stake = "..."      # the staked amount for this account, in motes (optional)
 balance = "..."    # account balance, in motes (optional)
+
+# if the account is supposed to be validator, define the section below
+[accounts.validator]
+bonded_amount = "..."      # the staked amount for this account, in motes
+delegation_rate = ...      # the delegation rate for this validator (optional)
+
+# define delegators as entries in accounts.validator.delegators
+# multiple definitions per validator are possible
+[[accounts.validator.delegators]]
+public_key = "..."         # the delegator's public key
+delegated_amount = "..."   # the amount delegated to the validator, in motes
 
 # multiple [[transfers]] definitions are possible
 [[transfers]]
@@ -44,7 +54,7 @@ The `[[accounts]]` definitions control the balances and stakes of accounts on th
 
 For every such definition, if the `balance` key is present, the balance of the account will be updated. The account will be created if it didn't exist previously. If the `balance` key is not present, the pre-existing balance (if any) will be left untouched.
 
-Updating the stakes behaves differently based on the value of `only_listed_validators`. If it is false, the existing list of validators is treated as a base, and stakes are modified based on the entries in the config. If the `stake` key is present, the stake is set to the configured value. If it is not present, the pre-existing stake is left untouched.
+Updating the validator properties (stake, delegators) behaves differently based on the value of `only_listed_validators`. If it is false, the existing list of validators is treated as a base, and validator properties are modified based on the entries in the config. If the `validator` key is present, the stake and delegators are set to the configured values. If it is not present, the pre-existing properties are left untouched.
 
 If `only_listed_validators` is true, pre-existing validators are discarded, and only the accounts with non-zero stakes configured in the config file will be validators after the update. This option exists to match the behavior of the legacy `validators` subcommand and to cater to some use cases in testing.
 
@@ -80,8 +90,10 @@ Every `-v` instance configures a single validator to be included in the set afte
 ```toml
 [[accounts]]
 public_key = "KEY"
-stake = "STAKE"
 balance = "BALANCE"
+
+[accounts.validator]
+bonded_amount = "STAKE"
 ```
 
 The command as a whole works just like a config file with only `[[accounts]]` entries and `only_listed_validators` set to `true`.

--- a/utils/global-state-update-gen/src/balances.rs
+++ b/utils/global-state-update-gen/src/balances.rs
@@ -27,6 +27,7 @@ pub(crate) fn generate_balances_update(matches: &ArgMatches<'_>) {
             amount,
         }],
         only_listed_validators: false,
+        slash_instead_of_unbonding: false,
     };
 
     let builder = LmdbWasmTestBuilder::open_raw(data_dir, Default::default(), state_hash);

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -3,6 +3,7 @@ mod state_reader;
 mod state_tracker;
 #[cfg(test)]
 mod testing;
+mod update;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -11,24 +12,20 @@ use std::{
 
 use casper_engine_test_support::LmdbWasmTestBuilder;
 use casper_types::{
-    system::auction::{Bid, SeigniorageRecipient, SeigniorageRecipientsSnapshot},
-    CLValue, EraId, Key, PublicKey, StoredValue, U512,
+    system::auction::{Bid, Delegator, SeigniorageRecipient, SeigniorageRecipientsSnapshot},
+    CLValue, EraId, PublicKey, StoredValue, U512,
 };
 
 use clap::ArgMatches;
 
-use crate::utils::{hash_from_str, print_entry, print_validators, validators_diff, ValidatorsDiff};
+use crate::utils::{hash_from_str, validators_diff, ValidatorsDiff};
 
 use self::{
     config::{AccountConfig, Config, Transfer},
     state_reader::StateReader,
     state_tracker::StateTracker,
+    update::Update,
 };
-
-struct Update {
-    validators: Vec<PublicKey>,
-    entries: BTreeMap<Key, StoredValue>,
-}
 
 pub(crate) fn generate_generic_update(matches: &ArgMatches<'_>) {
     let data_dir = matches.value_of("data_dir").unwrap_or(".");
@@ -54,21 +51,17 @@ fn get_update<T: StateReader>(reader: T, config: Config) -> Update {
         &mut state_tracker,
         &config.accounts,
         config.only_listed_validators,
+        config.slash_instead_of_unbonding,
     );
 
     let entries = state_tracker.get_entries();
-    Update {
-        validators,
-        entries,
-    }
+
+    Update::new(entries, validators)
 }
 
 pub(crate) fn update_from_config<T: StateReader>(reader: T, config: Config) {
     let update = get_update(reader, config);
-    print_validators(&update.validators);
-    for (key, value) in update.entries {
-        print_entry(&key, &value);
-    }
+    update.print();
 }
 
 fn process_transfers<T: StateReader>(state: &mut StateTracker<T>, transfers: &[Transfer]) {
@@ -101,6 +94,7 @@ fn update_auction_state<T: StateReader>(
     state: &mut StateTracker<T>,
     accounts: &[AccountConfig],
     only_listed_validators: bool,
+    slash: bool,
 ) -> Vec<PublicKey> {
     // Read the old SeigniorageRecipientsSnapshot
     let (validators_key, old_snapshot) = state.read_snapshot();
@@ -131,6 +125,7 @@ fn update_auction_state<T: StateReader>(
             &validators_diff,
             &new_snapshot,
             only_listed_validators,
+            slash,
         );
 
         state.remove_withdraws(&validators_diff.removed);
@@ -159,12 +154,15 @@ fn gen_snapshot_only_listed(
     let mut era_validators = BTreeMap::new();
     for account in accounts {
         // don't add validators with zero stake to the snapshot
-        let stake = match account.stake {
-            Some(stake) if stake != U512::zero() => stake,
+        let validator_cfg = match &account.validator {
+            Some(validator) if validator.bonded_amount != U512::zero() => validator,
             _ => continue,
         };
-        let seigniorage_recipient =
-            SeigniorageRecipient::new(stake, Default::default(), Default::default());
+        let seigniorage_recipient = SeigniorageRecipient::new(
+            validator_cfg.bonded_amount,
+            validator_cfg.delegation_rate.unwrap_or_default(),
+            validator_cfg.delegators_map().unwrap_or_default(),
+        );
         let _ = era_validators.insert(account.public_key.clone(), seigniorage_recipient);
     }
     for era_id in starting_era_id.iter(count) {
@@ -180,37 +178,69 @@ fn gen_snapshot_from_old(
     mut snapshot: SeigniorageRecipientsSnapshot,
     accounts: &[AccountConfig],
 ) -> SeigniorageRecipientsSnapshot {
-    let stakes_map: BTreeMap<_, _> = accounts
+    // Read the modifications to be applied to the validators set from the config.
+    let validators_map: BTreeMap<_, _> = accounts
         .iter()
-        .filter_map(|acc| acc.stake.map(|stake| (acc.public_key.clone(), stake)))
+        .filter_map(|acc| {
+            acc.validator
+                .as_ref()
+                .map(|validator| (acc.public_key.clone(), validator.clone()))
+        })
         .collect();
 
+    // We will be modifying the entries in the old snapshot passed in as `snapshot` according to
+    // the config.
     for recipients in snapshot.values_mut() {
-        recipients.retain(|public_key, recipient| match stakes_map.get(public_key) {
-            Some(stake) if *stake == U512::zero() => false,
-            Some(stake) => {
-                *recipient =
-                    SeigniorageRecipient::new(*stake, Default::default(), Default::default());
-                true
-            }
-            None => true,
-        });
+        // We use `retain` to drop some entries and modify some of the ones that will be retained.
+        recipients.retain(
+            |public_key, recipient| match validators_map.get(public_key) {
+                // If the validator's stake is configured to be zero, we drop them from the
+                // snapshot.
+                Some(validator) if validator.bonded_amount.is_zero() => false,
+                // Otherwise, we keep them, but modify the properties.
+                Some(validator) => {
+                    *recipient = SeigniorageRecipient::new(
+                        validator.bonded_amount,
+                        validator
+                            .delegation_rate
+                            // If the delegation rate wasn't specified in the config, keep the one
+                            // from the old snapshot.
+                            .unwrap_or(*recipient.delegation_rate()),
+                        validator
+                            .delegators_map()
+                            // If the delegators weren't specified in the config, keep the ones
+                            // from the old snapshot.
+                            .unwrap_or_else(|| recipient.delegator_stake().clone()),
+                    );
+                    true
+                }
+                // Validators not present in the config will be kept unmodified.
+                None => true,
+            },
+        );
 
-        // add the validators that weren't present in the old snapshot
-        for (public_key, stake) in &stakes_map {
+        // Add the validators that weren't present in the old snapshot.
+        for (public_key, validator) in &validators_map {
             if recipients.contains_key(public_key) {
                 continue;
             }
 
-            if *stake != U512::zero() {
+            if validator.bonded_amount != U512::zero() {
                 recipients.insert(
                     public_key.clone(),
-                    SeigniorageRecipient::new(*stake, Default::default(), Default::default()),
+                    SeigniorageRecipient::new(
+                        validator.bonded_amount,
+                        // Unspecified delegation rate will be treated as 0.
+                        validator.delegation_rate.unwrap_or_default(),
+                        // Unspecified delegators will be treated as an empty list.
+                        validator.delegators_map().unwrap_or_default(),
+                    ),
                 );
             }
         }
     }
 
+    // Return the modified snapshot.
     snapshot
 }
 
@@ -225,6 +255,7 @@ pub fn add_and_remove_bids<T: StateReader>(
     validators_diff: &ValidatorsDiff,
     new_snapshot: &SeigniorageRecipientsSnapshot,
     only_listed_validators: bool,
+    slash: bool,
 ) {
     let to_unbid = if only_listed_validators {
         let large_bids = find_large_bids(state, new_snapshot);
@@ -237,9 +268,8 @@ pub fn add_and_remove_bids<T: StateReader>(
         validators_diff.removed.clone()
     };
 
-    for (pub_key, seigniorage_recipient) in new_snapshot.values().next().unwrap() {
-        let stake = *seigniorage_recipient.stake();
-        create_or_update_bid(state, pub_key, stake);
+    for (pub_key, seigniorage_recipient) in new_snapshot.values().rev().next().unwrap() {
+        create_or_update_bid(state, pub_key, seigniorage_recipient, slash);
     }
 
     // Refresh the bids - we modified them above.
@@ -248,7 +278,7 @@ pub fn add_and_remove_bids<T: StateReader>(
     for pub_key in to_unbid {
         if let Some(bid) = bids.get(&pub_key) {
             let new_bid = Bid::empty(pub_key.clone(), *bid.bonding_purse());
-            state.set_bid(pub_key.clone(), new_bid);
+            state.set_bid(pub_key.clone(), new_bid, slash);
         }
     }
 }
@@ -285,24 +315,64 @@ fn find_large_bids<T: StateReader>(
 fn create_or_update_bid<T: StateReader>(
     state: &mut StateTracker<T>,
     pub_key: &PublicKey,
-    stake: U512,
+    recipient: &SeigniorageRecipient,
+    slash: bool,
 ) {
+    // Checks whether the data in the bid is the same as in the recipient info from a snapshot.
+    let check_bid = |bid: &Bid| {
+        let bid_delegators: BTreeMap<_, _> = bid
+            .delegators()
+            .iter()
+            .map(|(key, delegator)| (key.clone(), *delegator.staked_amount()))
+            .collect();
+        &bid_delegators == recipient.delegator_stake() && *bid.staked_amount() == *recipient.stake()
+    };
+
+    // Check whether we need to do anything with the bid - if it exists and matches the snapshot,
+    // nothing needs to be done. Otherwise we need to either create it, or change it so that it
+    // matches the snapshot.
     if state
         .get_bids()
         .get(pub_key)
-        .and_then(|bid| bid.total_staked_amount().ok())
-        == Some(stake)
+        .map(check_bid)
+        .unwrap_or(false)
     {
-        // already staked the amount we need, nothing to do
+        // The stake and delegators match the snapshot, nothing to do.
         return;
     }
-    let new_bid = if let Some(bid) = state.get_bids().get(pub_key) {
-        Bid::unlocked(
+
+    let stake = *recipient.stake();
+    let new_bid = if let Some(old_bid) = state.get_bids().get(pub_key) {
+        let mut bid = Bid::unlocked(
             pub_key.clone(),
-            *bid.bonding_purse(),
+            *old_bid.bonding_purse(),
             stake,
-            Default::default(),
-        )
+            *recipient.delegation_rate(),
+        );
+
+        for (delegator_pub_key, delegator_stake) in recipient.delegator_stake() {
+            let delegator = if let Some(delegator) = old_bid.delegators().get(delegator_pub_key) {
+                Delegator::unlocked(
+                    delegator_pub_key.clone(),
+                    *delegator_stake,
+                    *delegator.bonding_purse(),
+                    pub_key.clone(),
+                )
+            } else {
+                let delegator_bonding_purse = state.create_purse(*delegator_stake);
+                Delegator::unlocked(
+                    delegator_pub_key.clone(),
+                    *delegator_stake,
+                    delegator_bonding_purse,
+                    pub_key.clone(),
+                )
+            };
+
+            bid.delegators_mut()
+                .insert(delegator_pub_key.clone(), delegator);
+        }
+
+        bid
     } else {
         if stake == U512::zero() {
             // there was no bid for this key and it still is supposed to have zero amount staked -
@@ -310,7 +380,29 @@ fn create_or_update_bid<T: StateReader>(
             return;
         }
         let bonding_purse = state.create_purse(stake);
-        Bid::unlocked(pub_key.clone(), bonding_purse, stake, Default::default())
+        let mut bid = Bid::unlocked(
+            pub_key.clone(),
+            bonding_purse,
+            stake,
+            *recipient.delegation_rate(),
+        );
+
+        for (delegator_pub_key, delegator_stake) in recipient.delegator_stake() {
+            let delegator_bonding_purse = state.create_purse(*delegator_stake);
+            let delegator = Delegator::unlocked(
+                delegator_pub_key.clone(),
+                *delegator_stake,
+                delegator_bonding_purse,
+                pub_key.clone(),
+            );
+
+            bid.delegators_mut()
+                .insert(delegator_pub_key.clone(), delegator);
+        }
+
+        bid
     };
-    state.set_bid(pub_key.clone(), new_bid);
+
+    // This will take care of updating the bonding purse balances and unbonding purses entries.
+    state.set_bid(pub_key.clone(), new_bid, slash);
 }

--- a/utils/global-state-update-gen/src/generic/config.rs
+++ b/utils/global-state-update-gen/src/generic/config.rs
@@ -1,6 +1,8 @@
-use casper_types::{account::AccountHash, PublicKey, U512};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+
+use casper_types::{account::AccountHash, PublicKey, U512};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -10,6 +12,8 @@ pub struct Config {
     pub accounts: Vec<AccountConfig>,
     #[serde(default)]
     pub only_listed_validators: bool,
+    #[serde(default)]
+    pub slash_instead_of_unbonding: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,5 +27,29 @@ pub struct Transfer {
 pub struct AccountConfig {
     pub public_key: PublicKey,
     pub balance: Option<U512>,
-    pub stake: Option<U512>,
+    pub validator: Option<ValidatorConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ValidatorConfig {
+    pub bonded_amount: U512,
+    pub delegation_rate: Option<u8>,
+    pub delegators: Option<Vec<DelegatorConfig>>,
+}
+
+impl ValidatorConfig {
+    pub fn delegators_map(&self) -> Option<BTreeMap<PublicKey, U512>> {
+        self.delegators.as_ref().map(|delegators| {
+            delegators
+                .iter()
+                .map(|delegator| (delegator.public_key.clone(), delegator.delegated_amount))
+                .collect()
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegatorConfig {
+    pub public_key: PublicKey,
+    pub delegated_amount: U512,
 }

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 
 use casper_types::{
     account::{Account, AccountHash},
-    system::auction::{Bid, Bids, SeigniorageRecipientsSnapshot},
+    system::auction::{Bid, Bids, SeigniorageRecipientsSnapshot, UnbondingPurse},
     AccessRights, CLValue, Key, PublicKey, StoredValue, URef, U512,
 };
 
@@ -21,6 +21,7 @@ pub struct StateTracker<T> {
     total_supply: U512,
     total_supply_key: Key,
     accounts_cache: BTreeMap<AccountHash, Account>,
+    unbonds_cache: BTreeMap<AccountHash, Vec<UnbondingPurse>>,
     purses_cache: BTreeMap<URef, U512>,
     bids_cache: Option<Bids>,
 }
@@ -44,6 +45,7 @@ impl<T: StateReader> StateTracker<T> {
             total_supply_key,
             total_supply: total_supply.into_t().expect("should be U512"),
             accounts_cache: BTreeMap::new(),
+            unbonds_cache: BTreeMap::new(),
             purses_cache: BTreeMap::new(),
             bids_cache: None,
         }
@@ -209,16 +211,14 @@ impl<T: StateReader> StateTracker<T> {
     }
 
     /// Sets the bid for the given account.
-    pub fn set_bid(&mut self, public_key: PublicKey, bid: Bid) {
+    pub fn set_bid(&mut self, public_key: PublicKey, bid: Bid, slash: bool) {
         let maybe_current_bid = self.get_bids().get(&public_key).cloned();
 
-        let new_amount = match bid.total_staked_amount() {
-            Ok(amount) => amount,
-            Err(e) => {
-                eprintln!("invalid new bid for {:?}: {:?}", public_key, e);
-                return;
-            }
-        };
+        let new_amount = *bid.staked_amount();
+        let old_amount = maybe_current_bid
+            .as_ref()
+            .map(|bid| self.get_purse_balance(*bid.bonding_purse()))
+            .unwrap_or_else(U512::zero);
 
         // we called `get_bids` above, so `bids_cache` will be `Some`
         self.bids_cache
@@ -233,9 +233,71 @@ impl<T: StateReader> StateTracker<T> {
 
         // Update the bonding purses - this will also take care of the total supply changes.
         if let Some(old_bid) = maybe_current_bid {
-            self.set_purse_balance(*old_bid.bonding_purse(), U512::zero());
+            // only zero the bonding purse and write the balance to the new purse if the new one is
+            // different (just to save unnecessary writes)
+            if old_bid.bonding_purse() != bid.bonding_purse() {
+                self.set_purse_balance(*old_bid.bonding_purse(), U512::zero());
+                self.set_purse_balance(*bid.bonding_purse(), old_amount);
+            }
+            //
+            for (delegator_pub_key, delegator) in old_bid.delegators() {
+                // skip zeroing purses of delegators whose purses don't change - that will be
+                // handled later
+                if bid
+                    .delegators()
+                    .get(delegator_pub_key)
+                    .map(|new_delegator| new_delegator.bonding_purse() == delegator.bonding_purse())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                // zero the old purse if we are going to transfer the funds to a new purse, or if
+                // we're supposed to slash the delegator
+                if slash || bid.delegators().contains_key(delegator_pub_key) {
+                    // if we're transferring funds to a new purse, set the new purse balance to the
+                    // old amount
+                    let old_amount = self.get_purse_balance(*delegator.bonding_purse());
+                    if let Some(new_delegator) = bid.delegators().get(delegator_pub_key) {
+                        self.set_purse_balance(*new_delegator.bonding_purse(), old_amount);
+                    }
+                    self.set_purse_balance(*delegator.bonding_purse(), U512::zero());
+                } else {
+                    let amount = self.get_purse_balance(*delegator.bonding_purse());
+                    self.create_unbonding_purse(
+                        *delegator.bonding_purse(),
+                        &public_key,
+                        delegator_pub_key,
+                        amount,
+                    );
+                }
+            }
         }
-        self.set_purse_balance(*bid.bonding_purse(), new_amount);
+
+        if (slash && new_amount != old_amount) || new_amount > old_amount {
+            self.set_purse_balance(*bid.bonding_purse(), new_amount);
+        } else if new_amount < old_amount {
+            self.create_unbonding_purse(
+                *bid.bonding_purse(),
+                &public_key,
+                &public_key,
+                old_amount - new_amount,
+            );
+        }
+
+        for (delegator_public_key, delegator) in bid.delegators() {
+            let old_amount = self.get_purse_balance(*delegator.bonding_purse());
+            let new_amount = *delegator.staked_amount();
+            if (slash && new_amount != old_amount) || new_amount > old_amount {
+                self.set_purse_balance(*delegator.bonding_purse(), *delegator.staked_amount());
+            } else if new_amount < old_amount {
+                self.create_unbonding_purse(
+                    *delegator.bonding_purse(),
+                    &public_key,
+                    delegator_public_key,
+                    old_amount - new_amount,
+                );
+            }
+        }
     }
 
     /// Generates the writes to the global state that will remove the pending withdraws of all the
@@ -251,5 +313,45 @@ impl<T: StateReader> StateTracker<T> {
         {
             self.write_entry(key, value);
         }
+    }
+
+    pub fn create_unbonding_purse(
+        &mut self,
+        bonding_purse: URef,
+        validator_key: &PublicKey,
+        unbonder_key: &PublicKey,
+        amount: U512,
+    ) {
+        let account_hash = validator_key.to_account_hash();
+        let unbonding_era = self.read_snapshot().1.keys().next().copied().unwrap();
+        let unbonding_purses = match self.unbonds_cache.entry(account_hash) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let existing_purses = self
+                    .reader
+                    .query(Key::Unbond(account_hash))
+                    .and_then(|stored_val| stored_val.as_unbonding().cloned())
+                    .unwrap_or_default();
+                entry.insert(existing_purses)
+            }
+        };
+        // Take the first era from the snapshot as the unbonding era.
+        let new_purse = UnbondingPurse::new(
+            bonding_purse,
+            validator_key.clone(),
+            unbonder_key.clone(),
+            unbonding_era,
+            amount,
+            None,
+        );
+
+        // This doesn't actually transfer or create any funds - the funds will be transferred from
+        // the bonding purse to the unbonder's main purse later by the auction contract.
+        unbonding_purses.push(new_purse);
+        let unbonding_purses = unbonding_purses.clone();
+        self.write_entry(
+            Key::Unbond(account_hash),
+            StoredValue::Unbonding(unbonding_purses),
+        );
     }
 }

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -5,18 +5,17 @@ use rand::Rng;
 use casper_types::{
     account::{Account, AccountHash},
     system::auction::{
-        Bid, Bids, SeigniorageRecipient, SeigniorageRecipients, SeigniorageRecipientsSnapshot,
-        UnbondingPurses,
+        Bid, Bids, Delegator, SeigniorageRecipient, SeigniorageRecipients,
+        SeigniorageRecipientsSnapshot, UnbondingPurses,
     },
     testing::TestRng,
     AccessRights, CLValue, Key, PublicKey, StoredValue, URef, URefAddr, U512,
 };
 
 use super::{
-    config::{AccountConfig, Config, Transfer},
+    config::{AccountConfig, Config, DelegatorConfig, Transfer, ValidatorConfig},
     get_update,
     state_reader::StateReader,
-    Update,
 };
 
 const TOTAL_SUPPLY_KEY: URef = URef::new([1; 32], AccessRights::READ_ADD_WRITE);
@@ -50,21 +49,25 @@ impl MockStateReader {
         let main_purse = URef::new(rng.gen(), AccessRights::READ_ADD_WRITE);
         let account = Account::create(account_hash, Default::default(), main_purse);
         self.purses.insert(main_purse.addr(), balance);
-        self.accounts.insert(account_hash, account);
+        // If `insert` returns `Some()`, it means we used the same account hash twice, which is
+        // a programmer error and the function will panic.
+        assert!(self.accounts.insert(account_hash, account).is_none());
         self.total_supply += balance;
         self
     }
 
     fn with_validators<R: Rng>(
         mut self,
-        validators: Vec<(PublicKey, U512, U512)>,
+        validators: Vec<(PublicKey, U512, ValidatorConfig)>,
         rng: &mut R,
     ) -> Self {
         let mut recipients = SeigniorageRecipients::new();
-        for (public_key, stake, balance) in validators {
+        for (public_key, balance, validator_cfg) in validators {
+            let stake = validator_cfg.bonded_amount;
+            let delegation_rate = validator_cfg.delegation_rate.unwrap_or_default();
+            let delegators = validator_cfg.delegators_map().unwrap_or_default();
             // add an entry to the recipients snapshot
-            let recipient =
-                SeigniorageRecipient::new(stake, Default::default(), Default::default());
+            let recipient = SeigniorageRecipient::new(stake, delegation_rate, delegators.clone());
             recipients.insert(public_key.clone(), recipient);
 
             // create the account if it doesn't exist
@@ -77,8 +80,31 @@ impl MockStateReader {
             self.purses.insert(bonding_purse.addr(), stake);
             self.total_supply += stake;
 
+            for delegator_pub_key in delegators.keys() {
+                let account_hash = delegator_pub_key.to_account_hash();
+                if !self.accounts.contains_key(&account_hash) {
+                    self = self.with_account(account_hash, U512::zero(), rng);
+                }
+            }
+
             // create the bid
-            let bid = Bid::unlocked(public_key.clone(), bonding_purse, stake, Default::default());
+            let mut bid = Bid::unlocked(public_key.clone(), bonding_purse, stake, delegation_rate);
+
+            for (delegator_pub_key, delegator_stake) in &delegators {
+                let bonding_purse = URef::new(rng.gen(), AccessRights::READ_ADD_WRITE);
+                self.purses.insert(bonding_purse.addr(), *delegator_stake);
+                self.total_supply += *delegator_stake;
+
+                let delegator = Delegator::unlocked(
+                    delegator_pub_key.clone(),
+                    *delegator_stake,
+                    bonding_purse,
+                    public_key.clone(),
+                );
+                bid.delegators_mut()
+                    .insert(delegator_pub_key.clone(), delegator);
+            }
+
             self.bids.insert(public_key, bid);
         }
 
@@ -146,10 +172,20 @@ fn should_transfer_funds() {
         vec![
             (
                 public_key1.clone(),
-                U512::from(1),
                 U512::from(1_000_000_000),
+                ValidatorConfig {
+                    bonded_amount: U512::from(1),
+                    ..Default::default()
+                },
             ),
-            (public_key2.clone(), U512::zero(), U512::zero()),
+            (
+                public_key2.clone(),
+                U512::zero(),
+                ValidatorConfig {
+                    bonded_amount: U512::zero(),
+                    ..Default::default()
+                },
+            ),
         ],
         &mut rng,
     );
@@ -163,45 +199,28 @@ fn should_transfer_funds() {
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators.len(), 2);
-    assert!(validators.contains(&public_key1));
-    assert!(validators.contains(&public_key2));
-
-    let account1 = reader.get_account(account1).unwrap();
-    let account2 = reader.get_account(account2).unwrap();
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&public_key1, &public_key2]);
 
     // should write decreased balance to the first purse
-    assert_eq!(
-        entries.get(&Key::Balance(account1.main_purse().addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(700_000_000)).expect("should convert U512 to CLValue")
-        )),
-    );
+    let account1 = reader.get_account(account1).expect("should have account");
+    update.assert_written_balance(account1.main_purse(), 700_000_000);
 
     // should write increased balance to the second purse
-    assert_eq!(
-        entries.get(&Key::Balance(account2.main_purse().addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(300_000_000)).expect("should convert U512 to CLValue")
-        )),
-    );
+    let account2 = reader.get_account(account2).expect("should have account");
+    update.assert_written_balance(account2.main_purse(), 300_000_000);
 
     // total supply is written on every purse balance change, so we'll have a write to this key
     // even though the changes cancel each other out
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(1_000_000_001)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_total_supply(&mut reader, 1_000_000_001);
 
-    // 3 keys tested above should be all that would be written
-    assert_eq!(entries.len(), 3);
+    // 3 keys should be written:
+    // - balance of account 1
+    // - balance of account 2
+    // - total supply
+    assert_eq!(update.len(), 3);
 }
 
 #[test]
@@ -216,8 +235,11 @@ fn should_create_account_when_transferring_funds() {
     let mut reader = MockStateReader::new().with_validators(
         vec![(
             public_key1.clone(),
-            U512::from(1),
             U512::from(1_000_000_000),
+            ValidatorConfig {
+                bonded_amount: U512::from(1),
+                ..Default::default()
+            },
         )],
         &mut rng,
     );
@@ -231,58 +253,34 @@ fn should_create_account_when_transferring_funds() {
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators, vec![public_key1]);
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&public_key1]);
 
-    let account1 = reader.get_account(account1).unwrap();
+    let account1 = reader.get_account(account1).expect("should have account");
+    // account2 shouldn't exist in the reader itself, only the update should be creating it
     assert!(reader.get_account(account2).is_none());
+    let account2 = update.get_written_account(account2);
 
     // should write decreased balance to the first purse
-    assert_eq!(
-        entries.get(&Key::Balance(account1.main_purse().addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(700_000_000)).expect("should convert U512 to CLValue")
-        )),
-    );
-
-    // the new account should be created
-    let account_write = entries
-        .get(&Key::Account(account2))
-        .expect("should create account")
-        .as_account()
-        .expect("should be account")
-        .clone();
-    let new_purse = account_write.main_purse();
+    update.assert_written_balance(account1.main_purse(), 700_000_000);
 
     // check that the main purse for the new account has been created with the correct amount
-    assert_eq!(
-        entries.get(&Key::URef(new_purse)),
-        Some(&StoredValue::from(
-            CLValue::from_t(()).expect("should convert unit to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(new_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(300_000_000)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_balance(account2.main_purse(), 300_000_000);
+    update.assert_written_purse_is_unit(account2.main_purse());
 
     // total supply is written on every purse balance change, so we'll have a write to this key
     // even though the changes cancel each other out
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(1_000_000_001)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_total_supply(&mut reader, 1_000_000_001);
 
-    // 5 keys tested above should be all that would be written
-    assert_eq!(entries.len(), 5);
+    // 5 keys should be written:
+    // - balance of account 1
+    // - account 2
+    // - main purse of account 2
+    // - balance of account 2
+    // - total supply
+    assert_eq!(update.len(), 5);
 }
 
 #[test]
@@ -295,9 +293,30 @@ fn should_change_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1.clone(), U512::from(101), U512::from(101)),
-            (validator2.clone(), U512::from(102), U512::from(102)),
-            (validator3.clone(), U512::from(103), U512::from(103)),
+            (
+                validator1.clone(),
+                U512::from(101),
+                ValidatorConfig {
+                    bonded_amount: U512::from(101),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator2.clone(),
+                U512::from(102),
+                ValidatorConfig {
+                    bonded_amount: U512::from(102),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator3.clone(),
+                U512::from(103),
+                ValidatorConfig {
+                    bonded_amount: U512::from(103),
+                    ..Default::default()
+                },
+            ),
         ],
         &mut rng,
     );
@@ -306,64 +325,49 @@ fn should_change_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: Some(U512::from(104)),
             balance: Some(U512::from(100)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(104),
+                delegation_rate: None,
+                delegators: None,
+            }),
         }],
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators.len(), 3);
-    assert!(validators.contains(&validator1));
-    assert!(validators.contains(&validator2));
-    assert!(validators.contains(&validator3));
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1, &validator2, &validator3]);
 
-    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(610)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 610);
 
-    // check purse writes
-    let account3 = validator3.to_account_hash();
-    let bid_purse = *reader
+    let account3_hash = validator3.to_account_hash();
+    let account3 = reader
+        .get_account(account3_hash)
+        .expect("should have account");
+    update.assert_written_balance(account3.main_purse(), 100);
+
+    let old_bid3 = reader
         .get_bids()
         .get(&validator3)
-        .expect("should have bid")
-        .bonding_purse();
-    let main_purse = reader
-        .get_account(account3)
-        .expect("should have account")
-        .main_purse();
-
-    assert_eq!(
-        entries.get(&Key::Balance(bid_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(main_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
-        ))
-    );
+        .cloned()
+        .expect("should have bid");
+    let bid_purse = *old_bid3.bonding_purse();
+    update.assert_written_balance(bid_purse, 104);
 
     // check bid overwrite
     let expected_bid = Bid::unlocked(validator3, bid_purse, U512::from(104), Default::default());
-    assert_eq!(
-        entries.get(&Key::Bid(account3)),
-        Some(&StoredValue::from(expected_bid))
-    );
+    update.assert_written_bid(account3_hash, expected_bid);
 
-    // 5 keys above should be all that was overwritten
-    assert_eq!(entries.len(), 5);
+    // 5 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - balance of bid purse of validator 3
+    // - balance of main purse of validator 3
+    // - bid of validator 3
+    assert_eq!(update.len(), 5);
 }
 
 #[test]
@@ -376,9 +380,30 @@ fn should_change_only_stake_of_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1.clone(), U512::from(101), U512::from(101)),
-            (validator2.clone(), U512::from(102), U512::from(102)),
-            (validator3.clone(), U512::from(103), U512::from(103)),
+            (
+                validator1.clone(),
+                U512::from(101),
+                ValidatorConfig {
+                    bonded_amount: U512::from(101),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator2.clone(),
+                U512::from(102),
+                ValidatorConfig {
+                    bonded_amount: U512::from(102),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator3.clone(),
+                U512::from(103),
+                ValidatorConfig {
+                    bonded_amount: U512::from(103),
+                    ..Default::default()
+                },
+            ),
         ],
         &mut rng,
     );
@@ -387,54 +412,45 @@ fn should_change_only_stake_of_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: Some(U512::from(104)),
             balance: None,
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(104),
+                delegation_rate: None,
+                delegators: None,
+            }),
         }],
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators.len(), 3);
-    assert!(validators.contains(&validator1));
-    assert!(validators.contains(&validator2));
-    assert!(validators.contains(&validator3));
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1, &validator2, &validator3]);
 
-    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(613)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 613);
 
     // check purse writes
-    let account3 = validator3.to_account_hash();
-    let bid_purse = *reader
+    let account3_hash = validator3.to_account_hash();
+    let old_bid3 = reader
         .get_bids()
         .get(&validator3)
-        .expect("should have bid")
-        .bonding_purse();
+        .cloned()
+        .expect("should have bid");
+    let bid_purse = *old_bid3.bonding_purse();
 
-    assert_eq!(
-        entries.get(&Key::Balance(bid_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_balance(bid_purse, 104);
 
     // check bid overwrite
     let expected_bid = Bid::unlocked(validator3, bid_purse, U512::from(104), Default::default());
-    assert_eq!(
-        entries.get(&Key::Bid(account3)),
-        Some(&StoredValue::from(expected_bid))
-    );
+    update.assert_written_bid(account3_hash, expected_bid);
 
-    // 4 keys above should be all that was overwritten
-    assert_eq!(entries.len(), 4);
+    // 4 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid purse balance for validator 3
+    // - bid for validator 3
+    assert_eq!(update.len(), 4);
 }
 
 #[test]
@@ -447,9 +463,30 @@ fn should_change_only_balance_of_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1.clone(), U512::from(101), U512::from(101)),
-            (validator2.clone(), U512::from(102), U512::from(102)),
-            (validator3.clone(), U512::from(103), U512::from(103)),
+            (
+                validator1.clone(),
+                U512::from(101),
+                ValidatorConfig {
+                    bonded_amount: U512::from(101),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator2.clone(),
+                U512::from(102),
+                ValidatorConfig {
+                    bonded_amount: U512::from(102),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator3.clone(),
+                U512::from(103),
+                ValidatorConfig {
+                    bonded_amount: U512::from(103),
+                    ..Default::default()
+                },
+            ),
         ],
         &mut rng,
     );
@@ -458,45 +495,31 @@ fn should_change_only_balance_of_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator3.clone(),
-            stake: None,
             balance: Some(U512::from(100)),
+            validator: None,
         }],
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators.len(), 3);
-    assert!(validators.contains(&validator1));
-    assert!(validators.contains(&validator2));
-    assert!(validators.contains(&validator3));
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1, &validator2, &validator3]);
 
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(609)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_total_supply(&mut reader, 609);
 
     // check purse writes
-    let account3 = validator3.to_account_hash();
-    let main_purse = reader
-        .get_account(account3)
-        .expect("should have account")
-        .main_purse();
+    let account3_hash = validator3.to_account_hash();
+    let account3 = reader
+        .get_account(account3_hash)
+        .expect("should have account");
 
-    assert_eq!(
-        entries.get(&Key::Balance(main_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_balance(account3.main_purse(), 100);
 
-    // 2 keys above should be all that was overwritten
-    assert_eq!(entries.len(), 2);
+    // 2 keys should be written:
+    // - total supply
+    // - balance for main purse of validator 3
+    assert_eq!(update.len(), 2);
 }
 
 #[test]
@@ -507,7 +530,14 @@ fn should_replace_one_validator() {
     let validator2 = PublicKey::random(&mut rng);
 
     let mut reader = MockStateReader::new().with_validators(
-        vec![(validator1.clone(), U512::from(101), U512::from(101))],
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                ..Default::default()
+            },
+        )],
         &mut rng,
     );
 
@@ -515,83 +545,53 @@ fn should_replace_one_validator() {
     let config = Config {
         accounts: vec![AccountConfig {
             public_key: validator2.clone(),
-            stake: Some(U512::from(102)),
             balance: Some(U512::from(102)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(102),
+                delegation_rate: None,
+                delegators: None,
+            }),
         }],
         only_listed_validators: true,
+        slash_instead_of_unbonding: true,
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators, vec![validator2.clone()]);
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator2]);
 
-    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(305)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 305);
 
     // check purse write for validator1
-    let bid_purse = *reader
+    let old_bid1 = reader
         .get_bids()
         .get(&validator1)
-        .expect("should have bid")
-        .bonding_purse();
+        .cloned()
+        .expect("should have bid");
+    let bid_purse = *old_bid1.bonding_purse();
 
-    assert_eq!(
-        entries.get(&Key::Balance(bid_purse.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::zero()).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_balance(bid_purse, 0);
 
     // check bid overwrite
-    let account1 = validator1.to_account_hash();
+    let account1_hash = validator1.to_account_hash();
     let mut expected_bid_1 = Bid::unlocked(validator1, bid_purse, U512::zero(), Default::default());
     expected_bid_1.deactivate();
-    assert_eq!(
-        entries.get(&Key::Bid(account1)),
-        Some(&StoredValue::from(expected_bid_1))
-    );
+    update.assert_written_bid(account1_hash, expected_bid_1);
 
     // check writes for validator2
-    let account2 = validator2.to_account_hash();
+    let account2_hash = validator2.to_account_hash();
 
     // the new account should be created
-    let account_write = entries
-        .get(&Key::Account(account2))
-        .expect("should create account")
-        .as_account()
-        .expect("should be account")
-        .clone();
-    let main_purse_2 = account_write.main_purse();
+    let account2 = update.get_written_account(account2_hash);
 
     // check that the main purse for the new account has been created with the correct amount
-    assert_eq!(
-        entries.get(&Key::URef(main_purse_2)),
-        Some(&StoredValue::from(
-            CLValue::from_t(()).expect("should convert unit to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(main_purse_2.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(102)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_purse_is_unit(account2.main_purse());
+    update.assert_written_balance(account2.main_purse(), 102);
 
-    let bid_write = entries
-        .get(&Key::Bid(account2))
-        .expect("should create bid")
-        .as_bid()
-        .expect("should be bid")
-        .clone();
+    let bid_write = update.get_written_bid(account2_hash);
     assert_eq!(bid_write.validator_public_key(), &validator2);
     assert_eq!(
         bid_write
@@ -601,24 +601,122 @@ fn should_replace_one_validator() {
     );
     assert!(!bid_write.inactive());
 
-    let bid_purse_2 = *bid_write.bonding_purse();
+    // check that the bid purse for the new validator has been created with the correct amount
+    update.assert_written_purse_is_unit(*bid_write.bonding_purse());
+    update.assert_written_balance(*bid_write.bonding_purse(), 102);
+
+    // 10 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - bonding purse balance for validator 1
+    // - account for validator 2
+    // - main purse for account for validator 2
+    // - main purse balance for account for validator 2
+    // - bid for validator 2
+    // - bonding purse for validator 2
+    // - bonding purse balance for validator 2
+    assert_eq!(update.len(), 10);
+}
+
+#[test]
+fn should_replace_one_validator_with_unbonding() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let validator2 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                ..Default::default()
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be updating the validators set to only contain validator2
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator2.clone(),
+            balance: Some(U512::from(102)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(102),
+                ..Default::default()
+            }),
+        }],
+        only_listed_validators: true,
+        slash_instead_of_unbonding: false,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator2]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 406);
+
+    // check purse write for validator1
+    let old_bid1 = reader
+        .get_bids()
+        .get(&validator1)
+        .cloned()
+        .expect("should have bid");
+    let bid_purse = *old_bid1.bonding_purse();
+
+    // bid purse balance should be unchanged
+    update.assert_key_absent(&Key::Balance(bid_purse.addr()));
+
+    // should write an unbonding purse
+    update.assert_unbonding_purse(bid_purse, &validator1, &validator1, 101);
+
+    // check bid overwrite
+    let account1_hash = validator1.to_account_hash();
+    let mut expected_bid_1 = Bid::unlocked(validator1, bid_purse, U512::zero(), Default::default());
+    expected_bid_1.deactivate();
+    update.assert_written_bid(account1_hash, expected_bid_1);
+
+    // check writes for validator2
+    let account2_hash = validator2.to_account_hash();
+
+    // the new account should be created
+    let account2 = update.get_written_account(account2_hash);
+
+    // check that the main purse for the new account has been created with the correct amount
+    update.assert_written_purse_is_unit(account2.main_purse());
+    update.assert_written_balance(account2.main_purse(), 102);
+
+    let bid_write = update.get_written_bid(account2_hash);
+    assert_eq!(bid_write.validator_public_key(), &validator2);
+    assert_eq!(
+        bid_write
+            .total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(102)
+    );
+    assert!(!bid_write.inactive());
 
     // check that the bid purse for the new validator has been created with the correct amount
-    assert_eq!(
-        entries.get(&Key::URef(bid_purse_2)),
-        Some(&StoredValue::from(
-            CLValue::from_t(()).expect("should convert unit to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(bid_purse_2.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(102)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_purse_is_unit(*bid_write.bonding_purse());
+    update.assert_written_balance(*bid_write.bonding_purse(), 102);
 
-    // 10 keys above should be all that was overwritten
-    assert_eq!(entries.len(), 10);
+    // 10 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - unbonding purse for validator 1
+    // - account for validator 2
+    // - main purse for account for validator 2
+    // - main purse balance for account for validator 2
+    // - bid for validator 2
+    // - bonding purse for validator 2
+    // - bonding purse balance for validator 2
+    assert_eq!(update.len(), 10);
 }
 
 #[test]
@@ -632,9 +730,30 @@ fn should_add_one_validator() {
 
     let mut reader = MockStateReader::new().with_validators(
         vec![
-            (validator1.clone(), U512::from(101), U512::from(101)),
-            (validator2.clone(), U512::from(102), U512::from(102)),
-            (validator3.clone(), U512::from(103), U512::from(103)),
+            (
+                validator1.clone(),
+                U512::from(101),
+                ValidatorConfig {
+                    bonded_amount: U512::from(101),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator2.clone(),
+                U512::from(102),
+                ValidatorConfig {
+                    bonded_amount: U512::from(102),
+                    ..Default::default()
+                },
+            ),
+            (
+                validator3.clone(),
+                U512::from(103),
+                ValidatorConfig {
+                    bonded_amount: U512::from(103),
+                    ..Default::default()
+                },
+            ),
         ],
         &mut rng,
     );
@@ -644,88 +763,588 @@ fn should_add_one_validator() {
         accounts: vec![AccountConfig {
             public_key: validator4.clone(),
             balance: Some(U512::from(100)),
-            stake: Some(U512::from(104)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(104),
+                delegation_rate: None,
+                delegators: None,
+            }),
         }],
         only_listed_validators: false,
         ..Default::default()
     };
 
-    let Update {
-        validators,
-        entries,
-    } = get_update(&mut reader, config);
+    let update = get_update(&mut reader, config);
 
-    assert_eq!(validators.len(), 4);
-    assert!(validators.contains(&validator1));
-    assert!(validators.contains(&validator2));
-    assert!(validators.contains(&validator3));
-    assert!(validators.contains(&validator4));
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1, &validator2, &validator3, &validator4]);
 
-    assert!(entries.contains_key(&reader.get_seigniorage_recipients_key()));
-    assert_eq!(
-        entries.get(&reader.get_total_supply_key()),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(816)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 816);
 
     // check writes for validator4
-    let account4 = validator4.to_account_hash();
+    let account4_hash = validator4.to_account_hash();
 
     // the new account should be created
-    let account_write = entries
-        .get(&Key::Account(account4))
-        .expect("should create account")
-        .as_account()
-        .expect("should be account")
-        .clone();
-    let main_purse_4 = account_write.main_purse();
+    let account4 = update.get_written_account(account4_hash);
 
     // check that the main purse for the new account has been created with the correct amount
-    assert_eq!(
-        entries.get(&Key::URef(main_purse_4)),
-        Some(&StoredValue::from(
-            CLValue::from_t(()).expect("should convert unit to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(main_purse_4.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(100)).expect("should convert U512 to CLValue")
-        ))
-    );
+    update.assert_written_purse_is_unit(account4.main_purse());
+    update.assert_written_balance(account4.main_purse(), 100);
 
-    let bid_write = entries
-        .get(&Key::Bid(account4))
-        .expect("should create bid")
-        .as_bid()
-        .expect("should be bid")
-        .clone();
-    assert_eq!(bid_write.validator_public_key(), &validator4);
+    let bid4 = update.get_written_bid(account4_hash);
+    assert_eq!(bid4.validator_public_key(), &validator4);
     assert_eq!(
-        bid_write
-            .total_staked_amount()
+        bid4.total_staked_amount()
             .expect("should read total staked amount"),
         U512::from(104)
     );
-    assert!(!bid_write.inactive());
-
-    let bid_purse_4 = *bid_write.bonding_purse();
+    assert!(!bid4.inactive());
 
     // check that the bid purse for the new validator has been created with the correct amount
-    assert_eq!(
-        entries.get(&Key::URef(bid_purse_4)),
-        Some(&StoredValue::from(
-            CLValue::from_t(()).expect("should convert unit to CLValue")
-        ))
-    );
-    assert_eq!(
-        entries.get(&Key::Balance(bid_purse_4.addr())),
-        Some(&StoredValue::from(
-            CLValue::from_t(U512::from(104)).expect("should convert U512 to CLValue")
-        ))
+    update.assert_written_purse_is_unit(*bid4.bonding_purse());
+    update.assert_written_balance(*bid4.bonding_purse(), 104);
+
+    // 8 keys should be written:
+    // - seigniorage recipients snapshot
+    // - total supply
+    // - account for validator 4
+    // - main purse for account for validator 4
+    // - main purse balance for account for validator 4
+    // - bid for validator 4
+    // - bonding purse for validator 4
+    // - bonding purse balance for validator 4
+    assert_eq!(update.len(), 8);
+}
+
+#[test]
+fn should_add_one_validator_with_delegators() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let validator2 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                ..Default::default()
+            },
+        )],
+        &mut rng,
     );
 
-    // 8 keys above should be all that was written
-    assert_eq!(entries.len(), 8);
+    // we'll be adding validator 2
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator2.clone(),
+            balance: Some(U512::from(100)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(102),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1.clone(),
+                    delegated_amount: U512::from(13),
+                }]),
+            }),
+        }],
+        only_listed_validators: false,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1, &validator2]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 417);
+
+    // check writes for validator2
+    let account2_hash = validator2.to_account_hash();
+
+    // the new account should be created
+    let account2 = update.get_written_account(account2_hash);
+
+    // check that the main purse for the new account has been created with the correct amount
+    update.assert_written_purse_is_unit(account2.main_purse());
+    update.assert_written_balance(account2.main_purse(), 100);
+
+    let bid2 = update.get_written_bid(account2_hash);
+    assert_eq!(bid2.validator_public_key(), &validator2);
+    assert_eq!(*bid2.staked_amount(), U512::from(102));
+    assert_eq!(
+        bid2.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(115)
+    );
+    assert!(!bid2.inactive());
+
+    // check that the bid purse for the new validator has been created with the correct amount
+    update.assert_written_purse_is_unit(*bid2.bonding_purse());
+    update.assert_written_balance(*bid2.bonding_purse(), 102);
+
+    let bid_delegator_purse = *bid2
+        .delegators()
+        .get(&delegator1)
+        .expect("should have delegator")
+        .bonding_purse();
+
+    // check that the bid purse for the new delegator has been created with the correct amount
+    update.assert_written_purse_is_unit(bid_delegator_purse);
+    update.assert_written_balance(bid_delegator_purse, 13);
+
+    // 10 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - account for validator 2
+    // - main purse for account for validator 2
+    // - main purse balance for account for validator 2
+    // - bid for validator 2
+    // - bonding purse for validator 2
+    // - bonding purse balance for validator2
+    // - bonding purse for delegator
+    // - bonding purse balance for delegator
+    assert_eq!(update.len(), 10);
+}
+
+#[test]
+fn should_replace_a_delegator() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+    let delegator2 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1.clone(),
+                    delegated_amount: U512::from(13),
+                }]),
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be replacing the delegator
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator1.clone(),
+            balance: Some(U512::from(101)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: None,
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator2.clone(),
+                    delegated_amount: U512::from(14),
+                }]),
+            }),
+        }],
+        only_listed_validators: false,
+        slash_instead_of_unbonding: true,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 216);
+
+    let account1_hash = validator1.to_account_hash();
+
+    let bid1 = update.get_written_bid(account1_hash);
+    assert_eq!(bid1.validator_public_key(), &validator1);
+    assert_eq!(*bid1.staked_amount(), U512::from(101));
+    assert_eq!(
+        bid1.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(115)
+    );
+    assert!(!bid1.inactive());
+
+    let old_bid1 = reader
+        .get_bids()
+        .get(&validator1)
+        .cloned()
+        .expect("should have old bid");
+    let delegator1_bid_purse = *old_bid1
+        .delegators()
+        .get(&delegator1)
+        .expect("should have old delegator")
+        .bonding_purse();
+
+    let delegator2_bid_purse = *bid1
+        .delegators()
+        .get(&delegator2)
+        .expect("should have new delegator")
+        .bonding_purse();
+
+    // check that the old delegator's bid purse got zeroed
+    update.assert_written_balance(delegator1_bid_purse, 0);
+
+    // check that the bid purse for the new delegator has been created with the correct amount
+    update.assert_written_purse_is_unit(delegator2_bid_purse);
+    update.assert_written_balance(delegator2_bid_purse, 14);
+
+    // 6 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - bonding purse balance for old delegator
+    // - bonding purse for new delegator
+    // - bonding purse balance for new delegator
+    assert_eq!(update.len(), 6);
+}
+
+#[test]
+fn should_replace_a_delegator_with_unbonding() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+    let delegator2 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1.clone(),
+                    delegated_amount: U512::from(13),
+                }]),
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be replacing the delegator
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator1.clone(),
+            balance: Some(U512::from(101)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: None,
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator2.clone(),
+                    delegated_amount: U512::from(14),
+                }]),
+            }),
+        }],
+        only_listed_validators: false,
+        slash_instead_of_unbonding: false,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 229);
+
+    let account1_hash = validator1.to_account_hash();
+
+    let bid1 = update.get_written_bid(account1_hash);
+    assert_eq!(bid1.validator_public_key(), &validator1);
+    assert_eq!(*bid1.staked_amount(), U512::from(101));
+    assert_eq!(
+        bid1.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(115)
+    );
+    assert!(!bid1.inactive());
+
+    let old_bid1 = reader
+        .get_bids()
+        .get(&validator1)
+        .cloned()
+        .expect("should have old bid");
+    let delegator1_bid_purse = *old_bid1
+        .delegators()
+        .get(&delegator1)
+        .expect("should have old delegator")
+        .bonding_purse();
+
+    let delegator2_bid_purse = *bid1
+        .delegators()
+        .get(&delegator2)
+        .expect("should have new delegator")
+        .bonding_purse();
+
+    // check that the old delegator's bid purse hasn't been updated
+    update.assert_key_absent(&Key::Balance(delegator1_bid_purse.addr()));
+
+    // check that the old delegator has been unbonded
+    update.assert_unbonding_purse(delegator1_bid_purse, &validator1, &delegator1, 13);
+
+    // check that the bid purse for the new delegator has been created with the correct amount
+    update.assert_written_purse_is_unit(delegator2_bid_purse);
+    update.assert_written_balance(delegator2_bid_purse, 14);
+
+    // 6 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - unbonding purse for old delegator
+    // - bonding purse for new delegator
+    // - bonding purse balance for new delegator
+    assert_eq!(update.len(), 6);
+}
+
+#[test]
+fn should_not_change_the_delegator() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1,
+                    delegated_amount: U512::from(13),
+                }]),
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be changing the validator's stake
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator1.clone(),
+            balance: Some(U512::from(101)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(111),
+                delegation_rate: None,
+                delegators: None,
+            }),
+        }],
+        only_listed_validators: false,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 225);
+
+    let account1_hash = validator1.to_account_hash();
+
+    let bid1 = update.get_written_bid(account1_hash);
+    assert_eq!(bid1.validator_public_key(), &validator1);
+    assert_eq!(*bid1.staked_amount(), U512::from(111));
+    assert_eq!(
+        bid1.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(124)
+    );
+    assert!(!bid1.inactive());
+
+    // check that the validator's bid purse got updated
+    update.assert_written_balance(*bid1.bonding_purse(), 111);
+
+    // 4 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - bonding purse balance for validator 1
+    assert_eq!(update.len(), 4);
+}
+
+#[test]
+fn should_remove_the_delegator() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1.clone(),
+                    delegated_amount: U512::from(13),
+                }]),
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be removing the delegator
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator1.clone(),
+            balance: Some(U512::from(101)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(111),
+                delegation_rate: None,
+                delegators: Some(vec![]),
+            }),
+        }],
+        only_listed_validators: false,
+        slash_instead_of_unbonding: true,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 212);
+
+    let account1_hash = validator1.to_account_hash();
+
+    let bid1 = update.get_written_bid(account1_hash);
+    assert_eq!(bid1.validator_public_key(), &validator1);
+    assert_eq!(*bid1.staked_amount(), U512::from(111));
+    assert_eq!(
+        bid1.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(111)
+    );
+    assert!(!bid1.inactive());
+
+    // check that the validator's bid purse got updated
+    update.assert_written_balance(*bid1.bonding_purse(), 111);
+
+    let old_bid1 = reader
+        .get_bids()
+        .get(&validator1)
+        .cloned()
+        .expect("should have old bid");
+    let delegator1_bid_purse = *old_bid1
+        .delegators()
+        .get(&delegator1)
+        .expect("should have old delegator")
+        .bonding_purse();
+
+    // check that the old delegator's bid purse got zeroed
+    update.assert_written_balance(delegator1_bid_purse, 0);
+
+    // 5 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - bonding purse balance for validator 1
+    // - bonding purse balance for delegator
+    assert_eq!(update.len(), 5);
+}
+
+#[test]
+fn should_remove_the_delegator_with_unbonding() {
+    let mut rng = TestRng::new();
+
+    let validator1 = PublicKey::random(&mut rng);
+    let delegator1 = PublicKey::random(&mut rng);
+
+    let mut reader = MockStateReader::new().with_validators(
+        vec![(
+            validator1.clone(),
+            U512::from(101),
+            ValidatorConfig {
+                bonded_amount: U512::from(101),
+                delegation_rate: Some(5),
+                delegators: Some(vec![DelegatorConfig {
+                    public_key: delegator1.clone(),
+                    delegated_amount: U512::from(13),
+                }]),
+            },
+        )],
+        &mut rng,
+    );
+
+    // we'll be removing the delegator
+    let config = Config {
+        accounts: vec![AccountConfig {
+            public_key: validator1.clone(),
+            balance: Some(U512::from(101)),
+            validator: Some(ValidatorConfig {
+                bonded_amount: U512::from(111),
+                delegation_rate: None,
+                delegators: Some(vec![]),
+            }),
+        }],
+        only_listed_validators: false,
+        slash_instead_of_unbonding: false,
+        ..Default::default()
+    };
+
+    let update = get_update(&mut reader, config);
+
+    // check that the update contains the correct list of validators
+    update.assert_validators(&[&validator1]);
+
+    update.assert_seigniorage_recipients_written(&mut reader);
+    update.assert_total_supply(&mut reader, 225);
+
+    let account1_hash = validator1.to_account_hash();
+
+    let bid1 = update.get_written_bid(account1_hash);
+    assert_eq!(bid1.validator_public_key(), &validator1);
+    assert_eq!(*bid1.staked_amount(), U512::from(111));
+    assert_eq!(
+        bid1.total_staked_amount()
+            .expect("should read total staked amount"),
+        U512::from(111)
+    );
+    assert!(!bid1.inactive());
+
+    // check that the validator's bid purse got updated
+    update.assert_written_balance(*bid1.bonding_purse(), 111);
+
+    let old_bid1 = reader
+        .get_bids()
+        .get(&validator1)
+        .cloned()
+        .expect("should have old bid");
+    let delegator1_bid_purse = *old_bid1
+        .delegators()
+        .get(&delegator1)
+        .expect("should have old delegator")
+        .bonding_purse();
+
+    // check that the old delegator's bid purse hasn't been updated
+    update.assert_key_absent(&Key::Balance(delegator1_bid_purse.addr()));
+
+    // check that the unbonding purse got created
+    update.assert_unbonding_purse(delegator1_bid_purse, &validator1, &delegator1, 13);
+
+    // 5 keys should be written:
+    // - seigniorage recipients
+    // - total supply
+    // - bid for validator 1
+    // - bonding purse balance for validator 1
+    // - unbonding purse for delegator
+    assert_eq!(update.len(), 5);
 }

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -1,0 +1,135 @@
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::collections::HashSet;
+
+use casper_types::PublicKey;
+#[cfg(test)]
+use casper_types::{
+    account::{Account, AccountHash},
+    system::auction::Bid,
+    CLValue, URef, U512,
+};
+use casper_types::{Key, StoredValue};
+
+#[cfg(test)]
+use super::state_reader::StateReader;
+
+use crate::utils::{print_entry, print_validators};
+
+pub(crate) struct Update {
+    entries: BTreeMap<Key, StoredValue>,
+    validators: Vec<PublicKey>,
+}
+
+impl Update {
+    pub(crate) fn new(entries: BTreeMap<Key, StoredValue>, validators: Vec<PublicKey>) -> Self {
+        Self {
+            entries,
+            validators,
+        }
+    }
+
+    pub(crate) fn print(&self) {
+        print_validators(&self.validators);
+        for (key, value) in &self.entries {
+            print_entry(key, value);
+        }
+    }
+}
+
+#[cfg(test)]
+impl Update {
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn get_written_account(&self, account: AccountHash) -> Account {
+        self.entries
+            .get(&Key::Account(account))
+            .expect("account should exist")
+            .as_account()
+            .expect("should be an account")
+            .clone()
+    }
+
+    pub(crate) fn get_written_bid(&self, account: AccountHash) -> Bid {
+        self.entries
+            .get(&Key::Bid(account))
+            .expect("should create bid")
+            .as_bid()
+            .expect("should be bid")
+            .clone()
+    }
+
+    pub(crate) fn assert_written_balance(&self, purse: URef, balance: u64) {
+        assert_eq!(
+            self.entries.get(&Key::Balance(purse.addr())),
+            Some(&StoredValue::from(
+                CLValue::from_t(U512::from(balance)).expect("should convert U512 to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_total_supply<R: StateReader>(&self, reader: &mut R, supply: u64) {
+        assert_eq!(
+            self.entries.get(&reader.get_total_supply_key()),
+            Some(&StoredValue::from(
+                CLValue::from_t(U512::from(supply)).expect("should convert U512 to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_written_purse_is_unit(&self, purse: URef) {
+        assert_eq!(
+            self.entries.get(&Key::URef(purse)),
+            Some(&StoredValue::from(
+                CLValue::from_t(()).expect("should convert unit to CLValue")
+            ))
+        );
+    }
+
+    pub(crate) fn assert_seigniorage_recipients_written<R: StateReader>(&self, reader: &mut R) {
+        assert!(self
+            .entries
+            .contains_key(&reader.get_seigniorage_recipients_key()));
+    }
+
+    pub(crate) fn assert_written_bid(&self, account: AccountHash, bid: Bid) {
+        assert_eq!(
+            self.entries.get(&Key::Bid(account)),
+            Some(&StoredValue::from(bid))
+        );
+    }
+
+    pub(crate) fn assert_unbonding_purse(
+        &self,
+        bid_purse: URef,
+        validator_key: &PublicKey,
+        unbonder_key: &PublicKey,
+        amount: u64,
+    ) {
+        let account_hash = validator_key.to_account_hash();
+        let unbonds = self
+            .entries
+            .get(&Key::Unbond(account_hash))
+            .expect("should have unbonds for the account")
+            .as_unbonding()
+            .expect("should be unbonding purses");
+        assert!(unbonds.iter().any(
+            |unbonding_purse| unbonding_purse.bonding_purse() == &bid_purse
+                && unbonding_purse.validator_public_key() == validator_key
+                && unbonding_purse.unbonder_public_key() == unbonder_key
+                && unbonding_purse.amount() == &U512::from(amount)
+        ))
+    }
+
+    pub(crate) fn assert_key_absent(&self, key: &Key) {
+        assert!(!self.entries.contains_key(key))
+    }
+
+    pub(crate) fn assert_validators(&self, validators: &[&PublicKey]) {
+        let self_set: HashSet<_> = self.validators.iter().collect();
+        let other_set: HashSet<_> = validators.iter().cloned().collect();
+        assert_eq!(self_set, other_set);
+    }
+}

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -2,14 +2,13 @@ use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::HashSet;
 
-use casper_types::PublicKey;
 #[cfg(test)]
 use casper_types::{
     account::{Account, AccountHash},
     system::auction::Bid,
     CLValue, URef, U512,
 };
-use casper_types::{Key, StoredValue};
+use casper_types::{Key, PublicKey, StoredValue};
 
 #[cfg(test)]
 use super::state_reader::StateReader;

--- a/utils/global-state-update-gen/src/validators.rs
+++ b/utils/global-state-update-gen/src/validators.rs
@@ -5,7 +5,7 @@ use casper_types::{AsymmetricType, PublicKey, U512};
 
 use crate::{
     generic::{
-        config::{AccountConfig, Config},
+        config::{AccountConfig, Config, ValidatorConfig},
         update_from_config,
     },
     utils::hash_from_str,
@@ -40,8 +40,12 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
 
                 AccountConfig {
                     public_key,
-                    stake: Some(stake),
                     balance: maybe_new_balance,
+                    validator: Some(ValidatorConfig {
+                        bonded_amount: stake,
+                        delegation_rate: None,
+                        delegators: None,
+                    }),
                 }
             })
             .collect(),
@@ -51,6 +55,7 @@ pub(crate) fn generate_validators_update(matches: &ArgMatches<'_>) {
         accounts,
         transfers: vec![],
         only_listed_validators: true,
+        slash_instead_of_unbonding: true, // for consistency with the old behavior
     };
 
     let builder = LmdbWasmTestBuilder::open_raw(data_dir, Default::default(), state_hash);


### PR DESCRIPTION
This ports the changes related to delegator handling in `global-state-update-gen` from `dev`.

Closes #3459 
