### PR TITLE
Update changelogs

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.  The format
 * Update the default `control_flow` opcode cost from `440` to `440000`.
 
 
+
 ## 2.0.1
 
 ### Security

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -14,17 +14,17 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Added `WasmTestBuilder::get_execution_journals` method for returning execution journals for all test runs.
-* Added support to load values from a given Chainspec.
-* Added static and constants that represent Casper-mainnet chainspec values. These values will change as new ProtocolVersions are added. The current values reflect ones used in the 1.5.0 ProtocolVersion.
-* Added `WasmTestBuilder::advance_era`, `WasmTestBuilder::advance_eras_by`, and `WasmTestBuilder::advance_eras_by_default_auction_delay` to advance chain and run auction contract in test environment.
+* Add `WasmTestBuilder::get_execution_journals` method for returning execution journals for all test runs.
+* Add support to load values from a given Chainspec.
+* Add static and constants that represent Casper-mainnet chainspec values. These values will change as new ProtocolVersions are added. The current values reflect ones used in the 1.5.0 ProtocolVersion.
+* Add `WasmTestBuilder::advance_era`, `WasmTestBuilder::advance_eras_by`, and `WasmTestBuilder::advance_eras_by_default_auction_delay` to advance chain and run auction contract in test environment.
 
 ### Changed
 * `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.
 * `deploy_hash` field is now defaulted to a random value rather than zeros in `DeployItemBuilder`.
 
 ### Deprecated
-* Deprecated the `DEFAULT_GENESIS_REQUEST` in favor of `PRODUCTION_GENESIS_REQUEST`.
+* Deprecate the `DEFAULT_GENESIS_REQUEST` in favor of `PRODUCTION_GENESIS_REQUEST`.
 
 
 

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -5,14 +5,6 @@ use crate::types::BlockHash;
 
 use casper_types::TimeDiff;
 
-/// Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
-const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 5000;
-/// Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
-const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 5000;
-const DEFAULT_MAX_PARALLEL_BLOCK_FETCHES: u32 = 50;
-const DEFAULT_MAX_SYNC_FETCH_ATTEMPTS: u32 = 5;
-const DEFAULT_PEER_REDEMPTION_INTERVAL: u32 = 10_000;
-const DEFAULT_RETRY_INTERVAL: &str = "100ms";
 const DEFAULT_IDLE_TOLERANCE: &str = "20min";
 const DEFAULT_MAX_ATTEMPTS: usize = 3;
 const DEFAULT_CONTROL_LOGIC_DEFAULT_DELAY: &str = "1sec";
@@ -24,26 +16,6 @@ const DEFAULT_CONTROL_LOGIC_DEFAULT_DELAY: &str = "1sec";
 pub struct NodeConfig {
     /// Hash used as a trust anchor when joining, if any.
     pub trusted_hash: Option<BlockHash>,
-
-    /// Maximum number of deploys to fetch in parallel.
-    pub max_parallel_deploy_fetches: u32,
-
-    /// Maximum number of blocks to fetch in parallel.
-    pub max_parallel_block_fetches: u32,
-
-    /// Maximum number of trie nodes to fetch in parallel.
-    pub max_parallel_trie_fetches: u32,
-
-    /// The maximum number of retries of fetch operations during the chain synchronization process.
-    /// The retry limit is in effect only when the network component reports that enough peers
-    /// are connected, until that happens, the retries are unbounded.
-    pub max_sync_fetch_attempts: u32,
-
-    /// The duration for which to pause between retry attempts while synchronising during joining.
-    pub retry_interval: TimeDiff,
-
-    /// How many items to fetch before redeeming a random peer.
-    pub sync_peer_redemption_interval: u32,
 
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
@@ -67,16 +39,10 @@ impl Default for NodeConfig {
     fn default() -> NodeConfig {
         NodeConfig {
             trusted_hash: None,
-            max_parallel_deploy_fetches: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES,
-            max_parallel_block_fetches: DEFAULT_MAX_PARALLEL_BLOCK_FETCHES,
-            max_parallel_trie_fetches: DEFAULT_MAX_PARALLEL_TRIE_FETCHES,
-            max_sync_fetch_attempts: DEFAULT_MAX_SYNC_FETCH_ATTEMPTS,
-            retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
-            sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
+            sync_to_genesis: false,
             idle_tolerance: DEFAULT_IDLE_TOLERANCE.parse().unwrap(),
             max_attempts: DEFAULT_MAX_ATTEMPTS,
             control_logic_default_delay: DEFAULT_CONTROL_LOGIC_DEFAULT_DELAY.parse().unwrap(),
-            sync_to_genesis: false,
             force_resync: false,
         }
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -6,26 +6,6 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
-max_parallel_deploy_fetches = 5000
-
-# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
-max_parallel_trie_fetches = 5000
-
-# Maximum number of fetch-block tasks to run in parallel during chain synchronization.
-max_parallel_block_fetches = 50
-
-# The duration for which to pause between retry attempts while synchronising during joining.
-retry_interval = '100ms'
-
-# The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
-# only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
-# TODO: Temporarily set to a high value, because `has_connected_to_network()` is not implemented yet.
-max_sync_fetch_attempts = 5000
-
-# How often between sync attempts to redeem a bad node.
-sync_peer_redemption_interval = 0
-
 # Whether to synchronize all data back to genesis, or just [deploys.max_ttl] (chainspec setting) worth of data.
 sync_to_genesis = true
 
@@ -40,6 +20,7 @@ control_logic_default_delay = '1sec'
 
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
+
 
 # =================================
 # Configuration options for logging
@@ -70,9 +51,9 @@ secret_key_path = 'secret_key.pem'
 max_execution_delay = 3
 
 
-# ==========================================
-# Configuration options for Zug
-# ==========================================
+# =======================================
+# Configuration options for Zug consensus
+# =======================================
 [consensus.zug]
 
 # Request the latest protocol state from a random peer periodically, with this interval.
@@ -238,7 +219,7 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
-# How long peers remain blocked after they get blacklisted.
+# How long peers remain blocked after they get blocklisted.
 blocklist_retain_duration = '1min'
 
 # Identity of a node
@@ -466,7 +447,7 @@ purge_interval = '1min'
 # ================================================
 [block_synchronizer]
 
-# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+# Maximum number of fetch-trie tasks to run in parallel during block synchronization.
 max_parallel_trie_fetches = 5000
 
 # Time interval for the node to ask for refreshed peers.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -6,26 +6,6 @@
 # If set, use this hash as a trust anchor when joining an existing network.
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
-# Maximum number of fetch-deploy tasks to run in parallel during chain synchronization.
-max_parallel_deploy_fetches = 5000
-
-# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
-max_parallel_trie_fetches = 5000
-
-# Maximum number of fetch-block tasks to run in parallel during chain synchronization.
-max_parallel_block_fetches = 50
-
-# The duration for which to pause between retry attempts while synchronising during joining.
-retry_interval = '100ms'
-
-# The maximum number of retries of fetch operations during the chain synchronization process. The retry limit is in effect
-# only when the network component reports that enough peers are connected, until that happens, the retries are unbounded.
-# TODO: Temporarily set to a high value, because `has_connected_to_network()` is not implemented yet.
-max_sync_fetch_attempts = 5000
-
-# How often between sync attempts to redeem a bad node.
-sync_peer_redemption_interval = 0
-
 # Whether to synchronize all data back to genesis, or just [deploys.max_ttl] (chainspec setting) worth of data.
 sync_to_genesis = true
 
@@ -40,6 +20,7 @@ control_logic_default_delay = '1sec'
 
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
+
 
 # =================================
 # Configuration options for logging
@@ -70,9 +51,9 @@ secret_key_path = '/etc/casper/validator_keys/secret_key.pem'
 max_execution_delay = 3
 
 
-# ==========================================
-# Configuration options for Zug
-# ==========================================
+# =======================================
+# Configuration options for Zug consensus
+# =======================================
 [consensus.zug]
 
 # Request the latest protocol state from a random peer periodically, with this interval.
@@ -238,7 +219,7 @@ tarpit_duration = '10min'
 # legacy nodes running this software.
 tarpit_chance = 0.2
 
-# How long peers remain blocked after they get blacklisted.
+# How long peers remain blocked after they get blocklisted.
 blocklist_retain_duration = '10min'
 
 # Identity of a node
@@ -466,7 +447,7 @@ purge_interval = '1min'
 # ================================================
 [block_synchronizer]
 
-# Maximum number of fetch-trie tasks to run in parallel during chain synchronization.
+# Maximum number of fetch-trie tasks to run in parallel during block synchronization.
 max_parallel_trie_fetches = 5000
 
 # Time interval for the node to ask for refreshed peers.

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -14,11 +14,16 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Add `named_dictionary_get` and `named_dictionary_put` to the storage component of the contract API.
+* Support fetching the calling account's authorization keys via the new function `runtime::list_authorization_keys` which calls the new `ext_ffi::casper_load_authorization_keys`.
+* Support providing 32 random bytes via the new function `runtime::random_bytes` which calls the new `ext_ffi::casper_random_bytes`.
+* Add `storage::read_from_key` for reading a value under a given `Key`.
+* Add `storage::dictionary_read` for reading a value from a dictionary under a given `Key`, calling the new `ext_ffi::casper_dictionary_read`.
+* Add `storage::named_dictionary_put` for writing a named value to a named dictionary.
+* Add `storage::named_dictionary_get` for reading a named value from a named dictionary.
 
 ### Changed
-* Increased `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
-* Update pinned version of Rust to `nightly-2022-01-13`.
+* Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
+* Update pinned version of Rust to `nightly-2022-08-03`.
 
 
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -15,22 +15,27 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Add new `bytesrepr::Error::NotRepresentable` error variant that represents values that are not representable by the serialization format.
+* Add new `Key::Unbond` key variant under which the new unbonding information (to support redelegation) is written.
 * Add new `Key::ChainspecRegistry` key variant under which the `ChainspecRegistry` is written.
