### PR TITLE
Update control_flow opcode cost.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ dependencies = [
  "anyhow",
  "base16",
  "casper-types 1.5.0",
- "clap 3.2.16",
+ "clap 3.2.23",
  "derive_more",
  "hex",
  "serde",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -769,14 +769,14 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -3120,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "output_vt100"
@@ -4516,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.  The format
 * Lift the temporary limit of the size of individual values stored in global state.
 * Lift the temporary limit of the global maximum delegator capacity.
 * Providing incorrect Wasm for execution will cause the default 2.5CSPR to be charged.
-
+* Update the default `control_flow` opcode cost from `440` to `440000`.
 
 
 ## 2.0.1

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_LOCAL_COST: u32 = 390;
 /// Default cost of the `global` Wasm opcode.
 pub const DEFAULT_GLOBAL_COST: u32 = 390;
 /// Default cost of the `control_flow` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_COST: u32 = 440;
+pub const DEFAULT_CONTROL_FLOW_COST: u32 = 440000;
 /// Default cost of the `integer_comparison` Wasm opcode.
 pub const DEFAULT_INTEGER_COMPARISON_COST: u32 = 250;
 /// Default cost of the `conversion` Wasm opcode.

--- a/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
@@ -2598,9 +2598,11 @@ mod payment {
     use rand::Rng;
 
     use casper_engine_test_support::{
-        DeployItemBuilder, ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR,
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     };
-    use casper_types::{runtime_args, system::mint, RuntimeArgs};
+    use casper_execution_engine::core::engine_state::{Error as CoreError, ExecError};
+    use casper_types::{runtime_args, system::mint, HashAddr, RuntimeArgs};
+    use get_call_stack_recursive_subcall::Call;
 
     use crate::wasm_utils;
 
@@ -2610,15 +2612,204 @@ mod payment {
     };
 
     // DEPTHS should not contain 1, as it will eliminate the initial element from the subcalls
-    // vector.  Going further than 5 will git the gas limit.
+    // vector.  Going further than 5 will hit the gas limit.
     const DEPTHS: &[usize] = &[0, 2, 5];
+
+    fn execute(builder: &mut InMemoryWasmTestBuilder, call_depth: usize, subcalls: Vec<Call>) {
+        let execute_request = {
+            let mut rng = rand::thread_rng();
+            let deploy_hash = rng.gen();
+            let sender = *DEFAULT_ACCOUNT_ADDR;
+            let args = runtime_args! {
+                ARG_CALLS => subcalls,
+                ARG_CURRENT_DEPTH => 0u8,
+                mint::ARG_AMOUNT => approved_amount(call_depth),
+            };
+            let deploy = DeployItemBuilder::new()
+                .with_address(sender)
+                .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
+                .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
+                .with_authorization_keys(&[sender])
+                .with_deploy_hash(deploy_hash)
+                .build();
+            ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        };
+
+        if call_depth == 0 {
+            builder.exec(execute_request).commit().expect_success();
+        } else {
+            builder.exec(execute_request).commit().expect_failure();
+            let error = builder.get_error().expect("must have an error");
+            assert!(matches!(error, CoreError::Exec(ExecError::GasLimit)));
+        }
+    }
+
+    fn execute_stored_payment_by_package_name(
+        builder: &mut InMemoryWasmTestBuilder,
+        call_depth: usize,
+        subcalls: Vec<Call>,
+    ) {
+        let execute_request = {
+            let mut rng = rand::thread_rng();
+            let deploy_hash = rng.gen();
+
+            let sender = *DEFAULT_ACCOUNT_ADDR;
+
+            let args = runtime_args! {
+                ARG_CALLS => subcalls,
+                ARG_CURRENT_DEPTH => 0u8,
+                mint::ARG_AMOUNT => approved_amount(call_depth),
+            };
+
+            let deploy = DeployItemBuilder::new()
+                .with_address(sender)
+                .with_stored_versioned_payment_contract_by_name(
+                    CONTRACT_PACKAGE_NAME,
+                    None,
+                    CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
+                    args,
+                )
+                .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
+                .with_authorization_keys(&[sender])
+                .with_deploy_hash(deploy_hash)
+                .build();
+
+            ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        };
+
+        if call_depth == 0 {
+            builder.exec(execute_request).commit().expect_success();
+        } else {
+            builder.exec(execute_request).commit().expect_failure();
+            let error = builder.get_error().expect("must have an error");
+            assert!(matches!(error, CoreError::Exec(ExecError::GasLimit)));
+        }
+    }
+
+    fn execute_stored_payment_by_package_hash(
+        builder: &mut InMemoryWasmTestBuilder,
+        call_depth: usize,
+        subcalls: Vec<Call>,
+        current_contract_package_hash: HashAddr,
+    ) {
+        let execute_request = {
+            let mut rng = rand::thread_rng();
+            let deploy_hash = rng.gen();
+            let sender = *DEFAULT_ACCOUNT_ADDR;
+            let args = runtime_args! {
+                ARG_CALLS => subcalls,
+                ARG_CURRENT_DEPTH => 0u8,
+                mint::ARG_AMOUNT => approved_amount(call_depth),
+            };
+            let deploy = DeployItemBuilder::new()
+                .with_address(sender)
+                .with_stored_versioned_payment_contract_by_hash(
+                    current_contract_package_hash,
+                    None,
+                    CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
+                    args,
+                )
+                .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
+                .with_authorization_keys(&[sender])
+                .with_deploy_hash(deploy_hash)
+                .build();
+            ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        };
+
+        if call_depth == 0 {
+            builder.exec(execute_request).expect_success().commit();
+        } else {
+            builder.exec(execute_request).commit().expect_failure();
+            let error = builder.get_error().expect("must have an error");
+            assert!(matches!(error, CoreError::Exec(ExecError::GasLimit)));
+        }
+    }
+
+    fn execute_stored_payment_by_contract_name(
+        builder: &mut InMemoryWasmTestBuilder,
+        call_depth: usize,
+        subcalls: Vec<Call>,
+    ) {
+        let execute_request = {
+            let mut rng = rand::thread_rng();
+            let deploy_hash = rng.gen();
+
+            let sender = *DEFAULT_ACCOUNT_ADDR;
+
+            let args = runtime_args! {
+                ARG_CALLS => subcalls,
+                ARG_CURRENT_DEPTH => 0u8,
+                mint::ARG_AMOUNT => approved_amount(call_depth),
+            };
+
+            let deploy = DeployItemBuilder::new()
+                .with_address(sender)
+                .with_stored_payment_named_key(
+                    CONTRACT_NAME,
+                    CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
+                    args,
+                )
+                .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
+                .with_authorization_keys(&[sender])
+                .with_deploy_hash(deploy_hash)
+                .build();
+
+            ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        };
+
+        if call_depth == 0 {
+            builder.exec(execute_request).commit().expect_success();
+        } else {
+            builder.exec(execute_request).commit().expect_failure();
+            let error = builder.get_error().expect("must have an error");
+            assert!(matches!(error, CoreError::Exec(ExecError::GasLimit)));
+        }
+    }
+
+    fn execute_stored_payment_by_contract_hash(
+        builder: &mut InMemoryWasmTestBuilder,
+        call_depth: usize,
+        subcalls: Vec<Call>,
+        current_contract_hash: HashAddr,
+    ) {
+        let execute_request = {
+            let mut rng = rand::thread_rng();
+            let deploy_hash = rng.gen();
+            let sender = *DEFAULT_ACCOUNT_ADDR;
+            let args = runtime_args! {
+                ARG_CALLS => subcalls,
+                ARG_CURRENT_DEPTH => 0u8,
+                mint::ARG_AMOUNT => approved_amount(call_depth),
+            };
+            let deploy = DeployItemBuilder::new()
+                .with_address(sender)
+                .with_stored_payment_hash(
+                    current_contract_hash.into(),
+                    CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
+                    args,
+                )
+                .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
+                .with_authorization_keys(&[sender])
+                .with_deploy_hash(deploy_hash)
+                .build();
+            ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        };
+
+        if call_depth == 0 {
+            builder.exec(execute_request).commit().expect_success();
+        } else {
+            builder.exec(execute_request).commit().expect_failure();
+            let error = builder.get_error().expect("must have an error");
+            assert!(matches!(error, CoreError::Exec(ExecError::GasLimit)));
+        }
+    }
 
     // Session + recursive subcall
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_versioned_session_to_stored_versioned_contract() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_versioned_session_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -2626,47 +2817,22 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_session(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_contract(
                     current_contract_package_hash.into(),
                 ));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info_module_bytes(
-                &mut builder,
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute(&mut builder, *call_depth, subcalls);
         }
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_versioned_session_to_stored_contract() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_versioned_session_to_stored_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -2675,137 +2841,78 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_session(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_contract(current_contract_hash.into()));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info_module_bytes(
-                &mut builder,
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute(&mut builder, *call_depth, subcalls);
         }
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_session_to_stored_versioned_contract() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_session_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_session(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_session(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_contract(
                     current_contract_package_hash.into(),
                 ));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info_module_bytes(
-                &mut builder,
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute(&mut builder, *call_depth, subcalls)
         }
+    }
+
+    // Payment logic is tethered to a low gas amount. It is not forbidden to attempt to do calls
+    // however they are expensive and if you exceed the gas limit it should fail with a
+    // GasLimit error.
+    #[ignore]
+    #[test]
+    fn payment_bytes_to_stored_contract_to_stored_session() {
+        let call_depth = 5usize;
+        let mut builder = super::setup();
+        let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+        let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+        let subcalls = vec![
+            super::stored_contract(current_contract_hash.into()),
+            super::stored_session(current_contract_hash.into()),
+        ];
+        execute(&mut builder, call_depth, subcalls)
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_contract_to_stored_session() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+    fn payment_bytes_to_stored_session_to_stored_contract_() {
+        let call_depth = 5usize;
+        let mut builder = super::setup();
+        let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+        let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_session(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
-                subcalls.push(super::stored_contract(current_contract_hash.into()));
-            }
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info_module_bytes(
-                &mut builder,
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
+        let subcalls = vec![
+            super::stored_session(current_contract_hash.into()),
+            super::stored_contract(current_contract_hash.into()),
+        ];
+        execute(&mut builder, call_depth, subcalls)
     }
 
     // Session + recursive subcall failure cases
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_versioned_contract_to_stored_versioned_session_should_fail() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_versioned_contract_to_stored_versioned_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -2813,43 +2920,22 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_versioned_contract_to_stored_session_should_fail() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_versioned_contract_to_stored_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -2858,115 +2944,56 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_contract_to_stored_versioned_session_should_fail() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_contract_to_stored_versioned_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn session_bytes_to_stored_contract_to_stored_session_should_fail() {
-        for len in DEPTHS {
+    fn payment_bytes_to_stored_contract_to_stored_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()));
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_payment_code(CONTRACT_CALL_RECURSIVE_SUBCALL, args)
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute(&mut builder, *call_depth, subcalls)
         }
     }
 
@@ -2974,725 +3001,301 @@ mod payment {
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_name_to_stored_versioned_session() {
-        for len in DEPTHS {
+    fn stored_versioned_payment_by_name_to_stored_versioned_session() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
 
             let subcalls =
-                vec![super::stored_versioned_session(current_contract_package_hash.into()); *len];
+                vec![
+                    super::stored_versioned_session(current_contract_package_hash.into());
+                    *call_depth
+                ];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_contract_by_name(
-                        CONTRACT_PACKAGE_NAME,
-                        None,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute_stored_payment_by_package_name(&mut builder, *call_depth, subcalls);
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_hash_to_stored_versioned_session() {
-        for len in DEPTHS {
+    fn stored_versioned_payment_by_hash_to_stored_versioned_session() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
 
             let subcalls =
-                vec![super::stored_versioned_session(current_contract_package_hash.into()); *len];
+                vec![
+                    super::stored_versioned_session(current_contract_package_hash.into());
+                    *call_depth
+                ];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_contract_by_hash(
-                        current_contract_package_hash,
-                        None,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
+            execute_stored_payment_by_package_hash(
                 &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
+                *call_depth,
                 subcalls,
                 current_contract_package_hash,
-            );
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_name_to_stored_session() {
-        for len in DEPTHS {
+    fn stored_versioned_payment_by_name_to_stored_session() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+            let subcalls = vec![super::stored_session(current_contract_hash.into()); *call_depth];
+
+            execute_stored_payment_by_package_name(&mut builder, *call_depth, subcalls)
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_versioned_payment_by_hash_to_stored_session() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let subcalls = vec![super::stored_session(current_contract_hash.into()); *len];
+            let subcalls = vec![super::stored_session(current_contract_hash.into()); *call_depth];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_contract_by_name(
-                        CONTRACT_PACKAGE_NAME,
-                        None,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
+            execute_stored_payment_by_package_hash(
                 &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
+                *call_depth,
                 subcalls,
                 current_contract_package_hash,
-            );
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_hash_to_stored_session() {
-        for len in DEPTHS {
+    fn stored_payment_by_name_to_stored_versioned_session() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let subcalls = vec![super::stored_session(current_contract_hash.into()); *len];
+            let subcalls =
+                vec![
+                    super::stored_versioned_session(current_contract_package_hash.into());
+                    *call_depth
+                ];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_contract_by_hash(
-                        current_contract_package_hash,
-                        None,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_name_to_stored_versioned_session() {
-        for len in DEPTHS {
+    fn stored_payment_by_hash_to_stored_versioned_session() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
             let subcalls =
-                vec![super::stored_versioned_session(current_contract_package_hash.into()); *len];
+                vec![
+                    super::stored_versioned_session(current_contract_package_hash.into());
+                    *call_depth
+                ];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
+            execute_stored_payment_by_contract_hash(
                 &mut builder,
-                super::stored_session(current_contract_hash.into()),
+                *call_depth,
                 subcalls,
-                current_contract_package_hash,
-            );
+                current_contract_hash,
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_hash_to_stored_versioned_session() {
-        for len in DEPTHS {
+    fn stored_payment_by_name_to_stored_session() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+            let subcalls = vec![super::stored_session(current_contract_hash.into()); *call_depth];
+
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_payment_by_hash_to_stored_session() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+            let subcalls = vec![super::stored_session(current_contract_hash.into()); *call_depth];
+
+            execute_stored_payment_by_contract_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_hash,
+            )
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_versioned_payment_by_name_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
+
+            let subcalls =
+                vec![
+                    super::stored_versioned_contract(current_contract_package_hash.into());
+                    *call_depth
+                ];
+
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_versioned_payment_by_hash_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
+
+            let subcalls =
+                vec![
+                    super::stored_versioned_contract(current_contract_package_hash.into());
+                    *call_depth
+                ];
+
+            execute_stored_payment_by_package_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_package_hash,
+            )
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_versioned_payment_by_name_to_stored_contract() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *call_depth];
+
+            execute_stored_payment_by_package_name(&mut builder, *call_depth, subcalls)
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_versioned_payment_by_hash_to_stored_contract() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
+            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
+
+            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *call_depth];
+
+            execute_stored_payment_by_package_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_package_hash,
+            )
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_payment_by_name_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
+            let mut builder = super::setup();
+            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
+            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
+
+            let subcalls =
+                vec![
+                    super::stored_versioned_contract(current_contract_package_hash.into());
+                    *call_depth
+                ];
+
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn stored_payment_by_hash_to_stored_versioned_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
             let subcalls =
-                vec![super::stored_versioned_session(current_contract_package_hash.into()); *len];
+                vec![
+                    super::stored_versioned_contract(current_contract_package_hash.into());
+                    *call_depth
+                ];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_hash(
-                        current_contract_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
+            execute_stored_payment_by_contract_hash(
                 &mut builder,
-                super::stored_session(current_contract_hash.into()),
+                *call_depth,
                 subcalls,
-                current_contract_package_hash,
-            );
+                current_contract_hash,
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_name_to_stored_session() {
-        for len in DEPTHS {
+    fn stored_payment_by_name_to_stored_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let subcalls = vec![super::stored_session(current_contract_hash.into()); *len];
+            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *call_depth];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_hash_to_stored_session() {
-        for len in DEPTHS {
+    fn stored_payment_by_hash_to_stored_contract() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let subcalls = vec![super::stored_session(current_contract_hash.into()); *len];
+            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *call_depth];
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_hash(
-                        current_contract_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
+            execute_stored_payment_by_contract_hash(
                 &mut builder,
-                super::stored_session(current_contract_hash.into()),
+                *call_depth,
                 subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_versioned_session_by_name_to_stored_versioned_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-
-            let subcalls =
-                vec![super::stored_versioned_contract(current_contract_package_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_named_key(
-                        CONTRACT_PACKAGE_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_versioned_session_by_hash_to_stored_versioned_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-
-            let subcalls =
-                vec![super::stored_versioned_contract(current_contract_package_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_hash(
-                        current_contract_package_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_versioned_session_by_name_to_stored_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_named_key(
-                        CONTRACT_PACKAGE_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_versioned_session_by_hash_to_stored_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_hash(
-                        current_contract_package_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_versioned_session(current_contract_package_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_session_by_name_to_stored_versioned_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls =
-                vec![super::stored_versioned_contract(current_contract_package_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_session_by_hash_to_stored_versioned_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls =
-                vec![super::stored_versioned_contract(current_contract_package_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_hash(
-                        current_contract_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_session_by_name_to_stored_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn stored_session_by_hash_to_stored_contract() {
-        for len in DEPTHS {
-            let mut builder = super::setup();
-            let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
-            let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
-            let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
-
-            let subcalls = vec![super::stored_contract(current_contract_hash.into()); *len];
-
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_hash(
-                        current_contract_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-            builder.exec(execute_request).commit().expect_success();
-
-            super::assert_each_context_has_correct_call_stack_info(
-                &mut builder,
-                super::stored_session(current_contract_hash.into()),
-                subcalls,
-                current_contract_package_hash,
-            );
+                current_contract_hash,
+            )
         }
     }
 
@@ -3700,9 +3303,9 @@ mod payment {
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_name_to_stored_versioned_contract_to_stored_versioned_session_should_fail(
+    fn stored_versioned_payment_by_name_to_stored_versioned_contract_to_stored_versioned_session_should_fail(
     ) {
-        for len in DEPTHS {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -3710,48 +3313,23 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_named_key(
-                        CONTRACT_PACKAGE_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_package_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_hash_to_stored_versioned_contract_to_stored_session_should_fail()
+    fn stored_versioned_payment_by_hash_to_stored_versioned_contract_to_stored_session_should_fail()
     {
-        for len in DEPTHS {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -3760,137 +3338,76 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_hash(
-                        current_contract_package_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_package_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_package_hash,
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_name_to_stored_contract_to_stored_versioned_session_should_fail()
+    fn stored_versioned_payment_by_name_to_stored_contract_to_stored_versioned_session_should_fail()
     {
-        for len in DEPTHS {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_named_key(
-                        CONTRACT_PACKAGE_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_package_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_versioned_session_by_hash_to_stored_contract_to_stored_session_should_fail() {
-        for len in DEPTHS {
+    fn stored_versioned_payment_by_hash_to_stored_contract_to_stored_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_versioned_payment_hash(
-                        current_contract_package_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_package_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_package_hash,
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_name_to_stored_versioned_contract_to_stored_versioned_session_should_fail()
+    fn stored_payment_by_name_to_stored_versioned_contract_to_stored_versioned_session_should_fail()
     {
-        for len in DEPTHS {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -3898,47 +3415,22 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
     fn stored_session_by_hash_to_stored_versioned_contract_to_stored_session_should_fail() {
-        for len in DEPTHS {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
@@ -3947,127 +3439,61 @@ mod payment {
             let mut subcalls =
                 vec![
                     super::stored_versioned_contract(current_contract_package_hash.into());
-                    len.saturating_sub(1)
+                    call_depth.saturating_sub(1)
                 ];
-            if *len > 0 {
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_hash(
-                        current_contract_hash.into(),
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_contract_hash(
+                &mut builder,
+                *call_depth,
+                subcalls,
+                current_contract_hash,
+            )
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_name_to_stored_contract_to_stored_versioned_session_should_fail() {
-        for len in DEPTHS {
+    fn stored_payment_by_name_to_stored_contract_to_stored_versioned_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_package_hash = default_account.get_hash(CONTRACT_PACKAGE_NAME);
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_versioned_session(
                     current_contract_package_hash.into(),
                 ))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
         }
     }
 
     #[ignore]
     #[test]
-    fn stored_session_by_name_to_stored_contract_to_stored_session_should_fail() {
-        for len in DEPTHS {
+    fn stored_payment_by_name_to_stored_contract_to_stored_session_should_fail() {
+        for call_depth in DEPTHS {
             let mut builder = super::setup();
             let default_account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
             let current_contract_hash = default_account.get_hash(CONTRACT_NAME);
 
-            let mut subcalls =
-                vec![super::stored_contract(current_contract_hash.into()); len.saturating_sub(1)];
-            if *len > 0 {
+            let mut subcalls = vec![
+                super::stored_contract(current_contract_hash.into());
+                call_depth.saturating_sub(1)
+            ];
+            if *call_depth > 0 {
                 subcalls.push(super::stored_session(current_contract_hash.into()))
             }
 
-            let execute_request = {
-                let mut rng = rand::thread_rng();
-                let deploy_hash = rng.gen();
-                let sender = *DEFAULT_ACCOUNT_ADDR;
-                let args = runtime_args! {
-                    ARG_CALLS => subcalls.clone(),
-                    ARG_CURRENT_DEPTH => 0u8,
-                    mint::ARG_AMOUNT => approved_amount(*len),
-                };
-                let deploy = DeployItemBuilder::new()
-                    .with_address(sender)
-                    .with_stored_payment_named_key(
-                        CONTRACT_NAME,
-                        CONTRACT_FORWARDER_ENTRYPOINT_SESSION,
-                        args,
-                    )
-                    .with_session_bytes(wasm_utils::do_nothing_bytes(), RuntimeArgs::default())
-                    .with_authorization_keys(&[sender])
-                    .with_deploy_hash(deploy_hash)
-                    .build();
-                ExecuteRequestBuilder::new().push_deploy(deploy).build()
-            };
-
-            builder.exec(execute_request).commit();
-
-            super::assert_invalid_context(&mut builder, *len);
+            execute_stored_payment_by_contract_name(&mut builder, *call_depth, subcalls)
         }
     }
 }

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -21,10 +21,10 @@ use super::{
     ARG_AMOUNT, ARG_AVAILABLE_AMOUNT, ARG_DISTRIBUTIONS_PER_INTERVAL, ARG_ID, ARG_TARGET,
     ARG_TIME_INTERVAL, AUTHORIZED_ACCOUNT_NAMED_KEY, AVAILABLE_AMOUNT_NAMED_KEY,
     DISTRIBUTIONS_PER_INTERVAL_NAMED_KEY, ENTRY_POINT_FAUCET, ENTRY_POINT_SET_VARIABLES,
-    FAUCET_CALL_DEFAULT_PAYMENT, FAUCET_CONTRACT_NAMED_KEY, FAUCET_FUND_AMOUNT, FAUCET_ID,
-    FAUCET_INSTALLER_SESSION, FAUCET_PURSE_NAMED_KEY, FAUCET_TIME_INTERVAL, INSTALLER_ACCOUNT,
-    INSTALLER_FUND_AMOUNT, INSTALLER_NAMED_KEY, LAST_DISTRIBUTION_TIME_NAMED_KEY,
-    REMAINING_REQUESTS_NAMED_KEY, TIME_INTERVAL_NAMED_KEY, TWO_HOURS_AS_MILLIS,
+    FAUCET_CONTRACT_NAMED_KEY, FAUCET_FUND_AMOUNT, FAUCET_ID, FAUCET_INSTALLER_SESSION,
+    FAUCET_PURSE_NAMED_KEY, FAUCET_TIME_INTERVAL, INSTALLER_ACCOUNT, INSTALLER_FUND_AMOUNT,
+    INSTALLER_NAMED_KEY, LAST_DISTRIBUTION_TIME_NAMED_KEY, REMAINING_REQUESTS_NAMED_KEY,
+    TIME_INTERVAL_NAMED_KEY, TWO_HOURS_AS_MILLIS,
 };
 
 /// User error variant defined in the faucet contract.
@@ -303,7 +303,7 @@ fn should_fund_existing_account() {
         .expect_success()
         .commit();
 
-    let user_account_initial_balance = U512::from(5_000_000_000u64);
+    let user_account_initial_balance = U512::from(15_000_000_000u64);
 
     let fund_user_request = FundAccountRequestBuilder::new()
         .with_target_account(user_account)
@@ -332,6 +332,7 @@ fn should_fund_existing_account() {
             helper
                 .new_faucet_fund_request_builder()
                 .with_user_account(user_account)
+                .with_payment_amount(user_account_initial_balance)
                 .build(),
         )
         .expect_success()
@@ -346,7 +347,7 @@ fn should_fund_existing_account() {
 
     assert_eq!(
         user_purse_balance_after,
-        user_purse_balance_before + one_distribution - FAUCET_CALL_DEFAULT_PAYMENT
+        user_purse_balance_before + one_distribution - user_account_initial_balance
     );
 }
 
@@ -408,6 +409,7 @@ fn should_not_fund_once_exhausted() {
     let user_fund_amount = U512::from(3_000_000_000u64);
     let num_funds = 4;
 
+    let payment_amount = 10_000_000_000u64;
     let faucet_call_by_installer = helper
         .new_faucet_fund_request_builder()
         .with_installer_account(helper.installer_account())
@@ -420,33 +422,44 @@ fn should_not_fund_once_exhausted() {
         .expect_success()
         .commit();
 
+    let user_main_purse_balance_before =
+        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
+
     for i in 0..num_funds {
         let faucet_call_by_user = helper
             .new_faucet_fund_request_builder()
             .with_user_account(user_account)
             .with_arg_fund_amount(user_fund_amount)
             .with_block_time(1000 + i as u64)
+            .with_payment_amount(U512::from(payment_amount))
             .build();
 
         builder.exec(faucet_call_by_user).expect_success().commit();
     }
 
+    let user_main_purse_balance_after =
+        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
+
     let remaining_requests = get_remaining_requests(&builder, faucet_contract_hash);
     assert_eq!(remaining_requests, U512::zero());
 
-    let one_distribution = half_of_faucet_fund_amount / assigned_distributions_per_interval;
-    let user_main_purse_balance_after =
-        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
+    let one_distribution =
+        half_of_faucet_fund_amount / U512::from(assigned_distributions_per_interval);
+
     assert_eq!(
-        user_main_purse_balance_after,
-        one_distribution * num_funds,
-        "users main purse balance must match expected amount after user faucet calls"
+        user_main_purse_balance_after - user_main_purse_balance_before,
+        one_distribution * num_funds - (payment_amount * num_funds),
+        "users main purse balance must match expected amount after user faucet calls ({} != {}*{} [{}])", user_main_purse_balance_after, one_distribution, num_funds, one_distribution * num_funds,
     );
+
+    let user_main_purse_balance_before =
+        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
 
     let faucet_call_by_user = helper
         .new_faucet_fund_request_builder()
         .with_user_account(user_account)
         .with_arg_fund_amount(user_fund_amount)
+        .with_payment_amount(U512::from(payment_amount))
         .with_block_time(1010)
         .build();
 
@@ -455,9 +468,9 @@ fn should_not_fund_once_exhausted() {
     let user_main_purse_balance_after =
         builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
     assert_eq!(
-        user_main_purse_balance_after,
-        one_distribution * num_funds - user_fund_amount,
-        "users main purse balance must match expected amount after all user faucet calls"
+        user_main_purse_balance_before - user_main_purse_balance_after,
+        U512::from(payment_amount),
+        "no funds are distributed after faucet"
     );
 
     // faucet may resume distributions once block time is > last_distribution_time + time_interval.
@@ -468,14 +481,22 @@ fn should_not_fund_once_exhausted() {
     );
     assert_eq!(last_distribution_time, 0);
 
+    let user_main_purse_balance_before =
+        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
+
     let faucet_call_by_user = helper
         .new_faucet_fund_request_builder()
         .with_user_account(user_account)
         .with_arg_fund_amount(user_fund_amount)
         .with_block_time(11_011u64)
+        .with_payment_amount(U512::from(payment_amount))
         .build();
 
     builder.exec(faucet_call_by_user).expect_success().commit();
+
+    let user_main_purse_balance_after =
+        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
+
     let last_distribution_time = query_stored_value::<u64>(
         &mut builder,
         faucet_contract_hash.into(),
@@ -495,12 +516,11 @@ fn should_not_fund_once_exhausted() {
         U512::from(assigned_distributions_per_interval - 1)
     );
 
-    let user_main_purse_balance_after =
-        builder.get_purse_balance(builder.get_expected_account(user_account).main_purse());
-
     assert_eq!(
-        user_main_purse_balance_after,
-        one_distribution * (num_funds + 1) - user_fund_amount * 2
+        user_main_purse_balance_after - user_main_purse_balance_before + payment_amount,
+        // one_distribution * (num_funds + 1), // - user_fund_amount * 2
+        // user_fund_amount,
+        one_distribution,
     );
 }
 
@@ -751,7 +771,7 @@ fn should_allow_funding_by_an_authorized_account() {
         Some(authorized_account_public_key.clone())
     );
 
-    let authorized_account_fund_amount = U512::from(3_000_000_000u64);
+    let authorized_account_fund_amount = U512::from(10_000_000_000u64);
     let faucet_fund_authorized_account_by_installer_request = helper
         .new_faucet_fund_request_builder()
         .with_arg_fund_amount(authorized_account_fund_amount)
@@ -763,12 +783,13 @@ fn should_allow_funding_by_an_authorized_account() {
         .expect_success()
         .commit();
 
-    let user_fund_amount = U512::from(3_000_000_000u64);
+    let user_fund_amount = U512::from(10_000_000_000u64);
     let faucet_fund_user_by_authorized_account_request = helper
         .new_faucet_fund_request_builder()
         .with_authorized_account(authorized_account)
         .with_arg_fund_amount(user_fund_amount)
         .with_arg_target(user_account)
+        .with_payment_amount(user_fund_amount)
         .build();
 
     builder
@@ -784,6 +805,7 @@ fn should_allow_funding_by_an_authorized_account() {
     let faucet_fund_by_user_request = helper
         .new_faucet_fund_request_builder()
         .with_user_account(user_account)
+        .with_payment_amount(user_fund_amount)
         .build();
 
     builder
@@ -800,12 +822,17 @@ fn should_allow_funding_by_an_authorized_account() {
         .expect("an exec result must exist")
         .clone();
 
-    assert!(matches!(
-        exec_result.as_error().unwrap(),
-        engine_state::Error::Exec(execution::Error::Revert(ApiError::User(
-            FAUCET_CALL_BY_USER_WITH_AUTHORIZED_ACCOUNT_SET
-        )))
-    ));
+    let error = exec_result.as_error().unwrap();
+    assert!(
+        matches!(
+            error,
+            engine_state::Error::Exec(execution::Error::Revert(ApiError::User(
+                FAUCET_CALL_BY_USER_WITH_AUTHORIZED_ACCOUNT_SET
+            )))
+        ),
+        "{:?}",
+        error,
+    );
 }
 
 #[ignore]
@@ -814,10 +841,10 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 70_284_257_610;
-    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 47_354_470;
-    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_584_397_250;
-    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_531_252_060;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 77_820_432_810;
+    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 1_651_748_470;
+    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 4129508320;
+    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 5100480260;
 
     let installer_account = AccountHash::new([1u8; 32]);
     let user_account = AccountHash::new([2u8; 32]);
@@ -892,7 +919,7 @@ fn faucet_costs() {
         EXPECTED_FAUCET_SET_VARIABLES_COST
     );
 
-    let user_fund_amount = U512::from(3_000_000_000u64);
+    let user_fund_amount = U512::from(10_000_000_000u64);
     let faucet_call_by_installer = {
         let deploy_item = DeployItemBuilder::new()
             .with_address(installer_account)
@@ -902,7 +929,7 @@ fn faucet_costs() {
                 ENTRY_POINT_FAUCET,
                 runtime_args! {ARG_TARGET => user_account, ARG_AMOUNT => user_fund_amount, ARG_ID => <Option<u64>>::None},
             )
-            .with_empty_payment_bytes(runtime_args! {ARG_AMOUNT => user_fund_amount})
+            .with_empty_payment_bytes(runtime_args! {ARG_AMOUNT => *DEFAULT_PAYMENT})
             .with_deploy_hash([4; 32])
             .build();
 

--- a/execution_engine_testing/tests/src/test/explorer/faucet_test_helpers.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet_test_helpers.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_PAYMENT,
 };
 use casper_execution_engine::core::engine_state::ExecuteRequest;
 use casper_types::{
@@ -12,9 +13,9 @@ use casper_types::{
 use super::{
     ARG_AMOUNT, ARG_AVAILABLE_AMOUNT, ARG_DISTRIBUTIONS_PER_INTERVAL, ARG_ID, ARG_TARGET,
     ARG_TIME_INTERVAL, AVAILABLE_AMOUNT_NAMED_KEY, ENTRY_POINT_AUTHORIZE_TO, ENTRY_POINT_FAUCET,
-    ENTRY_POINT_SET_VARIABLES, FAUCET_CALL_DEFAULT_PAYMENT, FAUCET_CONTRACT_NAMED_KEY,
-    FAUCET_FUND_AMOUNT, FAUCET_ID, FAUCET_INSTALLER_SESSION, FAUCET_PURSE_NAMED_KEY,
-    INSTALLER_ACCOUNT, INSTALLER_FUND_AMOUNT, REMAINING_REQUESTS_NAMED_KEY,
+    ENTRY_POINT_SET_VARIABLES, FAUCET_CONTRACT_NAMED_KEY, FAUCET_FUND_AMOUNT, FAUCET_ID,
+    FAUCET_INSTALLER_SESSION, FAUCET_PURSE_NAMED_KEY, INSTALLER_ACCOUNT, INSTALLER_FUND_AMOUNT,
+    REMAINING_REQUESTS_NAMED_KEY,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -307,6 +308,11 @@ impl FaucetFundRequestBuilder {
         self
     }
 
+    pub fn with_payment_amount(mut self, payment_amount: U512) -> Self {
+        self.payment_amount = payment_amount;
+        self
+    }
+
     pub fn build(self) -> ExecuteRequest {
         let mut rng = rand::thread_rng();
 
@@ -346,7 +352,7 @@ impl Default for FaucetFundRequestBuilder {
     fn default() -> Self {
         Self {
             arg_fund_amount: None,
-            payment_amount: U512::from(FAUCET_CALL_DEFAULT_PAYMENT),
+            payment_amount: *DEFAULT_PAYMENT,
             faucet_contract_hash: None,
             caller_account: FaucetCallerAccount::Installer(INSTALLER_ACCOUNT),
             arg_target: None,

--- a/execution_engine_testing/tests/src/test/explorer/mod.rs
+++ b/execution_engine_testing/tests/src/test/explorer/mod.rs
@@ -12,7 +12,6 @@ pub const FAUCET_ID: u64 = 1337;
 pub const INSTALLER_ACCOUNT: AccountHash = AccountHash::new([1u8; 32]);
 pub const FAUCET_FUND_AMOUNT: u64 = 500_000u64;
 pub const FAUCET_TIME_INTERVAL: u64 = 10_000;
-pub const FAUCET_CALL_DEFAULT_PAYMENT: u64 = 3_000_000_000;
 
 // contract args and entry points.
 pub const ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
+++ b/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
@@ -22,7 +22,7 @@ const CONTRACT_TRANSFER_TO_ACCOUNT_U512: &str = "transfer_to_account_u512.wasm";
 // This value is not systemic, as code is added the size of WASM will increase,
 // you can change this value to reflect the increase in WASM size.
 const HOST_FUNCTION_METRICS_STANDARD_SIZE: usize = 97_569;
-const HOST_FUNCTION_METRICS_STANDARD_GAS_COST: u64 = 150_973_798_070;
+const HOST_FUNCTION_METRICS_STANDARD_GAS_COST: u64 = 568_850_860_190;
 
 /// Acceptable size regression/improvement in percentage.
 const SIZE_MARGIN: usize = 5;

--- a/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
+++ b/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
@@ -1,12 +1,10 @@
 //! Tests whether transforms produced by contracts appear ordered in the transform journal.
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    PRODUCTION_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::shared::transform::Transform;
-use casper_types::{
-    runtime_args, system::standard_payment, ContractHash, Key, RuntimeArgs, URef, U512,
-};
+use casper_types::{runtime_args, system::standard_payment, ContractHash, Key, RuntimeArgs, URef};
 use core::convert::TryInto;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -30,7 +28,7 @@ fn contract_transforms_should_be_ordered_in_the_journal() {
                 DeployItemBuilder::new()
                     .with_address(*DEFAULT_ACCOUNT_ADDR)
                     .with_empty_payment_bytes(runtime_args! {
-                        standard_payment::ARG_AMOUNT => U512::from(30_000_000_000_u64)
+                        standard_payment::ARG_AMOUNT => *DEFAULT_PAYMENT,
                     })
                     .with_session_code("ordered-transforms.wasm", runtime_args! { "n" => N_UREFS })
                     .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
@@ -73,7 +71,7 @@ fn contract_transforms_should_be_ordered_in_the_journal() {
                 DeployItemBuilder::new()
                     .with_address(*DEFAULT_ACCOUNT_ADDR)
                     .with_empty_payment_bytes(runtime_args! {
-                        standard_payment::ARG_AMOUNT => U512::from(10_000_000_000_u64),
+                        standard_payment::ARG_AMOUNT => *DEFAULT_PAYMENT,
                     })
                     .with_stored_session_hash(
                         contract_hash,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -129,7 +129,7 @@ local = 390
 # Global operations multiplier.
 global = 390
 # Control flow operations multiplier.
-control_flow = 440
+control_flow = 440000
 # Integer operations multiplier.
 integer_comparison = 250
 # Conversion operations multiplier.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -132,7 +132,7 @@ local = 390
 # Global operations multiplier.
 global = 390
 # Control flow operations multiplier.
-control_flow = 440
+control_flow = 440000
 # Integer operations multiplier.
 integer_comparison = 250
 # Conversion operations multiplier.

--- a/smart_contracts/contract_as/README.md
+++ b/smart_contracts/contract_as/README.md
@@ -32,7 +32,7 @@ for the name of the wasm file.
   "name": "your-contract-name",
   ...
   "scripts": {
-    "asbuild:optimized": "asc assembly/index.ts -o dist/your-contract-name.wasm --validate --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc assembly/index.ts -b dist/your-contract-name.wasm --validate --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized",
     ...
   },

--- a/smart_contracts/contract_as/assembly/bignum.ts
+++ b/smart_contracts/contract_as/assembly/bignum.ts
@@ -109,12 +109,12 @@ export class U512 {
         }
 
         // Decodes hex string into an array of bytes
-        let bytes = new Uint8Array(this.width);
+        let bytes = new StaticArray<u8>(this.width);
 
         // Convert ascii codes into values
         let i = 0;
         while (digits > 0 && i < bytes.length) {
-            bytes[i] = HEX_DIGITS[value.charCodeAt(--digits)];
+            bytes[i] = <u8>HEX_DIGITS[value.charCodeAt(--digits)];
 
             if (digits > 0) {
                 bytes[i] |= <u8>HEX_DIGITS[value.charCodeAt(--digits)] << 4;
@@ -494,9 +494,10 @@ export class U512 {
      * Sets the value of this U512 to the value represented by `bytes` when treated as a
      * little-endian representation of a number.
      */
-    setBytesLE(bytes: Uint8Array): void {
+    setBytesLE(bytes: StaticArray<u8>): void {
+        let ptr = changetype<usize>(bytes);
         for (let i = 0; i < this.pn.length; i++) {
-            let num = load<u32>(bytes.dataStart + (i * 4));
+            let num = load<u32>(ptr + (i * 4));
             this.pn[i] = num;
         }
     }
@@ -548,7 +549,7 @@ export class U512 {
      * @returns A [[Result]] that contains the deserialized U512 if the deserialization was
      *    successful, or an error otherwise.
      */
-    static fromBytes(bytes: Uint8Array): Result<U512> {
+    static fromBytes(bytes: StaticArray<u8>): Result<U512> {
         if (bytes.length < 1) {
             return new Result<U512>(null, Error.EarlyEndOfStream, 0);
         }
@@ -562,7 +563,7 @@ export class U512 {
         let res = new U512();
 
         // Creates a buffer so individual bytes can be placed there
-        let buffer = new Uint8Array(res.width);
+        let buffer = new StaticArray<u8>(res.width);
         for (let i = 0; i < lengthPrefix; i++) {
             buffer[i] = bytes[i + 1];
         }

--- a/smart_contracts/contract_as/assembly/option.ts
+++ b/smart_contracts/contract_as/assembly/option.ts
@@ -7,13 +7,13 @@ const OPTION_TAG_SOME: u8 = 1;
  * no value at all. Similar to Rust's `Option` or Haskell's `Maybe`.
  */
 export class Option{
-    private bytes: Uint8Array | null;
+    private bytes: Array<u8>  | null;
 
 	/**
 	 * Constructs a new option containing the value of `bytes`. `bytes` can be `null`, which
 	 * indicates no value.
 	 */
-    constructor(bytes: Uint8Array | null) {
+    constructor(bytes: Array<u8>  | null) {
         this.bytes = bytes;
     }
 
@@ -40,9 +40,9 @@ export class Option{
 	 *
 	 * @returns The inner value, or `null` if there was none.
 	 */
-    unwrap(): Uint8Array{
+    unwrap(): Array<u8> {
         assert(this.isSome());
-        return <Uint8Array>this.bytes;
+        return <Array<u8>>this.bytes;
     }
 
 	/**
@@ -54,7 +54,7 @@ export class Option{
             result[0] = OPTION_TAG_NONE;
             return result;
         }
-        const bytes = <Uint8Array>this.bytes;
+        const bytes = <Array<u8>>this.bytes;
 
         let result = new Array<u8>(bytes.length + 1);
         result[0] = OPTION_TAG_SOME;
@@ -68,11 +68,11 @@ export class Option{
 	/**
 	 * Deserializes an array of bytes into an `Option`.
 	 */
-    static fromBytes(bytes: Uint8Array): Option{
+    static fromBytes(bytes: StaticArray<u8>): Option{
         // check SOME / NONE flag at head
         // TODO: what if length is exactly 1?
         if (bytes.length >= 1 && bytes[0] == 1)
-            return new Option(bytes.subarray(1));
+            return new Option(bytes.slice(1));
 
         return new Option(null);
     }

--- a/smart_contracts/contract_as/assembly/public_key.ts
+++ b/smart_contracts/contract_as/assembly/public_key.ts
@@ -13,17 +13,17 @@ export enum PublicKeyVariant {
 }
 
 export class PublicKey {
-    constructor(private variant: PublicKeyVariant, private bytes: Uint8Array) {
+    constructor(private variant: PublicKeyVariant, private bytes: Array<u8> ) {
     }
 
-    getRawBytes(): Uint8Array{
+    getRawBytes(): Array<u8> {
         return this.bytes;
     }
 
     getAlgorithmName(): string {
         const ED25519_LOWERCASE: string = "ed25519";
         const SECP256K1_LOWERCASE: string = "secp256k1";
-        
+
         switch (this.variant) {
             case PublicKeyVariant.Ed25519:
                 return ED25519_LOWERCASE;
@@ -36,11 +36,11 @@ export class PublicKey {
 
     toBytes(): Array<u8> {
         let variantBytes: Array<u8> = [<u8>this.variant];
-        return variantBytes.concat(typedToArray(this.bytes));
+        return variantBytes.concat(this.bytes);
     }
-    
+
     /** Deserializes a `PublicKey` from an array of bytes. */
-    static fromBytes(bytes: Uint8Array): Result<PublicKey> {
+    static fromBytes(bytes: StaticArray<u8>): Result<PublicKey> {
         if (bytes.length < 1) {
             return new Result<PublicKey>(null, BytesreprError.EarlyEndOfStream, 0);
         }
@@ -59,7 +59,7 @@ export class PublicKey {
             default:
                 return new Result<PublicKey>(null, BytesreprError.FormattingError, 0);
         }
-        let publicKeyBytes = bytes.subarray(currentPos, currentPos + expectedPublicKeySize);
+        let publicKeyBytes = bytes.slice(currentPos, currentPos + expectedPublicKeySize);
         currentPos += expectedPublicKeySize;
 
         let publicKey = new PublicKey(variant, publicKeyBytes);

--- a/smart_contracts/contract_as/assembly/runtime.ts
+++ b/smart_contracts/contract_as/assembly/runtime.ts
@@ -1,5 +1,6 @@
 import * as externals from "./externals";
-import {Error} from "./error";
+import { Error } from "./error";
+import { typedToArray } from "./utils";
 
 const BLAKE2B_DIGEST_LENGTH: i32 = 32;
 const RANDOM_BYTES_COUNT: usize = 32;
@@ -8,11 +9,11 @@ const RANDOM_BYTES_COUNT: usize = 32;
  * Performs a blake2b hash using a host function.
  * @param data Input bytes
  */
-export function blake2b(data: Array<u8>): Uint8Array {
-    let hashBytes = new Uint8Array(BLAKE2B_DIGEST_LENGTH);
+export function blake2b(data: Array<u8>): Array<u8> {
+    let hashBytes = new Array<u8>(BLAKE2B_DIGEST_LENGTH);
     const ret = externals.casper_blake2b(data.dataStart, data.length, hashBytes.dataStart, hashBytes.length);
     let error = Error.fromResult(ret);
-    if(error != null){
+    if (error != null) {
         error.revert();
     }
     return hashBytes;

--- a/smart_contracts/contract_as/assembly/utils.ts
+++ b/smart_contracts/contract_as/assembly/utils.ts
@@ -2,9 +2,8 @@
  * Encodes an UTF8 string into bytes.
  * @param str Input string.
  */
-export function encodeUTF8(str: String): Uint8Array {
-  let utf8Bytes = String.UTF8.encode(str);
-  return Uint8Array.wrap(utf8Bytes);
+export function encodeUTF8(str: String): ArrayBuffer {
+  return String.UTF8.encode(str);
 }
 
 /** Converts typed array to array */
@@ -38,7 +37,7 @@ export function checkItemsEqual<T>(a: Array<T>, b: Array<T>): bool {
 }
 
 /** Checks if two ordered arrays are equal */
-export function checkArraysEqual<T>(a: Array<T>, b: Array<T>, len: i32 = 0): bool {
+export function checkArraysEqual<T, U extends ArrayLike<T> = Array<T>>(a: U, b: U, len: i32 = 0): bool {
   if (!len) {
     len = a.length;
     if (len != b.length) return false;

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "npm run asbuild:test && npx ava -v --serial",
     "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --sourceMap  --debug --use abort=",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --sourceMap  --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --sourceMap  --disable bulk-memory --optimize  --optimizeLevel 3 --converge  --noAssert  --use abort=",
     "asbuild:test:bytesrepr": "asc tests/assembly/bytesrepr.spec.as.ts -b build/bytesrepr.spec.as.wasm -t build/bytesrepr.spec.as.wat --sourceMap  --optimize",
     "asbuild:test:bignum": "asc tests/assembly/bignum.spec.as.ts -b build/bignum.spec.as.wasm -t build/bignum.spec.as.wat --sourceMap  --optimize",
     "asbuild:test:utils": "asc tests/assembly/utils.spec.as.ts -b build/utils.spec.as.wasm -t build/utils.spec.as.wat --sourceMap  --optimize",

--- a/smart_contracts/contract_as/tests/assembly/bignum.spec.as.ts
+++ b/smart_contracts/contract_as/tests/assembly/bignum.spec.as.ts
@@ -199,46 +199,46 @@ export function testDivision(): bool {
 
 export function testSerializeU512Zero(): bool {
     let truth = hex2bin("00");
-    let result = U512.fromBytes(truth);
+    let result = U512.fromBytes(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     let zero = result.value;
     assert(zero.isZero());
     const bytes = zero.toBytes();
-    return checkArraysEqual(bytes, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(bytes, truth);
 };
 
 export function testSerializeU512_3BytesWide(): bool {
     let truth = hex2bin("03807801");
-    let result = U512.fromBytes(truth);
+    let result = U512.fromBytes(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     let num = result.value;
     assert(num.toString() == "17880"); // dec: 96384
     const bytes = num.toBytes();
-    return checkArraysEqual(bytes, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(bytes, truth);
 };
 
 export function testSerializeU512_2BytesWide(): bool {
     let truth = hex2bin("020004");
-    let result = U512.fromBytes(truth);
+    let result = U512.fromBytes(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     let num = result.value;
     assert(num.toString() == "400"); // dec: 1024
     const bytes = num.toBytes();
-    return checkArraysEqual(bytes, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(bytes, truth);
 };
 
 export function testSerializeU512_1BytesWide(): bool {
     let truth = hex2bin("0101");
-    let result = U512.fromBytes(truth);
+    let result = U512.fromBytes(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     let num = result.value;
     assert(num.toString() == "1");
     const bytes = num.toBytes();
-    return checkArraysEqual(bytes, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(bytes, truth);
 };
 
 export function testSerialize100mTimes10(): bool {
@@ -251,9 +251,9 @@ export function testSerialize100mTimes10(): bool {
 
     let bytes = valU512.toBytes();
     assert(bytes !== null)
-    assert(checkArraysEqual(bytes, typedToArray(truth)));
+    assert(checkArraysEqual<u8, Array<u8>>(bytes, truth));
 
-    let roundTrip = U512.fromBytes(arrayToTyped(bytes));
+    let roundTrip = U512.fromBytes(StaticArray.fromArray(bytes));
     assert(roundTrip.error == Error.Ok);
     assert(roundTrip.value.toString() == hex);
 
@@ -267,13 +267,13 @@ export function testDeserLargeRandomU512(): bool {
     // bytesrepr
     let truth = hex2bin("40752c392d2ecd6123de0f1d3d4cdb7992aa85e049a94795975e81e20b78731cde6d4aa13da210479acce5f24a296ae787bada0aba1889c8fe2f2fb030d62feed2");
 
-    let deser = U512.fromBytes(truth);
+    let deser = U512.fromBytes(StaticArray.fromArray(truth));
     assert(deser.error == Error.Ok);
     assert(deser !== null);
     assert(deser.value.toString() == hex);
 
     let ser = deser.value.toBytes();
-    assert(checkArraysEqual(ser, typedToArray(truth)));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
 
     return true;
 }

--- a/smart_contracts/contract_as/tests/assembly/bytesrepr.spec.as.ts
+++ b/smart_contracts/contract_as/tests/assembly/bytesrepr.spec.as.ts
@@ -14,8 +14,8 @@ import { Key, KeyVariant, AccountHash } from "../../assembly/key";
 import { URef, AccessRights } from "../../assembly/uref";
 import { Option } from "../../assembly/option";
 import { hex2bin } from "../utils/helpers";
-import { checkArraysEqual, checkTypedArrayEqual, checkItemsEqual } from "../../assembly/utils";
-import { typedToArray, arrayToTyped } from "../../assembly/utils";
+import { checkArraysEqual, checkItemsEqual } from "../../assembly/utils";
+import { typedToArray, }from "../../assembly/utils";
 import { Pair } from "../../assembly/pair";
 import { EntryPointAccess, PublicAccess, GroupAccess, EntryPoint, EntryPoints, EntryPointType } from "../../assembly";
 
@@ -24,7 +24,7 @@ import { EntryPointAccess, PublicAccess, GroupAccess, EntryPoint, EntryPoints, E
 
 export function testDeserializeInvalidU8(): bool {
     const bytes: u8[] = [];
-    let deser = fromBytesU8(arrayToTyped(bytes));
+    let deser = fromBytesU8(StaticArray.fromArray(bytes));
     assert(deser.error == Error.EarlyEndOfStream);
     assert(deser.position == 0);
     return !deser.hasValue();
@@ -33,8 +33,8 @@ export function testDeserializeInvalidU8(): bool {
 export function testDeSerU8(): bool {
     const truth: u8[] = [222];
     let ser = toBytesU8(222);
-    assert(checkArraysEqual(ser, truth));
-    let deser = fromBytesU8(arrayToTyped(ser));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
+    let deser = fromBytesU8(StaticArray.fromArray(ser));
     assert(deser.error == Error.Ok);
     return deser.value == 222;
 }
@@ -44,8 +44,8 @@ export function xtestDeSerU8_Zero(): bool {
     // NOTE: Currently probably unable to check if `foo(): U8 | null` result is null
     const truth: u8[] = [0];
     let ser = toBytesU8(0);
-    assert(checkArraysEqual(ser, truth));
-    let deser = fromBytesU8(arrayToTyped(ser));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
+    let deser = fromBytesU8(StaticArray.fromArray(ser));
     assert(deser.error == Error.Ok);
     return deser.value == 0;
 }
@@ -53,8 +53,8 @@ export function xtestDeSerU8_Zero(): bool {
 export function testDeSerU32(): bool {
     const truth: u8[] = [239, 190, 173, 222];
     let ser = toBytesU32(3735928559);
-    assert(checkArraysEqual(ser, truth));
-    let deser = fromBytesU32(arrayToTyped(ser));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
+    let deser = fromBytesU32(StaticArray.fromArray(ser));
     assert(deser.error == Error.Ok);
     assert(deser.position == 4);
     return deser.value == 0xdeadbeef;
@@ -63,8 +63,8 @@ export function testDeSerU32(): bool {
 export function testDeSerZeroU32(): bool {
     const truth: u8[] = [0, 0, 0, 0];
     let ser = toBytesU32(0);
-    assert(checkArraysEqual(ser, truth));
-    let deser = fromBytesU32(arrayToTyped(ser));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
+    let deser = fromBytesU32(StaticArray.fromArray(ser));
     assert(deser.error == Error.Ok);
     assert(deser.hasValue());
     return deser.value == 0;
@@ -72,7 +72,7 @@ export function testDeSerZeroU32(): bool {
 
 export function testDeserializeU64_1024(): bool {
     const truth = hex2bin("0004000000000000");
-    var deser = fromBytesU64(truth);
+    var deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.error == Error.Ok);
     assert(deser.position == 8);
     return deser.value == <u64>1024;
@@ -80,7 +80,7 @@ export function testDeserializeU64_1024(): bool {
 
 export function testDeserializeU64_zero(): bool {
     const truth = hex2bin("0000000000000000");
-    var deser = fromBytesU64(truth);
+    var deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.error == Error.Ok);
     assert(deser.position == 8);
     assert(deser.hasValue());
@@ -89,7 +89,7 @@ export function testDeserializeU64_zero(): bool {
 
 export function testDeserializeU64_u32max(): bool {
     const truth = hex2bin("ffffffff00000000");
-    const deser = fromBytesU64(truth);
+    const deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.error == Error.Ok);
     assert(deser.position == 8);
     return deser.value == 0xffffffff;
@@ -97,7 +97,7 @@ export function testDeserializeU64_u32max(): bool {
 
 export function testDeserializeU64_u32max_plus1(): bool {
     const truth = hex2bin("0000000001000000");
-    const deser = fromBytesU64(truth);
+    const deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.hasValue());
     assert(deser.error == Error.Ok);
     assert(deser.position == 8);
@@ -106,7 +106,7 @@ export function testDeserializeU64_u32max_plus1(): bool {
 
 export function testDeserializeU64_EOF(): bool {
     const truth = hex2bin("0000");
-    const deser = fromBytesU64(truth);
+    const deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.error == Error.EarlyEndOfStream);
     assert(deser.position == 0);
     return !deser.hasValue();
@@ -114,7 +114,7 @@ export function testDeserializeU64_EOF(): bool {
 
 export function testDeserializeU64_u64max(): bool {
     const truth = hex2bin("feffffffffffffff");
-    const deser = fromBytesU64(truth);
+    const deser = fromBytesU64(StaticArray.fromArray(truth));
     assert(deser.error == Error.Ok);
     assert(deser.position == 8);
     return deser.value == <u64>18446744073709551614;
@@ -122,41 +122,41 @@ export function testDeserializeU64_u64max(): bool {
 
 export function testDeSerListOfStrings(): bool {
     const truth = hex2bin("03000000030000006162630a0000003132333435363738393006000000717765727479");
-    const result = fromBytesStringList(truth);
+    const result = fromBytesStringList(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     const strList = result.value;
     assert(result.position == truth.length);
 
-    assert(checkArraysEqual(strList, <String[]>[
+    assert(checkArraysEqual<String, Array<String>>(strList, <String[]>[
         "abc",
         "1234567890",
         "qwerty",
     ]));
 
     let lhs = toBytesStringList(strList);
-    let rhs = typedToArray(truth);
-    return checkArraysEqual(lhs, rhs);
+    let rhs = truth;
+    return checkArraysEqual<u8, Array<u8>>(lhs, rhs);
 };
 
 export function testDeSerEmptyListOfStrings(): bool {
     const truth = hex2bin("00000000");
-    const result = fromBytesStringList(truth);
+    const result = fromBytesStringList(StaticArray.fromArray(truth));
     assert(result.error == Error.Ok);
     assert(result.position == 4);
-    return checkArraysEqual(<String[]>result.value, <String[]>[]);
+    return checkArraysEqual<String, Array<String>>(<String[]>result.value, <String[]>[]);
 };
 
 export function testDeSerEmptyMap(): bool {
     const truth = hex2bin("00000000");
     const result = fromBytesMap<String, Key>(
-        truth,
+        StaticArray.fromArray(truth),
         fromBytesString,
         Key.fromBytes);
     assert(result.error == Error.Ok);
     assert(result.hasValue());
     assert(result.position == 4);
-    return checkArraysEqual(result.value, <Array<Pair<String, Key>>>[]);
+    return checkArraysEqual<Pair<String, Key>, Array<Pair<String, Key>>>(result.value, <Array<Pair<String, Key>>>[]);
 };
 
 export function testSerializeMap(): bool {
@@ -171,10 +171,10 @@ export function testSerializeMap(): bool {
     pairs.push(new Pair("Key1", "Value1"));
     pairs.push(new Pair("Key2", "Value2"));
     const serialized = toBytesMap(pairs, toBytesString, toBytesString);
-    assert(checkArraysEqual(serialized, typedToArray(truth)));
+    assert(checkArraysEqual<u8, Array<u8>>(serialized, truth));
 
     const deser = fromBytesMap<String, String>(
-        arrayToTyped(serialized),
+        StaticArray.fromArray(serialized),
         fromBytesString,
         fromBytesString);
 
@@ -204,18 +204,18 @@ export function testToBytesVecT(): bool {
     let serialized = toBytesVecT<CLValue>([
         CLValue.fromString("get_payment_purse"),
     ], serialize);
-    return checkArraysEqual(serialized, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(serialized, truth);
 }
 
 export function testKeyOfURefVariantSerializes(): bool {
     // URef with access rights
     const truth = hex2bin("022a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a07");
     const urefBytes = hex2bin("2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a");
-    let uref = new URef(urefBytes, AccessRights.READ_ADD_WRITE);
-    let urefKey = Key.fromURef(uref);
-    let serialized = urefKey.toBytes();
+    let uref = new URef(StaticArray.fromArray(urefBytes), AccessRights.READ_ADD_WRITE);
+    let key = Key.fromURef(uref);
+    let serialized = key.toBytes();
 
-    return checkArraysEqual(serialized, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(serialized, truth);
 };
 
 export function testDeSerString(): bool {
@@ -223,9 +223,9 @@ export function testDeSerString(): bool {
     const truth = hex2bin("0b00000068656c6c6f5f776f726c64");
 
     const ser = toBytesString("hello_world");
-    assert(checkArraysEqual(ser, typedToArray(truth)));
+    assert(checkArraysEqual<u8, Array<u8>>(ser, truth));
 
-    const deser = fromBytesString(arrayToTyped(ser));
+    const deser = fromBytesString(StaticArray.fromArray(ser));
     assert(deser.error == Error.Ok);
     return deser.value == "hello_world";
 }
@@ -234,14 +234,14 @@ export function testDeSerIncompleteString(): bool {
     // Rust: let bytes = "hello_world".to_bytes().unwrap();
     const truth = hex2bin("0b00000068656c6c6f5f776f726c");
     // last byte removed from the truth to signalize incomplete data
-    const deser = fromBytesString(truth);
+    const deser = fromBytesString(StaticArray.fromArray(truth));
     assert(deser.error == Error.EarlyEndOfStream);
     return !deser.hasValue();
 }
 
 export function testDecodeURefFromBytesWithoutAccessRights(): bool {
     const truth = hex2bin("2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a00");
-    let urefResult = URef.fromBytes(truth);
+    let urefResult = URef.fromBytes(StaticArray.fromArray(truth));
     assert(urefResult.error == Error.Ok);
     assert(urefResult.hasValue());
     let uref = urefResult.value;
@@ -250,19 +250,19 @@ export function testDecodeURefFromBytesWithoutAccessRights(): bool {
     urefBytes.fill(42);
 
 
-    assert(checkArraysEqual(typedToArray(uref.getBytes()), urefBytes));
+    assert(checkArraysEqual<u8, Array<u8>>(uref.getBytes().slice(0), urefBytes));
     assert(uref.getAccessRights() === AccessRights.NONE);
     let serialized = uref.toBytes();
-    return checkArraysEqual(serialized, typedToArray(truth));
+    return checkArraysEqual<u8, Array<u8>>(serialized, truth);
 }
 
 export function testDecodeURefFromBytesWithAccessRights(): bool {
     const truth = hex2bin("2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a07");
-    const urefResult = URef.fromBytes(truth);
+    const urefResult = URef.fromBytes(StaticArray.fromArray(truth));
     assert(urefResult.error == Error.Ok);
     assert(urefResult.position == truth.length);
     const uref = urefResult.value;
-    assert(checkArraysEqual(typedToArray(uref.getBytes()), <u8[]>[
+    assert(checkArraysEqual<u8, Array<u8>>(uref.getBytes().slice(0), <u8[]>[
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
@@ -272,7 +272,7 @@ export function testDecodeURefFromBytesWithAccessRights(): bool {
 }
 
 export function testDecodedOptionalIsNone(): bool {
-    let optionalSome = new Uint8Array(10);
+    let optionalSome = new StaticArray<u8>(10);
     optionalSome[0] = 0;
     let res = Option.fromBytes(optionalSome);
     assert(res.isNone(), "option should be NONE");
@@ -280,17 +280,17 @@ export function testDecodedOptionalIsNone(): bool {
 };
 
 export function testDecodedOptionalIsSome(): bool {
-    let optionalSome = new Uint8Array(10);
+    let optionalSome = new StaticArray<u8>(10);
     for (let i = 0; i < 10; i++) {
-        optionalSome[i] = i + 1;
+        optionalSome[i] = <u8>i + 1;
     }
     let res = Option.fromBytes(optionalSome);
     assert(res !== null);
     let unwrapped = res.unwrap();
     assert(unwrapped !== null, "unwrapped should not be null");
-    let values = <Uint8Array>unwrapped;
+    let values = <Array<u8>>unwrapped;
     let rhs: Array<u8> = [2, 3, 4, 5, 6, 7, 8, 9, 10];
-    return checkArraysEqual(typedToArray(values), rhs);
+    return checkArraysEqual<u8, Array<u8>>(values, rhs);
 };
 
 export function testDeserMapOfNamedKeys(): bool {
@@ -301,7 +301,7 @@ export function testDeserMapOfNamedKeys(): bool {
     let truth = hex2bin(truthBytes + extraBytes);
 
     const mapResult = fromBytesMap<String, Key>(
-        truth,
+        StaticArray.fromArray(truth),
         fromBytesString,
         Key.fromBytes);
     assert(mapResult.error == Error.Ok);
@@ -317,8 +317,8 @@ export function testDeserMapOfNamedKeys(): bool {
     let accountBytes = new Array<u8>(32);
     accountBytes.fill(1);
 
-    assert(checkTypedArrayEqual((<AccountHash>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
-    assert(checkTypedArrayEqual((<AccountHash>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
+    assert(checkArraysEqual<u8, Array<u8>>((<AccountHash>deser[0].second.account).bytes, accountBytes));
+    assert(checkArraysEqual<u8, Array<u8>>((<AccountHash>deser[0].second.account).bytes, accountBytes));
 
     //
 
@@ -330,7 +330,7 @@ export function testDeserMapOfNamedKeys(): bool {
 
     assert(deser[1].second.uref !== null);
     let deser1Uref = <URef>deser[1].second.uref;
-    assert(checkTypedArrayEqual(<Uint8Array>deser1Uref.bytes, arrayToTyped(urefBytes)));
+    assert(checkArraysEqual<u8, Array<u8>>(<Array<u8>>deser1Uref.bytes.slice(0), urefBytes));
     assert(deser1Uref.accessRights == AccessRights.READ_ADD_WRITE);
 
     //
@@ -341,19 +341,19 @@ export function testDeserMapOfNamedKeys(): bool {
     let hashBytes = new Array<u8>(32);
     hashBytes.fill(3);
 
-    assert(checkTypedArrayEqual(<Uint8Array>deser[2].second.hash, arrayToTyped(hashBytes)));
+    assert(checkArraysEqual<u8, Array<u8>>((<StaticArray<u8>>deser[2].second.hash).slice(0), hashBytes));
 
     // Compares to truth
 
     let truthObj = new Array<Pair<String, Key>>();
-    let keyA = Key.fromAccount(new AccountHash(arrayToTyped(accountBytes)));
+    let keyA = Key.fromAccount(new AccountHash(accountBytes));
     truthObj.push(new Pair<String, Key>("A", keyA));
 
-    let urefB = new URef(arrayToTyped(urefBytes), AccessRights.READ_ADD_WRITE);
+    let urefB = new URef(StaticArray.fromArray(urefBytes), AccessRights.READ_ADD_WRITE);
     let keyB = Key.fromURef(urefB);
     truthObj.push(new Pair<String, Key>("BB", keyB));
 
-    let keyC = Key.fromHash(arrayToTyped(hashBytes));
+    let keyC = Key.fromHash(StaticArray.fromArray(hashBytes));
     truthObj.push(new Pair<String, Key>("CCC", keyC));
 
     assert(truthObj.length === deser.length);
@@ -361,7 +361,7 @@ export function testDeserMapOfNamedKeys(): bool {
     assert(truthObj[1] == deser[1]);
     assert(truthObj[2] == deser[2]);
 
-    assert(checkArraysEqual(truthObj, deser));
+    assert(checkArraysEqual<Pair<String, Key>, Array<Pair<String, Key>>>(truthObj, deser));
     assert(checkItemsEqual(truthObj, deser));
 
     return true;
@@ -376,7 +376,7 @@ export function testPublicEntryPointAccess(): bool {
     let publicAccess = new PublicAccess();
     let bytes = useEntryPointAccess(publicAccess);
     assert(bytes.length == 1);
-    assert(checkArraysEqual(typedToArray(publicTruth), bytes));
+    assert(checkArraysEqual<u8, Array<u8>>(publicTruth, bytes));
     return true;
 }
 
@@ -384,7 +384,7 @@ export function testGroupEntryPointAccess(): bool {
     let publicTruth = hex2bin("02030000000700000047726f757020310700000047726f757020320700000047726f75702033");
     let publicAccess = new GroupAccess(["Group 1", "Group 2", "Group 3"]);
     let bytes = useEntryPointAccess(publicAccess);
-    assert(checkArraysEqual(typedToArray(publicTruth), bytes));
+    assert(checkArraysEqual<u8, Array<u8>>(publicTruth, bytes));
     return true;
 }
 
@@ -392,7 +392,7 @@ export function testComplexCLType(): bool {
     let type = CLType.byteArray(32);
     let bytes = type.toBytes();
     let truth = hex2bin("0f20000000");
-    assert(checkArraysEqual(typedToArray(truth), bytes));
+    assert(checkArraysEqual<u8, Array<u8>>(truth, bytes));
 
     return true;
 }
@@ -405,6 +405,6 @@ export function testToBytesEntryPoint(): bool {
     entryPoints.addEntryPoint(entryPoint);
     let bytes = entryPoints.toBytes();
     let truth = hex2bin("010000000800000064656c65676174650800000064656c65676174650100000006000000706172616d3108090101");
-    assert(checkArraysEqual(typedToArray(truth), bytes));
+    assert(checkArraysEqual<u8, Array<u8>>(truth, bytes));
     return true;
 }

--- a/smart_contracts/contract_as/tests/assembly/runtime_args.spec.as.ts
+++ b/smart_contracts/contract_as/tests/assembly/runtime_args.spec.as.ts
@@ -25,7 +25,7 @@ export function testRuntimeArgs(): bool {
         new Pair("arg3", CLValue.fromU512(U512.fromU64(123456789))),
     ]);
     let bytes = runtimeArgs.toBytes();
-    return checkArraysEqual(typedToArray(truth), bytes);
+    return checkArraysEqual<u8, Array<u8>>(truth, bytes);
 }
 
 export function testRuntimeArgs_Empty(): bool {
@@ -42,5 +42,5 @@ export function testRuntimeArgs_Empty(): bool {
 
     let runtimeArgs = new RuntimeArgs();
     let bytes = runtimeArgs.toBytes();
-    return checkArraysEqual(typedToArray(truth), bytes);
+    return checkArraysEqual<u8, Array<u8>>(truth, bytes);
 }

--- a/smart_contracts/contract_as/tests/assembly/utils.spec.as.ts
+++ b/smart_contracts/contract_as/tests/assembly/utils.spec.as.ts
@@ -4,16 +4,15 @@ import { typedToArray } from "../../assembly/utils";
 import { Pair } from "../../assembly/pair";
 
 export function testHex2Bin(): bool {
-    let truth = hex2bin("deadbeef");
-    let lhs = typedToArray(truth);
+    let lhs = hex2bin("deadbeef");
     let rhs: Array<u8> = [222, 173, 190, 239];
-    return checkArraysEqual(lhs, rhs);
+    return checkArraysEqual<u8>(lhs, rhs);
 }
 
 export function testcheckArraysEqual(): bool {
-    assert(checkArraysEqual(<u8[]>[], <u8[]>[]));
-    assert(!checkArraysEqual(<u8[]>[1, 2, 3], <u8[]>[1]));
-    return checkArraysEqual(<u8[]>[1, 2, 3], <u8[]>[1, 2, 3]);
+    assert(checkArraysEqual<u8, Array<u8>>(<u8[]>[], <u8[]>[]));
+    assert(!checkArraysEqual<u8, Array<u8>>(<u8[]>[1, 2, 3], <u8[]>[1]));
+    return checkArraysEqual<u8, Array<u8>>(<u8[]>[1, 2, 3], <u8[]>[1, 2, 3]);
 }
 
 export function testItemsEqual(): bool {
@@ -25,7 +24,7 @@ export function testItemsEqual(): bool {
 export function testItemsNotEqual(): bool {
     let lhs1: u32[] = [1,2,3,4,5];
     let rhs1: u32[] = [1,2,3,4,5,6];
-    
+
     let lhs2: u32[] = [1,2,3,4,5,6];
     let rhs2: u32[] = [1,2,3,4,5];
     assert(!checkItemsEqual(lhs1, rhs1));

--- a/smart_contracts/contract_as/tests/utils/helpers.ts
+++ b/smart_contracts/contract_as/tests/utils/helpers.ts
@@ -1,7 +1,7 @@
 const HEX_TABLE: String[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
 
-export function hex2bin(hex: String): Uint8Array {
-  let bin = new Uint8Array(hex.length / 2);
+export function hex2bin(hex: String): Array<u8> {
+  let bin = new Array<u8>(hex.length / 2);
 
   for (let i = 0; i < hex.length / 2; i++) {
     // NOTE: hex.substr + parseInt gives weird results under AssemblyScript
@@ -10,7 +10,7 @@ export function hex2bin(hex: String): Uint8Array {
     const lo = HEX_TABLE.indexOf(hex[(i * 2) + 1]);
     assert(lo > -1);
     const number = (hi << 4) | lo;
-    bin[i] = number;
+    bin[i] = <u8>number;
   }
   return bin;
 }

--- a/smart_contracts/contracts/test/get-call-stack-call-recursive-subcall/src/main.rs
+++ b/smart_contracts/contracts/test/get-call-stack-call-recursive-subcall/src/main.rs
@@ -9,14 +9,16 @@ use casper_contract::contract_api::{runtime, storage};
 use casper_types::{runtime_args, ApiError, Key, Phase, RuntimeArgs, U512};
 use get_call_stack_recursive_subcall::{standard_payment, Call, ContractAddress};
 
-const DEFAULT_PAYMENT: u64 = 1_500_000_000_000;
 const ARG_CALLS: &str = "calls";
 const ARG_CURRENT_DEPTH: &str = "current_depth";
+const AMOUNT: &str = "amount";
 
 #[no_mangle]
 pub extern "C" fn call() {
     let calls: Vec<Call> = runtime::get_named_arg(ARG_CALLS);
     let current_depth: u8 = runtime::get_named_arg(ARG_CURRENT_DEPTH);
+    let amount: U512 = runtime::get_named_arg(AMOUNT);
+    let calls_count = calls.len() as u8;
 
     // The important bit
     {
@@ -27,10 +29,10 @@ pub extern "C" fn call() {
     }
 
     if current_depth == 0 && runtime::get_phase() == Phase::Payment {
-        standard_payment(U512::from(DEFAULT_PAYMENT))
+        standard_payment(amount);
     }
 
-    if current_depth == calls.len() as u8 {
+    if current_depth == calls_count {
         return;
     }
 

--- a/smart_contracts/contracts_as/client/add-bid/package.json
+++ b/smart_contracts/contracts_as/client/add-bid/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/add_bid.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/add_bid.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/delegate/package.json
+++ b/smart_contracts/contracts_as/client/delegate/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/delegate.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/delegate.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/named-purse-payment/package.json
+++ b/smart_contracts/contracts_as/client/named-purse-payment/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/named_purse_payment.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/named_purse_payment.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/revert/package.json
+++ b/smart_contracts/contracts_as/client/revert/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/revert.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/revert.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/transfer-to-account-u512/package.json
+++ b/smart_contracts/contracts_as/client/transfer-to-account-u512/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_to_account_u512.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_to_account_u512.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/transfer-to-public-key/assembly/index.ts
+++ b/smart_contracts/contracts_as/client/transfer-to-public-key/assembly/index.ts
@@ -10,7 +10,7 @@ const ARG_AMOUNT = "amount";
 export function call(): void {
     const publicKeyBytes = CL.getNamedArg(ARG_TARGET);
     const publicKey = PublicKey.fromBytes(publicKeyBytes).unwrap();
-  
+
     const amountBytes = CL.getNamedArg(ARG_AMOUNT);
     const amount = U512.fromBytes(amountBytes).unwrap();
 

--- a/smart_contracts/contracts_as/client/transfer-to-public-key/package.json
+++ b/smart_contracts/contracts_as/client/transfer-to-public-key/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_to_public_key.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_to_public_key.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/undelegate/package.json
+++ b/smart_contracts/contracts_as/client/undelegate/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/undelegate.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/undelegate.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/client/withdraw-bid/package.json
+++ b/smart_contracts/contracts_as/client/withdraw-bid/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/withdraw_bid.wasm --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/withdraw_bid.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/example/counter-installer/README.md
+++ b/smart_contracts/contracts_as/example/counter-installer/README.md
@@ -78,7 +78,7 @@ export function counter_get(): void {
     Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
     return;
   }
-  let value = fromBytesI32(<Uint8Array>countData).unwrap();
+  let value = fromBytesI32(<StaticArray<u8>>countData).unwrap();
   CL.ret(CLValue.fromI32(value));
 }
 

--- a/smart_contracts/contracts_as/example/counter-installer/assembly/index.ts
+++ b/smart_contracts/contracts_as/example/counter-installer/assembly/index.ts
@@ -46,7 +46,7 @@ export function counter_get(): void {
     Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
     return;
   }
-  let value = fromBytesI32(<Uint8Array>countData).unwrap();
+  let value = fromBytesI32(<StaticArray<u8>>countData).unwrap();
   CL.ret(CLValue.fromI32(value));
 }
 

--- a/smart_contracts/contracts_as/example/increment-counter/assembly/index.ts
+++ b/smart_contracts/contracts_as/example/increment-counter/assembly/index.ts
@@ -13,12 +13,18 @@ const COUNTER_GET = "counter_get";
 const COUNTER_KEY = "counter";
 const CONTRACT_VERSION_KEY = "version";
 
-function counterGet(contractHash: Uint8Array): i32 {
+function counterGet(contractHash: StaticArray<u8>): i32 {
   let bytes = CL.callContract(contractHash, COUNTER_GET, new RuntimeArgs());
-  return fromBytesI32(bytes).unwrap();
+  if (bytes !== null) {
+    return fromBytesI32(bytes).unwrap();
+  }
+  else {
+    Error.fromErrorCode(ErrorCode.Formatting).revert();
+    return <i32>unreachable();
+  }
 }
 
-function counterInc(contractHash: Uint8Array): void {
+function counterInc(contractHash: StaticArray<u8>): void {
   CL.callContract(contractHash, COUNTER_INC, new RuntimeArgs());
 }
 

--- a/smart_contracts/contracts_as/test/add-update-associated-key/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/add-update-associated-key/assembly/index.ts
@@ -13,13 +13,13 @@ const ARG_ACCOUNT = "account";
 
 export function call(): void {
   let accountHashBytes = CL.getNamedArg(ARG_ACCOUNT);
-  const accountHashResult = AccountHash.fromBytes(accountHashBytes);
+  const accountHashResult = AccountHash.fromBytes(accountHashBytes.slice(0));
   if (accountHashResult.hasError()) {
     Error.fromUserError(<u16>4464 + <u16>accountHashResult.error).revert();
     return;
   }
   const accountHash = accountHashResult.value;
-  
+
   if (addAssociatedKey(accountHash, INIT_WEIGHT) != AddKeyFailure.Ok) {
     Error.fromUserError(<u16>4464).revert();
     return;

--- a/smart_contracts/contracts_as/test/add-update-associated-key/package.json
+++ b/smart_contracts/contracts_as/test/add-update-associated-key/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/add_update_associated_key.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/add_update_associated_key.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/authorized-keys/package.json
+++ b/smart_contracts/contracts_as/test/authorized-keys/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/set_action_thresholds.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/authorized_keys.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/create-purse-01/package.json
+++ b/smart_contracts/contracts_as/test/create-purse-01/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/create_purse_01.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/create_purse_01.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/dictionary-read/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/dictionary-read/assembly/index.ts
@@ -1,13 +1,13 @@
 //@ts-nocheck
-import {Error} from "../../../../contract_as/assembly/error";
-import {Key} from "../../../../contract_as/assembly/key";
+import { Error } from "../../../../contract_as/assembly/error";
+import { Key } from "../../../../contract_as/assembly/key";
 import { newDictionary, dictionaryGet, dictionaryPut, dictionaryRead } from "../../../../contract_as/assembly/dictionary";
-import {CLValue} from "../../../../contract_as/assembly/clvalue";
-import {checkTypedArrayEqual} from "../../../../contract_as/assembly/utils";
+import { CLValue } from "../../../../contract_as/assembly/clvalue";
+import { checkArraysEqual } from "../../../../contract_as/assembly/utils";
 
 const DICTIONARY_NAME = "dictionary-name";
 const DICTIONARY_ITEM_KEY = "dictionary-item-key";
-const DICTIONARY_VALUE= "dictionary-value";
+const DICTIONARY_VALUE = "dictionary-value";
 
 export function call(): void {
     let dictionary_seed_uref = newDictionary(DICTIONARY_NAME);
@@ -24,7 +24,7 @@ export function call(): void {
         Error.fromUserError(15).revert()
         return
     }
-    if (!checkTypedArrayEqual(valueViaDictionaryRead, valueViaDictionaryGet)) {
+    if (!checkArraysEqual<u8, StaticArray<u8>>(valueViaDictionaryRead, valueViaDictionaryGet)) {
         Error.fromUserError(18).revert()
         return
     }

--- a/smart_contracts/contracts_as/test/dictionary/package.json
+++ b/smart_contracts/contracts_as/test/dictionary/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/dictionary.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/dictionary.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/do-nothing-stored-caller/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/do-nothing-stored-caller/assembly/index.ts
@@ -18,7 +18,7 @@ export function call(): void {
   const newPurseNameBytes = CL.getNamedArg(ARG_NEW_PURSE_NAME);
   const newPurseName = fromBytesString(newPurseNameBytes).unwrap();
   const versionNumber = CL.getNamedArg(ARG_VERSION)[0];
-  let contractVersion = new Option(arrayToTyped(toBytesU32(versionNumber)));
+  let contractVersion = new Option(toBytesU32(versionNumber));
   let runtimeArgs = RuntimeArgs.fromArray([
     new Pair(PURSE_NAME_ARG_NAME, CLValue.fromString(newPurseName)),
   ]);

--- a/smart_contracts/contracts_as/test/do-nothing-stored-caller/package.json
+++ b/smart_contracts/contracts_as/test/do-nothing-stored-caller/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/do_nothing_stored_caller.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/do_nothing_stored_caller.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/do-nothing-stored-upgrader/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/do-nothing-stored-upgrader/assembly/index.ts
@@ -15,11 +15,11 @@ const DO_NOTHING_PACKAGE_HASH_KEY_NAME = "do_nothing_package_hash";
 const DO_NOTHING_ACCESS_KEY_NAME = "do_nothing_access";
 
 export function delegate(): void {
-  let hashBytes = new Uint8Array(32);
+  let key = new StaticArray<u8>(32);
   for (var i = 0; i < 32; i++) {
-    hashBytes[i] = 1;
+    key[i] = 1;
   }
-  CL.putKey("called_do_nothing_ver_2", Key.fromHash(hashBytes));
+  CL.putKey("called_do_nothing_ver_2", Key.fromHash(key));
   CreatePurse01.delegate();
 }
 
@@ -49,7 +49,7 @@ export function call(): void {
   }
 
   const result = CL.addContractVersion(
-    <Uint8Array>doNothingPackageHash.hash,
+    <StaticArray<u8>>doNothingPackageHash.hash,
     entryPoints,
     new Array<Pair<String, Key>>(),
   );

--- a/smart_contracts/contracts_as/test/do-nothing-stored-upgrader/package.json
+++ b/smart_contracts/contracts_as/test/do-nothing-stored-upgrader/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/do_nothing_stored_upgrader.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/do_nothing_stored_upgrader.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/do-nothing-stored/package.json
+++ b/smart_contracts/contracts_as/test/do-nothing-stored/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/do_nothing_stored.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/do_nothing_stored.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/do-nothing/package.json
+++ b/smart_contracts/contracts_as/test/do-nothing/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/do_nothing.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/do_nothing.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/endless-loop/package.json
+++ b/smart_contracts/contracts_as/test/endless-loop/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/endless_loop.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/endless_loop.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/get-arg/package.json
+++ b/smart_contracts/contracts_as/test/get-arg/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/get_arg.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/get_arg.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/get-blocktime/package.json
+++ b/smart_contracts/contracts_as/test/get-blocktime/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/get_blocktime.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/get_blocktime.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/get-caller/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/get-caller/assembly/index.ts
@@ -7,7 +7,7 @@ const ARG_ACCOUNT = "account";
 
 export function call(): void {
   const knownAccountHashBytes = CL.getNamedArg(ARG_ACCOUNT);
-  let knownAccountHashResult = AccountHash.fromBytes(knownAccountHashBytes);
+  let knownAccountHashResult = AccountHash.fromBytes(knownAccountHashBytes.slice(0));
   if (knownAccountHashResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;

--- a/smart_contracts/contracts_as/test/get-caller/package.json
+++ b/smart_contracts/contracts_as/test/get-caller/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/get_caller.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/get_caller.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/get-phase-payment/package.json
+++ b/smart_contracts/contracts_as/test/get-phase-payment/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/get_phase_payment.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/get_phase_payment.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/get-phase/package.json
+++ b/smart_contracts/contracts_as/test/get-phase/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/get_phase.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/get_phase.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/groups/package.json
+++ b/smart_contracts/contracts_as/test/groups/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/groups.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/groups.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/key-management-thresholds/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/key-management-thresholds/assembly/index.ts
@@ -21,15 +21,15 @@ export function call(): void {
 
   let key42sBytes = new Array<u8>(32);
   key42sBytes.fill(42);
-  let key42s = new AccountHash(arrayToTyped(key42sBytes));
+  let key42s = new AccountHash(key42sBytes);
 
   let key43sBytes = new Array<u8>(32);
   key43sBytes.fill(43);
-  let key43s = new AccountHash(arrayToTyped(key43sBytes));
+  let key43s = new AccountHash(key43sBytes);
 
   let key1sBytes = new Array<u8>(32);
   key1sBytes.fill(1);
-  let key1s = new AccountHash(arrayToTyped(key1sBytes));
+  let key1s = new AccountHash(key1sBytes);
 
   if (stage == "init") {
     if (addAssociatedKey(key42s, 100) != AddKeyFailure.Ok) {
@@ -53,7 +53,7 @@ export function call(): void {
   else if (stage == "test-permission-denied") {
     let key44sBytes = new Array<u8>(32);
     key44sBytes.fill(44);
-    let key44s = new AccountHash(arrayToTyped(key44sBytes));
+    let key44s = new AccountHash(key44sBytes);
     switch (addAssociatedKey(key44s, 1)) {
       case AddKeyFailure.Ok:
         Error.fromUserError(200).revert();
@@ -67,7 +67,7 @@ export function call(): void {
 
     let key43sBytes = new Array<u8>(32);
     key43sBytes.fill(43);
-    let key43s = new AccountHash(arrayToTyped(key43sBytes));
+    let key43s = new AccountHash(key43sBytes);
 
     switch (updateAssociatedKey(key43s, 2)) {
       case UpdateKeyFailure.Ok:
@@ -105,7 +105,7 @@ export function call(): void {
   else if (stage == "test-key-mgmnt-succeed") {
     let key44sBytes = new Array<u8>(32);
     key44sBytes.fill(44);
-    let key44s = new AccountHash(arrayToTyped(key44sBytes));
+    let key44s = new AccountHash(key44sBytes);
 
     // Has to be executed with keys of total weight >= 254
     if (addAssociatedKey(key44s, 1) != AddKeyFailure.Ok) {

--- a/smart_contracts/contracts_as/test/key-management-thresholds/package.json
+++ b/smart_contracts/contracts_as/test/key-management-thresholds/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/key_management_thresholds.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/key_management_thresholds.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/list-authorization-keys/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/list-authorization-keys/assembly/index.ts
@@ -1,10 +1,10 @@
 //@ts-nocheck
 import * as CL from "../../../../contract_as/assembly";
-import {Error, ErrorCode} from "../../../../contract_as/assembly/error";
-import {fromBytesMap, fromBytesArray} from "../../../../contract_as/assembly/bytesrepr";
-import {AccountHash, Key} from "../../../../contract_as/assembly/key";
-import {listAuthorizationKeys} from "../../../../contract_as/assembly/account";
-import {checkItemsEqual} from "../../../../contract_as/assembly/utils";
+import { Error, ErrorCode } from "../../../../contract_as/assembly/error";
+import { Result, fromBytesMap, fromBytesArray } from "../../../../contract_as/assembly/bytesrepr";
+import { AccountHash, Key } from "../../../../contract_as/assembly/key";
+import { listAuthorizationKeys } from "../../../../contract_as/assembly/account";
+import { checkItemsEqual } from "../../../../contract_as/assembly/utils";
 
 const ARG_EXPECTED_AUTHORIZATION_KEYS = "expected_authorization_keys";
 
@@ -16,11 +16,12 @@ export function call(): void {
   const authorizationKeys = listAuthorizationKeys();
   const expectedAuthorizedKeysBytes = CL.getNamedArg(ARG_EXPECTED_AUTHORIZATION_KEYS);
   if (expectedAuthorizedKeysBytes === null) {
-      Error.fromErrorCode(ErrorCode.MissingArgument).revert();
-      return;
+    Error.fromErrorCode(ErrorCode.MissingArgument).revert();
+    return;
   }
 
-  let expectedAuthorizedKeys = fromBytesArray<AccountHash>(expectedAuthorizedKeysBytes, AccountHash.fromBytes).unwrap();
+  let fromBytesAccountHash = (bytes: StaticArray<u8>): Result<AccountHash> => AccountHash.fromBytes(bytes.slice(0))
+  let expectedAuthorizedKeys = fromBytesArray<AccountHash>(expectedAuthorizedKeysBytes, fromBytesAccountHash).unwrap();
   expectedAuthorizedKeys.sort();
 
   if (authorizationKeys.length != expectedAuthorizedKeys.length) {

--- a/smart_contracts/contracts_as/test/list-named-keys/package.json
+++ b/smart_contracts/contracts_as/test/list-named-keys/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/list_named_keys.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/list_named_keys.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/main-purse/package.json
+++ b/smart_contracts/contracts_as/test/main-purse/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/main_purse.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/main_purse.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/manage-groups/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/manage-groups/assembly/index.ts
@@ -47,7 +47,7 @@ export function create_group(): void {
   }
 
   let newURefs = CL.createContractUserGroup(
-    <Uint8Array>packageHashKey.hash,
+    <StaticArray<u8>>(packageHashKey.hash),
     group_name,
     total_urefs as u8,
     existingURefs,
@@ -62,7 +62,7 @@ export function remove_group(): void {
   }
   let groupName: String = fromBytesString(CL.getNamedArg(GROUP_NAME_ARG)).unwrap();
   CL.removeContractUserGroup(
-    <Uint8Array>packageHashKey.hash,
+    <StaticArray<u8>>packageHashKey.hash,
     groupName);
 }
 
@@ -83,7 +83,7 @@ export function extend_group_urefs(): void {
   // Creates 1 additional uref inside group
   for (var i = <u64>0; i < newURefsCount; i++) {
     let _newURef = CL.extendContractUserGroupURefs(
-      <Uint8Array>packageHashKey.hash,
+      <StaticArray<u8>>packageHashKey.hash,
       groupName
     );
   }
@@ -97,7 +97,9 @@ export function remove_group_urefs(): void {
   }
   let groupName: String = fromBytesString(CL.getNamedArg(GROUP_NAME_ARG)).unwrap();
 
-  let ordinals = fromBytesArray(CL.getNamedArg(GROUP_NAME_ARG), fromBytesU64);
+  let decodeOrdinal = function (bytes: StaticArray<u8>): Result<u64> { return fromBytesU64(bytes); }
+
+  let ordinals = fromBytesArray(CL.getNamedArg(GROUP_NAME_ARG), decodeOrdinal);
 
   let contractPackageBytes = packageHashKey.read();
   if (contractPackageBytes === null) {
@@ -108,13 +110,13 @@ export function remove_group_urefs(): void {
   // Finds last uref in the groups in the contract package bytes.
   // ContractPackage serialization structure is defined in `types/src/contracts.rs`
   let urefBytes = contractPackageBytes.slice(contractPackageBytes.length - 1 - 33, contractPackageBytes.length - 1);
-  let uref = URef.fromBytes(urefBytes).unwrap();
+  let uref = URef.fromBytes(StaticArray.fromArray(urefBytes)).unwrap();
 
   let urefs = new Array<URef>();
   urefs.push(uref);
 
   CL.removeContractUserGroupURefs(
-    <Uint8Array>packageHashKey.hash,
+    <StaticArray<u8>>(packageHashKey.hash),
     groupName,
     urefs,
   );
@@ -185,10 +187,10 @@ function createEntryPoints1(): CL.EntryPoints {
   return entryPoints;
 }
 
-function installVersion1(package_hash: Uint8Array): void {
+function installVersion1(packageHash: StaticArray<u8>): void {
   let contractNamedKeys = new Array<Pair<String, Key>>();
   let entryPoints = createEntryPoints1();
-  const result = CL.addContractVersion(package_hash, entryPoints, contractNamedKeys);
+  const result = CL.addContractVersion(packageHash, entryPoints, contractNamedKeys);
 }
 
 export function call(): void {

--- a/smart_contracts/contracts_as/test/manage-groups/package.json
+++ b/smart_contracts/contracts_as/test/manage-groups/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/manage_groups.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/manage_groups.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/named-keys/package.json
+++ b/smart_contracts/contracts_as/test/named-keys/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/named_keys.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/named_keys.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/overwrite-uref-content/package.json
+++ b/smart_contracts/contracts_as/test/overwrite-uref-content/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/overwrite_uref_content.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/overwrite_uref_content.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/purse-holder-stored-caller/package.json
+++ b/smart_contracts/contracts_as/test/purse-holder-stored-caller/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/purse_holder_stored_caller.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/purse_holder_stored_caller.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/purse-holder-stored-upgrader/package.json
+++ b/smart_contracts/contracts_as/test/purse-holder-stored-upgrader/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/purse_holder_stored_upgrader.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/purse_holder_stored_upgrader.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/purse-holder-stored/package.json
+++ b/smart_contracts/contracts_as/test/purse-holder-stored/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/purse_holder_stored.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/purse_holder_stored.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/remove-associated-key/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/remove-associated-key/assembly/index.ts
@@ -9,13 +9,13 @@ const ARG_ACCOUNT = "account";
 
 export function call(): void {
   let accountBytes = CL.getNamedArg(ARG_ACCOUNT);
-  const accountResult = AccountHash.fromBytes(accountBytes);
+  const accountResult = AccountHash.fromBytes(accountBytes.slice(0));
   if (accountResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
   const account = accountResult.value;
-  
+
   if (removeAssociatedKey(account) != RemoveKeyFailure.Ok) {
     Error.fromUserError(<u16>4464).revert();
     return;

--- a/smart_contracts/contracts_as/test/remove-associated-key/package.json
+++ b/smart_contracts/contracts_as/test/remove-associated-key/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/remove_associated_key.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/remove_associated_key.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-main-purse-to-new-purse/package.json
+++ b/smart_contracts/contracts_as/test/transfer-main-purse-to-new-purse/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_main_purse_to_new_purse.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_main_purse_to_new_purse.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-purse-to-account-stored/package.json
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-account-stored/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_purse_to_account_stored.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_purse_to_account_stored.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert  --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-purse-to-account-with-id/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-account-with-id/assembly/index.ts
@@ -38,7 +38,7 @@ export function delegate(): void {
     let maybeId: Ref<u64> | null = null;
     if (maybeOptionalId.isSome()) {
         const maybeIdBytes = maybeOptionalId.unwrap();
-        maybeId = new Ref(fromBytesU64(maybeIdBytes).unwrap());
+        maybeId = new Ref(fromBytesU64(StaticArray.fromArray(maybeIdBytes)).unwrap());
     }
 
     if (amountResult.hasError()) {
@@ -46,7 +46,7 @@ export function delegate(): void {
         return;
     }
     let amount = amountResult.value;
-    const result = transferFromPurseToAccount(<URef>mainPurse, <Uint8Array>destinationAccountAddrArg, amount, maybeId);
+    const result = transferFromPurseToAccount(<URef>mainPurse, destinationAccountAddrArg, amount, maybeId);
     let message = "";
     if (result.isOk) {
         const foo = result.ok;

--- a/smart_contracts/contracts_as/test/transfer-purse-to-account-with-id/package.json
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-account-with-id/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_purse_to_account_with_id.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_purse_to_account_with_id.wasm --disable bulk-memory --optimize  --optimizeLevel 3 --converge  --noAssert  --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-purse-to-account/assembly/index.ts
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-account/assembly/index.ts
@@ -33,8 +33,7 @@ export function delegate(): void {
         return;
     }
     let amount = amountResult.value;
-    let message = "";
-    const result = transferFromPurseToAccount(<URef>mainPurse, <Uint8Array>destinationAccountAddrArg, amount);
+    const result = transferFromPurseToAccount(<URef>mainPurse, destinationAccountAddrArg, amount);
     if (result.isErr) {
         let error = result.err;
         error.revert();

--- a/smart_contracts/contracts_as/test/transfer-purse-to-account/package.json
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-account/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_purse_to_account.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_purse_to_account.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge  --noAssert  --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-purse-to-public-key/package.json
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-public-key/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_purse_to_public_key.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_purse_to_public_key.wasm --disable bulk-memory --optimize --optimizeLevel 3 --converge --noAssert  --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {

--- a/smart_contracts/contracts_as/test/transfer-purse-to-purse/package.json
+++ b/smart_contracts/contracts_as/test/transfer-purse-to-purse/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -o ../../../../target_as/transfer_purse_to_purse.wasm   --disable bulk-memory --optimize --use abort=",
+    "asbuild:optimized": "asc --lib ../../.. assembly/index.ts -b ../../../../target_as/transfer_purse_to_purse.wasm   --disable bulk-memory --optimize  --optimizeLevel 3 --converge  --noAssert  --use abort=",
     "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {


### PR DESCRIPTION
This change backports changes from the 1.4.9 release onto the dev branch and fixes all the affected tests due to the `control_flow` opcode increase.

All necessary changes from private release-1.4.9 are squashed into one commit, with extra changes essential due to many merge conflicts.