### PR TITLE
Revert merge of #2777

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -499,7 +499,7 @@ where
                     .withdraw_to_unbond()
                     .ok_or_else(|| Error::Bytesrepr("unbond".to_string()))?;
 
-                let _ = tracking_copy
+                tracking_copy
                     .borrow_mut()
                     .write(unbonding_key, StoredValue::Unbonding(unbonding_purses));
             }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -393,19 +393,6 @@ where
                 .write(locked_funds_period_key, value);
         }
 
-        if let Some(new_unbonding_delay) = upgrade_config.new_unbonding_delay() {
-            let auction_contract = tracking_copy
-                .borrow_mut()
-                .get_contract(correlation_id, *auction_hash)?;
-
-            let unbonding_delay_key = auction_contract.named_keys()[UNBONDING_DELAY_KEY];
-            let value = StoredValue::CLValue(
-                CLValue::from_t(new_unbonding_delay)
-                    .map_err(|_| Error::Bytesrepr("new_unbonding_delay".to_string()))?,
-            );
-            tracking_copy.borrow_mut().write(unbonding_delay_key, value);
-        }
-
         if let Some(new_round_seigniorage_rate) = upgrade_config.new_round_seigniorage_rate() {
             let new_round_seigniorage_rate: Ratio<U512> = {
                 let (numer, denom) = new_round_seigniorage_rate.into();
@@ -503,6 +490,21 @@ where
                     .borrow_mut()
                     .write(unbonding_key, StoredValue::Unbonding(unbonding_purses));
             }
+        }
+
+        // We insert the new unbonding delay once the purses to be paid out have been transformed
+        // based on the previous unbonding delay.
+        if let Some(new_unbonding_delay) = upgrade_config.new_unbonding_delay() {
+            let auction_contract = tracking_copy
+                .borrow_mut()
+                .get_contract(correlation_id, *auction_hash)?;
+
+            let unbonding_delay_key = auction_contract.named_keys()[UNBONDING_DELAY_KEY];
+            let value = StoredValue::CLValue(
+                CLValue::from_t(new_unbonding_delay)
+                    .map_err(|_| Error::Bytesrepr("new_unbonding_delay".to_string()))?,
+            );
+            tracking_copy.borrow_mut().write(unbonding_delay_key, value);
         }
 
         let execution_effect = tracking_copy.borrow().effect();

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -39,8 +39,8 @@ use casper_types::{
     contracts::NamedKeys,
     system::{
         auction::{
-            EraValidators, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_EVICTED_VALIDATORS,
-            ARG_REWARD_FACTORS, ARG_VALIDATOR_PUBLIC_KEYS, AUCTION_DELAY_KEY,
+            EraValidators, UnbondingPurse, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_EVICTED_VALIDATORS,
+            ARG_REWARD_FACTORS, ARG_VALIDATOR_PUBLIC_KEYS, AUCTION_DELAY_KEY, ERA_ID_KEY,
             LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY,
             VALIDATOR_SLOTS_KEY,
         },
@@ -48,8 +48,8 @@ use casper_types::{
         mint::{self, ROUND_SEIGNIORAGE_RATE_KEY},
         AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
-    AccessRights, ApiError, BlockTime, CLValue, ContractHash, DeployHash, DeployInfo, Gas, Key,
-    KeyTag, Motes, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, URef, U512,
+    AccessRights, ApiError, BlockTime, CLValue, ContractHash, DeployHash, DeployInfo, EraId, Gas,
+    Key, KeyTag, Motes, Phase, ProtocolVersion, PublicKey, RuntimeArgs, StoredValue, URef, U512,
 };
 
 pub use self::{
@@ -429,6 +429,80 @@ where
         // apply the arbitrary modifications
         for (key, value) in upgrade_config.global_state_update() {
             tracking_copy.borrow_mut().write(*key, value.clone());
+        }
+
+        // This is a one time data transformation which will be removed
+        // in a following upgrade.
+        // TODO: CRef={https://github.com/casper-network/casper-node/issues/2479}
+        {
+            let withdraw_keys = tracking_copy
+                .borrow_mut()
+                .get_keys(correlation_id, &KeyTag::Withdraw)
+                .map_err(|_| Error::FailedToGetWithdrawKeys)?;
+
+            let (unbonding_delay, current_era_id) = {
+                let auction_contract = tracking_copy
+                    .borrow_mut()
+                    .get_contract(correlation_id, *auction_hash)?;
+
+                let unbonding_delay_key = auction_contract.named_keys()[UNBONDING_DELAY_KEY];
+                let delay = tracking_copy
+                    .borrow_mut()
+                    .read(correlation_id, &unbonding_delay_key)
+                    .map_err(|error| error.into())?
+                    .ok_or(Error::FailedToRetrieveUnbondingDelay)?
+                    .as_cl_value()
+                    .ok_or_else(|| Error::Bytesrepr("unbonding_delay".to_string()))?
+                    .clone()
+                    .into_t::<u64>()
+                    .map_err(execution::Error::from)?;
+
+                let era_id_key = auction_contract.named_keys()[ERA_ID_KEY];
+
+                let era_id = tracking_copy
+                    .borrow_mut()
+                    .read(correlation_id, &era_id_key)
+                    .map_err(|error| error.into())?
+                    .ok_or(Error::FailedToRetrieveEraId)?
+                    .as_cl_value()
+                    .ok_or_else(|| Error::Bytesrepr("era_id".to_string()))?
+                    .clone()
+                    .into_t::<EraId>()
+                    .map_err(execution::Error::from)?;
+
+                (delay, era_id)
+            };
+
+            for key in withdraw_keys {
+                // Transform only those withdraw purses that are still to be
+                // processed in the unbonding queue.
+                let withdraw_purses = tracking_copy
+                    .borrow_mut()
+                    .read(correlation_id, &key)
+                    .map_err(|_| Error::FailedToGetWithdrawKeys)?
+                    .ok_or(Error::FailedToGetStoredWithdraws)?
+                    .as_withdraw()
+                    .ok_or(Error::FailedToGetWithdrawPurses)?
+                    .to_owned();
+
+                let unbonding_purses: Vec<UnbondingPurse> = withdraw_purses
+                    .into_iter()
+                    .filter_map(|purse| {
+                        if purse.era_of_creation() + unbonding_delay >= current_era_id {
+                            return Some(UnbondingPurse::from(purse));
+                        }
+                        None
+                    })
+                    .collect();
+
+                let unbonding_key = key
+                    .withdraw_to_unbond()
+                    .ok_or_else(|| Error::Bytesrepr("unbond".to_string()))?;
+
+                let _ = tracking_copy
+                    .borrow_mut()
+                    .write(unbonding_key, StoredValue::Unbonding(unbonding_purses));
+            }
         }
 
         let execution_effect = tracking_copy.borrow().effect();

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -368,12 +368,12 @@ impl From<&Transform> for casper_types::Transform {
             Transform::Write(StoredValue::Bid(bid)) => {
                 casper_types::Transform::WriteBid(bid.clone())
             }
-            Transform::Write(StoredValue::Unbonding(unbonding_purses)) => {
-                casper_types::Transform::WriteWithdraw(unbonding_purses.clone())
+            Transform::Write(StoredValue::Withdraw(withdraw_purses)) => {
+                casper_types::Transform::WriteWithdraw(withdraw_purses.clone())
             }
-            Transform::Write(StoredValue::Withdraw(_)) => casper_types::Transform::Failure(
-                "withdraw purses should not be be written to global state".to_string(),
-            ),
+            Transform::Write(StoredValue::Unbonding(unbonding_purses)) => {
+                casper_types::Transform::WriteUnbonding(unbonding_purses.clone())
+            }
             Transform::AddInt32(value) => casper_types::Transform::AddInt32(*value),
             Transform::AddUInt64(value) => casper_types::Transform::AddUInt64(*value),
             Transform::AddUInt128(value) => casper_types::Transform::AddUInt128(*value),

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -5,8 +5,9 @@ use num_traits::{One, Zero};
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_EXEC_CONFIG, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder,
+    UpgradeRequestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
+    DEFAULT_AUCTION_DELAY, DEFAULT_EXEC_CONFIG, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
     DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_UNBONDING_DELAY, MINIMUM_ACCOUNT_CREATION_BALANCE,
     PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
 };
@@ -20,7 +21,7 @@ use casper_execution_engine::{
                 DEFAULT_STRICT_ARGUMENT_CHECKING, DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
             },
             genesis::{GenesisAccount, GenesisValidator},
-            EngineConfig, RewardItem,
+            EngineConfig, Error, RewardItem,
         },
         execution,
     },
@@ -35,13 +36,15 @@ use casper_types::{
     system::{
         self,
         auction::{
-            self, Bids, DelegationRate, EraValidators, UnbondingPurses, ValidatorWeights,
-            ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_NEW_VALIDATOR, ARG_PUBLIC_KEY,
-            ARG_VALIDATOR, ERA_ID_KEY, INITIAL_ERA_ID,
+            self, Bids, DelegationRate, EraValidators, Error as AuctionError, UnbondingPurses,
+            ValidatorWeights, WithdrawPurses, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR,
+            ARG_NEW_VALIDATOR, ARG_PUBLIC_KEY, ARG_VALIDATOR, ERA_ID_KEY, INITIAL_ERA_ID,
         },
     },
-    EraId, Motes, PublicKey, RuntimeArgs, SecretKey, U256, U512,
+    EraId, Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U256, U512,
 };
+
+use crate::lmdb_fixture;
 
 const ARG_TARGET: &str = "target";
 
@@ -99,6 +102,16 @@ static ACCOUNT_2_PK: Lazy<PublicKey> = Lazy::new(|| {
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_2_PK));
 const ACCOUNT_2_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_2_BOND: u64 = 200_000;
+
+static GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
+    let secret_key = SecretKey::ed25519_from_bytes([200; SecretKey::ED25519_LENGTH]).unwrap();
+    PublicKey::from(&secret_key)
+});
+
+static GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
+    let secret_key = SecretKey::ed25519_from_bytes([202; SecretKey::ED25519_LENGTH]).unwrap();
+    PublicKey::from(&secret_key)
+});
 
 static BID_ACCOUNT_1_PK: Lazy<PublicKey> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([204; SecretKey::ED25519_LENGTH]).unwrap();
