### PR TITLE
Use manual padding for `ReactorState` flowchart

### DIFF
--- a/node/src/reactor/main_reactor/reactor_state.rs
+++ b/node/src/reactor/main_reactor/reactor_state.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// flowchart TD
+///     %%{init: { 'flowchart': {'diagramPadding':100} }}%%
 ///     style Start fill:#66ccff,stroke:#333,stroke-width:4px
 ///     style End fill:#66ccff,stroke:#333,stroke-width:4px
 ///     


### PR DESCRIPTION
This PR adds manual padding to the `ReactorState` flowchart to fix the missing part as in the picture.

![image](https://user-images.githubusercontent.com/88321181/216300780-9b3b87fd-3bd7-42a5-ba5c-3e3d60c823a4.png)