### PR TITLE
Harden gossiper against malicious messages

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `strict_argument_checking` to the chainspec to enable strict args checking when executing a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
 * A diagnostics port can now be enabled via the `[diagnostics_port]` config section. See the `README.md` for details.
 * Add `SIGUSR2` signal handling to dump the queue in JSON format (see "Changed" section for `SIGUSR1`).
+* Add `validate_and_store_timeout` config option under `[gossip]` section to control the time the gossiper waits for another component to validate and store an item received via gossip.
 * Add metrics:
   * `block_accumulator_block_acceptors`, `block_accumulator_known_child_blocks` to report status of the block accumulator component
   * `(forward|historical)_block_sync_duration_seconds` to report the progress of block synchronization

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -44,8 +44,6 @@ pub(crate) use tag::Tag;
 pub(crate) type FetchResult<T> = Result<FetchedData<T>, Error<T>>;
 pub(crate) type FetchResponder<T> = Responder<FetchResult<T>>;
 
-const COMPONENT_NAME: &str = "fetcher";
-
 /// The component which fetches an item from local storage or asks a peer if it's not in storage.
 #[derive(DataSize, Debug)]
 pub(crate) struct Fetcher<T>
@@ -55,18 +53,21 @@ where
     get_from_peer_timeout: Duration,
     item_handles: HashMap<T::Id, HashMap<NodeId, ItemHandle<T>>>,
     #[data_size(skip)]
+    name: &'static str,
+    #[data_size(skip)]
     metrics: Metrics,
 }
 
 impl<T: FetchItem> Fetcher<T> {
     pub(crate) fn new(
-        name: &str,
+        name: &'static str,
         config: &Config,
         registry: &Registry,
     ) -> Result<Self, prometheus::Error> {
         Ok(Fetcher {
             get_from_peer_timeout: config.get_from_peer_timeout().into(),
             item_handles: HashMap::new(),
+            name,
             metrics: Metrics::new(name, registry)?,
         })
     }
@@ -142,6 +143,6 @@ where
     }
 
     fn name(&self) -> &str {
-        COMPONENT_NAME
+        self.name
     }
 }

--- a/node/src/components/gossiper/config.rs
+++ b/node/src/components/gossiper/config.rs
@@ -18,12 +18,15 @@ pub(super) const MAX_SATURATION_LIMIT_PERCENT: u8 = 99;
 pub(super) const DEFAULT_FINISHED_ENTRY_DURATION: &str = "60sec";
 const DEFAULT_GOSSIP_REQUEST_TIMEOUT: &str = "10sec";
 const DEFAULT_GET_REMAINDER_TIMEOUT: &str = "60sec";
+const DEFAULT_VALIDATE_AND_STORE_TIMEOUT: &str = "60sec";
 #[cfg(test)]
 const SMALL_TIMEOUTS_FINISHED_ENTRY_DURATION: &str = "2sec";
 #[cfg(test)]
 const SMALL_TIMEOUTS_GOSSIP_REQUEST_TIMEOUT: &str = "1sec";
 #[cfg(test)]
 const SMALL_TIMEOUTS_GET_REMAINDER_TIMEOUT: &str = "1sec";
+#[cfg(test)]
+const SMALL_TIMEOUTS_VALIDATE_AND_STORE_TIMEOUT: &str = "1sec";
 
 /// Configuration options for gossiping.
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -50,6 +53,9 @@ pub struct Config {
     /// The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered
     /// data from a peer which gossiped information about that data to this node.
     get_remainder_timeout: TimeDiff,
+    /// The timeout duration for a newly-received, gossiped item to be validated and stored by
+    /// another component before the gossiper abandons waiting to gossip the item onwards.
+    validate_and_store_timeout: TimeDiff,
 }
 
 impl Config {
@@ -60,6 +66,7 @@ impl Config {
         finished_entry_duration: TimeDiff,
         gossip_request_timeout: TimeDiff,
         get_remainder_timeout: TimeDiff,
+        validate_and_store_timeout: TimeDiff,
     ) -> Result<Self, Error> {
         if saturation_limit_percent > MAX_SATURATION_LIMIT_PERCENT {
             return Err(Error::InvalidSaturationLimit);
@@ -70,6 +77,7 @@ impl Config {
             finished_entry_duration,
             gossip_request_timeout,
             get_remainder_timeout,
+            validate_and_store_timeout,
         })
     }
 
@@ -82,6 +90,10 @@ impl Config {
                 .unwrap(),
             get_remainder_timeout: TimeDiff::from_str(SMALL_TIMEOUTS_GET_REMAINDER_TIMEOUT)
                 .unwrap(),
+            validate_and_store_timeout: TimeDiff::from_str(
+                SMALL_TIMEOUTS_VALIDATE_AND_STORE_TIMEOUT,
+            )
+            .unwrap(),
             ..Default::default()
         }
     }
