### PR TITLE
Network watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "assert-json-diff",
+ "assert_matches",
  "async-trait",
  "backtrace",
  "base16",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add a `consensus_protocol` setting to the chainspec to choose a consensus protocol, and a `minimum_block_time` setting for the minimum difference between a block's timestamp and its child's.
 * Move `finality_threshold_fraction` from the `highway` to the `core` section in the chainspec.
 * Move `max_execution_delay` from the `highway` to the `consensus` section in the `config.toml`.
+* Connections to unresponsive nodes will be terminated, based on a watchdog feature.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -60,14 +60,6 @@ All notable changes to this project will be documented in this file.  The format
   * `execution_queue_size` to report the number of blocks enqueued pending execution
   * `accumulated_(outgoing|incoming)_limiter_delay` to report how much time was spent throttling other peers.
 * Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
-* The network handshake now contains the hash of the chainspec used and will be successful only if they match.
-* Add an `identity` option to load existing network identity certificates signed by a CA.
-* Add a `lock_status` field to the JSON representation of the `ContractPackage` values.
-* Make consensus settings non-optional. A value 0 disables them.
-* Add a `[consensus.zug]` section to `config.toml` for the Zug protocol.
-* Add a `consensus_protocol` setting to the chainspec to choose a consensus protocol, and a `minimum_block_time` setting for the minimum difference between a block's timestamp and its child's.
-* Move `finality_threshold_fraction` from the `highway` to the `core` section in the chainspec.
-* Move `max_execution_delay` from the `highway` to the `consensus` section in the `config.toml`.
 * Connections to unresponsive nodes will be terminated, based on a watchdog feature.
 
 ### Changed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -94,6 +94,7 @@ vergen = { version = "7", default-features = false, features = ["git"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
+assert_matches = "1.5.0"
 casper-types = { path = "../types", features = ["datasize", "json-schema", "std", "testing"] }
 fake_instant = "0.4.0"
 pnet = "0.28.0"

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -129,6 +129,11 @@ const OUTGOING_MANAGER_SWEEP_INTERVAL: Duration = Duration::from_secs(1);
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Maximum time for a ping until it connections are severed.
+///
+/// If you are running a network under very extreme conditions, it may make sense to alter these
+/// values, but usually these values should require no changing.
+///
+/// `PING_TIMEOUT` should be less than `PING_INTERVAL` at all times.
 const PING_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// How many pings to send before giving up and dropping the connection.

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -815,6 +815,13 @@ where
                         debug!("dropping connection, as requested");
                     })
                 }
+                DialRequest::SendPing {
+                    peer_id,
+                    nonce,
+                    span,
+                } => {
+                    todo!("handle send ping request")
+                }
             }
         }
 
@@ -1136,7 +1143,7 @@ where
             }
             (ComponentStatus::Initialized, Event::SweepOutgoing) => {
                 let now = Instant::now();
-                let requests = self.outgoing_manager.perform_housekeeping(now);
+                let requests = self.outgoing_manager.perform_housekeeping(rng, now);
 
                 let mut effects = self.process_dial_requests(requests);
 

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -736,6 +736,7 @@ where
                         addr: peer_addr,
                         handle,
                         node_id: peer_id,
+                        when: now,
                     });
 
                 let mut effects = self.process_dial_requests(request);

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -31,6 +31,7 @@ mod counting_format;
 mod error;
 mod event;
 mod gossiped_address;
+mod health;
 mod identity;
 mod insights;
 mod limiter;
@@ -87,6 +88,7 @@ use self::{
     counting_format::{ConnectionId, CountingFormat, Role},
     error::{ConnectionError, Result},
     event::{IncomingConnection, OutgoingConnection},
+    health::HealthConfig,
     limiter::Limiter,
     message::NodeKeyPair,
     metrics::Metrics,
@@ -250,10 +252,12 @@ where
                 base_timeout: BASE_RECONNECTION_TIMEOUT,
                 unblock_after: cfg.blocklist_retain_duration.into(),
                 sweep_timeout: cfg.max_addr_pending_time.into(),
-                ping_interval: PING_INTERVAL,
-                ping_timeout: PING_TIMEOUT,
-                ping_retries: PING_RETRIES,
-                pong_limit: (1 + PING_RETRIES as u32) * 2,
+                health: HealthConfig {
+                    ping_interval: PING_INTERVAL,
+                    ping_timeout: PING_TIMEOUT,
+                    ping_retries: PING_RETRIES,
+                    pong_limit: (1 + PING_RETRIES as u32) * 2,
+                },
             },
             net_metrics.create_outgoing_metrics(),
         );

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -123,6 +123,15 @@ const BASE_RECONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
 /// Interval during which to perform outgoing manager housekeeping.
 const OUTGOING_MANAGER_SWEEP_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How often to send a ping down a healthy connection.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Maximum time for a ping until it connections are severed.
+const PING_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// How many pings to send before giving up and dropping the connection.
+const PING_RETRIES: u16 = 5;
+
 #[derive(Clone, DataSize, Debug)]
 pub(crate) struct OutgoingHandle<P> {
     #[data_size(skip)] // Unfortunately, there is no way to inspect an `UnboundedSender`.
@@ -241,6 +250,10 @@ where
                 base_timeout: BASE_RECONNECTION_TIMEOUT,
                 unblock_after: cfg.blocklist_retain_duration.into(),
                 sweep_timeout: cfg.max_addr_pending_time.into(),
+                ping_interval: PING_INTERVAL,
+                ping_timeout: PING_TIMEOUT,
+                ping_retries: PING_RETRIES,
+                pong_limit: (1 + PING_RETRIES as u32) * 2,
             },
             net_metrics.create_outgoing_metrics(),
         );

--- a/node/src/components/network/blocklist.rs
+++ b/node/src/components/network/blocklist.rs
@@ -37,6 +37,8 @@ pub(crate) enum BlocklistJustification {
         /// The era for which the invalid value was destined.
         era: EraId,
     },
+    /// Too many unasked or expired pongs were sent by the peer.
+    PongLimitExceeded,
     /// Peer misbehaved during consensus and is blocked for it.
     BadConsensusBehavior,
     /// Peer is on the wrong network.
