### PR TITLE
Add debug logs around fetching execution results

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -759,7 +759,7 @@ impl BlockAcquisitionState {
                 acq @ ExecutionResultsAcquisition::Needed { .. },
             ) if need_execution_state => {
                 info!(
-                    "BlockAcquisition: registering execution results hash for: {}",
+                    "BlockAcquisition: registering execution results checksum for: {}",
                     block.hash()
                 );
                 *acq = acq

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -493,7 +493,7 @@ impl BlockBuilder {
         maybe_peer: Option<NodeId>,
         block_execution_results_or_chunk: BlockExecutionResultsOrChunk,
     ) -> Result<Option<HashMap<DeployHash, casper_types::ExecutionResult>>, Error> {
-        debug!(block_hash=%self.block_hash, "register_fetched_execution_results");
+        debug!(block_hash=%self.block_hash, %block_execution_results_or_chunk, "register_fetched_execution_results");
         match self.acquisition_state.register_execution_results_or_chunk(
             block_execution_results_or_chunk,
             self.should_fetch_execution_state,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -737,10 +737,24 @@ impl Storage {
                 )?)
             }
             NetRequest::BlockExecutionResults(ref serialized_id) => {
+                debug!(
+                    "got net request for execution results from {}",
+                    incoming.sender
+                );
                 let item_id = decode_item_id::<BlockExecutionResultsOrChunk>(serialized_id)?;
+
+                debug!(
+                    "successfully decoded execution results ID for {}",
+                    incoming.sender
+                );
+
                 let opt_item = self.read_block_execution_results_or_chunk(&item_id)?;
                 let fetch_response = FetchResponse::from_opt(item_id, opt_item);
 
+                debug!(
+                    "successfully read execution results for {} - sending response",
+                    incoming.sender
+                );
                 Ok(self.update_pool_and_send(
                     effect_builder,
                     incoming.sender,


### PR DESCRIPTION
This PR adds more detailed logging in order to analyze the fetching of execution results.

It should be reverted once the root-cause of https://github.com/casper-network/casper-node/issues/3583 is identified and the problem is fixed.