@@ -105,6 +117,10 @@ impl Config {
     pub(crate) fn get_remainder_timeout(&self) -> TimeDiff {
         self.get_remainder_timeout
     }
+
+    pub(crate) fn validate_and_store_timeout(&self) -> TimeDiff {
+        self.validate_and_store_timeout
+    }
 }
 
 impl Default for Config {
@@ -115,6 +131,8 @@ impl Default for Config {
             finished_entry_duration: TimeDiff::from_str(DEFAULT_FINISHED_ENTRY_DURATION).unwrap(),
             gossip_request_timeout: TimeDiff::from_str(DEFAULT_GOSSIP_REQUEST_TIMEOUT).unwrap(),
             get_remainder_timeout: TimeDiff::from_str(DEFAULT_GET_REMAINDER_TIMEOUT).unwrap(),
+            validate_and_store_timeout: TimeDiff::from_str(DEFAULT_VALIDATE_AND_STORE_TIMEOUT)
+                .unwrap(),
         }
     }
 }
@@ -152,6 +170,8 @@ mod tests {
             finished_entry_duration: TimeDiff::from_str(DEFAULT_FINISHED_ENTRY_DURATION).unwrap(),
             gossip_request_timeout: TimeDiff::from_str(DEFAULT_GOSSIP_REQUEST_TIMEOUT).unwrap(),
             get_remainder_timeout: TimeDiff::from_str(DEFAULT_GET_REMAINDER_TIMEOUT).unwrap(),
+            validate_and_store_timeout: TimeDiff::from_str(DEFAULT_VALIDATE_AND_STORE_TIMEOUT)
+                .unwrap(),
         };
 
         // Parsing should fail.
@@ -165,6 +185,7 @@ mod tests {
             TimeDiff::from_str(DEFAULT_FINISHED_ENTRY_DURATION).unwrap(),
             TimeDiff::from_str(DEFAULT_GOSSIP_REQUEST_TIMEOUT).unwrap(),
             TimeDiff::from_str(DEFAULT_GET_REMAINDER_TIMEOUT).unwrap(),
+            TimeDiff::from_str(DEFAULT_VALIDATE_AND_STORE_TIMEOUT).unwrap()
         )
         .is_err())
     }

--- a/node/src/components/gossiper/item_provider.rs
+++ b/node/src/components/gossiper/item_provider.rs
@@ -1,13 +1,17 @@
-use super::{Event, GossipItem};
-use crate::{
-    effect::{requests::StorageRequest, EffectBuilder, Effects},
-    types::NodeId,
-};
+use async_trait::async_trait;
 
+use super::GossipItem;
+use crate::effect::{requests::StorageRequest, EffectBuilder};
+
+#[async_trait]
 pub(super) trait ItemProvider<T: GossipItem> {
-    fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn is_stored<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: T::Id,
-        requester: NodeId,
-    ) -> Effects<Event<T>>;
+    ) -> bool;
+
+    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+        effect_builder: EffectBuilder<REv>,
+        item_id: T::Id,
+    ) -> Option<T>;
 }

--- a/node/src/components/gossiper/provider_impls/address_provider.rs
+++ b/node/src/components/gossiper/provider_impls/address_provider.rs
@@ -1,20 +1,31 @@
+use async_trait::async_trait;
+use tracing::error;
+
 use crate::{
     components::{
-        gossiper::{Event, GossipItem, Gossiper, ItemProvider},
+        gossiper::{GossipItem, Gossiper, ItemProvider},
         network::GossipedAddress,
     },
-    effect::{EffectBuilder, Effects},
-    types::NodeId,
+    effect::EffectBuilder,
 };
 
