### PR TITLE
Update current switch block only with blocks that were marked complete

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -233,11 +233,6 @@ impl BlockAccumulator {
         }
     }
 
-    /// Returns the height of the local tip, i.e. the latest executed block.
-    pub(crate) fn local_tip_height(&self) -> Option<u64> {
-        self.local_tip.map(|identifier| identifier.height)
-    }
-
     /// Registers a peer with an existing acceptor, or creates a new one.
     ///
     /// If the era is outdated or the peer has already caused us to create more acceptors than


### PR DESCRIPTION
Set the current switch block only after the block is marked complete.
We *always* want to initialize the contract runtime with the highest complete block.
In case of an upgrade, we want the reactor to hold off in the `Upgrading` state until the immediate switch block is stored and *also* marked complete.
This will allow the contract runtime to initialize properly (in `refresh_contract_runtime`) when the reactor is transitioning from `CatchUp` to `KeepUp`.

Fixes: https://github.com/casper-network/casper-node/issues/3597