### PR TITLE
remove ConsensusValueT::needs_validation and corresponding test

### DIFF
--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -48,11 +48,7 @@ impl ValidatorSecret for Keypair {
     }
 }
 
-impl ConsensusValueT for Arc<BlockPayload> {
-    fn needs_validation(&self) -> bool {
-        !self.transfers().is_empty() || !self.deploys().is_empty() || !self.accusations().is_empty()
-    }
-}
+impl ConsensusValueT for Arc<BlockPayload> {}
 
 /// The collection of types used for cryptography, IDs and blocks in the CasperLabs node.
 #[derive(Clone, DataSize, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -44,11 +44,7 @@ use crate::{
 #[derive(Eq, PartialEq, Clone, Debug, Hash, Serialize, Deserialize, DataSize, Default)]
 pub(crate) struct ConsensusValue(Vec<u8>);
 
-impl ConsensusValueT for ConsensusValue {
-    fn needs_validation(&self) -> bool {
-        !self.0.is_empty()
-    }
-}
+impl ConsensusValueT for ConsensusValue {}
 
 impl Display for ConsensusValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -57,11 +57,7 @@ pub(crate) const BOB_SEC: TestSecret = TestSecret(1);
 pub(crate) const CAROL_SEC: TestSecret = TestSecret(2);
 pub(crate) const DAN_SEC: TestSecret = TestSecret(3);
 
-impl ConsensusValueT for u32 {
-    fn needs_validation(&self) -> bool {
-        false
-    }
-}
+impl ConsensusValueT for u32 {}
 
 impl Context for TestContext {
     type ConsensusValue = u32;

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -37,7 +37,7 @@ use crate::{
             synchronizer::Synchronizer,
         },
         protocols,
-        traits::{ConsensusValueT, Context},
+        traits::Context,
         utils::ValidatorIndex,
         ActionId, EraMessage, EraRequest, TimerId,
     },
@@ -320,26 +320,22 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         {
             let panorama = &swunit.wire_unit().panorama;
             let fork_choice = self.highway.state().fork_choice(panorama);
-            if value.needs_validation() {
-                self.log_proposal(vertex, "requesting proposal validation");
-                let ancestor_values = self.ancestors(fork_choice).cloned().collect();
-                let block_context = BlockContext::new(timestamp, ancestor_values);
-                let proposed_block = ProposedBlock::new(value.clone(), block_context);
-                if self
-                    .pending_values
-                    .entry(proposed_block.clone())
-                    .or_default()
-                    .insert((vv, sender))
-                {
-                    outcomes.push(ProtocolOutcome::ValidateConsensusValue {
-                        sender,
-                        proposed_block,
-                    });
-                }
-                return outcomes;
-            } else {
-                self.log_proposal(vertex, "proposal does not need validation");
+            self.log_proposal(vertex, "requesting proposal validation");
+            let ancestor_values = self.ancestors(fork_choice).cloned().collect();
+            let block_context = BlockContext::new(timestamp, ancestor_values);
+            let proposed_block = ProposedBlock::new(value.clone(), block_context);
+            if self
+                .pending_values
+                .entry(proposed_block.clone())
+                .or_default()
+                .insert((vv, sender))
+            {
+                outcomes.push(ProtocolOutcome::ValidateConsensusValue {
+                    sender,
+                    proposed_block,
+                });
             }
+            return outcomes;
         }
 
         // Either consensus value doesn't need validation or it's not a proposal.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -161,7 +161,8 @@ fn send_a_valid_wire_unit() {
         match outcome {
             ProtocolOutcome::CreatedGossipMessage(_)
             | ProtocolOutcome::FinalizedBlock(_)
-            | ProtocolOutcome::HandledProposedBlock(_) => (),
+            | ProtocolOutcome::HandledProposedBlock(_)
+            | ProtocolOutcome::ValidateConsensusValue { .. } => (),
             ProtocolOutcome::QueueAction(ACTION_ID_VERTEX) => {
                 outcomes.extend(highway_protocol.handle_action(ACTION_ID_VERTEX, now))
             }

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -89,7 +89,7 @@ use crate::{
             ProtocolOutcomes, TerminalBlockData,
         },
         protocols,
-        traits::{ConsensusValueT, Context},
+        traits::Context,
         utils::{ValidatorIndex, ValidatorMap, Validators, Weight},
         ActionId, EraMessage, EraRequest, LeaderSequence, TimerId,
     },
@@ -1630,11 +1630,7 @@ impl<C: Context + 'static> Zug<C> {
             }
         }
         let block_context = BlockContext::new(proposal.timestamp(), ancestor_values);
-        if let Some(block) = proposal
-            .maybe_block()
-            .filter(|value| value.needs_validation())
-            .cloned()
-        {
+        if let Some(block) = proposal.maybe_block().cloned() {
             self.log_proposal(&proposal, round_id, "requesting proposal validation");
             let proposed_block = ProposedBlock::new(block, block_context);
             if self

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -15,8 +15,6 @@ impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send
 pub trait ConsensusValueT:
     Eq + Clone + Debug + Display + Hash + Serialize + DeserializeOwned + Send + DataSize
 {
-    /// Returns whether the consensus value needs validation.
-    fn needs_validation(&self) -> bool;
 }
 
 /// A hash, as an identifier for a block or unit.


### PR DESCRIPTION
This PR removes the `needs_validation` method from `ConsensusValueT` and the corresponding test.  All values are now considered as needing validation.

Closes #3513.
