### PR TITLE
NCTL: set validator_slots

### DIFF
--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -259,7 +259,8 @@ function setup_asset_chainspec()
         )
     fi
 
-    if [[ "$PATH_TO_CHAINSPEC_TEMPLATE" == *"resources/local/chainspec.toml.in"* ]]; then
+    if [[ "$PATH_TO_CHAINSPEC_TEMPLATE" == *"resources/local/chainspec.toml.in"* ]] || \
+       [[ "$PATH_TO_CHAINSPEC_TEMPLATE" == *"stages"* ]]; then
         SCRIPT+=("cfg['core']['validator_slots']=$COUNT_NODES;")
     fi
 

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -248,7 +248,6 @@ function setup_asset_chainspec()
             "cfg['protocol']['activation_point']='$ACTIVATION_POINT';"
             "cfg['protocol']['version']='$PROTOCOL_VERSION';"
             "cfg['network']['name']='$(get_chain_name)';"
-            "toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));"
         )
     else
         SCRIPT=(
@@ -257,9 +256,14 @@ function setup_asset_chainspec()
             "cfg['protocol']['activation_point']=$ACTIVATION_POINT;"
             "cfg['protocol']['version']='$PROTOCOL_VERSION';"
             "cfg['network']['name']='$(get_chain_name)';"
-            "toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));"
         )
     fi
+
+    if [[ "$PATH_TO_CHAINSPEC_TEMPLATE" == *"resources/local/chainspec.toml.in"* ]]; then
+        SCRIPT+=("cfg['core']['validator_slots']=$COUNT_NODES;")
+    fi
+
+    SCRIPT+=("toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));")
 
     python3 -c "${SCRIPT[*]}"
 }

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -108,8 +108,8 @@ function _setup_asset_chainspec()
     local SCRIPT
     local COUNT_NODES
 
-    # Shouldnt matter, maybe, idk ?, blame Tom if this causes an issue :)
-    COUNT_NODES='100'
+    # Use # of nodes in assets dir
+    COUNT_NODES="$(get_count_of_nodes)"
 
     # Set file.
     PATH_TO_CHAINSPEC="$(get_path_to_net)/chainspec/chainspec.toml"


### PR DESCRIPTION
Changes:
- sets the `validator_slots` equal to the number of nodes generated in `assets/net/nodes` when utilizing the default chainspec
- for upgrade tests which utilize a single node upgrade, we used to just set this to 100, changed this to match the number of nodes.


Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/gh/casper-network/sre/688