### PR TITLE
Fix chain available block metrics

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,11 +15,12 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_duration_seconds` histogram metric to track the progress of block synchronization, `lowest_available_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_duration_seconds` histogram metric to track the progress of block synchronization, `lowest_available_block_height` and `highest_available_block_height` to report the highest and lowest height of the blocks that were synchronized and available on the node, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
 
 ### Changed
 
 * Log messages for blocked nodes have been unified and reasons for blocking peers are better tracked.
+* `chain_height` metric is now deprecated and will be removed in the future. Please use `highest_available_block_height` instead.
 
 ## [Unreleased]
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 
 * Add `net-info` command to diagnostics port to gain insights into the nodes network connectivity state.
-* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_duration_seconds` histogram metric to track the progress of block synchronization, `chain_low_seq_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
+* Add metrics `deploy_buffer_total_deploys`, `deploy_buffer_held_deploys`, `deploy_buffer_dead_deploys` to report status of the node deploy buffer, `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to track status of the block accumulator component, `{forward|historical}_block_sync_duration_seconds` histogram metric to track the progress of block synchronization, `lowest_available_block_height` to report the lowest height that has been synchronized continuously from the tip, `sync_leap_duration_seconds`, `sync_leap_fetched_from_peer_total`, `sync_leap_rejected_by_peer_total`, `sync_leap_cant_fetch_total` to track progress of the sync leaper component.
 
 ### Changed
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2438,10 +2438,11 @@ impl Storage {
     fn update_chain_height_metrics(&self) {
         if let Some(metrics) = self.metrics.as_ref() {
             if let Some(sequence) = self.completed_blocks.highest_sequence() {
-                let chain_height: i64 = sequence.high().try_into().unwrap_or(i64::MIN);
-                let low_seq_height: i64 = sequence.low().try_into().unwrap_or(i64::MIN);
-                metrics.chain_height.set(chain_height);
-                metrics.chain_low_seq_block_height.set(low_seq_height);
+                let highest_available_block: i64 = sequence.high().try_into().unwrap_or(i64::MIN);
+                let lowest_available_block: i64 = sequence.low().try_into().unwrap_or(i64::MIN);
+                metrics.chain_height.set(highest_available_block);
+                metrics.highest_available_block.set(highest_available_block);
+                metrics.lowest_available_block.set(lowest_available_block);
             }
         }
     }


### PR DESCRIPTION
Add `highest_available_block_height` metric and mark `chain_height` as deprecated. Also rename `chain_low_seq_block_height` to `lowest_available_block_height` for consistency.