### PR TITLE
Ensure new blocks are marked complete only when strict finality is reached

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -232,7 +232,7 @@ impl BlockAccumulator {
     }
 
     /// Returns the height of the local tip, i.e. the latest executed block.
-    pub(crate) fn local_tip(&self) -> Option<u64> {
+    pub(crate) fn local_tip_height(&self) -> Option<u64> {
         self.local_tip.map(|identifier| identifier.height)
     }
 

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -12,6 +12,7 @@ use std::{
     cmp::Ordering,
     collections::{btree_map, BTreeMap, VecDeque},
     convert::TryInto,
+    sync::Arc,
 };
 
 use datasize::DataSize;
@@ -26,20 +27,24 @@ use crate::{
     components::{network::blocklist::BlocklistJustification, Component},
     effect::{
         announcements::{
-            BlockAccumulatorAnnouncement, FatalAnnouncement, PeerBehaviorAnnouncement,
+            BlockAccumulatorAnnouncement, FatalAnnouncement, HotBlockAnnouncement,
+            PeerBehaviorAnnouncement,
         },
         requests::{BlockAccumulatorRequest, BlockCompleteConfirmationRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
     fatal,
-    types::{Block, BlockHash, BlockSignatures, FinalitySignature, NodeId, ValidatorMatrix},
+    types::{
+        BlockHash, BlockSignatures, FinalitySignature, HotBlock, HotBlockState, NodeId,
+        ValidatorMatrix,
+    },
     NodeRng,
 };
 
 use crate::components::ValidatorBoundComponent;
 use block_acceptor::{BlockAcceptor, ShouldStore};
 pub(crate) use config::Config;
-pub use error::Error;
+pub(crate) use error::Error;
 pub(crate) use event::Event;
 pub(crate) use sync_identifier::SyncIdentifier;
 pub(crate) use sync_instruction::SyncInstruction;
@@ -226,6 +231,11 @@ impl BlockAccumulator {
         }
     }
 
+    /// Returns the height of the local tip, i.e. the latest executed block.
+    pub(crate) fn local_tip(&self) -> Option<u64> {
+        self.local_tip.map(|identifier| identifier.height)
+    }
+
     /// Registers a peer with an existing acceptor, or creates a new one.
     ///
     /// If the era is outdated or the peer has already caused us to create more acceptors than
@@ -297,17 +307,20 @@ impl BlockAccumulator {
     fn register_block<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        block: Block,
+        hot_block: HotBlock,
         sender: Option<NodeId>,
-        executed: bool,
     ) -> Effects<Event>
     where
-        REv: From<StorageRequest> + From<PeerBehaviorAnnouncement> + From<FatalAnnouncement> + Send,
+        REv: From<StorageRequest>
+            + From<PeerBehaviorAnnouncement>
+            + From<BlockCompleteConfirmationRequest>
+            + From<FatalAnnouncement>
+            + Send,
     {
-        let block_hash = block.hash();
+        let block_hash = hot_block.block.hash();
         debug!(%block_hash, "registering block");
-        let era_id = block.header().era_id();
-        let block_height = block.header().height();
+        let era_id = hot_block.block.header().era_id();
+        let block_height = hot_block.block.header().height();
         if self
             .local_tip
             .as_ref()
@@ -323,7 +336,7 @@ impl BlockAccumulator {
             Some(acceptor) => acceptor,
         };
 
-        match acceptor.register_block(block, sender, executed) {
+        match acceptor.register_block(hot_block, sender) {
             Ok(_) => match self.validator_matrix.validator_weights(era_id) {
                 Some(evw) => {
                     let (should_store, faulty_senders) = acceptor.should_store_block(&evw);
@@ -379,6 +392,10 @@ impl BlockAccumulator {
                     error!(%error, "unexpected detection of bogus validator, this is a bug");
                     Effects::new()
                 }
+                Error::HotBlockMerge(error) => {
+                    error!(%error, "failed to merge hot blocks, this is a bug");
+                    Effects::new()
+                }
             },
         }
     }
@@ -390,7 +407,11 @@ impl BlockAccumulator {
         sender: Option<NodeId>,
     ) -> Effects<Event>
     where
-        REv: From<StorageRequest> + From<PeerBehaviorAnnouncement> + From<FatalAnnouncement> + Send,
+        REv: From<StorageRequest>
+            + From<PeerBehaviorAnnouncement>
+            + From<BlockCompleteConfirmationRequest>
+            + From<FatalAnnouncement>
+            + Send,
     {
         debug!(%finality_signature, "registering finality signature");
         let block_hash = finality_signature.block_hash;
@@ -469,6 +490,10 @@ impl BlockAccumulator {
                         error!(%error, "unexpected detection of bogus validator, this is a bug");
                         Effects::new()
                     }
+                    Error::HotBlockMerge(error) => {
+                        error!(%error, "failed to merge hot blocks, this is a bug");
+                        Effects::new()
+                    }
                 }
             }
         }
@@ -477,22 +502,27 @@ impl BlockAccumulator {
     fn register_stored<REv>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        block: Option<Box<Block>>,
-        finality_signatures: Vec<FinalitySignature>,
+        maybe_hot_block: Option<HotBlock>,
+        maybe_block_signatures: Option<BlockSignatures>,
     ) -> Effects<Event>
     where
-        REv: From<BlockAccumulatorAnnouncement> + From<BlockCompleteConfirmationRequest> + Send,
+        REv: From<BlockAccumulatorAnnouncement>
+            + From<BlockCompleteConfirmationRequest>
+            + From<HotBlockAnnouncement>
+            + Send,
     {
         let mut effects = Effects::new();
-        if let Some(block) = block {
-            effects.extend(effect_builder.announce_block_added(block).ignore());
+        if let Some(hot_block) = maybe_hot_block {
+            effects.extend(effect_builder.announce_hot_block(hot_block).ignore());
         };
-        for finality_signature in finality_signatures {
-            effects.extend(
-                effect_builder
-                    .announce_finality_signature_accepted(Box::new(finality_signature))
-                    .ignore(),
-            );
+        if let Some(block_signatures) = maybe_block_signatures {
+            for finality_signature in block_signatures.finality_signatures() {
+                effects.extend(
+                    effect_builder
+                        .announce_finality_signature_accepted(Box::new(finality_signature))
+                        .ignore(),
+                );
+            }
         }
         effects
     }
@@ -610,6 +640,18 @@ impl BlockAccumulator {
             .set(self.block_children.len().try_into().unwrap_or(i64::MIN));
     }
 
+    fn update_block_children(&mut self, hot_block: &HotBlock) {
+        if let Some(parent_hash) = hot_block.block.parent() {
+            if self
+                .block_children
+                .insert(*parent_hash, *hot_block.block.hash())
+                .is_none()
+            {
+                self.metrics.known_child_blocks.inc();
+            }
+        }
+    }
+
     fn store_block_and_finality_signatures<REv, I>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
@@ -617,71 +659,71 @@ impl BlockAccumulator {
         faulty_senders: I,
     ) -> Effects<Event>
     where
-        REv: From<PeerBehaviorAnnouncement> + From<StorageRequest> + Send,
+        REv: From<PeerBehaviorAnnouncement>
+            + From<StorageRequest>
+            + From<BlockCompleteConfirmationRequest>
+            + Send,
         I: IntoIterator<Item = (NodeId, Error)>,
     {
         let mut effects = match should_store {
             ShouldStore::SufficientlySignedBlock {
-                block,
-                signatures,
-                executed,
+                hot_block,
+                block_signatures,
             } => {
-                debug!(block_hash = %block.hash(), %executed, "storing block and finality signatures");
-                if let Some(parent_hash) = block.parent() {
-                    if self
-                        .block_children
-                        .insert(*parent_hash, *block.hash())
-                        .is_none()
-                    {
-                        self.metrics.known_child_blocks.inc();
-                    }
-                }
-                let mut block_signatures =
-                    BlockSignatures::new(*block.hash(), block.header().era_id());
-                signatures.iter().for_each(|signature| {
-                    block_signatures
-                        .insert_proof(signature.public_key.clone(), signature.signature);
-                });
-                // We do the if branching like this instead of doing
-                // `wrap_effects` or `effects.extend` in order to make sure we
-                // chain the futures one after the other.
-                // TODO: optimize `ShouldStore` and the adjacent flow so that
-                // we don't store the block multiple times. The acceptor should
-                // know whether the block was stored or not and in the case of
-                // subsequent calls to this function, we should just store new
-                // information (i.e. only mark the block complete if it's
-                // already in storage).
-                if executed {
-                    // If the block was executed, it means we have the global
-                    // state for it. As on this code path we also know it is
-                    // sufficiently signed, we mark it as complete.
-                    effect_builder
-                        .put_complete_block_to_storage(Box::new(block.clone()))
-                        .then(move |_| effect_builder.put_signatures_to_storage(block_signatures))
-                        .event(move |_| Event::Stored {
-                            block: Some(Box::new(block)),
-                            finality_signatures: signatures,
-                        })
-                } else {
-                    // If the block wasn't executed yet, we just put it to
-                    // storage. An `ExecutedBlock` event will then retrigger
-                    // this flow and eventually mark it complete.
-                    effect_builder
-                        .put_block_to_storage(Box::new(block.clone()))
-                        .then(move |_| effect_builder.put_signatures_to_storage(block_signatures))
-                        .event(move |_| Event::Stored {
-                            block: Some(Box::new(block)),
-                            finality_signatures: signatures,
-                        })
-                }
+                let block_hash = hot_block.block.hash();
+                debug!(%block_hash, "storing block and finality signatures");
+                self.update_block_children(&hot_block);
+                // The block wasn't executed yet, so we just put it to storage. An `ExecutedBlock`
+                // event will then re-trigger this flow and eventually mark it complete.
+                let cloned_signatures = block_signatures.clone();
+                effect_builder
+                    .put_block_to_storage(Arc::clone(&hot_block.block))
+                    .then(move |_| effect_builder.put_signatures_to_storage(cloned_signatures))
+                    .event(move |_| Event::Stored {
+                        maybe_hot_block: Some(hot_block),
+                        maybe_block_signatures: Some(block_signatures),
+                    })
+            }
+            ShouldStore::CompletedBlock {
+                hot_block,
+                block_signatures,
+            } => {
+                let block_hash = hot_block.block.hash();
+                debug!(%block_hash, "storing finality signatures and marking block complete");
+                self.update_block_children(&hot_block);
+                // The block was already executed, which means it is stored and we have the global
+                // state for it. As on this code path we also know it is sufficiently signed,
+                // we mark it as complete.
+                let block_height = hot_block.block.height();
+                effect_builder
+                    .put_signatures_to_storage(block_signatures.clone())
+                    .then(move |_| effect_builder.mark_block_completed(block_height))
+                    .event(move |_| Event::Stored {
+                        maybe_hot_block: Some(hot_block),
+                        maybe_block_signatures: Some(block_signatures),
+                    })
+            }
+            ShouldStore::MarkComplete(hot_block) => {
+                let block_hash = hot_block.block.hash();
+                debug!(%block_hash, "marking block complete");
+                let block_height = hot_block.block.height();
+                effect_builder
+                    .mark_block_completed(block_height)
+                    .event(move |_| Event::Stored {
+                        maybe_hot_block: Some(hot_block),
+                        maybe_block_signatures: None,
+                    })
             }
             ShouldStore::SingleSignature(signature) => {
                 debug!(%signature, "storing finality signature");
+                let mut block_signatures =
+                    BlockSignatures::new(signature.block_hash, signature.era_id);
+                block_signatures.insert_proof(signature.public_key.clone(), signature.signature);
                 effect_builder
-                    .put_finality_signature_to_storage(signature.clone())
+                    .put_finality_signature_to_storage(signature)
                     .event(move |_| Event::Stored {
-                        block: None,
-                        finality_signatures: vec![signature],
+                        maybe_hot_block: None,
+                        maybe_block_signatures: Some(block_signatures),
                     })
             }
             ShouldStore::Nothing => {
@@ -706,6 +748,7 @@ pub(crate) trait ReactorEvent:
     + From<PeerBehaviorAnnouncement>
     + From<BlockAccumulatorAnnouncement>
     + From<BlockCompleteConfirmationRequest>
+    + From<HotBlockAnnouncement>
     + From<FatalAnnouncement>
     + Send
     + 'static
@@ -717,6 +760,7 @@ impl<REv> ReactorEvent for REv where
         + From<PeerBehaviorAnnouncement>
         + From<BlockAccumulatorAnnouncement>
         + From<BlockCompleteConfirmationRequest>
+        + From<HotBlockAnnouncement>
         + From<FatalAnnouncement>
         + Send
         + 'static
@@ -747,7 +791,8 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 Effects::new()
             }
             Event::ReceivedBlock { block, sender } => {
-                self.register_block(effect_builder, *block, Some(sender), false)
+                let hot_block = HotBlock::new(Arc::new(*block), vec![], HotBlockState::new());
+                self.register_block(effect_builder, hot_block, Some(sender))
             }
             Event::CreatedFinalitySignature { finality_signature } => {
                 self.register_finality_signature(effect_builder, *finality_signature, None)
@@ -758,16 +803,16 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
             } => {
                 self.register_finality_signature(effect_builder, *finality_signature, Some(sender))
             }
-            Event::ExecutedBlock { block } => {
-                let height = block.header().height();
-                let era_id = block.header().era_id();
+            Event::ExecutedBlock { hot_block } => {
+                let height = hot_block.block.header().height();
+                let era_id = hot_block.block.header().era_id();
                 self.register_local_tip(height, era_id);
-                self.register_block(effect_builder, *block, None, true)
+                self.register_block(effect_builder, hot_block, None)
             }
             Event::Stored {
-                block,
-                finality_signatures,
-            } => self.register_stored(effect_builder, block, finality_signatures),
+                maybe_hot_block,
+                maybe_block_signatures,
+            } => self.register_stored(effect_builder, maybe_hot_block, maybe_block_signatures),
         }
     }
 }

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -222,7 +222,7 @@ impl BlockAcceptor {
             return (ShouldStore::Nothing, Vec::new());
         }
 
-        if self.hot_block.is_none() || self.signatures.is_empty() {
+        if no_block || no_sigs {
             debug!(%block_hash, no_block, no_sigs, "not storing block");
             return (ShouldStore::Nothing, Vec::new());
         }

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -10,7 +10,7 @@ use crate::{
     components::block_accumulator::error::{Bogusness, Error as AcceptorError, InvalidGossipError},
     types::{
         BlockHash, BlockSignatures, EmptyValidationMetadata, EraValidatorWeights, FetcherItem,
-        FinalitySignature, HotBlock, HotBlockStateChange, NodeId, SignatureWeight,
+        FinalitySignature, HotBlock, NodeId, SignatureWeight,
     },
 };
 
@@ -205,7 +205,7 @@ impl BlockAcceptor {
         if self.has_sufficient_finality() {
             if let Some(hot_block) = self.hot_block.as_mut() {
                 if hot_block.state.is_executed()
-                    && hot_block.state.register_as_marked_complete() == HotBlockStateChange::Updated
+                    && hot_block.state.register_as_marked_complete().was_updated()
                 {
                     debug!(
                         %block_hash, no_block, no_sigs,
@@ -241,8 +241,10 @@ impl BlockAcceptor {
                     block_signatures
                         .insert_proof(signature.public_key.clone(), signature.signature);
                 });
-                if hot_block.state.register_has_sufficient_finality()
-                    == HotBlockStateChange::AlreadySet
+                if hot_block
+                    .state
+                    .register_has_sufficient_finality()
+                    .was_already_registered()
                 {
                     error!(
                         %block_hash,
@@ -253,8 +255,10 @@ impl BlockAcceptor {
                     );
                 }
                 if hot_block.state.is_executed() {
-                    if hot_block.state.register_as_marked_complete()
-                        == HotBlockStateChange::AlreadySet
+                    if hot_block
+                        .state
+                        .register_as_marked_complete()
+                        .was_already_registered()
                     {
                         error!(
                             %block_hash,
@@ -272,7 +276,11 @@ impl BlockAcceptor {
                         faulty_senders,
                     );
                 } else {
-                    if hot_block.state.register_as_stored() == HotBlockStateChange::AlreadySet {
+                    if hot_block
+                        .state
+                        .register_as_stored()
+                        .was_already_registered()
+                    {
                         error!(
                             %block_hash,
                             block_height = hot_block.block.height(),

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -2,37 +2,39 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use datasize::DataSize;
 use itertools::Itertools;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use casper_types::{EraId, PublicKey, Timestamp};
 
 use crate::{
     components::block_accumulator::error::{Bogusness, Error as AcceptorError, InvalidGossipError},
     types::{
-        Block, BlockHash, EmptyValidationMetadata, EraValidatorWeights, FetcherItem,
-        FinalitySignature, NodeId, SignatureWeight,
+        BlockHash, BlockSignatures, EmptyValidationMetadata, EraValidatorWeights, FetcherItem,
+        FinalitySignature, HotBlock, HotBlockStateChange, NodeId, SignatureWeight,
     },
 };
 
 #[derive(DataSize, Debug)]
 pub(super) struct BlockAcceptor {
     block_hash: BlockHash,
-    block: Option<Block>,
+    hot_block: Option<HotBlock>,
     signatures: BTreeMap<PublicKey, (FinalitySignature, BTreeSet<NodeId>)>,
     peers: BTreeSet<NodeId>,
-    has_sufficient_finality: bool,
     last_progress: Timestamp,
-    executed: bool,
 }
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(super) enum ShouldStore {
     SufficientlySignedBlock {
-        block: Block,
-        signatures: Vec<FinalitySignature>,
-        executed: bool,
+        hot_block: HotBlock,
+        block_signatures: BlockSignatures,
     },
+    CompletedBlock {
+        hot_block: HotBlock,
+        block_signatures: BlockSignatures,
+    },
+    MarkComplete(HotBlock),
     SingleSignature(FinalitySignature),
     Nothing,
 }
@@ -44,12 +46,10 @@ impl BlockAcceptor {
     {
         Self {
             block_hash,
-            block: None,
+            hot_block: None,
             signatures: BTreeMap::new(),
             peers: peers.into_iter().collect(),
-            has_sufficient_finality: false,
             last_progress: Timestamp::now(),
-            executed: false,
         }
     }
 
@@ -63,25 +63,24 @@ impl BlockAcceptor {
 
     pub(super) fn register_block(
         &mut self,
-        block: Block,
+        hot_block: HotBlock,
         peer: Option<NodeId>,
-        executed: bool,
     ) -> Result<(), AcceptorError> {
-        if self.block_hash() != *block.hash() {
+        if self.block_hash() != *hot_block.block.hash() {
             return Err(AcceptorError::BlockHashMismatch {
                 expected: self.block_hash(),
-                actual: *block.hash(),
+                actual: *hot_block.block.hash(),
             });
         }
 
-        if let Err(error) = block.validate(&EmptyValidationMetadata) {
+        if let Err(error) = hot_block.block.validate(&EmptyValidationMetadata) {
             warn!(%error, "received invalid block");
             // TODO[RC]: Consider renaming `InvalidGossip` and/or restructuring the errors
             match peer {
                 Some(node_id) => {
                     return Err(AcceptorError::InvalidGossip(Box::new(
                         InvalidGossipError::Block {
-                            block_hash: *block.hash(),
+                            block_hash: *hot_block.block.hash(),
                             peer: node_id,
                             validation_error: error,
                         },
@@ -95,11 +94,15 @@ impl BlockAcceptor {
             self.register_peer(node_id);
         }
 
-        if self.block.is_none() {
-            self.block = Some(block);
+        match self.hot_block.take() {
+            Some(existing_hot_block) => {
+                let merged_hot_block = existing_hot_block.merge(hot_block)?;
+                self.hot_block = Some(merged_hot_block);
+            }
+            None => {
+                self.hot_block = Some(hot_block);
+            }
         }
-
-        self.executed |= executed;
 
         Ok(())
     }
@@ -131,7 +134,7 @@ impl BlockAcceptor {
             }
         }
 
-        let had_sufficient_finality = self.has_sufficient_finality;
+        let had_sufficient_finality = self.has_sufficient_finality();
         // if we don't have finality yet, collect the signature and return
         // while we could store the finality signature, we currently prefer
         // to store block and signatures when sufficient weight is attained
@@ -146,15 +149,15 @@ impl BlockAcceptor {
             return Ok(None);
         }
 
-        if let Some(block) = &self.block {
+        if let Some(hot_block) = &self.hot_block {
             // if the signature's era does not match the block's era
             // it's malicious / bogus / invalid.
-            if block.header().era_id() != finality_signature.era_id {
+            if hot_block.block.header().era_id() != finality_signature.era_id {
                 match peer {
                     Some(node_id) => {
                         return Err(AcceptorError::EraMismatch {
                             block_hash: finality_signature.block_hash,
-                            expected: block.header().era_id(),
+                            expected: hot_block.block.header().era_id(),
                             actual: finality_signature.era_id,
                             peer: node_id,
                         });
@@ -163,7 +166,7 @@ impl BlockAcceptor {
                 }
             }
         } else {
-            // should have block if self.has_sufficient_finality
+            // should have block if self.has_sufficient_finality()
             return Err(AcceptorError::SufficientFinalityWithoutBlock {
                 block_hash: finality_signature.block_hash,
             });
@@ -196,23 +199,31 @@ impl BlockAcceptor {
         &mut self,
         era_validator_weights: &EraValidatorWeights,
     ) -> (ShouldStore, Vec<(NodeId, AcceptorError)>) {
-        if self.has_sufficient_finality {
+        let block_hash = self.block_hash;
+        let no_block = self.hot_block.is_none();
+        let no_sigs = self.signatures.is_empty();
+        if self.has_sufficient_finality() {
+            if let Some(hot_block) = self.hot_block.as_mut() {
+                if hot_block.state.is_executed()
+                    && hot_block.state.register_as_marked_complete() == HotBlockStateChange::Updated
+                {
+                    debug!(
+                        %block_hash, no_block, no_sigs,
+                        "already have sufficient finality signatures, but marking block complete"
+                    );
+                    return (ShouldStore::MarkComplete(hot_block.clone()), Vec::new());
+                }
+            }
+
             debug!(
-                block_hash = %self.block_hash,
-                no_block = self.block.is_none(),
-                no_sigs = self.signatures.is_empty(),
+                %block_hash, no_block, no_sigs,
                 "not storing anything - already have sufficient finality signatures"
             );
             return (ShouldStore::Nothing, Vec::new());
         }
 
-        if self.block.is_none() || self.signatures.is_empty() {
-            debug!(
-                block_hash = %self.block_hash,
-                no_block = self.block.is_none(),
-                no_sigs = self.signatures.is_empty(),
-                "not storing block"
-            );
+        if self.hot_block.is_none() || self.signatures.is_empty() {
+            debug!(%block_hash, no_block, no_sigs, "not storing block");
             return (ShouldStore::Nothing, Vec::new());
         }
 
@@ -220,40 +231,83 @@ impl BlockAcceptor {
         if SignatureWeight::Sufficient
             == era_validator_weights.has_sufficient_weight(self.signatures.keys())
         {
-            if let Some(block) = self.block.clone() {
-                self.touch();
-                self.has_sufficient_finality = true;
-                return (
-                    ShouldStore::SufficientlySignedBlock {
-                        block,
-                        signatures: self
-                            .signatures
-                            .values()
-                            .map(|(sig, _)| sig.clone())
-                            .collect_vec(),
-                        executed: self.executed,
-                    },
-                    faulty_senders,
+            self.touch();
+            if let Some(hot_block) = self.hot_block.as_mut() {
+                let mut block_signatures = BlockSignatures::new(
+                    *hot_block.block.hash(),
+                    hot_block.block.header().era_id(),
                 );
+                self.signatures.values().for_each(|(signature, _)| {
+                    block_signatures
+                        .insert_proof(signature.public_key.clone(), signature.signature);
+                });
+                if hot_block.state.register_has_sufficient_finality()
+                    == HotBlockStateChange::AlreadySet
+                {
+                    error!(
+                        %block_hash,
+                        block_height = hot_block.block.height(),
+                        hot_block_state = ?hot_block.state,
+                        "should not register having sufficient finality for the same block more \
+                        than once"
+                    );
+                }
+                if hot_block.state.is_executed() {
+                    if hot_block.state.register_as_marked_complete()
+                        == HotBlockStateChange::AlreadySet
+                    {
+                        error!(
+                            %block_hash,
+                            block_height = hot_block.block.height(),
+                            hot_block_state = ?hot_block.state,
+                            "should not mark the same block complete more than once"
+                        );
+                    }
+
+                    return (
+                        ShouldStore::CompletedBlock {
+                            hot_block: hot_block.clone(),
+                            block_signatures,
+                        },
+                        faulty_senders,
+                    );
+                } else {
+                    if hot_block.state.register_as_stored() == HotBlockStateChange::AlreadySet {
+                        error!(
+                            %block_hash,
+                            block_height = hot_block.block.height(),
+                            hot_block_state = ?hot_block.state,
+                            "should not store the same block more than once"
+                        );
+                    }
+                    return (
+                        ShouldStore::SufficientlySignedBlock {
+                            hot_block: hot_block.clone(),
+                            block_signatures,
+                        },
+                        faulty_senders,
+                    );
+                }
             }
         }
 
         debug!(
-            block_hash = %self.block_hash,
-            no_block = self.block.is_none(),
-            no_sigs = self.signatures.is_empty(),
+            %block_hash, no_block, no_sigs,
             "not storing anything - insufficient finality signatures"
         );
         (ShouldStore::Nothing, faulty_senders)
     }
 
     pub(super) fn has_sufficient_finality(&self) -> bool {
-        self.has_sufficient_finality
+        self.hot_block
+            .as_ref()
+            .map(|hot_block| hot_block.state.has_sufficient_finality())
+            .unwrap_or(false)
     }
 
     pub(super) fn era_id(&self) -> Option<EraId> {
-        if let Some(block) = &self.block {
-            return Some(block.header().era_id());
+        if let Some(hot_block) = &self.hot_block {
+            return Some(hot_block.block.header().era_id());
         }
         if let Some((finality_signature, _)) = self.signatures.values().next() {
             return Some(finality_signature.era_id);
@@ -262,7 +316,9 @@ impl BlockAcceptor {
     }
 
     pub(super) fn block_height(&self) -> Option<u64> {
-        self.block.as_ref().map(|block| block.header().height())
+        self.hot_block
+            .as_ref()
+            .map(|hot_block| hot_block.block.header().height())
     }
 
     pub(super) fn block_hash(&self) -> BlockHash {
@@ -294,11 +350,11 @@ impl BlockAcceptor {
             }
         });
 
-        if let Some(block) = &self.block {
+        if let Some(hot_block) = &self.hot_block {
             let bogus_validators = self
                 .signatures
                 .iter()
-                .filter(|(_, (v, _))| v.era_id != block.header().era_id())
+                .filter(|(_, (v, _))| v.era_id != hot_block.block.header().era_id())
                 .map(|(k, _)| k.clone())
                 .collect_vec();
 

--- a/node/src/components/block_accumulator/error.rs
+++ b/node/src/components/block_accumulator/error.rs
@@ -2,10 +2,10 @@ use thiserror::Error;
 
 use casper_types::{crypto, EraId};
 
-use crate::types::{BlockHash, BlockValidationError, NodeId};
+use crate::types::{BlockHash, BlockValidationError, HotBlockMergeError, NodeId};
 
 #[derive(Error, Debug)]
-pub enum InvalidGossipError {
+pub(crate) enum InvalidGossipError {
     #[error("received cryptographically invalid block for: {block_hash} from: {peer} with error: {validation_error}")]
     Block {
         block_hash: BlockHash,
@@ -30,7 +30,7 @@ impl InvalidGossipError {
 }
 
 #[derive(Error, Debug)]
-pub enum Bogusness {
+pub(crate) enum Bogusness {
     #[error("peer is not a validator in current era")]
     NotAValidator,
     #[error("peer provided finality signatures from incorrect era")]
@@ -38,7 +38,7 @@ pub enum Bogusness {
 }
 
 #[derive(Error, Debug)]
-pub enum Error {
+pub(crate) enum Error {
     #[error(transparent)]
     InvalidGossip(Box<InvalidGossipError>),
     #[error("invalid configuration")]
@@ -59,4 +59,6 @@ pub enum Error {
     SufficientFinalityWithoutBlock { block_hash: BlockHash },
     #[error("bogus validator detected")]
     BogusValidator(Bogusness),
+    #[error(transparent)]
+    HotBlockMerge(#[from] HotBlockMergeError),
 }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -35,7 +35,10 @@ use casper_types::{EraId, PublicKey, Timestamp};
 use crate::{
     components::Component,
     effect::{
-        announcements::{ConsensusAnnouncement, FatalAnnouncement, PeerBehaviorAnnouncement},
+        announcements::{
+            ConsensusAnnouncement, FatalAnnouncement, HotBlockAnnouncement,
+            PeerBehaviorAnnouncement,
+        },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{ConsensusDemand, ConsensusMessageIncoming},
         requests::{
@@ -335,6 +338,7 @@ pub(crate) trait ReactorEventT:
     + From<ContractRuntimeRequest>
     + From<ChainspecRawBytesRequest>
     + From<PeerBehaviorAnnouncement>
+    + From<HotBlockAnnouncement>
     + From<FatalAnnouncement>
 {
 }
@@ -353,6 +357,7 @@ impl<REv> ReactorEventT for REv where
         + From<ContractRuntimeRequest>
         + From<ChainspecRawBytesRequest>
         + From<PeerBehaviorAnnouncement>
+        + From<HotBlockAnnouncement>
         + From<FatalAnnouncement>
 {
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -53,7 +53,7 @@ use crate::{
     fatal, protocol,
     types::{
         chainspec::ConsensusProtocolName, BlockHash, BlockHeader, Chainspec, Deploy, DeployHash,
-        DeployOrTransferHash, FinalizedApprovals, FinalizedBlock, NodeId,
+        DeployOrTransferHash, FinalizedApprovals, FinalizedBlock, HotBlockState, NodeId,
     },
     NodeRng,
 };
@@ -1190,14 +1190,6 @@ async fn execute_finalized_block<REv>(
 ) where
     REv: From<StorageRequest> + From<FatalAnnouncement> + From<ContractRuntimeRequest>,
 {
-    // if the block exists in storage, it either has been executed before, or we fast synced to a
-    // higher block - skip execution
-    if effect_builder
-        .block_header_exists(finalized_block.height())
-        .await
-    {
-        return;
-    }
     for (deploy_hash, finalized_approvals) in finalized_approvals {
         effect_builder
             .store_finalized_approvals(deploy_hash, finalized_approvals)
@@ -1224,9 +1216,8 @@ async fn execute_finalized_block<REv>(
             return;
         }
     };
-
     effect_builder
-        .enqueue_block_for_execution(finalized_block, deploys)
+        .enqueue_block_for_execution(finalized_block, deploys, HotBlockState::new())
         .await
 }
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -51,7 +51,7 @@ use crate::{
     protocol::Message,
     types::{
         BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, ChunkingError, Deploy,
-        FinalizedBlock, HotBlock, HotBlockState, HotBlockStateChange, TrieOrChunk, TrieOrChunkId,
+        FinalizedBlock, HotBlock, HotBlockState, TrieOrChunk, TrieOrChunkId,
     },
     NodeRng,
 };
@@ -805,7 +805,7 @@ impl ContractRuntime {
             .map(|(deploy_hash, _, execution_result)| (deploy_hash, execution_result))
             .collect();
 
-        if hot_block_state.register_as_stored() == HotBlockStateChange::Updated {
+        if hot_block_state.register_as_stored().was_updated() {
             effect_builder
                 .put_executed_block_to_storage(
                     Arc::clone(&block),
@@ -821,7 +821,10 @@ impl ContractRuntime {
                 .put_execution_results_to_storage(*block.hash(), execution_results_map)
                 .await;
         }
-        if hot_block_state.register_as_executed() == HotBlockStateChange::AlreadySet {
+        if hot_block_state
+            .register_as_executed()
+            .was_already_registered()
+        {
             error!(
                 block_hash = %block.hash(),
                 block_height = block.height(),

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -8,7 +8,7 @@ mod types;
 
 use std::{
     cmp::Ordering,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     convert::TryInto,
     fmt::{self, Debug, Display, Formatter},
     path::Path,
@@ -42,16 +42,16 @@ use casper_types::{bytesrepr::Bytes, EraId, ProtocolVersion, Timestamp};
 use crate::{
     components::{fetcher::FetchResponse, Component, ComponentStatus},
     effect::{
-        announcements::{ContractRuntimeAnnouncement, FatalAnnouncement},
+        announcements::{ContractRuntimeAnnouncement, FatalAnnouncement, HotBlockAnnouncement},
         incoming::{TrieDemand, TrieRequest, TrieRequestIncoming},
-        requests::{ContractRuntimeRequest, NetworkRequest},
+        requests::{ContractRuntimeRequest, NetworkRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
     fatal,
     protocol::Message,
     types::{
         BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, ChunkingError, Deploy,
-        FinalizedBlock, TrieOrChunk, TrieOrChunkId,
+        FinalizedBlock, HotBlock, HotBlockState, HotBlockStateChange, TrieOrChunk, TrieOrChunkId,
     },
     NodeRng,
 };
@@ -161,7 +161,7 @@ impl ExecutionPreState {
     }
 }
 
-type ExecQueue = Arc<Mutex<BTreeMap<u64, (FinalizedBlock, Vec<Deploy>)>>>;
+type ExecQueue = Arc<Mutex<BTreeMap<u64, (FinalizedBlock, Vec<Deploy>, HotBlockState)>>>;
 
 #[derive(Debug, From, Serialize)]
 pub(crate) enum Event {
@@ -213,6 +213,8 @@ where
     REv: From<ContractRuntimeRequest>
         + From<ContractRuntimeAnnouncement>
         + From<NetworkRequest<Message>>
+        + From<StorageRequest>
+        + From<HotBlockAnnouncement>
         + From<FatalAnnouncement>
         + Send,
 {
@@ -314,6 +316,8 @@ impl ContractRuntime {
     where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
+            + From<StorageRequest>
+            + From<HotBlockAnnouncement>
             + From<FatalAnnouncement>
             + Send,
     {
@@ -438,6 +442,7 @@ impl ContractRuntime {
             ContractRuntimeRequest::EnqueueBlockForExecution {
                 finalized_block,
                 deploys,
+                hot_block_state,
             } => {
                 let mut effects = Effects::new();
                 let exec_queue = Arc::clone(&self.exec_queue);
@@ -470,6 +475,7 @@ impl ContractRuntime {
                                 protocol_version,
                                 finalized_block,
                                 deploys,
+                                hot_block_state,
                             )
                             .ignore(),
                         )
@@ -487,7 +493,7 @@ impl ContractRuntime {
                         exec_queue
                             .lock()
                             .expect("components::contract_runtime: couldn't enqueue block for execution; mutex poisoned")
-                            .insert(finalized_block_height, (finalized_block, deploys));
+                            .insert(finalized_block_height, (finalized_block, deploys, hot_block_state));
                     }
                 }
                 self.metrics
@@ -713,9 +719,12 @@ impl ContractRuntime {
         protocol_version: ProtocolVersion,
         finalized_block: FinalizedBlock,
         deploys: Vec<Deploy>,
+        mut hot_block_state: HotBlockState,
     ) where
         REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
+            + From<StorageRequest>
+            + From<HotBlockAnnouncement>
             + From<FatalAnnouncement>
             + Send,
     {
@@ -744,8 +753,11 @@ impl ContractRuntime {
             Err(error) => return fatal!(effect_builder, "{}", error).await,
         };
 
-        debug!("ContractRuntime: updating new_execution_pre_state");
         let new_execution_pre_state = ExecutionPreState::from_block_header(block.header());
+        debug!(
+            next_block_height = new_execution_pre_state.next_block_height,
+            "ContractRuntime: updating new_execution_pre_state",
+        );
         *execution_pre_state.lock().unwrap() = new_execution_pre_state.clone();
         debug!("ContractRuntime: updated new_execution_pre_state");
 
@@ -779,9 +791,47 @@ impl ContractRuntime {
                 .await;
         }
 
-        effect_builder
-            .announce_executed_block(block, approvals_hashes, execution_results)
-            .await;
+        info!(
+            block_hash = %block.hash(),
+            height = block.header().height(),
+            era = block.header().era_id().value(),
+            is_switch_block = block.header().is_switch_block(),
+            "executed block"
+        );
+
+        let execution_results_map: HashMap<_, _> = execution_results
+            .iter()
+            .cloned()
+            .map(|(deploy_hash, _, execution_result)| (deploy_hash, execution_result))
+            .collect();
+
+        if hot_block_state.register_as_stored() == HotBlockStateChange::Updated {
+            effect_builder
+                .put_executed_block_to_storage(
+                    Arc::clone(&block),
+                    approvals_hashes,
+                    execution_results_map,
+                )
+                .await;
+        } else {
+            effect_builder
+                .put_approvals_hashes_to_storage(approvals_hashes)
+                .await;
+            effect_builder
+                .put_execution_results_to_storage(*block.hash(), execution_results_map)
+                .await;
+        }
+        if hot_block_state.register_as_executed() == HotBlockStateChange::AlreadySet {
+            error!(
+                block_hash = %block.hash(),
+                block_height = block.height(),
+                ?hot_block_state,
+                "should not execute the same block more than once"
+            );
+        }
+
+        let hot_block = HotBlock::new(block, execution_results, hot_block_state);
+        effect_builder.announce_hot_block(hot_block).await;
 
         // If the child is already finalized, start execution.
         let next_block = {
@@ -791,12 +841,12 @@ impl ContractRuntime {
                 .expect("components::contract_runtime: couldn't get next block for execution; mutex poisoned");
             queue.remove(&new_execution_pre_state.next_block_height)
         };
-        if let Some((finalized_block, deploys)) = next_block {
+        if let Some((finalized_block, deploys, hot_block_state)) = next_block {
             metrics.exec_queue_size.dec();
             debug!("ContractRuntime: next block enqueue_block_for_execution");
             effect_builder
-                .enqueue_block_for_execution(finalized_block, deploys)
-                .await
+                .enqueue_block_for_execution(finalized_block, deploys, hot_block_state)
+                .await;
         }
     }
 

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -20,16 +20,15 @@ use casper_types::{
     CLValue, DeployHash, EraId, ExecutionResult, Key, ProtocolVersion, PublicKey, U512,
 };
 
-use super::SpeculativeExecutionState;
 use crate::{
     components::{
         consensus::EraReport,
         contract_runtime::{
             error::BlockExecutionError, types::StepEffectAndUpcomingEraValidators,
-            BlockAndExecutionResults, ExecutionPreState, Metrics,
+            BlockAndExecutionResults, ExecutionPreState, Metrics, SpeculativeExecutionState,
+            APPROVALS_CHECKSUM_NAME, EXECUTION_RESULTS_CHECKSUM_NAME,
         },
     },
-    contract_runtime::{APPROVALS_CHECKSUM_NAME, EXECUTION_RESULTS_CHECKSUM_NAME},
     types::{
         self, error::BlockCreationError, ApprovalsHashes, Block, Chunkable, Deploy, DeployHeader,
         FinalizedBlock, Item,
@@ -191,7 +190,7 @@ pub fn execute_finalized_block(
                         .cloned()
                 },
             );
-    let block = Box::new(Block::new(
+    let block = Arc::new(Block::new(
         parent_hash,
         parent_seed,
         state_root_hash,

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use datasize::DataSize;
 
@@ -8,7 +8,7 @@ use casper_execution_engine::{
 use casper_hashing::Digest;
 use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, U512};
 
-use crate::types::{ApprovalsHashes, Block, BlockHeader, DeployHash, DeployHeader};
+use crate::types::{ApprovalsHashes, Block, DeployHash, DeployHeader};
 
 /// Request for validator weights for a specific era.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,7 +98,7 @@ pub(crate) struct StepEffectAndUpcomingEraValidators {
 #[derive(Clone, Debug, DataSize)]
 pub struct BlockAndExecutionResults {
     /// The [`Block`] the contract runtime executed.
-    pub(crate) block: Box<Block>,
+    pub(crate) block: Arc<Block>,
     /// The [`ApprovalsHashes`] for the deploys in this block.
     pub(crate) approvals_hashes: Box<ApprovalsHashes>,
     /// The results from executing the deploys in the block.
@@ -106,17 +106,4 @@ pub struct BlockAndExecutionResults {
     /// The [`ExecutionJournal`] and the upcoming validator sets determined by the `step`
     pub(crate) maybe_step_effect_and_upcoming_era_validators:
         Option<StepEffectAndUpcomingEraValidators>,
-}
-
-impl BlockAndExecutionResults {
-    #[doc(hidden)]
-    pub fn block_header(&self) -> &BlockHeader {
-        self.block.header()
-    }
-}
-
-impl From<BlockAndExecutionResults> for Block {
-    fn from(block_and_execution_results: BlockAndExecutionResults) -> Self {
-        *block_and_execution_results.block
-    }
 }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -636,7 +636,7 @@ impl reactor::Reactor for Reactor {
 }
 
 fn put_block_to_storage_and_mark_complete(
-    block: Box<Block>,
+    block: Arc<Block>,
     result_sender: Sender<bool>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
@@ -729,7 +729,7 @@ async fn run_deploy_acceptor_without_timeout(
     .await
     .unwrap();
 
-    let block = Box::new(Block::random(&mut rng));
+    let block = Arc::new(Block::random(&mut rng));
     // Create a channel to assert that the block was successfully injected into storage.
     let (result_sender, result_receiver) = oneshot::channel();
 

--- a/node/src/components/deploy_buffer/event.rs
+++ b/node/src/components/deploy_buffer/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use datasize::DataSize;
 use derive_more::From;
@@ -17,7 +20,7 @@ pub(crate) enum Event {
     ReceiveDeployGossiped(DeployId),
     StoredDeploy(DeployId, Box<Option<Deploy>>),
     BlockProposed(Box<ProposedBlock<ClContext>>),
-    Block(Box<Block>),
+    Block(Arc<Block>),
     BlockFinalized(Box<FinalizedBlock>),
     Expire,
 }

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -212,7 +212,7 @@ where
             (ComponentStatus::Initialized, Event::BlockAdded(block)) => {
                 self.broadcast(SseData::BlockAdded {
                     block_hash: *block.hash(),
-                    block: Box::new(JsonBlock::new(*block, None)),
+                    block: Box::new(JsonBlock::new(&*block, None)),
                 })
             }
             (ComponentStatus::Initialized, Event::DeployAccepted(deploy)) => {

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey, Timestamp};
 use itertools::Itertools;
@@ -8,7 +11,7 @@ use crate::types::{Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalityS
 #[derive(Debug)]
 pub enum Event {
     Initialize,
-    BlockAdded(Box<Block>),
+    BlockAdded(Arc<Block>),
     DeployAccepted(Box<Deploy>),
     DeployProcessed {
         deploy_hash: DeployHash,

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -151,7 +151,7 @@ impl SseData {
         let block = Block::random(rng);
         SseData::BlockAdded {
             block_hash: *block.hash(),
-            block: Box::new(JsonBlock::new(block, None)),
+            block: Box::new(JsonBlock::new(&block, None)),
         }
     }
 

--- a/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -38,7 +38,7 @@ impl ItemFetcher<Block> for Fetcher<Block> {
     ) -> StoringState<'a, Block> {
         StoringState::Enqueued(
             effect_builder
-                .put_block_to_storage(Box::new(item))
+                .put_block_to_storage(Arc::new(item))
                 .map(|_| ())
                 .boxed(),
         )

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -166,7 +166,7 @@ impl RpcWithOptionalParams for GetBlock {
             effect_builder,
         )
         .await?;
-        let json_block = JsonBlock::new(block, Some(block_signatures));
+        let json_block = JsonBlock::new(&block, Some(block_signatures));
 
         // Return the result.
         let result = Self::ResponseResult {

--- a/node/src/components/shutdown_trigger.rs
+++ b/node/src/components/shutdown_trigger.rs
@@ -4,7 +4,7 @@
 //! detects a specific spec has been triggered. If so, it instructs the system to shut down through
 //! a [`ControlAnnouncement`].
 
-use std::{fmt::Display, mem};
+use std::{fmt::Display, mem, sync::Arc};
 
 use datasize::DataSize;
 use derive_more::From;
@@ -13,16 +13,38 @@ use tracing::{info, trace};
 
 use crate::{
     effect::{
-        announcements::{ControlAnnouncement, ReactorAnnouncement},
-        requests::SetNodeStopRequest,
-        EffectBuilder, EffectExt, Effects,
+        announcements::ControlAnnouncement, requests::SetNodeStopRequest, EffectBuilder, EffectExt,
+        Effects,
     },
-    types::NodeRng,
+    types::{Block, NodeRng},
 };
 
 use super::{diagnostics_port::StopAtSpec, Component};
 
-//// Shutdown trigger component.
+/// The shutdown trigger component's event.
+#[derive(DataSize, Debug, From, Serialize)]
+pub(crate) enum Event {
+    /// A reactor announcement (usually checked for block completion).
+    CompletedBlock(Arc<Block>),
+    /// A request to trigger a shutdown.
+    #[from]
+    SetNodeStopRequest(SetNodeStopRequest),
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::CompletedBlock(block) => {
+                write!(f, "completed block: {}", block)
+            }
+            Event::SetNodeStopRequest(inner) => {
+                write!(f, "set node stop request: {}", inner)
+            }
+        }
+    }
+}
+
+/// Shutdown trigger component.
 #[derive(DataSize, Debug)]
 pub(crate) struct ShutdownTrigger {
     /// The currently active spec for shutdown triggers.
@@ -32,17 +54,6 @@ pub(crate) struct ShutdownTrigger {
     /// Constantly kept up to date, so that requests for shutting down on `block:next` can be
     /// answered without additional requests.
     highest_block_height_seen: Option<u64>,
-}
-
-/// The shutdown trigger component's event.
-#[derive(DataSize, Debug, From, Serialize)]
-pub(crate) enum Event {
-    /// A reactor announcement (usually checked for block completion).
-    #[from]
-    ReactorAnnouncement(ReactorAnnouncement),
-    /// A request to trigger a shutdown.
-    #[from]
-    SetNodeStopRequest(SetNodeStopRequest),
 }
 
 impl ShutdownTrigger {
@@ -68,7 +79,7 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::ReactorAnnouncement(ReactorAnnouncement::CompletedBlock { block }) => {
+            Event::CompletedBlock(block) => {
                 // We ignore every block that is older than one we already possess.
                 let prev_height = self.highest_block_height_seen.unwrap_or_default();
                 if block.height() > prev_height {
@@ -136,19 +147,6 @@ where
                 }
 
                 effects
-            }
-        }
-    }
-}
-
-impl Display for Event {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Event::ReactorAnnouncement(inner) => {
-                write!(f, "reactor announcement: {}", inner)
-            }
-            Event::SetNodeStopRequest(inner) => {
-                write!(f, "set node stop request: {}", inner)
             }
         }
     }

--- a/node/src/components/shutdown_trigger.rs
+++ b/node/src/components/shutdown_trigger.rs
@@ -24,7 +24,7 @@ use super::{diagnostics_port::StopAtSpec, Component};
 /// The shutdown trigger component's event.
 #[derive(DataSize, Debug, From, Serialize)]
 pub(crate) enum Event {
-    /// A reactor announcement (usually checked for block completion).
+    /// An announcement that a block has been completed.
     CompletedBlock(Arc<Block>),
     /// A request to trigger a shutdown.
     #[from]

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -754,13 +754,6 @@ impl Storage {
             StorageRequest::PutBlock { block, responder } => {
                 responder.respond(self.write_block(&*block)?).ignore()
             }
-            StorageRequest::PutCompleteBlock { block, responder } => {
-                let wrote = self.write_block(&*block)?;
-                if wrote {
-                    self.mark_block_complete(block.height())?;
-                }
-                responder.respond(wrote).ignore()
-            }
             StorageRequest::PutApprovalsHashes {
                 approvals_hashes,
                 responder,
@@ -813,12 +806,6 @@ impl Storage {
                     )?)
                     .ignore()
             }
-            StorageRequest::CheckBlockHeaderExistence {
-                block_height,
-                responder,
-            } => responder
-                .respond(self.block_header_exists(block_height))
-                .ignore(),
             StorageRequest::GetBlockTransfers {
                 block_hash,
                 responder,
@@ -1978,13 +1965,6 @@ impl Storage {
             block_header,
             block_signatures,
         }))
-    }
-
-    /// Checks whether a block at the given height exists in the block height index (and, since the
-    /// index is initialized on startup based on the actual contents of storage, if it exists in
-    /// storage).
-    fn block_header_exists(&self, block_height: u64) -> bool {
-        self.block_height_index.contains_key(&block_height)
     }
 
     /// Stores block headers in the db and, if successful, updates the in-memory indices.

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -24,7 +24,10 @@ use super::{
 };
 use crate::{
     components::fetcher::FetchResponse,
-    effect::{requests::StorageRequest, Multiple},
+    effect::{
+        requests::{BlockCompleteConfirmationRequest, StorageRequest},
+        Multiple,
+    },
     storage::{
         lmdb_ext::{deserialize_internal, serialize_internal},
         FORCE_RESYNC_FILE_NAME,
@@ -409,10 +412,19 @@ fn get_highest_complete_block_header(
 fn put_complete_block(
     harness: &mut ComponentHarness<UnitTestEvent>,
     storage: &mut Storage,
-    block: Box<Block>,
+    block: Arc<Block>,
 ) -> bool {
+    let block_height = block.height();
     let response = harness.send_request(storage, move |responder| {
-        StorageRequest::PutCompleteBlock { block, responder }.into()
+        StorageRequest::PutBlock { block, responder }.into()
+    });
+    assert!(harness.is_idle());
+    harness.send_request(storage, move |responder| {
+        BlockCompleteConfirmationRequest {
+            block_height,
+            responder,
+        }
+        .into()
     });
     assert!(harness.is_idle());
     response
@@ -494,7 +506,7 @@ fn can_retrieve_block_by_height() {
     let mut harness = ComponentHarness::default();
 
     // Create a random blocks, load and store them.
-    let block_33 = Box::new(Block::random_with_specifics(
+    let block_33 = Arc::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         33,
@@ -502,7 +514,7 @@ fn can_retrieve_block_by_height() {
         true,
         None,
     ));
-    let block_14 = Box::new(Block::random_with_specifics(
+    let block_14 = Arc::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         14,
@@ -510,7 +522,7 @@ fn can_retrieve_block_by_height() {
         false,
         None,
     ));
-    let block_99 = Box::new(Block::random_with_specifics(
+    let block_99 = Arc::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(2),
         99,
@@ -642,7 +654,7 @@ fn different_block_at_height_is_fatal() {
     let mut storage = storage_fixture(&harness);
 
     // Create two different blocks at the same height.
-    let block_44_a = Box::new(Block::random_with_specifics(
+    let block_44_a = Arc::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         44,
@@ -650,7 +662,7 @@ fn different_block_at_height_is_fatal() {
         false,
         None,
     ));
-    let block_44_b = Box::new(Block::random_with_specifics(
+    let block_44_b = Arc::new(Block::random_with_specifics(
         &mut harness.rng,
         EraId::new(1),
         44,
@@ -1048,7 +1060,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
     let deploy = Deploy::random(&mut harness.rng);
     let execution_result: ExecutionResult = harness.rng.gen();
     put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
-    put_complete_block(&mut harness, &mut storage, Box::new(block.clone()));
+    put_complete_block(&mut harness, &mut storage, Arc::new(block.clone()));
     let mut execution_results = HashMap::new();
     execution_results.insert(*deploy.hash(), execution_result.clone());
     put_execution_results(&mut harness, &mut storage, *block.hash(), execution_results);
@@ -1119,7 +1131,7 @@ fn should_hard_reset() {
         assert!(put_complete_block(
             &mut harness,
             &mut storage,
-            Box::new(block.clone())
+            Arc::new(block.clone())
         ));
     }
 
@@ -1335,7 +1347,7 @@ fn can_put_and_get_block() {
 
     // Create a random block, store and load it.
     let block = Block::random(&mut harness.rng);
-    let block = Box::new(block);
+    let block = Arc::new(block);
 
     let mut storage = storage_fixture(&harness);
 
@@ -1654,7 +1666,7 @@ fn should_get_block_header_by_height() {
     // Requesting the block header before it is in storage should return None.
     assert!(get_block_header_by_height(&mut harness, &mut storage, height).is_none());
 
-    let was_new = put_complete_block(&mut harness, &mut storage, Box::new(block));
+    let was_new = put_complete_block(&mut harness, &mut storage, Arc::new(block));
     assert!(was_new);
 
     // Requesting the block header after it is in storage should return the block header.
@@ -1673,9 +1685,9 @@ fn check_force_resync_with_marker_file() {
 
     // Add a couple of blocks into storage.
     let first_block = Block::random(&mut harness.rng);
-    put_complete_block(&mut harness, &mut storage, Box::new(first_block.clone()));
+    put_complete_block(&mut harness, &mut storage, Arc::new(first_block.clone()));
     let second_block = Block::random(&mut harness.rng);
-    put_complete_block(&mut harness, &mut storage, Box::new(second_block));
+    put_complete_block(&mut harness, &mut storage, Arc::new(second_block));
     // Make sure the completed blocks are not the default anymore.
     assert_ne!(
         storage.get_available_block_range(),
@@ -1697,7 +1709,7 @@ fn check_force_resync_with_marker_file() {
     );
     let first_block_height = first_block.height();
     // Add a block into storage.
-    put_complete_block(&mut harness, &mut storage, Box::new(first_block));
+    put_complete_block(&mut harness, &mut storage, Arc::new(first_block));
     assert_eq!(
         storage.get_available_block_range(),
         AvailableBlockRange::new(first_block_height, first_block_height)

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -17,7 +17,7 @@ mod upgrade_shutdown;
 mod upgrading_instruction;
 mod validate;
 
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant};
 
 use datasize::DataSize;
 use memory_metrics::MemoryMetrics;
@@ -42,7 +42,7 @@ use crate::{
         network::{self, GossipedAddress, Identity as NetworkIdentity, Network},
         rest_server::RestServer,
         rpc_server::RpcServer,
-        shutdown_trigger::ShutdownTrigger,
+        shutdown_trigger::{self, ShutdownTrigger},
         storage::Storage,
         sync_leaper::SyncLeaper,
         upgrade_watcher::{self, UpgradeWatcher},
@@ -52,13 +52,14 @@ use crate::{
         announcements::{
             BlockAccumulatorAnnouncement, BlockSynchronizerAnnouncement, ConsensusAnnouncement,
             ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
-            DeployBufferAnnouncement, GossiperAnnouncement, PeerBehaviorAnnouncement,
-            ReactorAnnouncement, RpcServerAnnouncement, UpgradeWatcherAnnouncement,
+            DeployBufferAnnouncement, GossiperAnnouncement, HotBlockAnnouncement,
+            PeerBehaviorAnnouncement, RpcServerAnnouncement, UpgradeWatcherAnnouncement,
         },
         incoming::{NetResponseIncoming, TrieResponseIncoming},
         requests::ChainspecRawBytesRequest,
         EffectBuilder, EffectExt, Effects,
     },
+    fatal,
     protocol::Message,
     reactor::{
         self, event_queue_metrics::EventQueueMetrics, main_reactor::fetchers::Fetchers,
@@ -66,7 +67,7 @@ use crate::{
     },
     types::{
         Block, BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, Deploy, FinalitySignature,
-        Item, TrieOrChunk, ValidatorMatrix,
+        HotBlock, HotBlockState, HotBlockStateChange, Item, TrieOrChunk, ValidatorMatrix,
     },
     utils::{Source, WithDir},
     NodeRng,
@@ -394,34 +395,229 @@ impl reactor::Reactor for MainReactor {
             MainEvent::MainReactorRequest(req) => {
                 req.0.respond((self.state, self.last_progress)).ignore()
             }
-            MainEvent::MainReactorAnnouncement(
-                ref ann @ ReactorAnnouncement::CompletedBlock { ref block },
-            ) => {
+            MainEvent::HotBlockAnnouncement(HotBlockAnnouncement(HotBlock {
+                block,
+                execution_results,
+                mut state,
+            })) => {
+                debug!(
+                    "handling hot block {} {} {:?}",
+                    block.height(),
+                    block.hash(),
+                    state
+                );
+                if !state.is_stored() {
+                    return fatal!(
+                        effect_builder,
+                        "block should be stored after execution or accumulation"
+                    )
+                    .ignore();
+                }
+
                 let mut effects = Effects::new();
-                effects.extend(self.dispatch_event(
+
+                let should_update_switch_block = match self.block_accumulator.local_tip() {
+                    Some(local_tip_height) => block.height() > local_tip_height,
+                    None => true,
+                };
+                if should_update_switch_block {
+                    if block.header().is_switch_block() {
+                        match self.switch_block.as_ref().map(|header| header.height()) {
+                            Some(current_height) => {
+                                if block.height() > current_height {
+                                    self.switch_block = Some(block.header().clone());
+                                }
+                            }
+                            None => {
+                                self.switch_block = Some(block.header().clone());
+                            }
+                        }
+                    } else {
+                        self.switch_block = None;
+                    }
+                }
+
+                if state.register_as_sent_to_deploy_buffer() == HotBlockStateChange::Updated {
+                    effects.extend(reactor::wrap_effects(
+                        MainEvent::DeployBuffer,
+                        self.deploy_buffer.handle_event(
+                            effect_builder,
+                            rng,
+                            deploy_buffer::Event::Block(Arc::clone(&block)),
+                        ),
+                    ));
+                }
+
+                if state.register_updated_validator_matrix() == HotBlockStateChange::Updated {
+                    if let Some(validator_weights) = block.header().next_era_validator_weights() {
+                        let era_id = block.header().era_id();
+                        self.validator_matrix.register_validator_weights(
+                            era_id.successor(),
+                            validator_weights.clone(),
+                        );
+                        debug!(
+                            "added switch block (notifying components of validator weights at end \
+                            of {})",
+                            era_id
+                        );
+                        effects.extend(reactor::wrap_effects(
+                            MainEvent::BlockAccumulator,
+                            self.block_accumulator.handle_event(
+                                effect_builder,
+                                rng,
+                                block_accumulator::Event::ValidatorMatrixUpdated,
+                            ),
+                        ));
+                        effects.extend(reactor::wrap_effects(
+                            MainEvent::BlockSynchronizer,
+                            self.block_synchronizer.handle_event(
+                                effect_builder,
+                                rng,
+                                block_synchronizer::Event::ValidatorMatrixUpdated,
+                            ),
+                        ));
+                    }
+                }
+
+                // Validators gossip the block as soon as they deem it valid, but non-validators
+                // only gossip once the block is marked complete.
+                if let Some(true) = self
+                    .validator_matrix
+                    .is_this_node_validator_in_era(block.header().era_id())
+                {
+                    self.update_hot_block_gossip_state(
+                        effect_builder,
+                        rng,
+                        block.hash(),
+                        &mut state,
+                        &mut effects,
+                    );
+                }
+
+                if !state.is_executed() {
+                    // We've done as much as we can on a valid but un-executed block.
+                    return effects;
+                }
+
+                if state.register_we_have_tried_to_sign() == HotBlockStateChange::Updated {
+                    // When this node is a validator in this era, sign and announce.
+                    if let Some(finality_signature) = self
+                        .validator_matrix
+                        .create_finality_signature(block.header())
+                    {
+                        effects.extend(reactor::wrap_effects(
+                            MainEvent::BlockAccumulator,
+                            self.block_accumulator.handle_event(
+                                effect_builder,
+                                rng,
+                                block_accumulator::Event::CreatedFinalitySignature {
+                                    finality_signature: Box::new(finality_signature.clone()),
+                                },
+                            ),
+                        ));
+
+                        let era_id = finality_signature.era_id;
+                        let payload = Message::FinalitySignature(Box::new(finality_signature));
+                        effects.extend(reactor::wrap_effects(
+                            MainEvent::Network,
+                            effect_builder
+                                .broadcast_message_to_validators(payload, era_id)
+                                .ignore(),
+                        ));
+                    }
+                }
+
+                if state.register_as_sent_to_consensus_post_execution()
+                    == HotBlockStateChange::Updated
+                {
+                    effects.extend(reactor::wrap_effects(
+                        MainEvent::Consensus,
+                        self.consensus.handle_event(
+                            effect_builder,
+                            rng,
+                            consensus::Event::BlockAdded {
+                                header: Box::new(block.header().clone()),
+                                header_hash: *block.hash(),
+                            },
+                        ),
+                    ));
+                }
+
+                if state.register_as_sent_to_accumulator_post_execution()
+                    == HotBlockStateChange::Updated
+                {
+                    let hot_block = HotBlock {
+                        block,
+                        execution_results,
+                        state,
+                    };
+                    effects.extend(reactor::wrap_effects(
+                        MainEvent::BlockAccumulator,
+                        self.block_accumulator.handle_event(
+                            effect_builder,
+                            rng,
+                            block_accumulator::Event::ExecutedBlock { hot_block },
+                        ),
+                    ));
+                    // We've done as much as we can for now, we need to wait for the block
+                    // accumulator to mark the block complete before proceeding further.
+                    return effects;
+                }
+
+                if !state.is_marked_complete() {
+                    error!(
+                        block = %*block,
+                        ?state,
+                        "should be a complete block after passing to accumulator"
+                    );
+                }
+
+                self.update_hot_block_gossip_state(
                     effect_builder,
                     rng,
-                    MainEvent::EventStreamServer(event_stream_server::Event::BlockAdded(
-                        block.clone(),
-                    )),
+                    block.hash(),
+                    &mut state,
+                    &mut effects,
+                );
+
+                debug_assert!(
+                    state.verify_complete(),
+                    "hot block {} at height {} has invalid state: {:?}",
+                    block.hash(),
+                    block.height(),
+                    state
+                );
+
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::EventStreamServer,
+                    self.event_stream_server.handle_event(
+                        effect_builder,
+                        rng,
+                        event_stream_server::Event::BlockAdded(Arc::clone(&block)),
+                    ),
                 ));
-                effects.extend(self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    MainEvent::DeployBuffer(deploy_buffer::Event::Block(block.clone())),
-                ));
-                effects.extend(self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    MainEvent::Consensus(consensus::Event::BlockAdded {
-                        header: Box::new(block.header().clone()),
-                        header_hash: *block.hash(),
-                    }),
-                ));
+
+                for (deploy_hash, deploy_header, execution_result) in execution_results {
+                    let event = event_stream_server::Event::DeployProcessed {
+                        deploy_hash,
+                        deploy_header: Box::new(deploy_header),
+                        block_hash: *block.hash(),
+                        execution_result: Box::new(execution_result),
+                    };
+                    effects.extend(reactor::wrap_effects(
+                        MainEvent::EventStreamServer,
+                        self.event_stream_server
+                            .handle_event(effect_builder, rng, event),
+                    ));
+                }
+
                 effects.extend(reactor::wrap_effects(
                     MainEvent::ShutdownTrigger,
-                    self.shutdown_trigger
-                        .handle_event(effect_builder, rng, ann.clone().into()),
+                    self.shutdown_trigger.handle_event(
+                        effect_builder,
+                        rng,
+                        shutdown_trigger::Event::CompletedBlock(Arc::clone(&block)),
+                    ),
                 ));
                 effects
             }
@@ -638,64 +834,35 @@ impl reactor::Reactor for MainReactor {
             ),
             MainEvent::BlockSynchronizerAnnouncement(
                 BlockSynchronizerAnnouncement::CompletedBlock { block },
-            ) => self.dispatch_event(
-                effect_builder,
-                rng,
-                MainEvent::MainReactorAnnouncement(ReactorAnnouncement::CompletedBlock { block }),
-            ),
-
-            MainEvent::BlockAccumulatorAnnouncement(
-                BlockAccumulatorAnnouncement::AcceptedNewBlock { block },
             ) => {
-                let mut effects = Effects::new();
-                let deploy_buffer_event =
-                    MainEvent::DeployBuffer(deploy_buffer::Event::Block(block.clone()));
-                effects.extend(self.dispatch_event(effect_builder, rng, deploy_buffer_event));
-
-                // if it is a switch block, get validators
-                if let Some(validator_weights) = block.header().next_era_validator_weights() {
-                    self.switch_block = Some(block.header().clone());
-
-                    let era_id = block.header().era_id();
-                    self.validator_matrix
-                        .register_validator_weights(era_id.successor(), validator_weights.clone());
-                    debug!(
-                        "block_accumulator added switch block (notifying components of validator \
-                        weights at end of: {})",
-                        era_id
-                    );
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::BlockAccumulator,
-                        self.block_accumulator.handle_event(
-                            effect_builder,
-                            rng,
-                            block_accumulator::Event::ValidatorMatrixUpdated,
-                        ),
-                    ));
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::BlockSynchronizer,
-                        self.block_synchronizer.handle_event(
-                            effect_builder,
-                            rng,
-                            block_synchronizer::Event::ValidatorMatrixUpdated,
-                        ),
-                    ));
-                }
-                debug!(
-                    "notifying block gossiper to start gossiping for: {}",
-                    block.id()
-                );
-                effects.extend(reactor::wrap_effects(
-                    MainEvent::BlockGossiper,
-                    self.block_gossiper.handle_event(
+                let mut effects = reactor::wrap_effects(
+                    MainEvent::DeployBuffer,
+                    self.deploy_buffer.handle_event(
                         effect_builder,
                         rng,
-                        gossiper::Event::ItemReceived {
-                            item_id: *block.hash(),
-                            source: Source::Ourself,
+                        deploy_buffer::Event::Block(Arc::clone(&block)),
+                    ),
+                );
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::Consensus,
+                    self.consensus.handle_event(
+                        effect_builder,
+                        rng,
+                        consensus::Event::BlockAdded {
+                            header: Box::new(block.header().clone()),
+                            header_hash: *block.hash(),
                         },
                     ),
                 ));
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::EventStreamServer,
+                    self.event_stream_server.handle_event(
+                        effect_builder,
+                        rng,
+                        event_stream_server::Event::BlockAdded(Arc::clone(&block)),
+                    ),
+                ));
+                // TODO - fetch execution results from storage and send to event stream
                 effects
             }
             MainEvent::BlockAccumulatorAnnouncement(
@@ -973,108 +1140,6 @@ impl reactor::Reactor for MainReactor {
                     .handle_event(effect_builder, rng, req.into()),
             ),
             MainEvent::ContractRuntimeAnnouncement(
-                ContractRuntimeAnnouncement::ExecutedBlock {
-                    block,
-                    approvals_hashes,
-                    execution_results,
-                },
-            ) => {
-                let mut effects = Effects::new();
-                let block_hash = *block.hash();
-                let is_switch_block = block.header().is_switch_block();
-                info!(
-                    %block_hash,
-                    height=block.header().height(),
-                    era=block.header().era_id().value(),
-                    is_switch_block=is_switch_block,
-                    "executed block"
-                );
-
-                if is_switch_block {
-                    self.switch_block = Some(block.header().clone());
-                } else {
-                    self.switch_block = None;
-                }
-
-                let execution_results_map: HashMap<_, _> = execution_results
-                    .iter()
-                    .cloned()
-                    .map(|(deploy_hash, _, execution_result)| (deploy_hash, execution_result))
-                    .collect();
-
-                effects.extend(
-                    effect_builder
-                        .put_executed_block_to_storage(
-                            block.clone(),
-                            approvals_hashes,
-                            execution_results_map,
-                        )
-                        .ignore(),
-                );
-
-                // When this node is a validator in this era, sign and announce.
-                if let Some(finality_signature) = self
-                    .validator_matrix
-                    .create_finality_signature(block.header())
-                {
-                    // send to block accumulator
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::BlockAccumulator,
-                        self.block_accumulator.handle_event(
-                            effect_builder,
-                            rng,
-                            block_accumulator::Event::CreatedFinalitySignature {
-                                finality_signature: Box::new(finality_signature.clone()),
-                            },
-                        ),
-                    ));
-
-                    // broadcast to validator peers
-                    let era_id = finality_signature.era_id;
-                    let payload = Message::FinalitySignature(Box::new(finality_signature));
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::Network,
-                        effect_builder
-                            .broadcast_message_to_validators(payload, era_id)
-                            .ignore(),
-                    ));
-                }
-
-                effects.extend(effect_builder.mark_block_completed(block.height()).ignore());
-                effects.extend(self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    MainEvent::MainReactorAnnouncement(ReactorAnnouncement::CompletedBlock {
-                        block: block.clone(),
-                    }),
-                ));
-                effects.extend(reactor::wrap_effects(
-                    MainEvent::BlockAccumulator,
-                    self.block_accumulator.handle_event(
-                        effect_builder,
-                        rng,
-                        block_accumulator::Event::ExecutedBlock { block },
-                    ),
-                ));
-
-                // send deploy processed events to event stream
-                for (deploy_hash, deploy_header, execution_result) in execution_results {
-                    let event = event_stream_server::Event::DeployProcessed {
-                        deploy_hash,
-                        deploy_header: Box::new(deploy_header),
-                        block_hash,
-                        execution_result: Box::new(execution_result),
-                    };
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::EventStreamServer,
-                        self.event_stream_server
-                            .handle_event(effect_builder, rng, event),
-                    ));
-                }
-
-                effects
-            }
-            MainEvent::ContractRuntimeAnnouncement(
                 ContractRuntimeAnnouncement::CommitStepSuccess {
                     era_id,
                     execution_effect,
@@ -1160,6 +1225,35 @@ impl reactor::Reactor for MainReactor {
             | MainEvent::BlockExecutionResultsOrChunkFetcherRequest(..) => self
                 .fetchers
                 .dispatch_fetcher_event(effect_builder, rng, event),
+        }
+    }
+}
+
+impl MainReactor {
+    fn update_hot_block_gossip_state(
+        &mut self,
+        effect_builder: EffectBuilder<MainEvent>,
+        rng: &mut NodeRng,
+        block_hash: &BlockHash,
+        state: &mut HotBlockState,
+        effects: &mut Effects<MainEvent>,
+    ) {
+        if state.register_as_gossiped() == HotBlockStateChange::Updated {
+            debug!(
+                "notifying block gossiper to start gossiping for: {}",
+                block_hash
+            );
+            effects.extend(reactor::wrap_effects(
+                MainEvent::BlockGossiper,
+                self.block_gossiper.handle_event(
+                    effect_builder,
+                    rng,
+                    gossiper::Event::ItemReceived {
+                        item_id: *block_hash,
+                        source: Source::Ourself,
+                    },
+                ),
+            ));
         }
     }
 }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -22,7 +22,7 @@ use crate::{
         upgrade_shutdown::UpgradeShutdownInstruction, upgrading_instruction::UpgradingInstruction,
         utils, validate::ValidateInstruction, MainEvent, MainReactor, ReactorState,
     },
-    types::{BlockHash, BlockPayload, FinalizedBlock, Item},
+    types::{BlockHash, BlockPayload, FinalizedBlock, HotBlockState, Item},
     NodeRng,
 };
 
@@ -358,8 +358,13 @@ impl MainReactor {
             next_block_height,
             PublicKey::System,
         );
+
         Ok(effect_builder
-            .enqueue_block_for_execution(finalized_block, vec![])
+            .enqueue_block_for_execution(
+                finalized_block,
+                vec![],
+                HotBlockState::new_immediate_switch(),
+            )
             .ignore())
     }
 
@@ -414,7 +419,11 @@ impl MainReactor {
                         PublicKey::System,
                     );
                     Ok(effect_builder
-                        .enqueue_block_for_execution(finalized_block, vec![])
+                        .enqueue_block_for_execution(
+                            finalized_block,
+                            vec![],
+                            HotBlockState::new_immediate_switch(),
+                        )
                         .ignore())
                 }
                 Err(err) => Err(err.to_string()),
@@ -454,7 +463,11 @@ impl MainReactor {
     }
 
     fn refresh_contract_runtime(&mut self) -> Result<(), String> {
-        match self.storage.read_highest_complete_block() {
+        // Note: we don't want to read the highest COMPLETE block, as an immediate switch block is
+        // only marked complete after we receive enough signatures from validators.  Using the
+        // highest stored block ensures the ContractRuntime's `exec_queue` isn't set to a block
+        // height we already executed but haven't yet marked complete.
+        match self.storage.read_highest_block() {
             Ok(Some(block)) => {
                 let block_height = block.height();
                 let state_root_hash = block.state_root_hash();
@@ -470,7 +483,7 @@ impl MainReactor {
             Ok(None) => {
                 Ok(()) // noop
             }
-            Err(error) => Err(format!("failed to read highest complete block: {}", error)),
+            Err(error) => Err(format!("failed to read highest block: {}", error)),
         }
     }
 

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -17,7 +17,7 @@ use crate::{
             BlockAccumulatorAnnouncement, BlockSynchronizerAnnouncement, ConsensusAnnouncement,
             ContractRuntimeAnnouncement, ControlAnnouncement, DeployAcceptorAnnouncement,
             DeployBufferAnnouncement, FatalAnnouncement, GossiperAnnouncement,
-            PeerBehaviorAnnouncement, ReactorAnnouncement, RpcServerAnnouncement,
+            HotBlockAnnouncement, PeerBehaviorAnnouncement, RpcServerAnnouncement,
             UpgradeWatcherAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
@@ -220,13 +220,13 @@ pub(crate) enum MainEvent {
     #[from]
     Storage(storage::Event),
     #[from]
-    StorageRequest(#[serde(skip_serializing)] StorageRequest),
+    StorageRequest(StorageRequest),
     #[from]
     SetNodeStopRequest(SetNodeStopRequest),
     #[from]
-    MainReactorRequest(#[serde(skip_serializing)] ReactorStatusRequest),
+    MainReactorRequest(ReactorStatusRequest),
     #[from]
-    MainReactorAnnouncement(#[serde(skip_serializing)] ReactorAnnouncement),
+    HotBlockAnnouncement(HotBlockAnnouncement),
 }
 
 impl ReactorEvent for MainEvent {
@@ -333,8 +333,8 @@ impl ReactorEvent for MainEvent {
             MainEvent::BlockFetcherRequest(_) => "BlockFetcherRequest",
             MainEvent::SetNodeStopRequest(_) => "SetNodeStopRequest",
             MainEvent::MainReactorRequest(_) => "MainReactorRequest",
-            MainEvent::MainReactorAnnouncement(_) => "MainReactorAnnouncement",
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
+            MainEvent::HotBlockAnnouncement(_) => "HotBlockAnnouncement",
         }
     }
 }
@@ -510,8 +510,8 @@ impl Display for MainEvent {
             MainEvent::BlockFetcherRequest(inner) => Display::fmt(inner, f),
             MainEvent::SetNodeStopRequest(inner) => Display::fmt(inner, f),
             MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
-            MainEvent::MainReactorAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),
+            MainEvent::HotBlockAnnouncement(inner) => Display::fmt(inner, f),
         }
     }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -26,7 +26,8 @@ use rand_chacha::ChaCha20Rng;
 pub use available_block_range::AvailableBlockRange;
 pub(crate) use block::{
     compute_approvals_checksum, ApprovalsHashes, BlockHashAndHeight, BlockHeaderWithMetadata,
-    BlockPayload, BlockWithMetadata, FinalitySignatureId,
+    BlockPayload, BlockWithMetadata, FinalitySignatureId, HotBlock, HotBlockMergeError,
+    HotBlockState, HotBlockStateChange,
 };
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -27,7 +27,7 @@ pub use available_block_range::AvailableBlockRange;
 pub(crate) use block::{
     compute_approvals_checksum, ApprovalsHashes, BlockHashAndHeight, BlockHeaderWithMetadata,
     BlockPayload, BlockWithMetadata, FinalitySignatureId, HotBlock, HotBlockMergeError,
-    HotBlockState, HotBlockStateChange,
+    HotBlockState,
 };
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -50,7 +50,6 @@ use crate::{
 pub(crate) use approvals_hashes::ApprovalsHashes;
 pub(crate) use hot_block::{
     HotBlock, MergeMismatchError as HotBlockMergeError, State as HotBlockState,
-    StateChange as HotBlockStateChange,
 };
 
 static ERA_REPORT: Lazy<EraReport> = Lazy::new(|| {

--- a/node/src/types/block/hot_block.rs
+++ b/node/src/types/block/hot_block.rs
@@ -11,7 +11,7 @@ use casper_types::ExecutionResult;
 use crate::types::{Block, DeployHash, DeployHeader};
 
 pub(crate) use merge_mismatch_error::MergeMismatchError;
-pub(crate) use state::{State, StateChange};
+pub(crate) use state::State;
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug, DataSize)]
 pub(crate) struct HotBlock {

--- a/node/src/types/block/hot_block.rs
+++ b/node/src/types/block/hot_block.rs
@@ -56,6 +56,8 @@ impl HotBlock {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use rand::Rng;
 
     use casper_types::testing::TestRng;
@@ -126,7 +128,14 @@ mod tests {
         let mut rng = TestRng::new();
 
         let block1 = Arc::new(Block::random(&mut rng));
-        let block2 = Arc::new(Block::random(&mut rng));
+        let block2 = Arc::new(Block::random_with_specifics(
+            &mut rng,
+            block1.header().era_id().successor(),
+            block1.height() + 1,
+            block1.protocol_version(),
+            true,
+            iter::empty(),
+        ));
         let deploy = Deploy::random(&mut rng);
         let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
         let state = State::new();

--- a/node/src/types/block/hot_block.rs
+++ b/node/src/types/block/hot_block.rs
@@ -1,0 +1,170 @@
+mod merge_mismatch_error;
+mod state;
+
+use std::sync::Arc;
+
+use datasize::DataSize;
+use serde::Serialize;
+
+use casper_types::ExecutionResult;
+
+use crate::types::{Block, DeployHash, DeployHeader};
+
+pub(crate) use merge_mismatch_error::MergeMismatchError;
+pub(crate) use state::{State, StateChange};
+
+#[derive(Clone, Eq, PartialEq, Serialize, Debug, DataSize)]
+pub(crate) struct HotBlock {
+    pub(crate) block: Arc<Block>,
+    pub(crate) execution_results: Vec<(DeployHash, DeployHeader, ExecutionResult)>,
+    pub(crate) state: State,
+}
+
+impl HotBlock {
+    pub(crate) fn new(
+        block: Arc<Block>,
+        execution_results: Vec<(DeployHash, DeployHeader, ExecutionResult)>,
+        state: State,
+    ) -> Self {
+        HotBlock {
+            block,
+            execution_results,
+            state,
+        }
+    }
+
+    pub(crate) fn merge(mut self, other: HotBlock) -> Result<Self, MergeMismatchError> {
+        if self.block != other.block {
+            return Err(MergeMismatchError::Block);
+        }
+
+        if self.execution_results.is_empty() {
+            if !other.execution_results.is_empty() {
+                self.execution_results = other.execution_results;
+            }
+        } else if !other.execution_results.is_empty()
+            && self.execution_results != other.execution_results
+        {
+            return Err(MergeMismatchError::ExecutionResults);
+        }
+
+        self.state = self.state.merge(other.state)?;
+
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use casper_types::testing::TestRng;
+
+    use super::*;
+    use crate::types::Deploy;
+
+    #[test]
+    fn should_merge_when_same_non_empty_execution_results() {
+        let mut rng = TestRng::new();
+
+        let block = Arc::new(Block::random(&mut rng));
+        let deploy = Deploy::random(&mut rng);
+        let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
+        let state = State::new_synced();
+
+        let hot_block1 = HotBlock::new(Arc::clone(&block), execution_results.clone(), state);
+        let hot_block2 = HotBlock::new(Arc::clone(&block), execution_results.clone(), state);
+
+        let merged = hot_block1.clone().merge(hot_block2.clone()).unwrap();
+
+        assert_eq!(merged.block, block);
+        assert_eq!(merged.execution_results, execution_results);
+        assert_eq!(merged.state, State::new_synced());
+        assert_eq!(hot_block2.merge(hot_block1).unwrap(), merged)
+    }
+
+    #[test]
+    fn should_merge_when_both_empty_execution_results() {
+        let mut rng = TestRng::new();
+
+        let block = Arc::new(Block::random(&mut rng));
+        let state = State::new();
+
+        let hot_block1 = HotBlock::new(Arc::clone(&block), vec![], state);
+        let hot_block2 = HotBlock::new(Arc::clone(&block), vec![], state);
+
+        let merged = hot_block1.clone().merge(hot_block2.clone()).unwrap();
+
+        assert_eq!(merged.block, block);
+        assert!(merged.execution_results.is_empty());
+        assert_eq!(merged.state, state);
+        assert_eq!(hot_block2.merge(hot_block1).unwrap(), merged)
+    }
+
+    #[test]
+    fn should_merge_when_one_empty_execution_results() {
+        let mut rng = TestRng::new();
+
+        let block = Arc::new(Block::random(&mut rng));
+        let deploy = Deploy::random(&mut rng);
+        let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
+        let state = State::new_immediate_switch();
+
+        let hot_block1 = HotBlock::new(Arc::clone(&block), execution_results.clone(), state);
+        let hot_block2 = HotBlock::new(Arc::clone(&block), vec![], state);
+
+        let merged = hot_block1.clone().merge(hot_block2.clone()).unwrap();
+
+        assert_eq!(merged.block, block);
+        assert_eq!(merged.execution_results, execution_results);
+        assert_eq!(merged.state, state);
+        assert_eq!(hot_block2.merge(hot_block1).unwrap(), merged)
+    }
+
+    #[test]
+    fn should_fail_to_merge_different_blocks() {
+        let mut rng = TestRng::new();
+
+        let block1 = Arc::new(Block::random(&mut rng));
+        let block2 = Arc::new(Block::random(&mut rng));
+        let deploy = Deploy::random(&mut rng);
+        let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
+        let state = State::new();
+
+        let hot_block1 = HotBlock::new(block1, execution_results.clone(), state);
+        let hot_block2 = HotBlock::new(block2, execution_results, state);
+
+        assert!(matches!(
+            hot_block1.clone().merge(hot_block2.clone()),
+            Err(MergeMismatchError::Block)
+        ));
+        assert!(matches!(
+            hot_block2.merge(hot_block1),
+            Err(MergeMismatchError::Block)
+        ));
+    }
+
+    #[test]
+    fn should_fail_to_merge_different_execution_results() {
+        let mut rng = TestRng::new();
+
+        let block = Arc::new(Block::random(&mut rng));
+        let deploy1 = Deploy::random(&mut rng);
+        let execution_results1 = vec![(*deploy1.hash(), deploy1.take_header(), rng.gen())];
+        let deploy2 = Deploy::random(&mut rng);
+        let execution_results2 = vec![(*deploy2.hash(), deploy2.take_header(), rng.gen())];
+        let state = State::new();
+
+        let hot_block1 = HotBlock::new(Arc::clone(&block), execution_results1, state);
+        let hot_block2 = HotBlock::new(Arc::clone(&block), execution_results2, state);
+
+        assert!(matches!(
+            hot_block1.clone().merge(hot_block2.clone()),
+            Err(MergeMismatchError::ExecutionResults)
+        ));
+        assert!(matches!(
+            hot_block2.merge(hot_block1),
+            Err(MergeMismatchError::ExecutionResults)
+        ));
+    }
+}

--- a/node/src/types/block/hot_block/merge_mismatch_error.rs
+++ b/node/src/types/block/hot_block/merge_mismatch_error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+use tracing::error;
+
+#[derive(Error, Debug)]
+pub(crate) enum MergeMismatchError {
+    #[error("block mismatch when merging hot blocks")]
+    Block,
+    #[error("execution results mismatch when merging hot blocks")]
+    ExecutionResults,
+    #[error("state mismatch when merging hot blocks")]
+    State,
+}

--- a/node/src/types/block/hot_block/state.rs
+++ b/node/src/types/block/hot_block/state.rs
@@ -1,0 +1,244 @@
+use datasize::DataSize;
+use serde::Serialize;
+
+use super::MergeMismatchError;
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, DataSize)]
+pub(crate) enum StateChange {
+    Updated,
+    AlreadySet,
+}
+
+impl From<bool> for StateChange {
+    fn from(current_state: bool) -> Self {
+        if current_state {
+            StateChange::AlreadySet
+        } else {
+            StateChange::Updated
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Default, Serialize, Debug, DataSize)]
+pub(crate) struct State {
+    pub(super) is_immediate_switch_block_for_current_protocol_version: bool,
+    pub(super) is_stored: bool,
+    pub(super) has_been_sent_to_deploy_buffer: bool,
+    pub(super) has_updated_validator_matrix: bool,
+    pub(super) has_been_gossiped: bool,
+    pub(super) is_executed: bool,
+    pub(super) we_have_tried_to_sign: bool,
+    pub(super) has_been_sent_to_consensus_post_execution: bool,
+    pub(super) has_been_sent_to_accumulator_post_execution: bool,
+    pub(super) has_sufficient_finality: bool,
+    pub(super) is_marked_complete: bool,
+}
+
+impl State {
+    /// Returns a new `State` with all fields set to `false`.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a new `State` with all fields set to `false` except for
+    /// `is_immediate_switch_block_for_current_protocol_version`.
+    pub(crate) fn new_immediate_switch() -> Self {
+        State {
+            is_immediate_switch_block_for_current_protocol_version: true,
+            ..Self::default()
+        }
+    }
+
+    /// Returns a new `State` with all fields set to `false` except for `is_stored`.
+    pub(crate) fn new_synced() -> Self {
+        State {
+            is_stored: true,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn is_stored(&self) -> bool {
+        self.is_stored
+    }
+
+    pub(crate) fn is_executed(&self) -> bool {
+        self.is_executed
+    }
+
+    pub(crate) fn has_sufficient_finality(&self) -> bool {
+        self.has_sufficient_finality
+    }
+
+    pub(crate) fn is_marked_complete(&self) -> bool {
+        self.is_marked_complete
+    }
+
+    pub(crate) fn register_as_stored(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.is_stored);
+        self.is_stored = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_sent_to_deploy_buffer(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.has_been_sent_to_deploy_buffer);
+        self.has_been_sent_to_deploy_buffer = true;
+        outcome
+    }
+
+    pub(crate) fn register_updated_validator_matrix(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.has_updated_validator_matrix);
+        self.has_updated_validator_matrix = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_gossiped(&mut self) -> StateChange {
+        // We don't gossip immediate switch blocks
+        if self.is_immediate_switch_block_for_current_protocol_version {
+            return StateChange::AlreadySet;
+        }
+        let outcome = StateChange::from(self.has_been_gossiped);
+        self.has_been_gossiped = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_executed(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.is_executed);
+        self.is_executed = true;
+        outcome
+    }
+
+    pub(crate) fn register_we_have_tried_to_sign(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.we_have_tried_to_sign);
+        self.we_have_tried_to_sign = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_sent_to_consensus_post_execution(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.has_been_sent_to_consensus_post_execution);
+        self.has_been_sent_to_consensus_post_execution = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_sent_to_accumulator_post_execution(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.has_been_sent_to_accumulator_post_execution);
+        self.has_been_sent_to_accumulator_post_execution = true;
+        outcome
+    }
+
+    pub(crate) fn register_has_sufficient_finality(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.has_sufficient_finality);
+        self.has_sufficient_finality = true;
+        outcome
+    }
+
+    pub(crate) fn register_as_marked_complete(&mut self) -> StateChange {
+        let outcome = StateChange::from(self.is_marked_complete);
+        self.is_marked_complete = true;
+        outcome
+    }
+
+    pub(super) fn merge(mut self, other: State) -> Result<Self, MergeMismatchError> {
+        let State {
+            is_immediate_switch_block_for_current_protocol_version,
+            ref mut is_stored,
+            ref mut has_been_sent_to_deploy_buffer,
+            ref mut has_updated_validator_matrix,
+            ref mut has_been_gossiped,
+            ref mut is_executed,
+            ref mut we_have_tried_to_sign,
+            ref mut has_been_sent_to_consensus_post_execution,
+            ref mut has_been_sent_to_accumulator_post_execution,
+            ref mut has_sufficient_finality,
+            ref mut is_marked_complete,
+        } = self;
+
+        if is_immediate_switch_block_for_current_protocol_version
+            != other.is_immediate_switch_block_for_current_protocol_version
+        {
+            return Err(MergeMismatchError::State);
+        }
+
+        *is_stored |= other.is_stored;
+        *has_been_sent_to_deploy_buffer |= other.has_been_sent_to_deploy_buffer;
+        *has_updated_validator_matrix |= other.has_updated_validator_matrix;
+        *has_been_gossiped |= other.has_been_gossiped;
+        *is_executed |= other.is_executed;
+        *we_have_tried_to_sign |= other.we_have_tried_to_sign;
+        *has_been_sent_to_consensus_post_execution |=
+            other.has_been_sent_to_consensus_post_execution;
+        *has_been_sent_to_accumulator_post_execution |=
+            other.has_been_sent_to_accumulator_post_execution;
+        *has_sufficient_finality |= other.has_sufficient_finality;
+        *is_marked_complete |= other.is_marked_complete;
+
+        Ok(self)
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) fn verify_complete(&self) -> bool {
+        self.is_stored
+            && self.has_been_sent_to_deploy_buffer
+            && self.has_updated_validator_matrix
+            && (self.has_been_gossiped
+                || self.is_immediate_switch_block_for_current_protocol_version)
+            && self.is_executed
+            && self.we_have_tried_to_sign
+            && self.has_been_sent_to_consensus_post_execution
+            && self.has_been_sent_to_accumulator_post_execution
+            && self.has_sufficient_finality
+            && self.is_marked_complete
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_merge() {
+        let all_true = State {
+            is_immediate_switch_block_for_current_protocol_version: true,
+            is_stored: true,
+            has_been_sent_to_deploy_buffer: true,
+            has_updated_validator_matrix: true,
+            has_been_gossiped: true,
+            is_executed: true,
+            we_have_tried_to_sign: true,
+            has_been_sent_to_consensus_post_execution: true,
+            has_been_sent_to_accumulator_post_execution: true,
+            has_sufficient_finality: true,
+            is_marked_complete: true,
+        };
+        let all_false = State {
+            // this must be set the same as the `all_true`'s - all other fields are `false`.
+            is_immediate_switch_block_for_current_protocol_version: true,
+            ..State::default()
+        };
+
+        assert_eq!(all_true.merge(all_false).unwrap(), all_true);
+        assert_eq!(all_false.merge(all_true).unwrap(), all_true);
+        assert_eq!(all_true.merge(all_true).unwrap(), all_true);
+        assert_eq!(all_false.merge(all_false).unwrap(), all_false);
+    }
+
+    #[test]
+    fn should_fail_to_merge_different_immediate_switch_block_states() {
+        let state1 = State {
+            is_immediate_switch_block_for_current_protocol_version: true,
+            ..State::default()
+        };
+        let state2 = State {
+            is_immediate_switch_block_for_current_protocol_version: false,
+            ..State::default()
+        };
+
+        assert!(matches!(
+            state1.merge(state2),
+            Err(MergeMismatchError::State)
+        ));
+        assert!(matches!(
+            state2.merge(state1),
+            Err(MergeMismatchError::State)
+        ));
+    }
+}

--- a/node/src/types/block/hot_block/state.rs
+++ b/node/src/types/block/hot_block/state.rs
@@ -174,7 +174,6 @@ impl State {
         Ok(self)
     }
 
-    #[cfg(debug_assertions)]
     pub(crate) fn verify_complete(&self) -> bool {
         self.is_stored
             && self.has_been_sent_to_deploy_buffer

--- a/node/src/types/block/hot_block/state.rs
+++ b/node/src/types/block/hot_block/state.rs
@@ -51,7 +51,7 @@ impl State {
     }
 
     /// Returns a new `State` with all fields set to `false` except for
-    /// `is_immediate_switch_block_for_current_protocol_version`.
+    /// `immediate_switch_block_for_current_protocol_version`.
     pub(crate) fn new_immediate_switch() -> Self {
         State {
             immediate_switch_block_for_current_protocol_version: true,
@@ -59,7 +59,7 @@ impl State {
         }
     }
 
-    /// Returns a new `State` with all fields set to `false` except for `is_stored`.
+    /// Returns a new `State` with all fields set to `false` except for `stored`.
     pub(crate) fn new_synced() -> Self {
         State {
             stored: true,

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -174,6 +174,12 @@ impl ValidatorMatrix {
         }
     }
 
+    /// Returns whether `pub_key` is the ID of a validator in this era, or `None` if the validator
+    /// information for that era is missing.
+    pub(crate) fn is_this_node_validator_in_era(&self, era_id: EraId) -> Option<bool> {
+        self.is_validator_in_era(era_id, &self.public_signing_key)
+    }
+
     /// Determine if the active validator is in a current or upcoming set of active validators.
     #[inline]
     pub(crate) fn is_active_or_upcoming_validator(&self, public_key: &PublicKey) -> bool {
@@ -191,7 +197,7 @@ impl ValidatorMatrix {
         block_header: &BlockHeader,
     ) -> Option<FinalitySignature> {
         if self
-            .is_validator_in_era(block_header.era_id(), &self.public_signing_key)
+            .is_this_node_validator_in_era(block_header.era_id())
             .unwrap_or(false)
         {
             return Some(FinalitySignature::create(

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -176,7 +176,7 @@ impl ValidatorMatrix {
 
     /// Returns whether `pub_key` is the ID of a validator in this era, or `None` if the validator
     /// information for that era is missing.
-    pub(crate) fn is_this_node_validator_in_era(&self, era_id: EraId) -> Option<bool> {
+    pub(crate) fn is_self_validator_in_era(&self, era_id: EraId) -> Option<bool> {
         self.is_validator_in_era(era_id, &self.public_signing_key)
     }
 
@@ -197,7 +197,7 @@ impl ValidatorMatrix {
         block_header: &BlockHeader,
     ) -> Option<FinalitySignature> {
         if self
-            .is_this_node_validator_in_era(block_header.era_id())
+            .is_self_validator_in_era(block_header.era_id())
             .unwrap_or(false)
         {
             return Some(FinalitySignature::create(

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -135,7 +135,7 @@ function _step_06()
     do
         HEIGHT_2=$(get_chain_height "$NODE_ID")
         if [ "$HEIGHT_2" != "N/A" ] && [ "$HEIGHT_2" -le "$HEIGHT_1" ]; then
-            log "ERROR :: protocol upgrade failure - >= 1 nodes have stalled"
+            log "ERROR :: protocol upgrade failure - node $NODE_ID has stalled - current height $HEIGHT_2 is <= starting height $HEIGHT_1"
             exit 1
         fi
     done

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_03.sh
@@ -256,7 +256,7 @@ function _step_09()
     do
         HEIGHT_2=$(get_chain_height "$NODE_ID")
         if [ "$HEIGHT_2" != "N/A" ] && [ "$HEIGHT_2" -le "$HEIGHT_1" ]; then
-            log "ERROR :: protocol upgrade failure - >= 1 nodes have stalled"
+            log "ERROR :: protocol upgrade failure - node $NODE_ID has stalled - current height $HEIGHT_2 is <= starting height $HEIGHT_1"
             exit 1
         fi
     done

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -7,7 +7,7 @@ set -e
 
 #######################################
 # Runs an integration tests that tries to simulate
-# transfers being sent to a node that falls over 
+# transfers being sent to a node that falls over
 # mid-stream.
 # Arguments:
 #   `timeout=XXX` timeout (in seconds) when syncing.
@@ -35,7 +35,7 @@ function main() {
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
     check_network_sync 1 5
-    # 8. Give the tranfers a chance to be included
+    # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks
     check_transfer_inclusion '1' '1000'
@@ -65,7 +65,7 @@ function do_background_wasmless_transfers() {
     sleep 1
 }
 
-# Loops lines the hashes in the temp file. Check if all transfers we recieved a hash
+# Loops lines the hashes in the temp file. Check if all transfers we received a hash
 # back from the client are included in a block.
 function check_transfer_inclusion() {
     local NODE_ID=${1}
@@ -74,7 +74,7 @@ function check_transfer_inclusion() {
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
     log_step "Checking transfer inclusion..."
-    for (( i='1'; i<="$TRANSFER_COUNT"; i++ )); do
+    for (( i=1; i<="$TRANSFER_COUNT"; i++ )); do
         HASH=$(echo "$TRANSFER_HASHES" | sed -n "$i"p)
         if [ -z "$HASH" ]; then
             log "Error: No Hash found!"
@@ -101,7 +101,7 @@ for ARGUMENT in "$@"; do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in
         timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
-        deploy_log) DEPLOY_LOG=$(VALUE} ;;
+        deploy_log) DEPLOY_LOG=${VALUE} ;;
         *) ;;
     esac
 done

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -34,7 +34,7 @@ function main() {
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
     check_network_sync 1 5
-    # 8. Give the tranfers a chance to be included
+    # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks
     check_wasm_inclusion '1' '1000'
@@ -64,7 +64,7 @@ function do_background_wasm_transfers() {
     sleep 1
 }
 
-# Loops lines the hashes in the temp file. Check if all transfers we recieved a hash
+# Loops lines the hashes in the temp file. Check if all transfers we received a hash
 # back from the client are included in a block.
 function check_wasm_inclusion() {
     local NODE_ID=${1}
@@ -73,7 +73,7 @@ function check_wasm_inclusion() {
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
     log_step "Checking wasm inclusion..."
-    for (( i='1'; i<="$TRANSFER_COUNT"; i++ )); do
+    for (( i=1; i<="$TRANSFER_COUNT"; i++ )); do
         HASH=$(echo "$TRANSFER_HASHES" | sed -n "$i"p)
         if [ -z "$HASH" ]; then
             log "Error: No Hash found!"
@@ -100,7 +100,7 @@ for ARGUMENT in "$@"; do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in
         timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
-        deploy_log) DEPLOY_LOG=$(VALUE} ;;
+        deploy_log) DEPLOY_LOG=${VALUE} ;;
         *) ;;
     esac
 done

--- a/utils/nctl/sh/utils/queries.sh
+++ b/utils/nctl/sh/utils/queries.sh
@@ -32,7 +32,7 @@ function get_chain_era()
         STATUS=$(curl $NCTL_CURL_ARGS_FOR_NODE_RELATED_QUERIES "$(get_node_address_rest $NODE_ID)/status")
         ERA=$(echo $STATUS | jq '.last_added_block_info.era_id')
         if [ "$ERA" == "null" ]; then
-            echo 0
+            echo -2
         else
             echo $ERA
         fi


### PR DESCRIPTION
This PR introduces a small collection of state flags which are carried around with blocks being executed and accumulated.

The state is held in a type named `HotBlock` - i.e. a new block which is currently being worked upon.  The state is primarily used in the reactor's `dispatch_event` via the `HotBlockAnnouncement`.  This announcement is made by the `ContractRuntime` after executing a `FinalizedBlock` and by the `BlockAccumulator` after storing a block which has just reached sufficient finality.

The introduction of this state has allowed for the removal of some state from the `BlockAccumulator` and also should ensure that actions such as executing a block, storing a block or marking it complete are all done only once per block.

It also has allowed the node to avoid needlessly gossiping new immediate switch blocks (all nodes going through an upgrade create the immediate switch block, not just the validators).

Closes #3520.
