### PR TITLE
Add a log message showing inactive and faulty validators

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1012,6 +1012,14 @@ impl EraSupervisor {
                         )
                     })
                     .collect();
+                if let Some(era_report) = report.as_ref() {
+                    info!(
+                        inactive = ?era_report.inactive_validators,
+                        faulty = ?era_report.equivocators,
+                        era_id = era_id.value(),
+                        "era end: inactive and faulty validators"
+                    );
+                }
                 let finalized_block = FinalizedBlock::new(
                     proposed_block,
                     report,


### PR DESCRIPTION
Closes #3521 

This adds a message that looks like this in the JSON logs:
`{"timestamp":"2022-12-22T12:14:15.212828Z","level":"INFO","fields":{"message":"era end: inactive and faulty validators","inactive":"[PublicKey::Ed25519(9221aa896dad32b9c7982cc7d5935e7f65b1074bc485057b4ad03fd74d0576d1)]","faulty":"[]","era_id":3},"target":"casper_node::components::consensus::era_supervisor","span":{"a":8588,"ev":8589,"name":"dispatch"},"spans":[{"a":8588,"ev":8589,"name":"dispatch"}]}`

Note that NCTL won't show inactive validators by default: this is because it only considers validators inactive after `max_round_length` has passed, which is set to 525 seconds in NCTL, and with the era length being 41 seconds, eras end before any validators can be considered inactive.