@@ -3272,6 +3285,48 @@ fn should_delegate_and_redelegate() {
 
 #[ignore]
 #[test]
+fn should_upgrade_unbonding_purses_from_rel_1_4_2() {
+    // The `lmdb_fixture::RELEASE_1_4_2` has a single withdraw key
+    // present in the unbonding queue at the upgrade point
+    let (mut builder, lmdb_fixture_state, _temp_dir) =
+        lmdb_fixture::builder_from_global_state_fixture(lmdb_fixture::RELEASE_1_4_2);
+
+    let previous_protocol_version = lmdb_fixture_state.genesis_protocol_version();
+
+    let new_protocol_version = ProtocolVersion::from_parts(
+        previous_protocol_version.value().major,
+        previous_protocol_version.value().minor + 1,
+        0,
+    );
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(previous_protocol_version)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(EraId::new(1u64))
+            .build()
+    };
+
+    builder
+        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
+        .expect_upgrade_success();
+
+    let unbonding_purses: UnbondingPurses = builder.get_unbonds();
+    assert_eq!(unbonding_purses.len(), 1);
+
+    let unbond_list = unbonding_purses
+        .get(&NON_FOUNDER_VALIDATOR_1_ADDR)
+        .expect("should have unbonding purse for non founding validator");
+    assert_eq!(unbond_list.len(), 1);
+    assert_eq!(
+        unbond_list[0].validator_public_key(),
+        &*NON_FOUNDER_VALIDATOR_1_PK
+    );
+    assert!(unbond_list[0].new_validator().is_none())
+}
+
+#[ignore]
+#[test]
 fn should_handle_redelegation_to_inactive_validator() {
     let validator_1_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -3457,4 +3512,627 @@ fn should_handle_redelegation_to_inactive_validator() {
         delegator_2_purse_balance_before,
         delegator_2_purse_balance_after
     );
+}
+
+#[ignore]
+#[test]
+fn should_continue_auction_state_from_release_1_4_x() {
+    // The `lmdb_fixture::RELEASE_1_4_3` has three withdraw keys
+    // in the unbonding queue which will each be processed
+    // in the three eras after the upgrade.
+    let (mut builder, lmdb_fixture_state, _temp_dir) =
+        lmdb_fixture::builder_from_global_state_fixture(lmdb_fixture::RELEASE_1_4_3);
+
+    let withdraw_purses: WithdrawPurses = builder.get_withdraw_purses();
+
+    assert_eq!(withdraw_purses.len(), 1);
+
+    let previous_protocol_version = lmdb_fixture_state.genesis_protocol_version();
+
+    let new_protocol_version = ProtocolVersion::from_parts(
+        previous_protocol_version.value().major,
+        previous_protocol_version.value().minor + 1,
+        0,
+    );
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(previous_protocol_version)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(EraId::new(20u64))
+            .build()
+    };
+
+    builder
+        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
+        .expect_upgrade_success();
+
+    let unbonding_purses: UnbondingPurses = builder.get_unbonds();
+    assert_eq!(unbonding_purses.len(), 1);
+
+    let unbond_list = unbonding_purses
+        .get(&NON_FOUNDER_VALIDATOR_1_ADDR)
+        .expect("should have unbonding purse for non founding validator");
+    assert_eq!(unbond_list.len(), 3);
+    assert_eq!(
+        unbond_list[0].validator_public_key(),
+        &*NON_FOUNDER_VALIDATOR_1_PK
+    );
+    assert!(unbond_list[0].new_validator().is_none());
+    assert!(unbond_list[1].new_validator().is_none());
+    assert!(unbond_list[2].new_validator().is_none());
+
+    let delegator_1_undelegate_purse = builder
+        .get_account(*BID_ACCOUNT_1_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_1_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_1_purse_balance_post_step =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+
+    assert_eq!(
+        delegator_1_purse_balance_post_step,
+        delegator_1_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_2_undelegate_purse = builder
+        .get_account(*BID_ACCOUNT_2_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_2_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_2_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_2_purse_balance_post_step =
+        builder.get_purse_balance(delegator_2_undelegate_purse);
+
+    assert_eq!(
+        delegator_2_purse_balance_post_step,
+        delegator_2_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_3_undelegate_purse = builder
+        .get_account(*DELEGATOR_1_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_3_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_3_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_3_purse_balance_post_step =
+        builder.get_purse_balance(delegator_3_undelegate_purse);
+
+    assert_eq!(
+        delegator_3_purse_balance_post_step,
+        delegator_3_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_4_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_2_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_fund_request)
+        .expect_success()
+        .commit();
+
+    let delegator_4_validator_1_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => DELEGATOR_2.clone(),
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_validator_1_delegate_request)
+        .expect_success()
+        .commit();
+
+    let delegator_4_redelegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_REDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => DELEGATOR_2.clone(),
+            ARG_NEW_VALIDATOR => GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone()
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_redelegate_request)
+        .expect_success()
+        .commit();
+
+    let delegator_4_purse = builder
+        .get_account(*DELEGATOR_2_ADDR)
+        .expect("must have account")
+        .main_purse();
+
+    let delegator_4_purse_balance_before = builder.get_purse_balance(delegator_4_purse);
+
+    for _ in 0..=DEFAULT_UNBONDING_DELAY {
+        let delegator_4_redelegate_purse_balance = builder.get_purse_balance(delegator_4_purse);
+        assert_eq!(
+            delegator_4_redelegate_purse_balance,
+            delegator_4_purse_balance_before
+        );
+
+        builder.advance_era(vec![
+            RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+            RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+            RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+        ]);
+    }
+
+    let delegator_4_purse_balance_after = builder.get_purse_balance(delegator_4_purse);
+
+    // redelegation will not transfer funds back to the user
+    // therefore the balance must remain the same
+    assert_eq!(
+        delegator_4_purse_balance_before,
+        delegator_4_purse_balance_after
+    );
+
+    let bids: Bids = builder.get_bids();
+    assert_eq!(bids.len(), 3);
+
+    let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
+    assert_eq!(delegators.len(), 4);
+    let delegated_amount_1 = *delegators[&DELEGATOR_2].staked_amount();
+    assert_eq!(
+        delegated_amount_1,
+        U512::from(DELEGATE_AMOUNT_1 - UNDELEGATE_AMOUNT_1 - DEFAULT_MINIMUM_DELEGATION_AMOUNT)
+    );
+
+    let delegators = bids[&GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY].delegators();
+    assert_eq!(delegators.len(), 1);
+    let redelegated_amount_1 = *delegators[&DELEGATOR_2].staked_amount();
+    assert_eq!(
+        redelegated_amount_1,
+        U512::from(UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT)
+    );
+}
+
+#[ignore]
+#[test]
+fn should_transfer_to_main_purse_when_validator_is_no_longer_active() {
+    let (mut builder, lmdb_fixture_state, _temp_dir) =
+        lmdb_fixture::builder_from_global_state_fixture(lmdb_fixture::RELEASE_1_4_3);
+
+    let withdraw_purses: WithdrawPurses = builder.get_withdraw_purses();
+
+    assert_eq!(withdraw_purses.len(), 1);
+
+    let previous_protocol_version = lmdb_fixture_state.genesis_protocol_version();
+
+    let new_protocol_version = ProtocolVersion::from_parts(
+        previous_protocol_version.value().major,
+        previous_protocol_version.value().minor + 1,
+        0,
+    );
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(previous_protocol_version)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(EraId::new(20u64))
+            .build()
+    };
+
+    builder
+        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
+        .expect_upgrade_success();
+
+    let unbonding_purses: UnbondingPurses = builder.get_unbonds();
+    assert_eq!(unbonding_purses.len(), 1);
+
+    let unbond_list = unbonding_purses
+        .get(&NON_FOUNDER_VALIDATOR_1_ADDR)
+        .expect("should have unbonding purses for non founding validator");
+    assert_eq!(unbond_list.len(), 3);
+    assert_eq!(
+        unbond_list[0].validator_public_key(),
+        &*NON_FOUNDER_VALIDATOR_1_PK
+    );
+    assert!(unbond_list[0].new_validator().is_none());
+    assert!(unbond_list[1].new_validator().is_none());
+    assert!(unbond_list[2].new_validator().is_none());
+
+    let delegator_1_undelegate_purse = builder
+        .get_account(*BID_ACCOUNT_1_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_1_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_1_purse_balance_post_step =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+
+    assert_eq!(
+        delegator_1_purse_balance_post_step,
+        delegator_1_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_2_undelegate_purse = builder
+        .get_account(*BID_ACCOUNT_2_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_2_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_2_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_2_purse_balance_post_step =
+        builder.get_purse_balance(delegator_2_undelegate_purse);
+
+    assert_eq!(
+        delegator_2_purse_balance_post_step,
+        delegator_2_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_3_undelegate_purse = builder
+        .get_account(*DELEGATOR_1_ADDR)
+        .expect("should have account")
+        .main_purse();
+
+    let delegator_3_purse_balance_pre_step =
+        builder.get_purse_balance(delegator_3_undelegate_purse);
+
+    builder.advance_era(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_3_purse_balance_post_step =
+        builder.get_purse_balance(delegator_3_undelegate_purse);
+
+    assert_eq!(
+        delegator_3_purse_balance_post_step,
+        delegator_3_purse_balance_pre_step + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+
+    let delegator_4_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_2_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_fund_request)
+        .expect_success()
+        .commit();
+
+    let delegator_4_validator_1_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(),
+            ARG_DELEGATOR => DELEGATOR_2.clone(),
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_validator_1_delegate_request)
+        .expect_success()
+        .commit();
+
+    let delegator_4_redelegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_REDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(),
+            ARG_DELEGATOR => DELEGATOR_2.clone(),
+            ARG_NEW_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone()
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_4_redelegate_request)
+        .expect_success()
+        .commit();
+
+    let withdraw_request = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_WITHDRAW_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+        },
+    )
+    .build();
+
+    builder.exec(withdraw_request).expect_success().commit();
+
+    builder.advance_eras_by_default_auction_delay(vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ]);
+
+    let delegator_4_purse = builder
+        .get_account(*DELEGATOR_2_ADDR)
+        .expect("must have account")
+        .main_purse();
+
+    let delegator_4_purse_balance_before = builder.get_purse_balance(delegator_4_purse);
+
+    let rewards = vec![
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY.clone(), 0),
+        RewardItem::new(GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY.clone(), 0),
+    ];
+
+    for _ in 0..(DEFAULT_UNBONDING_DELAY - DEFAULT_AUCTION_DELAY) {
+        let delegator_4_redelegate_purse_balance = builder.get_purse_balance(delegator_4_purse);
+        assert_eq!(
+            delegator_4_redelegate_purse_balance,
+            delegator_4_purse_balance_before
+        );
+
+        builder.advance_era(rewards.clone());
+    }
+
+    let delegator_4_purse_balance_after = builder.get_purse_balance(delegator_4_purse);
+
+    let bids: Bids = builder.get_bids();
+
+    assert!(bids[&NON_FOUNDER_VALIDATOR_1_PK].inactive());
+
+    // Since we have re-delegated to an inactive validator,
+    // the funds should cycle back to the delegator.
+    assert_eq!(
+        delegator_4_purse_balance_before + UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+        delegator_4_purse_balance_after
+    );
+
+    let delegators = bids[&GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY].delegators();
+    assert_eq!(delegators.len(), 1);
+    let delegated_amount_1 = *delegators[&DELEGATOR_2].staked_amount();
+    assert_eq!(
+        delegated_amount_1,
+        U512::from(DELEGATE_AMOUNT_1 - UNDELEGATE_AMOUNT_1 - DEFAULT_MINIMUM_DELEGATION_AMOUNT)
+    );
+}
+
+#[ignore]
+#[test]
+fn should_enforce_minimum_delegation_amount() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_1_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let post_genesis_request = vec![transfer_to_validator_1, transfer_to_delegator_1];
+
+    for request in post_genesis_request {
+        builder.exec(request).expect_success().commit();
+    }
+
+    let add_bid_request_1 = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_ADD_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    builder.exec(add_bid_request_1).expect_success().commit();
+
+    for _ in 0..=DEFAULT_AUCTION_DELAY {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step request");
+    }
+
+    let delegation_request_1 = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_1_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(100u64),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK.clone(),
+        },
+    )
+    .build();
+
+    // The delegation amount is below the default value of 500 CSPR,
+    // therefore the delegation should not succeed.
+    builder.exec(delegation_request_1).expect_failure();
+
+    let error = builder.get_error().expect("must get error");
+    assert!(matches!(
+        error,
+        Error::Exec(execution::Error::Revert(ApiError::AuctionError(auction_error)))
+        if auction_error == AuctionError::DelegationAmountTooSmall as u8));
+}
+
+#[ignore]
+#[test]
+fn should_allow_delegations_with_minimal_floor_amount() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_1_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_2_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let post_genesis_request = vec![
+        transfer_to_validator_1,
+        transfer_to_delegator_1,
+        transfer_to_delegator_2,
+    ];
+
+    for request in post_genesis_request {
+        builder.exec(request).expect_success().commit();
+    }
+
+    let add_bid_request_1 = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_ADD_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    builder.exec(add_bid_request_1).expect_success().commit();
+
+    for _ in 0..=DEFAULT_AUCTION_DELAY {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step request");
+    }
+
+    let delegation_request_1 = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_1_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT - 1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK.clone(),
+        },
+    )
+    .build();
+
+    // The delegation amount is below the default value of 500 CSPR,
+    // therefore the delegation should not succeed.
+    builder.exec(delegation_request_1).expect_failure();
+
+    let error = builder.get_error().expect("must get error");
+
+    assert!(matches!(
+        error,
+        Error::Exec(execution::Error::Revert(ApiError::AuctionError(auction_error)))
+        if auction_error == AuctionError::DelegationAmountTooSmall as u8));
+
+    let delegation_request_2 = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_2_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_2_PK.clone(),
+        },
+    )
+    .build();
+
+    builder.exec(delegation_request_2).expect_success().commit();
 }

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2511,7 +2511,7 @@
                   "WriteWithdraw": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/UnbondingPurse"
