### PR TITLE
NCTL: move away from log for defining joined node

### DIFF
--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -186,7 +186,7 @@ function do_await_era_change() {
     # allow chain height to grow
     local ERA_COUNT=${1:-"1"}
     log_step "awaiting $ERA_COUNT eras…"
-    await_n_eras "$ERA_COUNT"
+    nctl-await-n-eras offset="$ERA_COUNT" sleep_interval='5.0'
 }
 
 function check_current_era {

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -87,7 +87,7 @@ function assert_joined_in_era_4() {
 
     log_step "Waiting for node-$NODE_ID to join..."
     while true; do
-        OUTPUT=$(nctl-view-node-status node=5)
+        OUTPUT=$(nctl-view-node-status node="$NODE_ID")
         REACTOR_STATE=$(echo "$OUTPUT" | tail -n +2 | jq -r '.reactor_state')
 
         if [ "$REACTOR_STATE" == "KeepUp" ] || [ "$REACTOR_STATE" == "Validate" ]; then


### PR DESCRIPTION
Changes:
- log message 'finished joining' no longer exists
    - using reactor state instead

Unreleated change:
- updated do_await_era_change function to use a more verbose form