@@ -71,6 +73,9 @@ impl Display for BlocklistJustification {
             ),
             BlocklistJustification::SentInvalidConsensusValue { era } => {
                 write!(f, "sent an invalid consensus value in {}", era)
+            }
+            BlocklistJustification::PongLimitExceeded => {
+                f.write_str("wrote too many expired or invalid pongs")
             }
             BlocklistJustification::BadConsensusBehavior => {
                 f.write_str("sent invalid data in consensus")

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -1,0 +1,101 @@
+//! Health-check state machine.
+//!
+//! Health checks perform periodic pings to remote peers to ensure the connection is still alive. It
+//! has somewhat complicated logic that is encoded in the `ConnectionHealth` struct, which has
+//! multiple implicit states.
+
+use std::time::{Duration, Instant};
+
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+/// Connection health information.
+///
+/// All data related to the ping/pong functionality used to verify a peer's networking liveness.
+#[derive(Clone, Copy, DataSize, Debug)]
+pub(crate) struct ConnectionHealth {
+    /// The moment the connection was established.
+    pub(crate) connected_since: Instant,
+    /// The last ping that was requested to be sent.
+    pub(crate) last_ping_sent: Option<TaggedTimestamp>,
+    /// The most recent pong received.
+    pub(crate) last_pong_received: Option<TaggedTimestamp>,
+    /// Number of invalid pongs received, reset upon receiving a valid pong.
+    pub(crate) invalid_pong_count: u32,
+    /// Number of pings that timed out.
+    pub(crate) ping_timeouts: u32,
+}
+
+/// Health check configuration.
+#[derive(DataSize, Debug)]
+pub(crate) struct HealthConfig {
+    /// How often to send a ping to ensure a connection is established.
+    ///
+    /// The interval determines how soon after connecting or a successful ping another ping is sent.
+    pub(crate) ping_interval: Duration,
+    /// Duration during which a ping must succeed to be considered successful.
+    pub(crate) ping_timeout: Duration,
+    /// Number of attempts before giving up and disconnecting a peer due to too many failed pings.
+    pub(crate) ping_retries: u16,
+    /// How many spurious pongs to tolerate before banning a peer.
+    pub(crate) pong_limit: u32,
+}
+
+/// A timestamp with an associated nonce.
+#[derive(Clone, Copy, DataSize, Debug)]
+pub(crate) struct TaggedTimestamp {
+    /// The nonce of the timestamp.
+    pub nonce: Nonce,
+    /// The actual timestamp.
+    pub timestamp: Instant,
+}
+
+/// A number-used-once, specifically one used in pings.
+#[derive(Clone, Copy, DataSize, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct Nonce(u32);
+
+impl ConnectionHealth {
+    /// Creates a new connection health instance, recording when the connection was established.
+    pub(crate) fn new(connected_since: Instant) -> Self {
+        Self {
+            connected_since,
+            last_ping_sent: None,
+            last_pong_received: None,
+            invalid_pong_count: 0,
+            ping_timeouts: 0,
+        }
+    }
+}
+
+impl ConnectionHealth {
+    /// Calculate the round-trip time, if possible.
+    pub(crate) fn calc_rrt(&self) -> Option<Duration> {
+        match (self.last_ping_sent, self.last_pong_received) {
+            (Some(last_ping), Some(last_pong)) if last_ping.nonce == last_pong.nonce => {
+                Some(last_pong.timestamp.duration_since(last_ping.timestamp))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn check_health(&self, cfg: &HealthConfig, now: Instant) -> HealthCheckOutcome {
+        // Our honeymoon period is from first establishment of the connection until we send a ping.
+        if now.duration_since(self.connected_since) < cfg.ping_interval {
+            return HealthCheckOutcome::DoNothing;
+        }
+
+        todo!("remaining health check logic")
+    }
+}
+
+/// The outcome of periodic health check.
+#[derive(Clone, Copy, Debug)]
+
+pub(crate) enum HealthCheckOutcome {
+    /// Do nothing, as we recently took action.
+    DoNothing,
+    /// Send a ping with the given nonce.
+    SendPing(Nonce),
+    /// Give up on (i.e. terminate) the connection, as we exceeded the allowable ping limit.
+    GiveUp,
+}

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -87,7 +87,7 @@ impl TaggedTimestamp {
 //
 //       While we do check for consecutive ping nonces being generated, we still like the lower
 //       collision chance for repeated pings being sent.
-#[derive(Clone, Copy, DataSize, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, DataSize, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct Nonce(u64);
 
 impl rand::distributions::Distribution<Nonce> for rand::distributions::Standard {
@@ -393,25 +393,25 @@ mod tests {
 
         nonce_set.insert(assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce)
+            HealthCheckOutcome::SendPing(nonce) => nonce
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce)
+            HealthCheckOutcome::SendPing(nonce) => nonce
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce)
+            HealthCheckOutcome::SendPing(nonce) => nonce
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce)
+            HealthCheckOutcome::SendPing(nonce) => nonce
         ));
 
         // Since it is a set, we expect less than 4 items if there were any duplicates.

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -130,6 +130,11 @@ impl ConnectionHealth {
         cfg: &HealthConfig,
         now: Instant,
     ) -> HealthCheckOutcome {
+        // Having received too many pongs should always result in a disconnect.
+        if self.invalid_pong_count > cfg.pong_limit {
+            return HealthCheckOutcome::GiveUp;
+        }
+
         // Our honeymoon period is from first establishment of the connection until we send a ping.
         if now.duration_since(self.connected_since) < cfg.ping_interval {
             return HealthCheckOutcome::DoNothing;

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -281,9 +281,9 @@ mod tests {
 
     /// Sets up fixtures used in almost every test.
     fn fixtures() -> Fixtures {
-        let mut clock = TestClock::new();
+        let clock = TestClock::new();
         let cfg = HealthConfig::test_config();
-        let mut rng = crate::new_rng();
+        let rng = crate::new_rng();
 
         let health = ConnectionHealth::new(clock.now());
 

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -668,7 +668,7 @@ mod tests {
             mut health,
         } = fixtures();
 
-        clock.advance(Duration::from_secs(5));
+        clock.advance(Duration::from_secs(5)); // t = 5
 
         let nonce_1 = assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
@@ -676,12 +676,12 @@ mod tests {
         );
 
         // Ignore the nonce if sent in the past (and also don't crash).
-        clock.rewind(Duration::from_secs(1));
+        clock.rewind(Duration::from_secs(1)); // t = 4
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
 
         // Another ping should be sent out, since `nonce_1` was ignored.
-        clock.advance(Duration::from_secs(2));
+        clock.advance(Duration::from_secs(3)); // t = 7
         let nonce_2 = assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -765,6 +765,23 @@ mod tests {
 
     #[test]
     fn duplicate_pong_immediately_terminates() {
-        todo!()
+        let Fixtures {
+            mut clock,
+            cfg,
+            mut rng,
+            mut health,
+        } = fixtures();
+
+        clock.advance(Duration::from_secs(5));
+        let nonce_1 = assert_matches!(
+            health.update_health(&mut rng, &cfg, clock.now()),
+            HealthCheckOutcome::SendPing(nonce) => nonce
+        );
+
+        clock.advance(Duration::from_secs(1));
+
+        // Recording the pong once is fine, but the second time should result in a ban.
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
+        assert!(health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
     }
 }

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -597,13 +597,13 @@ mod tests {
 
         clock.advance(Duration::from_secs(5));
 
-        let nonce_1 = assert_matches!(
+        assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce) => nonce
+            HealthCheckOutcome::SendPing(_)
         );
 
-        // We have received `nonce_1`. Make the `ConnectionHealth` receive some unasked pongs,
-        // without exceeding the unasked pong limit.
+        // Make the `ConnectionHealth` receive some unasked pongs, without exceeding the unasked
+        // pong limit.
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
@@ -631,13 +631,13 @@ mod tests {
 
         clock.advance(Duration::from_secs(5));
 
-        let nonce_1 = assert_matches!(
+        assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
-            HealthCheckOutcome::SendPing(nonce) => nonce
+            HealthCheckOutcome::SendPing(_)
         );
 
-        // We have received `nonce_1`. Make the `ConnectionHealth` receive some unasked pongs,
-        // without exceeding the unasked pong limit.
+        // Make the `ConnectionHealth` receive some unasked pongs, without exceeding the unasked
+        // pong limit.
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -136,7 +136,7 @@ impl ConnectionHealth {
         }
 
         // Our honeymoon period is from first establishment of the connection until we send a ping.
-        if now.duration_since(self.connected_since) < cfg.ping_interval {
+        if now.saturating_duration_since(self.connected_since) < cfg.ping_interval {
             return HealthCheckOutcome::DoNothing;
         }
 
@@ -760,24 +760,24 @@ mod tests {
             mut health,
         } = fixtures();
 
-        clock.advance(Duration::from_secs(5));
+        clock.advance(Duration::from_secs(5)); // t = 5
         assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
-        clock.rewind(Duration::from_secs(3));
+        clock.rewind(Duration::from_secs(3)); // t = 2
         assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
-        clock.advance(Duration::from_secs(6));
+        clock.advance(Duration::from_secs(4)); // t = 6
         assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
-        clock.advance(Duration::from_secs(1));
+        clock.advance(Duration::from_secs(1)); // t = 7
 
         assert_matches!(
             health.update_health(&mut rng, &cfg, clock.now()),

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -4,7 +4,10 @@
 //! has somewhat complicated logic that is encoded in the `ConnectionHealth` struct, which has
 //! multiple implicit states.
 
-use std::time::{Duration, Instant};
+use std::{
+    fmt::{self, Display, Formatter},
+    time::{Duration, Instant},
+};
 
 use datasize::DataSize;
 use rand::Rng;
@@ -89,6 +92,19 @@ impl TaggedTimestamp {
 //       collision chance for repeated pings being sent.
 #[derive(Clone, Copy, DataSize, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct Nonce(u64);
+
+impl Display for Nonce {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:016X}", self.0)
+    }
+}
+
+impl Nonce {
+    /// Convert the nonce into an integer.
+    pub(crate) fn into_inner(self) -> u64 {
+        self.0
+    }
+}
 
 impl rand::distributions::Distribution<Nonce> for rand::distributions::Standard {
     #[inline(always)]

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -99,13 +99,6 @@ impl Display for Nonce {
     }
 }
 
-impl Nonce {
-    /// Convert the nonce into an integer.
-    pub(crate) fn into_inner(self) -> u64 {
-        self.0
-    }
-}
-
 impl rand::distributions::Distribution<Nonce> for rand::distributions::Standard {
     #[inline(always)]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Nonce {

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -45,15 +45,50 @@ pub(crate) struct HealthConfig {
 /// A timestamp with an associated nonce.
 #[derive(Clone, Copy, DataSize, Debug)]
 pub(crate) struct TaggedTimestamp {
-    /// The nonce of the timestamp.
-    pub nonce: Nonce,
     /// The actual timestamp.
-    pub timestamp: Instant,
+    timestamp: Instant,
+    /// The nonce of the timestamp.
+    nonce: Nonce,
+}
+
+impl TaggedTimestamp {
+    /// Creates a new tagged timestamp with a random nonce.
+    pub(crate) fn new<R: Rng>(rng: &mut R, timestamp: Instant) -> Self {
+        Self {
+            timestamp,
+            nonce: rng.gen(),
+        }
+    }
+
+    /// Creates a new tagged timestamp from parts.
+    #[cfg(test)]
+    pub(crate) fn from_parts(timestamp: Instant, nonce: Nonce) -> Self {
+        TaggedTimestamp { nonce, timestamp }
+    }
+
+    /// Returns the actual timestamp.
+    pub(crate) fn timestamp(&self) -> Instant {
+        self.timestamp
+    }
+
+    /// Returns the nonce inside the timestamp.
+    pub(crate) fn nonce(self) -> Nonce {
+        self.nonce
+    }
 }
 
 /// A number-used-once, specifically one used in pings.
+// Note: This nonce used to be a `u32`, but that is too small - since we immediately disconnect when
+//       a duplicate ping is generated, a `u32` has a ~ 1/(2^32) chance of a consecutive collision.
+//
+//       If we ping every 5 seconds, this is a ~ 0.01% chance over a month, which is too high over
+//       thousands over nodes. At 64 bits, in theory the upper bound is 0.0000000002%, which is
+//       better (the period of the RNG used should be >> 64 bits).
+//
+//       While we do check for consecutive ping nonces being generated, we still like the lower
+//       collision chance for repeated pings being sent.
 #[derive(Clone, Copy, DataSize, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub(crate) struct Nonce(u32);
+pub(crate) struct Nonce(u64);
 
 impl rand::distributions::Distribution<Nonce> for rand::distributions::Standard {
     #[inline(always)]
@@ -86,7 +121,10 @@ impl ConnectionHealth {
         }
     }
 
-    pub(crate) fn check_health<R: Rng>(
+    /// Check current health status.
+    ///
+    /// This function must be polled periodically and returns a potential action to be performed.
+    pub(crate) fn update_health<R: Rng>(
         &mut self,
         rng: &mut R,
         cfg: &HealthConfig,
@@ -97,14 +135,88 @@ impl ConnectionHealth {
             return HealthCheckOutcome::DoNothing;
         }
 
-        todo!("remaining health check logic")
+        let send_ping = match self.last_ping_sent {
+            Some(last_ping) => {
+                let next_ping = match self.last_pong_received {
+                    Some(prev_pong) if prev_pong.nonce() == last_ping.nonce() => {
+                        // Normal operation. The next ping should be sent in a regular interval
+                        // after receiving the last pong.
+                        prev_pong.timestamp() + cfg.ping_interval
+                    }
+
+                    _ => {
+                        // We have either never received a pong, or the one received does not match
+                        // the outstanding ping.
+                        last_ping.timestamp() + cfg.ping_timeout
+                    }
+                };
+
+                now >= next_ping
+            }
+            None => true,
+        };
+
+        if send_ping {
+            let ping = loop {
+                let candidate = TaggedTimestamp::new(rng, now);
+
+                if let Some(prev) = self.last_ping_sent {
+                    if prev.nonce() == candidate.nonce() {
+                        // Ensure we don't produce consecutive pings.
+                        continue;
+                    }
+                }
+
+                break candidate;
+            };
+
+            self.last_ping_sent = Some(ping);
+            HealthCheckOutcome::SendPing(ping.nonce())
+        } else {
+            HealthCheckOutcome::DoNothing
+        }
     }
 
     /// Records a pong that has been sent.
     ///
     /// If `true`, the maximum number of pongs has been exceeded and the peer should be banned.
-    pub(crate) fn record_pong(&mut self, cfg: &HealthConfig, now: Instant, nonce: Nonce) -> bool {
-        todo!()
+    pub(crate) fn record_pong(&mut self, cfg: &HealthConfig, tt: TaggedTimestamp) -> bool {
+        let is_valid_pong = match self.last_ping_sent {
+            Some(last_ping) if last_ping.nonce() == tt.nonce => {
+                // Check if we already received a pong for this ping, which is a protocol violation.
+                if self
+                    .last_pong_received
+                    .map(|existing| existing.nonce() == tt.nonce)
+                    .unwrap_or(false)
+                {
+                    // Ping is a collsion, ban.
+                    return true;
+                }
+
+                if last_ping.timestamp() > tt.timestamp() {
+                    // Ping is from the past somehow, ignore it (probably a bug on our side).
+                    return false;
+                }
+
+                // The ping is valid if it is within the timeout period.
+                last_ping.timestamp() + cfg.ping_timeout >= tt.timestamp()
+            }
+            _ => {
+                // Either the nonce did not match, or the nonce mismatched.
+                false
+            }
+        };
+
+        if is_valid_pong {
+            // Our pong is valid, reset invalid count and record it.
+            self.invalid_pong_count = 0;
+            self.last_pong_received = Some(tt);
+            false
+        } else {
+            self.invalid_pong_count += 1;
+            // If we have exceeded the invalid pong limit, ban.
+            self.invalid_pong_count > cfg.pong_limit
+        }
     }
 }
 
@@ -128,7 +240,10 @@ mod tests {
     use rand::Rng;
 
     use super::{ConnectionHealth, HealthCheckOutcome, HealthConfig};
-    use crate::{testing::test_clock::TestClock, types::NodeRng};
+    use crate::{
+        components::network::health::TaggedTimestamp, testing::test_clock::TestClock,
+        types::NodeRng,
+    };
 
     impl HealthConfig {
         pub(crate) fn test_config() -> Self {
@@ -175,17 +290,17 @@ mod tests {
         } = fixtures();
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
         // Repeated checks should not change the outcome.
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
@@ -193,7 +308,7 @@ mod tests {
         clock.advance(Duration::from_millis(4900));
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
@@ -201,26 +316,26 @@ mod tests {
         clock.advance(Duration::from_millis(100));
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         // Checking health again should not result in another ping.
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
         clock.advance(Duration::from_millis(100));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
         // After two seconds, we expect another ping to be sent, due to timeouts.
         clock.advance(Duration::from_millis(2000));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
@@ -228,20 +343,20 @@ mod tests {
         // of five pings is expected.
         clock.advance(Duration::from_millis(2000));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         clock.advance(Duration::from_millis(2000));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         // Finally, without receiving a ping at all, we give up.
         clock.advance(Duration::from_millis(2000));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::GiveUp
         );
     }
@@ -256,7 +371,7 @@ mod tests {
         } = fixtures();
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
         clock.advance(Duration::from_secs(5));
@@ -264,25 +379,25 @@ mod tests {
         let mut nonce_set = HashSet::new();
 
         nonce_set.insert(assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce)
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce)
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce)
         ));
         clock.advance(Duration::from_secs(2));
 
         nonce_set.insert(assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce)
         ));
 
@@ -300,7 +415,7 @@ mod tests {
         } = fixtures();
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
@@ -308,34 +423,34 @@ mod tests {
         clock.advance(Duration::from_secs(5));
 
         let nonce_1 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // Record a reply 500 ms later.
         clock.advance(Duration::from_millis(500));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_1));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
 
         // Our next pong should be 5 seconds later, not 4.5.
         clock.advance(Duration::from_millis(4500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
         clock.advance(Duration::from_millis(500));
 
         let nonce_2 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // We test an edge case here where we use the same timestamp for the received pong.
         clock.advance(Duration::from_millis(500));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_2));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_2)));
 
         // Afterwards, no ping should be sent.
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
@@ -343,19 +458,19 @@ mod tests {
         for _ in 0..1000 {
             clock.advance(Duration::from_millis(5000));
             let nonce = assert_matches!(
-                health.check_health(&mut rng, &cfg, clock.now()),
+                health.update_health(&mut rng, &cfg, clock.now()),
                 HealthCheckOutcome::SendPing(nonce) => nonce
             );
             assert_matches!(
-                health.check_health(&mut rng, &cfg, clock.now()),
+                health.update_health(&mut rng, &cfg, clock.now()),
                 HealthCheckOutcome::DoNothing
             );
 
             clock.advance(Duration::from_millis(250));
-            assert!(!health.record_pong(&cfg, clock.now(), nonce));
+            assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce)));
 
             assert_matches!(
-                health.check_health(&mut rng, &cfg, clock.now()),
+                health.update_health(&mut rng, &cfg, clock.now()),
                 HealthCheckOutcome::DoNothing
             );
         }
@@ -374,69 +489,69 @@ mod tests {
         clock.advance(Duration::from_secs(5));
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         clock.advance(Duration::from_secs(2));
 
         let nonce_1 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         clock.advance(Duration::from_secs(1));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_1));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
 
         // We successfully "recovered", this should reset our ping counts. Miss three pings before
         // successfully receiving a pong from 4th from here on out.
         clock.advance(Duration::from_millis(5500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         let nonce_2 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
         clock.advance(Duration::from_millis(500));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_2));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_2)));
 
         // This again should reset. We miss four more pings and are disconnected.
         clock.advance(Duration::from_millis(5500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
         clock.advance(Duration::from_millis(2500));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::GiveUp
         );
     }
@@ -453,24 +568,24 @@ mod tests {
         clock.advance(Duration::from_secs(5));
 
         let nonce_1 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // We have received `nonce_1`. Make the `ConnectionHealth` receive some unasked pongs,
         // without exceeding the unasked pong limit.
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
 
         // The retry delay is 2 seconds (instead of 5 for the next pong after success), so ensure
         // we retry due to not having received the correct nonce in the pong.
 
         clock.advance(Duration::from_secs(2));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
     }
@@ -487,31 +602,31 @@ mod tests {
         clock.advance(Duration::from_secs(5));
 
         let nonce_1 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // We have received `nonce_1`. Make the `ConnectionHealth` receive some unasked pongs,
         // without exceeding the unasked pong limit.
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         // 6 unasked pongs is still okay.
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
-        assert!(health.record_pong(&cfg, clock.now(), rng.gen()));
+        assert!(health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
         // 7 is too much.
 
         // For good measure, we expect the health check to also output a disconnect instruction.
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::GiveUp
         );
     }
@@ -534,25 +649,25 @@ mod tests {
         clock.advance(Duration::from_secs(5));
 
         let nonce_1 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // Ignore the nonce if sent in the past (and also don't crash).
         clock.rewind(Duration::from_secs(1));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_1));
