### PR TITLE
Fix deploy buffer TTL check.

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -212,11 +212,6 @@ impl BlockAccumulator {
         }
     }
 
-    /// Gets local tip block_height if available.
-    pub(crate) fn local_tip(&self) -> Option<u64> {
-        self.local_tip.map(|lti| lti.height)
-    }
-
     /// Drops all old block acceptors and tracks new local block height;
     /// subsequent attempts to register a block lower than tip will be rejected.
     pub(crate) fn register_local_tip(&mut self, height: u64, era_id: EraId) {

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -100,7 +100,7 @@ impl DeployBuffer {
     /// which is the switch block's timestamp. A deploy D in a block B cannot have timed out as of
     /// B's timestamp, so it cannot be older than T - ttl, where ttl is the maximum deploy
     /// time-to-live. So if D were also in an earlier block C, then C's timestamp would be at
-    /// least T - ttl. Thus to prevent replays, we need all blocks with a timetstamp between
+    /// least T - ttl. Thus to prevent replays, we need all blocks with a timestamp between
     /// T - ttl and T.
     ///
     /// Note that we don't need to already have any blocks from E itself, since the consensus

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -28,8 +28,8 @@ use crate::{
     types::{
         appendable_block::{AddError, AppendableBlock},
         chainspec::DeployConfig,
-        Approval, Block, Deploy, DeployFootprint, DeployHash, DeployHashWithApprovals, DeployId,
-        FinalizedBlock,
+        Approval, Block, BlockHeader, Deploy, DeployFootprint, DeployHash, DeployHashWithApprovals,
+        DeployId, FinalizedBlock,
     },
     NodeRng,
 };
@@ -92,10 +92,28 @@ impl DeployBuffer {
         })
     }
 
-    /// True if we have full TTL worth of deploy awareness, else false.
-    pub(crate) fn have_full_ttl_of_deploys(&self, from_height: u64) -> bool {
-        debug!(?self.chain_index, "DeployBuffer: chain_index check from_height: {}", from_height);
-        let ttl = self.deploy_config.max_ttl;
+    /// Returns `true` if we have enough information to participate in consensus in the era after
+    /// the `switch block`.
+    ///
+    /// To validate and propose blocks we need to be able to avoid and detect deploy replays.
+    /// Each block in the new era E will have a timestamp greater or equal to E's start time T,
+    /// which is the switch block's timestamp. A deploy D in a block B cannot have timed out as of
+    /// B's timestamp, so it cannot be older than T - ttl, where ttl is the maximum deploy
+    /// time-to-live. So if D were also in an earlier block C, then C's timestamp would be at
+    /// least T - ttl. Thus to prevent replays, we need all blocks with a timetstamp between
+    /// T - ttl and T.
+    ///
+    /// Note that we don't need to already have any blocks from E itself, since the consensus
+    /// protocol will announce all proposed and finalized blocks in E anyway.
+    pub(crate) fn have_full_ttl_of_deploys(&self, switch_block: &BlockHeader) -> bool {
+        let from_height = switch_block.height();
+        let earliest_needed = switch_block
+            .timestamp()
+            .saturating_sub(self.deploy_config.max_ttl);
+        debug!(
+            ?self.chain_index, %earliest_needed,
+            "DeployBuffer: chain_index check from_height: {}", from_height
+        );
         let mut current = match self.chain_index.get(&from_height) {
             None => {
                 debug!("DeployBuffer: not in chain_index: {}", from_height);
@@ -117,7 +135,7 @@ impl DeployBuffer {
         for (height, timestamp) in self.chain_index.range(..from_height).rev() {
             // if we've reached genesis via an unbroken sequence, we're good
             // if we've seen a full ttl period of blocks, we're good
-            if *height == 0 || timestamp.elapsed() > ttl {
+            if *height == 0 || *timestamp < earliest_needed {
                 return true;
             }
             // gap detection; any gaps in the chain index means we do not have full ttl awareness

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -103,13 +103,10 @@ impl MainReactor {
             return Ok(None);
         }
 
-        // use local tip if it is higher than highest switch block, otherwise highest switch block
-        let from_height = match self.block_accumulator.local_tip() {
-            Some(tip) => highest_switch_block_header.height().max(tip),
-            None => highest_switch_block_header.height(),
-        };
-
-        if self.deploy_buffer.have_full_ttl_of_deploys(from_height) {
+        if self
+            .deploy_buffer
+            .have_full_ttl_of_deploys(highest_switch_block_header)
+        {
             debug!("Validate: sufficient deploy TTL awareness to safely participate in consensus");
         } else {
             info!("Validate: insufficient deploy TTL awareness to safely participate in consensus");


### PR DESCRIPTION
To prevent and detect replays in an era we need to know about all deploys up to the era start time, starting one max TTL before that.