+                      "$ref": "#/components/schemas/WithdrawPurse"
                     }
                   }
                 },
@@ -2610,6 +2610,22 @@
                 "properties": {
                   "Failure": {
                     "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Writes the given Unbonding to global state.",
+                "type": "object",
+                "required": [
+                  "WriteUnbonding"
+                ],
+                "properties": {
+                  "WriteUnbonding": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
+                    }
                   }
                 },
                 "additionalProperties": false
@@ -2995,6 +3011,93 @@
             },
             "additionalProperties": false
           },
+          "WithdrawPurse": {
+            "description": "A withdraw purse, a legacy structure.",
+            "type": "object",
+            "required": [
+              "amount",
+              "bonding_purse",
+              "era_of_creation",
+              "unbonder_public_key",
+              "validator_public_key"
+            ],
+            "properties": {
+              "bonding_purse": {
+                "description": "Bonding Purse",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/URef"
+                  }
+                ]
+              },
+              "validator_public_key": {
+                "description": "Validators public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "unbonder_public_key": {
+                "description": "Unbonders public key.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                ]
+              },
+              "era_of_creation": {
+                "description": "Era in which this unbonding request was created.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
+              },
+              "amount": {
+                "description": "Unbonding Amount.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/U512"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "EraId": {
+            "description": "Era ID newtype.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "U128": {
+            "description": "Decimal representation of a 128-bit integer.",
+            "type": "string"
+          },
+          "U256": {
+            "description": "Decimal representation of a 256-bit integer.",
+            "type": "string"
+          },
+          "NamedKey": {
+            "description": "A named key.",
+            "type": "object",
+            "required": [
+              "key",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "description": "The name of the entry.",
+                "type": "string"
+              },
+              "key": {
+                "description": "The value of the entry: a casper `Key` type.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
           "UnbondingPurse": {
             "description": "Unbonding purse.",
             "type": "object",
@@ -3056,39 +3159,6 @@
                     "type": "null"
                   }
                 ]
-              }
-            },
-            "additionalProperties": false
-          },
-          "EraId": {
-            "description": "Era ID newtype.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "U128": {
-            "description": "Decimal representation of a 128-bit integer.",
-            "type": "string"
-          },
-          "U256": {
-            "description": "Decimal representation of a 256-bit integer.",
-            "type": "string"
-          },
-          "NamedKey": {
-            "description": "A named key.",
-            "type": "object",
-            "required": [
-              "key",
-              "name"
-            ],
-            "properties": {
-              "name": {
-                "description": "The name of the entry.",
-                "type": "string"
-              },
-              "key": {
-                "description": "The value of the entry: a casper `Key` type.",
-                "type": "string"
               }
             },
             "additionalProperties": false
@@ -3701,60 +3771,6 @@
               "Locked",
               "Unlocked"
             ]