-        assert!(!health.record_pong(&cfg, clock.now(), rng.gen()));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_1)));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), rng.gen())));
 
         // Another ping should be sent out, since `nonce_1` was ignored.
         clock.advance(Duration::from_secs(2));
         let nonce_2 = assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(nonce) => nonce
         );
 
         // Nonce 2 will be received seemingly before the connection was even established.
         clock.rewind(Duration::from_secs(3600));
-        assert!(!health.record_pong(&cfg, clock.now(), nonce_2));
+        assert!(!health.record_pong(&cfg, TaggedTimestamp::from_parts(clock.now(), nonce_2)));
     }
 
     #[test]
@@ -569,7 +684,7 @@ mod tests {
         // We initially exceed our scheduled first ping by 10 seconds. This will cause the ping to
         // be sent right there and then.
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
@@ -577,7 +692,7 @@ mod tests {
         clock.advance(Duration::from_secs(1));
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
@@ -585,28 +700,28 @@ mod tests {
         // send another once.
         clock.advance(Duration::from_secs(1));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         // We have missed two pings total, now wait an hour. This will trigger the third ping.
         clock.advance(Duration::from_secs(3600));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         // Fourth right after
         clock.advance(Duration::from_secs(2));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         // Followed by a disconnect.
         clock.advance(Duration::from_secs(2));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::GiveUp
         );
     }
@@ -625,26 +740,31 @@ mod tests {
 
         clock.advance(Duration::from_secs(5));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
 
         clock.rewind(Duration::from_secs(3));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
 
         clock.advance(Duration::from_secs(6));
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::DoNothing
         );
         clock.advance(Duration::from_secs(1));
 
         assert_matches!(
-            health.check_health(&mut rng, &cfg, clock.now()),
+            health.update_health(&mut rng, &cfg, clock.now()),
             HealthCheckOutcome::SendPing(_)
         );
+    }
+
+    #[test]
+    fn duplicate_pong_immediately_terminates() {
+        todo!()
     }
 }

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -64,7 +64,6 @@ impl TaggedTimestamp {
     }
 
     /// Creates a new tagged timestamp from parts.
