### PR TITLE
Notify consensus of previously executed blocks in restart scenarios

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1571,6 +1571,27 @@ impl Storage {
             .transpose()
     }
 
+    /// Retrieves a single complete block header by height by looking it up in
+    /// the index and returning it.
+    pub fn read_complete_block_header_by_height(
+        &self,
+        height: u64,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let mut txn = self.env.begin_ro_txn()?;
+        let res = self
+            .block_height_index
+            .get(&height)
+            .and_then(|block_hash| {
+                self.get_single_block_header(&mut txn, block_hash)
+                    .transpose()
+            })
+            .transpose();
+        if !(self.should_return_block(height, true)?) {
+            return Ok(None);
+        }
+        res
+    }
+
     /// Retrieves a single block header by hash.
     pub fn read_block_header(
         &self,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1603,8 +1603,8 @@ impl Storage {
             .transpose()
     }
 
-    /// Retrieves a single complete block header by height by looking it up in
-    /// the index and returning it.
+    /// Retrieves a single block header by height from the available block
+    /// range by looking it up in the index and returning it.
     pub fn read_complete_block_header_by_height(
         &self,
         height: u64,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1621,12 +1621,11 @@ impl Storage {
         if !(self.should_return_block(height, true)?) {
             return Ok(None);
         }
-        if self
+        if !self
             .completed_blocks
             .sequences()
             .iter()
-            .find(|sequence| sequence.low() <= height && height <= sequence.high())
-            .is_none()
+            .any(|sequence| sequence.low() <= height && height <= sequence.high())
         {
             return Ok(None);
         }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1621,6 +1621,15 @@ impl Storage {
         if !(self.should_return_block(height, true)?) {
             return Ok(None);
         }
+        if self
+            .completed_blocks
+            .sequences()
+            .iter()
+            .find(|sequence| sequence.low() <= height && height <= sequence.high())
+            .is_none()
+        {
+            return Ok(None);
+        }
         res
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1621,14 +1621,6 @@ impl Storage {
         if !(self.should_return_block(height, true)?) {
             return Ok(None);
         }
-        if !self
-            .completed_blocks
-            .sequences()
-            .iter()
-            .any(|sequence| sequence.low() <= height && height <= sequence.high())
-        {
-            return Ok(None);
-        }
         res
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -170,8 +170,9 @@ use requests::{
     UpgradeWatcherRequest,
 };
 
-use self::requests::{
-    ContractRuntimeRequest, DeployBufferRequest, MetricsRequest, SetNodeStopRequest,
+use self::{
+    announcements::UnexecutedBlockAnnouncement,
+    requests::{ContractRuntimeRequest, DeployBufferRequest, MetricsRequest, SetNodeStopRequest},
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
@@ -1754,6 +1755,20 @@ impl<REv> EffectBuilder<REv> {
     {
         self.event_queue
             .schedule(MetaBlockAnnouncement(meta_block), QueueKind::Regular)
+            .await
+    }
+
+    /// Announces that a finalized block has been created, but it was not
+    /// executed.
+    pub(crate) async fn announce_unexecuted_block(self, block_height: u64)
+    where
+        REv: From<UnexecutedBlockAnnouncement>,
+    {
+        self.event_queue
+            .schedule(
+                UnexecutedBlockAnnouncement(block_height),
+                QueueKind::Regular,
+            )
             .await
     }
 

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -130,6 +130,19 @@ impl Display for MetaBlockAnnouncement {
     }
 }
 
+#[derive(DataSize, Serialize, Debug)]
+pub(crate) struct UnexecutedBlockAnnouncement(pub(crate) u64);
+
+impl Display for UnexecutedBlockAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "announcement for unexecuted finalized block at height {}",
+            self.0,
+        )
+    }
+}
+
 /// Queue dump format with handler.
 #[derive(Serialize)]
 pub(crate) enum QueueDumpFormat {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -475,11 +475,10 @@ impl reactor::Reactor for MainReactor {
                     // era by enqueuing all finalized blocks starting from the
                     // first one in that era, blocks which should have already
                     // been executed and marked complete in storage.
-                    warn!(
-                        "Finalized block with height {} enqueued for execution, \
-                        but a complete block header with the same height is \
-                        not present in storage.",
-                        block_height
+                    error!(
+                        block_height,
+                        "Finalized block enqueued for execution, but a complete \
+                        block header with the same height is not present in storage."
                     );
                     Effects::new()
                 }

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -19,7 +19,8 @@ use crate::{
             BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
             ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
             FatalAnnouncement, GossiperAnnouncement, MetaBlockAnnouncement,
-            PeerBehaviorAnnouncement, RpcServerAnnouncement, UpgradeWatcherAnnouncement,
+            PeerBehaviorAnnouncement, RpcServerAnnouncement, UnexecutedBlockAnnouncement,
+            UpgradeWatcherAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
@@ -226,6 +227,8 @@ pub(crate) enum MainEvent {
     MainReactorRequest(ReactorStatusRequest),
     #[from]
     MetaBlockAnnouncement(MetaBlockAnnouncement),
+    #[from]
+    UnexecutedBlockAnnouncement(UnexecutedBlockAnnouncement),
 
     // Event related to figuring out validators for immediate switch blocks.
     GotImmediateSwitchBlockEraValidators(EraId, EraValidators, EraValidators),
@@ -336,6 +339,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::MainReactorRequest(_) => "MainReactorRequest",
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
             MainEvent::MetaBlockAnnouncement(_) => "MetaBlockAnnouncement",
+            MainEvent::UnexecutedBlockAnnouncement(_) => "UnexecutedBlockAnnouncement",
             MainEvent::GotImmediateSwitchBlockEraValidators(_, _, _) => {
                 "GotImmediateSwitchBlockEraValidators"
             }
@@ -513,6 +517,7 @@ impl Display for MainEvent {
             MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),
             MainEvent::MetaBlockAnnouncement(inner) => Display::fmt(inner, f),
+            MainEvent::UnexecutedBlockAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::GotImmediateSwitchBlockEraValidators(era_id, _, _) => {
                 write!(
                     f,


### PR DESCRIPTION
Fixes #3618

This PR adds a new announcement for finalized blocks enqueued for execution, but which contract runtime will not execute because their height is lower than the next expected executable height. In this scenario, contract runtime will raise this announcement which will be handled by the reactor. If there is a complete block in storage with that same height, it means the block can be safely considered executed and the reactor raises an event letting consensus know that the finalized block it had enqueued was handled, the same way it would happen if the block was executed. Consensus is oblivious to the fact that execution didn't take place.

We do this to ensure the smooth operation of the consensus validating process in the case of a restart in the middle of an era, where the restarted node couldn't make any consensus proposals until all the previous blocks in the era along with their vertices were "executed".
