### PR TITLE
CI: add markdown lints workaround

### DIFF
--- a/.github/workflows/lints-md.yml
+++ b/.github/workflows/lints-md.yml
@@ -1,0 +1,30 @@
+---
+name: lints
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - dev
+      - trying
+      - staging
+      - 'release-**'
+      - 'feat-**'
+    paths:
+      - '**.md'
+
+  pull_request:
+    branches:
+      - dev
+      - 'release-**'
+      - 'feat-**'
+    paths:
+      - '**.md'
+
+jobs:
+  lints:
+    name: lints
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Markdown only change, no lints required"'

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -11,12 +11,16 @@ on:
       - staging
       - 'release-**'
       - 'feat-**'
+    paths-ignore:
+      - '**.md'
 
   pull_request:
     branches:
       - dev
       - 'release-**'
       - 'feat-**'
+    paths-ignore:
+      - '**.md'
 
 jobs:
   lints:


### PR DESCRIPTION
Changes:
- adds back markdown ignore for rust lints
- adds another 'lint' workflow as a workaround.

Notes: 
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
