### PR TITLE
GH-3629: Backport PR #2807 on top of 1.4.13.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,13 +377,16 @@ dependencies = [
  "casper-hashing",
  "casper-types",
  "filesize",
+ "humantime",
  "lmdb",
  "log",
  "num-rational 0.4.0",
  "num-traits",
  "once_cell",
  "rand 0.8.5",
+ "serde",
  "tempfile",
+ "toml",
  "version-sync",
 ]
 

--- a/execution_engine/src/core/engine_state/engine_config.rs
+++ b/execution_engine/src/core/engine_state/engine_config.rs
@@ -1,5 +1,10 @@
 //! Support for runtime configuration of the execution engine - as an integral property of the
 //! `EngineState` instance.
+use casper_types::{
+    bytesrepr::{U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH},
+    KEY_HASH_LENGTH,
+};
+
 use crate::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
 
 /// Default value for a maximum query depth configuration option.
@@ -14,6 +19,41 @@ pub const DEFAULT_MAX_STORED_VALUE_SIZE: u32 = 8 * 1024 * 1024;
 pub const DEFAULT_MAX_DELEGATOR_SIZE_LIMIT: u32 = 950;
 /// Default value for minimum delegation amount in motes.
 pub const DEFAULT_MINIMUM_DELEGATION_AMOUNT: u64 = 500 * 1_000_000_000;
