### PR TITLE
Various fast-sync fixes

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -418,6 +418,7 @@ impl BlockSynchronizer {
         &mut self,
         effect_builder: EffectBuilder<REv>,
         block_hash: &BlockHash,
+        was_not_previously_marked_complete: bool,
     ) -> Effects<Event>
     where
         REv: From<StorageRequest>
@@ -427,7 +428,10 @@ impl BlockSynchronizer {
     {
         if let Some(builder) = &self.forward {
             if builder.block_hash() == *block_hash {
-                error!(%block_hash, "forward block should not be marked complete in block synchronizer");
+                error!(
+                    %block_hash,
+                    "forward block should not be marked complete in block synchronizer"
+                );
             }
         }
 
@@ -435,6 +439,10 @@ impl BlockSynchronizer {
         match &mut self.historical {
             Some(builder) if builder.block_hash() == *block_hash => {
                 builder.register_marked_complete();
+                if was_not_previously_marked_complete {
+                    warn!(%block_hash, "marked complete an already-complete block");
+                    return effects;
+                }
                 // other components need to know that we've added an historical block
                 // that they may be interested in
                 if let Some(block) = builder.maybe_block() {
@@ -635,11 +643,12 @@ impl BlockSynchronizer {
                     // any).
                     if builder.should_fetch_execution_state() {
                         builder.set_in_flight_latch();
-                        results.extend(
-                            effect_builder
-                                .mark_block_completed(block_height)
-                                .event(move |_| Event::MarkBlockCompleted(block_hash)),
-                        )
+                        results.extend(effect_builder.mark_block_completed(block_height).event(
+                            move |was_not_previously_marked_complete| Event::MarkBlockCompleted {
+                                block_hash,
+                                was_not_previously_marked_complete,
+                            },
+                        ))
                     }
                 }
                 NeedNext::Peers(block_hash) => {
@@ -1144,7 +1153,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                     | Event::MadeFinalizedBlock { .. }
                     | Event::MarkBlockExecutionEnqueued(_)
                     | Event::MarkBlockExecuted(_)
-                    | Event::MarkBlockCompleted(_)
+                    | Event::MarkBlockCompleted { .. }
                     | Event::ValidatorMatrixUpdated
                     | Event::BlockHeaderFetched(_)
                     | Event::BlockFetched(_)
@@ -1354,11 +1363,18 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                     self.register_block_executed(&block_hash);
                     Effects::new()
                 }
-                Event::MarkBlockCompleted(block_hash) => {
+                Event::MarkBlockCompleted {
+                    block_hash,
+                    was_not_previously_marked_complete,
+                } => {
                     // when syncing an historical block, the synchronizer considers it
                     // finished after receiving confirmation that the complete block
                     // has been stored.
-                    self.register_marked_complete(effect_builder, &block_hash)
+                    self.register_marked_complete(
+                        effect_builder,
+                        &block_hash,
+                        was_not_previously_marked_complete,
+                    )
                 }
             },
         }

--- a/node/src/components/block_synchronizer/event.rs
+++ b/node/src/components/block_synchronizer/event.rs
@@ -30,7 +30,10 @@ pub(crate) enum Event {
     },
     MarkBlockExecutionEnqueued(BlockHash),
     MarkBlockExecuted(BlockHash),
-    MarkBlockCompleted(BlockHash),
+    MarkBlockCompleted {
+        block_hash: BlockHash,
+        was_not_previously_marked_complete: bool,
+    },
     ValidatorMatrixUpdated,
     #[from]
     BlockHeaderFetched(FetchResult<BlockHeader>),
@@ -157,7 +160,7 @@ impl Display for Event {
             Event::MarkBlockExecuted(..) => {
                 write!(f, "block execution complete")
             }
-            Event::MarkBlockCompleted(..) => {
+            Event::MarkBlockCompleted { .. } => {
                 write!(f, "mark block completed")
             }
         }

--- a/node/src/components/block_synchronizer/event.rs
+++ b/node/src/components/block_synchronizer/event.rs
@@ -32,7 +32,7 @@ pub(crate) enum Event {
     MarkBlockExecuted(BlockHash),
     MarkBlockCompleted {
         block_hash: BlockHash,
-        was_not_previously_marked_complete: bool,
+        is_new: bool,
     },
     ValidatorMatrixUpdated,
     #[from]

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -193,6 +193,8 @@ pub(crate) type Multiple<T> = SmallVec<[T; 2]>;
 /// The type of peers that should receive the gossip message.
 #[derive(Debug, Serialize, PartialEq, Eq, Hash, Copy, Clone, DataSize)]
 pub(crate) enum GossipTarget {
+    /// Both validators and non validators.
+    Mixed(EraId),
     /// Peers which are not validators in the given era.
     NonValidators(EraId),
     /// All peers.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -902,7 +902,7 @@ impl<REv> EffectBuilder<REv> {
     /// Completion means that the block itself (along with its header) and all of its deploys have
     /// been persisted to storage and its global state root hash is missing no dependencies in the
     /// global state.
-    pub(crate) async fn mark_block_completed(self, block_height: u64)
+    pub(crate) async fn mark_block_completed(self, block_height: u64) -> bool
     where
         REv: From<BlockCompleteConfirmationRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -621,10 +621,9 @@ impl Display for MakeBlockExecutableRequest {
 // joiner reactor might exit before handling the announcement and it would go un-actioned.
 #[derive(Debug, Serialize)]
 pub(crate) struct BlockCompleteConfirmationRequest {
-    /// Height of the block that was completed.
     pub block_height: u64,
-    /// Responder indicating that the change has been recorded.
-    pub responder: Responder<()>,
+    /// Responds `true` if the block was not previously marked complete.
+    pub responder: Responder<bool>,
 }
 
 impl Display for BlockCompleteConfirmationRequest {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1107,19 +1107,14 @@ impl MainReactor {
                     ),
                 ));
 
-                // We want to force the gossiper to handle this to deliberately cause the validators
-                // to slow down a little at era boundaries, with the expectation that slower
-                // following peers can remain caught up.
-                if false == block.header().is_switch_block() {
-                    let era_id = finality_signature.era_id;
-                    let payload = Message::FinalitySignature(Box::new(finality_signature));
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::Network,
-                        effect_builder
-                            .broadcast_message_to_validators(payload, era_id)
-                            .ignore(),
-                    ));
-                }
+                let era_id = finality_signature.era_id;
+                let payload = Message::FinalitySignature(Box::new(finality_signature));
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::Network,
+                    effect_builder
+                        .broadcast_message_to_validators(payload, era_id)
+                        .ignore(),
+                ));
             }
         }
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1107,14 +1107,16 @@ impl MainReactor {
                     ),
                 ));
 