-    #[cfg(test)]
     pub(crate) fn from_parts(timestamp: Instant, nonce: Nonce) -> Self {
         TaggedTimestamp { nonce, timestamp }
     }

--- a/node/src/components/network/health.rs
+++ b/node/src/components/network/health.rs
@@ -35,7 +35,7 @@ pub(crate) struct ConnectionHealth {
 pub(crate) struct HealthConfig {
     /// How often to send a ping to ensure a connection is established.
     ///
-    /// The interval determines how soon after connecting or a successful ping another ping is sent.
+    /// Determines how soon after connecting or a successful ping another ping is sent.
     pub(crate) ping_interval: Duration,
     /// Duration during which a ping must succeed to be considered successful.
     pub(crate) ping_timeout: Duration,

--- a/node/src/components/network/insights.rs
+++ b/node/src/components/network/insights.rs
@@ -179,13 +179,15 @@ impl OutgoingStateInsight {
             } => {
                 let rtt_ms = rtt.map(|duration| duration.as_millis());
 
-                // TODO: Display last ping/pong and invalid pong count in a concise, but meaningful manner.
                 write!(
                     f,
-                    "connected -> {} @ {} (rtt {})",
+                    "connected -> {} @ {} (rtt {}, invalid {}, last ping/pong {}/{})",
                     peer_id,
                     peer_addr,
-                    OptDisplay::new(rtt_ms, "?")
+                    OptDisplay::new(rtt_ms, "?"),
+                    invalid_pong_count,
+                    OptDisplay::new(last_ping_sent.map(|t| time_delta(now, t)), "-"),
+                    OptDisplay::new(last_pong_received.map(|t| time_delta(now, t)), "-"),
                 )
             }
             OutgoingStateInsight::Blocked {

--- a/node/src/components/network/insights.rs
+++ b/node/src/components/network/insights.rs
@@ -122,27 +122,17 @@ impl OutgoingStateInsight {
             OutgoingState::Connected {
                 peer_id,
                 handle,
-                last_ping_sent,
-                last_pong_received,
-                invalid_pong_count,
-            } => {
-                // If we have matching ping/pongs stored, we can calculate a round-trip time.
-                let rtt = match (last_ping_sent, last_pong_received) {
-                    (Some(last_ping), Some(last_pong)) if last_ping.nonce == last_pong.nonce => {
-                        Some(last_pong.timestamp.duration_since(last_ping.timestamp))
-                    }
-                    _ => None,
-                };
-
-                OutgoingStateInsight::Connected {
-                    peer_id: *peer_id,
-                    peer_addr: handle.peer_addr,
-                    last_ping_sent: last_ping_sent.map(|tt| anchor.convert(tt.timestamp)),
-                    last_pong_received: last_pong_received.map(|tt| anchor.convert(tt.timestamp)),
-                    invalid_pong_count: *invalid_pong_count,
-                    rtt,
-                }
-            }
+                health,
+            } => OutgoingStateInsight::Connected {
+                peer_id: *peer_id,
+                peer_addr: handle.peer_addr,
+                last_ping_sent: health.last_ping_sent.map(|tt| anchor.convert(tt.timestamp)),
+                last_pong_received: health
+                    .last_pong_received
+                    .map(|tt| anchor.convert(tt.timestamp)),
+                invalid_pong_count: health.invalid_pong_count,
+                rtt: health.calc_rrt(),
+            },
             OutgoingState::Blocked {
                 since,
                 justification,

--- a/node/src/components/network/insights.rs
+++ b/node/src/components/network/insights.rs
@@ -126,10 +126,12 @@ impl OutgoingStateInsight {
             } => OutgoingStateInsight::Connected {
                 peer_id: *peer_id,
                 peer_addr: handle.peer_addr,
-                last_ping_sent: health.last_ping_sent.map(|tt| anchor.convert(tt.timestamp)),
+                last_ping_sent: health
+                    .last_ping_sent
+                    .map(|tt| anchor.convert(tt.timestamp())),
                 last_pong_received: health
                     .last_pong_received
-                    .map(|tt| anchor.convert(tt.timestamp)),
+                    .map(|tt| anchor.convert(tt.timestamp())),
                 invalid_pong_count: health.invalid_pong_count,
                 rtt: health.calc_rrt(),
             },

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -606,25 +606,23 @@ mod tests {
 
         let modern_handshake: Message<protocol::Message> = roundtrip_message(&legacy_handshake);
 
-        match modern_handshake {
-            Message::Handshake {
-                network_name,
-                public_addr,
-                protocol_version,
-                consensus_certificate,
-                is_syncing,
-                chainspec_hash,
-            } => {
-                assert_eq!(network_name, "example-handshake");
-                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
-                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
-                assert!(consensus_certificate.is_none());
-                assert!(!is_syncing);
-                assert!(chainspec_hash.is_none())
-            }
-            Message::Payload(_) | Message::Ping { .. } | Message::Pong { .. } => {
-                panic!("did not expect modern handshake to deserialize to anything but")
-            }
+        if let Message::Handshake {
+            network_name,
+            public_addr,
+            protocol_version,
+            consensus_certificate,
+            is_syncing,
+            chainspec_hash,
+        } = modern_handshake
+        {
+            assert_eq!(network_name, "example-handshake");
+            assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
+            assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            assert!(consensus_certificate.is_none());
+            assert!(!is_syncing);
+            assert!(chainspec_hash.is_none())
+        } else {
+            panic!("did not expect modern handshake to deserialize to anything but")
         }
     }
 
@@ -632,26 +630,24 @@ mod tests {
     fn current_handshake_decodes_from_historic_v1_0_0() {
         let modern_handshake: Message<protocol::Message> = deserialize_message(V1_0_0_HANDSHAKE);
 
-        match modern_handshake {
-            Message::Handshake {
-                network_name,
-                public_addr,
-                protocol_version,
-                consensus_certificate,
-                is_syncing,
-                chainspec_hash,
-            } => {
-                assert!(!is_syncing);
-                assert_eq!(network_name, "serialization-test");
-                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
-                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
-                assert!(consensus_certificate.is_none());
-                assert!(!is_syncing);
-                assert!(chainspec_hash.is_none())
-            }
-            Message::Payload(_) | Message::Ping { .. } | Message::Pong { .. } => {
-                panic!("did not expect modern handshake to deserialize to anything but")
-            }
+        if let Message::Handshake {
+            network_name,
+            public_addr,
+            protocol_version,
+            consensus_certificate,
+            is_syncing,
+            chainspec_hash,
+        } = modern_handshake
+        {
+            assert!(!is_syncing);
+            assert_eq!(network_name, "serialization-test");
+            assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
+            assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            assert!(consensus_certificate.is_none());
+            assert!(!is_syncing);
+            assert!(chainspec_hash.is_none())
+        } else {
+            panic!("did not expect modern handshake to deserialize to anything but")
         }
     }
 
@@ -659,45 +655,43 @@ mod tests {
     fn current_handshake_decodes_from_historic_v1_4_2() {
         let modern_handshake: Message<protocol::Message> = deserialize_message(V1_4_2_HANDSHAKE);
 
-        match modern_handshake {
-            Message::Handshake {
-                network_name,
-                public_addr,
-                protocol_version,
-                consensus_certificate,
-                is_syncing,
-                chainspec_hash,
-            } => {
-                assert_eq!(network_name, "example-handshake");
-                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
-                assert_eq!(protocol_version, ProtocolVersion::from_parts(1, 4, 2));
-                assert!(!is_syncing);
-                let ConsensusCertificate {
-                    public_key,
-                    signature,
-                } = consensus_certificate.unwrap();
+        if let Message::Handshake {
+            network_name,
+            public_addr,
+            protocol_version,
+            consensus_certificate,
+            is_syncing,
+            chainspec_hash,
+        } = modern_handshake
+        {
+            assert_eq!(network_name, "example-handshake");
+            assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
+            assert_eq!(protocol_version, ProtocolVersion::from_parts(1, 4, 2));
+            assert!(!is_syncing);
+            let ConsensusCertificate {
+                public_key,
+                signature,
+            } = consensus_certificate.unwrap();
 
-                assert_eq!(
-                    public_key,
-                    PublicKey::from_hex(
-                        "020283c0d687933eb20a541c8540478877861ede4affaf04a68ea194b7a40046424e"
-                    )
-                    .unwrap()
-                );
-                assert_eq!(
-                    signature,
-                    Signature::from_hex(
-                        "02cdfa333c18893d9f36035a3b7702348acff0fd5a2ae9cbc0e48e59dd085581a6015\
+            assert_eq!(
+                public_key,
+                PublicKey::from_hex(
+                    "020283c0d687933eb20a541c8540478877861ede4affaf04a68ea194b7a40046424e"
+                )
+                .unwrap()
+            );
+            assert_eq!(
+                signature,
+                Signature::from_hex(
+                    "02cdfa333c18893d9f36035a3b7702348acff0fd5a2ae9cbc0e48e59dd085581a6015\
                         9b7fccc54dd0fa9443d2e3573378d61ea16e659d16d0009a40b7750bcceae"
-                    )
-                    .unwrap()
-                );
-                assert!(!is_syncing);
-                assert!(chainspec_hash.is_none())
-            }
-            Message::Payload(_) | Message::Ping { .. } | Message::Pong { .. } => {
-                panic!("did not expect modern handshake to deserialize to anything but")
-            }
+                )
+                .unwrap()
+            );
+            assert!(!is_syncing);
+            assert!(chainspec_hash.is_none())
+        } else {
+            panic!("did not expect modern handshake to deserialize to anything but")
         }
     }
 
@@ -705,45 +699,43 @@ mod tests {
     fn current_handshake_decodes_from_historic_v1_4_3() {
         let modern_handshake: Message<protocol::Message> = deserialize_message(V1_4_3_HANDSHAKE);
 
-        match modern_handshake {
-            Message::Handshake {
-                network_name,
-                public_addr,
-                protocol_version,
-                consensus_certificate,
-                is_syncing,
-                chainspec_hash,
-            } => {
-                assert!(!is_syncing);
-                assert_eq!(network_name, "example-handshake");
-                assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
-                assert_eq!(protocol_version, ProtocolVersion::from_parts(1, 4, 3));
-                let ConsensusCertificate {
-                    public_key,
-                    signature,
-                } = consensus_certificate.unwrap();
+        if let Message::Handshake {
+            network_name,
+            public_addr,
+            protocol_version,
+            consensus_certificate,
+            is_syncing,
+            chainspec_hash,
+        } = modern_handshake
+        {
+            assert!(!is_syncing);
+            assert_eq!(network_name, "example-handshake");
+            assert_eq!(public_addr, ([12, 34, 56, 78], 12346).into());
+            assert_eq!(protocol_version, ProtocolVersion::from_parts(1, 4, 3));
+            let ConsensusCertificate {
+                public_key,
+                signature,
+            } = consensus_certificate.unwrap();
 
-                assert_eq!(
-                    public_key,
-                    PublicKey::from_hex(
-                        "020331efbf7cc3381515a7229f9c3e797030228caa189fb2a1028ade04e2970f74c5"
-                    )
-                    .unwrap()
-                );
-                assert_eq!(
-                    signature,
-                    Signature::from_hex(
-                        "027664866794bacce441392f432dba2de67da3ba785e59c9480f126794ed78b8e5299\
+            assert_eq!(
+                public_key,
+                PublicKey::from_hex(
+                    "020331efbf7cc3381515a7229f9c3e797030228caa189fb2a1028ade04e2970f74c5"
+                )
+                .unwrap()
+            );
+            assert_eq!(
+                signature,
+                Signature::from_hex(
+                    "027664866794bacce441392f432dba2de67da3ba785e59c9480f126794ed78b8e5299\
                         9761c08158285580b4a67b7e343c228133c41d4250bf79d786d7c199ca977"
-                    )
-                    .unwrap()
-                );
-                assert!(!is_syncing);
-                assert!(chainspec_hash.is_none())
-            }
-            Message::Payload(_) | Message::Ping { .. } | Message::Pong { .. } => {
-                panic!("did not expect modern handshake to deserialize to anything but")
-            }
+                )
+                .unwrap()
+            );
+            assert!(!is_syncing);
+            assert!(chainspec_hash.is_none())
+        } else {
+            panic!("did not expect modern handshake to deserialize to anything but")
         }
     }
 

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -945,12 +945,7 @@ mod tests {
             base_timeout: Duration::from_secs(1),
             unblock_after: Duration::from_secs(60),
             sweep_timeout: Duration::from_secs(45),
-            health: HealthConfig {
-                ping_interval: Duration::from_secs(5),
-                ping_timeout: Duration::from_secs(2),
-                ping_retries: 3,
-                pong_limit: 6,
-            },
+            health: HealthConfig::test_config(),
         }
     }
 

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -1681,23 +1681,20 @@ mod tests {
         let mut rng = crate::new_rng();
         let mut clock = TestClock::new();
 
-        let addr_a: SocketAddr = "1.2.3.4:1234".parse().unwrap();
-        let id_a = NodeId::random(&mut rng);
+        let addr: SocketAddr = "1.2.3.4:1234".parse().unwrap();
+        let id = NodeId::random(&mut rng);
 
         // Setup a connection and put it into the connected state.
         let mut manager = OutgoingManager::<u32, TestDialerError>::new(test_config());
 
         // Trigger a new connection via learning an address.
-        assert!(dials(
-            addr_a,
-            &manager.learn_addr(addr_a, false, clock.now())
-        ));
+        assert!(dials(addr, &manager.learn_addr(addr, false, clock.now())));
 
         assert!(manager
             .handle_dial_outcome(DialOutcome::Successful {
-                addr: addr_a,
+                addr: addr,
                 handle: 1,
-                node_id: id_a,
+                node_id: id,
                 when: clock.now(),
             })
             .is_none());
@@ -1721,6 +1718,7 @@ mod tests {
                     .as_slice(),
                 &[DialRequest::SendPing { nonce, peer_id, ..  }] => (nonce, peer_id)
             );
+            assert_eq!(peer_id, id);
 
             // After a second, nothing should have changed.
             assert!(manager
@@ -1739,7 +1737,7 @@ mod tests {
             );
 
             // Ensure the ID is correct.
-            assert_eq!(peer_id, id_a);
+            assert_eq!(peer_id, id);
 
             // Pong arrives 1 second later.
             clock.advance(Duration::from_secs(1));
@@ -1792,7 +1790,7 @@ mod tests {
             &[DialRequest::Disconnect { .. }, DialRequest::Dial { addr, .. }] => addr
         );
 
-        assert_eq!(dial_addr, addr_a);
+        assert_eq!(dial_addr, addr);
     }
 
     #[test]

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -206,6 +206,8 @@ pub enum DialOutcome<H, E> {
         handle: H,
         /// The remote peer's authenticated node ID.
         node_id: NodeId,
+        /// The moment the connection was established.
+        when: Instant,
     },
     /// The connection attempt failed.
     Failed {
@@ -796,7 +798,7 @@ where
                 addr,
                 handle,
                 node_id,
-                ..
+                when
             } => {
                 info!("established outgoing connection");
 
@@ -815,7 +817,7 @@ where
                         OutgoingState::Connected {
                             peer_id: node_id,
                             handle,
-                            health: todo!("update `Successful` to carry timestamp and instantiate health here")
+                            health: ConnectionHealth::new(when),
                         },
                     );
                     None
@@ -1033,6 +1035,7 @@ mod tests {
                 addr: addr_a,
                 handle: 99,
                 node_id: id_a,
+                when: clock.now(),
             },)
             .is_none());
         assert_eq!(manager.metrics().out_state_connecting.get(), 0);
@@ -1242,6 +1245,7 @@ mod tests {
                 addr: addr_b,
                 handle: 101,
                 node_id: id_b,
+                when: clock.now(),
             },)
             .is_none());
         assert_eq!(manager.get_route(id_b), Some(&101));
@@ -1283,6 +1287,7 @@ mod tests {
                 addr: addr_c,
                 handle: 42,
                 node_id: id_c,
+                when: clock.now(),
             },)
         ));
 
@@ -1308,6 +1313,7 @@ mod tests {
                 addr: addr_b,
                 handle: 77,
                 node_id: id_b,
+                when: clock.now(),
             },)
             .is_none());
         assert!(manager
@@ -1315,6 +1321,7 @@ mod tests {
                 addr: addr_a,
                 handle: 66,
                 node_id: id_a,
+                when: clock.now(),
             },)
             .is_none());
 
