### PR TITLE
Don't require chain_index length of 1 for genesis special case in deploy buffer

### DIFF
--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -184,10 +184,7 @@ impl DeployBuffer {
         };
 
         // genesis special case
-        if from_height == 0
-            && self.chain_index.len() == 1
-            && self.chain_index.contains_key(&from_height)
-        {
+        if from_height == 0 && self.chain_index.contains_key(&from_height) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes an issue highlighted by itst14.sh whereby a node which has accrued a few blocks after genesis and which is restarted during era 1 is unable to validate.

The deploy buffer previously reported that insufficient deploys were available, although it really only needed the genesis block to be available.  The check that `self.chain_index.len() == 1` was overly restrictive.