### PR TITLE
nctl: rework ejection healthcheck

### DIFF
--- a/utils/nctl/sh/scenarios/common/health_checks.sh
+++ b/utils/nctl/sh/scenarios/common/health_checks.sh
@@ -266,12 +266,15 @@ function assert_eject_count() {
     GLOBAL_DIVIDER='0'
     for i in $(seq 1 "$(get_count_of_nodes)"); do
         COUNT=$(cat "$NCTL"/assets/net-1/nodes/node-"$i"/logs/stdout.log 2>/dev/null \
-                | jq '.fields.finalized_block | select( . != null )' \
-                | grep 'EraReport' \
-                | grep -o 'inactive_validators: \[PublicKey.*\})' \
+                | grep 'era end:' \
+                | jq -r '.fields.inactive | select(length > 2)' \
+                | tr -d '[()]' \
+                | tr ',' '\n' \
+                | sed -e 's/^[ \t]*//' \
+                | sort \
                 | uniq \
-                | sed  's/,/\n/g' \
                 | wc -l)
+
         if [ "$COUNT" != "0" ]; then
             GLOBAL_DIVIDER=$((GLOBAL_DIVIDER + 1))
         fi


### PR DESCRIPTION
Changes:
- switched out the way we detect ejected nodes from the logs
    - the log message no longer contains `.fields.finalized_block` so it was switched to derive it from `.fields.inactive`
    
Notes:
- fixes failures like this: https://drone-auto-casper-network.casperlabs.io/casper-network/casper-node/7084/1/4