-          },
-          "WithdrawPurse": {
-            "description": "A withdraw purse, a legacy structure.",
-            "type": "object",
-            "required": [
-              "amount",
-              "bonding_purse",
-              "era_of_creation",
-              "unbonder_public_key",
-              "validator_public_key"
-            ],
-            "properties": {
-              "bonding_purse": {
-                "description": "Bonding Purse",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/URef"
-                  }
-                ]
-              },
-              "validator_public_key": {
-                "description": "Validators public key.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ]
-              },
-              "unbonder_public_key": {
-                "description": "Unbonders public key.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicKey"
-                  }
-                ]
-              },
-              "era_of_creation": {
-                "description": "Era in which this unbonding request was created.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/EraId"
-                  }
-                ]
-              },
-              "amount": {
-                "description": "Unbonding Amount.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/U512"
-                  }
-                ]
-              }
-            },
-            "additionalProperties": false
           },
           "GlobalStateIdentifier": {
             "description": "Identifier for possible ways to query Global State",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1343,7 +1343,7 @@
             "WriteWithdraw": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/UnbondingPurse"
+                "$ref": "#/definitions/WithdrawPurse"
               }
             }
           },
@@ -1442,6 +1442,22 @@
           "properties": {
             "Failure": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Writes the given Unbonding to global state.",
+          "type": "object",
+          "required": [
+            "WriteUnbonding"
+          ],
+          "properties": {
+            "WriteUnbonding": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnbondingPurse"
+              }
             }
           },
           "additionalProperties": false