+
+/// The size in bytes per delegator entry in SeigniorageRecipient struct.
+/// 34 bytes PublicKey + 10 bytes U512 for the delegated amount
+const SIZE_PER_DELEGATOR_ENTRY: u32 = 44;
+/// The fixed portion, in bytes, of the SeigniorageRecipient struct and its key in the
+/// `SeigniorageRecipients` map.
+/// 34 bytes for the public key + 10 bytes validator weight + 1 byte for delegation rate.
+const FIXED_SIZE_PER_VALIDATOR: u32 = 45;
+/// The size of a key of the `SeigniorageRecipientsSnapshot`, i.e. an `EraId`.
+const FIXED_SIZE_PER_ERA: u32 = U64_SERIALIZED_LENGTH as u32;
+/// The overhead of the Key::Hash under which the seigniorage snapshot lives.
+/// The hash length plus an additional byte for the tag.
+const KEY_HASH_SERIALIZED_LENGTH: u32 = KEY_HASH_LENGTH as u32 + 1;
+
+#[doc(hidden)]
+pub const fn compute_max_delegator_size_limit(
+    max_stored_value_size: u32,
+    auction_delay: u64,
+    validator_slots: u32,
+) -> u32 {
+    let size_limit_per_snapshot =
+        (max_stored_value_size - U8_SERIALIZED_LENGTH as u32 - KEY_HASH_SERIALIZED_LENGTH)
+            / (auction_delay + 1) as u32;
+    let size_per_seigniorage_recipients = size_limit_per_snapshot - FIXED_SIZE_PER_ERA;
+    let size_limit_per_validator =
+        (size_per_seigniorage_recipients / validator_slots) - FIXED_SIZE_PER_VALIDATOR;
+    // The max number of the delegators per validator is the size limit allotted
+    // to a single validator divided by the size of a single delegator entry.
+    // For the given:
+    // 1. max limit of 8MB
+    // 2. 100 validator slots
+    // 3. an auction delay of 1
+    // There will be a maximum of roughly 953 delegators per validator.
+    size_limit_per_validator / SIZE_PER_DELEGATOR_ENTRY
+}
 
 /// The runtime configuration of the execution engine
 #[derive(Debug, Copy, Clone)]

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add some auction and transfer test support functions for reuse among benchmarks and unit tests.
 
 
+### Deprecated
+* Deprecated the `DEFAULT_GENESIS_REQUEST` in favor of `PRODUCTION_GENESIS_REQUEST`.
 
 ## 2.1.0
 

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -14,6 +14,7 @@ license-file = "../../LICENSE"
 casper-execution-engine = { version = "2.0.1", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
+humantime = "2"
 filesize = "0.2.0"
 lmdb = "0.8.0"
 log = "0.4.14"
@@ -21,6 +22,8 @@ num-rational = "0.4.0"
 num-traits = "0.2.14"
 once_cell = "1.8.0"
 rand = "0.8.4"
+serde = { version = "1", features = ["derive", "rc"] }
+toml = "0.5.6"
 tempfile = "3"
 
 [dev-dependencies]

--- a/execution_engine_testing/test_support/resources/chainspec.toml
+++ b/execution_engine_testing/test_support/resources/chainspec.toml
@@ -1,0 +1,1 @@
+../../../resources/production/chainspec.toml

--- a/execution_engine_testing/test_support/src/chainspec_config.rs
+++ b/execution_engine_testing/test_support/src/chainspec_config.rs
@@ -1,0 +1,188 @@
+use std::{
+    convert::TryFrom,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use num_rational::Ratio;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use casper_execution_engine::{
+    core::engine_state::{run_genesis_request::RunGenesisRequest, ExecConfig, GenesisAccount},
+    shared::{system_config::SystemConfig, wasm_config::WasmConfig},
+};
+use casper_types::ProtocolVersion;
+
+use crate::{DEFAULT_ACCOUNTS, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS};
+
+/// The name of the chainspec file on disk.
+pub const CHAINSPEC_NAME: &str = "chainspec.toml";
+
+/// Path to the production chainspec used in the Casper mainnet.
+pub static PRODUCTION_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources/")
+        .join(CHAINSPEC_NAME)
+});
+
+#[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum Error {
+    FailedToLoadChainspec {
+        /// Path that failed to be read.
+        path: PathBuf,
+        /// The underlying OS error.
+        error: io::Error,
+    },
+    FailedToParseChainspec(toml::de::Error),
+    FailedToCreateExecConfig,
+    FailedToParseLockedFundsPeriod,
+    FailedToCreateGenesisRequest,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub struct CoreConfig {
+    /// The number of validator slots in the auction.
+    pub(crate) validator_slots: u32,
+    /// Number of eras before an auction actually defines the set of validators.
+    /// If you bond with a sufficient bid in era N, you will be a validator in era N +
+    /// auction_delay + 1
+    pub(crate) auction_delay: u64,
+    /// The period after genesis during which a genesis validator's bid is locked.
+    pub(crate) locked_funds_period: String,
+    /// The delay in number of eras for paying out the the unbonding amount.
+    pub(crate) unbonding_delay: u64,
+    /// Round seigniorage rate represented as a fractional number.
+    pub(crate) round_seigniorage_rate: Ratio<u64>,
+    /// Maximum number of associated keys for a single account.
+    pub(crate) max_associated_keys: u32,
+    /// Maximum height of contract runtime call stack.
+    pub(crate) max_runtime_call_stack_height: u32,
+    /// Maximum serialized size of values stored in global state.
+    pub(crate) max_stored_value_size: u32,
+    /// The minimum bound of motes that can be delegated to a validator.
+    pub(crate) minimum_delegation_amount: u64,
+}
+
+/// This struct can be parsed from a TOML-encoded chainspec file.  It means that as the
+/// chainspec format changes over versions, as long as we maintain the core config in this form
+/// in the chainspec file, it can continue to be parsed as an `ChainspecConfig`.
+#[derive(Deserialize, Clone)]
+pub struct ChainspecConfig {
+    #[serde(rename = "core")]
+    pub(crate) core_config: CoreConfig,
+    #[serde(rename = "wasm")]
+    pub(crate) wasm_config: WasmConfig,
+    #[serde(rename = "system_costs")]
+    pub(crate) system_costs_config: SystemConfig,
+}
+
+impl ChainspecConfig {
+    pub(crate) fn from_chainspec_path<P: AsRef<Path>>(filename: P) -> Result<Self, Error> {
+        let path = filename.as_ref();
+        let bytes = fs::read(path).map_err(|error| Error::FailedToLoadChainspec {
+            path: path.into(),
+            error,
+        })?;
+        let chainspec_config: ChainspecConfig =
+            toml::from_slice(&bytes).map_err(Error::FailedToParseChainspec)?;
+        Ok(chainspec_config)
+    }
+
+    pub(crate) fn create_genesis_request_from_chainspec<P: AsRef<Path>>(
+        filename: P,
+        genesis_accounts: Vec<GenesisAccount>,
+        protocol_version: ProtocolVersion,
+    ) -> Result<RunGenesisRequest, Error> {
+        let path = filename.as_ref();
+        let bytes = fs::read(path).map_err(|error| Error::FailedToLoadChainspec {
+            path: path.into(),
+            error,
+        })?;
+        let chainspec_config: ChainspecConfig =
+            toml::from_slice(&bytes).map_err(Error::FailedToParseChainspec)?;
+        let locked_funds_period_millis =
+            humantime::parse_duration(&*chainspec_config.core_config.locked_funds_period)
+                .map_err(|_| Error::FailedToCreateGenesisRequest)?
+                .as_millis() as u64;
+        let exec_config = ExecConfig::new(
+            genesis_accounts,
+            chainspec_config.wasm_config,
+            chainspec_config.system_costs_config,
+            chainspec_config.core_config.validator_slots,
+            chainspec_config.core_config.auction_delay,
+            locked_funds_period_millis,
+            chainspec_config.core_config.round_seigniorage_rate,
+            chainspec_config.core_config.unbonding_delay,
+            DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+        );
+        Ok(RunGenesisRequest::new(
+            *DEFAULT_GENESIS_CONFIG_HASH,
+            protocol_version,
+            exec_config,
+        ))
+    }
+
+    /// Create a `RunGenesisRequest` using values from the production `chainspec.toml`.
+    pub fn create_genesis_request_from_production_chainspec(
+        genesis_accounts: Vec<GenesisAccount>,
+        protocol_version: ProtocolVersion,
+    ) -> Result<RunGenesisRequest, Error> {
+        Self::create_genesis_request_from_chainspec(
+            &*PRODUCTION_PATH,
+            genesis_accounts,
+            protocol_version,
+        )
+    }
+}
+
+impl TryFrom<ChainspecConfig> for ExecConfig {
+    type Error = Error;
+
+    fn try_from(chainspec_config: ChainspecConfig) -> Result<Self, Self::Error> {
+        let locked_funds_period_millis =
+            humantime::parse_duration(&*chainspec_config.core_config.locked_funds_period)
+                .map_err(|_| Error::FailedToCreateExecConfig)?
+                .as_millis() as u64;
+        Ok(ExecConfig::new(
+            DEFAULT_ACCOUNTS.clone(),
+            chainspec_config.wasm_config,
+            chainspec_config.system_costs_config,
+            chainspec_config.core_config.validator_slots,
+            chainspec_config.core_config.auction_delay,
+            locked_funds_period_millis,
+            chainspec_config.core_config.round_seigniorage_rate,
+            chainspec_config.core_config.unbonding_delay,
+            DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::TryFrom, path::PathBuf};
+
+    use once_cell::sync::Lazy;
+
+    use super::{ChainspecConfig, ExecConfig, CHAINSPEC_NAME};
+
+    pub static LOCAL_PATH: Lazy<PathBuf> =
+        Lazy::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../resources/local/"));
+
+    #[test]
+    fn should_load_chainspec_config_from_chainspec() {
+        let path = &LOCAL_PATH.join(CHAINSPEC_NAME);
+        let chainspec_config = ChainspecConfig::from_chainspec_path(path).unwrap();
+        // Check that the loaded values matches values present in the local chainspec.
+        assert_eq!(chainspec_config.core_config.auction_delay, 3);
+    }
+
+    #[test]
+    fn should_get_exec_config_from_chainspec_values() {
+        let path = &LOCAL_PATH.join(CHAINSPEC_NAME);
+        let chainspec_config = ChainspecConfig::from_chainspec_path(path).unwrap();
+        let exec_config = ExecConfig::try_from(chainspec_config).unwrap();
+        assert_eq!(exec_config.auction_delay(), 3)
+    }
+}

--- a/execution_engine_testing/test_support/src/transfer.rs
+++ b/execution_engine_testing/test_support/src/transfer.rs
@@ -3,7 +3,7 @@ use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U
 
 use crate::{
     DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 const CONTRACT_CREATE_ACCOUNTS: &str = "create_accounts.wasm";
@@ -45,7 +45,7 @@ pub fn create_initial_accounts_and_run_genesis(
 ) {
     let exec_request = create_accounts_request(accounts, amount);
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -12,12 +12,15 @@ use std::{
 use filesize::PathExt;
 use lmdb::DatabaseFlags;
 use log::LevelFilter;
+use num_rational::Ratio;
+use num_traits::CheckedMul;
 
 use bytesrepr::FromBytes;
 use casper_execution_engine::{
     core::{
         engine_state,
         engine_state::{
+            engine_config,
             era_validators::GetEraValidatorsRequest,
             execute_request::ExecuteRequest,
             execution_result::ExecutionResult,
@@ -25,7 +28,7 @@ use casper_execution_engine::{
             step::{StepRequest, StepSuccess},
             BalanceResult, EngineConfig, EngineState, Error, GenesisSuccess, GetBidsRequest,
             QueryRequest, QueryResult, StepError, SystemContractRegistry, UpgradeConfig,
-            UpgradeSuccess,
+            UpgradeSuccess, DEFAULT_MAX_QUERY_DEPTH,
         },
         execution,
     },
@@ -33,6 +36,10 @@ use casper_execution_engine::{
         additive_map::AdditiveMap,
         logging::{self, Settings, Style},
         newtypes::CorrelationId,
+        system_config::{
+            auction_costs::AuctionCosts, handle_payment_costs::HandlePaymentCosts,
+            mint_costs::MintCosts,
+        },
         transform::Transform,
         utils::OS_PAGE_SIZE,
     },
@@ -54,8 +61,9 @@ use casper_types::{
         auction::{
             Bids, EraValidators, UnbondingPurses, ValidatorWeights, ARG_ERA_END_TIMESTAMP_MILLIS,
             ARG_EVICTED_VALIDATORS, AUCTION_DELAY_KEY, ERA_ID_KEY, METHOD_RUN_AUCTION,
+            UNBONDING_DELAY_KEY,
         },
-        mint::TOTAL_SUPPLY_KEY,
+        mint::{ROUND_SEIGNIORAGE_RATE_KEY, TOTAL_SUPPLY_KEY},
         AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
     CLTyped, CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash, ContractWasm,
@@ -64,6 +72,7 @@ use casper_types::{
 };
 
 use crate::{
+    chainspec_config::{ChainspecConfig, PRODUCTION_PATH},
     utils, ExecuteRequestBuilder, DEFAULT_PROPOSER_ADDR, DEFAULT_PROTOCOL_VERSION, SYSTEM_ADDR,
 };
 
@@ -116,25 +125,7 @@ impl<S> WasmTestBuilder<S> {
 
 impl Default for InMemoryWasmTestBuilder {
     fn default() -> Self {
-        Self::initialize_logging();
-        let engine_config = EngineConfig::default();
-
-        let global_state = InMemoryGlobalState::empty().expect("should create global state");
-        let engine_state = EngineState::new(global_state, engine_config);
-
-        WasmTestBuilder {
-            engine_state: Rc::new(engine_state),
-            exec_results: Vec::new(),
-            upgrade_results: Vec::new(),
-            genesis_hash: None,
-            post_state_hash: None,
-            transforms: Vec::new(),
-            genesis_account: None,
-            genesis_transforms: None,
-            system_contract_registry: None,
-            global_state_dir: None,
-            scratch_engine_state: None,
-        }
+        Self::new_with_chainspec(&*PRODUCTION_PATH, None)
     }
 }
 
@@ -168,11 +159,48 @@ impl InMemoryWasmTestBuilder {
         Self::initialize_logging();
         let engine_state = EngineState::new(global_state, engine_config);
         WasmTestBuilder {
+            exec_results: Vec::new(),
+            upgrade_results: Vec::new(),
             engine_state: Rc::new(engine_state),
             genesis_hash: maybe_post_state_hash,
             post_state_hash: maybe_post_state_hash,
-            ..Default::default()
+            transforms: Vec::new(),
+            genesis_account: None,
+            genesis_transforms: None,
+            scratch_engine_state: None,
+            system_contract_registry: None,
+            global_state_dir: None,
         }
+    }
+
+    /// Returns an [`InMemoryWasmTestBuilder`] instantiated using values from a given chainspec.
+    pub fn new_with_chainspec<P: AsRef<Path>>(
+        chainspec_path: P,
+        post_state_hash: Option<Digest>,
+    ) -> Self {
+        let chainspec_config = ChainspecConfig::from_chainspec_path(chainspec_path)
+            .expect("must build chainspec configuration");
+
+        let max_delegator_size_limit = engine_config::compute_max_delegator_size_limit(
+            chainspec_config.core_config.max_stored_value_size,
+            chainspec_config.core_config.auction_delay,
+            chainspec_config.core_config.validator_slots,
+        );
+
+        let engine_config = EngineConfig::new(
+            DEFAULT_MAX_QUERY_DEPTH,
+            chainspec_config.core_config.max_associated_keys,
+            chainspec_config.core_config.max_runtime_call_stack_height,
+            chainspec_config.core_config.max_stored_value_size,
+            max_delegator_size_limit,
+            chainspec_config.core_config.minimum_delegation_amount,
+            chainspec_config.wasm_config,
+            chainspec_config.system_costs_config,
+        );
+
+        let global_state = InMemoryGlobalState::empty().expect("should create global state");
+
+        Self::new(global_state, engine_config, post_state_hash)
     }
 }
 
@@ -217,6 +245,41 @@ impl LmdbWasmTestBuilder {
             global_state_dir: Some(global_state_dir),
             scratch_engine_state: None,
         }
+    }
+
+    /// Returns an [`LmdbWasmTestBuilder`] with configuration and values from
+    /// a given chainspec.
+    pub fn new_with_chainspec<T: AsRef<OsStr> + ?Sized, P: AsRef<Path>>(
+        data_dir: &T,
+        chainspec_path: P,
+    ) -> Self {
+        let chainspec_config = ChainspecConfig::from_chainspec_path(chainspec_path)
+            .expect("must build chainspec configuration");
+
+        let max_delegator_size_limit = engine_config::compute_max_delegator_size_limit(
+            chainspec_config.core_config.max_stored_value_size,
+            chainspec_config.core_config.auction_delay,
+            chainspec_config.core_config.validator_slots,
+        );
+
+        let engine_config = EngineConfig::new(
+            DEFAULT_MAX_QUERY_DEPTH,
+            chainspec_config.core_config.max_associated_keys,
+            chainspec_config.core_config.max_runtime_call_stack_height,
+            chainspec_config.core_config.max_stored_value_size,
+            max_delegator_size_limit,
+            chainspec_config.core_config.minimum_delegation_amount,
+            chainspec_config.wasm_config,
+            chainspec_config.system_costs_config,
+        );
+
+        Self::new_with_config(data_dir, engine_config)
+    }
+
+    /// Returns an [`LmdbWasmTestBuilder`] with configuration and values from
+    /// the production chainspec.
+    pub fn new_with_production_chainspec<T: AsRef<OsStr> + ?Sized>(data_dir: &T) -> Self {
+        Self::new_with_chainspec(data_dir, &*PRODUCTION_PATH)
     }
 
     /// Flushes the LMDB environment to disk.
@@ -514,6 +577,54 @@ where
         };
 
         total_supply
+    }
+
+    /// Queries for the base round reward.
+    /// # Panics
+    /// Panics if the total supply or seigniorage rate can't be found.
+    pub fn base_round_reward(&mut self, maybe_post_state: Option<Digest>) -> U512 {
+        let mint_key: Key = self.get_mint_contract_hash().into();
+
+        let mint_contract = self
+            .query(maybe_post_state, mint_key, &[])
+            .expect("must get mint stored value")
+            .as_contract()
+            .expect("must convert to mint contract")
+            .clone();
+
+        let mint_named_keys = mint_contract.named_keys().clone();
+
+        let total_supply_uref = *mint_named_keys
+            .get(TOTAL_SUPPLY_KEY)
+            .expect("must track total supply")
+            .as_uref()
+            .expect("must get uref");
+
+        let round_seigniorage_rate_uref = *mint_named_keys
+            .get(ROUND_SEIGNIORAGE_RATE_KEY)
+            .expect("must track round seigniorage rate");
+
+        let total_supply = self
+            .query(maybe_post_state, Key::URef(total_supply_uref), &[])
+            .expect("must read value under total supply URef")
+            .as_cl_value()
+            .expect("must convert into CL value")
+            .clone()
+            .into_t::<U512>()
+            .expect("must convert into U512");
+
+        let rate = self
+            .query(maybe_post_state, round_seigniorage_rate_uref, &[])
+            .expect("must read value")
+            .as_cl_value()
+            .expect("must conver to cl value")
+            .clone()
+            .into_t::<Ratio<U512>>()
+            .expect("must conver to ratio");
+
+        rate.checked_mul(&Ratio::from(total_supply))
+            .map(|ratio| ratio.to_integer())
+            .expect("must get base round reward")
     }
 
     /// Runs an [`ExecuteRequest`].
@@ -1105,6 +1216,12 @@ where
         self.get_value(auction_contract, AUCTION_DELAY_KEY)
     }
 
+    /// Gets the unbonding delay
+    pub fn get_unbonding_delay(&mut self) -> u64 {
+        let auction_contract = self.get_auction_contract_hash();
+        self.get_value(auction_contract, UNBONDING_DELAY_KEY)
+    }
+
     /// Gets the [`ContractHash`] of the system auction contract, panics if it can't be found.
     pub fn get_system_auction_hash(&self) -> ContractHash {
         let correlation_id = CorrelationId::new();
@@ -1156,5 +1273,24 @@ where
         self.engine_state
             .get_trie(CorrelationId::default(), state_hash)
             .unwrap()
+    }
+
+    /// Returns the costs related to interacting with the auction system contract.
+    pub fn get_auction_costs(&self) -> AuctionCosts {
+        *self.engine_state.config().system_config().auction_costs()
+    }
+
+    /// Returns the costs related to interacting with the mint system contract.
+    pub fn get_mint_costs(&self) -> MintCosts {
+        *self.engine_state.config().system_config().mint_costs()
+    }
+
+    /// Returns the costs related to interacting with the handle payment system contract.
+    pub fn get_handle_payment_costs(&self) -> HandlePaymentCosts {
+        *self
+            .engine_state
+            .config()
+            .system_config()
+            .handle_payment_costs()
     }
 }

--- a/execution_engine_testing/tests/benches/transfer_bench.rs
+++ b/execution_engine_testing/tests/benches/transfer_bench.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::engine_state::{EngineConfig, ExecuteRequest};
 use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U512};
@@ -52,7 +52,7 @@ fn bootstrap(data_dir: &Path, accounts: Vec<AccountHash>, amount: U512) -> LmdbW
     let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/associated_keys.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{
     account::{AccountHash, Weight},
@@ -38,7 +38,7 @@ fn should_manage_associated_key() {
     .build();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{self, Error},
@@ -36,7 +36,7 @@ fn should_deploy_with_authorized_identity_key() {
     .build();
     // Basic deploy with single key
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .expect_success();
@@ -69,7 +69,7 @@ fn should_raise_auth_failure_with_invalid_key() {
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -118,7 +118,7 @@ fn should_raise_auth_failure_with_invalid_keys() {
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -177,7 +177,7 @@ fn should_raise_deploy_authorization_failure() {
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         // Reusing a test contract that would add new key
         .exec(exec_request_1)
         .expect_success()
@@ -342,7 +342,7 @@ fn should_authorize_deploy_with_multiple_keys() {
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         // Reusing a test contract that would add new key
         .exec(exec_request_1)
         .expect_success()
@@ -399,8 +399,9 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
     .build();
     // Basic deploy with single key
     let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
         // Reusing a test contract that would add new key
         .exec(exec_request_1)
         .expect_success()
@@ -484,7 +485,7 @@ fn should_not_authorize_transfer_without_deploy_key_threshold() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         // Reusing a test contract that would add new key
         .exec(add_key_1_request)
         .expect_success()

--- a/execution_engine_testing/tests/src/test/contract_api/account/key_management_thresholds.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/key_management_thresholds.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs};
 
@@ -24,7 +24,7 @@ fn should_verify_key_management_permission_with_low_weight() {
     )
     .build();
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()
@@ -61,7 +61,7 @@ fn should_verify_key_management_permission_with_sufficient_weight() {
         ExecuteRequestBuilder::from_deploy_item(deploy).build()
     };
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/contract_api/account/named_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/named_keys.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{bytesrepr::FromBytes, runtime_args, CLTyped, CLValue, Key, RuntimeArgs, U512};
 
@@ -44,7 +44,7 @@ fn read_value<T: CLTyped + FromBytes>(builder: &mut InMemoryWasmTestBuilder, key
 fn should_run_named_keys_contract() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     run_command(&mut builder, COMMAND_CREATE_UREF1);
 

--- a/execution_engine_testing/tests/src/test/contract_api/account/named_keys_stored.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/named_keys_stored.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, RuntimeArgs};
 
@@ -122,7 +122,7 @@ fn should_run_stored_named_keys_module_bytes_to_session_to_session() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         "named_keys_stored.wasm",

--- a/execution_engine_testing/tests/src/test/contract_api/blake2b.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/blake2b.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account, runtime_args, RuntimeArgs, BLAKE2B_DIGEST_LENGTH};
 
@@ -39,7 +39,7 @@ fn should_hash() {
     let mut rng = rand::thread_rng();
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     for _ in 0..RUNS {
         let input: [u8; INPUT_LENGTH] = rng.gen();

--- a/execution_engine_testing/tests/src/test/contract_api/create_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/create_purse.rs
@@ -1,8 +1,8 @@
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
 
@@ -31,9 +31,9 @@ fn should_insert_account_into_named_keys() {
     )
     .build();
 
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -65,9 +65,9 @@ fn should_create_usable_purse() {
         runtime_args! { ARG_PURSE_NAME => TEST_PURSE_NAME },
     )
     .build();
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/contract_api/dictionary.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/dictionary.rs
@@ -2,7 +2,7 @@ use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
     DEFAULT_GENESIS_CONFIG, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{run_genesis_request::RunGenesisRequest, Error as EngineError, GenesisAccount},
@@ -24,7 +24,7 @@ const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 fn setup() -> (InMemoryWasmTestBuilder, ContractHash) {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let fund_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,
@@ -452,7 +452,7 @@ fn should_fail_get_with_invalid_dictionary_item_key() {
 fn dictionary_put_should_fail_with_large_item_key() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let fund_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,
@@ -496,7 +496,7 @@ fn dictionary_put_should_fail_with_large_item_key() {
 fn dictionary_get_should_fail_with_large_item_key() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let fund_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, ApiError, RuntimeArgs, U512};
 
@@ -17,7 +17,7 @@ fn call_get_arg(args: RuntimeArgs) -> Result<(), String> {
         ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, CONTRACT_GET_ARG, args).build();
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 

--- a/execution_engine_testing/tests/src/test/contract_api/get_blocktime.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_blocktime.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, RuntimeArgs};
 
@@ -20,7 +20,7 @@ fn should_run_get_blocktime_contract() {
     .with_block_time(block_time)
     .build();
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .expect_success();

--- a/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_call_stack.rs
@@ -2,7 +2,7 @@ use num_traits::One;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, WasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::engine_state::{Error as CoreError, ExecError, ExecuteRequest},
@@ -183,7 +183,7 @@ impl BuilderExt for WasmTestBuilder<InMemoryGlobalState> {
 
 fn setup() -> WasmTestBuilder<InMemoryGlobalState> {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     store_contract(&mut builder, CONTRACT_RECURSIVE_SUBCALL);
     builder
 }

--- a/execution_engine_testing/tests/src/test/contract_api/get_caller.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_caller.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs};
 
@@ -13,7 +13,7 @@ const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 #[test]
 fn should_run_get_caller_contract() {
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(
             ExecuteRequestBuilder::standard(
                 *DEFAULT_ACCOUNT_ADDR,
@@ -31,7 +31,7 @@ fn should_run_get_caller_contract() {
 fn should_run_get_caller_contract_other_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(
@@ -63,7 +63,7 @@ fn should_run_get_caller_contract_other_account() {
 fn should_run_get_caller_subcall_contract() {
     {
         let mut builder = InMemoryWasmTestBuilder::default();
-        builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+        builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
         builder
             .exec(
@@ -80,7 +80,7 @@ fn should_run_get_caller_subcall_contract() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(
             ExecuteRequestBuilder::standard(
                 *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/contract_api/get_phase.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_phase.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, Phase, RuntimeArgs};
 
@@ -34,7 +34,7 @@ fn should_run_get_phase_contract() {
     };
 
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .expect_success();

--- a/execution_engine_testing/tests/src/test/contract_api/list_named_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/list_named_keys.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, contracts::NamedKeys, runtime_args, Key, RuntimeArgs};
 
@@ -14,7 +14,7 @@ const ARG_NEW_NAMED_KEYS: &str = "new_named_keys";
 #[test]
 fn should_list_named_keys() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let initial_named_keys: NamedKeys = NamedKeys::new();
 

--- a/execution_engine_testing/tests/src/test/contract_api/main_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/main_purse.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, StoredValue};
 
@@ -15,7 +15,7 @@ const ARG_AMOUNT: &str = "amount";
 fn should_run_main_purse_contract_default_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    let builder = builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    let builder = builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = if let Ok(StoredValue::Account(account)) =
         builder.query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
@@ -48,7 +48,7 @@ fn should_run_main_purse_contract_account_1() {
     .build();
 
     let builder = builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/contract_api/mint_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mint_purse.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_RUN_GENESIS_REQUEST,
-    MINIMUM_ACCOUNT_CREATION_BALANCE, SYSTEM_ADDR,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
 };
 use casper_types::{runtime_args, RuntimeArgs, U512};
 
@@ -21,9 +21,9 @@ fn should_run_mint_purse_contract() {
         ExecuteRequestBuilder::standard(*SYSTEM_ADDR, CONTRACT_MINT_PURSE, RuntimeArgs::default())
             .build();
 
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit().expect_success();
     builder.exec(exec_request_2).commit().expect_success();
@@ -39,8 +39,8 @@ fn should_not_allow_non_system_accounts_to_mint() {
     )
     .build();
 
-    assert!(WasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+    assert!(InMemoryWasmTestBuilder::default()
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .is_error());

--- a/execution_engine_testing/tests/src/test/contract_api/revert.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/revert.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -13,7 +13,7 @@ fn should_revert() {
         ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, REVERT_WASM, RuntimeArgs::default())
             .build();
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .is_error();

--- a/execution_engine_testing/tests/src/test/contract_api/subcall.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/subcall.rs
@@ -3,7 +3,7 @@ use num_traits::cast::AsPrimitive;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{contracts::CONTRACT_INITIAL_VERSION, runtime_args, RuntimeArgs, U512};
 
@@ -42,7 +42,7 @@ fn should_charge_gas_for_subcall() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(do_nothing_request).expect_success().commit();
 
@@ -130,7 +130,7 @@ fn should_add_all_gas_for_subcall() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(add_zero_gas_from_session_request)
@@ -186,7 +186,7 @@ fn expensive_subcall_should_cost_more() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     // store the contracts first
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(store_do_nothing_request)

--- a/execution_engine_testing/tests/src/test/contract_api/transfer.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer.rs
@@ -3,8 +3,8 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
-    MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error as EngineError, execution::Error};
 use casper_types::{
@@ -54,7 +54,7 @@ fn should_transfer_to_account() {
     // Run genesis
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -107,7 +107,7 @@ fn should_transfer_to_public_key() {
     // Run genesis
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -158,7 +158,7 @@ fn should_transfer_from_purse_to_public_key() {
     // Run genesis
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // Create a funded a purse, and store it in named keys
     let exec_request_1 = ExecuteRequestBuilder::standard(
@@ -237,7 +237,7 @@ fn should_transfer_from_account_to_account() {
     // Run genesis
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    let builder = builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    let builder = builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -327,7 +327,7 @@ fn should_transfer_to_existing_account() {
     // Run genesis
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    let builder = builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    let builder = builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -444,7 +444,7 @@ fn should_fail_when_insufficient_funds() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         // Exec transfer contract
         .exec(exec_request_1)
         .expect_success()
@@ -487,7 +487,7 @@ fn should_transfer_total_amount() {
     )
     .build();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{
     account::AccountHash,
@@ -24,7 +24,7 @@ static ACCOUNT_1_INITIAL_FUND: Lazy<U512> = Lazy::new(|| *DEFAULT_PAYMENT + 42);
 #[test]
 fn should_run_purse_to_account_transfer() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let account_1_account_hash = ACCOUNT_1_ADDR;
     assert!(
@@ -67,7 +67,7 @@ fn should_fail_when_sending_too_much_from_purse_to_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_failure().commit();
 

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_purse.rs
@@ -4,7 +4,7 @@ use casper_types::{runtime_args, system::mint, ApiError, CLValue, RuntimeArgs, U
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_PURSE: &str = "transfer_purse_to_purse.wasm";
@@ -32,7 +32,7 @@ fn should_run_purse_to_purse_transfer() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();
@@ -96,7 +96,7 @@ fn should_run_purse_to_purse_transfer_with_error() {
         .build();
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/contract_context.rs
+++ b/execution_engine_testing/tests/src/test/contract_context.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error, execution};
 use casper_types::{contracts::CONTRACT_INITIAL_VERSION, runtime_args, Key, RuntimeArgs};
@@ -84,7 +84,7 @@ fn should_enforce_intended_execution_contexts() {
     };
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -181,7 +181,7 @@ fn should_enforce_intended_execution_context_direct_by_name() {
     };
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -226,7 +226,7 @@ fn should_enforce_intended_execution_context_direct_by_hash() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -324,7 +324,7 @@ fn should_not_call_session_from_contract() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/contract_headers.rs
+++ b/execution_engine_testing/tests/src/test/contract_headers.rs
@@ -1,7 +1,7 @@
 use casper_engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_PAYMENT,
-        DEFAULT_RUN_GENESIS_REQUEST,
+        PRODUCTION_RUN_GENESIS_REQUEST,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
@@ -81,7 +81,7 @@ fn should_enforce_intended_execution_contexts() {
     };
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/counter.rs
+++ b/execution_engine_testing/tests/src/test/counter.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, Key, RuntimeArgs};
 
@@ -26,7 +26,7 @@ fn should_run_counter_example_contract() {
     .build();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();
@@ -111,7 +111,7 @@ fn should_default_contract_hash_arg() {
     .build();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();
@@ -168,7 +168,7 @@ fn should_call_counter_contract_directly() {
     .build();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/deploy/context_association.rs
+++ b/execution_engine_testing/tests/src/test/deploy/context_association.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_KEY, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_KEY, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 use casper_types::{
@@ -31,7 +31,7 @@ fn should_put_system_contract_hashes_to_account_context() {
     };
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
 
@@ -42,7 +42,7 @@ fn should_charge_non_main_purse() {
     )
     .build();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(setup_exec_request)

--- a/execution_engine_testing/tests/src/test/deploy/preconditions.rs
+++ b/execution_engine_testing/tests/src/test/deploy/preconditions.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 
 use casper_engine_test_support::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::engine_state::Error;
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
@@ -36,7 +36,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -67,7 +67,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -105,7 +105,7 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 

--- a/execution_engine_testing/tests/src/test/deploy/receipts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/receipts.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::shared::system_config::DEFAULT_WASMLESS_TRANSFER_COST;
 use casper_types::{
@@ -52,7 +52,7 @@ static TRANSFER_AMOUNT_3: Lazy<U512> = Lazy::new(|| U512::from(300_100_000));
 #[test]
 fn should_record_wasmless_transfer() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let id = Some(0);
 
@@ -120,7 +120,7 @@ fn should_record_wasmless_transfer() {
 #[test]
 fn should_record_wasm_transfer() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -183,7 +183,7 @@ fn should_record_wasm_transfer() {
 #[test]
 fn should_record_wasm_transfer_with_id() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let id = Some(0);
 
@@ -250,7 +250,7 @@ fn should_record_wasm_transfer_with_id() {
 #[test]
 fn should_record_wasm_transfers() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let alice_id = Some(0);
     let bob_id = Some(1);
@@ -385,7 +385,7 @@ fn should_record_wasm_transfers() {
 #[test]
 fn should_record_wasm_transfers_with_subcall() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let alice_id = Some(0);
     let bob_id = Some(1);

--- a/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
@@ -1,7 +1,7 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
     WasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_KEY,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -108,7 +108,7 @@ fn should_exec_non_stored_code() {
     };
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let proposer_reward_starting_balance = builder.get_proposer_purse_balance();
 
@@ -142,7 +142,7 @@ fn should_fail_if_calling_non_existent_entry_point() {
     let payment_purse_amount = *DEFAULT_PAYMENT;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // first, store payment contract with entry point named "pay"
     let exec_request = ExecuteRequestBuilder::standard(
@@ -205,7 +205,7 @@ fn should_exec_stored_code_by_hash() {
 
     // genesis
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store payment
     let proposer_reward_starting_balance_alpha = builder.get_proposer_purse_balance();
@@ -292,7 +292,7 @@ fn should_not_transfer_above_balance_using_stored_payment_code_by_hash() {
 
     // genesis
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store payment
     let (default_account, hash) = store_payment_to_account_context(&mut builder);
@@ -348,7 +348,7 @@ fn should_empty_account_using_stored_payment_code_by_hash() {
 
     // genesis
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store payment
     let proposer_reward_starting_balance_alpha = builder.get_proposer_purse_balance();
@@ -440,7 +440,7 @@ fn should_exec_stored_code_by_named_hash() {
 
     // genesis
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store payment
     let proposer_reward_starting_balance_alpha = builder.get_proposer_purse_balance();
@@ -535,7 +535,7 @@ fn should_fail_payment_stored_at_named_key_with_incompatible_major_version() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -619,7 +619,7 @@ fn should_fail_payment_stored_at_hash_with_incompatible_major_version() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -689,7 +689,7 @@ fn should_fail_session_stored_at_named_key_with_incompatible_major_version() {
     let payment_purse_amount = *DEFAULT_PAYMENT;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // first, store payment contract for v1.0.0
     let exec_request_1 = ExecuteRequestBuilder::standard(
@@ -698,6 +698,9 @@ fn should_fail_session_stored_at_named_key_with_incompatible_major_version() {
         RuntimeArgs::default(),
     )
     .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit();
 
@@ -797,7 +800,7 @@ fn should_fail_session_stored_at_named_key_with_missing_new_major_version() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit();
 
@@ -876,7 +879,7 @@ fn should_fail_session_stored_at_hash_with_incompatible_major_version() {
     let payment_purse_amount = *DEFAULT_PAYMENT;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // first, store payment contract for v1.0.0
     let exec_request_1 = ExecuteRequestBuilder::standard(
@@ -885,6 +888,9 @@ fn should_fail_session_stored_at_hash_with_incompatible_major_version() {
         RuntimeArgs::default(),
     )
     .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit();
 
@@ -975,7 +981,7 @@ fn should_execute_stored_payment_and_session_code_with_new_major_version() {
     let payment_purse_amount = *DEFAULT_PAYMENT;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     //
     // upgrade with new wasm costs with modified mint for given version

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, ApiError, RuntimeArgs, U512};
 
@@ -23,7 +23,7 @@ fn should_get_funds_from_faucet() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();
@@ -60,7 +60,7 @@ fn should_fail_if_already_funded() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/gas_counter.rs
+++ b/execution_engine_testing/tests/src/test/gas_counter.rs
@@ -6,7 +6,7 @@ use parity_wasm::{
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_WASM_CONFIG,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_WASM_CONFIG, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{core::engine_state::Error, shared::wasm_prep::PreprocessingError};
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, runtime_args, Gas, RuntimeArgs};
@@ -89,7 +89,7 @@ fn should_fail_to_overflow_gas_counter() {
         ExecuteRequestBuilder::from_deploy_item(deploy_item).build()
     };
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -182,7 +182,7 @@ fn should_correctly_measure_gas_for_opcodes() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy_item = DeployItemBuilder::new()

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{core, core::ValidationError};
 use casper_hashing::Digest;
@@ -27,7 +27,7 @@ static TRANSFER_AMOUNT_1: Lazy<U512> = Lazy::new(|| U512::from(100_000_000));
 #[test]
 fn get_balance_should_work() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,
@@ -112,7 +112,7 @@ fn get_balance_should_work() {
 #[test]
 fn get_balance_using_public_key_should_work() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/groups.rs
+++ b/execution_engine_testing/tests/src/test/groups.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error, execution};
 use casper_types::{
@@ -46,7 +46,7 @@ fn should_call_group_restricted_session() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -111,7 +111,7 @@ fn should_call_group_restricted_session_caller() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -181,7 +181,7 @@ fn should_not_call_restricted_session_from_wrong_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -261,7 +261,7 @@ fn should_not_call_restricted_session_caller_from_wrong_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -336,7 +336,7 @@ fn should_call_group_restricted_contract() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -409,7 +409,7 @@ fn should_not_call_group_restricted_contract_from_wrong_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
     builder.exec(exec_request_2).expect_success().commit();
@@ -479,7 +479,7 @@ fn should_call_group_unrestricted_contract_caller() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -546,7 +546,7 @@ fn should_call_unrestricted_contract_caller_from_different_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
     builder.exec(exec_request_2).expect_success().commit();
@@ -613,7 +613,7 @@ fn should_call_group_restricted_contract_as_session() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
     builder.exec(exec_request_2).expect_success().commit();
@@ -680,7 +680,7 @@ fn should_call_group_restricted_contract_as_session_from_wrong_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
     builder.exec(exec_request_2).expect_success().commit();
@@ -750,7 +750,7 @@ fn should_not_call_uncallable_contract_from_deploy() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -840,7 +840,7 @@ fn should_not_call_uncallable_session_from_deploy() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -937,7 +937,7 @@ fn should_not_call_group_restricted_stored_payment_code_from_invalid_account() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -1021,7 +1021,7 @@ fn should_call_group_restricted_stored_payment_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/host_function_costs.rs
+++ b/execution_engine_testing/tests/src/test/host_function_costs.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{bytesrepr::Bytes, runtime_args, ContractHash, RuntimeArgs};
 
@@ -30,7 +30,7 @@ fn should_measure_gas_cost() {
     .build();
 
     // Create Accounts
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -98,7 +98,7 @@ fn should_measure_nested_host_function_call_cost() {
     .build();
 
     // Create Accounts
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -176,7 +176,7 @@ fn should_measure_argument_size_in_host_function_call() {
     .build();
 
     // Create Accounts
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/manage_groups.rs
+++ b/execution_engine_testing/tests/src/test/manage_groups.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error, execution};
 use casper_types::{
@@ -50,7 +50,7 @@ fn should_create_and_remove_group() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -156,7 +156,7 @@ fn should_create_and_extend_user_group() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -267,7 +267,7 @@ fn should_create_and_remove_urefs_from_group() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -377,7 +377,7 @@ fn should_limit_max_urefs_while_extending() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1071.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1071.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -20,7 +20,7 @@ fn should_run_ee_1071_regression() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -5,7 +5,7 @@ use parity_wasm::builder;
 use casper_engine_test_support::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_PUBLIC_KEY,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -184,7 +184,7 @@ fn should_run_ee_1129_underfunded_add_bid_call() {
 fn should_run_ee_1129_underfunded_mint_contract_call() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -232,7 +232,7 @@ fn should_run_ee_1129_underfunded_mint_contract_call() {
 fn should_not_panic_when_calling_session_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -280,7 +280,7 @@ fn should_not_panic_when_calling_session_contract_by_uref() {
 fn should_not_panic_when_calling_payment_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -326,7 +326,7 @@ fn should_not_panic_when_calling_payment_contract_by_uref() {
 fn should_not_panic_when_calling_contract_package_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -379,7 +379,7 @@ fn should_not_panic_when_calling_contract_package_by_uref() {
 fn should_not_panic_when_calling_payment_versioned_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -446,7 +446,7 @@ fn do_nothing_without_memory() -> Vec<u8> {
 fn should_not_panic_when_calling_module_without_memory() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()

--- a/execution_engine_testing/tests/src/test/regression/ee_1160.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1160.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_INITIAL_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::engine_state::WASMLESS_TRANSFER_FIXED_GAS_PRICE,
@@ -26,7 +26,7 @@ fn ee_1160_wasmless_transfer_should_empty_account() {
         U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE) - wasmless_transfer_cost.value();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -79,7 +79,7 @@ fn ee_1160_transfer_larger_than_balance_should_fail() {
         + U512::one();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -139,7 +139,7 @@ fn ee_1160_large_wasmless_transfer_should_avoid_overflow() {
     let transfer_amount = U512::max_value();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/execution_engine_testing/tests/src/test/regression/ee_1163.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1163.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_GAS_PRICE, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_GAS_PRICE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -21,7 +21,7 @@ const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     builder
 }
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1174.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1174.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 use casper_execution_engine::core::{engine_state::Error, execution};
@@ -21,7 +21,7 @@ fn should_run_ee_1174_delegation_rate_too_high() {
     let bid_amount = U512::one();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let auction = builder.get_auction_contract_hash();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1217.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1217.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT, Error as CoreError},
@@ -57,7 +57,7 @@ fn should_fail_to_add_bid_from_stored_session_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(store_call_auction_request)
@@ -99,7 +99,7 @@ fn should_fail_to_add_bid_from_stored_contract_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(store_call_auction_request)
@@ -152,7 +152,7 @@ fn should_fail_to_withdraw_bid_from_stored_session_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(add_bid_request).commit().expect_success();
 
@@ -207,7 +207,7 @@ fn should_fail_to_withdraw_bid_from_stored_contract_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(add_bid_request).commit().expect_success();
 
@@ -282,7 +282,7 @@ fn should_fail_to_delegate_from_stored_session_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(validator_fund_request)
@@ -362,7 +362,7 @@ fn should_fail_to_delegate_from_stored_contract_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
         .exec(validator_fund_request)
@@ -430,7 +430,7 @@ fn should_fail_to_undelegate_from_stored_session_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let delegate_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
@@ -524,7 +524,7 @@ fn should_fail_to_undelegate_from_stored_contract_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let delegate_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
@@ -609,7 +609,7 @@ fn should_fail_to_activate_bid_from_stored_session_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(add_bid_request).commit().expect_success();
     builder.exec(withdraw_bid_request).commit().expect_success();
@@ -675,7 +675,7 @@ fn should_fail_to_activate_bid_from_stored_contract_code() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(add_bid_request).commit().expect_success();
     builder.exec(withdraw_bid_request).commit().expect_success();

--- a/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1217_mint_proxy.rs
@@ -2,7 +2,8 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{self, genesis::GenesisAccount},
@@ -42,7 +43,7 @@ fn get_builder() -> InMemoryWasmTestBuilder {
         )
         .build();
 
-        builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+        builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
         builder.exec(store_request).commit();
     }
     builder

--- a/execution_engine_testing/tests/src/test/regression/ee_1225.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1225.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 use casper_types::{runtime_args, RuntimeArgs};
@@ -14,7 +14,7 @@ const DO_NOTHING_CONTRACT: &str = "do_nothing.wasm";
 #[test]
 fn should_run_ee_1225_verify_finalize_payment_invariants() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()

--- a/execution_engine_testing/tests/src/test/regression/ee_221.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_221.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -20,7 +20,7 @@ fn should_run_ee_221_get_uref_regression_test() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_401.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_401.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -25,7 +25,7 @@ fn should_execute_contracts_which_provide_extra_urefs() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
     builder.exec(exec_request_2).expect_success().commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_441.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_441.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, Key, RuntimeArgs, URef};
 
@@ -34,7 +34,7 @@ fn do_pass(pass: &str) -> (URef, URef) {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_460.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_460.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::shared::transform::Transform;
 use casper_types::{runtime_args, RuntimeArgs, U512};
@@ -20,7 +20,7 @@ fn should_run_ee_460_no_side_effects_on_error_regression() {
     .build();
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_468.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_468.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -16,7 +16,7 @@ fn should_not_fail_deserializing() {
     )
     .build();
     let is_error = InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit()
         .is_error();

--- a/execution_engine_testing/tests/src/test/regression/ee_470.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_470.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::storage::global_state::in_memory::InMemoryGlobalState;
 use casper_types::RuntimeArgs;
@@ -20,7 +20,7 @@ fn regression_test_genesis_hash_mismatch() {
     .build();
 
     // Step 1.
-    let builder = builder_base.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    let builder = builder_base.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // This is trie's post state hash after calling run_genesis endpoint.
     // Step 1a)
@@ -46,7 +46,7 @@ fn regression_test_genesis_hash_mismatch() {
 
     // No step 3.
     // Step 4.
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // Step 4a)
     let second_genesis_run_hash = builder.get_genesis_hash();

--- a/execution_engine_testing/tests/src/test/regression/ee_532.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_532.rs
@@ -1,5 +1,5 @@
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::engine_state::Error;
 use casper_types::{account::AccountHash, RuntimeArgs};
@@ -22,7 +22,7 @@ fn should_run_ee_532_get_uref_regression_test() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_536.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_536.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -20,7 +20,7 @@ fn should_run_ee_536_get_uref_regression_test() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_539.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_539.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::Weight, runtime_args, RuntimeArgs};
 
@@ -22,7 +22,7 @@ fn should_run_ee_539_serialize_action_thresholds_regression() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_549.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_549.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -19,7 +19,7 @@ fn should_run_ee_549_set_refund_regression() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request);
 
     // Execution should encounter an error because set_refund

--- a/execution_engine_testing/tests/src/test/regression/ee_550.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_550.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs};
 
@@ -42,7 +42,7 @@ fn should_run_ee_550_remove_with_saturated_threshold_regression() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()
@@ -79,7 +79,7 @@ fn should_run_ee_550_update_with_saturated_threshold_regression() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/regression/ee_572.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_572.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, StoredValue, U512};
 
@@ -48,7 +48,7 @@ fn should_run_ee_572_regression() {
 
     // Create Accounts
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/regression/ee_584.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_584.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::shared::transform::Transform;
 use casper_types::{RuntimeArgs, StoredValue};
@@ -20,7 +20,7 @@ fn should_run_ee_584_no_errored_session_transforms() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request);
 
     assert!(builder.is_error());

--- a/execution_engine_testing/tests/src/test/regression/ee_599.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_599.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
 
@@ -36,7 +36,7 @@ fn setup() -> InMemoryWasmTestBuilder {
     };
 
     let mut ctx = InMemoryWasmTestBuilder::default();
-    ctx.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+    ctx.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/regression/ee_601.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_601.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::shared::transform::Transform;
 use casper_types::{runtime_args, CLValue, Key, RuntimeArgs, StoredValue};
@@ -30,7 +30,7 @@ fn should_run_ee_601_pay_session_new_uref_collision() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request);
 
     let transforms = builder.get_transforms();

--- a/execution_engine_testing/tests/src/test/regression/ee_771.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_771.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -18,7 +18,7 @@ fn should_run_ee_771_regression() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_890.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_890.rs
@@ -2,7 +2,7 @@ use parity_wasm::{self, builder};
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, runtime_args, RuntimeArgs};
 
@@ -52,7 +52,7 @@ fn should_run_ee_890_gracefully_reject_start_node_in_session() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .commit();
     let message = builder.exec_error_message(0).expect("should fail");
@@ -80,7 +80,7 @@ fn should_run_ee_890_gracefully_reject_start_node_in_payment() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .commit();
     let message = builder.exec_error_message(0).expect("should fail");

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -5,7 +5,7 @@ use parity_wasm::builder;
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
     ARG_AMOUNT, DEFAULT_ACCOUNT_ADDR, DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE,
-    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -97,7 +97,7 @@ fn should_run_ee_966_with_zero_min_and_zero_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -111,7 +111,7 @@ fn should_run_ee_966_cant_have_too_much_initial_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -132,7 +132,7 @@ fn should_run_ee_966_should_request_exactly_maximum() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -146,7 +146,7 @@ fn should_run_ee_966_should_request_exactly_maximum_as_initial() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -163,7 +163,7 @@ fn should_run_ee_966_cant_have_too_much_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -186,7 +186,7 @@ fn should_run_ee_966_cant_have_way_too_much_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -207,7 +207,7 @@ fn should_run_ee_966_cant_have_larger_initial_than_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -230,7 +230,7 @@ fn should_run_ee_966_regression_fail_when_growing_mem_past_max() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -253,7 +253,7 @@ fn should_run_ee_966_regression_when_growing_mem_after_upgrade() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit();
 

--- a/execution_engine_testing/tests/src/test/regression/gh_1470.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1470.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, LmdbWasmTestBuilder, UpgradeRequestBuilder,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST,
-    MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{Error, SystemContractRegistry},
@@ -35,7 +35,7 @@ const ARG_TARGET: &str = "target";
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gh_1688.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1688.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::engine_state::ExecuteRequest;
 use casper_types::{
@@ -17,7 +17,7 @@ const CONTRACT_HASH_KEY: &str = "contract_hash";
 
 fn setup() -> (InMemoryWasmTestBuilder, ContractPackageHash, ContractHash) {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_contract_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gh_2280.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2280.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE,
-    DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PROTOCOL_VERSION, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::engine_state::{
@@ -13,13 +13,7 @@ use casper_execution_engine::{
     },
     shared::{
         host_function_costs::{Cost, HostFunction, HostFunctionCosts},
-        opcode_costs::OpcodeCosts,
-        storage_costs::StorageCosts,
-        system_config::{
-            auction_costs::AuctionCosts, handle_payment_costs::HandlePaymentCosts,
-            mint_costs::MintCosts, standard_payment_costs::StandardPaymentCosts, SystemConfig,
-            DEFAULT_WASMLESS_TRANSFER_COST,
-        },
+        system_config::{mint_costs::MintCosts, SystemConfig},
         wasm_config::{WasmConfig, DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY},
     },
 };
@@ -144,7 +138,10 @@ fn gh_2280_transfer_should_always_cost_the_same_gas() {
         ..default_host_function_costs
     };
 
-    let new_wasm_config = make_wasm_config(new_host_function_costs);
+    let new_wasm_config = make_wasm_config(
+        new_host_function_costs,
+        *builder.get_engine_state().config().wasm_config(),
+    );
 
     // Inflate affected system contract entry point cost to the maximum
     let new_mint_create_cost = u32::MAX;
@@ -153,7 +150,11 @@ fn gh_2280_transfer_should_always_cost_the_same_gas() {
         ..Default::default()
     };
 
-    let new_engine_config = make_engine_config(new_mint_costs, new_wasm_config);
+    let new_engine_config = make_engine_config(
+        new_mint_costs,
+        new_wasm_config,
+        *builder.get_engine_state().config().system_config(),
+    );
 
     builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
 
@@ -246,9 +247,13 @@ fn gh_2280_create_purse_should_always_cost_the_same_gas() {
 
     // Increase "transfer_to_account" host function call exactly by X, so we can assert that
     // transfer cost increased by exactly X without hidden fees.
-    let default_host_function_costs = HostFunctionCosts::default();
+    let host_function_costs = builder
+        .get_engine_state()
+        .config()
+        .wasm_config()
+        .take_host_function_costs();
 
-    let default_create_purse_cost = default_host_function_costs.create_purse.cost();
+    let default_create_purse_cost = host_function_costs.create_purse.cost();
     let new_create_purse_cost = default_create_purse_cost
         .checked_add(HOST_FUNCTION_COST_CHANGE)
         .expect("should add without overflow");
@@ -256,10 +261,13 @@ fn gh_2280_create_purse_should_always_cost_the_same_gas() {
 
     let new_host_function_costs = HostFunctionCosts {
         create_purse: new_create_purse,
-        ..default_host_function_costs
+        ..host_function_costs
     };
 
-    let new_wasm_config = make_wasm_config(new_host_function_costs);
+    let new_wasm_config = make_wasm_config(
+        new_host_function_costs,
+        *builder.get_engine_state().config().wasm_config(),
+    );
 
     // Inflate affected system contract entry point cost to the maximum
     let new_mint_create_cost = u32::MAX;
@@ -268,9 +276,15 @@ fn gh_2280_create_purse_should_always_cost_the_same_gas() {
         ..Default::default()
     };
 
-    let new_engine_config = make_engine_config(new_mint_costs, new_wasm_config);
+    let new_engine_config = make_engine_config(
+        new_mint_costs,
+        new_wasm_config,
+        *builder.get_engine_state().config().system_config(),
+    );
 
-    builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
+    builder
+        .upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request)
+        .expect_upgrade_success();
 
     let fund_request_3 = {
         let deploy_hash: [u8; 32] = [77; 32];
@@ -378,7 +392,10 @@ fn gh_2280_transfer_purse_to_account_should_always_cost_the_same_gas() {
         ..default_host_function_costs
     };
 
-    let new_wasm_config = make_wasm_config(new_host_function_costs);
+    let new_wasm_config = make_wasm_config(
+        new_host_function_costs,
+        *builder.get_engine_state().config().wasm_config(),
+    );
 
     // Inflate affected system contract entry point cost to the maximum
     let new_mint_create_cost = u32::MAX;
@@ -386,8 +403,11 @@ fn gh_2280_transfer_purse_to_account_should_always_cost_the_same_gas() {
         create: new_mint_create_cost,
         ..Default::default()
     };
-
-    let new_engine_config = make_engine_config(new_mint_costs, new_wasm_config);
+    let new_engine_config = make_engine_config(
+        new_mint_costs,
+        new_wasm_config,
+        *builder.get_engine_state().config().system_config(),
+    );
 
     builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
 
@@ -501,7 +521,10 @@ fn gh_2280_stored_transfer_to_account_should_always_cost_the_same_gas() {
         ..default_host_function_costs
     };
 
-    let new_wasm_config = make_wasm_config(new_host_function_costs);
+    let new_wasm_config = make_wasm_config(
+        new_host_function_costs,
+        *builder.get_engine_state().config().wasm_config(),
+    );
 
     // Inflate affected system contract entry point cost to the maximum
     let new_mint_create_cost = u32::MAX;
@@ -510,7 +533,11 @@ fn gh_2280_stored_transfer_to_account_should_always_cost_the_same_gas() {
         ..Default::default()
     };
 
-    let new_engine_config = make_engine_config(new_mint_costs, new_wasm_config);
+    let new_engine_config = make_engine_config(
+        new_mint_costs,
+        new_wasm_config,
+        *builder.get_engine_state().config().system_config(),
+    );
 
     builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
 
@@ -620,7 +647,10 @@ fn gh_2280_stored_faucet_call_should_cost_the_same() {
         ..default_host_function_costs
     };
 
-    let new_wasm_config = make_wasm_config(new_host_function_costs);
+    let new_wasm_config = make_wasm_config(
+        new_host_function_costs,
+        *builder.get_engine_state().config().wasm_config(),
+    );
 
     // Inflate affected system contract entry point cost to the maximum
     let new_mint_create_cost = u32::MAX;
@@ -629,7 +659,11 @@ fn gh_2280_stored_faucet_call_should_cost_the_same() {
         ..Default::default()
     };
 
-    let new_engine_config = make_engine_config(new_mint_costs, new_wasm_config);
+    let new_engine_config = make_engine_config(
+        new_mint_costs,
+        new_wasm_config,
+        *builder.get_engine_state().config().system_config(),
+    );
 
     builder.upgrade_with_upgrade_request(new_engine_config, &mut upgrade_request);
 
@@ -676,7 +710,7 @@ struct TestContext {
 
 fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let session_args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
@@ -705,13 +739,17 @@ fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
     (builder, TestContext { gh_2280_regression })
 }
 
-fn make_engine_config(new_mint_costs: MintCosts, new_wasm_config: WasmConfig) -> EngineConfig {
+fn make_engine_config(
+    new_mint_costs: MintCosts,
+    new_wasm_config: WasmConfig,
+    old_system_config: SystemConfig,
+) -> EngineConfig {
     let new_system_config = SystemConfig::new(
-        DEFAULT_WASMLESS_TRANSFER_COST,
-        AuctionCosts::default(),
+        old_system_config.wasmless_transfer_cost(),
+        *old_system_config.auction_costs(),
         new_mint_costs,
-        HandlePaymentCosts::default(),
-        StandardPaymentCosts::default(),
+        *old_system_config.handle_payment_costs(),
+        *old_system_config.standard_payment_costs(),
     );
     EngineConfig::new(
         DEFAULT_MAX_QUERY_DEPTH,
@@ -725,12 +763,15 @@ fn make_engine_config(new_mint_costs: MintCosts, new_wasm_config: WasmConfig) ->
     )
 }
 
-fn make_wasm_config(new_host_function_costs: HostFunctionCosts) -> WasmConfig {
+fn make_wasm_config(
+    new_host_function_costs: HostFunctionCosts,
+    old_wasm_config: WasmConfig,
+) -> WasmConfig {
     WasmConfig::new(
         DEFAULT_WASM_MAX_MEMORY,
         DEFAULT_MAX_STACK_HEIGHT,
-        OpcodeCosts::default(),
-        StorageCosts::default(),
+        old_wasm_config.opcode_costs(),
+        old_wasm_config.storage_costs(),
         new_host_function_costs,
     )
 }

--- a/execution_engine_testing/tests/src/test/regression/gh_2605.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2605.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_MAX_ASSOCIATED_KEYS,
-    DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_PROTOCOL_VERSION, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -282,7 +282,7 @@ fn gh_2605_large_write_exact_trie_limit() {
 fn setup(custom_upgrade_request: Setup) -> (InMemoryWasmTestBuilder, ProtocolVersion) {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_config = make_upgrade_request(*OLD_PROTOCOL_VERSION, *NEW_PROTOCOL_VERSION);
     let engine_config = match custom_upgrade_request {

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -43,7 +43,7 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
 
 fn initialize_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     builder
 }
 

--- a/execution_engine_testing/tests/src/test/regression/regression_20210707.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210707.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{Error as CoreError, ExecuteRequest},
@@ -92,7 +92,7 @@ fn assert_forged_uref_error(error: CoreError, forged_uref: URef) {
 fn should_transfer_funds_from_contract_to_new_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -130,7 +130,7 @@ fn should_transfer_funds_from_contract_to_new_account() {
 fn should_transfer_funds_from_contract_to_existing_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -173,7 +173,7 @@ fn should_transfer_funds_from_contract_to_existing_account() {
 fn should_not_transfer_funds_from_forged_purse_to_account_native_transfer() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -213,7 +213,7 @@ fn should_not_transfer_funds_from_forged_purse_to_account_native_transfer() {
 fn should_not_transfer_funds_from_forged_purse_to_owned_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -263,7 +263,7 @@ fn should_not_transfer_funds_from_forged_purse_to_owned_purse() {
 fn should_not_transfer_funds_into_bob_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -306,7 +306,7 @@ fn should_not_transfer_funds_into_bob_purse() {
 fn should_not_transfer_from_hardcoded_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -345,7 +345,7 @@ fn should_not_transfer_from_hardcoded_purse() {
 fn should_not_refund_to_bob_and_charge_alice() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -401,7 +401,7 @@ fn should_not_refund_to_bob_and_charge_alice() {
 fn should_not_charge_alice_for_execution() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -457,7 +457,7 @@ fn should_not_charge_alice_for_execution() {
 fn should_not_charge_for_execution_from_hardcoded_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 

--- a/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::{engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT, Error as CoreError},
@@ -47,7 +47,7 @@ static DELEGATE_AMOUNT: Lazy<U512> = Lazy::new(|| U512::from(500_000));
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let id: Option<u64> = None;
 
@@ -75,7 +75,7 @@ fn setup() -> InMemoryWasmTestBuilder {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let id: Option<u64> = None;
 

--- a/execution_engine_testing/tests/src/test/regression/regression_20210924.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210924.rs
@@ -2,7 +2,7 @@ use num_traits::Zero;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::engine_state::{Error as CoreError, MAX_PAYMENT},
@@ -66,7 +66,7 @@ fn should_charge_minimum_for_do_nothing_session() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
 
@@ -122,7 +122,7 @@ fn should_execute_do_minimum_session() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
 
@@ -177,7 +177,7 @@ fn should_charge_minimum_for_do_nothing_payment() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let account = builder.get_account(*DEFAULT_ACCOUNT_ADDR).unwrap();
 

--- a/execution_engine_testing/tests/src/test/regression/regression_20211110.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20211110.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state::Error as CoreError, execution::Error as ExecError,
@@ -27,7 +27,7 @@ fn regression_20211110() {
     let mut funds: u64 = STARTING_BALANCE;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220119.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220119.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::RuntimeArgs;
 
@@ -10,7 +10,7 @@ const REGRESSION_20220119_CONTRACT: &str = "regression_20220119.wasm";
 #[test]
 fn should_create_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220204.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220204.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state, execution};
 use casper_types::{runtime_args, system::mint, AccessRights, ApiError, RuntimeArgs};
@@ -464,7 +464,7 @@ fn regression_20220204_main_purse_as_session_by_hash() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let install_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         REGRESSION_20220204_CONTRACT,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220207.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220207.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error, execution::Error as ExecError};
 use casper_types::{account::AccountHash, runtime_args, system::mint, ApiError, RuntimeArgs, U512};
@@ -17,7 +17,7 @@ const UNAPPROVED_SPENDING_AMOUNT_ERR: Error = Error::Exec(ExecError::Revert(ApiE
 #[test]
 fn should_not_transfer_above_approved_limit() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(1000u64), // What we approved.
@@ -38,7 +38,7 @@ fn should_not_transfer_above_approved_limit() {
 #[test]
 fn should_transfer_within_approved_limit() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(1000u64),
@@ -57,7 +57,7 @@ fn should_transfer_within_approved_limit() {
 #[test]
 fn should_fail_without_amount_arg() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         // If `amount` arg is absent, host assumes that limit is 0.

--- a/execution_engine_testing/tests/src/test/regression/regression_20220208.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220208.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state::Error, execution::Error as ExecError};
 use casper_types::{account::AccountHash, runtime_args, system::mint, ApiError, RuntimeArgs, U512};
@@ -18,7 +18,7 @@ const UNAPPROVED_SPENDING_AMOUNT_ERR: Error = Error::Exec(ExecError::Revert(ApiE
 #[test]
 fn should_transfer_within_approved_limit_multiple_transfers() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let part_1 = U512::from(100u64);
     let part_2 = U512::from(100u64);
@@ -42,7 +42,7 @@ fn should_transfer_within_approved_limit_multiple_transfers() {
 #[test]
 fn should_not_transfer_above_approved_limit_multiple_transfers() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let part_1 = U512::from(100u64);
     let part_2 = U512::from(100u64);

--- a/execution_engine_testing/tests/src/test/regression/regression_20220211.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220211.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state, execution};
 use casper_types::{runtime_args, AccessRights, RuntimeArgs, URef};
@@ -33,7 +33,7 @@ fn regression_20220211_ret_as_session() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let install_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         REGRESSION_20220211_CONTRACT,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220217.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220217.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state, execution};
 use casper_types::{
@@ -240,7 +240,7 @@ fn regression_20220217_should_not_transfer_funds_on_unrelated_purses() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let fund_account_1_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,
@@ -383,7 +383,7 @@ fn mint_by_hash_transfer_should_fail_because_lack_of_target_uref_access() {
     // TODO create two named purses and verify we can pass source and target known non-main purses
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/execution_engine_testing/tests/src/test/regression/regression_20220221.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220221.rs
@@ -3,8 +3,8 @@ use once_cell::sync::Lazy;
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, UpgradeRequestBuilder,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
-    MINIMUM_ACCOUNT_CREATION_BALANCE, TIMESTAMP_MILLIS_INCREMENT,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST, TIMESTAMP_MILLIS_INCREMENT,
 };
 use casper_execution_engine::core::engine_state::{
     EngineConfig, RewardItem, DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
@@ -63,7 +63,7 @@ fn regression_20220221_should_distribute_to_many_validators() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_request = UpgradeRequestBuilder::default()
         .with_new_validator_slots(DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT + 1)

--- a/execution_engine_testing/tests/src/test/regression/regression_20220222.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220222.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state, execution};
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
@@ -11,7 +11,7 @@ const ALICE_ADDR: AccountHash = AccountHash::new([42; 32]);
 #[test]
 fn regression_20220222_escalate() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220223.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220223.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{
     engine_state, engine_state::engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT, execution,
@@ -274,7 +274,7 @@ fn should_fail_to_mint_transfer_over_the_limit() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let validator_1_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220224.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220224.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::core::{engine_state, execution};
 use casper_types::{runtime_args, system::mint, ApiError, RuntimeArgs};
@@ -12,7 +12,7 @@ const CONTRACT_REVERT: &str = "revert.wasm";
 #[test]
 fn should_not_transfer_above_approved_limit_in_payment_code() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let account_hash = *DEFAULT_ACCOUNT_ADDR;

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -7,7 +7,7 @@ use parity_wasm::{
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -58,7 +58,7 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 #[test]
 fn should_not_oom() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let test_cases = vec![
         OOM_INIT,
@@ -91,7 +91,7 @@ fn should_not_oom() {
 #[test]
 fn should_pass_table_validation() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
 
@@ -165,7 +165,7 @@ fn test_element_section(
     // )
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut wat = String::new();
 
@@ -222,7 +222,7 @@ fn test_element_section(
 #[test]
 fn should_not_allow_more_than_one_table() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
 
@@ -354,7 +354,7 @@ fn should_allow_large_br_table() {
         .expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -373,7 +373,7 @@ fn should_not_allow_large_br_table() {
         make_arbitrary_br_table(FAILING_BR_TABLE_SIZE).expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -445,7 +445,7 @@ fn should_allow_multiple_globals() {
         make_arbitrary_global(DEFAULT_MAX_GLOBALS as usize).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -464,7 +464,7 @@ fn should_not_allow_too_many_globals() {
         make_arbitrary_global(FAILING_GLOBALS_SIZE).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -496,7 +496,7 @@ fn should_verify_max_param_count() {
             .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -521,7 +521,7 @@ fn should_verify_max_param_count() {
         wasm_utils::make_n_arg_call_bytes(100, "i32").expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -540,7 +540,7 @@ fn should_not_allow_too_many_params() {
         .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -576,7 +576,7 @@ fn should_not_allow_to_import_gas_function() {
     .unwrap();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -710,7 +710,7 @@ fn should_not_set_non_existing_global_above_declared_range() {
 fn test_non_existing_global(module_wat: &str, index: u32) {
     let module_bytes = wat::parse_str(module_wat).unwrap();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,

--- a/execution_engine_testing/tests/src/test/regression/slow_input.rs
+++ b/execution_engine_testing/tests/src/test/regression/slow_input.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{engine_state::Error, execution},
@@ -65,7 +65,7 @@ const SLOW_INPUT: &str = r#"(module
 fn should_measure_slow_input() {
     let module_bytes = wat::parse_str(SLOW_INPUT).unwrap();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -83,7 +83,7 @@ fn should_measure_slow_input_with_infinite_br_loop() {
     let module_bytes = make_cpu_burner_br();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -100,7 +100,7 @@ fn should_measure_slow_input_with_infinite_br_loop() {
 fn should_measure_br_if_cpu_burner_with_br_if_iterations() {
     let module_bytes = cpu_burner_br_if(u32::MAX as i64);
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -118,7 +118,7 @@ fn should_measure_br_table_cpu_burner_with_br_table_iterations() {
     let module_bytes = cpu_burner_br_table(u32::MAX as i64);
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -134,7 +134,7 @@ fn should_measure_br_table_cpu_burner_with_br_table_iterations() {
 #[test]
 fn should_charge_extra_per_amount_of_br_table_elements() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     const FIXED_BLOCK_AMOUNT: usize = 256;
     const N_ELEMENTS: u32 = 5;

--- a/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
+++ b/execution_engine_testing/tests/src/test/regression/transforms_must_be_ordered.rs
@@ -5,7 +5,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{self, shared::transform::Transform};
 use casper_types::{
@@ -21,7 +21,7 @@ fn contract_transforms_should_be_ordered_in_the_journal() {
     const N_OPS: usize = 1000;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut rng = StdRng::seed_from_u64(0);
 

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -6,7 +6,7 @@ use casper_engine_test_support::DEFAULT_ACCOUNT_PUBLIC_KEY;
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 #[cfg(not(feature = "use-as-wasm"))]
 use casper_execution_engine::shared::system_config::auction_costs::DEFAULT_ADD_BID_COST;
@@ -168,7 +168,7 @@ fn initialize_isolated_storage_costs() -> InMemoryWasmTestBuilder {
     //
     // Isolate storage costs without host function costs, and without opcode costs
     //
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_request = UpgradeRequestBuilder::new()
         .with_current_protocol_version(*DEFAULT_PROTOCOL_VERSION)
@@ -414,7 +414,7 @@ fn should_measure_unisolated_gas_cost_for_storage_usage_write() {
     let cost_per_byte = U512::from(StorageCosts::default().gas_per_byte());
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -640,7 +640,7 @@ fn should_measure_unisolated_gas_cost_for_storage_usage_add() {
     let cost_per_byte = U512::from(StorageCosts::default().gas_per_byte());
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -1,15 +1,19 @@
 use std::collections::BTreeMap;
 
 use num_rational::Ratio;
+use num_traits::{CheckedMul, CheckedSub};
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
-    SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, UpgradeRequestBuilder,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+    DEFAULT_PROTOCOL_VERSION, DEFAULT_ROUND_SEIGNIORAGE_RATE, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_ROUND_SEIGNIORAGE_RATE, PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
+    TIMESTAMP_MILLIS_INCREMENT,
 };
-use casper_execution_engine::core::engine_state::engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT;
+use casper_execution_engine::core::engine_state::{
+    engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT, RewardItem,
+};
 use casper_types::{
     self,
     account::AccountHash,
@@ -64,8 +68,8 @@ static DELEGATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DE
 static DELEGATOR_3_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DELEGATOR_3));
 static GENESIS_ROUND_SEIGNIORAGE_RATE: Lazy<Ratio<U512>> = Lazy::new(|| {
     Ratio::new(
-        U512::from(*DEFAULT_ROUND_SEIGNIORAGE_RATE.numer()),
-        U512::from(*DEFAULT_ROUND_SEIGNIORAGE_RATE.denom()),
+        U512::from(*PRODUCTION_ROUND_SEIGNIORAGE_RATE.numer()),
+        U512::from(*PRODUCTION_ROUND_SEIGNIORAGE_RATE.denom()),
     )
 });
 
@@ -153,11 +157,10 @@ fn should_distribute_delegation_rate_zero() {
     const VALIDATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
     const DELEGATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
     const DELEGATOR_2_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
+    const TOTAL_DELEGATOR_STAKE: u64 = DELEGATOR_1_STAKE + DELEGATOR_2_STAKE;
+    const TOTAL_STAKE: u64 = VALIDATOR_1_STAKE + TOTAL_DELEGATOR_STAKE;
 
     const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
-
-    let participant_portion = Ratio::new(U512::one(), U512::from(3));
-    let remainders = Ratio::from(U512::zero());
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -242,46 +245,90 @@ fn should_distribute_delegation_rate_zero() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), BLOCK_REWARD);
-        tmp
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
+
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
+
+    let delegators_share = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
     };
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    let delegator_1_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 1 payout")
+    };
 
-    builder.exec(distribute_request).commit().expect_success();
+    let delegator_2_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 2 payout")
+    };
 
-    let validator_1_balance = {
+    let validator_1_expected_payout = {
+        let total_delegator_payout = delegator_1_expected_payout + delegator_2_expected_payout;
+        let validator_share = expected_total_reward - Ratio::from(total_delegator_payout);
+        validator_share.to_integer()
+    };
+
+    let validator_1_actual_payout = {
         let vaildator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
@@ -290,35 +337,27 @@ fn should_distribute_delegation_rate_zero() {
         validator_stake_after - vaildator_stake_before
     };
 
-    let expected_validator_1_balance_ratio =
-        expected_total_reward * participant_portion + remainders;
-    let expected_validator_1_balance = expected_validator_1_balance_ratio.to_integer();
     assert_eq!(
-        validator_1_balance, expected_validator_1_balance,
+        validator_1_actual_payout, validator_1_expected_payout,
         "rhs {}",
-        expected_validator_1_balance_ratio
+        validator_1_expected_payout
     );
 
-    let delegator_1_balance = {
+    let delegator_1_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_balance = (expected_total_reward * participant_portion).to_integer();
-    assert_eq!(delegator_1_balance, expected_delegator_1_balance);
+    assert_eq!(delegator_1_actual_payout, delegator_1_expected_payout);
 
-    let delegator_2_balance = {
+    let delegator_2_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_balance = (expected_total_reward * participant_portion).to_integer();
-    assert_eq!(delegator_2_balance, expected_delegator_2_balance);
-
-    let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
-    assert_eq!(total_payout, expected_total_reward_integer);
+    assert_eq!(delegator_2_actual_payout, delegator_2_expected_payout);
 
     // Subsequently, there should be no more rewards
     let validator_1_balance = {
@@ -326,7 +365,7 @@ fn should_distribute_delegation_rate_zero() {
             &mut builder,
             *VALIDATOR_1_ADDR,
             VALIDATOR_1.clone(),
-            validator_1_balance + U512::from(VALIDATOR_1_STAKE),
+            validator_1_actual_payout + U512::from(VALIDATOR_1_STAKE),
         );
         let validator_1_bid = get_validator_bid(&mut builder, VALIDATOR_1.clone()).unwrap();
         assert!(validator_1_bid.inactive());
@@ -354,7 +393,7 @@ fn should_distribute_delegation_rate_zero() {
     assert!(delegator_2_balance.is_zero());
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -369,19 +408,19 @@ fn should_distribute_delegation_rate_zero() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_balance
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_expected_payout
     ));
 }
 
@@ -391,11 +430,10 @@ fn should_withdraw_bids_after_distribute() {
     const VALIDATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
     const DELEGATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
     const DELEGATOR_2_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
+    const TOTAL_DELEGATOR_STAKE: u64 = DELEGATOR_1_STAKE + DELEGATOR_2_STAKE;
+    const TOTAL_STAKE: u64 = VALIDATOR_1_STAKE + TOTAL_DELEGATOR_STAKE;
 
     const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
-
-    let participant_portion = Ratio::new(U512::one(), U512::from(3));
-    let remainders = Ratio::from(U512::zero());
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -480,46 +518,46 @@ fn should_withdraw_bids_after_distribute() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), BLOCK_REWARD);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_next_era_id(builder.get_era())
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_run_auction(true)
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
-
-    let validator_1_balance = {
+    let validator_1_actual_payout = {
         let vaildator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
@@ -528,42 +566,79 @@ fn should_withdraw_bids_after_distribute() {
         validator_stake_after - vaildator_stake_before
     };
 
-    let expected_validator_1_balance_ratio =
-        expected_total_reward * participant_portion + remainders;
-    let expected_validator_1_balance = expected_validator_1_balance_ratio.to_integer();
+    let delegators_share = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
+    };
+
+    let delegator_1_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        reward_multiplier
+            .checked_mul(&delegators_share)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
+
+    let delegator_2_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        reward_multiplier
+            .checked_mul(&delegators_share)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
+
+    let validator_1_expected_payout = {
+        let total_delegator_payout = delegator_1_expected_payout + delegator_2_expected_payout;
+        let validator_share = expected_total_reward - Ratio::from(total_delegator_payout);
+        validator_share.to_integer()
+    };
     assert_eq!(
-        validator_1_balance, expected_validator_1_balance,
+        validator_1_actual_payout, validator_1_expected_payout,
         "rhs {}",
-        expected_validator_1_balance_ratio
+        validator_1_expected_payout
     );
 
-    let delegator_1_balance = {
+    let delegator_1_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_balance = (expected_total_reward * participant_portion).to_integer();
-    assert_eq!(delegator_1_balance, expected_delegator_1_balance);
 
-    let delegator_2_balance = {
+    assert_eq!(delegator_1_actual_payout, delegator_1_expected_payout);
+
+    let delegator_2_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_balance = (expected_total_reward * participant_portion).to_integer();
-    assert_eq!(delegator_2_balance, expected_delegator_2_balance);
 
-    let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
-    assert_eq!(total_payout, expected_total_reward_integer);
+    assert_eq!(delegator_2_actual_payout, delegator_2_expected_payout);
 
     let delegator_1_unstaked_amount = {
         assert!(
             get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone()).is_some(),
             "delegator 1 should have a stake"
         );
-        let undelegate_amount = U512::from(DELEGATOR_1_STAKE) + delegator_1_balance;
+        let undelegate_amount = U512::from(DELEGATOR_1_STAKE) + delegator_1_actual_payout;
         undelegate(
             &mut builder,
             *DELEGATOR_1_ADDR,
@@ -575,7 +650,7 @@ fn should_withdraw_bids_after_distribute() {
             get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone()).is_none(),
             "delegator 1 did not unstake full expected amount"
         );
-        delegator_1_balance
+        delegator_1_actual_payout
     };
     assert!(
         !delegator_1_unstaked_amount.is_zero(),
@@ -587,7 +662,7 @@ fn should_withdraw_bids_after_distribute() {
             get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone()).is_some(),
             "delegator 2 should have a stake"
         );
-        let undelegate_amount = U512::from(DELEGATOR_2_STAKE) + delegator_2_balance;
+        let undelegate_amount = U512::from(DELEGATOR_2_STAKE) + delegator_2_actual_payout;
         undelegate(
             &mut builder,
             *DELEGATOR_2_ADDR,
@@ -599,7 +674,7 @@ fn should_withdraw_bids_after_distribute() {
             get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone()).is_none(),
             "delegator 2 did not unstake full expected amount"
         );
-        delegator_2_balance
+        delegator_2_actual_payout
     };
     assert!(
         !delegator_2_unstaked_amount.is_zero(),
@@ -611,7 +686,7 @@ fn should_withdraw_bids_after_distribute() {
             get_validator_bid(&mut builder, VALIDATOR_1.clone()).is_some(),
             "validator 1 should have a stake"
         );
-        let withdraw_bid_amount = validator_1_balance + U512::from(VALIDATOR_1_STAKE);
+        let withdraw_bid_amount = validator_1_actual_payout + U512::from(VALIDATOR_1_STAKE);
         withdraw_bid(
             &mut builder,
             *VALIDATOR_1_ADDR,
@@ -628,7 +703,7 @@ fn should_withdraw_bids_after_distribute() {
     assert!(!validator_1_balance.is_zero());
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -643,19 +718,19 @@ fn should_withdraw_bids_after_distribute() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_balance
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_1_expected_payout
     ));
 }
 
@@ -665,11 +740,10 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     const VALIDATOR_1_STAKE: u64 = 1_000_000_000_000;
     const DELEGATOR_1_STAKE: u64 = 1_000_000_000_000;
     const DELEGATOR_2_STAKE: u64 = 1_000_000_000_000;
+    const TOTAL_DELEGATOR_STAKE: u64 = DELEGATOR_1_STAKE + DELEGATOR_2_STAKE;
+    const TOTAL_STAKE: u64 = TOTAL_DELEGATOR_STAKE + VALIDATOR_1_STAKE;
 
     const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
-
-    let participant_portion = Ratio::new(U512::one(), U512::from(3));
-    let remainders = Ratio::from(U512::zero());
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -754,44 +828,45 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward_1 = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_1_integer = expected_total_reward_1.to_integer();
+    assert_eq!(total_payout, expected_total_reward_1_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), BLOCK_REWARD);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
 
-    let distribute_request_1 = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors.clone(),
-        },
-    )
-    .build();
-
-    builder.exec(distribute_request_1).commit().expect_success();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
     let validator_1_staked_amount_1 = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
         .expect("should have validator bid")
@@ -801,47 +876,77 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     let delegator_2_staked_amount_1 =
         get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
 
-    let validator_1_updated_stake_1 = {
+    let delegators_share = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward_1
+            .checked_mul(&reward_multiplier)
+            .expect("should get delegator reward ratio");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get delegator reward");
+        delegator_reward.checked_sub(&commission).unwrap()
+    };
+
+    let delegator_1_expected_payout_1 = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 1 reward")
+    };
+
+    let delegator_2_expected_payout_1 = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 2 reward")
+    };
+
+    let validator_1_actual_payout_1 = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = validator_1_staked_amount_1;
 
         validator_stake_after - validator_stake_before
     };
 
-    let expected_validator_1_balance_ratio_1 =
-        expected_total_reward_1 * participant_portion + remainders;
-    let expected_validator_1_payout_1 = expected_validator_1_balance_ratio_1.to_integer();
-    assert_eq!(
-        validator_1_updated_stake_1, expected_validator_1_payout_1,
-        "rhs {}",
-        expected_validator_1_balance_ratio_1
-    );
+    let validator_1_expected_payout_1 = {
+        let total_delegator_payout = delegator_1_expected_payout_1 + delegator_2_expected_payout_1;
+        let validator_share = expected_total_reward_1 - Ratio::from(total_delegator_payout);
+        validator_share.to_integer()
+    };
+    assert_eq!(validator_1_actual_payout_1, validator_1_expected_payout_1);
 
-    let delegator_1_updated_stake_1 = {
+    let delegator_1_actual_payout_1 = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after = delegator_1_staked_amount_1;
 
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_payout_1 =
-        (expected_total_reward_1 * participant_portion).to_integer();
-    assert_eq!(delegator_1_updated_stake_1, expected_delegator_1_payout_1);
 
-    let delegator_2_updated_stake_1 = {
+    assert_eq!(delegator_1_actual_payout_1, delegator_1_expected_payout_1);
+
+    let delegator_2_actual_payout_1 = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
         let delegator_stake_after = delegator_2_staked_amount_1;
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_payout_1 =
-        (expected_total_reward_1 * participant_portion).to_integer();
-    assert_eq!(delegator_2_updated_stake_1, expected_delegator_2_payout_1);
 
-    let total_payout_1 =
-        validator_1_updated_stake_1 + delegator_1_updated_stake_1 + delegator_2_updated_stake_1;
-    assert_eq!(total_payout_1, expected_total_reward_1_integer);
+    assert_eq!(delegator_2_actual_payout_1, delegator_2_expected_payout_1);
 
     let era_info_1 = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -856,45 +961,42 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     assert!(matches!(
         era_info_1.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout_1
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout_1
     ));
 
     assert!(matches!(
         era_info_1.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_payout_1
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout_1
     ));
 
     assert!(matches!(
         era_info_1.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_2_payout_1
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_expected_payout_1
     ));
 
     // Next round of rewards
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
-    }
-
     let total_supply_2 = builder.total_supply(None);
+    let total_payout_2 = builder.base_round_reward(None);
     assert!(total_supply_2 > initial_supply);
-
-    let distribute_request_2 = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors,
-        },
-    )
-    .build();
-
-    builder.exec(distribute_request_2).commit().expect_success();
 
     let expected_total_reward_2 = *GENESIS_ROUND_SEIGNIORAGE_RATE * total_supply_2;
 
     let expected_total_reward_2_integer = expected_total_reward_2.to_integer();
+    assert_eq!(total_payout_2, expected_total_reward_2_integer);
+
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
+
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
     let validator_1_staked_amount_2 = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
         .expect("should have validator bid")
@@ -904,43 +1006,81 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     let delegator_2_staked_amount_2 =
         get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
 
-    let validator_1_updated_stake_2 = {
+    let delegators_share_2 = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward_2
+            .checked_mul(&reward_multiplier)
+            .expect("should get delegator reward ratio");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get delegator reward");
+        delegator_reward.checked_sub(&commission).unwrap()
+    };
+
+    let delegator_1_expected_payout_2 = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share_2
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 1 reward")
+    };
+
+    let delegator_2_expected_payout_2 = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share_2
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .expect("must get delegator 2 reward")
+    };
+
+    let validator_1_expected_payout_2 = {
+        let total_delegator_payout = delegator_1_expected_payout_2 + delegator_2_expected_payout_2;
+        let validator_share = expected_total_reward_2 - Ratio::from(total_delegator_payout);
+        validator_share.to_integer()
+    };
+
+    let validator_1_actual_payout_2 = {
         let validator_stake_before = validator_1_staked_amount_1;
         let validator_stake_after = validator_1_staked_amount_2;
         validator_stake_after - validator_stake_before
     };
+    assert_eq!(validator_1_actual_payout_2, validator_1_expected_payout_2);
 
-    let delegator_1_updated_stake_2 = {
+    let delegator_1_actual_payout_2 = {
         let delegator_stake_before = delegator_1_staked_amount_1;
         let delegator_stake_after = delegator_1_staked_amount_2;
 
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_payout_2 =
-        (expected_total_reward_2 * participant_portion).to_integer();
-    assert_eq!(delegator_1_updated_stake_2, expected_delegator_1_payout_2);
 
-    let delegator_2_updated_stake_2 = {
+    assert_eq!(delegator_1_actual_payout_2, delegator_1_expected_payout_2);
+
+    let delegator_2_actual_payout_2 = {
         let delegator_stake_before = delegator_2_staked_amount_1;
         let delegator_stake_after = delegator_2_staked_amount_2;
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_payout_2 =
-        (expected_total_reward_2 * participant_portion).to_integer();
-    assert_eq!(delegator_2_updated_stake_2, expected_delegator_2_payout_2);
+
+    assert_eq!(delegator_2_actual_payout_2, delegator_2_expected_payout_2);
 
     // Ensure that paying out next set of rewards gives higher payouts than previous time.
-    assert!(validator_1_updated_stake_2 > validator_1_updated_stake_1);
-    assert!(delegator_1_updated_stake_2 > delegator_1_updated_stake_1);
-    assert!(delegator_2_updated_stake_2 > delegator_2_updated_stake_1);
-
-    let total_payout_2 =
-        validator_1_updated_stake_2 + delegator_1_updated_stake_2 + delegator_2_updated_stake_2;
-    assert_eq!(total_payout_2, expected_total_reward_2_integer);
-    assert!(total_payout_2 > total_payout_1);
+    assert!(validator_1_actual_payout_2 > validator_1_actual_payout_1);
+    assert!(delegator_1_actual_payout_2 > delegator_1_actual_payout_1);
+    assert!(delegator_2_actual_payout_2 > delegator_2_actual_payout_1);
 
     let era_info_2 = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -953,33 +1093,26 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     };
     assert_ne!(era_info_2, era_info_1);
 
-    let expected_validator_1_balance_ratio_2 =
-        expected_total_reward_2 * participant_portion + remainders;
-
-    assert!(expected_validator_1_balance_ratio_2 > expected_validator_1_balance_ratio_1);
-
-    let expected_validator_1_payout_2 = expected_validator_1_balance_ratio_2.to_integer();
-
     assert!(matches!(
         era_info_2.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount, .. })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout_2
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout_2
     ));
 
     assert!(matches!(
         era_info_2.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_payout_2
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout_2
     ));
 
     assert!(matches!(
         era_info_2.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_2_payout_2
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_expected_payout_2
     ));
 
     // Withdraw delegator rewards
-    let delegator_1_rewards = delegator_1_updated_stake_1 + delegator_1_updated_stake_2;
+    let delegator_1_rewards = delegator_1_actual_payout_1 + delegator_1_actual_payout_2;
     undelegate(
         &mut builder,
         *DELEGATOR_1_ADDR,
@@ -995,7 +1128,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
         U512::from(DELEGATOR_1_STAKE)
     );
 
-    let delegator_2_rewards = delegator_2_updated_stake_1 + delegator_2_updated_stake_2;
+    let delegator_2_rewards = delegator_2_actual_payout_1 + delegator_2_actual_payout_2;
     undelegate(
         &mut builder,
         *DELEGATOR_2_ADDR,
@@ -1012,7 +1145,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     );
 
     // Withdraw validator rewards
-    let validator_1_rewards = validator_1_updated_stake_1 + validator_1_updated_stake_2;
+    let validator_1_rewards = validator_1_actual_payout_1 + validator_1_actual_payout_2;
     withdraw_bid(
         &mut builder,
         *VALIDATOR_1_ADDR,
@@ -1043,8 +1176,6 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     const VALIDATOR_1_REWARD_FACTOR_2: u64 = 333333333333;
     const VALIDATOR_2_REWARD_FACTOR_2: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR_2: u64 = 333333333334;
-
-    let one_third = Ratio::new(U512::one(), U512::from(3));
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -1129,46 +1260,55 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         validator_3_add_bid_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout_1 = builder.base_round_reward(None);
     let expected_total_reward_1 = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_1_integer = expected_total_reward_1.to_integer();
+    assert_eq!(total_payout_1, expected_total_reward_1_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors_1: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR_1);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR_1);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR_1);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR_1,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR_1,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR_1,
+        ))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
 
-    let distribute_request_1 = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors_1,
-        },
-    )
-    .build();
-
-    builder.exec(distribute_request_1).commit().expect_success();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
     let validator_1_staked_amount_1 = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
         .expect("should have validator bid")
@@ -1182,44 +1322,50 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         .expect("should have validator bid")
         .staked_amount();
 
-    let validator_1_updated_stake_1 = {
+    let validator_1_actual_payout_1 = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = validator_1_staked_amount_1;
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_payout = (expected_total_reward_1 * one_third).to_integer();
-    assert_eq!(validator_1_updated_stake_1, expected_validator_1_payout);
+    let validator_1_expected_payout_1 = expected_total_reward_1
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_1_REWARD_FACTOR_1),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_1_actual_payout_1, validator_1_expected_payout_1);
 
-    let rounded_amount = U512::one();
-
-    let validator_2_updated_stake_1 = {
+    let validator_2_actual_payout_1 = {
         let validator_stake_before = U512::from(VALIDATOR_2_STAKE);
         let validator_stake_after = validator_2_staked_amount_1;
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_2_payout_1 =
-        (expected_total_reward_1 * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_2_updated_stake_1, expected_validator_2_payout_1);
+    let validator_2_expected_payout_1 = expected_total_reward_1
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_2_REWARD_FACTOR_1),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_2_actual_payout_1, validator_2_expected_payout_1);
 
-    let validator_3_updated_stake_1 = {
+    let validator_3_actual_payout_1 = {
         let validator_stake_before = U512::from(VALIDATOR_3_STAKE);
         let validator_stake_after = validator_3_staked_amount_1;
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_3_payout_1 =
-        (expected_total_reward_1 * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_3_updated_stake_1, expected_validator_3_payout_1);
-
-    let total_payout =
-        validator_1_updated_stake_1 + validator_2_updated_stake_1 + expected_validator_3_payout_1;
-    let rounded_amount = U512::from(2);
-    assert_eq!(
-        total_payout,
-        expected_total_reward_1_integer - rounded_amount
-    );
+    let validator_3_expected_payout_1 = expected_total_reward_1
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_3_REWARD_FACTOR_1),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_3_actual_payout_1, validator_3_expected_payout_1);
 
     let era_info_1 = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -1234,54 +1380,52 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     assert!(matches!(
         era_info_1.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout_1
     ));
 
     assert!(matches!(
         era_info_1.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_payout_1
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout_1
     ));
 
     assert!(matches!(
         era_info_1.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_payout_1
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout_1
     ));
 
-    // New rewards
-
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
-    }
-
     let total_supply_2 = builder.total_supply(None);
-    assert!(total_supply_2 > initial_supply);
+    let total_payout_2 = builder.base_round_reward(None);
 
-    let reward_factors_2 = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR_2);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR_2);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR_2);
-        tmp
-    };
+    // Distribute new rewards
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR_2,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR_2,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR_2,
+        ))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
 
-    let distribute_request_2 = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors_2,
-        },
-    )
-    .build();
-
-    builder.exec(distribute_request_2).commit().expect_success();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
     let expected_total_reward_2 = *GENESIS_ROUND_SEIGNIORAGE_RATE * total_supply_2;
     assert!(expected_total_reward_2 > expected_total_reward_1);
     let expected_total_reward_2_integer = expected_total_reward_2.to_integer();
+    assert_eq!(total_payout_2, expected_total_reward_2_integer);
 
     let validator_1_staked_amount_2 = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
         .expect("should have validator bid")
@@ -1295,53 +1439,66 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         .expect("should have validator bid")
         .staked_amount();
 
-    let rounded_amount = U512::one();
-
-    let validator_1_updated_stake_2 = {
+    let validator_1_actual_payout_2 = {
         let validator_stake_before = validator_1_staked_amount_1;
         let validator_stake_after = validator_1_staked_amount_2;
         validator_stake_after - validator_stake_before
     };
-    assert!(validator_1_updated_stake_2 > validator_1_updated_stake_1);
+    assert!(validator_1_actual_payout_2 > validator_1_actual_payout_1);
 
-    let expected_validator_1_payout_2 =
-        (expected_total_reward_2 * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_1_updated_stake_2, expected_validator_1_payout_2);
+    let validator_1_expected_payout_2 = {
+        expected_total_reward_2
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_1_REWARD_FACTOR_2),
+                U512::from(BLOCK_REWARD),
+            ))
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
+    assert_eq!(validator_1_actual_payout_2, validator_1_expected_payout_2);
 
-    let validator_2_updated_stake_2 = {
+    let validator_2_actual_payout_2 = {
         let validator_stake_before = validator_2_staked_amount_1;
         let validator_stake_after = validator_2_staked_amount_2;
         validator_stake_after - validator_stake_before
     };
-    assert!(validator_2_updated_stake_2 > validator_2_updated_stake_1);
+    assert!(validator_2_actual_payout_2 > validator_2_actual_payout_1);
 
-    let expected_validator_2_payout_2 =
-        (expected_total_reward_2 * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_2_updated_stake_2, expected_validator_2_payout_2);
+    let validator_2_expected_payout_2 = {
+        expected_total_reward_2
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_2_REWARD_FACTOR_2),
+                U512::from(BLOCK_REWARD),
+            ))
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
 
-    let validator_3_updated_stake_2 = {
+    assert_eq!(validator_2_actual_payout_2, validator_2_expected_payout_2);
+
+    let validator_3_actual_payout_2 = {
         let validator_stake_before = validator_3_staked_amount_1;
         let validator_stake_after = validator_3_staked_amount_2;
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_3_payout_2 = (expected_total_reward_2 * one_third).to_integer();
-    assert_eq!(validator_3_updated_stake_2, expected_validator_3_payout_2);
-    assert!(validator_3_updated_stake_2 > validator_3_updated_stake_1);
+    let validator_3_expected_payout_2 = {
+        expected_total_reward_2
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_3_REWARD_FACTOR_2),
+                U512::from(BLOCK_REWARD),
+            ))
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
+    assert_eq!(validator_3_actual_payout_2, validator_3_expected_payout_2);
+    assert!(validator_3_actual_payout_2 > validator_3_actual_payout_1);
 
-    assert!(validator_1_updated_stake_2 > validator_1_updated_stake_1);
-    assert!(validator_2_updated_stake_2 > validator_2_updated_stake_1);
-    assert!(validator_3_updated_stake_2 > validator_3_updated_stake_1);
-
-    let total_payout_2 =
-        validator_1_updated_stake_2 + validator_2_updated_stake_2 + expected_validator_3_payout_2;
-    let rounded_amount = U512::from(2);
-    assert_eq!(
-        total_payout_2,
-        expected_total_reward_2_integer - rounded_amount
-    );
+    assert!(validator_1_actual_payout_2 > validator_1_actual_payout_1);
+    assert!(validator_2_actual_payout_2 > validator_2_actual_payout_1);
+    assert!(validator_3_actual_payout_2 > validator_3_actual_payout_1);
 
     let era_info_2 = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -1358,23 +1515,23 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     assert!(matches!(
         era_info_2.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout_2
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout_2
     ));
 
     assert!(matches!(
         era_info_2.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_payout_2
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout_2
     ));
 
     assert!(matches!(
         era_info_2.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_payout_2
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout_2
     ));
 
     // Ensure validators can withdraw their reinvested rewards
-    let validator_1_reward = validator_1_updated_stake_1 + validator_1_updated_stake_2;
+    let validator_1_reward = validator_1_actual_payout_1 + validator_1_actual_payout_2;
     assert!(validator_1_reward > U512::from(VALIDATOR_1_STAKE));
     withdraw_bid(
         &mut builder,
@@ -1389,7 +1546,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         U512::from(VALIDATOR_1_STAKE)
     );
 
-    let validator_2_reward = validator_2_updated_stake_1 + validator_2_updated_stake_2;
+    let validator_2_reward = validator_2_actual_payout_1 + validator_2_actual_payout_2;
     assert!(validator_2_reward > U512::from(VALIDATOR_2_STAKE));
     withdraw_bid(
         &mut builder,
@@ -1404,7 +1561,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         U512::from(VALIDATOR_2_STAKE)
     );
 
-    let validator_3_reward = validator_3_updated_stake_1 + validator_3_updated_stake_2;
+    let validator_3_reward = validator_3_actual_payout_1 + validator_3_actual_payout_2;
     assert!(validator_3_reward > U512::from(VALIDATOR_3_STAKE));
     withdraw_bid(
         &mut builder,
@@ -1426,16 +1583,10 @@ fn should_distribute_delegation_rate_half() {
     const VALIDATOR_1_STAKE: u64 = 1_000_000_000_000;
     const DELEGATOR_1_STAKE: u64 = 1_000_000_000_000;
     const DELEGATOR_2_STAKE: u64 = 1_000_000_000_000;
+    const TOTAL_DELEGATOR_STAKE: u64 = DELEGATOR_1_STAKE + DELEGATOR_2_STAKE;
+    const TOTAL_STAKE: u64 = VALIDATOR_1_STAKE + TOTAL_DELEGATOR_STAKE;
 
     const VALIDATOR_1_DELEGATION_RATE: DelegationRate = DELEGATION_RATE_DENOMINATOR / 2;
-
-    // Validator share
-    let validator_share = Ratio::new(U512::from(2), U512::from(3));
-    let remainders = Ratio::from(U512::from(2));
-    let rounded_amount = U512::from(2);
-
-    // Delegator shares
-    let delegator_shares = Ratio::new(U512::one(), U512::from(6));
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -1520,80 +1671,118 @@ fn should_distribute_delegation_rate_half() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), BLOCK_REWARD);
-        tmp
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_next_era_id(builder.get_era())
+        .with_run_auction(true)
+        .build();
+
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
+
+    let delegators_share = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
     };
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    let delegator_1_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
 
-    builder.exec(distribute_request).commit().expect_success();
+    let delegator_2_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
 
-    let validator_1_balance = {
+    let validator_1_expected_payout = {
+        let total_delegator_payout = delegator_1_expected_payout + delegator_2_expected_payout;
+        let validators_part = expected_total_reward - Ratio::from(total_delegator_payout);
+        validators_part.to_integer()
+    };
+
+    let validator_1_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_balance =
-        (expected_total_reward * validator_share + remainders - rounded_amount).to_integer();
 
-    assert_eq!(validator_1_balance, expected_validator_1_balance);
+    assert_eq!(validator_1_actual_payout, validator_1_expected_payout);
 
-    let delegator_1_balance = {
+    let delegator_1_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_balance = (expected_total_reward * delegator_shares).to_integer();
-    assert_eq!(delegator_1_balance, expected_delegator_1_balance);
+    assert_eq!(delegator_1_actual_payout, delegator_1_expected_payout);
 
-    let delegator_2_balance = {
+    let delegator_2_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_balance = (expected_total_reward * delegator_shares).to_integer();
-    assert_eq!(delegator_2_balance, expected_delegator_2_balance);
-
-    let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
-    assert_eq!(total_payout, expected_total_reward_integer);
+    assert_eq!(delegator_2_actual_payout, delegator_2_expected_payout);
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -1608,19 +1797,19 @@ fn should_distribute_delegation_rate_half() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_balance
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_1_balance
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_expected_payout
     ));
 }
 
@@ -1721,7 +1910,7 @@ fn should_distribute_delegation_rate_full() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
@@ -1825,14 +2014,10 @@ fn should_distribute_uneven_delegation_rate_zero() {
     const VALIDATOR_1_STAKE: u64 = 200_000_000_000;
     const DELEGATOR_1_STAKE: u64 = 600_000_000_000;
     const DELEGATOR_2_STAKE: u64 = 800_000_000_000;
+    const TOTAL_DELEGATOR_STAKE: u64 = DELEGATOR_1_STAKE + DELEGATOR_2_STAKE;
+    const TOTAL_STAKE: u64 = VALIDATOR_1_STAKE + TOTAL_DELEGATOR_STAKE;
 
     const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
-
-    let validator_1_portion = Ratio::new(U512::one(), U512::from(8));
-    let delegator_1_portion = Ratio::new(U512::from(3), U512::from(8));
-    let delegator_2_portion = Ratio::new(U512::from(4), U512::from(8));
-
-    let remainder = Ratio::from(U512::from(1));
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -1917,44 +2102,89 @@ fn should_distribute_uneven_delegation_rate_zero() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), BLOCK_REWARD);
-        tmp
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(VALIDATOR_1.clone(), BLOCK_REWARD))
+        .with_next_era_id(builder.get_era())
+        .with_run_auction(true)
+        .build();
+
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
+
+    let delegators_share = {
+        let commission_rate = Ratio::new(
+            U512::from(VALIDATOR_1_DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(U512::from(TOTAL_DELEGATOR_STAKE), U512::from(TOTAL_STAKE));
+        let delegator_reward = expected_total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
     };
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    let delegator_1_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_1_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
 
-    builder.exec(distribute_request).commit().expect_success();
+    let delegator_2_expected_payout = {
+        let reward_multiplier = Ratio::new(
+            U512::from(DELEGATOR_2_STAKE),
+            U512::from(TOTAL_DELEGATOR_STAKE),
+        );
+        delegators_share
+            .checked_mul(&reward_multiplier)
+            .map(|ratio| ratio.to_integer())
+            .unwrap()
+    };
+
+    let validator_1_expected_payout = {
+        let total_delegator_payout = delegator_1_expected_payout + delegator_2_expected_payout;
+        let validators_part = expected_total_reward - Ratio::from(total_delegator_payout);
+        validators_part.to_integer()
+    };
 
     let validator_1_updated_stake = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
@@ -1963,9 +2193,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_payout =
-        (expected_total_reward * validator_1_portion + remainder).to_integer();
-    assert_eq!(validator_1_updated_stake, expected_validator_1_payout);
+    assert_eq!(validator_1_updated_stake, validator_1_expected_payout);
 
     let delegator_1_updated_stake = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
@@ -1973,8 +2201,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_payout = (expected_total_reward * delegator_1_portion).to_integer();
-    assert_eq!(delegator_1_updated_stake, expected_delegator_1_payout);
+    assert_eq!(delegator_1_updated_stake, delegator_1_expected_payout);
 
     let delegator_2_updated_stake = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
@@ -1982,15 +2209,10 @@ fn should_distribute_uneven_delegation_rate_zero() {
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_2_payout = (expected_total_reward * delegator_2_portion).to_integer();
-    assert_eq!(delegator_2_updated_stake, expected_delegator_2_payout);
-
-    let total_payout =
-        validator_1_updated_stake + delegator_1_updated_stake + delegator_2_updated_stake;
-    assert_eq!(total_payout, expected_total_reward_integer);
+    assert_eq!(delegator_2_updated_stake, delegator_2_expected_payout);
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -2005,19 +2227,19 @@ fn should_distribute_uneven_delegation_rate_zero() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == expected_delegator_1_payout
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == expected_delegator_2_payout
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_expected_payout
     ));
 }
 
@@ -2034,8 +2256,6 @@ fn should_distribute_by_factor() {
     const VALIDATOR_2_REWARD_FACTOR: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
 
-    let one_third = Ratio::new(U512::one(), U512::from(3));
-
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
@@ -2119,89 +2339,106 @@ fn should_distribute_by_factor() {
         validator_3_add_bid_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(expected_total_reward_integer, total_payout);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+        builder
+            .step(step_request)
+            .expect("must execute step request");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR,
+        ))
+        .with_run_auction(true)
+        .with_next_era_id(builder.get_era().successor())
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
-
-    let validator_1_updated_stake = {
+    let validator_1_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_payout = (expected_total_reward * one_third).to_integer();
-    assert_eq!(validator_1_updated_stake, expected_validator_1_payout);
+    let validator_1_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_1_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_1_actual_payout, validator_1_expected_payout);
 
-    let rounded_amount = U512::one();
-
-    let validator_2_updated_stake = {
+    let validator_2_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_2_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_2.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_2_payout =
-        (expected_total_reward * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_2_updated_stake, expected_validator_2_payout);
+    let validator_2_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_2_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
-    let validator_3_updated_stake = {
+    let validator_3_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_3_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_3.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-
-    let expected_validator_3_payout =
-        (expected_total_reward * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_3_updated_stake, expected_validator_3_payout);
-
-    let total_payout =
-        validator_1_updated_stake + validator_2_updated_stake + validator_3_updated_stake;
-    let rounded_amount = U512::from(2);
-    assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+    let validator_3_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_3_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -2216,19 +2453,19 @@ fn should_distribute_by_factor() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_payout
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_payout
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout
     ));
 }
 
@@ -2245,8 +2482,6 @@ fn should_distribute_by_factor_regardless_of_stake() {
     const VALIDATOR_2_REWARD_FACTOR: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
 
-    let one_third = Ratio::new(U512::one(), U512::from(3));
-
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
@@ -2330,88 +2565,107 @@ fn should_distribute_by_factor_regardless_of_stake() {
         validator_3_add_bid_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR,
+        ))
+        .with_run_auction(true)
+        .with_next_era_id(builder.get_era().successor())
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
-
-    let validator_1_updated_stake = {
+    let validator_1_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_payout = (expected_total_reward * one_third).to_integer();
-    assert_eq!(validator_1_updated_stake, expected_validator_1_payout);
+    let validator_1_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_1_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_1_actual_payout, validator_1_expected_payout);
 
-    let rounded_amount = U512::one();
-
-    let validator_2_updated_stake = {
+    let validator_2_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_2_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_2.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_2_payout =
-        (expected_total_reward * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_2_updated_stake, expected_validator_2_payout);
+    let validator_2_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_2_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
-    let validator_3_updated_stake = {
+    let validator_3_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_3_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_3.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_3_payout =
-        (expected_total_reward * one_third - rounded_amount).to_integer();
-    assert_eq!(validator_3_updated_stake, expected_validator_3_payout);
-
-    let total_payout =
-        validator_1_updated_stake + validator_2_updated_stake + expected_validator_3_payout;
-    let rounded_amount = U512::from(2);
-    assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+    let validator_3_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_3_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -2426,19 +2680,19 @@ fn should_distribute_by_factor_regardless_of_stake() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_payout
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_payout
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout
     ));
 }
 
@@ -2455,10 +2709,6 @@ fn should_distribute_by_factor_uneven() {
     const VALIDATOR_2_REWARD_FACTOR: u64 = 300000000000;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 200000000000;
 
-    let one_half = Ratio::new(U512::one(), U512::from(2));
-    let three_tenths = Ratio::new(U512::from(3), U512::from(10));
-    let one_fifth = Ratio::new(U512::from(1), U512::from(5));
-
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
@@ -2542,84 +2792,107 @@ fn should_distribute_by_factor_uneven() {
         validator_3_add_bid_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR,
+        ))
+        .with_run_auction(true)
+        .with_next_era_id(builder.get_era().successor())
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
-
-    let validator_1_updated_stake = {
+    let validator_1_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_1_payout = (expected_total_reward * one_half).to_integer();
-    assert_eq!(validator_1_updated_stake, expected_validator_1_payout);
+    let validator_1_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_1_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_1_actual_payout, validator_1_expected_payout);
 
-    let validator_2_updated_stake = {
+    let validator_2_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_2_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_2.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_2_balance = (expected_total_reward * three_tenths).to_integer();
-    assert_eq!(validator_2_updated_stake, expected_validator_2_balance);
+    let validator_2_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_2_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
-    let validator_3_updated_stake = {
+    let validator_3_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_3_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_3.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_stake_after - validator_stake_before
     };
-    let expected_validator_3_payout = (expected_total_reward * one_fifth).to_integer();
-    assert_eq!(validator_3_updated_stake, expected_validator_3_payout);
-
-    let total_payout =
-        validator_1_updated_stake + validator_2_updated_stake + validator_3_updated_stake;
-    let rounded_amount = U512::one();
-    assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+    let validator_3_expected_payout = expected_total_reward
+        .checked_mul(&Ratio::new(
+            U512::from(VALIDATOR_3_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        ))
+        .map(|ratio| ratio.to_integer())
+        .unwrap();
+    assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -2634,19 +2907,19 @@ fn should_distribute_by_factor_uneven() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_balance
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_payout
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout
     ));
 }
 
@@ -2668,8 +2941,6 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     const DELEGATOR_1_STAKE: u64 = 6_000_000_000_000;
     const DELEGATOR_2_STAKE: u64 = 8_000_000_000_000;
     const DELEGATOR_3_STAKE: u64 = 2_000_000_000_000;
-
-    let remainder = U512::one();
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -2823,48 +3094,58 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         delegator_3_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR,
+        ))
+        .with_run_auction(true)
+        .with_next_era_id(builder.get_era().successor())
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
-
-    let validator_1_updated_stake = {
+    let validator_1_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_1_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
@@ -2872,7 +3153,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         validator_stake_after - validator_stake_before
     };
 
-    let validator_2_updated_stake = {
+    let validator_2_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_2_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_2.clone())
             .expect("should have validator bid")
@@ -2880,7 +3161,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         validator_stake_after - validator_stake_before
     };
 
-    let validator_3_updated_stake = {
+    let validator_3_actual_payout = {
         let validator_stake_before = U512::from(VALIDATOR_3_STAKE);
         let validator_stake_after = *get_validator_bid(&mut builder, VALIDATOR_3.clone())
             .expect("should have validator bid")
@@ -2888,43 +3169,29 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         validator_stake_after - validator_stake_before
     };
 
-    let delegator_1_updated_stake = {
+    let delegator_1_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
 
-    let delegator_2_updated_stake = {
+    let delegator_2_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_2_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone());
         delegator_stake_after - delegator_stake_before
     };
 
-    let delegator_3_updated_stake = {
+    let delegator_3_actual_payout = {
         let delegator_stake_before = U512::from(DELEGATOR_3_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_2.clone(), DELEGATOR_3.clone());
         delegator_stake_after - delegator_stake_before
     };
 
-    let total_payout: U512 = [
-        validator_1_updated_stake,
-        validator_2_updated_stake,
-        validator_3_updated_stake,
-        delegator_1_updated_stake,
-        delegator_2_updated_stake,
-        delegator_3_updated_stake,
-    ]
-    .iter()
-    .cloned()
-    .sum();
-
-    assert_eq!(total_payout, expected_total_reward_integer - remainder);
-
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -2939,37 +3206,37 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_updated_stake
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_actual_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_updated_stake
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_actual_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_updated_stake
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_actual_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_updated_stake
+        if *delegator_public_key == *DELEGATOR_1 && *amount == delegator_1_actual_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_updated_stake
+        if *delegator_public_key == *DELEGATOR_2 && *amount == delegator_2_actual_payout
     ));
 
     assert!(matches!(
         era_info.select(DELEGATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
-        if *delegator_public_key == *DELEGATOR_3 && *amount == delegator_3_updated_stake
+        if *delegator_public_key == *DELEGATOR_3 && *amount == delegator_3_actual_payout
     ));
 }
 
@@ -2987,15 +3254,6 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
 
     const DELEGATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
-
-    let validator_1_portion = Ratio::new(U512::from(1), U512::from(4));
-    let validator_2_portion = Ratio::new(U512::from(1), U512::from(4));
-    let validator_3_portion = Ratio::new(U512::from(1), U512::from(4));
-    let delegator_1_validator_1_portion = Ratio::new(U512::from(1), U512::from(12));
-    let delegator_1_validator_2_portion = Ratio::new(U512::from(1), U512::from(12));
-    let delegator_1_validator_3_portion = Ratio::new(U512::from(1), U512::from(12));
-
-    let remainder = U512::from(2);
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -3149,48 +3407,86 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         delegator_1_validator_3_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
+    let total_payout = builder.base_round_reward(None);
     let expected_total_reward = *GENESIS_ROUND_SEIGNIORAGE_RATE * initial_supply;
     let expected_total_reward_integer = expected_total_reward.to_integer();
+    assert_eq!(total_payout, expected_total_reward_integer);
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
     }
 
-    for _ in 0..5 {
-        builder.run_auction(timestamp_millis, Vec::new());
-        timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+        builder
+            .step(step_request)
+            .expect("must execute step successfully");
     }
 
-    let reward_factors: BTreeMap<PublicKey, u64> = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(VALIDATOR_1.clone(), VALIDATOR_1_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_2.clone(), VALIDATOR_2_REWARD_FACTOR);
-        tmp.insert(VALIDATOR_3.clone(), VALIDATOR_3_REWARD_FACTOR);
-        tmp
-    };
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_1.clone(),
+            VALIDATOR_1_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_2.clone(),
+            VALIDATOR_2_REWARD_FACTOR,
+        ))
+        .with_reward_item(RewardItem::new(
+            VALIDATOR_3.clone(),
+            VALIDATOR_3_REWARD_FACTOR,
+        ))
+        .with_next_era_id(builder.get_era().successor())
+        .with_run_auction(true)
+        .build();
 
-    let distribute_request = ExecuteRequestBuilder::standard(
-        *SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
-            ARG_REWARD_FACTORS => reward_factors
-        },
-    )
-    .build();
+    builder
+        .step(step_request)
+        .expect("must execute step successfully");
 
-    builder.exec(distribute_request).commit().expect_success();
+    let validator_1_delegator_1_share = {
+        let reward_rate = Ratio::new(
+            U512::from(VALIDATOR_1_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        );
 
-    let validator_1_updated_stake = {
+        let total_reward = reward_rate
+            .checked_mul(&Ratio::from(expected_total_reward_integer))
+            .unwrap();
+
+        let validator_1_total_stake = VALIDATOR_1_STAKE + DELEGATOR_1_STAKE;
+
+        let delegator_total_stake = U512::from(DELEGATOR_1_STAKE);
+        let commission_rate = Ratio::new(
+            U512::from(DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(delegator_total_stake, U512::from(validator_1_total_stake));
+        let delegator_reward = total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
+    }
+    .to_integer();
+
+    let validator_1_actual_payout = {
         let validator_balance_before = U512::from(VALIDATOR_1_STAKE);
         let validator_balance_after = *get_validator_bid(&mut builder, VALIDATOR_1.clone())
             .expect("should have validator bid")
@@ -3198,32 +3494,113 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         validator_balance_after - validator_balance_before
     };
 
-    let expected_validator_1_payout = (expected_total_reward * validator_1_portion).to_integer();
-    assert_eq!(validator_1_updated_stake, expected_validator_1_payout);
+    let validator_1_expected_payout = {
+        let validator_share = expected_total_reward
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_1_REWARD_FACTOR),
+                U512::from(BLOCK_REWARD),
+            ))
+            .unwrap();
+        let validator_portion = validator_share - Ratio::from(validator_1_delegator_1_share);
+        validator_portion.to_integer()
+    };
+    assert_eq!(validator_1_actual_payout, validator_1_expected_payout);
 
-    let validator_2_updated_stake = {
+    let validator_2_delegator_1_share = {
+        let validator_2_total_stake = VALIDATOR_2_STAKE + DELEGATOR_1_STAKE;
+
+        let reward_rate = Ratio::new(
+            U512::from(VALIDATOR_2_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        );
+
+        let total_reward = reward_rate
+            .checked_mul(&Ratio::from(expected_total_reward_integer))
+            .unwrap();
+
+        let delegator_total_stake = U512::from(DELEGATOR_1_STAKE);
+        let commission_rate = Ratio::new(
+            U512::from(DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(delegator_total_stake, U512::from(validator_2_total_stake));
+        let delegator_reward = total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
+    }
+    .to_integer();
+
+    let validator_2_actual_payout = {
         let validator_balance_before = U512::from(VALIDATOR_2_STAKE);
         let validator_balance_after = *get_validator_bid(&mut builder, VALIDATOR_2.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_balance_after - validator_balance_before
     };
-    let expected_validator_2_balance = (expected_total_reward * validator_2_portion).to_integer();
-    assert_eq!(validator_2_updated_stake, expected_validator_2_balance);
+    let validator_2_expected_payout = {
+        let validator_share = expected_total_reward
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_2_REWARD_FACTOR),
+                U512::from(BLOCK_REWARD),
+            ))
+            .unwrap();
+        let validator_portion = validator_share - Ratio::from(validator_2_delegator_1_share);
+        validator_portion.to_integer()
+    };
+    assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
-    let validator_3_updated_stake = {
+    let validator_3_delegator_1_share = {
+        let validator_3_total_stake = VALIDATOR_3_STAKE + DELEGATOR_1_STAKE;
+
+        let reward_rate = Ratio::new(
+            U512::from(VALIDATOR_3_REWARD_FACTOR),
+            U512::from(BLOCK_REWARD),
+        );
+
+        let total_reward = reward_rate
+            .checked_mul(&Ratio::from(expected_total_reward_integer))
+            .unwrap();
+
+        let delegator_total_stake = U512::from(DELEGATOR_1_STAKE);
+        let commission_rate = Ratio::new(
+            U512::from(DELEGATION_RATE),
+            U512::from(DELEGATION_RATE_DENOMINATOR),
+        );
+        let reward_multiplier =
+            Ratio::new(delegator_total_stake, U512::from(validator_3_total_stake));
+        let delegator_reward = total_reward
+            .checked_mul(&reward_multiplier)
+            .expect("must get delegator reward");
+        let commission = delegator_reward
+            .checked_mul(&commission_rate)
+            .expect("must get commission");
+        delegator_reward.checked_sub(&commission).unwrap()
+    }
+    .to_integer();
+
+    let validator_3_actual_payout = {
         let validator_balance_before = U512::from(VALIDATOR_3_STAKE);
         let validator_balance_after = *get_validator_bid(&mut builder, VALIDATOR_3.clone())
             .expect("should have validator bid")
             .staked_amount();
         validator_balance_after - validator_balance_before
     };
-    let expected_validator_3_updated_stake =
-        (expected_total_reward * validator_3_portion).to_integer();
-    assert_eq!(
-        validator_3_updated_stake,
-        expected_validator_3_updated_stake
-    );
+    let validator_3_expected_payout = {
+        let validator_share = expected_total_reward
+            .checked_mul(&Ratio::new(
+                U512::from(VALIDATOR_3_REWARD_FACTOR),
+                U512::from(BLOCK_REWARD),
+            ))
+            .unwrap();
+        let validator_portion = validator_share - Ratio::from(validator_3_delegator_1_share);
+        validator_portion.to_integer()
+    };
+    assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let delegator_1_validator_1_updated_stake = {
         let delegator_balance_before = U512::from(DELEGATOR_1_STAKE);
@@ -3231,25 +3608,21 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
             get_delegator_staked_amount(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
         delegator_balance_after - delegator_balance_before
     };
-    let expected_delegator_1_validator_1_payout =
-        (expected_total_reward * delegator_1_validator_1_portion).to_integer();
+
     assert_eq!(
         delegator_1_validator_1_updated_stake,
-        expected_delegator_1_validator_1_payout
+        validator_1_delegator_1_share
     );
 
-    let rounded_amount = U512::one();
     let delegator_1_validator_2_updated_stake = {
         let delegator_stake_before = U512::from(DELEGATOR_1_STAKE);
         let delegator_stake_after =
             get_delegator_staked_amount(&mut builder, VALIDATOR_2.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_validator_2_payout =
-        (expected_total_reward * delegator_1_validator_2_portion - rounded_amount).to_integer();
     assert_eq!(
         delegator_1_validator_2_updated_stake,
-        expected_delegator_1_validator_2_payout
+        validator_2_delegator_1_share
     );
 
     let delegator_1_validator_3_updated_stake = {
@@ -3258,29 +3631,13 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
             get_delegator_staked_amount(&mut builder, VALIDATOR_3.clone(), DELEGATOR_1.clone());
         delegator_stake_after - delegator_stake_before
     };
-    let expected_delegator_1_validator_3_payout =
-        (expected_total_reward * delegator_1_validator_3_portion - rounded_amount).to_integer();
     assert_eq!(
         delegator_1_validator_3_updated_stake,
-        expected_delegator_1_validator_3_payout
+        validator_3_delegator_1_share
     );
 
-    let total_payout: U512 = [
-        validator_1_updated_stake,
-        validator_2_updated_stake,
-        validator_3_updated_stake,
-        delegator_1_validator_1_updated_stake,
-        delegator_1_validator_2_updated_stake,
-        delegator_1_validator_3_updated_stake,
-    ]
-    .iter()
-    .cloned()
-    .sum();
-
-    assert_eq!(total_payout, expected_total_reward_integer - remainder);
-
     let era_info = {
-        let era = builder.get_era();
+        let era = builder.get_era() - 1;
 
         let era_info_value = builder
             .query(None, Key::EraInfo(era), &[])
@@ -3295,19 +3652,19 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     assert!(matches!(
         era_info.select(VALIDATOR_1.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_1 && *amount == expected_validator_1_payout
+        if *validator_public_key == *VALIDATOR_1 && *amount == validator_1_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_2.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_2 && *amount == expected_validator_2_balance
+        if *validator_public_key == *VALIDATOR_2 && *amount == validator_2_expected_payout
     ));
 
     assert!(matches!(
         era_info.select(VALIDATOR_3.clone()).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
-        if *validator_public_key == *VALIDATOR_3 && *amount == expected_validator_3_updated_stake
+        if *validator_public_key == *VALIDATOR_3 && *amount == validator_3_expected_payout
     ));
 
     let delegator_1_allocations: Vec<SeigniorageAllocation> =
@@ -3319,7 +3676,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
             DELEGATOR_1.clone(),
             VALIDATOR_1.clone(),
-            expected_delegator_1_validator_1_payout,
+            validator_1_delegator_1_share,
         ))
     );
 
@@ -3327,7 +3684,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
             DELEGATOR_1.clone(),
             VALIDATOR_2.clone(),
-            expected_delegator_1_validator_2_payout,
+            validator_2_delegator_1_share,
         ))
     );
 
@@ -3335,7 +3692,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
             DELEGATOR_1.clone(),
             VALIDATOR_3.clone(),
-            expected_delegator_1_validator_3_payout,
+            validator_3_delegator_1_share,
         ))
     );
 }
@@ -3512,7 +3869,7 @@ fn should_increase_total_supply_after_distribute() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
@@ -3691,7 +4048,7 @@ fn should_not_create_purses_during_distribute() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);
@@ -3852,7 +4209,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // initial token supply
     let initial_supply = builder.total_supply(None);

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -4,8 +4,8 @@ use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNTS,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
     DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PAYMENT, DEFAULT_PROPOSER_PUBLIC_KEY,
-    DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_UNBONDING_DELAY,
-    MINIMUM_ACCOUNT_CREATION_BALANCE, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
+    DEFAULT_PROTOCOL_VERSION, DEFAULT_UNBONDING_DELAY, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
 };
 use casper_execution_engine::core::{
     engine_state::{
@@ -53,7 +53,7 @@ const DELEGATION_RATE: DelegationRate = 42;
 fn should_run_successful_bond_and_unbond_and_slashing() {
     let default_public_key_arg = DEFAULT_ACCOUNT_PUBLIC_KEY.clone();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -208,7 +208,7 @@ fn should_fail_bonding_with_insufficient_funds_directly() {
     let transfer_amount = U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE);
     let delegation_rate: DelegationRate = 10;
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_args = runtime_args! {
         mint::ARG_TARGET => new_validator_hash,
@@ -285,7 +285,7 @@ fn should_fail_bonding_with_insufficient_funds() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .commit();
 
@@ -383,7 +383,7 @@ fn should_fail_unbonding_validator_without_bonding_first() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -413,7 +413,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -568,7 +568,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let new_unbonding_delay = DEFAULT_UNBONDING_DELAY + 5;
 

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -2,9 +2,10 @@ use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    InMemoryWasmTestBuilder, DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG,
-    DEFAULT_UNBONDING_DELAY, DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG,
+    ChainspecConfig, InMemoryWasmTestBuilder, DEFAULT_AUCTION_DELAY,
+    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
+    DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG,
 };
 use casper_execution_engine::core::engine_state::{
     genesis::{ExecConfig, GenesisAccount, GenesisValidator},
@@ -64,28 +65,12 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
 #[test]
 fn should_run_genesis() {
     let protocol_version = ProtocolVersion::V1_0_0;
-    let wasm_config = *DEFAULT_WASM_CONFIG;
-    let system_config = *DEFAULT_SYSTEM_CONFIG;
-    let validator_slots = DEFAULT_VALIDATOR_SLOTS;
-    let auction_delay = DEFAULT_AUCTION_DELAY;
-    let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
-    let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
-    let unbonding_delay = DEFAULT_UNBONDING_DELAY;
-    let genesis_timestamp = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
 
-    let exec_config = ExecConfig::new(
+    let run_genesis_request = ChainspecConfig::create_genesis_request_from_production_chainspec(
         GENESIS_CUSTOM_ACCOUNTS.clone(),
-        wasm_config,
-        system_config,
-        validator_slots,
-        auction_delay,
-        locked_funds_period,
-        round_seigniorage_rate,
-        unbonding_delay,
-        genesis_timestamp,
-    );
-    let run_genesis_request =
-        RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config);
+        protocol_version,
+    )
+    .expect("must create genesis request");
 
     let mut builder = InMemoryWasmTestBuilder::default();
 

--- a/execution_engine_testing/tests/src/test/system_contracts/handle_payment/finalize_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/handle_payment/finalize_payment.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE, SYSTEM_ADDR,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
 };
 use casper_types::{
     account::{Account, AccountHash},
@@ -46,7 +46,7 @@ fn initialize() -> InMemoryWasmTestBuilder {
     )
     .build();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).expect_success().commit();
 
@@ -99,7 +99,7 @@ fn finalize_payment_should_refund_to_specified_purse() {
         ARG_PURSE_NAME => LOCAL_REFUND_PURSE,
     };
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let create_purse_request = {
         ExecuteRequestBuilder::standard(

--- a/execution_engine_testing/tests/src/test/system_contracts/handle_payment/get_payment_purse.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/handle_payment/get_payment_purse.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
 
@@ -23,7 +23,7 @@ fn should_run_get_payment_purse_contract_default_account() {
     )
     .build();
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit();
@@ -47,7 +47,7 @@ fn should_run_get_payment_purse_contract_account_1() {
     )
     .build();
     InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request_1)
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/system_contracts/handle_payment/refund_purse.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/handle_payment/refund_purse.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{account::AccountHash, runtime_args, system::mint, RuntimeArgs, U512};
 
@@ -36,7 +36,7 @@ fn should_run_refund_purse_contract_account_1() {
 fn initialize() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/standard_payment.rs
@@ -3,7 +3,7 @@ use assert_matches::assert_matches;
 use casper_engine_test_support::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_KEY, DEFAULT_GAS_PRICE, DEFAULT_PAYMENT,
-    DEFAULT_RUN_GENESIS_REQUEST, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -40,7 +40,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .expect_success()
         .commit()
@@ -99,7 +99,7 @@ fn should_forward_payment_execution_runtime_error() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let proposer_reward_starting_balance = builder.get_proposer_purse_balance();
 
@@ -153,7 +153,7 @@ fn should_forward_payment_execution_gas_limit_error() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()
@@ -243,7 +243,7 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -283,7 +283,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(exec_request)
         .commit();
 
@@ -349,7 +349,7 @@ fn should_correctly_charge_when_session_code_fails() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let proposer_reward_starting_balance = builder.get_proposer_purse_balance();
 
@@ -399,7 +399,7 @@ fn should_correctly_charge_when_session_code_succeeds() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let proposer_reward_starting_balance_1 = builder.get_proposer_purse_balance();
 
@@ -456,7 +456,7 @@ fn should_finalize_to_rewards_purse() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let proposer_reward_starting_balance = builder.get_proposer_purse_balance();
 
@@ -496,7 +496,7 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
 
     // create another account via transfer
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(setup_exec_request)
         .expect_success()
         .commit();

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -4,8 +4,8 @@ use num_rational::Ratio;
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_RUN_GENESIS_REQUEST,
-    DEFAULT_UNBONDING_DELAY, DEFAULT_WASM_CONFIG,
+    DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE, DEFAULT_UNBONDING_DELAY,
+    DEFAULT_WASM_CONFIG, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
 use casper_execution_engine::{
@@ -107,7 +107,9 @@ fn get_upgraded_wasm_config() -> WasmConfig {
 fn should_upgrade_only_protocol_version() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let old_wasm_config = *builder.get_engine_state().config().wasm_config();
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -128,7 +130,7 @@ fn should_upgrade_only_protocol_version() {
     let upgraded_engine_config = builder.get_engine_state().config();
 
     assert_eq!(
-        *DEFAULT_WASM_CONFIG,
+        old_wasm_config,
         *upgraded_engine_config.wasm_config(),
         "upgraded costs should equal original costs"
     );
@@ -139,7 +141,7 @@ fn should_upgrade_only_protocol_version() {
 fn should_allow_only_wasm_costs_patch_version() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -184,7 +186,7 @@ fn should_allow_only_wasm_costs_patch_version() {
 fn should_allow_only_wasm_costs_minor_version() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -229,7 +231,9 @@ fn should_allow_only_wasm_costs_minor_version() {
 fn should_not_downgrade() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let old_wasm_config = *builder.get_engine_state().config().wasm_config();
 
     let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
 
@@ -248,7 +252,7 @@ fn should_not_downgrade() {
     let upgraded_engine_config = builder.get_engine_state().config();
 
     assert_eq!(
-        *DEFAULT_WASM_CONFIG,
+        old_wasm_config,
         *upgraded_engine_config.wasm_config(),
         "upgraded costs should equal original costs"
     );
@@ -278,7 +282,7 @@ fn should_not_downgrade() {
 fn should_not_skip_major_versions() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
 
@@ -306,7 +310,7 @@ fn should_not_skip_major_versions() {
 fn should_allow_skip_minor_versions() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
 
@@ -335,7 +339,7 @@ fn should_allow_skip_minor_versions() {
 fn should_upgrade_only_validator_slots() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -390,7 +394,7 @@ fn should_upgrade_only_validator_slots() {
 fn should_upgrade_only_auction_delay() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -445,7 +449,7 @@ fn should_upgrade_only_auction_delay() {
 fn should_upgrade_only_locked_funds_period() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -500,7 +504,7 @@ fn should_upgrade_only_locked_funds_period() {
 fn should_upgrade_only_round_seigniorage_rate() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -562,7 +566,7 @@ fn should_upgrade_only_round_seigniorage_rate() {
 fn should_upgrade_only_unbonding_delay() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -619,7 +623,7 @@ fn should_upgrade_only_unbonding_delay() {
 fn should_apply_global_state_upgrade() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =
@@ -683,7 +687,7 @@ fn should_apply_global_state_upgrade() {
 fn should_increase_max_associated_keys_after_upgrade() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let sem_ver = PROTOCOL_VERSION.value();
     let new_protocol_version =

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -5,8 +5,8 @@ use casper_engine_test_support::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
     UpgradeRequestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
     DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE,
-    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
-    MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::engine_state::{
@@ -20,18 +20,9 @@ use casper_execution_engine::{
         opcode_costs::{BrTableCost, ControlFlowCosts, OpcodeCosts},
         storage_costs::StorageCosts,
         system_config::{
-            auction_costs::{
-                AuctionCosts, DEFAULT_ADD_BID_COST, DEFAULT_DELEGATE_COST, DEFAULT_DISTRIBUTE_COST,
-                DEFAULT_RUN_AUCTION_COST, DEFAULT_SLASH_COST, DEFAULT_UNDELEGATE_COST,
-                DEFAULT_WITHDRAW_BID_COST,
-            },
-            handle_payment_costs::{
-                HandlePaymentCosts, DEFAULT_FINALIZE_PAYMENT_COST, DEFAULT_SET_REFUND_PURSE_COST,
-            },
-            mint_costs::{
-                MintCosts, DEFAULT_BALANCE_COST, DEFAULT_MINT_COST,
-                DEFAULT_REDUCE_TOTAL_SUPPLY_COST, DEFAULT_TRANSFER_COST,
-            },
+            auction_costs::{AuctionCosts, DEFAULT_ADD_BID_COST},
+            handle_payment_costs::HandlePaymentCosts,
+            mint_costs::{MintCosts, DEFAULT_TRANSFER_COST},
             standard_payment_costs::StandardPaymentCosts,
             SystemConfig, DEFAULT_WASMLESS_TRANSFER_COST,
         },
@@ -86,7 +77,7 @@ const ARG_AMOUNT: &str = "amount";
 fn add_bid_and_withdraw_bid_have_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let system_contract_hashes_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -131,7 +122,14 @@ fn add_bid_and_withdraw_bid_have_expected_costs() {
     let transaction_fee_1 =
         builder.get_proposer_purse_balance() - proposer_reward_starting_balance_1;
 
-    let expected_call_cost = U512::from(DEFAULT_ADD_BID_COST);
+    let expected_call_cost = U512::from(
+        builder
+            .get_engine_state()
+            .config()
+            .system_config()
+            .auction_costs()
+            .add_bid,
+    );
     assert_eq!(
         balance_after,
         balance_before - U512::from(BOND_AMOUNT) - transaction_fee_1
@@ -167,7 +165,14 @@ fn add_bid_and_withdraw_bid_have_expected_costs() {
     let transaction_fee_2 =
         builder.get_proposer_purse_balance() - proposer_reward_starting_balance_2;
 
-    let expected_call_cost = U512::from(DEFAULT_WITHDRAW_BID_COST);
+    let expected_call_cost = U512::from(
+        builder
+            .get_engine_state()
+            .config()
+            .system_config()
+            .auction_costs()
+            .withdraw_bid,
+    );
     assert_eq!(balance_after, balance_before - transaction_fee_2);
     assert_eq!(builder.last_exec_gas_cost().value(), expected_call_cost);
 }
@@ -207,7 +212,7 @@ fn upgraded_add_bid_and_withdraw_bid_have_expected_costs() {
     );
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
@@ -373,7 +378,14 @@ fn delegate_and_undelegate_have_expected_costs() {
     let transaction_fee_1 =
         builder.get_proposer_purse_balance() - proposer_reward_starting_balance_1;
 
-    let expected_call_cost = U512::from(DEFAULT_DELEGATE_COST);
+    let expected_call_cost = U512::from(
+        builder
+            .get_engine_state()
+            .config()
+            .system_config()
+            .auction_costs()
+            .delegate,
+    );
     assert_eq!(
         balance_after,
         balance_before - U512::from(BID_AMOUNT) - transaction_fee_1,
@@ -409,7 +421,14 @@ fn delegate_and_undelegate_have_expected_costs() {
     let transaction_fee_2 =
         builder.get_proposer_purse_balance() - proposer_reward_starting_balance_2;
 
-    let expected_call_cost = U512::from(DEFAULT_UNDELEGATE_COST);
+    let expected_call_cost = U512::from(
+        builder
+            .get_engine_state()
+            .config()
+            .system_config()
+            .auction_costs()
+            .undelegate,
+    );
     assert_eq!(balance_after, balance_before - transaction_fee_2);
     assert_eq!(builder.last_exec_gas_cost().value(), expected_call_cost);
 }
@@ -569,7 +588,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
 fn mint_transfer_has_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -636,7 +655,7 @@ fn mint_transfer_has_expected_costs() {
 fn should_charge_for_erroneous_system_contract_calls() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let auction_hash = builder.get_auction_contract_hash();
     let mint_hash = builder.get_mint_contract_hash();
@@ -646,52 +665,74 @@ fn should_charge_for_erroneous_system_contract_calls() {
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");
 
+    let system_config = *builder.get_engine_state().config().system_config();
+
     // Entrypoints that could fail early due to missing arguments
     let entrypoint_calls = vec![
-        (auction_hash, auction::METHOD_ADD_BID, DEFAULT_ADD_BID_COST),
+        (
+            auction_hash,
+            auction::METHOD_ADD_BID,
+            system_config.auction_costs().add_bid,
+        ),
         (
             auction_hash,
             auction::METHOD_WITHDRAW_BID,
-            DEFAULT_WITHDRAW_BID_COST,
+            system_config.auction_costs().withdraw_bid,
         ),
         (
             auction_hash,
             auction::METHOD_DELEGATE,
-            DEFAULT_DELEGATE_COST,
+            system_config.auction_costs().delegate,
         ),
         (
             auction_hash,
             auction::METHOD_UNDELEGATE,
-            DEFAULT_UNDELEGATE_COST,
+            system_config.auction_costs().undelegate,
         ),
         (
             auction_hash,
             auction::METHOD_RUN_AUCTION,
-            DEFAULT_RUN_AUCTION_COST,
+            system_config.auction_costs().run_auction,
         ),
-        (auction_hash, auction::METHOD_SLASH, DEFAULT_SLASH_COST),
+        (
+            auction_hash,
+            auction::METHOD_SLASH,
+            system_config.auction_costs().slash,
+        ),
         (
             auction_hash,
             auction::METHOD_DISTRIBUTE,
-            DEFAULT_DISTRIBUTE_COST,
+            system_config.auction_costs().distribute,
         ),
-        (mint_hash, mint::METHOD_MINT, DEFAULT_MINT_COST),
+        (
+            mint_hash,
+            mint::METHOD_MINT,
+            system_config.mint_costs().mint,
+        ),
         (
             mint_hash,
             mint::METHOD_REDUCE_TOTAL_SUPPLY,
-            DEFAULT_REDUCE_TOTAL_SUPPLY_COST,
+            system_config.mint_costs().reduce_total_supply,
         ),
-        (mint_hash, mint::METHOD_BALANCE, DEFAULT_BALANCE_COST),
-        (mint_hash, mint::METHOD_TRANSFER, DEFAULT_TRANSFER_COST),
+        (
+            mint_hash,
+            mint::METHOD_BALANCE,
+            system_config.mint_costs().balance,
+        ),
+        (
+            mint_hash,
+            mint::METHOD_TRANSFER,
+            system_config.mint_costs().transfer,
+        ),
         (
             handle_payment_hash,
             handle_payment::METHOD_SET_REFUND_PURSE,
-            DEFAULT_SET_REFUND_PURSE_COST,
+            system_config.handle_payment_costs().set_refund_purse,
         ),
         (
             handle_payment_hash,
             handle_payment::METHOD_FINALIZE_PAYMENT,
-            DEFAULT_FINALIZE_PAYMENT_COST,
+            system_config.handle_payment_costs().finalize_payment,
         ),
     ];
 
@@ -741,7 +782,7 @@ fn should_charge_for_erroneous_system_contract_calls() {
 fn should_verify_do_nothing_charges_only_for_standard_payment() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -781,7 +822,7 @@ fn should_verify_do_nothing_charges_only_for_standard_payment() {
 fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let new_opcode_costs = OpcodeCosts {
         bit: 0,

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1,6 +1,6 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{
     contracts::{ContractVersion, CONTRACT_INITIAL_VERSION},
@@ -38,7 +38,7 @@ const ARG_IS_LOCKED: &str = "is_locked";
 fn should_upgrade_do_nothing_to_do_something_version_hash_call() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // Create contract package and store contract ver: 1.0.0 with "delegate" entry function
     {
@@ -130,7 +130,7 @@ fn should_upgrade_do_nothing_to_do_something_version_hash_call() {
 fn should_upgrade_do_nothing_to_do_something_contract_call() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     // Create contract package and store contract ver: 1.0.0
     {
@@ -242,7 +242,7 @@ fn should_upgrade_do_nothing_to_do_something_contract_call() {
 fn should_be_able_to_observe_state_transition_across_upgrade() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store do-nothing-stored
     {
@@ -341,7 +341,7 @@ fn should_be_able_to_observe_state_transition_across_upgrade() {
 fn should_support_extending_functionality() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store do-nothing-stored
     {
@@ -484,7 +484,7 @@ fn should_support_extending_functionality() {
 fn should_maintain_named_keys_across_upgrade() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store contract
     {
@@ -588,7 +588,7 @@ fn should_maintain_named_keys_across_upgrade() {
 fn should_fail_upgrade_for_locked_contract() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // store contract
     {

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
     DEFAULT_ACCOUNT_ADDR, DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_MAX_STORED_VALUE_SIZE,
-    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -666,7 +666,7 @@ fn init_wasmless_transform_builder(create_account_2: bool) -> InMemoryWasmTestBu
     .build();
 
     builder
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(create_account_1_request)
         .expect_success()
         .commit();
@@ -1004,7 +1004,7 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
     );
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -10,11 +10,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::info;
 
-use casper_execution_engine::core::engine_state;
-use casper_types::{
-    bytesrepr::{U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH},
-    KEY_HASH_LENGTH,
-};
+use casper_execution_engine::core::engine_state::{self, engine_config};
 
 use crate::{
     components::{
@@ -39,40 +35,6 @@ use crate::{
     utils::WithDir,
     NodeRng,
 };
-
-/// The size in bytes per delegator entry in SeigniorageRecipient struct.
-/// 34 bytes PublicKey + 10 bytes U512 for the delegated amount
-const SIZE_PER_DELEGATOR_ENTRY: u32 = 44;
-/// The fixed portion, in bytes, of the SeigniorageRecipient struct and its key in the
-/// `SeigniorageRecipients` map.
-/// 34 bytes for the public key + 10 bytes validator weight + 1 byte for delegation rate.
-const FIXED_SIZE_PER_VALIDATOR: u32 = 45;
-/// The size of a key of the `SeigniorageRecipientsSnapshot`, i.e. an `EraId`.
-const FIXED_SIZE_PER_ERA: u32 = U64_SERIALIZED_LENGTH as u32;
-/// The overhead of the Key::Hash under which the seigniorage snapshot lives.
-/// The hash length plus an additional byte for the tag.
-const KEY_HASH_SERIALIZED_LENGTH: u32 = KEY_HASH_LENGTH as u32 + 1;
-
-fn compute_max_delegator_size_limit(
-    max_stored_value_size: u32,
-    auction_delay: u64,
-    validator_slots: u32,
-) -> u32 {
-    let size_limit_per_snapshot =
-        (max_stored_value_size - U8_SERIALIZED_LENGTH as u32 - KEY_HASH_SERIALIZED_LENGTH)
-            / (auction_delay + 1) as u32;
-    let size_per_seigniorage_recipients = size_limit_per_snapshot - FIXED_SIZE_PER_ERA;
-    let size_limit_per_validator =
-        (size_per_seigniorage_recipients / validator_slots) - FIXED_SIZE_PER_VALIDATOR;
-    // The max number of the delegators per validator is the size limit allotted
-    // to a single validator divided by the size of a single delegator entry.
-    // For the given:
-    // 1. max limit of 8MB
-    // 2. 100 validator slots
-    // 3. an auction delay of 1
-    // There will be a maximum of roughly 953 delegators per validator.
-    size_limit_per_validator / SIZE_PER_DELEGATOR_ENTRY
-}
 
 /// Top-level event for the reactor.
 #[derive(Debug, From, Serialize)]
@@ -260,7 +222,7 @@ impl Reactor {
             &chainspec_loader.chainspec().network_config.name,
         )?;
 
-        let max_delegator_size_limit = compute_max_delegator_size_limit(
+        let max_delegator_size_limit = engine_config::compute_max_delegator_size_limit(
             chainspec_loader
                 .chainspec()
                 .core_config
@@ -458,7 +420,7 @@ pub(crate) mod test {
         const AUCTION_DELAY: u64 = 1;
         const VALIDATOR_SLOTS: u32 = 100;
 
-        let number_of_delegators_per_validator = compute_max_delegator_size_limit(
+        let number_of_delegators_per_validator = engine_config::compute_max_delegator_size_limit(
             DEFAULT_MAX_STORED_VALUE_SIZE,
             AUCTION_DELAY,
             VALIDATOR_SLOTS,


### PR DESCRIPTION
Closes #3629 

This change contains backport of PR #2807 on top of 1.4.13 to allow users of the test support to use real chainspec values, rather than constants.