### PR TITLE
Fix nctl upgrade test 6 and 7

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -1102,7 +1102,7 @@ impl BlockAcquisitionState {
                 None => {
                     debug!(
                         "BlockAcquisition: finality signature for {:?} from {} while not actively \
-                        trying to actively acquire finality signatures",
+                        trying to acquire finality signatures",
                         block_hash, signer
                     );
                 }

--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -48,7 +48,6 @@ impl SignatureAcquisition {
         }
     }
 
-    /// Returns `true` if new signature was registered.
     pub(super) fn apply_signature(
         &mut self,
         finality_signature: FinalitySignature,

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -248,6 +248,10 @@ function _step_09()
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"
         _update_node_config_on_start "$PATH_TO_NODE_CONFIG_UPGRADE" "$HASH"
+
+        # remove stored state of the launcher - this will make the launcher start from the highest
+        # available version instead of from the previously executed one
+        rm "$(get_path_to_node_config $i)/casper-node-launcher-state.toml"
     done
 
     log "... restarting nodes 1 & 10"
@@ -346,7 +350,7 @@ function _step_13()
             equivocators='0' \
             doppels='0' \
             crashes=0 \
-            restarts=12 \
+            restarts=10 \
             ejections=0
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -248,6 +248,10 @@ function _step_09()
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"
         _update_node_config_on_start "$PATH_TO_NODE_CONFIG_UPGRADE" "$HASH"
+
+        # remove stored state of the launcher - this will make the launcher start from the highest
+        # available version instead of from the previously executed one
+        rm "$(get_path_to_node_config $i)/casper-node-launcher-state.toml"
     done
 
     log "... restarting nodes 1 & 10"
@@ -346,7 +350,7 @@ function _step_13()
             equivocators='0' \
             doppels='0' \
             crashes=0 \
-            restarts=12 \
+            restarts=10 \
             ejections=0
 }
 


### PR DESCRIPTION
This PR fixes two nctl upgrade tests.  The tests both involved having nodes 1 and 10 missing the upgrade (running through it but without the new binary staged) then restarting them after staging their upgrades to ensure they rejoin and sync up.

With the network component now rejecting connections between different protocol versions, the two affected nodes need to have their launchers' state files removed so that on restart the launcher runs the highest binary.

Closes #3619.