@@ -1823,6 +1839,87 @@
       },
       "additionalProperties": false
     },
+    "WithdrawPurse": {
+      "description": "A withdraw purse, a legacy structure.",
+      "type": "object",
+      "required": [
+        "amount",
+        "bonding_purse",
+        "era_of_creation",
+        "unbonder_public_key",
+        "validator_public_key"
+      ],
+      "properties": {
+        "bonding_purse": {
+          "description": "Bonding Purse",
+          "allOf": [
+            {
+              "$ref": "#/definitions/URef"
+            }
+          ]
+        },
+        "validator_public_key": {
+          "description": "Validators public key.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        },
+        "unbonder_public_key": {
+          "description": "Unbonders public key.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PublicKey"
+            }
+          ]
+        },
+        "era_of_creation": {
+          "description": "Era in which this unbonding request was created.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EraId"
+            }
+          ]
+        },
+        "amount": {
+          "description": "Unbonding Amount.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/U512"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "U128": {
+      "description": "Decimal representation of a 128-bit integer.",
+      "type": "string"
+    },
+    "U256": {
+      "description": "Decimal representation of a 256-bit integer.",
+      "type": "string"
+    },
+    "NamedKey": {
+      "description": "A named key.",
+      "type": "object",
+      "required": [
+        "key",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name of the entry.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The value of the entry: a casper `Key` type.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "UnbondingPurse": {
       "description": "Unbonding purse.",
       "type": "object",
@@ -1884,33 +1981,6 @@
               "type": "null"
             }
           ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "U128": {
-      "description": "Decimal representation of a 128-bit integer.",
-      "type": "string"
-    },
-    "U256": {
-      "description": "Decimal representation of a 256-bit integer.",
-      "type": "string"
-    },
-    "NamedKey": {
-      "description": "A named key.",
-      "type": "object",
-      "required": [
-        "key",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name of the entry.",
-          "type": "string"
-        },
-        "key": {
-          "description": "The value of the entry: a casper `Key` type.",
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/utils/validation/src/generators.rs
+++ b/utils/validation/src/generators.rs
@@ -194,11 +194,21 @@ pub fn make_abi_test_fixtures() -> Result<TestFixtures, Error> {
         transform.insert(
             "WriteWithdraw".to_string(),
             ABITestCase::from_inputs(vec![Transform::WriteWithdraw(vec![
+                withdraw_purse_1.clone(),
+                withdraw_purse_2.clone(),
+            ])
+            .into()])?,
+        );
+
+        transform.insert(
+            "WriteUnbonding".to_string(),
+            ABITestCase::from_inputs(vec![Transform::WriteUnbonding(vec![
                 unbonding_purse_1.clone(),
                 unbonding_purse_2.clone(),
             ])
             .into()])?,
         );
+
         transform.insert(
             "AddInt32".to_string(),
             ABITestCase::from_inputs(vec![Transform::AddInt32(i32::MAX).into()])?,

--- a/utils/validation/tests/fixtures/ABI/transform.json
+++ b/utils/validation/tests/fixtures/ABI/transform.json
@@ -247,6 +247,32 @@
               "validator_public_key": "01197f6b23e16C8532c6ABC838fAcD5eA789be0c76b2920334039bfa8b3d368D61",
               "unbonder_public_key": "01197f6b23e16C8532c6ABC838fAcD5eA789be0c76b2920334039bfa8b3d368D61",
               "era_of_creation": 41,
+              "amount": "60000000000"
+            },
+            {
+              "bonding_purse": "uref-0B0b0B0b0b0B0b0b0b0b0b0B0b0b0b0b0B0B0B0b0B0b0b0b0b0B0B0B0B0B0B0b-001",
+              "validator_public_key": "01197f6b23e16C8532c6ABC838fAcD5eA789be0c76b2920334039bfa8b3d368D61",
+              "unbonder_public_key": "0202Bb58B5FEcA505C74EDC000d8282fc556E51a1024fc8E7D7E56C6F887C5c8d5f2",
+              "era_of_creation": 42,
+              "amount": "50000000000"
+            }
+          ]
+        }
+      }
+    ],
+    "output": "0a020000000a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d6101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61290000000000000005005847f80d0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610202bb58b5feca505c74edc000d8282fc556e51a1024fc8e7d7e56c6f887c5c8d5f22a000000000000000500743ba40b"
+  },
+  "WriteUnbonding": {
+    "input": [
+      {
+        "type": "Transform",
+        "value": {
+          "WriteUnbonding": [
+            {
+              "bonding_purse": "uref-0A0a0a0a0A0a0a0a0a0a0A0a0A0A0a0a0A0A0A0A0A0a0a0A0a0A0a0a0a0A0A0a-001",
+              "validator_public_key": "01197f6b23e16C8532c6ABC838fAcD5eA789be0c76b2920334039bfa8b3d368D61",
+              "unbonder_public_key": "01197f6b23e16C8532c6ABC838fAcD5eA789be0c76b2920334039bfa8b3d368D61",
+              "era_of_creation": 41,
               "amount": "60000000000",
               "new_validator": null
             },
@@ -262,6 +288,6 @@
         }
       }
     ],
-    "output": "0a020000000a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d6101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61290000000000000005005847f80d000b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610202bb58b5feca505c74edc000d8282fc556e51a1024fc8e7d7e56c6f887c5c8d5f22a000000000000000500743ba40b00"
+    "output": "12020000000a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d6101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61290000000000000005005847f80d000b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0101197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d610202bb58b5feca505c74edc000d8282fc556e51a1024fc8e7d7e56c6f887c5c8d5f22a000000000000000500743ba40b00"
   }
 }


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/casper-network/casper-node/pull/2777, because https://github.com/casper-network/casper-node/pull/2777 should only be merged after 1.5 is released.

It also includes the new `WriteUnbonding` execution transform.

Closes #3583 