### PR TITLE
Add more debug logs for processing of execution results

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -587,6 +587,7 @@ impl BlockSynchronizer {
                 NeedNext::ExecutionResults(block_hash, id, checksum) => {
                     builder.set_in_flight_latch();
                     results.extend(peers.into_iter().flat_map(|node_id| {
+                        debug!("attempting to fetch BlockExecutionResultsOrChunk");
                         effect_builder
                             .fetch::<BlockExecutionResultsOrChunk>(id, node_id, checksum)
                             .event(move |result| Event::ExecutionResultsFetched {
@@ -954,6 +955,7 @@ impl BlockSynchronizer {
     where
         REv: From<StorageRequest> + Send,
     {
+        debug!(%block_hash, "execution_results_fetched");
         let (maybe_value_or_chunk, maybe_peer_id) = match result {
             Ok(FetchedData::FromPeer { item, peer }) => {
                 debug!(
@@ -973,15 +975,21 @@ impl BlockSynchronizer {
                 }
             }
         };
+        debug!(
+            ?maybe_value_or_chunk,
+            ?maybe_peer_id,
+            "execution_results_fetched"
+        );
 
         if let Some(builder) = &mut self.historical {
             if builder.block_hash() != block_hash {
-                trace!(%block_hash, "BlockSynchronizer: not currently synchronizing block");
+                debug!(%block_hash, "BlockSynchronizer: not currently synchronizing block");
                 return Effects::new();
             }
 
             match maybe_value_or_chunk {
                 None => {
+                    debug!(%block_hash, "execution_results_fetched: No maybe_value_or_chunk");
                     builder.demote_peer(maybe_peer_id);
                 }
                 Some(value_or_chunk) => {
@@ -992,11 +1000,14 @@ impl BlockSynchronizer {
                     match builder.register_fetched_execution_results(maybe_peer_id, *value_or_chunk)
                     {
                         Ok(Some(execution_results)) => {
+                            debug!(%block_hash, "execution_results_fetched: putting execution results to storage");
                             return effect_builder
                                 .put_execution_results_to_storage(block_hash, execution_results)
                                 .event(move |()| Event::ExecutionResultsStored(block_hash));
                         }
-                        Ok(None) => {}
+                        Ok(None) => {
+                            debug!(%block_hash, "execution_results_fetched: Ok(None)");
+                        }
                         Err(error) => {
                             error!(%block_hash, %error, "BlockSynchronizer: failed to apply execution results or chunk");
                         }
@@ -1010,9 +1021,9 @@ impl BlockSynchronizer {
     fn register_execution_results_stored(&mut self, block_hash: BlockHash) {
         if let Some(builder) = &mut self.historical {
             if builder.block_hash() != block_hash {
-                trace!(%block_hash, "BlockSynchronizer: not currently synchronizing block");
+                debug!(%block_hash, "BlockSynchronizer: register_execution_results_stored: not currently synchronizing block");
             } else if let Err(error) = builder.register_execution_results_stored_notification() {
-                error!(%block_hash, %error, "BlockSynchronizer: failed to apply stored execution results");
+                error!(%block_hash, %error, "BlockSynchronizer: register_execution_results_stored: failed to apply stored execution results");
             }
         }
     }

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -324,6 +324,7 @@ impl BlockBuilder {
     }
 
     pub(super) fn disqualify_peer(&mut self, peer: Option<NodeId>) {
+        debug!(?peer, "disqualify_peer");
         self.peer_list.disqualify_peer(peer);
     }
 
@@ -462,10 +463,12 @@ impl BlockBuilder {
         &mut self,
         execution_results_checksum: ExecutionResultsChecksum,
     ) -> Result<(), Error> {
+        debug!(block_hash=%self.block_hash, "register_execution_results_checksum");
         if let Err(err) = self.acquisition_state.register_execution_results_checksum(
             execution_results_checksum,
             self.should_fetch_execution_state,
         ) {
+            debug!(block_hash=%self.block_hash, %err, "register_execution_results_checksum: Error::BlockAcquisition");
             return Err(Error::BlockAcquisition(err));
         }
         self.touch();
@@ -477,11 +480,13 @@ impl BlockBuilder {
         maybe_peer: Option<NodeId>,
         block_execution_results_or_chunk: BlockExecutionResultsOrChunk,
     ) -> Result<Option<HashMap<DeployHash, casper_types::ExecutionResult>>, Error> {
+        debug!(block_hash=%self.block_hash, "register_fetched_execution_results");
         match self.acquisition_state.register_execution_results_or_chunk(
             block_execution_results_or_chunk,
             self.should_fetch_execution_state,
         ) {
             Ok(maybe) => {
+                debug!("register_fetched_execution_results: Ok(maybe)");
                 self.touch();
                 self.promote_peer(maybe_peer);
                 Ok(maybe)
@@ -496,7 +501,9 @@ impl BlockBuilder {
                     // programmer error
                     execution_results_acquisition::Error::BlockHashMismatch { .. }
                     | execution_results_acquisition::Error::InvalidAttemptToApplyChecksum { .. }
-                    | execution_results_acquisition::Error::AttemptToApplyDataWhenMissingChecksum { .. } => {},
+                    | execution_results_acquisition::Error::AttemptToApplyDataWhenMissingChecksum { .. } => {
+                        debug!("register_fetched_execution_results: BlockHashMismatch | InvalidAttemptToApplyChecksum | AttemptToApplyDataWhenMissingChecksum");
+                    },
                     // malicious peer if checksum is available.
                     execution_results_acquisition::Error::ChunkCountMismatch { .. } => {
                         let is_checkable = match &self.acquisition_state {
@@ -508,6 +515,7 @@ impl BlockBuilder {
                             ) => execution_results_acquisition.is_checkable(),
                             _ => false,
                         };
+                        debug!(is_checkable, "register_fetched_execution_results: ChunkCountMismatch");
                         if is_checkable {
                             self.disqualify_peer(maybe_peer);
                         }
@@ -517,10 +525,14 @@ impl BlockBuilder {
                     | execution_results_acquisition::Error::ChecksumMismatch { .. }
                     | execution_results_acquisition::Error::FailedToDeserialize { .. }
                     | execution_results_acquisition::Error::ExecutionResultToDeployHashLengthDiscrepancy { .. } => {
+                        debug!("register_fetched_execution_results: InvalidChunkCount | ChecksumMismatch | FailedToDeserialize | ExecutionResultToDeployHashLengthDiscrepancy");
                         self.disqualify_peer(maybe_peer);
                     }
                     // checksum unavailable, so unknown if this peer is malicious
-                    execution_results_acquisition::Error::ChunksWithDifferentChecksum { .. } => {}
+                    execution_results_acquisition::Error::ChunksWithDifferentChecksum { .. } => {
+                        debug!("register_fetched_execution_results: ChunksWithDifferentChecksum");
+
+                    }
                 }
                 Err(Error::BlockAcquisition(
                     BlockAcquisitionError::ExecutionResults(error),
@@ -534,10 +546,12 @@ impl BlockBuilder {
     }
 
     pub(super) fn register_execution_results_stored_notification(&mut self) -> Result<(), Error> {
+        debug!(block_hash=%self.block_hash, "register_execution_results_stored_notification");
         if let Err(err) = self
             .acquisition_state
             .register_execution_results_stored_notification(self.should_fetch_execution_state)
         {
+            debug!(block_hash=%self.block_hash, "register_execution_results_stored_notification: abort");
             self.abort();
             return Err(Error::BlockAcquisition(err));
         }


### PR DESCRIPTION
This PR adds more detailed logging in order to analyze the processing of execution results.

It should be reverted once the root-cause of https://github.com/casper-network/casper-node/issues/3583 is identified and the problem is fixed.