### PR TITLE
Pass correct era id to `ee_upgrade_config()` while committing an upgrade

### DIFF
--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -385,7 +385,7 @@ impl MainReactor {
         match self.chainspec.ee_upgrade_config(
             *previous_block_header.state_root_hash(),
             previous_block_header.protocol_version(),
-            previous_block_header.era_id(),
+            self.chainspec.protocol_config.activation_point.era_id(),
             self.chainspec_raw_bytes.clone(),
         ) {
             Ok(cfg) => match self.contract_runtime.commit_upgrade(cfg) {


### PR DESCRIPTION
This PR changes the era id which is passed to `ee_upgrade_config()` while committing an upgrade.