@@ -1388,11 +1395,13 @@ mod tests {
             addr: addr_a,
             handle: 22,
             node_id: id_a,
+            when: clock.now(),
         });
         manager.handle_dial_outcome(DialOutcome::Successful {
             addr: addr_b,
             handle: 33,
             node_id: id_b,
+            when: clock.now(),
         });
 
         let mut peer_ids: Vec<_> = manager.connected_peers().collect();
@@ -1440,6 +1449,7 @@ mod tests {
                 addr: addr_a,
                 handle: 2,
                 node_id: id_a,
+                when: clock.now(),
             })
             .is_none());
 
@@ -1453,6 +1463,7 @@ mod tests {
                 addr: addr_a,
                 handle: 1,
                 node_id: id_a,
+                when: clock.now(),
             })
             .is_none());
 

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -104,12 +104,13 @@ use std::{
 use datasize::DataSize;
 
 use prometheus::IntGauge;
-use tracing::{debug, error_span, field::Empty, info, trace, warn, Span};
+use rand::Rng;
+use tracing::{debug, error, error_span, field::Empty, info, trace, warn, Span};
 
 use super::{
     blocklist::BlocklistJustification,
     display_error,
-    health::{ConnectionHealth, HealthConfig},
+    health::{ConnectionHealth, HealthCheckOutcome, HealthConfig, Nonce},
     NodeId,
 };
 
@@ -251,8 +252,17 @@ pub(crate) enum DialRequest<H> {
 
     /// Disconnects a potentially existing connection.
     ///
-    /// Used when a peer has been blocked or should be disconnected for other reasons.
+    /// Used when a peer has been blocked or should be disconnected for other reasons. Note that
+    /// this request can immediately be followed by a connection request, as in the case of a ping
+    /// timeout.
     Disconnect { handle: H, span: Span },
+
+    /// Send a ping to a peer.
+    SendPing {
+        peer_id: NodeId,
+        nonce: Nonce,
+        span: Span,
+    },
 }
 
 impl<H> Display for DialRequest<H>
@@ -266,6 +276,9 @@ where
             }
             DialRequest::Disconnect { handle, .. } => {
                 write!(f, "disconnect: {}", handle)
+            }
+            DialRequest::SendPing { peer_id, nonce, .. } => {
+                write!(f, "ping[{}]: {}", nonce, peer_id)
             }
         }
     }
