### PR TITLE
Various small fixes

### DIFF
--- a/node/src/components/fetcher/item_fetcher.rs
+++ b/node/src/components/fetcher/item_fetcher.rs
@@ -149,7 +149,7 @@ pub(super) trait ItemFetcher<T: FetcherItem + 'static> {
         };
 
         if let Err(err) = item.validate(validation_metadata) {
-            debug!(%peer, %err, ?item, "peer sent invalid item, banning peer");
+            debug!(%peer, %err, ?item, "peer sent invalid item");
             effect_builder
                 .announce_block_peer_with_justification(
                     peer,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1833,7 +1833,7 @@ impl<REv> EffectBuilder<REv> {
     ) where
         REv: From<PeerBehaviorAnnouncement>,
     {
-        warn!(%offender, %justification, "peer will be blocked");
+        warn!(%offender, %justification, "banning peer");
         self.event_queue
             .schedule(
                 PeerBehaviorAnnouncement::OffenseCommitted {

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -952,7 +952,7 @@ where
                         warn!(
                             %sender,
                             %deploy_id,
-                            "peer refused to provide deploy, banning peer"
+                            "peer refused to provide deploy"
                         );
                         return effect_builder
                             .announce_block_peer_with_justification(
@@ -965,7 +965,7 @@ where
                         warn!(
                             %sender,
                             %error,
-                            "received a deploy item we couldn't parse, banning peer",
+                            "received a deploy item we couldn't parse",
                         );
                         return effect_builder
                             .announce_block_peer_with_justification(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -24,7 +24,7 @@ maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.
-era_duration = '21seconds'
+era_duration = '41seconds'
 # Minimum number of blocks per era.  An era will take longer than `era_duration` if that is necessary to reach the
 # minimum height.
 minimum_era_height = 5


### PR DESCRIPTION
This PR changes the following:
* Reverts the `era_duration` back to 41 seconds in the default, local chainspec
* Adds details to `TooManyTrustedAncestors` error
* Unifies some log messages regarding banning a peer