### PR TITLE
Small log message fixes

### DIFF
--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -263,7 +263,7 @@ impl SyncLeaper {
     where
         REv: From<FetcherRequest<SyncLeap>> + Send,
     {
-        info!(%sync_leap_identifier, "Registering leap attempt");
+        info!(%sync_leap_identifier, "registering leap attempt");
         let mut effects = Effects::new();
         if peers_to_ask.is_empty() {
             error!("tried to start fetching a sync leap without peers to ask");

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -263,6 +263,7 @@ impl SyncLeaper {
     where
         REv: From<FetcherRequest<SyncLeap>> + Send,
     {
+        info!(%sync_leap_identifier, "Registering leap attempt");
         let mut effects = Effects::new();
         if peers_to_ask.is_empty() {
             error!("tried to start fetching a sync leap without peers to ask");

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -42,7 +42,7 @@ impl MainReactor {
         };
         debug!(
             ?sync_identifier,
-            block_hash = ?sync_identifier.block_hash(),
+            block_hash = %sync_identifier.block_hash(),
             "CatchUp: sync identifier"
         );
         // we check with the block accumulator before doing sync work as it may be aware of one or
@@ -50,7 +50,7 @@ impl MainReactor {
         let sync_instruction = self.block_accumulator.sync_instruction(sync_identifier);
         debug!(
             ?sync_instruction,
-            block_hash = ?sync_instruction.block_hash(),
+            block_hash = %sync_instruction.block_hash(),
             "CatchUp: sync_instruction"
         );
         if let Some(catch_up_instruction) =
@@ -269,7 +269,7 @@ impl MainReactor {
             self.chainspec.core_config.simultaneous_peer_requests,
         );
         let leap_status = self.sync_leaper.leap_status();
-        info!(?block_hash, ?leap_status, "CatchUp: status");
+        info!(%block_hash, %leap_status, "CatchUp: status");
         match leap_status {
             LeapStatus::Idle => self.catch_up_leaper_idle(effect_builder, rng, block_hash),
             LeapStatus::Awaiting { .. } => CatchUpInstruction::CheckLater(
@@ -297,7 +297,7 @@ impl MainReactor {
         self.attempts += 1;
         warn!(
             %error,
-            remaining_attempts = self.max_attempts.saturating_sub(self.attempts),
+            remaining_attempts = %self.max_attempts.saturating_sub(self.attempts),
             "CatchUp: failed leap",
         );
         self.catch_up_leaper_idle(effect_builder, rng, block_hash)
@@ -339,9 +339,9 @@ impl MainReactor {
         let block_hash = best_available.highest_block_hash();
         let block_height = best_available.highest_block_height();
         info!(
-            ?best_available,
-            ?block_height,
-            ?block_hash,
+            %best_available,
+            %block_height,
+            %block_hash,
             "CatchUp: leap received"
         );
 

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -316,7 +316,7 @@ impl MainReactor {
             .fully_connected_peers_random(rng, peers_to_ask_count);
         if peers_to_ask.len() < peers_to_ask_count {
             warn!(
-                "CatchUp: attmepting to Leap with less connected peers ({}) than required ({})",
+                "CatchUp: attempting to Leap with less connected peers ({}) than wanted ({})",
                 peers_to_ask.len(),
                 peers_to_ask_count
             );

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -319,7 +319,7 @@ impl MainReactor {
         warn!(
             %error,
             remaining_attempts = self.max_attempts.saturating_sub(self.attempts),
-            "Historical: failed leap",
+            "historical: failed leap",
         );
         self.sync_back_leaper_idle(effect_builder, rng, parent_hash)
     }
@@ -356,16 +356,16 @@ impl MainReactor {
         let block_hash = best_available.highest_block_hash();
         let block_height = best_available.highest_block_height();
         info!(
-            %best_available, ?block_height, ?block_hash, "Historical: leap received");
+            %best_available, ?block_height, ?block_hash, "historical: leap received");
 
         let era_validator_weights =
             best_available.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
         for evw in era_validator_weights {
             let era_id = evw.era_id();
             if self.validator_matrix.register_era_validator_weights(evw) {
-                info!(%era_id, "Historical: got era");
+                info!(%era_id, "historical: got era");
             } else {
-                debug!(%era_id, "Historical: already had era");
+                debug!(%era_id, "historical: already had era");
             }
         }
         KeepUpInstruction::CheckLater("historical sync leap received".to_string(), Duration::ZERO)
@@ -392,7 +392,7 @@ impl MainReactor {
                 self.chainspec.core_config.simultaneous_peer_requests as usize,
             );
             debug!(
-                "Historical: register_block_by_hash: {} peers count: {:?}",
+                "historical: register_block_by_hash: {} peers count: {:?}",
                 parent_hash,
                 peers_to_ask.len()
             );

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -293,7 +293,7 @@ impl MainReactor {
         // signatures against. we use the leaper to gain awareness of the necessary
         // trusted ancestors to our earliest contiguous block to do necessary validation.
         let leap_status = self.sync_leaper.leap_status();
-        info!("Historical status for {} is {}", parent_hash, leap_status);
+        info!("historical status for {} is {}", parent_hash, leap_status);
         match leap_status {
             LeapStatus::Idle => self.sync_back_leaper_idle(effect_builder, rng, parent_hash),
             LeapStatus::Awaiting { .. } => KeepUpInstruction::CheckLater(

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -225,7 +225,7 @@ impl MainReactor {
                     true,
                     self.chainspec.core_config.simultaneous_peer_requests,
                 ) {
-                    info!(?block_hash, "KeepUp: BlockSync: registered block by hash");
+                    info!(%block_hash, "KeepUp: BlockSync: registered block by hash");
                     Some(KeepUpInstruction::Do(
                         Duration::ZERO,
                         effect_builder.immediately().event(|_| {
@@ -290,7 +290,7 @@ impl MainReactor {
         // signatures against. we use the leaper to gain awareness of the necessary
         // trusted ancestors to our earliest contiguous block to do necessary validation.
         let leap_status = self.sync_leaper.leap_status();
-        info!(?parent_hash, ?leap_status, "historical status");
+        info!(%parent_hash, %leap_status, "historical status");
         match leap_status {
             LeapStatus::Idle => {
                 self.sync_back_leaper_idle(effect_builder, rng, parent_hash, Duration::ZERO)
@@ -320,7 +320,7 @@ impl MainReactor {
         self.attempts += 1;
         warn!(
             %error,
-            remaining_attempts = self.max_attempts.saturating_sub(self.attempts),
+            remaining_attempts = %self.max_attempts.saturating_sub(self.attempts),
             "historical: failed leap",
         );
         self.sync_back_leaper_idle(
@@ -370,7 +370,7 @@ impl MainReactor {
         let block_hash = best_available.highest_block_hash();
         let block_height = best_available.highest_block_height();
         info!(
-            %best_available, ?block_height, ?block_hash, "historical: leap received");
+            %best_available, %block_height, %block_hash, "historical: leap received");
 
         let era_validator_weights =
             best_available.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -225,10 +225,7 @@ impl MainReactor {
                     true,
                     self.chainspec.core_config.simultaneous_peer_requests,
                 ) {
-                    info!(
-                        ?block_hash,
-                        "KeepUp: BlockSync: registered block by hash {}", block_hash
-                    );
+                    info!(?block_hash, "KeepUp: BlockSync: registered block by hash");
                     Some(KeepUpInstruction::Do(
                         Duration::ZERO,
                         effect_builder.immediately().event(|_| {
@@ -293,7 +290,7 @@ impl MainReactor {
         // signatures against. we use the leaper to gain awareness of the necessary
         // trusted ancestors to our earliest contiguous block to do necessary validation.
         let leap_status = self.sync_leaper.leap_status();
-        info!("historical status for {} is {}", parent_hash, leap_status);
+        info!(?parent_hash, ?leap_status, "historical status");
         match leap_status {
             LeapStatus::Idle => self.sync_back_leaper_idle(effect_builder, rng, parent_hash),
             LeapStatus::Awaiting { .. } => KeepUpInstruction::CheckLater(
@@ -321,8 +318,8 @@ impl MainReactor {
         self.attempts += 1;
         warn!(
             %error,
-            "Historical: failed leap, remaining attempts: {}",
-            self.max_attempts.saturating_sub(self.attempts)
+            remaining_attempts = self.max_attempts.saturating_sub(self.attempts),
+            "Historical: failed leap",
         );
         self.sync_back_leaper_idle(effect_builder, rng, parent_hash)
     }
@@ -359,16 +356,16 @@ impl MainReactor {
         let block_hash = best_available.highest_block_hash();
         let block_height = best_available.highest_block_height();
         info!(
-            %best_available,"Historical: leap received({}) {}", block_height, block_hash);
+            %best_available, ?block_height, ?block_hash, "Historical: leap received");
 
         let era_validator_weights =
             best_available.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
         for evw in era_validator_weights {
             let era_id = evw.era_id();
             if self.validator_matrix.register_era_validator_weights(evw) {
-                info!("Historical: got era: {}", era_id);
+                info!(%era_id, "Historical: got era");
             } else {
-                debug!("Historical: already had era: {}", era_id);
+                debug!(%era_id, "Historical: already had era");
             }
         }
         KeepUpInstruction::CheckLater("historical sync leap received".to_string(), Duration::ZERO)

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{Display, Formatter},
     time::Duration,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use casper_types::{EraId, Timestamp};
 
@@ -293,13 +293,7 @@ impl MainReactor {
         // signatures against. we use the leaper to gain awareness of the necessary
         // trusted ancestors to our earliest contiguous block to do necessary validation.
         let leap_status = self.sync_leaper.leap_status();
-        info!(
-            ?parent_hash,
-            ?leap_status,
-            "Historical: {} {}",
-            parent_hash,
-            leap_status
-        );
+        info!("Historical status for {} is {}", parent_hash, leap_status);
         match leap_status {
             LeapStatus::Idle => self.sync_back_leaper_idle(effect_builder, rng, parent_hash),
             LeapStatus::Awaiting { .. } => KeepUpInstruction::CheckLater(
@@ -325,7 +319,7 @@ impl MainReactor {
         error: LeapActivityError,
     ) -> KeepUpInstruction {
         self.attempts += 1;
-        error!(
+        warn!(
             %error,
             "Historical: failed leap, remaining attempts: {}",
             self.max_attempts.saturating_sub(self.attempts)


### PR DESCRIPTION
* WARN instead of ERROR on failed sync leap
* Removed some duplicate information in sync leap logs
* ~~WARN when we attempt a sync leap with too few connected peers~~
* Use structured logging uniformly in KeepUp/CatchUp code.

Fixes: https://github.com/casper-network/casper-node/issues/3497