### PR TITLE
NCTL: allow node up check to loop until timeout

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -116,17 +116,29 @@ function _step_05()
 function _step_06()
 {
     local N1_PROTOCOL_VERSION_INITIAL=${1}
+    local TIMEOUT=${2:-'60'}
     local HEIGHT_1
     local HEIGHT_2
     local NODE_ID
 
     log_step_upgrades 6 "asserting node upgrades"
 
-    # Assert no nodes have stopped.
-    if [ "$(get_count_of_up_nodes)" != "$(get_count_of_genesis_nodes)" ]; then
-        log "ERROR :: protocol upgrade failure - >= 1 nodes have stopped"
-        exit 1
-    fi
+    while [ "$TIMEOUT" -ge 0 ]; do
+        # Assert no nodes have stopped.
+        if [ "$(get_count_of_up_nodes)" != "$(get_count_of_genesis_nodes)" ]; then
+            if [ "$TIMEOUT" != '0' ]; then
+                log "...waiting for nodes to come up, timeout=$TIMEOUT"
+                sleep 1
+                TIMEOUT=$((TIMEOUT-1))
+            else
+                log "ERROR :: protocol upgrade failure - >= 1 nodes have stopped"
+                exit 1
+            fi
+        else
+            log "... all nodes up! [continuing]"
+            break
+        fi
+    done
 
     # Assert no nodes have stalled.
     HEIGHT_1=$(get_chain_height)


### PR DESCRIPTION
Changes:
- adds a timeout around nodes being up check
    - this is to help alleviate the case where a node would of been up in a few more seconds

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/gh/casper-network/sre/572