### PR TITLE
Add protection against double component initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
+name = "aquamarine"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
+dependencies = [
+ "itertools 0.9.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +452,7 @@ dependencies = [
  "hex_fmt",
  "hostname",
  "humantime",
- "itertools",
+ "itertools 0.10.3",
  "libc",
  "linked-hash-map",
  "lmdb",
@@ -480,7 +493,7 @@ dependencies = [
  "hex",
  "hex-buffer-serde 0.3.0",
  "hex_fmt",
- "itertools",
+ "itertools 0.10.3",
  "once_cell",
  "proptest",
  "proptest-attr-macro",
@@ -501,7 +514,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "itertools",
+ "itertools 0.10.3",
  "serde",
  "serde_json",
  "tokio",
@@ -515,6 +528,7 @@ version = "1.4.8"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "aquamarine",
  "assert-json-diff",
  "async-trait",
  "backtrace",
@@ -542,7 +556,7 @@ dependencies = [
  "http",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.10.3",
  "libc",
  "linked-hash-map",
  "lmdb",
@@ -906,7 +920,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -928,7 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.3",
 ]
 
 [[package]]
@@ -2392,6 +2406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,6 +14,7 @@ default-run = "casper-node"
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1"
+aquamarine = "0.1.12"
 async-trait = "0.1.50"
 backtrace = "0.3.50"
 base16 = "0.2.1"

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -77,6 +77,13 @@ use crate::{
     NodeRng,
 };
 
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// ```mermaid
+/// flowchart TD
+///     Uninitialized --> Initializing
+///     Initializing --> Initialized
+///     Initializing --> Fatal
+/// ```
 #[derive(Clone, PartialEq, Eq, DataSize, Debug, Deserialize, Default)]
 pub(crate) enum ComponentStatus {
     #[default]

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -131,6 +131,9 @@ pub(crate) trait Component<REv> {
         rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event>;
+
+    /// Name of the component.
+    fn name(&self) -> &str;
 }
 
 pub(crate) trait InitializedComponent<REv>: Component<REv> {
@@ -157,8 +160,6 @@ pub(crate) trait InitializedComponent<REv>: Component<REv> {
     }
 
     fn set_state(&mut self, new_state: ComponentState);
-
-    fn name(&self) -> &str;
 }
 
 pub(crate) trait PortBoundComponent<REv>: InitializedComponent<REv> {

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -152,7 +152,7 @@ pub(crate) trait InitializedComponent<REv>: Component<REv> {
         if self.is_uninitialized() {
             self.set_status(ComponentState::Initializing);
         } else {
-            error!(name = self.name(), "component must be uninitialized");
+            info!(name = self.name(), "component must be uninitialized");
         }
     }
 

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -46,6 +46,8 @@ pub(crate) use sync_instruction::SyncInstruction;
 
 use metrics::Metrics;
 
+const COMPONENT_NAME: &str = "block_accumulator";
+
 /// If a peer "informs" us about more than the expected number of new blocks times this factor,
 /// they are probably spamming, and we refuse to create new block acceptors for them.
 const PEER_RATE_LIMIT_MULTIPLIER: usize = 2;
@@ -769,6 +771,10 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 finality_signatures,
             } => self.register_stored(effect_builder, block, finality_signatures),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -1076,7 +1076,24 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                                 Event::Request(BlockSynchronizerRequest::DishonestPeers)
                             })
                     }