-* Add new `Key::BlockEffectsRootHash` key variant under which the Merkle root of the execution results for a given block is written.
-* Add new `Key::DeployApprovalsRootHash` key variant under which the Merkle root of the approvals of all deploys for a given block is written.
+* Add new `Key::ChecksumRegistry` key variant under which a registry of checksums for a given block is written.  There are two checksums in the registry, one for the execution results and the other for the approvals of all deploys in the block.
+* Add new `StoredValue::Unbonding` variant to support redelegating.
 * Add a new type `WithdrawPurses` which is meant to represent `UnbondingPurses` as they exist in current live networks.
 * Extend asymmetric key functionality, available via feature "std".
 * Provide `Timestamp` and `TimeDiff` types for time operations, with extended functionality available via feature "std".
 * Provide test-only functionality, in particular a seedable RNG `TestRng` which outputs its seed on test failure. Available via a new feature "testing".
 
 ### Changed
-* Extend `UnbondingPurses` to take a new field `new_validator` which represents the validator to whom tokens will be re-delegated.
+* Extend `UnbondingPurse` to take a new field `new_validator` which represents the validator to whom tokens will be re-delegated.
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
-* Fixed some integer casts.
 * Change prefix of formatted string representation of `ContractPackageHash` from "contract-package-wasm" to "contract-package-". Parsing from the old format is still supported.
+* Applied `#[non_exhaustive]` to error enums.
+* Change Debug output of `DeployHash` to hex-encoded string rather than a list of integers.
 
 ### Deprecated
 * Deprecate "gens" feature (used for providing proptest helpers) in favor of new "testing" feature.
+
+### Fixed
+* Fix some integer casts, where failure is now detected and reported via new error variant `NotRepresentable`.
 
 
 


### PR DESCRIPTION
This PR updates and corrects the changelogs of the various crates in the repo, and removes a handful of config options which were only relevant to fast-sync v1.

Closes #3337.
