### PR TITLE
Swap lmdb for lmdb-rkv latest (0.14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
  "casper-types 1.5.0",
  "filesize",
  "humantime",
- "lmdb",
+ "lmdb-rkv",
  "log",
  "num-rational 0.4.1",
  "num-traits",
@@ -455,7 +455,7 @@ dependencies = [
  "itertools 0.10.5",
  "libc",
  "linked-hash-map",
- "lmdb",
+ "lmdb-rkv",
  "log",
  "num",
  "num-derive",
@@ -560,7 +560,7 @@ dependencies = [
  "itertools 0.10.5",
  "libc",
  "linked-hash-map",
- "lmdb",
+ "lmdb-rkv",
  "log",
  "num",
  "num-derive",
@@ -2089,7 +2089,7 @@ dependencies = [
  "casper-hashing",
  "casper-types 1.5.0",
  "clap 2.34.0",
- "lmdb",
+ "lmdb-rkv",
  "rand 0.8.5",
  "serde",
  "toml",
@@ -2547,21 +2547,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "lmdb"
-version = "0.8.0"
+name = "lmdb-rkv"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0908efb5d6496aa977d96f91413da2635a902e5e31dbef0bfb88986c248539"
+checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
 dependencies = [
  "bitflags",
+ "byteorder",
  "libc",
- "lmdb-sys",
+ "lmdb-rkv-sys",
 ]
 
 [[package]]
-name = "lmdb-sys"
-version = "0.8.0"
+name = "lmdb-rkv-sys"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b392838cfe8858e86fac37cf97a0e8c55cc60ba0a18365cadc33092f128ce9"
+checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
 dependencies = [
  "cc",
  "libc",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -24,7 +24,7 @@ humantime = "2"
 itertools = "0.10.0"
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
-lmdb = "0.8"
+lmdb-rkv = "0.14"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.4.0", default-features = false }
 num-derive = "0.3.0"

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -16,7 +16,7 @@ casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
 humantime = "2"
 filesize = "0.2.0"
-lmdb = "0.8.0"
+lmdb-rkv = "0.14"
 log = "0.4.14"
 num-rational = "0.4.0"
 num-traits = "0.2.14"

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -129,6 +129,7 @@ pub fn run_blocks_with_transfers_and_step(
 
         let existing_keys = cursor
             .iter()
+            .map(Result::unwrap)
             .map(|(key, _)| Digest::try_from(key).expect("should be a digest"));
         necessary_tries.extend(existing_keys);
     }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -43,7 +43,7 @@ hyper = "0.14.4"
 itertools = "0.10.0"
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
-lmdb = "0.8.0"
+lmdb-rkv = "0.14"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.4.0", default-features = false }
 num-derive = "0.3.0"

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -400,7 +400,8 @@ impl Storage {
 
         // Note: `iter_start` has an undocumented panic if called on an empty database. We rely on
         //       the iterator being at the start when created.
-        for (_, raw_val) in cursor.iter() {
+        for row in cursor.iter() {
+            let (_, raw_val) = row?;
             let mut body_txn = env.begin_ro_txn()?;
             let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
             let maybe_block_body =
@@ -2843,6 +2844,7 @@ impl Storage {
 
         cursor
             .iter()
+            .map(Result::unwrap)
             .map(|(raw_key, _)| {
                 DeployHash::new(Digest::try_from(raw_key).expect("malformed deploy hash in DB"))
             })
@@ -2887,7 +2889,8 @@ fn construct_block_body_to_block_header_reverse_lookup(
     block_header_db: &Database,
 ) -> Result<BTreeMap<Digest, BlockHeader>, LmdbExtError> {
     let mut block_body_hash_to_header_map: BTreeMap<Digest, BlockHeader> = BTreeMap::new();
-    for (_raw_key, raw_val) in txn.open_ro_cursor(*block_header_db)?.iter() {
+    for row in txn.open_ro_cursor(*block_header_db)?.iter() {
+        let (_raw_key, raw_val) = row?;
         let block_header: BlockHeader = lmdb_ext::deserialize(raw_val)?;
         block_body_hash_to_header_map.insert(block_header.body_hash().to_owned(), block_header);
     }
@@ -2909,7 +2912,8 @@ fn initialize_block_body_db(
 
     let mut cursor = txn.open_rw_cursor(*block_body_db)?;
 
-    for (raw_key, _raw_val) in cursor.iter() {
+    for row in cursor.iter() {
+        let (raw_key, _raw_val) = row?;
         let block_body_hash =
             Digest::try_from(raw_key).map_err(|err| LmdbExtError::DataCorrupted(Box::new(err)))?;
         if !block_body_hash_to_header_map.contains_key(&block_body_hash) {
@@ -2949,7 +2953,8 @@ fn initialize_block_metadata_db(
     let mut txn = env.begin_rw_txn()?;
     let mut cursor = txn.open_rw_cursor(*block_metadata_db)?;
 
-    for (raw_key, _) in cursor.iter() {
+    for row in cursor.iter() {
+        let (raw_key, _) = row?;
         if deleted_block_hashes.contains(raw_key) {
             cursor.del(WriteFlags::empty())?;
             continue;

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -15,7 +15,7 @@ casper-execution-engine = { path = "../../execution_engine" }
 casper-hashing = { path = "../../hashing" }
 casper-types = { path = "../../types" }
 clap = "2.33"
-lmdb = "0.8"
+lmdb-rkv = "0.14"
 rand = "0.8"
 serde = "1"
 toml = "0.5"

--- a/utils/global-state-update-gen/src/system_contract_registry.rs
+++ b/utils/global-state-update-gen/src/system_contract_registry.rs
@@ -49,7 +49,7 @@ fn generate_system_contract_registry_using_protocol_data(data_dir: &Path) {
         .open_ro_cursor(protocol_data_db)
         .unwrap_or_else(|error| panic!("failed to open a read-only cursor: {}", error));
 
-    let serialized_protocol_data = match cursor.iter().next() {
+    let serialized_protocol_data = match cursor.iter().next().map(Result::unwrap) {
         Some((_key, value)) => value,
         None => {
             println!("No protocol data found");


### PR DESCRIPTION
This PR swaps out `lmdb` for `lmdb-rkv`. All that was needed was handling a `Result` type which cursor iterators now yield.