### PR TITLE
Use `Arc` instead of `Box` for announcements

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -521,7 +521,7 @@ impl BlockAccumulator {
             for finality_signature in block_signatures.finality_signatures() {
                 effects.extend(
                     effect_builder
-                        .announce_finality_signature_accepted(Box::new(finality_signature))
+                        .announce_finality_signature_accepted(Arc::new(finality_signature))
                         .ignore(),
                 );
             }
@@ -793,7 +793,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 Effects::new()
             }
             Event::ReceivedBlock { block, sender } => {
-                let meta_block = MetaBlock::new(Arc::new(*block), vec![], MetaBlockState::new());
+                let meta_block = MetaBlock::new(block.clone(), vec![], MetaBlockState::new());
                 self.register_block(effect_builder, meta_block, Some(sender))
             }
             Event::CreatedFinalitySignature { finality_signature } => {

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use derive_more::From;
 
@@ -20,14 +23,14 @@ pub(crate) enum Event {
         sender: NodeId,
     },
     ReceivedBlock {
-        block: Box<Block>,
+        block: Arc<Block>,
         sender: NodeId,
     },
     CreatedFinalitySignature {
         finality_signature: Box<FinalitySignature>,
     },
     ReceivedFinalitySignature {
-        finality_signature: Box<FinalitySignature>,
+        finality_signature: Arc<FinalitySignature>,
         sender: NodeId,
     },
     ExecutedBlock {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -2,7 +2,7 @@ mod event;
 mod metrics;
 mod tests;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -179,7 +179,7 @@ impl DeployAcceptor {
     fn accept<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Effects<Event> {
@@ -785,7 +785,7 @@ impl DeployAcceptor {
         }
 
         effect_builder
-            .put_deploy_to_storage(Box::new((*event_metadata.deploy).clone()))
+            .put_deploy_to_storage(event_metadata.deploy.clone())
             .event(move |is_new| Event::PutToStorageResult {
                 event_metadata,
                 is_new,

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use serde::Serialize;
 
@@ -18,14 +21,14 @@ use casper_types::{
 /// A utility struct to hold duplicated information across events.
 #[derive(Debug, Serialize)]
 pub(crate) struct EventMetadata {
-    pub(crate) deploy: Box<Deploy>,
+    pub(crate) deploy: Arc<Deploy>,
     pub(crate) source: Source,
     pub(crate) maybe_responder: Option<Responder<Result<(), Error>>>,
 }
 
 impl EventMetadata {
     pub(crate) fn new(
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Self {
@@ -42,7 +45,7 @@ impl EventMetadata {
 pub(crate) enum Event {
     /// The initiating event to accept a new `Deploy`.
     Accept {
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     },

--- a/node/src/components/deploy_buffer/event.rs
+++ b/node/src/components/deploy_buffer/event.rs
@@ -19,9 +19,9 @@ pub(crate) enum Event {
     Request(DeployBufferRequest),
     ReceiveDeployGossiped(DeployId),
     StoredDeploy(DeployId, Box<Option<Deploy>>),
-    BlockProposed(Box<ProposedBlock<ClContext>>),
+    BlockProposed(Arc<ProposedBlock<ClContext>>),
     Block(Arc<Block>),
-    BlockFinalized(Box<FinalizedBlock>),
+    BlockFinalized(Arc<FinalizedBlock>),
     Expire,
 }
 

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -12,7 +12,7 @@ use crate::types::{Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalityS
 pub enum Event {
     Initialize,
     BlockAdded(Arc<Block>),
-    DeployAccepted(Box<Deploy>),
+    DeployAccepted(Arc<Deploy>),
     DeployProcessed {
         deploy_hash: DeployHash,
         deploy_header: Box<DeployHeader>,
@@ -25,7 +25,7 @@ pub enum Event {
         public_key: PublicKey,
         timestamp: Timestamp,
     },
-    FinalitySignature(Box<FinalitySignature>),
+    FinalitySignature(Arc<FinalitySignature>),
     Step {
         era_id: EraId,
         execution_effect: ExecutionEffect,

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -108,7 +108,7 @@ pub enum SseData {
         timestamp: Timestamp,
     },
     /// New finality signature received.
-    FinalitySignature(Box<FinalitySignature>),
+    FinalitySignature(Arc<FinalitySignature>),
     /// The execution effects produced by a `StepRequest`.
     Step {
         era_id: EraId,
@@ -197,7 +197,7 @@ impl SseData {
 
     /// Returns a random `SseData::FinalitySignature`.
     pub(super) fn random_finality_signature(rng: &mut TestRng) -> Self {
-        SseData::FinalitySignature(Box::new(FinalitySignature::random_for_block(
+        SseData::FinalitySignature(Arc::new(FinalitySignature::random_for_block(
             BlockHash::random(rng),
             rng.gen(),
         )))

--- a/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -39,7 +39,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
         StoringState::Enqueued(
             async move {
                 let is_new = effect_builder
-                    .put_deploy_to_storage(Box::new(item.clone()))
+                    .put_deploy_to_storage(Arc::new(item.clone()))
                     .await;
                 // If `is_new` is `false`, the deploy was previously stored, and the incoming
                 // deploy could have a different set of approvals to the one already stored.

--- a/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -40,7 +40,7 @@ impl ItemFetcher<LegacyDeploy> for Fetcher<LegacyDeploy> {
     ) -> StoringState<'a, LegacyDeploy> {
         StoringState::Enqueued(
             effect_builder
-                .put_deploy_to_storage(Box::new(Deploy::from(item)))
+                .put_deploy_to_storage(Arc::new(Deploy::from(item)))
                 .map(|_| ())
                 .boxed(),
         )

--- a/node/src/components/fetcher/item_fetcher.rs
+++ b/node/src/components/fetcher/item_fetcher.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
+    sync::Arc,
     time::Duration,
 };
 
@@ -129,7 +130,7 @@ pub(super) trait ItemFetcher<T: FetcherItem + 'static> {
         &mut self,
         effect_builder: EffectBuilder<REv>,
         peer: NodeId,
-        item: Box<T>,
+        item: Arc<T>,
     ) -> Effects<Event<T>>
     where
         REv: From<StorageRequest> + From<PeerBehaviorAnnouncement> + Send,

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -302,7 +302,7 @@ impl Reactor {
                 let deploy = match bincode::deserialize::<FetchResponse<Deploy, DeployHash>>(
                     serialized_item,
                 ) {
-                    Ok(FetchResponse::Fetched(deploy)) => Box::new(deploy),
+                    Ok(FetchResponse::Fetched(deploy)) => Arc::new(deploy),
                     Ok(FetchResponse::NotFound(deploy_hash)) => {
                         return fatal!(
                             effect_builder,
@@ -363,7 +363,7 @@ fn announce_deploy_received(
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
         effect_builder
-            .announce_deploy_received(Box::new(deploy), responder)
+            .announce_deploy_received(Arc::new(deploy), responder)
             .ignore()
     }
 }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -10,6 +10,7 @@ mod tests;
 use std::{
     collections::HashSet,
     fmt::{self, Debug, Formatter},
+    sync::Arc,
     time::Duration,
 };
 
@@ -524,7 +525,7 @@ impl<T: GossiperItem + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         item: T,
         requester: NodeId,
     ) -> Effects<Event<T>> {
-        let message = Message::Item(Box::new(item));
+        let message = Message::Item(Arc::new(item));
         effect_builder.send_message(requester, message).ignore()
     }
 
@@ -565,7 +566,7 @@ impl<T: GossiperItem + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
     fn handle_item_received_from_peer(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        item: Box<T>,
+        item: Arc<T>,
         sender: NodeId,
     ) -> Effects<Event<T>> {
         effect_builder

--- a/node/src/components/gossiper/message.rs
+++ b/node/src/components/gossiper/message.rs
@@ -1,6 +1,6 @@
 use std::{
-    boxed::Box,
     fmt::{self, Display, Formatter},
+    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ pub(crate) enum Message<T: GossiperItem> {
     GetItem(T::Id),
     // Response to either a `GossipResponse` with `is_already_held` set to `false` or to a
     // `GetItem` message. Contains the actual item requested.
-    Item(Box<T>),
+    Item(Arc<T>),
 }
 
 impl<T: GossiperItem> Display for Message<T> {

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -282,7 +282,7 @@ impl NetworkedReactor for Reactor {
 }
 
 fn announce_deploy_received(
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
     responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
@@ -304,7 +304,7 @@ async fn run_gossip(rng: &mut TestRng, network_size: usize, deploy_count: usize)
 
     // Create `deploy_count` random deploys.
     let (all_deploy_hashes, mut deploys): (BTreeSet<_>, Vec<_>) = iter::repeat_with(|| {
-        let deploy = Box::new(Deploy::random_valid_native_transfer(rng));
+        let deploy = Arc::new(Deploy::random_valid_native_transfer(rng));
         (*deploy.hash(), deploy)
     })
     .take(deploy_count)
@@ -361,7 +361,7 @@ async fn should_get_from_alternate_source() {
     let node_ids = network.add_nodes(&mut rng, NETWORK_SIZE).await;
 
     // Create random deploy.
-    let deploy = Box::new(Deploy::random_valid_native_transfer(&mut rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(&mut rng));
     let deploy_id = *deploy.hash();
 
     // Give the deploy to nodes 0 and 1 to be gossiped.
@@ -440,7 +440,7 @@ async fn should_timeout_gossip_response() {
         .await;
 
     // Create random deploy.
-    let deploy = Box::new(Deploy::random_valid_native_transfer(&mut rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(&mut rng));
     let deploy_id = *deploy.hash();
 
     // Give the deploy to node 0 to be gossiped.

--- a/node/src/components/rpc_server/rpcs/account.rs
+++ b/node/src/components/rpc_server/rpcs/account.rs
@@ -3,7 +3,7 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-use std::str;
+use std::{str, sync::Arc};
 
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
@@ -83,7 +83,7 @@ impl RpcWithParams for PutDeploy {
         let put_deploy_result = effect_builder
             .make_request(
                 |responder| RpcRequest::SubmitDeploy {
-                    deploy: Box::new(params.deploy),
+                    deploy: Arc::new(params.deploy),
                     responder,
                 },
                 QueueKind::Api,

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -451,7 +451,7 @@ fn put_block_signatures(
 fn put_deploy(
     harness: &mut ComponentHarness<UnitTestEvent>,
     storage: &mut Storage,
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
 ) -> bool {
     let response = harness.send_request(storage, move |responder| {
         StorageRequest::PutDeploy { deploy, responder }.into()
@@ -701,7 +701,7 @@ fn can_retrieve_store_and_load_deploys() {
     let mut storage = storage_fixture(&harness);
 
     // Create a random deploy, store and load it.
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
 
     let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
     let block_hash_and_height = BlockHashAndHeight::random(&mut harness.rng);
@@ -757,7 +757,7 @@ fn can_retrieve_store_and_load_deploys() {
     }
 
     // Create a random deploy, store and load it.
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
 
     assert!(put_deploy(&mut harness, &mut storage, deploy.clone()));
     // Don't insert to the deploy hash index. Since we have no execution results
@@ -797,7 +797,7 @@ fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
     let mut deploy_hashes = Vec::new();
 
     for _ in 0..total {
-        let deploy = Box::new(Deploy::random(&mut harness.rng));
+        let deploy = Arc::new(Deploy::random(&mut harness.rng));
         deploy_hashes.push(*deploy.hash());
         put_deploy(&mut harness, &mut storage, deploy);
     }
@@ -823,7 +823,7 @@ fn store_execution_results_for_two_blocks() {
     let block_hash_b = BlockHash::random(&mut harness.rng);
 
     // Store the deploy.
-    put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+    put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
 
     // Ensure deploy exists.
     assert_eq!(
@@ -890,7 +890,7 @@ fn store_random_execution_results() {
 
     // Store shared deploys.
     for deploy in &shared_deploys {
-        put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+        put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
     }
 
     // We collect the expected result per deploy in parallel to adding them.
@@ -913,7 +913,7 @@ fn store_random_execution_results() {
             let deploy = Deploy::random(&mut harness.rng);
 
             // Store unique deploy.
-            put_deploy(harness, storage, Box::new(deploy.clone()));
+            put_deploy(harness, storage, Arc::new(deploy.clone()));
 
             let execution_result: ExecutionResult = harness.rng.gen();
 
@@ -1031,7 +1031,7 @@ fn test_legacy_interface() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);
 
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
     let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
     assert!(was_new);
 
@@ -1059,7 +1059,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
     // Create some sample data.
     let deploy = Deploy::random(&mut harness.rng);
     let execution_result: ExecutionResult = harness.rng.gen();
-    put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+    put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
     put_complete_block(&mut harness, &mut storage, Arc::new(block.clone()));
     let mut execution_results = HashMap::new();
     execution_results.insert(*deploy.hash(), execution_result.clone());
@@ -1152,7 +1152,7 @@ fn should_hard_reset() {
     for (index, block_hash) in blocks.iter().map(|block| block.hash()).enumerate() {
         let deploy = random_deploys.get(index).expect("should have deploys");
         let execution_result: ExecutionResult = harness.rng.gen();
-        put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+        put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
         let mut exec_results = HashMap::new();
         exec_results.insert(*deploy.hash(), execution_result);
         put_execution_results(

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -845,7 +845,7 @@ impl<REv> EffectBuilder<REv> {
     /// item.
     pub(crate) async fn announce_item_body_received_via_gossip<T: GossiperItem>(
         self,
-        item: Box<T>,
+        item: Arc<T>,
         sender: NodeId,
     ) where
         REv: From<GossiperAnnouncement<T>>,
@@ -861,7 +861,7 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that the block accumulator has received and stored a new finality signature.
     pub(crate) async fn announce_finality_signature_accepted(
         self,
-        finality_signature: Box<FinalitySignature>,
+        finality_signature: Arc<FinalitySignature>,
     ) where
         REv: From<BlockAccumulatorAnnouncement>,
     {
@@ -917,7 +917,7 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that the HTTP API server has received a deploy.
     pub(crate) async fn announce_deploy_received(
         self,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
     ) where
         REv: From<RpcServerAnnouncement>,
@@ -933,7 +933,7 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that a deploy not previously stored has now been accepted and stored.
     pub(crate) fn announce_new_deploy_accepted(
         self,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
     ) -> impl Future<Output = ()>
     where
@@ -977,7 +977,7 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that an invalid deploy has been received.
     pub(crate) fn announce_invalid_deploy(
         self,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
     ) -> impl Future<Output = ()>
     where
@@ -1438,7 +1438,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts the given deploy into the deploy store.
-    pub(crate) async fn put_deploy_to_storage(self, deploy: Box<Deploy>) -> bool
+    pub(crate) async fn put_deploy_to_storage(self, deploy: Arc<Deploy>) -> bool
     where
         REv: From<StorageRequest>,
     {
@@ -1725,7 +1725,7 @@ impl<REv> EffectBuilder<REv> {
     {
         self.event_queue
             .schedule(
-                ConsensusAnnouncement::Proposed(Box::new(proposed_block)),
+                ConsensusAnnouncement::Proposed(Arc::new(proposed_block)),
                 QueueKind::Consensus,
             )
             .await
@@ -1738,7 +1738,7 @@ impl<REv> EffectBuilder<REv> {
     {
         self.event_queue
             .schedule(
-                ConsensusAnnouncement::Finalized(Box::new(finalized_block)),
+                ConsensusAnnouncement::Finalized(Arc::new(finalized_block)),
                 QueueKind::Consensus,
             )
             .await
@@ -1767,7 +1767,7 @@ impl<REv> EffectBuilder<REv> {
             .schedule(
                 ConsensusAnnouncement::Fault {
                     era_id,
-                    public_key: Box::new(public_key),
+                    public_key: Arc::new(public_key),
                     timestamp,
                 },
                 QueueKind::Consensus,
@@ -1789,8 +1789,8 @@ impl<REv> EffectBuilder<REv> {
         self.event_queue
             .schedule(
                 PeerBehaviorAnnouncement::OffenseCommitted {
-                    offender: Box::new(offender),
-                    justification: Box::new(justification),
+                    offender: Arc::new(offender),
+                    justification: Arc::new(justification),
                 },
                 QueueKind::NetworkInfo,
             )

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -7,6 +7,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Display, Formatter},
     fs::File,
+    sync::Arc,
 };
 
 use datasize::DataSize;
@@ -160,7 +161,7 @@ pub(crate) enum RpcServerAnnouncement {
     /// A new deploy received.
     DeployReceived {
         /// The received deploy.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// A client responder in the case where a client submits a deploy.
         responder: Option<Responder<Result<(), Error>>>,
     },
@@ -182,7 +183,7 @@ pub(crate) enum DeployAcceptorAnnouncement {
     /// A deploy which wasn't previously stored on this node has been accepted and stored.
     AcceptedNewDeploy {
         /// The new deploy.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// The source (peer or client) of the deploy.
         source: Source,
     },
@@ -190,7 +191,7 @@ pub(crate) enum DeployAcceptorAnnouncement {
     /// An invalid deploy was received.
     InvalidDeploy {
         /// The invalid deploy.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// The source (peer or client) of the deploy.
         source: Source,
     },
@@ -237,15 +238,15 @@ impl Display for DeployBufferAnnouncement {
 #[derive(Debug)]
 pub(crate) enum ConsensusAnnouncement {
     /// A block was proposed.
-    Proposed(Box<ProposedBlock<ClContext>>),
+    Proposed(Arc<ProposedBlock<ClContext>>),
     /// A block was finalized.
-    Finalized(Box<FinalizedBlock>),
+    Finalized(Arc<FinalizedBlock>),
     /// An equivocation has been detected.
     Fault {
         /// The Id of the era in which the equivocation was detected
         era_id: EraId,
         /// The public key of the equivocator.
-        public_key: Box<PublicKey>,
+        public_key: Arc<PublicKey>,
         /// The timestamp when the evidence of the equivocation was detected.
         timestamp: Timestamp,
     },
@@ -279,9 +280,9 @@ pub(crate) enum PeerBehaviorAnnouncement {
     /// A given peer committed a blockable offense.
     OffenseCommitted {
         /// The peer ID of the offending node.
-        offender: Box<NodeId>,
+        offender: Arc<NodeId>,
         /// Justification for blocking the peer.
-        justification: Box<BlocklistJustification>,
+        justification: Arc<BlocklistJustification>,
     },
 }
 
@@ -308,7 +309,7 @@ pub(crate) enum GossiperAnnouncement<T: GossiperItem> {
     NewCompleteItem(T::Id),
 
     /// A new item has been received where the item's ID is NOT the complete item.
-    NewItemBody { item: Box<T>, sender: NodeId },
+    NewItemBody { item: Arc<T>, sender: NodeId },
 
     /// Finished gossiping about the indicated item.
     FinishedGossiping(T::Id),
@@ -391,7 +392,7 @@ pub(crate) enum BlockAccumulatorAnnouncement {
     /// A finality signature which wasn't previously stored on this node has been accepted and
     /// stored.
     AcceptedNewFinalitySignature {
-        finality_signature: Box<FinalitySignature>,
+        finality_signature: Arc<FinalitySignature>,
     },
 }
 

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -79,7 +79,7 @@ pub(crate) type ConsensusDemand = DemandIncoming<consensus::ConsensusRequestMess
 pub(crate) type TrieResponseIncoming = MessageIncoming<TrieResponse>;
 
 /// A new finality signature arrived over the network.
-pub(crate) type FinalitySignatureIncoming = MessageIncoming<Box<FinalitySignature>>;
+pub(crate) type FinalitySignatureIncoming = MessageIncoming<Arc<FinalitySignature>>;
 
 /// A request for an object out of storage arrived.
 ///

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -353,7 +353,8 @@ pub(crate) enum StorageRequest {
     /// Store given deploy.
     PutDeploy {
         /// Deploy to store.
-        deploy: Box<Deploy>,
+        // Note: `Deploy` is an `Arc` here, because almost all sources of deploys use `Arc`s.
+        deploy: Arc<Deploy>,
         /// Responder to call with the result.  Returns `true` if the deploy was stored on this
         /// attempt or false if it was previously stored.
         responder: Responder<bool>,
@@ -665,7 +666,7 @@ pub(crate) enum RpcRequest {
     /// Submit a deploy to be announced.
     SubmitDeploy {
         /// The deploy to be announced.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// Responder to call.
         responder: Responder<Result<(), Error>>,
     },

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -65,7 +65,7 @@ pub(crate) enum Message {
     },
     /// Finality signature.
     #[from]
-    FinalitySignature(Box<FinalitySignature>),
+    FinalitySignature(Arc<FinalitySignature>),
 }
 
 impl Payload for Message {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1100,7 +1100,7 @@ impl MainReactor {
                 ));
 
                 let era_id = finality_signature.era_id;
-                let payload = Message::FinalitySignature(Box::new(finality_signature));
+                let payload = Message::FinalitySignature(Arc::new(finality_signature));
                 effects.extend(reactor::wrap_effects(
                     MainEvent::Network,
                     effect_builder

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -648,7 +648,7 @@ async fn should_store_finalized_approvals() {
             runner
                 .process_injected_effects(|effect_builder| {
                     effect_builder
-                        .put_deploy_to_storage(Box::new(deploy_alice_bob.clone()))
+                        .put_deploy_to_storage(Arc::new(deploy_alice_bob.clone()))
                         .ignore()
                 })
                 .await;
@@ -656,7 +656,7 @@ async fn should_store_finalized_approvals() {
                 .process_injected_effects(|effect_builder| {
                     effect_builder
                         .announce_new_deploy_accepted(
-                            Box::new(deploy_alice_bob.clone()),
+                            Arc::new(deploy_alice_bob.clone()),
                             Source::Client,
                         )
                         .ignore()
@@ -667,7 +667,7 @@ async fn should_store_finalized_approvals() {
             runner
                 .process_injected_effects(|effect_builder| {
                     effect_builder
-                        .put_deploy_to_storage(Box::new(deploy_alice_bob_charlie.clone()))
+                        .put_deploy_to_storage(Arc::new(deploy_alice_bob_charlie.clone()))
                         .ignore()
                 })
                 .await;
@@ -675,7 +675,7 @@ async fn should_store_finalized_approvals() {
                 .process_injected_effects(|effect_builder| {
                     effect_builder
                         .announce_new_deploy_accepted(
-                            Box::new(deploy_alice_bob_charlie.clone()),
+                            Arc::new(deploy_alice_bob_charlie.clone()),
                             Source::Client,
                         )
                         .ignore()

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -5,6 +5,8 @@
 //! `FakeDeployAcceptor` puts the deploy to storage, and once that has completed, announces the
 //! deploy if the storage result indicates it's a new deploy.
 
+use std::sync::Arc;
+
 use tracing::debug;
 
 use casper_types::Timestamp;
@@ -44,14 +46,14 @@ impl FakeDeployAcceptor {
     fn accept<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Effects<Event> {
         let verification_start_timestamp = Timestamp::now();
         let event_metadata = EventMetadata::new(deploy.clone(), source, maybe_responder);
         effect_builder
-            .put_deploy_to_storage(Box::new(*deploy))
+            .put_deploy_to_storage(deploy)
             .event(move |is_new| Event::PutToStorageResult {
                 event_metadata,
                 is_new,


### PR DESCRIPTION
Closes #3509.

Replaces all uses of `Box` with `Arc` where announcements are involved. This has a ripple effect of `Arc`'ing a few additional things.