### PR TITLE
Fix misleading participation log message.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -544,6 +544,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
             Vertex::Ping(ping) => trace!(?ping, "received ping"),
         }
     }
+
     /// Prevalidates the vertex but checks the cache for previously validated vertices.
     /// Avoids multiple validation of the same vertex.
     fn pre_validate_vertex(
@@ -876,18 +877,16 @@ where
                 let next_time = timestamp + self.config.pending_vertex_timeout;
                 vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
             }
-            TIMER_ID_LOG_PARTICIPATION => {
-                self.log_participation();
-                match self.config.log_participation_interval {
-                    Some(interval) if !self.evidence_only && !self.finalized_switch_block() => {
-                        vec![ProtocolOutcome::ScheduleTimer(
-                            timestamp + interval,
-                            timer_id,
-                        )]
-                    }
-                    _ => vec![],
+            TIMER_ID_LOG_PARTICIPATION => match self.config.log_participation_interval {
+                Some(interval) if !self.evidence_only && !self.finalized_switch_block() => {
+                    self.log_participation();
+                    vec![ProtocolOutcome::ScheduleTimer(
+                        timestamp + interval,
+                        timer_id,
+                    )]
                 }
-            }
+                _ => vec![],
+            },
             TIMER_ID_REQUEST_STATE => self.handle_request_state_timer(timestamp),
             TIMER_ID_SYNCHRONIZER_LOG => {
                 self.synchronizer.log_len();

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -114,7 +114,7 @@ request_state_interval = '20sec'
 
 # Log inactive or faulty validators periodically, with this interval.
 # '0sec' means it is disabled and we never print the log message.
-log_participation_interval = '1min'
+log_participation_interval = '15sec'
 
 # Log the synchronizer state periodically, with this interval.
 # '0sec' means it is disabled and we never print the log message.


### PR DESCRIPTION
If participation is logged after the DAG has been purged ("evidence only" mode) it looks like everyone was inactive, so we should skip the log in that case.

This also changes the testing config so that participation is logged every 15 seconds instead of 1 minute, otherwise we would never see the message in the 21 second testing eras.