-                let era_id = finality_signature.era_id;
-                let payload = Message::FinalitySignature(Box::new(finality_signature));
-                effects.extend(reactor::wrap_effects(
-                    MainEvent::Network,
-                    effect_builder
-                        .broadcast_message_to_validators(payload, era_id)
-                        .ignore(),
-                ));
+                if false == block.header().is_switch_block() {
+                    let era_id = finality_signature.era_id;
+                    let payload = Message::FinalitySignature(Box::new(finality_signature));
+                    effects.extend(reactor::wrap_effects(
+                        MainEvent::Network,
+                        effect_builder
+                            .broadcast_message_to_validators(payload, era_id)
+                            .ignore(),
+                    ));
+                }
             }
         }
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1107,6 +1107,9 @@ impl MainReactor {
                     ),
                 ));
 
+                // We want to force the gossiper to handle this to deliberately cause the validators
+                // to slow down a little at era boundaries, with the expectation that slower
+                // following peers can remain caught up.
                 if false == block.header().is_switch_block() {
                     let era_id = finality_signature.era_id;
                     let payload = Message::FinalitySignature(Box::new(finality_signature));

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -445,12 +445,9 @@ impl MainReactor {
     }
 
     fn refresh_contract_runtime(&mut self) -> Result<(), String> {
-        // Note: we don't want to read the highest COMPLETE block, as an immediate switch block is
-        // only marked complete after we receive enough signatures from validators.  Using the
-        // highest stored block ensures the ContractRuntime's `exec_queue` isn't set to a block
-        // height we already executed but haven't yet marked complete.
-        match self.storage.read_highest_block_header() {
-            Ok(Some(block_header)) => {
+        match self.storage.read_highest_complete_block() {
+            Ok(Some(block)) => {
+                let block_header = block.header();
                 let block_height = block_header.height();
                 let state_root_hash = block_header.state_root_hash();
                 let block_hash = block_header.id();

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1636,6 +1636,7 @@ impl GossiperItem for Block {
     const REQUIRES_GOSSIP_RECEIVED_ANNOUNCEMENT: bool = true;
 
     fn target(&self) -> GossipTarget {
+        // Validators make their own blocks thus we only gossip blocks to non validators.
         GossipTarget::NonValidators(self.header.era_id)
     }
 }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -2330,7 +2330,7 @@ impl GossiperItem for FinalitySignature {
     const REQUIRES_GOSSIP_RECEIVED_ANNOUNCEMENT: bool = true;
 
     fn target(&self) -> GossipTarget {
-        GossipTarget::All
+        GossipTarget::Mixed(self.era_id)
     }
 }
 


### PR DESCRIPTION
This PR contains multiple fixes:
* use the highest COMPLETE block to initialize the contract runtime (this guarantees the global state specified in the block exists as the node must have executed or synced the state)
* ensure finality signatures are gossiped to validators and non-validators to try to avoid a network with mostly validators exiting for upgrade before the non-validators have had a chance to participate in the gossiping of the finality signatures of the last block before upgrade
* ~for switch blocks, don't have the validators broadcast their finality signatures to help keep the non-validators following along more closely synced at era boundaries~
* for historical blocks, ensure the block synchronizer doesn't make multiple `MetaBlockAnnouncement`s for the same block, as this results in duplicate events being sent to the event stream server

Related to #3578.
