### PR TITLE
Fix "insufficient deploy TTL awareness" issue in upgrades

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1750,8 +1750,9 @@ impl Storage {
             for idx in (low..=hi).rev() {
                 match self.get_block_by_height(txn, idx) {
                     Ok(Some(block)) => {
+                        let should_continue = predicate(&block);
                         blocks.push(block);
-                        if false == predicate(&block) {
+                        if false == should_continue {
                             return Ok(blocks);
                         }
                     }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1733,8 +1733,8 @@ impl Storage {
         self.get_single_block(txn, highest_complete_block_hash)
     }
 
-    /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
-    /// the ancestry chain.
+    /// Returns a vector of blocks that satisfy the predicate, and one that doesn't (if one
+    /// exists), starting from the latest one and following the ancestry chain.
     fn get_blocks_while<F, Tx: Transaction>(
         &self,
         txn: &mut Tx,
@@ -1750,10 +1750,10 @@ impl Storage {
             for idx in (low..=hi).rev() {
                 match self.get_block_by_height(txn, idx) {
                     Ok(Some(block)) => {
+                        blocks.push(block);
                         if false == predicate(&block) {
                             return Ok(blocks);
                         }
-                        blocks.push(block);
                     }
                     Ok(None) => {
                         continue;

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -10,6 +10,6 @@
         }
     },
     "nctl_upgrade_tests": {
-        "protocol_1": "1.4.6"
+        "protocol_1": "1.4.8"
     }
 }


### PR DESCRIPTION
This should fix an issue encountered in tests based on a mainnet snapshot, where the nodes upgraded and got stuck in a loop with messages `Validate: insufficient deploy TTL awareness to safely participate in consensus`.

The issue here is that the range of blocks returned from storage for initializing the deploy buffer contained all blocks that were within max TTL, but no block that was outside of that time range. So when the deploy buffer was checking whether it had all necessary blocks, all of them were within max TTL, and so it couldn't know whether it actually has all of them (from its point of view there could have been more such blocks before the earliest known one), which made it return `false` from `have_full_ttl_of_deploys`. Including one block from outside the range in the set used to initialize the deploy buffer should fix the issue.

We haven't noticed this so far most likely because no other test uses a network that has been running for more than deploy max TTL, and so in other tests the set of blocks was always reaching genesis, causing the deploy buffer to know that no earlier blocks were possible and correctly return `true`.