@@ -423,11 +436,13 @@ where
     ///
     /// Will trigger an update of the routing table if necessary. Does not emit any other
     /// side-effects.
+    ///
+    /// Returns the new state, as well as any residual handle.
     fn change_outgoing_state(
         &mut self,
         addr: SocketAddr,
         mut new_state: OutgoingState<H, E>,
-    ) -> &mut Outgoing<H, E> {
+    ) -> (&mut Outgoing<H, E>, Option<H>) {
         let (prev_state, new_outgoing) = match self.outgoing.entry(addr) {
             Entry::Vacant(vacant) => {
                 let inserted = vacant.insert(Outgoing {
@@ -493,7 +508,14 @@ where
             OutgoingState::Waiting { .. } => self.metrics.out_state_waiting.inc(),
         }
 
-        new_outgoing
+        // Finally, deconstruct the previous state in case we need to preserve the handle.
+        let handle = if let Some(OutgoingState::Connected { handle, .. }) = prev_state {
+            Some(handle)
+        } else {
+            None
+        };
+
+        (new_outgoing, handle)
     }
 
     /// Retrieves the address by peer.
@@ -541,7 +563,7 @@ where
                 }
                 Entry::Vacant(_vacant) => {
                     info!("connecting to newly learned address");
-                    let outgoing = self.change_outgoing_state(
+                    let (outgoing, _) = self.change_outgoing_state(
                         addr,
                         OutgoingState::Connecting {
                             failures_so_far: 0,
@@ -663,15 +685,22 @@ where
     /// Performs housekeeping like reconnection or unblocking peers.
     ///
     /// This function must periodically be called. A good interval is every second.
-    pub(super) fn perform_housekeeping(&mut self, now: Instant) -> Vec<DialRequest<H>> {
+    pub(super) fn perform_housekeeping<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        now: Instant,
+    ) -> Vec<DialRequest<H>> {
         let mut to_forget = Vec::new();
         let mut to_fail = Vec::new();
+        let mut to_ping_timeout = Vec::new();
         let mut to_reconnect = Vec::new();
+        let mut to_ping = Vec::new();
 
-        for (&addr, outgoing) in self.outgoing.iter() {
-            let span = make_span(addr, Some(outgoing));
+        for (&addr, outgoing) in self.outgoing.iter_mut() {
+            // Note: `Span::in_scope` is no longer serviceable here due to borrow limitations.
+            let _span_guard = make_span(addr, Some(outgoing)).entered();
 
-            span.in_scope(|| match outgoing.state {
+            match outgoing.state {
                 // Decide whether to attempt reconnecting a failed-waiting address.
                 OutgoingState::Waiting {
                     failures_so_far,
@@ -727,18 +756,31 @@ where
                 }
                 OutgoingState::Connected {
                     peer_id,
-                    ref health,
+                    ref mut health,
                     ..
                 } => {
-                    // Check if we need to send a ping, or need to give up sending a ping and
-                    // disconnect.
-                    // TODO.
+                    // Check if we need to send a ping, or give up and disconnect.
+                    let health_outcome = health.update_health(rng, &self.config.health, now);
+
+                    match health_outcome {
+                        HealthCheckOutcome::DoNothing => {
+                            // Nothing to do.
+                        }
+                        HealthCheckOutcome::SendPing(nonce) => {
+                            debug!(nonce = nonce.into_inner(), "sending ping");
+                            to_ping.push((peer_id, addr, nonce));
+                        }
+                        HealthCheckOutcome::GiveUp => {
+                            info!("disconnecting after ping retries were exhausted");
+                            to_ping_timeout.push(addr);
+                        }
+                    }
                 }
                 OutgoingState::Loopback => {
                     // Entry is ignored. Not outputting any `trace` because this is log spam even at
                     // the `trace` level.
                 }
-            });
+            }
         }
 
         // Remove all addresses marked for forgetting.
@@ -762,25 +804,61 @@ where
             });
         });
 
-        // Reconnect all others.
-        to_reconnect
-            .into_iter()
-            .map(|(addr, failures_so_far)| {
-                let span = make_span(addr, self.outgoing.get(&addr));
+        let mut dial_requests = Vec::new();
 
-                span.clone().in_scope(|| {
-                    self.change_outgoing_state(
-                        addr,
-                        OutgoingState::Connecting {
-                            failures_so_far,
-                            since: now,
-                        },
-                    )
+        // Request disconnection from failed pings.
+        for addr in to_ping_timeout {
+            let span = make_span(addr, self.outgoing.get(&addr));
+
+            let (_, opt_handle) = span.clone().in_scope(|| {
+                self.change_outgoing_state(
+                    addr,
+                    OutgoingState::Connecting {
+                        failures_so_far: 0,
+                        since: now,
+                    },
+                )
+            });
+
+            if let Some(handle) = opt_handle {
+                dial_requests.push(DialRequest::Disconnect {
+                    handle,
+                    span: span.clone(),
                 });
+            } else {
+                error!("did not expect connection under ping timeout to not have a residual connection handle. this is a bug");
+            }
+            dial_requests.push(DialRequest::Dial { addr, span });
+        }
 
-                DialRequest::Dial { addr, span }
-            })
-            .collect()
+        // Reconnect others.
+        dial_requests.extend(to_reconnect.into_iter().map(|(addr, failures_so_far)| {
+            let span = make_span(addr, self.outgoing.get(&addr));
+
+            span.clone().in_scope(|| {
+                self.change_outgoing_state(
+                    addr,
+                    OutgoingState::Connecting {
+                        failures_so_far,
+                        since: now,
+                    },
+                )
+            });
+
+            DialRequest::Dial { addr, span }
+        }));
+
+        // Finally, schedule pings.
+        dial_requests.extend(to_ping.into_iter().map(|(peer_id, addr, nonce)| {
+            let span = make_span(addr, self.outgoing.get(&addr));
+            DialRequest::SendPing {
+                peer_id,
+                nonce,
+                span,
+            }
+        }));
+
+        dial_requests
     }
 
     /// Handles the outcome of a dialing attempt.
@@ -1018,14 +1096,25 @@ mod tests {
         assert_eq!(manager.metrics().out_state_waiting.get(), 1);
 
         // Performing housekeeping multiple times should not make a difference.
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Advancing the clock will trigger a reconnection on the next housekeeping.
         clock.advance_time(2_000);
-        assert!(dials(addr_a, &manager.perform_housekeeping(clock.now())));
+        assert!(dials(
+            addr_a,
+            &manager.perform_housekeeping(&mut rng, clock.now())
+        ));
         assert_eq!(manager.metrics().out_state_connecting.get(), 1);
         assert_eq!(manager.metrics().out_state_waiting.get(), 0);
 
@@ -1046,7 +1135,9 @@ mod tests {
         assert_eq!(manager.get_addr(id_a), Some(addr_a));
 
         // Time passes, and our connection drops. Reconnecting should be immediate.
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
         clock.advance_time(20_000);
         assert!(dials(
             addr_a,
@@ -1060,13 +1151,16 @@ mod tests {
         assert!(manager.get_addr(id_a).is_none());
 
         // Reconnection is already in progress, so we do not expect another request on housekeeping.
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
     }
 
     #[test]
     fn connections_forgotten_after_too_many_tries() {
         init_logging();
 
+        let mut rng = crate::new_rng();
         let mut clock = TestClock::new();
 
         let addr_a: SocketAddr = "1.2.3.4:1234".parse().unwrap();
@@ -1105,17 +1199,21 @@ mod tests {
         assert!(manager.learn_addr(addr_a, false, clock.now()).is_none());
         assert!(manager.learn_addr(addr_b, false, clock.now()).is_none());
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
         assert!(manager.learn_addr(addr_a, false, clock.now()).is_none());
         assert!(manager.learn_addr(addr_b, false, clock.now()).is_none());
 
         // After 1.999 seconds, reconnection should still be delayed.
         clock.advance_time(1_999);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Adding 0.001 seconds finally is enough to reconnect.
         clock.advance_time(1);
-        let requests = manager.perform_housekeeping(clock.now());
+        let requests = manager.perform_housekeeping(&mut rng, clock.now());
         assert!(dials(addr_a, &requests));
         assert!(dials(addr_b, &requests));
 
@@ -1123,7 +1221,9 @@ mod tests {
         // anything, as  we are currently connecting.
         clock.advance_time(6_000);
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Fail the connection again, wait 3.999 seconds, expecting no reconnection.
         assert!(manager
@@ -1142,11 +1242,13 @@ mod tests {
             .is_none());
 
         clock.advance_time(3_999);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Adding 0.001 seconds finally again pushes us over the threshold.
         clock.advance_time(1);
-        let requests = manager.perform_housekeeping(clock.now());
+        let requests = manager.perform_housekeeping(&mut rng, clock.now());
         assert!(dials(addr_a, &requests));
         assert!(dials(addr_b, &requests));
 
@@ -1166,14 +1268,18 @@ mod tests {
                 when: clock.now(),
             },)
             .is_none());
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // The last attempt should happen 8 seconds after the error, not the last attempt.
         clock.advance_time(7_999);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         clock.advance_time(1);
-        let requests = manager.perform_housekeeping(clock.now());
+        let requests = manager.perform_housekeeping(&mut rng, clock.now());
         assert!(dials(addr_a, &requests));
         assert!(dials(addr_b, &requests));
 
@@ -1194,13 +1300,15 @@ mod tests {
             .is_none());
 
         // Only the unforgettable address should be reconnecting.
-        let requests = manager.perform_housekeeping(clock.now());
+        let requests = manager.perform_housekeeping(&mut rng, clock.now());
         assert!(!dials(addr_a, &requests));
         assert!(dials(addr_b, &requests));
 
         // But not `addr_a`, even after a long wait.
         clock.advance_time(1_000_000_000);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
     }
 
     #[test]
@@ -1236,7 +1344,9 @@ mod tests {
             &manager.learn_addr(addr_b, true, clock.now())
         ));
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Fifteen seconds later we succeed in connecting to `addr_b`.
         clock.advance_time(15_000);
@@ -1251,7 +1361,9 @@ mod tests {
         assert_eq!(manager.get_route(id_b), Some(&101));
 
         // Invariant through housekeeping.
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         assert_eq!(manager.get_route(id_b), Some(&101));
 
@@ -1291,7 +1403,9 @@ mod tests {
             },)
         ));
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         assert!(manager.get_route(id_c).is_none());
 
@@ -1299,11 +1413,16 @@ mod tests {
         // unblocked due to the block timing out.
 
         clock.advance_time(30_000);
-        assert!(dials(addr_a, &manager.perform_housekeeping(clock.now())));
+        assert!(dials(
+            addr_a,
+            &manager.perform_housekeeping(&mut rng, clock.now())
+        ));
 
         // Fifteen seconds later, B and C are still blocked, but we redeem B early.
         clock.advance_time(15_000);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         assert!(dials(addr_b, &manager.redeem_addr(addr_b, clock.now())));
 
@@ -1333,6 +1452,7 @@ mod tests {
     fn loopback_handled_correctly() {
         init_logging();
 
+        let mut rng = crate::new_rng();
         let mut clock = TestClock::new();
 
         let loopback_addr: SocketAddr = "1.2.3.4:1234".parse().unwrap();
@@ -1351,7 +1471,9 @@ mod tests {
             },)
             .is_none());
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // Learning loopbacks again should not trigger another connection
         assert!(manager
@@ -1370,7 +1492,9 @@ mod tests {
 
         clock.advance_time(1_000_000_000);
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
     }
 
     #[test]
@@ -1435,12 +1559,17 @@ mod tests {
         // We now let enough time pass to cause the connection to be considered failed aborted.
         // No effects are expected at this point.
         clock.advance_time(50_000);
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
 
         // The connection will now experience a regular failure. Since this is the first connection
         // failure, it should reconnect after 2 seconds.
         clock.advance_time(2_000);
-        assert!(dials(addr_a, &manager.perform_housekeeping(clock.now())));
+        assert!(dials(
+            addr_a,
+            &manager.perform_housekeeping(&mut rng, clock.now())
+        ));
 
         // We now simulate the second connection (`handle: 2`) succeeding first, after 1 second.
         clock.advance_time(1_000);
@@ -1475,6 +1604,7 @@ mod tests {
     fn blocking_not_overridden_by_racing_failed_connections() {
         init_logging();
 
+        let mut rng = crate::new_rng();
         let mut clock = TestClock::new();
 
         let addr_a: SocketAddr = "1.2.3.4:1234".parse().unwrap();
@@ -1511,7 +1641,9 @@ mod tests {
         clock.advance_time(60);
         assert!(manager.is_blocked(addr_a));
 
-        assert!(manager.perform_housekeeping(clock.now()).is_empty());
+        assert!(manager
+            .perform_housekeeping(&mut rng, clock.now())
+            .is_empty());
         assert!(manager.is_blocked(addr_a));
     }
 }

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -1692,7 +1692,7 @@ mod tests {
 
         assert!(manager
             .handle_dial_outcome(DialOutcome::Successful {
-                addr: addr,
+                addr,
                 handle: 1,
                 node_id: id,
                 when: clock.now(),
@@ -1807,7 +1807,7 @@ mod tests {
         assert!(dials(addr, &manager.learn_addr(addr, false, clock.now())));
         assert!(manager
             .handle_dial_outcome(DialOutcome::Successful {
-                addr: addr,
+                addr,
                 handle: 1,
                 node_id: id,
                 when: clock.now(),


### PR DESCRIPTION
Closes #3530.

This PR adds a network watchdog in the form of a ping/pong functionality:

* Nodes will periodically send a `Ping`  down every outgoing connection.
* Any node receiving a `Ping`  will respond with a `Pong` .
* These pings/pongs contain nonces to prevent false positives on retries or allowing for spamming pongs (after a certain amount of invalid pongs, the peer is banned).
* If a ping times out, it is retried a few times.
* Once a certain amount of ping timeouts is hit, the connection is terminated (but the peer is *not* banned).

The core motivation for adding this to 1.5 is to prevent unlikely but possible connection stalls due to deadlock while interdependent nodes fetch backpressured tries from each other. As a side benefit, really slow connections or stalled are also terminated.

Test coverage for the functionality is extensive for the actual logic (see `health.rs`), which attempts to cover every possible edge case. Proper integration in layers up is also tested, but a certain amount of testing remains manual, as there is currently not a good way to easily write a tests that puts the nodes into the deadlocked state.

As a nice side benefit, the node can now be queries for round-trip times to other nodes through `net-info` on the diagnostics port.

Security aspects:

* Ping floods are prevented through rate limiting.
* Pong floods are prevented through rate limiting; also nodes ban peers that send too many unasked pings.
* A 2:1 cost ratio of ping:pong prevents blowing up a peers memory through pings.