+#[async_trait]
 impl ItemProvider<GossipedAddress>
     for Gossiper<{ GossipedAddress::ID_IS_COMPLETE_ITEM }, GossipedAddress>
 {
-    fn get_from_storage<REv>(
+    async fn is_stored<REv: Send>(
         _effect_builder: EffectBuilder<REv>,
         item_id: GossipedAddress,
-        _requester: NodeId,
-    ) -> Effects<Event<GossipedAddress>> {
-        panic!("address gossiper should never try to get {}", item_id)
+    ) -> bool {
+        error!(%item_id, "address gossiper should never try to check if item is stored");
+        false
+    }
+
+    async fn get_from_storage<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        item_id: GossipedAddress,
+    ) -> Option<GossipedAddress> {
+        error!(%item_id, "address gossiper should never try to get from storage");
+        None
     }
 }

--- a/node/src/components/gossiper/provider_impls/block_provider.rs
+++ b/node/src/components/gossiper/provider_impls/block_provider.rs
@@ -1,24 +1,24 @@
+use async_trait::async_trait;
+
 use crate::{
-    components::gossiper::{Event, GossipItem, Gossiper, ItemProvider},
-    effect::{requests::StorageRequest, EffectBuilder, EffectExt, Effects},
-    types::{Block, BlockHash, NodeId},
+    components::gossiper::{GossipItem, Gossiper, ItemProvider},
+    effect::{requests::StorageRequest, EffectBuilder},
+    types::{Block, BlockHash},
 };
 
+#[async_trait]
 impl ItemProvider<Block> for Gossiper<{ Block::ID_IS_COMPLETE_ITEM }, Block> {
-    fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn is_stored<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: BlockHash,
-        requester: NodeId,
-    ) -> Effects<Event<Block>> {
-        effect_builder
-            .get_block_from_storage(item_id)
-            .event(move |results| {
-                let result = results.ok_or_else(|| String::from("block not found"));
-                Event::GetFromStorageResult {
-                    item_id,
-                    requester,
-                    result: Box::new(result),
-                }
-            })
+    ) -> bool {
+        effect_builder.is_block_stored(item_id).await
+    }
+
+    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+        effect_builder: EffectBuilder<REv>,
+        item_id: BlockHash,
+    ) -> Option<Block> {
+        effect_builder.get_block_from_storage(item_id).await
     }
 }

--- a/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
+++ b/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
@@ -1,26 +1,30 @@
+use async_trait::async_trait;
+
 use crate::{
-    components::gossiper::{Event, GossipItem, Gossiper, ItemProvider},
-    effect::{requests::StorageRequest, EffectBuilder, EffectExt, Effects},
-    types::{FinalitySignature, FinalitySignatureId, NodeId},
+    components::gossiper::{GossipItem, Gossiper, ItemProvider},
+    effect::{requests::StorageRequest, EffectBuilder},
+    types::{FinalitySignature, FinalitySignatureId},
 };
 
