### PR TITLE
Fix the determination of validators for immediate switch blocks

### DIFF
--- a/node/src/components/block_synchronizer/event.rs
+++ b/node/src/components/block_synchronizer/event.rs
@@ -73,6 +73,17 @@ impl Display for Event {
             Event::Request(BlockSynchronizerRequest::NeedNext { .. }) => {
                 write!(f, "block synchronizer need next request")
             }
+            Event::Request(BlockSynchronizerRequest::SyncGlobalStates(global_states, _)) => {
+                write!(f, "global states to be synced: [")?;
+                for (block_hash, global_state_hash) in global_states {
+                    write!(
+                        f,
+                        "(block {}, global state {}), ",
+                        block_hash, global_state_hash
+                    )?;
+                }
+                write!(f, "]")
+            }
             Event::Request(_) => {
                 write!(f, "block synchronizer request from effect builder")
             }

--- a/node/src/components/block_synchronizer/global_state_synchronizer.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer.rs
@@ -208,6 +208,11 @@ impl GlobalStateSynchronizer {
         self.last_progress
     }
 
+    /// Returns whether we are already processing a request for the given hash.
+    pub(super) fn has_global_state_request(&self, global_state_hash: &Digest) -> bool {
+        self.request_states.contains_key(global_state_hash)
+    }
+
     fn handle_request<REv>(
         &mut self,
         request: SyncGlobalStateRequest,

--- a/node/src/components/network/tasks.rs
+++ b/node/src/components/network/tasks.rs
@@ -673,110 +673,111 @@ where
     let demands_in_flight = Arc::new(Semaphore::new(context.max_in_flight_demands));
     let event_queue = context.event_queue.expect("component not initialized");
 
-    let read_messages =
-        async move {
-            while let Some(msg_result) = stream.next().await {
-                match msg_result {
-                    Ok(msg) => {
-                        trace!(%msg, "message received");
+    let read_messages = async move {
+        while let Some(msg_result) = stream.next().await {
+            match msg_result {
+                Ok(msg) => {
+                    trace!(%msg, "message received");
 
-                        let effect_builder = EffectBuilder::new(event_queue);
+                    let effect_builder = EffectBuilder::new(event_queue);
 
-                        match msg.try_into_demand(effect_builder, peer_id) {
-                            Ok((event, wait_for_response)) => {
-                                // Note: For now, demands bypass the limiter, as we expect the
-                                //       backpressure to handle this instead.
+                    match msg.try_into_demand(effect_builder, peer_id) {
+                        Ok((event, wait_for_response)) => {
+                            // Note: For now, demands bypass the limiter, as we expect the
+                            //       backpressure to handle this instead.
 
-                                // Acquire a permit. If we are handling too many demands at this
-                                // time, this will block, halting the processing of new message,
-                                // thus letting the peer they have reached their maximum allowance.
-                                let in_flight = demands_in_flight
-                                    .clone()
-                                    .acquire_owned()
-                                    .await
-                                    // Note: Since the semaphore is reference counted, it must
-                                    //       explicitly be closed for acquisition to fail, which we
-                                    //       never do. If this happens, there is a bug in the code;
-                                    //       we exit with an error and close the connection.
-                                    .map_err(|_| {
-                                        io::Error::new(
-                                            io::ErrorKind::Other,
-                                            "demand limiter semaphore closed unexpectedly",
-                                        )
-                                    })?;
-
-                                Metrics::record_trie_request_start(&context.net_metrics);
-
-                                let net_metrics = context.net_metrics.clone();
-                                // Spawn a future that will eventually send the returned message. It
-                                // will essentially buffer the response.
-                                tokio::spawn(async move {
-                                    if let Some(payload) = wait_for_response.await {
-                                        // Send message and await its return. `send_message` should
-                                        // only return when the message has been buffered, if the
-                                        // peer is not accepting data, we will block here until the
-                                        // send buffer has sufficient room.
-                                        effect_builder.send_message(peer_id, payload).await;
-
-                                        // Note: We could short-circuit the event queue here and
-                                        //       directly insert into the outgoing message queue,
-                                        //       which may be potential performance improvement.
-                                    }
-
-                                    // Missing else: The handler of the demand did not deem it
-                                    // worthy a response. Just drop it.
-
-                                    // After we have either successfully buffered the message for
-                                    // sending, failed to do so or did not have a message to send
-                                    // out, we consider the request handled and free up the permit.
-                                    Metrics::record_trie_request_end(&net_metrics);
-                                    drop(in_flight);
-                                });
-
-                                // Schedule the created event.
-                                event_queue
-                                    .schedule::<REv>(event, QueueKind::NetworkDemand)
-                                    .await;
-                            }
-                            Err(msg) => {
-                                // We've received a non-demand message. Ensure we have the proper amount
-                                // of resources, then push it to the reactor.
-                                limiter
-                                    .request_allowance(msg.payload_incoming_resource_estimate(
-                                        &context.payload_weights,
-                                    ))
-                                    .await;
-
-                                let queue_kind = if msg.is_low_priority() {
-                                    QueueKind::NetworkLowPriority
-                                } else {
-                                    QueueKind::NetworkIncoming
-                                };
-
-                                event_queue
-                                    .schedule(
-                                        Event::IncomingMessage {
-                                            peer_id: Box::new(peer_id),
-                                            msg: Box::new(msg),
-                                            span: span.clone(),
-                                        },
-                                        queue_kind,
+                            // Acquire a permit. If we are handling too many demands at this
+                            // time, this will block, halting the processing of new message,
+                            // thus letting the peer they have reached their maximum allowance.
+                            let in_flight = demands_in_flight
+                                .clone()
+                                .acquire_owned()
+                                .await
+                                // Note: Since the semaphore is reference counted, it must
+                                //       explicitly be closed for acquisition to fail, which we
+                                //       never do. If this happens, there is a bug in the code;
+                                //       we exit with an error and close the connection.
+                                .map_err(|_| {
+                                    io::Error::new(
+                                        io::ErrorKind::Other,
+                                        "demand limiter semaphore closed unexpectedly",
                                     )
-                                    .await;
-                            }
+                                })?;
+
+                            Metrics::record_trie_request_start(&context.net_metrics);
+
+                            let net_metrics = context.net_metrics.clone();
+                            // Spawn a future that will eventually send the returned message. It
+                            // will essentially buffer the response.
+                            tokio::spawn(async move {
+                                if let Some(payload) = wait_for_response.await {
+                                    // Send message and await its return. `send_message` should
+                                    // only return when the message has been buffered, if the
+                                    // peer is not accepting data, we will block here until the
+                                    // send buffer has sufficient room.
+                                    effect_builder.send_message(peer_id, payload).await;
+
+                                    // Note: We could short-circuit the event queue here and
+                                    //       directly insert into the outgoing message queue,
+                                    //       which may be potential performance improvement.
+                                }
+
+                                // Missing else: The handler of the demand did not deem it
+                                // worthy a response. Just drop it.
+
+                                // After we have either successfully buffered the message for
+                                // sending, failed to do so or did not have a message to send
+                                // out, we consider the request handled and free up the permit.
+                                Metrics::record_trie_request_end(&net_metrics);
+                                drop(in_flight);
+                            });
+
+                            // Schedule the created event.
+                            event_queue
+                                .schedule::<REv>(event, QueueKind::NetworkDemand)
+                                .await;
+                        }
+                        Err(msg) => {
+                            // We've received a non-demand message. Ensure we have the proper amount
+                            // of resources, then push it to the reactor.
+                            limiter
+                                .request_allowance(
+                                    msg.payload_incoming_resource_estimate(
+                                        &context.payload_weights,
+                                    ),
+                                )
+                                .await;
+
+                            let queue_kind = if msg.is_low_priority() {
+                                QueueKind::NetworkLowPriority
+                            } else {
+                                QueueKind::NetworkIncoming
+                            };
+
+                            event_queue
+                                .schedule(
+                                    Event::IncomingMessage {
+                                        peer_id: Box::new(peer_id),
+                                        msg: Box::new(msg),
+                                        span: span.clone(),
+                                    },
+                                    queue_kind,
+                                )
+                                .await;
                         }
                     }
-                    Err(err) => {
-                        warn!(
-                            err = display_error(&err),
-                            "receiving message failed, closing connection"
-                        );
-                        return Err(err);
-                    }
+                }
+                Err(err) => {
+                    warn!(
+                        err = display_error(&err),
+                        "receiving message failed, closing connection"
+                    );
+                    return Err(err);
                 }
             }
-            Ok(())
-        };
+        }
+        Ok(())
+    };
 
     let shutdown_messages = async move { while close_incoming_receiver.changed().await.is_ok() {} };
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1138,6 +1138,7 @@ impl Display for BlockAccumulatorRequest {
 pub(crate) enum BlockSynchronizerRequest {
     NeedNext,
     DishonestPeers,
+    SyncGlobalStates(Vec<(BlockHash, Digest)>, Vec<NodeId>),
     Status {
         responder: Responder<BlockSynchronizerStatus>,
     },
@@ -1154,6 +1155,9 @@ impl Display for BlockSynchronizerRequest {
             }
             BlockSynchronizerRequest::Status { .. } => {
                 write!(f, "block synchronizer request: status")
+            }
+            BlockSynchronizerRequest::SyncGlobalStates(_, _) => {
+                write!(f, "request to sync global states")
             }
         }
     }

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -3,6 +3,8 @@ use std::fmt::{self, Debug, Display, Formatter};
 use derive_more::From;
 use serde::Serialize;
 
+use casper_types::{system::auction::EraValidators, EraId};
+
 use crate::{
     components::{
         block_accumulator,
@@ -224,6 +226,9 @@ pub(crate) enum MainEvent {
     MainReactorRequest(ReactorStatusRequest),
     #[from]
     MetaBlockAnnouncement(MetaBlockAnnouncement),
+
+    // Event related to figuring out validators for immediate switch blocks.
+    GotImmediateSwitchBlockEraValidators(EraId, EraValidators, EraValidators),
 }
 
 impl ReactorEvent for MainEvent {
@@ -331,6 +336,9 @@ impl ReactorEvent for MainEvent {
             MainEvent::MainReactorRequest(_) => "MainReactorRequest",
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
             MainEvent::MetaBlockAnnouncement(_) => "MetaBlockAnnouncement",
+            MainEvent::GotImmediateSwitchBlockEraValidators(_, _, _) => {
+                "GotImmediateSwitchBlockEraValidators"
+            }
         }
     }
 }
@@ -505,6 +513,13 @@ impl Display for MainEvent {
             MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),
             MainEvent::MetaBlockAnnouncement(inner) => Display::fmt(inner, f),
+            MainEvent::GotImmediateSwitchBlockEraValidators(era_id, _, _) => {
+                write!(
+                    f,
+                    "got immediate switch block era validators for era {}",
+                    era_id
+                )
+            }
         }
     }
 }

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -315,10 +315,12 @@ impl MainReactor {
                             Some(self.sync_back_leap(effect_builder, rng, parent_hash))
                         }
                         (false, Some(parent_metadata)) => {
-                            // The validators matrix doesn't have the validators _and_ we are trying to
-                            // sync an immediate switch block; we need to read the validators from the
-                            // global states of the block and its parent and compare them in order to
-                            // decide which validators to use - might require syncing global states in
+                            // The validators matrix doesn't have the validators _and_ we are trying
+                            // to sync an immediate switch block; we
+                            // need to read the validators from the
+                            // global states of the block and its parent and compare them in order
+                            // to decide which validators to use - might
+                            // require syncing global states in
                             // the process.
                             Some(self.try_read_validators_for_immediate_switch_block(
                                 effect_builder,

--- a/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test.sh
@@ -30,7 +30,7 @@ function main() {
     # 2. Send batch of native transfers
     do_send_transfers
     # 3. Wait until they're all included in the chain.
-    do_await_deploy_inclusion
+    do_await_deploy_inclusion '1'
     # 4. Stop the network for the emergency upgrade.
     do_stop_network
     # 5. Prepare the nodes for the emergency upgrade.
@@ -44,7 +44,7 @@ function main() {
     # 9. Send batch of native transfers
     do_send_transfers
     # 10. Wait until they're all included in the chain.
-    do_await_deploy_inclusion
+    do_await_deploy_inclusion '6'
     # 11. Prepare the second upgrade.
     do_upgrade_second_time
     # 12. Await the second upgrade.
@@ -54,14 +54,13 @@ function main() {
     # 14. Wait until node 1 syncs back to genesis.
     do_await_node_1_historical_sync
     # 15. Run Health Checks
-    # ... restarts=16: due to nodes being stopped and started
-    # ... crashes=5: expected in an emergency restart scenario?
-    # (TODO: double check the numbers once the test can properly finish)
+    # ... restarts=16: due to nodes being stopped and started; node 1 3 times, nodes 2-5 2 times,
+    # ................ node 6-10 1 time
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='0' \
             equivocators=0 \
             doppels=0 \
-            crashes=5 \
+            crashes=0 \
             restarts=16 \
             ejections=0
 
@@ -158,9 +157,10 @@ function do_send_transfers() {
 }
 
 function do_await_deploy_inclusion() {
+    local NODE_ID=${1}
     # Should be enough to await for one era.
     log_step "awaiting one era…"
-    nctl-await-n-eras offset='1' sleep_interval='5.0' timeout='180'
+    nctl-await-n-eras node_id=$NODE_ID offset='1' sleep_interval='5.0' timeout='180'
 }
 
 function do_upgrade_second_time() {
@@ -192,8 +192,8 @@ function do_reset_node_1() {
     local PATH_TO_STORAGE="${PATH_TO_NODE}/storage/$(get_chain_name)"
     # remove all storage, so that the node will start fresh
     rm -r "$PATH_TO_STORAGE"/*
-    # use node 2 for the latest block hash
-    TRUSTED_HASH=$(get_chain_latest_block_hash "2")
+    # use node 7 for the latest block hash
+    TRUSTED_HASH=$(get_chain_latest_block_hash "7")
     do_node_start "1" "$TRUSTED_HASH"
 }
 


### PR DESCRIPTION
This PR makes sure that the validators from immediate switch blocks are determined based on the global states of both the block itself and its parent; in such cases, if the validators have been altered, we need to use the validators from the immediate switch block instead of from the block preceding it.

Fixes the bug confirmed by the test introduced in #3570

Closes #3573