### PR TITLE
Add more detailed logs to `register_block_header()`

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -390,7 +390,11 @@ impl BlockAcquisitionState {
         let new_state = match self {
             BlockAcquisitionState::Initialized(block_hash, signatures) => {
                 if header.id() == *block_hash {
-                    info!("BlockAcquisition: registering header for: {}", block_hash);
+                    info!(
+                        "BlockAcquisition: registering header for: {:?}, height: {}",
+                        block_hash,
+                        header.height()
+                    );
                     BlockAcquisitionState::HaveBlockHeader(Box::new(header), signatures.clone())
                 } else {
                     return Err(BlockAcquisitionError::BlockHashMismatch {


### PR DESCRIPTION
This PR adds some more details to logs created by `register_block_header()` to ease up debugging.

When registering a header, instead of such message:
```
BlockAcquisition: registering header for: block hash 3fbe..6f3d
```

we'll see full block hash and a height:
```
BlockAcquisition: registering header for: BlockHash(3fbe346cc015db6b9081e3ce475346651c1497ac1c02fbe9187fd0bb2bb26f3d), height: 42
```