-                    _ => {
+                    Event::Request(_)
+                    | Event::DisconnectFromPeer(_)
+                    | Event::MadeFinalizedBlock { .. }
+                    | Event::MarkBlockExecutionEnqueued(_)
+                    | Event::MarkBlockCompleted(_)
+                    | Event::ValidatorMatrixUpdated
+                    | Event::BlockHeaderFetched(_)
+                    | Event::BlockFetched(_)
+                    | Event::ApprovalsHashesFetched(_)
+                    | Event::FinalitySignatureFetched(_)
+                    | Event::GlobalStateSynced { .. }
+                    | Event::GotExecutionResultsChecksum { .. }
+                    | Event::DeployFetched { .. }
+                    | Event::ExecutionResultsFetched { .. }
+                    | Event::ExecutionResultsStored(_)
+                    | Event::AccumulatedPeers(_, _)
+                    | Event::NetworkPeers(_, _)
+                    | Event::GlobalStateSynchronizer(_) => {
                         warn!(
                             ?event,
                             name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -92,6 +92,8 @@ static BLOCK_SYNCHRONIZER_STATUS: Lazy<BlockSynchronizerStatus> = Lazy::new(|| {
 });
 use metrics::Metrics;
 
+const COMPONENT_NAME: &str = "block_synchronizer";
+
 pub(crate) trait ReactorEvent:
     From<FetcherRequest<ApprovalsHashes>>
     + From<NetworkInfoRequest>
@@ -1025,14 +1027,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "block_synchronizer"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 
@@ -1054,7 +1052,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -1062,7 +1060,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -1101,7 +1099,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                     | Event::GlobalStateSynchronizer(_) => {
                         warn!(
                             ?event,
-                            name = <Self as InitializedComponent<MainEvent>>::name(self),
+                            name = <Self as Component<MainEvent>>::name(self),
                             "should not handle this event when component is pending initialization"
                         );
                         Effects::new()
@@ -1112,7 +1110,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -1292,6 +1290,10 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                 }
             },
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/block_synchronizer/global_state_synchronizer.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer.rs
@@ -25,6 +25,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "global_state_synchronizer";
+
 #[derive(Debug, Clone, Error)]
 pub(crate) enum Error {
     #[error(transparent)]
@@ -497,5 +499,9 @@ where
                     .handle_event(effect_builder, rng, event),
             ),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/block_synchronizer/trie_accumulator.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator.rs
@@ -28,6 +28,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "trie_accumulator";
+
 #[derive(Debug, From, Error, Clone, Serialize)]
 pub(crate) enum Error {
     #[error("trie accumulator fetcher error: {0}")]
@@ -292,5 +294,9 @@ where
                 }
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -45,6 +45,8 @@ use keyed_counter::KeyedCounter;
 
 use crate::components::fetcher::FetchedData;
 
+const COMPONENT_NAME: &str = "block_validator";
+
 impl ProposedBlock<ClContext> {
     fn timestamp(&self) -> Timestamp {
         self.context().timestamp()
@@ -387,6 +389,10 @@ where
             }
         }
         effects
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -63,6 +63,8 @@ pub(crate) use leader_sequence::LeaderSequence;
 pub(crate) use protocols::highway::HighwayMessage;
 pub(crate) use validator_change::ValidatorChange;
 
+const COMPONENT_NAME: &str = "consensus";
+
 /// A message to be handled by the consensus protocol instance in a particular era.
 #[derive(DataSize, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum EraMessage<C>
@@ -440,5 +442,9 @@ where
                 }
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -598,6 +598,7 @@ impl ContractRuntime {
 
         let metrics = Arc::new(Metrics::new(registry)?);
 
+        info!("initialization of ContractRuntime finished");
         Ok(ContractRuntime {
             status: ComponentStatus::Initialized,
             execution_pre_state,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -598,7 +598,7 @@ impl ContractRuntime {
 
         let metrics = Arc::new(Metrics::new(registry)?);
 
-        info!("initialization of ContractRuntime finished");
+        info!("initialization of contract_runtime finished");
         Ok(ContractRuntime {
             status: ComponentStatus::Initialized,
             execution_pre_state,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -40,7 +40,7 @@ use casper_hashing::Digest;
 use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion, Timestamp};
 
 use crate::{
-    components::{fetcher::FetchResponse, Component, ComponentStatus},
+    components::{fetcher::FetchResponse, Component, ComponentState},
     effect::{
         announcements::{ContractRuntimeAnnouncement, FatalAnnouncement},
         incoming::{TrieDemand, TrieRequest, TrieRequestIncoming},
@@ -190,7 +190,7 @@ impl Display for Event {
 /// The contract runtime components.
 #[derive(DataSize)]
 pub(crate) struct ContractRuntime {
-    status: ComponentStatus,
+    status: ComponentState,
     execution_pre_state: Arc<Mutex<ExecutionPreState>>,
     engine_state: Arc<EngineState<LmdbGlobalState>>,
     metrics: Arc<Metrics>,
@@ -600,7 +600,7 @@ impl ContractRuntime {
 
         info!("initialization of contract_runtime finished");
         Ok(ContractRuntime {
-            status: ComponentStatus::Initialized,
+            status: ComponentState::Initialized,
             execution_pre_state,
             engine_state,
             metrics,

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -64,6 +64,8 @@ pub(crate) use types::{
     BlockAndExecutionResults, EraValidatorsRequest, StepEffectAndUpcomingEraValidators,
 };
 
+const COMPONENT_NAME: &str = "contract_runtime";
+
 /// An enum that represents all possible error conditions of a `contract_runtime` component.
 #[derive(Debug, Error, From)]
 pub(crate) enum ContractRuntimeError {
@@ -233,6 +235,10 @@ where
             }
             Event::TrieDemand(demand) => self.handle_trie_demand(demand),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -190,7 +190,7 @@ impl Display for Event {
 /// The contract runtime components.
 #[derive(DataSize)]
 pub(crate) struct ContractRuntime {
-    status: ComponentState,
+    state: ComponentState,
     execution_pre_state: Arc<Mutex<ExecutionPreState>>,
     engine_state: Arc<EngineState<LmdbGlobalState>>,
     metrics: Arc<Metrics>,
@@ -598,9 +598,8 @@ impl ContractRuntime {
 
         let metrics = Arc::new(Metrics::new(registry)?);
 
-        info!("initialization of contract_runtime finished");
         Ok(ContractRuntime {
-            status: ComponentState::Initialized,
+            state: ComponentState::Initialized,
             execution_pre_state,
             engine_state,
             metrics,

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -42,6 +42,8 @@ use crate::{
 
 pub(crate) use event::{Event, EventMetadata};
 
+const COMPONENT_NAME: &str = "deploy_acceptor";
+
 const ARG_TARGET: &str = "target";
 
 #[derive(Debug, Error, Serialize)]
@@ -1005,5 +1007,9 @@ impl<REv: ReactorEventT> Component<REv> for DeployAcceptor {
                 verification_start_timestamp,
             ),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -567,7 +567,13 @@ where
                             .set_timeout(self.cfg.expiry_check_interval().into())
                             .event(move |_| Event::Expire)
                     }
-                    _ => {
+                    Event::Request(_)
+                    | Event::ReceiveDeployGossiped(_)
+                    | Event::StoredDeploy(_, _)
+                    | Event::BlockProposed(_)
+                    | Event::Block(_)
+                    | Event::BlockFinalized(_)
+                    | Event::Expire => {
                         warn!(
                             ?event,
                             name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/diagnostics_port.rs
+++ b/node/src/components/diagnostics_port.rs
@@ -117,6 +117,14 @@ where
         event: Event,
     ) -> Effects<Event> {
         match &self.status {
+            ComponentStatus::Fatal(msg) => {
+                error!(msg,
+                    ?event,
+                    name = <DiagnosticsPort as InitializedComponent<MainEvent>>::name(&self),
+                    "should not handle this event when this component has fatal error"
+                );
+                return Effects::new();
+            }
             ComponentStatus::Uninitialized => {
                 warn!(
                     ?event,
@@ -136,12 +144,6 @@ where
                 }
             },
             ComponentStatus::Initialized => Effects::new(),
-            ComponentStatus::Fatal(msg) => {
-                error!(msg,
-                "DiagnosticsPort: should not handle this event when this component has fatal error"
-                );
-                return Effects::new();
-            }
         }
     }
 }

--- a/node/src/components/diagnostics_port.rs
+++ b/node/src/components/diagnostics_port.rs
@@ -37,6 +37,8 @@ pub(crate) use stop_at::StopAtSpec;
 pub use tasks::FileSerializer;
 use util::ShowUnixAddr;
 
+const COMPONENT_NAME: &str = "diagnostics_port";
+
 /// Diagnostics port configuration.
 #[derive(Clone, DataSize, Debug, Deserialize)]
 pub(crate) struct Config {
@@ -121,7 +123,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -129,7 +131,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -147,6 +149,10 @@ where
             ComponentState::Initialized => Effects::new(),
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 
 impl<REv> InitializedComponent<REv> for DiagnosticsPort
@@ -162,14 +168,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "diagnostics"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 

--- a/node/src/components/diagnostics_port/tasks.rs
+++ b/node/src/components/diagnostics_port/tasks.rs
@@ -596,7 +596,7 @@ mod tests {
         components::{
             diagnostics_port::{self, Config as DiagnosticsPortConfig, DiagnosticsPort},
             network::{self, Identity as NetworkIdentity},
-            Component,
+            Component, InitializedComponent,
         },
         effect::{
             announcements::ControlAnnouncement,
@@ -722,12 +722,14 @@ mod tests {
             _event_queue: EventQueueHandle<Event>,
             _rng: &mut NodeRng,
         ) -> Result<(Self, Effects<Event>), Error> {
-            let diagnostics_console =
+            let mut diagnostics_console =
                 DiagnosticsPort::new(WithDir::new(cfg.base_dir.clone(), cfg.diagnostics_port));
+            <DiagnosticsPort as InitializedComponent<Event>>::start_initialization(
+                &mut diagnostics_console,
+            );
             let reactor = Reactor {
                 diagnostics_console,
             };
-
             let effects = reactor::wrap_effects(
                 Event::DiagnosticsConsole,
                 async {}.event(|()| diagnostics_port::Event::Initialize),

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -213,7 +213,13 @@ where
                     self.status = status;
                     effects
                 }
-                _ => {
+                Event::BlockAdded(_)
+                | Event::DeployAccepted(_)
+                | Event::DeployProcessed { .. }
+                | Event::DeploysExpired(_)
+                | Event::Fault { .. }
+                | Event::FinalitySignature(_)
+                | Event::Step { .. } => {
                     warn!(
                         ?event,
                         name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -55,6 +55,8 @@ use event_indexer::{EventIndex, EventIndexer};
 use sse_server::ChannelsAndFilter;
 pub(crate) use sse_server::SseData;
 
+const COMPONENT_NAME: &str = "event_stream_server";
+
 /// This is used to define the number of events to buffer in the tokio broadcast channel to help
 /// slower clients to try to avoid missing events (See
 /// <https://docs.rs/tokio/1.4.0/tokio/sync/broadcast/index.html#lagging> for further details).  The
@@ -194,7 +196,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -202,7 +204,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -222,7 +224,7 @@ where
                 | Event::Step { .. } => {
                     warn!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "should not handle this event when component is pending initialization"
                     );
                     Effects::new()
@@ -232,7 +234,7 @@ where
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -282,6 +284,10 @@ where
             },
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 
 impl<REv> InitializedComponent<REv> for EventStreamServer
@@ -292,14 +298,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "event_stream_server"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -40,6 +40,8 @@ use metrics::Metrics;
 pub(crate) type FetchResult<T> = Result<FetchedData<T>, Error<T>>;
 pub(crate) type FetchResponder<T> = Responder<FetchResult<T>>;
 
+const COMPONENT_NAME: &str = "fetcher";
+
 /// The component which fetches an item from local storage or asks a peer if it's not in storage.
 #[derive(DataSize, Debug)]
 pub(crate) struct Fetcher<T>
@@ -133,5 +135,9 @@ where
             }
             Event::PutToStorage { item, peer } => self.signal(item.id(), Ok(*item), peer),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -38,6 +38,8 @@ use gossip_table::{GossipAction, GossipTable};
 pub(crate) use message::Message;
 use metrics::Metrics;
 
+const COMPONENT_NAME: &str = "gossiper";
+
 /// A helper trait whose bounds represent the requirements for a reactor event that `Gossiper` can
 /// work with.
 pub(crate) trait ReactorEventT<T>:
@@ -643,6 +645,10 @@ where
         };
         self.update_gossip_table_metrics();
         effects
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -301,6 +301,8 @@ use crate::{
 
 use super::network::FromIncoming;
 
+const COMPONENT_NAME: &str = "in_memory_network";
+
 /// A network.
 type Network<P> = Arc<RwLock<HashMap<NodeId, mpsc::UnboundedSender<(NodeId, P)>>>>;
 
@@ -591,6 +593,10 @@ where
                 }
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/metrics.rs
+++ b/node/src/components/metrics.rs
@@ -33,6 +33,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "metrics";
+
 /// The metrics component.
 #[derive(DataSize, Debug)]
 pub(crate) struct Metrics {
@@ -68,6 +70,10 @@ impl<REv> Component<REv> for Metrics {
                 }
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -1044,7 +1044,17 @@ where
                         Effects::new()
                     }
                 },
-                _ => {
+                Event::IncomingConnection { .. }
+                | Event::IncomingMessage { .. }
+                | Event::IncomingClosed { .. }
+                | Event::OutgoingConnection { .. }
+                | Event::OutgoingDropped { .. }
+                | Event::NetworkRequest { .. }
+                | Event::NetworkInfoRequest { .. }
+                | Event::GossipOurAddress
+                | Event::PeerAddressReceived(_)
+                | Event::SweepOutgoing
+                | Event::BlocklistAnnouncement(_) => {
                     warn!(
                         ?event,
                         name = <Self as InitializedComponent<REv>>::name(self),

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -108,6 +108,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "network";
+
 const MAX_METRICS_DROP_ATTEMPTS: usize = 25;
 const DROP_RETRY_DELAY: Duration = Duration::from_millis(100);
 
@@ -1019,7 +1021,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<REv>>::name(self),
+                    name = <Self as Component<REv>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -1027,7 +1029,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<REv>>::name(self),
+                    name = <Self as Component<REv>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -1057,7 +1059,7 @@ where
                 | Event::BlocklistAnnouncement(_) => {
                     warn!(
                         ?event,
-                        name = <Self as InitializedComponent<REv>>::name(self),
+                        name = <Self as Component<REv>>::name(self),
                         "should not handle this event when component is pending initialization"
                     );
                     Effects::new()
@@ -1067,7 +1069,7 @@ where
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<REv>>::name(self),
+                        name = <Self as Component<REv>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -1170,6 +1172,10 @@ where
             },
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 
 impl<REv, P> InitializedComponent<REv> for Network<REv, P>
@@ -1187,14 +1193,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "network"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<REv>>::name(self),
+            name = <Self as Component<REv>>::name(self),
             "component state changed"
         );
 

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::{
     components::{
         gossiper::{self, Gossiper},
-        Component,
+        Component, InitializedComponent,
     },
     effect::{
         announcements::{ControlAnnouncement, GossiperAnnouncement, PeerBehaviorAnnouncement},
@@ -191,7 +191,7 @@ impl Reactor for TestReactor {
         rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let secret_key = SecretKey::random(rng);
-        let net = Network::new(
+        let mut net = Network::new(
             cfg,
             our_identity,
             None,
@@ -203,6 +203,7 @@ impl Reactor for TestReactor {
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", gossiper_config, registry)?;
 
+        net.start_initialization();
         let effects = smallvec![async { smallvec![Event::Net(NetworkEvent::Initialize)] }.boxed()];
 
         Ok((

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -166,7 +166,7 @@ where
                     self.status = status;
                     effects
                 }
-                _ => {
+                Event::RestRequest(_) | Event::GetMetricsResult { .. } => {
                     warn!(
                         ?event,
                         name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -142,95 +142,107 @@ where
         _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
-        match (self.status.clone(), event) {
-            (ComponentStatus::Fatal(msg), _) => {
+        match &self.status {
+            ComponentStatus::Fatal(msg) => {
                 error!(
                     msg,
+                    ?event,
+                    name = <RestServer as InitializedComponent<MainEvent>>::name(&self),
                     "should not handle this event when this component has fatal error"
                 );
-                Effects::new()
+                return Effects::new();
             }
-            (ComponentStatus::InitializationPending, Event::Initialize) => {
-                let (effects, status) = self.bind(self.config.enable_server, effect_builder);
-                self.status = status;
-                effects
+            ComponentStatus::Uninitialized => {
+                warn!(
+                    ?event,
+                    name = <RestServer as InitializedComponent<MainEvent>>::name(&self),
+                    "should not handle this event when component is uninitialized"
+                );
+                return Effects::new();
             }
-            (ComponentStatus::Uninitialized | ComponentStatus::InitializationPending, _) => {
-                warn!("should not handle this event when component is uninitialized");
-                Effects::new()
-            }
-            (ComponentStatus::Initialized, Event::Initialize) => {
-                // noop
-                // a programmer error?
-                Effects::new()
-            }
-            (
-                ComponentStatus::Initialized,
-                Event::RestRequest(RestRequest::Status { responder }),
-            ) => {
-                let node_uptime = self.node_startup_instant.elapsed();
-                let network_name = self.network_name.clone();
-                async move {
-                    let (
-                        last_added_block,
-                        peers,
-                        next_upgrade,
-                        consensus_status,
-                        (reactor_state, last_progress),
-                        available_block_range,
-                        block_sync,
-                    ) = join!(
-                        effect_builder.get_highest_complete_block_from_storage(),
-                        effect_builder.network_peers(),
-                        effect_builder.get_next_upgrade(),
-                        effect_builder.consensus_status(),
-                        effect_builder.get_reactor_status(),
-                        effect_builder.get_available_block_range_from_storage(),
-                        effect_builder.get_block_synchronizer_status(),
-                    );
-                    let starting_state_root_hash = effect_builder
-                        .get_block_header_at_height_from_storage(available_block_range.low(), true)
-                        .await
-                        .map(|header| *header.state_root_hash());
-                    let status_feed = StatusFeed::new(
-                        last_added_block,
-                        peers,
-                        ChainspecInfo::new(network_name, next_upgrade),
-                        consensus_status,
-                        node_uptime,
-                        reactor_state,
-                        last_progress,
-                        available_block_range,
-                        block_sync,
-                        starting_state_root_hash,
-                    );
-                    responder.respond(status_feed).await;
+            ComponentStatus::InitializationPending => match event {
+                Event::Initialize => {
+                    let (effects, status) = self.bind(self.config.enable_server, effect_builder);
+                    self.status = status;
+                    return effects;
                 }
-            }
-            .ignore(),
-            (
-                ComponentStatus::Initialized,
-                Event::RestRequest(RestRequest::Metrics { responder }),
-            ) => effect_builder
-                .get_metrics()
-                .event(move |text| Event::GetMetricsResult {
-                    text,
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
-                Event::RestRequest(RestRequest::RpcSchema { responder }),
-            ) => {
-                let schema = OPEN_RPC_SCHEMA.clone();
-                responder.respond(schema).ignore()
-            }
-            (
-                ComponentStatus::Initialized,
+                _ => {
+                    warn!(
+                        ?event,
+                        name = <RestServer as InitializedComponent<MainEvent>>::name(&self),
+                        "should not handle this event when component is pending initialization"
+                    );
+                    return Effects::new();
+                }
+            },
+            ComponentStatus::Initialized => match event {
+                Event::Initialize => {
+                    error!(
+                        ?event,
+                        name = <RestServer as InitializedComponent<MainEvent>>::name(&self),
+                        "component already initialized"
+                    );
+                    return Effects::new();
+                }
+                Event::RestRequest(RestRequest::Status { responder }) => {
+                    let node_uptime = self.node_startup_instant.elapsed();
+                    let network_name = self.network_name.clone();
+                    async move {
+                        let (
+                            last_added_block,
+                            peers,
+                            next_upgrade,
+                            consensus_status,
+                            (reactor_state, last_progress),
+                            available_block_range,
+                            block_sync,
+                        ) = join!(
+                            effect_builder.get_highest_complete_block_from_storage(),
+                            effect_builder.network_peers(),
+                            effect_builder.get_next_upgrade(),
+                            effect_builder.consensus_status(),
+                            effect_builder.get_reactor_status(),
+                            effect_builder.get_available_block_range_from_storage(),
+                            effect_builder.get_block_synchronizer_status(),
+                        );
+                        let starting_state_root_hash = effect_builder
+                            .get_block_header_at_height_from_storage(
+                                available_block_range.low(),
+                                true,
+                            )
+                            .await
+                            .map(|header| *header.state_root_hash());
+                        let status_feed = StatusFeed::new(
+                            last_added_block,
+                            peers,
+                            ChainspecInfo::new(network_name, next_upgrade),
+                            consensus_status,
+                            node_uptime,
+                            reactor_state,
+                            last_progress,
+                            available_block_range,
+                            block_sync,
+                            starting_state_root_hash,
+                        );
+                        responder.respond(status_feed).await;
+                    }
+                }
+                .ignore(),
+                Event::RestRequest(RestRequest::Metrics { responder }) => effect_builder
+                    .get_metrics()
+                    .event(move |text| Event::GetMetricsResult {
+                        text,
+                        main_responder: responder,
+                    }),
+                Event::RestRequest(RestRequest::RpcSchema { responder }) => {
+                    let schema = OPEN_RPC_SCHEMA.clone();
+                    responder.respond(schema).ignore()
+                }
                 Event::GetMetricsResult {
                     text,
                     main_responder,
-                },
-            ) => main_responder.respond(text).ignore(),
+                } => main_responder.respond(text).ignore(),
+            },
         }
     }
 }

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -54,6 +54,8 @@ use crate::{
 pub use config::Config;
 pub(crate) use event::Event;
 
+const COMPONENT_NAME: &str = "rest_server";
+
 /// A helper trait capturing all of this components Request type dependencies.
 pub(crate) trait ReactorEventT:
     From<Event>
@@ -147,7 +149,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -155,7 +157,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -169,7 +171,7 @@ where
                 Event::RestRequest(_) | Event::GetMetricsResult { .. } => {
                     warn!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "should not handle this event when component is pending initialization"
                     );
                     Effects::new()
@@ -179,7 +181,7 @@ where
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -245,6 +247,10 @@ where
             },
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 
 impl<REv> InitializedComponent<REv> for RestServer
@@ -255,14 +261,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "rest_server"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -222,300 +222,297 @@ where
         _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
-        match (self.status.clone(), event) {
-            (ComponentStatus::Fatal(msg), _) => {
+        match &self.status {
+            ComponentStatus::Fatal(msg) => {
                 error!(
                     msg,
+                    ?event,
+                    name = <RpcServer as InitializedComponent<MainEvent>>::name(&self),
                     "should not handle this event when this component has fatal error"
                 );
-                Effects::new()
+                return Effects::new();
             }
-            (ComponentStatus::InitializationPending, Event::Initialize) => {
-                let (effects, status) = self.bind(self.config.enable_server, effect_builder);
-                self.status = status;
-                effects
+            ComponentStatus::Uninitialized => {
+                warn!(
+                    ?event,
+                    name = <RpcServer as InitializedComponent<MainEvent>>::name(&self),
+                    "should not handle this event when component is uninitialized"
+                );
+                return Effects::new();
             }
-            (ComponentStatus::Uninitialized | ComponentStatus::InitializationPending, _) => {
-                warn!("should not handle this event when component is uninitialized");
-                Effects::new()
-            }
-            (ComponentStatus::Initialized, Event::Initialize) => {
-                // noop
-                Effects::new()
-            }
-            (
-                ComponentStatus::Initialized,
-                Event::RpcRequest(RpcRequest::SubmitDeploy { deploy, responder }),
-            ) => effect_builder
-                .announce_deploy_received(deploy, Some(responder))
-                .ignore(),
-            (
-                ComponentStatus::Initialized,
+            ComponentStatus::InitializationPending => match event {
+                Event::Initialize => {
+                    let (effects, status) = self.bind(self.config.enable_server, effect_builder);
+                    self.status = status;
+                    return effects;
+                }
+                _ => {
+                    warn!(
+                        ?event,
+                        name = <RpcServer as InitializedComponent<MainEvent>>::name(&self),
+                        "should not handle this event when component is pending initialization"
+                    );
+                    return Effects::new();
+                }
+            },
+            ComponentStatus::Initialized => match event {
+                Event::Initialize => {
+                    error!(
+                        ?event,
+                        name = <RpcServer as InitializedComponent<MainEvent>>::name(&self),
+                        "component already initialized"
+                    );
+                    return Effects::new();
+                }
+                Event::RpcRequest(RpcRequest::SubmitDeploy { deploy, responder }) => {
+                    return effect_builder
+                        .announce_deploy_received(deploy, Some(responder))
+                        .ignore()
+                }
                 Event::RpcRequest(RpcRequest::GetBlock {
                     maybe_id: Some(BlockIdentifier::Hash(hash)),
                     only_from_available_block_range,
                     responder,
-                }),
-            ) => effect_builder
-                .get_block_with_metadata_from_storage(hash, only_from_available_block_range)
-                .event(move |result| Event::GetBlockResult {
-                    maybe_id: Some(BlockIdentifier::Hash(hash)),
-                    result: Box::new(result),
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return effect_builder
+                        .get_block_with_metadata_from_storage(hash, only_from_available_block_range)
+                        .event(move |result| Event::GetBlockResult {
+                            maybe_id: Some(BlockIdentifier::Hash(hash)),
+                            result: Box::new(result),
+                            main_responder: responder,
+                        })
+                }
                 Event::RpcRequest(RpcRequest::GetBlock {
                     maybe_id: Some(BlockIdentifier::Height(height)),
                     only_from_available_block_range,
                     responder,
-                }),
-            ) => effect_builder
-                .get_block_at_height_with_metadata_from_storage(
-                    height,
-                    only_from_available_block_range,
-                )
-                .event(move |result| Event::GetBlockResult {
-                    maybe_id: Some(BlockIdentifier::Height(height)),
-                    result: Box::new(result),
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return effect_builder
+                        .get_block_at_height_with_metadata_from_storage(
+                            height,
+                            only_from_available_block_range,
+                        )
+                        .event(move |result| Event::GetBlockResult {
+                            maybe_id: Some(BlockIdentifier::Height(height)),
+                            result: Box::new(result),
+                            main_responder: responder,
+                        })
+                }
                 Event::RpcRequest(RpcRequest::GetBlock {
                     maybe_id: None,
-                    only_from_available_block_range: _, /* Requesting for highest block cannot be
-                                                         * restricted by block availability index */
+                    only_from_available_block_range: _,
                     responder,
-                }),
-            ) => effect_builder
-                .get_highest_block_with_metadata_from_storage()
-                .event(move |result| Event::GetBlockResult {
-                    maybe_id: None,
-                    result: Box::new(result),
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return effect_builder
+                        .get_highest_block_with_metadata_from_storage()
+                        .event(move |result| Event::GetBlockResult {
+                            maybe_id: None,
+                            result: Box::new(result),
+                            main_responder: responder,
+                        })
+                }
                 Event::RpcRequest(RpcRequest::GetBlockTransfers {
                     block_hash,
                     responder,
-                }),
-            ) => effect_builder
-                .get_block_transfers_from_storage(block_hash)
-                .event(move |result| Event::GetBlockTransfersResult {
-                    block_hash,
-                    result: Box::new(result),
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return effect_builder
+                        .get_block_transfers_from_storage(block_hash)
+                        .event(move |result| Event::GetBlockTransfersResult {
+                            block_hash,
+                            result: Box::new(result),
+                            main_responder: responder,
+                        })
+                }
                 Event::RpcRequest(RpcRequest::QueryGlobalState {
                     state_root_hash,
                     base_key,
                     path,
                     responder,
-                }),
-            ) => self.handle_query(effect_builder, state_root_hash, base_key, path, responder),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return self.handle_query(
+                        effect_builder,
+                        state_root_hash,
+                        base_key,
+                        path,
+                        responder,
+                    )
+                }
                 Event::RpcRequest(RpcRequest::QueryEraValidators {
                     state_root_hash,
                     protocol_version,
                     responder,
-                }),
-            ) => self.handle_era_validators(
-                effect_builder,
-                state_root_hash,
-                protocol_version,
-                responder,
-            ),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return self.handle_era_validators(
+                        effect_builder,
+                        state_root_hash,
+                        protocol_version,
+                        responder,
+                    )
+                }
                 Event::RpcRequest(RpcRequest::GetBids {
                     state_root_hash,
                     responder,
-                }),
-            ) => {
-                let get_bids_request = GetBidsRequest::new(state_root_hash);
-                effect_builder
-                    .get_bids(get_bids_request)
-                    .event(move |result| Event::GetBidsResult {
-                        result,
-                        main_responder: responder,
-                    })
-            }
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    let get_bids_request = GetBidsRequest::new(state_root_hash);
+                    return effect_builder
+                        .get_bids(get_bids_request)
+                        .event(move |result| Event::GetBidsResult {
+                            result,
+                            main_responder: responder,
+                        });
+                }
                 Event::RpcRequest(RpcRequest::GetBalance {
                     state_root_hash,
                     purse_uref,
                     responder,
-                }),
-            ) => self.handle_get_balance(effect_builder, state_root_hash, purse_uref, responder),
-            (
-                ComponentStatus::Initialized,
+                }) => {
+                    return self.handle_get_balance(
+                        effect_builder,
+                        state_root_hash,
+                        purse_uref,
+                        responder,
+                    );
+                }
                 Event::RpcRequest(RpcRequest::GetDeploy {
                     hash,
                     responder,
                     finalized_approvals,
-                }),
-            ) => effect_builder
-                .get_deploy_and_metadata_from_storage(hash)
-                .event(move |result| Event::GetDeployResult {
-                    hash,
-                    result: Box::new(result.map(
-                        |(deploy_with_finalized_approvals, metadata_ext)| {
-                            if finalized_approvals {
-                                (deploy_with_finalized_approvals.into_naive(), metadata_ext)
-                            } else {
-                                (
-                                    deploy_with_finalized_approvals.discard_finalized_approvals(),
-                                    metadata_ext,
-                                )
-                            }
-                        },
-                    )),
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
-                Event::RpcRequest(RpcRequest::GetPeers { responder }),
-            ) => effect_builder
-                .network_peers()
-                .event(move |peers| Event::GetPeersResult {
-                    peers,
-                    main_responder: responder,
-                }),
-            (
-                ComponentStatus::Initialized,
-                Event::RpcRequest(RpcRequest::GetStatus { responder }),
-            ) => {
-                let node_uptime = self.node_startup_instant.elapsed();
-                let network_name = self.network_name.clone();
-                async move {
-                    let (
-                        last_added_block,
-                        peers,
-                        next_upgrade,
-                        consensus_status,
-                        (reactor_state, last_progress),
-                        available_block_range,
-                        block_sync,
-                    ) = join!(
-                        effect_builder.get_highest_complete_block_from_storage(),
-                        effect_builder.network_peers(),
-                        effect_builder.get_next_upgrade(),
-                        effect_builder.consensus_status(),
-                        effect_builder.get_reactor_status(),
-                        effect_builder.get_available_block_range_from_storage(),
-                        effect_builder.get_block_synchronizer_status(),
-                    );
-                    let starting_state_root_hash = effect_builder
-                        .get_block_header_at_height_from_storage(available_block_range.low(), true)
-                        .await
-                        .map(|header| *header.state_root_hash());
-                    let status_feed = StatusFeed::new(
-                        last_added_block,
-                        peers,
-                        ChainspecInfo::new(network_name, next_upgrade),
-                        consensus_status,
-                        node_uptime,
-                        reactor_state,
-                        last_progress,
-                        available_block_range,
-                        block_sync,
-                        starting_state_root_hash,
-                    );
-                    responder.respond(status_feed).await;
+                }) => {
+                    return effect_builder
+                        .get_deploy_and_metadata_from_storage(hash)
+                        .event(move |result| Event::GetDeployResult {
+                            hash,
+                            result: Box::new(result.map(
+                                |(deploy_with_finalized_approvals, metadata_ext)| {
+                                    if finalized_approvals {
+                                        (deploy_with_finalized_approvals.into_naive(), metadata_ext)
+                                    } else {
+                                        (
+                                            deploy_with_finalized_approvals
+                                                .discard_finalized_approvals(),
+                                            metadata_ext,
+                                        )
+                                    }
+                                },
+                            )),
+                            main_responder: responder,
+                        })
                 }
-                .ignore()
-            }
-            (
-                ComponentStatus::Initialized,
-                Event::RpcRequest(RpcRequest::GetAvailableBlockRange { responder }),
-            ) => async move {
-                responder
-                    .respond(
-                        effect_builder
-                            .get_available_block_range_from_storage()
-                            .await,
-                    )
-                    .await
-            }
-            .ignore(),
-            (
-                ComponentStatus::Initialized,
+                Event::RpcRequest(RpcRequest::GetPeers { responder }) => {
+                    return effect_builder.network_peers().event(move |peers| {
+                        Event::GetPeersResult {
+                            peers,
+                            main_responder: responder,
+                        }
+                    })
+                }
+                Event::RpcRequest(RpcRequest::GetStatus { responder }) => {
+                    let node_uptime = self.node_startup_instant.elapsed();
+                    let network_name = self.network_name.clone();
+                    return async move {
+                        let (
+                            last_added_block,
+                            peers,
+                            next_upgrade,
+                            consensus_status,
+                            (reactor_state, last_progress),
+                            available_block_range,
+                            block_sync,
+                        ) = join!(
+                            effect_builder.get_highest_complete_block_from_storage(),
+                            effect_builder.network_peers(),
+                            effect_builder.get_next_upgrade(),
+                            effect_builder.consensus_status(),
+                            effect_builder.get_reactor_status(),
+                            effect_builder.get_available_block_range_from_storage(),
+                            effect_builder.get_block_synchronizer_status(),
+                        );
+                        let starting_state_root_hash = effect_builder
+                            .get_block_header_at_height_from_storage(
+                                available_block_range.low(),
+                                true,
+                            )
+                            .await
+                            .map(|header| *header.state_root_hash());
+                        let status_feed = StatusFeed::new(
+                            last_added_block,
+                            peers,
+                            ChainspecInfo::new(network_name, next_upgrade),
+                            consensus_status,
+                            node_uptime,
+                            reactor_state,
+                            last_progress,
+                            available_block_range,
+                            block_sync,
+                            starting_state_root_hash,
+                        );
+                        responder.respond(status_feed).await;
+                    }
+                    .ignore();
+                }
+                Event::RpcRequest(RpcRequest::GetAvailableBlockRange { responder }) => {
+                    return async move {
+                        responder
+                            .respond(
+                                effect_builder
+                                    .get_available_block_range_from_storage()
+                                    .await,
+                            )
+                            .await
+                    }
+                    .ignore()
+                }
                 Event::RpcRequest(RpcRequest::SpeculativeDeployExecute {
                     block_header,
                     deploy,
                     responder,
-                }),
-            ) => match self.speculative_exec {
-                Some(_) => {
-                    self.handle_execute_deploy(effect_builder, *block_header, *deploy, responder)
+                }) => {
+                    return match self.speculative_exec {
+                        Some(_) => self.handle_execute_deploy(
+                            effect_builder,
+                            *block_header,
+                            *deploy,
+                            responder,
+                        ),
+                        None => Effects::new(),
+                    }
                 }
-                None => Effects::new(),
-            },
-            (
-                ComponentStatus::Initialized,
                 Event::GetBlockResult {
-                    maybe_id: _,
+                    maybe_id,
                     result,
                     main_responder,
-                },
-            ) => main_responder.respond(*result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(*result).ignore(),
                 Event::GetBlockTransfersResult {
+                    block_hash,
                     result,
                     main_responder,
-                    ..
-                },
-            ) => main_responder.respond(*result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(*result).ignore(),
                 Event::QueryGlobalStateResult {
                     result,
                     main_responder,
-                },
-            ) => main_responder.respond(result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(result).ignore(),
                 Event::QueryEraValidatorsResult {
                     result,
                     main_responder,
-                },
-            ) => main_responder.respond(result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(result).ignore(),
                 Event::GetBidsResult {
                     result,
                     main_responder,
-                },
-            ) => main_responder.respond(result).ignore(),
-            (
-                ComponentStatus::Initialized,
-                Event::GetBalanceResult {
-                    result,
-                    main_responder,
-                },
-            ) => main_responder.respond(result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(result).ignore(),
                 Event::GetDeployResult {
-                    hash: _,
+                    hash,
                     result,
                     main_responder,
-                },
-            ) => main_responder.respond(*result).ignore(),
-            (
-                ComponentStatus::Initialized,
+                } => return main_responder.respond(*result).ignore(),
                 Event::GetPeersResult {
                     peers,
                     main_responder,
-                },
-            ) => main_responder.respond(peers).ignore(),
+                } => return main_responder.respond(peers).ignore(),
+                Event::GetBalanceResult {
+                    result,
+                    main_responder,
+                } => return main_responder.respond(result).ignore(),
+            },
         }
     }
 }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -246,7 +246,15 @@ where
                     self.status = status;
                     effects
                 }
-                _ => {
+                Event::RpcRequest(_)
+                | Event::GetBlockResult { .. }
+                | Event::GetBlockTransfersResult { .. }
+                | Event::QueryGlobalStateResult { .. }
+                | Event::QueryEraValidatorsResult { .. }
+                | Event::GetBidsResult { .. }
+                | Event::GetDeployResult { .. }
+                | Event::GetPeersResult { .. }
+                | Event::GetBalanceResult { .. } => {
                     warn!(
                         ?event,
                         name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -60,6 +60,8 @@ pub use config::Config;
 pub(crate) use event::Event;
 pub use speculative_exec_config::Config as SpeculativeExecConfig;
 
+const COMPONENT_NAME: &str = "rpc_server";
+
 /// A helper trait capturing all of this components Request type dependencies.
 pub(crate) trait ReactorEventT:
     From<Event>
@@ -227,7 +229,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -235,7 +237,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -257,7 +259,7 @@ where
                 | Event::GetBalanceResult { .. } => {
                     warn!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "should not handle this event when component is pending initialization"
                     );
                     Effects::new()
@@ -267,7 +269,7 @@ where
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -492,6 +494,10 @@ where
             },
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 
 impl<REv> InitializedComponent<REv> for RpcServer
@@ -502,14 +508,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "rpc_server"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 

--- a/node/src/components/shutdown_trigger.rs
+++ b/node/src/components/shutdown_trigger.rs
@@ -22,6 +22,8 @@ use crate::{
 
 use super::{diagnostics_port::StopAtSpec, Component};
 
+const COMPONENT_NAME: &str = "shutdown_trigger";
+
 //// Shutdown trigger component.
 #[derive(DataSize, Debug)]
 pub(crate) struct ShutdownTrigger {
@@ -138,6 +140,10 @@ where
                 effects
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -107,6 +107,8 @@ use lmdb_ext::{BytesreprError, LmdbExtError, TransactionExt, WriteTransactionExt
 use metrics::Metrics;
 use object_pool::ObjectPool;
 
+const COMPONENT_NAME: &str = "storage";
+
 /// Filename for the LMDB database created by the Storage component.
 const STORAGE_DB_FILENAME: &str = "storage.lmdb";
 
@@ -311,6 +313,10 @@ where
             Ok(effects) => effects,
             Err(err) => fatal!(effect_builder, "storage error: {}", err).ignore(),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1674,7 +1674,14 @@ fn check_force_resync_with_marker_file() {
     // Add a couple of blocks into storage.
     let first_block = Block::random(&mut harness.rng);
     put_complete_block(&mut harness, &mut storage, Box::new(first_block.clone()));
-    let second_block = Block::random(&mut harness.rng);
+    let second_block = loop {
+        // We need to make sure that the second random block has different height than the first
+        // one.
+        let block = Block::random(&mut harness.rng);
+        if block.height() != first_block.height() {
+            break block;
+        }
+    };
     put_complete_block(&mut harness, &mut storage, Box::new(second_block));
     // Make sure the completed blocks are not the default anymore.
     assert_ne!(

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -38,7 +38,7 @@ enum PeerState {
 }
 
 #[derive(Debug, DataSize)]
-pub(crate) enum LeapStatus {
+pub(crate) enum LeapState {
     Idle,
     Awaiting {
         sync_leap_identifier: SyncLeapIdentifier,
@@ -57,13 +57,13 @@ pub(crate) enum LeapStatus {
     },
 }
 
-impl Display for LeapStatus {
+impl Display for LeapState {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            LeapStatus::Idle => {
+            LeapState::Idle => {
                 write!(f, "Idle")
             }
-            LeapStatus::Awaiting {
+            LeapState::Awaiting {
                 sync_leap_identifier,
                 in_flight,
             } => {
@@ -74,7 +74,7 @@ impl Display for LeapStatus {
                     sync_leap_identifier.block_hash(),
                 )
             }
-            LeapStatus::Received {
+            LeapState::Received {
                 best_available,
                 from_peers,
                 in_flight,
@@ -87,7 +87,7 @@ impl Display for LeapStatus {
                     in_flight
                 )
             }
-            LeapStatus::Failed {
+            LeapState::Failed {
                 sync_leap_identifier,
                 error,
                 ..
@@ -103,13 +103,13 @@ impl Display for LeapStatus {
     }
 }
 
-impl LeapStatus {
+impl LeapState {
     fn in_flight(&self) -> usize {
         match self {
-            LeapStatus::Idle => 0,
-            LeapStatus::Awaiting { in_flight, .. }
-            | LeapStatus::Received { in_flight, .. }
-            | LeapStatus::Failed { in_flight, .. } => *in_flight,
+            LeapState::Idle => 0,
+            LeapState::Awaiting { in_flight, .. }
+            | LeapState::Received { in_flight, .. }
+            | LeapState::Failed { in_flight, .. } => *in_flight,
         }
     }
 
@@ -126,7 +126,7 @@ struct LeapActivity {
 }
 
 impl LeapActivity {
-    fn status(&self) -> LeapStatus {
+    fn status(&self) -> LeapState {
         let sync_leap_identifier = self.sync_leap_identifier;
         let in_flight = self
             .peers
@@ -135,7 +135,7 @@ impl LeapActivity {
             .count();
         let responsed = self.peers.len() - in_flight;
         if in_flight == 0 && responsed == 0 {
-            return LeapStatus::Failed {
+            return LeapState::Failed {
                 sync_leap_identifier,
                 in_flight,
                 error: LeapActivityError::NoPeers(sync_leap_identifier),
@@ -143,24 +143,24 @@ impl LeapActivity {
             };
         }
         if in_flight > 0 && responsed == 0 {
-            return LeapStatus::Awaiting {
+            return LeapState::Awaiting {
                 sync_leap_identifier,
                 in_flight,
             };
         }
         match self.best_response() {
-            Ok((best_available, from_peers)) => LeapStatus::Received {
+            Ok((best_available, from_peers)) => LeapState::Received {
                 in_flight,
                 best_available: Box::new(best_available),
                 from_peers,
             },
             // `Unobtainable` means we couldn't download it from any peer so far - don't treat it
             // as a failure if there are still requests in flight
-            Err(LeapActivityError::Unobtainable(_, _)) if in_flight > 0 => LeapStatus::Awaiting {
+            Err(LeapActivityError::Unobtainable(_, _)) if in_flight > 0 => LeapState::Awaiting {
                 sync_leap_identifier,
                 in_flight,
             },
-            Err(error) => LeapStatus::Failed {
+            Err(error) => LeapState::Failed {
                 sync_leap_identifier,
                 from_peers: vec![],
                 in_flight,
@@ -242,19 +242,19 @@ impl SyncLeaper {
     }
 
     // called from Reactor control logic to scrape results
-    pub(crate) fn leap_status(&mut self) -> LeapStatus {
+    pub(crate) fn leap_status(&mut self) -> LeapState {
         match &self.leap_activity {
-            None => LeapStatus::Idle,
+            None => LeapState::Idle,
             Some(activity) => {
                 let result = activity.status();
                 if result.active() == false {
                     match result {
-                        LeapStatus::Received { .. } | LeapStatus::Failed { .. } => {
+                        LeapState::Received { .. } | LeapState::Failed { .. } => {
                             self.metrics
                                 .sync_leap_duration
                                 .observe(activity.leap_start.elapsed().as_secs_f64());
                         }
-                        LeapStatus::Idle | LeapStatus::Awaiting { .. } => {
+                        LeapState::Idle | LeapState::Awaiting { .. } => {
                             // should be unreachable
                             error!(status = %result, ?activity, "sync leaper has inconsistent status");
                         }

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -29,6 +29,8 @@ pub(crate) use event::Event;
 
 use metrics::Metrics;
 
+const COMPONENT_NAME: &str = "sync_leaper";
+
 #[derive(Debug, DataSize)]
 enum PeerState {
     RequestSent,
@@ -435,5 +437,9 @@ where
                 Effects::new()
             }
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -301,7 +301,7 @@ where
             }
             ComponentState::Initializing => match event {
                 Event::Initialize => self.start_checking_for_upgrades(effect_builder),
-                _ => {
+                Event::Request(_) | Event::CheckForNextUpgrade | Event::GotNextUpgrade(_) => {
                     warn!(
                         ?event,
                         name = <Self as InitializedComponent<MainEvent>>::name(self),

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -41,6 +41,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "upgrade_watcher";
+
 const DEFAULT_UPGRADE_CHECK_INTERVAL: &str = "30sec";
 
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -282,7 +284,7 @@ where
                 error!(
                     msg,
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when this component has fatal error"
                 );
                 Effects::new()
@@ -290,7 +292,7 @@ where
             ComponentState::Uninitialized => {
                 warn!(
                     ?event,
-                    name = <Self as InitializedComponent<MainEvent>>::name(self),
+                    name = <Self as Component<MainEvent>>::name(self),
                     "should not handle this event when component is uninitialized"
                 );
                 Effects::new()
@@ -300,7 +302,7 @@ where
                 Event::Request(_) | Event::CheckForNextUpgrade | Event::GotNextUpgrade(_) => {
                     warn!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "should not handle this event when component is pending initialization"
                     );
                     Effects::new()
@@ -310,7 +312,7 @@ where
                 Event::Initialize => {
                     error!(
                         ?event,
-                        name = <Self as InitializedComponent<MainEvent>>::name(self),
+                        name = <Self as Component<MainEvent>>::name(self),
                         "component already initialized"
                     );
                     Effects::new()
@@ -321,6 +323,10 @@ where
             },
         }
     }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
+    }
 }
 impl<REv> InitializedComponent<REv> for UpgradeWatcher
 where
@@ -330,14 +336,10 @@ where
         &self.state
     }
 
-    fn name(&self) -> &str {
-        "upgrade_watcher"
-    }
-
     fn set_state(&mut self, new_state: ComponentState) {
         info!(
             ?new_state,
-            name = <Self as InitializedComponent<MainEvent>>::name(self),
+            name = <Self as Component<MainEvent>>::name(self),
             "component state changed"
         );
 

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -9,7 +9,7 @@ use crate::{
         block_accumulator::{SyncIdentifier, SyncInstruction},
         block_synchronizer::BlockSynchronizerProgress,
         sync_leaper,
-        sync_leaper::{LeapActivityError, LeapStatus},
+        sync_leaper::{LeapActivityError, LeapState},
         ValidatorBoundComponent,
     },
     effect::{requests::BlockSynchronizerRequest, EffectBuilder, EffectExt, Effects},
@@ -267,17 +267,17 @@ impl MainReactor {
         let leap_status = self.sync_leaper.leap_status();
         info!(%block_hash, %leap_status, "CatchUp: status");
         match leap_status {
-            LeapStatus::Idle => self.catch_up_leaper_idle(effect_builder, rng, block_hash),
-            LeapStatus::Awaiting { .. } => CatchUpInstruction::CheckLater(
+            LeapState::Idle => self.catch_up_leaper_idle(effect_builder, rng, block_hash),
+            LeapState::Awaiting { .. } => CatchUpInstruction::CheckLater(
                 "sync leaper is awaiting response".to_string(),
                 self.control_logic_default_delay.into(),
             ),
-            LeapStatus::Received {
+            LeapState::Received {
                 best_available,
                 from_peers,
                 ..
             } => self.catch_up_leap_received(effect_builder, best_available, from_peers),
-            LeapStatus::Failed { error, .. } => {
+            LeapState::Failed { error, .. } => {
                 self.catch_up_leap_failed(effect_builder, rng, block_hash, error)
             }
         }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -54,11 +54,11 @@ impl MainReactor {
     ) -> (Duration, Effects<MainEvent>) {
         match self.state {
             ReactorState::Initialize => match self.initialize_next_component(effect_builder) {
-                Some(effects) => (Duration::ZERO, effects),
+                Some(effects) => (self.control_logic_default_delay.into(), effects),
                 None => {
                     if false == self.net.has_sufficient_fully_connected_peers() {
                         info!("Initialize: awaiting sufficient fully-connected peers");
-                        return (Duration::from_secs(2), Effects::new());
+                        return (self.control_logic_default_delay.into(), Effects::new());
                     }
                     if let Err(msg) = self.refresh_contract_runtime() {
                         return (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore());

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -255,37 +255,6 @@ impl MainReactor {
             return Some(effects);
         }
 
-        /*
-        if <DeployBuffer as InitializedComponent<MainEvent>>::is_uninitialized(&self.deploy_buffer)
-        {
-            let blocks = match self.storage.read_blocks_for_replay_protection() {
-                Ok(blocks) => blocks,
-                Err(err) => {
-                    return Some(
-                        fatal!(
-                            effect_builder,
-                            "fatal block store error when attempting to read highest blocks: {}",
-                            err
-                        )
-                        .ignore(),
-                    )
-                }
-            };
-            debug!(
-                blocks = ?blocks.iter().map(|b| b.height()).collect_vec(),
-                "DeployBuffer: initialization"
-            );
-            let event = deploy_buffer::Event::Initialize(blocks);
-            if let Some(effects) = utils::initialize_component(
-                effect_builder,
-                &mut self.deploy_buffer,
-                MainEvent::DeployBuffer(event),
-            ) {
-                return Some(effects);
-            }
-        }
-        */
-
         // bring up rpc server near-to-last to defer complications (such as put_deploy)
         if let Some(effects) = utils::initialize_component(
             effect_builder,

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -12,7 +12,7 @@ use crate::{
         block_accumulator::{SyncIdentifier, SyncInstruction},
         block_synchronizer::BlockSynchronizerProgress,
         sync_leaper,
-        sync_leaper::{LeapActivityError, LeapStatus},
+        sync_leaper::{LeapActivityError, LeapState},
     },
     effect::{requests::BlockSynchronizerRequest, EffectBuilder, EffectExt, Effects},
     reactor::main_reactor::{MainEvent, MainReactor},
@@ -290,19 +290,19 @@ impl MainReactor {
         let leap_status = self.sync_leaper.leap_status();
         info!(%parent_hash, %leap_status, "historical status");
         match leap_status {
-            LeapStatus::Idle => {
+            LeapState::Idle => {
                 self.sync_back_leaper_idle(effect_builder, rng, parent_hash, Duration::ZERO)
             }
-            LeapStatus::Awaiting { .. } => KeepUpInstruction::CheckLater(
+            LeapState::Awaiting { .. } => KeepUpInstruction::CheckLater(
                 "historical sync leaper is awaiting response".to_string(),
                 self.control_logic_default_delay.into(),
             ),
-            LeapStatus::Received {
+            LeapState::Received {
                 best_available,
                 from_peers: _,
                 ..
             } => self.sync_back_leap_received(best_available),
-            LeapStatus::Failed { error, .. } => {
+            LeapState::Failed { error, .. } => {
                 self.sync_back_leap_failed(effect_builder, rng, parent_hash, error)
             }
         }

--- a/node/src/reactor/main_reactor/utils.rs
+++ b/node/src/reactor/main_reactor/utils.rs
@@ -15,7 +15,8 @@ pub(super) fn initialize_component(
     initiating_event: MainEvent,
 ) -> Option<Effects<MainEvent>> {
     if component.is_uninitialized() {
-        info!("initialized {}", component.name());
+        component.start_initialization();
+        info!("pending initialization of {}", component.name());
         return Some(smallvec![async { smallvec![initiating_event] }.boxed()]);
     }
     if component.is_fatal() {

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -21,6 +21,8 @@ use crate::{
     NodeRng,
 };
 
+const COMPONENT_NAME: &str = "fake_deploy_acceptor";
+
 pub(crate) trait ReactorEventT:
     From<Event> + From<DeployAcceptorAnnouncement> + From<StorageRequest> + Send
 {
@@ -107,5 +109,9 @@ impl<REv: ReactorEventT> Component<REv> for FakeDeployAcceptor {
             } => self.handle_put_to_storage(effect_builder, event_metadata, is_new),
             _ => unimplemented!("unexpected {:?}", event),
         }
+    }
+
+    fn name(&self) -> &str {
+        COMPONENT_NAME
     }
 }


### PR DESCRIPTION
Closes #3519 by adding the transitional component state (`Initializing`) which means that component initialization has already been initiated and further init requests will be rejected.

In addition, it also changes the following:
1. Implementations of `handle_event()` in all components has been unified in a sense that all components produce consistent log messages using the `tracing` crate capabilities. Also, the components are now consistent on what they log (for example, double initialization attempts, fatal errors, etc.).
2. All components now have a `name()`, not only the initialized ones
3. There are minor renames (mainly for consistency, for example: `ComponentStatus` is now `ComponentState` by reference to `ReactorState`), several code clean-ups (in particular, `DeployBuffer` now has its own `initialize_component` moved from the generic `control.rs`) and bugfixes
4. `control_logic_default_delay` is used instead of `Duration::ZERO` to conduct cranking of the initialization phase
5. It moves the initialization of RPC and REST components to the end, so the Status endpoint is only accessible only when other components that provide status info are up
6. It adds a first flow-chart using `aquamarine` crate - the rest will follow here: https://github.com/casper-network/casper-node/issues/3377