+#[async_trait]
 impl ItemProvider<FinalitySignature>
     for Gossiper<{ FinalitySignature::ID_IS_COMPLETE_ITEM }, FinalitySignature>
 {
-    fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn is_stored<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: FinalitySignatureId,
-        requester: NodeId,
-    ) -> Effects<Event<FinalitySignature>> {
+    ) -> bool {
+        effect_builder
+            .is_finality_signature_stored(item_id.clone())
+            .await
+    }
+
+    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+        effect_builder: EffectBuilder<REv>,
+        item_id: FinalitySignatureId,
+    ) -> Option<FinalitySignature> {
         effect_builder
             .get_finality_signature_from_storage(item_id.clone())
-            .event(move |results| {
-                let result = results.ok_or_else(|| String::from("finality signature not found"));
-                Event::GetFromStorageResult {
-                    item_id,
-                    requester,
-                    result: Box::new(result),
-                }
-            })
+            .await
     }
 }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -454,13 +454,13 @@ where
         // todo!() - consider sampling more validators (for example: 10%, but not fewer than 5)
 
         if peer_ids.len() != count {
-            let connected = self.outgoing_manager.connected_peers().count();
             let not_excluded = self
                 .outgoing_manager
                 .connected_peers()
                 .filter(|peer_id| !exclude.contains(peer_id))
                 .count();
             if not_excluded > 0 {
+                let connected = self.outgoing_manager.connected_peers().count();
                 debug!(
                     our_id=%self.context.our_id(),
                     %gossip_target,
@@ -1549,6 +1549,20 @@ mod gossip_target_tests {
             fixture.num_non_validators(chosen.iter()),
             VALIDATOR_COUNT - 1
         );
+        assert!(exclude.is_disjoint(&chosen));
+
+        // Choose 3 from all peers, exclude all non-validators, should return 3 validators.
+        let exclude: HashSet<_> = fixture.non_validators.iter().copied().collect();
+        let chosen = choose_gossip_peers(
+            &mut rng,
+            TARGET,
+            3,
+            exclude.clone(),
+            fixture.all_peers.iter().copied(),
+            fixture.is_validator_in_era(),
+        );
+        assert_eq!(chosen.len(), 3);
+        assert_eq!(fixture.num_validators(chosen.iter()), 3);
         assert!(exclude.is_disjoint(&chosen));
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1127,6 +1127,20 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    pub(crate) async fn is_block_stored(self, block_hash: BlockHash) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::IsBlockStored {
+                block_hash,
+                responder,
+            },
+            QueueKind::FromStorage,
+        )
+        .await
+    }
+
     /// Gets the requested `ApprovalsHashes` from storage.
     pub(crate) async fn get_approvals_hashes_from_storage(
         self,
@@ -1512,6 +1526,20 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    pub(crate) async fn is_deploy_stored(self, deploy_id: DeployId) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::IsDeployStored {
+                deploy_id,
+                responder,
+            },
+            QueueKind::FromStorage,
+        )
+        .await
+    }
+
     /// Stores the given execution results for the deploys in the given block in the linear block
     /// store.
     pub(crate) async fn put_execution_results_to_storage(
@@ -1580,6 +1608,20 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| StorageRequest::GetFinalitySignature {
+                id: Box::new(id),
+                responder,
+            },
+            QueueKind::FromStorage,
+        )
+        .await
+    }
+
+    pub(crate) async fn is_finality_signature_stored(self, id: FinalitySignatureId) -> bool
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::IsFinalitySignatureStored {
                 id: Box::new(id),
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -295,6 +295,10 @@ pub(crate) enum StorageRequest {
         /// storage.
         responder: Responder<Option<Block>>,
     },
+    IsBlockStored {
+        block_hash: BlockHash,
+        responder: Responder<bool>,
+    },
     /// Retrieve the approvals hashes.
     GetApprovalsHashes {
         /// Hash of the block for which to retrieve approvals hashes.
@@ -374,6 +378,10 @@ pub(crate) enum StorageRequest {
         deploy_id: DeployId,
         responder: Responder<Option<Deploy>>,
     },
+    IsDeployStored {
+        deploy_id: DeployId,
+        responder: Responder<bool>,
+    },
     /// Store execution results for a set of deploys of a single block.
     ///
     /// Will return a fatal error if there are already execution results known for a specific
@@ -421,6 +429,10 @@ pub(crate) enum StorageRequest {
     GetFinalitySignature {
         id: Box<FinalitySignatureId>,
         responder: Responder<Option<FinalitySignature>>,
+    },
+    IsFinalitySignatureStored {
+        id: Box<FinalitySignatureId>,
+        responder: Responder<bool>,
     },
     /// Retrieve block and its metadata at a given height.
     GetBlockAndMetadataByHeight {
@@ -496,6 +508,9 @@ impl Display for StorageRequest {
             StorageRequest::GetBlock { block_hash, .. } => {
                 write!(formatter, "get block {}", block_hash)
             }
+            StorageRequest::IsBlockStored { block_hash, .. } => {
+                write!(formatter, "is block {} stored", block_hash)
+            }
             StorageRequest::GetApprovalsHashes { block_hash, .. } => {
                 write!(formatter, "get approvals hashes {}", block_hash)
             }
@@ -527,6 +542,9 @@ impl Display for StorageRequest {
             StorageRequest::GetDeploy { deploy_id, .. } => {
                 write!(formatter, "get deploy {}", deploy_id)
             }
+            StorageRequest::IsDeployStored { deploy_id, .. } => {
+                write!(formatter, "is deploy {} stored", deploy_id)
+            }
             StorageRequest::PutExecutionResults { block_hash, .. } => {
                 write!(formatter, "put execution results for {}", block_hash)
             }
@@ -542,6 +560,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetFinalitySignature { id, .. } => {
                 write!(formatter, "get finality signature {}", id)
+            }
+            StorageRequest::IsFinalitySignatureStored { id, .. } => {
+                write!(formatter, "is finality signature {} stored", id)
             }
             StorageRequest::GetBlockAndMetadataByHash { block_hash, .. } => {
                 write!(

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -34,11 +34,17 @@ impl<REv> ReactorEventT for REv where
 }
 
 #[derive(Debug)]
-pub struct FakeDeployAcceptor;
+pub struct FakeDeployAcceptor {
+    is_active: bool,
+}
 
 impl FakeDeployAcceptor {
     pub(crate) fn new() -> Self {
-        FakeDeployAcceptor
+        FakeDeployAcceptor { is_active: true }
+    }
+
+    pub(crate) fn set_active(&mut self, new_setting: bool) {
+        self.is_active = new_setting;
     }
 
     fn accept<REv: ReactorEventT>(
@@ -95,6 +101,10 @@ impl<REv: ReactorEventT> Component<REv> for FakeDeployAcceptor {
         _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
+        if !self.is_active {
+            debug!(?event, "FakeDeployAcceptor: not active - ignoring event");
+            return Effects::new();
+        }
         debug!(?event, "FakeDeployAcceptor: handling event");
         match event {
             Event::Accept {

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -166,7 +166,7 @@ where
     }
 
     /// Crank the specified runner once.
-    async fn crank(&mut self, node_id: &NodeId, rng: &mut TestRng) -> TryCrankOutcome {
+    pub(crate) async fn crank(&mut self, node_id: &NodeId, rng: &mut TestRng) -> TryCrankOutcome {
         let runner = self.nodes.get_mut(node_id).expect("should find node");
         let node_id = runner.reactor().node_id();
         runner
@@ -250,6 +250,69 @@ where
         }
 
         event_count
+    }
+
+    /// Crank all runners until `condition` is true on the specified runner or until `within` has
+    /// elapsed.
+    ///
+    /// Returns `true` if `condition` has been met within the specified timeout.
+    ///
+    /// Panics if cranking causes the node to return an exit code.
+    pub(crate) async fn crank_all_until<F>(
+        &mut self,
+        node_id: &NodeId,
+        rng: &mut TestRng,
+        condition: F,
+        within: Duration,
+    ) where
+        F: Fn(&R::Event) -> bool + Send + 'static,
+    {
+        self.nodes
+            .get_mut(node_id)
+            .unwrap()
+            .reactor_mut()
+            .set_condition_checker(Box::new(condition));
+
+        time::timeout(within, self.crank_and_check_all_indefinitely(node_id, rng))
+            .await
+            .unwrap()
+    }
+
+    async fn crank_and_check_all_indefinitely(
+        &mut self,
+        node_to_check: &NodeId,
+        rng: &mut TestRng,
+    ) {
+        loop {
+            let mut no_events = true;
+            for node in self.nodes.values_mut() {
+                let node_id = node.reactor().node_id();
+                match node
+                    .try_crank(rng)
+                    .instrument(error_span!("crank", node_id = %node_id))
+                    .await
+                {
+                    TryCrankOutcome::NoEventsToProcess => (),
+                    TryCrankOutcome::ProcessedAnEvent => {
+                        no_events = false;
+                    }
+                    TryCrankOutcome::ShouldExit(exit_code) => {
+                        panic!("should not exit: {:?}", exit_code)
+                    }
+                    TryCrankOutcome::Exited => unreachable!(),
+                }
+                if node_id == *node_to_check && node.reactor().condition_result() {
+                    debug!("{} met condition", node_to_check);
+                    return;
+                }
+            }
+
+            if no_events {
+                Instant::advance_time(POLL_INTERVAL.as_millis() as u64);
+                time::sleep(POLL_INTERVAL).await;
+                continue;
+            }
+        }
     }
 
     /// Process events on all nodes until all event queues are empty for at least `quiet_for`.
@@ -382,6 +445,11 @@ where
     /// Returns the internal map of nodes.
     pub(crate) fn nodes(&self) -> &HashMap<NodeId, Runner<ConditionCheckReactor<R>>> {
         &self.nodes
+    }
+
+    /// Returns the internal map of nodes, mutable.
+    pub(crate) fn nodes_mut(&mut self) -> &mut HashMap<NodeId, Runner<ConditionCheckReactor<R>>> {
+        &mut self.nodes
     }
 
     /// Returns an iterator over all runners, mutable.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1251,6 +1251,10 @@ impl BlockSignatures {
         })
     }
 
+    pub(crate) fn has_finality_signature(&self, public_key: &PublicKey) -> bool {
+        self.proofs.contains_key(public_key)
+    }
+
     pub(crate) fn finality_signatures(&self) -> impl Iterator<Item = FinalitySignature> + '_ {
         self.proofs.iter().map(move |(public_key, signature)| {
             FinalitySignature::new(self.block_hash, self.era_id, *signature, public_key.clone())

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -415,7 +415,7 @@ saturation_limit_percent = 80
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration = '60sec'
+finished_entry_duration = '1min'
 
 # The timeout duration for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is
@@ -425,6 +425,10 @@ gossip_request_timeout = '10sec'
 # The timeout duration for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
 get_remainder_timeout = '5sec'
+
+# The timeout duration for a newly-received, gossiped item to be validated and stored by another
+# component before the gossiper abandons waiting to gossip the item onwards.
+validate_and_store_timeout = '1min'
 
 
 # ===============================================
@@ -436,7 +440,7 @@ get_remainder_timeout = '5sec'
 attempt_execution_threshold = 3
 
 # Accepted time interval for inactivity in block accumulator.
-dead_air_interval = '180sec'
+dead_air_interval = '3min'
 
 # Time after which the block acceptors are considered old and can be purged.
 purge_interval = '1min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -415,7 +415,7 @@ saturation_limit_percent = 80
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration = '60sec'
+finished_entry_duration = '1min'
 
 # The timeout duration for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is
@@ -425,6 +425,10 @@ gossip_request_timeout = '30sec'
 # The timeout duration for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
 get_remainder_timeout = '5sec'
+
+# The timeout duration for a newly-received, gossiped item to be validated and stored by another
+# component before the gossiper abandons waiting to gossip the item onwards.
+validate_and_store_timeout = '1min'
 
 
 # ===============================================
@@ -436,7 +440,7 @@ get_remainder_timeout = '5sec'
 attempt_execution_threshold = 3
 
 # Accepted time interval for inactivity in block accumulator.
-dead_air_interval = '180sec'
+dead_air_interval = '3min'
 
 # Time after which the block acceptors are considered old and can be purged.
 purge_interval = '1min'


### PR DESCRIPTION
This PR provides basic protection against wasting resources when receiving unexpected gossiper messages.

For an new incoming `Message::Gossip`, no action will be taken if the given item is not already being handled by the gossiper and if the item is already held in storage other than sending a `Message::GossipResponse`.  Potentially even sending the response could be omitted, but this might be overkill given how cheap that is to send and considering that the sender might not be malicious.

For all other incoming message variants, if the given item is not already being handled by the gossiper then no action is taken.

Additionally, there is now a timeout associated with handling a `Message::Item`.  The expectation in this flow is that after making the item body announcement (i.e. after calling `EffectBuilder::announce_item_body_received_via_gossip()`) then some other component will handle validating and storing the item, and will then re-engage the gossiper by creating an `ItemReceived` event.  However, if validation or storing fails, then the gossiper is not notified.  This new timeout ensures that in such a case the entry in the gossip table is force-finished and will subsequently be purged.

Closes #3572.