### PR TITLE
Avoid releasing synchronizer latch incorrectly

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -539,7 +539,7 @@ impl BlockAcquisitionState {
         // we will accept finality signatures we don't yet have while in every state other than
         // Initialized and Failed. However, it can only cause a state transition when we
         // are in a resting state that needs weak finality or strict finality.
-
+        let cloned_sig = signature.clone();
         let signer = signature.public_key.clone();
         let acceptance: Acceptance;
         let maybe_block_hash: Option<BlockHash>;
@@ -634,6 +634,16 @@ impl BlockAcquisitionState {
             }
         };
         let ret = currently_acquiring_sigs.then(|| acceptance);
+        info!(
+            signature=%cloned_sig,
+            ?ret,
+            "BlockAcquisition: registering finality signature for: {}",
+            if let Some(block_hash) = maybe_block_hash {
+                block_hash.to_string()
+            } else {
+                "unknown block".to_string()
+            }
+        );
         self.log_finality_signature_acceptance(&maybe_block_hash, &signer, ret);
         if let Some(new_state) = maybe_new_state {
             self.set_state(new_state);

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -602,10 +602,7 @@ impl BlockBuilder {
                 self.touch();
                 self.promote_peer(maybe_peer);
             }
-            Ok(Some(Acceptance::HadIt)) => {
-                self.in_flight_latch = None;
-            }
-            Ok(None) => (),
+            Ok(Some(Acceptance::HadIt)) | Ok(None) => (),
             Err(error) => {
                 self.disqualify_peer(maybe_peer);
                 return Err(Error::BlockAcquisition(error));


### PR DESCRIPTION
This PR fixes a bug in `SignatureAcquisition` so that all new signatures when registered result in `Acceptance::NeededIt`.

Closes #3626.
