### PR TITLE
NCTL: nightly failure itst13

### DIFF
--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.override
@@ -1,6 +1,5 @@
 [core]
-era_duration = '180seconds'
-minimum_era_height = 30
+era_duration = '210seconds'
 auction_delay = 1
 
 [highway]


### PR DESCRIPTION
Changes:
- bumps `era_duration` by 30s
- removed `minimum_era_height` which doesn't apply 