### PR TITLE
Remove cache of recent switch blocks from reactor

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1182,14 +1182,27 @@ impl Storage {
         Ok(maybe_block)
     }
 
-    pub(crate) fn read_blocks_since(
+    /// Retrieves the contiguous segment of the block chain starting at the highest known switch
+    /// block such that the blocks' timestamps cover a duration of at least the max TTL for deploys
+    /// (a chainspec setting).
+    ///
+    /// If storage doesn't hold enough blocks to cover the specified duration, it will still return
+    /// the highest contiguous segment starting at the highest switch block which it does hold.
+    pub(crate) fn read_blocks_for_replay_protection(
         &self,
-        timestamp: Timestamp,
     ) -> Result<Vec<Block>, FatalStorageError> {
         let mut txn = self
             .env
             .begin_ro_txn()
             .expect("Could not start read only transaction for lmdb");
+        let timestamp = match self.switch_block_era_id_index.keys().last() {
+            Some(era_id) => self
+                .get_switch_block_header_by_era_id(&mut txn, *era_id)?
+                .map(|switch_block| switch_block.timestamp().saturating_sub(self.max_ttl))
+                .unwrap_or_else(Timestamp::now),
+            None => Timestamp::now(),
+        };
+
         self.get_blocks_while(&mut txn, |block| block.timestamp() >= timestamp)
     }
 
@@ -1422,6 +1435,7 @@ impl Storage {
         Ok(true)
     }
 
+    /// Returns `count` highest switch block headers, sorted from lowest (oldest) to highest.
     pub(crate) fn read_highest_switch_block_headers(
         &self,
         count: u64,

--- a/node/src/reactor/main_reactor/upgrade_shutdown.rs
+++ b/node/src/reactor/main_reactor/upgrade_shutdown.rs
@@ -19,7 +19,16 @@ impl MainReactor {
         &self,
         effect_builder: EffectBuilder<MainEvent>,
     ) -> UpgradeShutdownInstruction {
-        if let Some(block_header) = self.recent_switch_block_headers.last() {
+        let recent_switch_block_headers = match self.storage.read_highest_switch_block_headers(1) {
+            Ok(headers) => headers,
+            Err(error) => {
+                return UpgradeShutdownInstruction::Fatal(format!(
+                    "error getting recent switch block headers: {}",
+                    error
+                ))
+            }
+        };
+        if let Some(block_header) = recent_switch_block_headers.last() {
             let highest_switch_block_era = block_header.era_id();
             return match self
                 .validator_matrix


### PR DESCRIPTION
This removes `recent_switch_block_headers` from the main reactor and instead retrieves the required headers from storage as required.

It also closes an outstanding `todo!` comments whereby storage's `read_blocks_since` has been replaced to be less general, and calculates the timestamp itself.