### PR TITLE
Fix sync to genesis after upgrade from 1.4.x to 1.5

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1869,7 +1869,7 @@ impl Storage {
                 };
 
             result.push(parent_block_header.clone());
-            if parent_block_header.is_switch_block() {
+            if parent_block_header.is_switch_block() || parent_block_header.is_genesis() {
                 break;
             }
             current_trusted_block_header = parent_block_header;

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -670,24 +670,24 @@ impl MainReactor {
                     }
                     Ok(None) => {
                         debug!(%parent_hash, "historical: did not find block header in storage");
-                        let maybe_sync_era = if block_header.era_id() == EraId::from(0) {
+                        let era_id = if block_header.era_id() == EraId::from(0) {
                             // if the block is in era 0 its parent can only be in era 0
-                            Some(EraId::from(0))
+                            EraId::from(0)
                         } else {
                             // we do not have the parent header and thus don't know what era
                             // the parent block is in (it could be the same era or the previous
                             // era). we assume the worst case and ask
-                            // for the earlier era's proof
-                            block_header.era_id().predecessor()
+                            // for the earlier era's proof;
+                            // subtracting 1 here is safe since the case where era id is 0 is
+                            // handled above
+                            block_header.era_id().saturating_sub(1)
                         };
 
-                        maybe_sync_era.map_or(Ok(None), |era_id| {
-                            Ok(Some(SyncBackInstruction::Sync {
-                                parent_hash: *parent_hash,
-                                maybe_parent_metadata: None,
-                                era_id,
-                            }))
-                        })
+                        Ok(Some(SyncBackInstruction::Sync {
+                            parent_hash: *parent_hash,
+                            maybe_parent_metadata: None,
+                            era_id,
+                        }))
                     }
                     Err(err) => Err(err.to_string()),
                 }

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -41,7 +41,9 @@ pub(crate) enum SyncLeapValidationError {
     TrustedAncestorsNotSorted,
     #[error("Last trusted ancestor is not a switch block.")]
     MissingAncestorSwitchBlock,
-    #[error("Only the last trusted ancestor is allowed to be a switch block.")]
+    #[error(
+        "Only the last trusted ancestor is allowed to be a switch block or the genesis block."
+    )]
     UnexpectedAncestorSwitchBlock,
     #[error("Signed block headers present despite trusted_ancestor_only flag.")]
     UnexpectedSignedBlockHeaders,
@@ -222,7 +224,7 @@ impl FetchItem for SyncLeap {
         }
         let mut trusted_ancestor_iter = self.trusted_ancestor_headers.iter().rev();
         if let Some(last_ancestor) = trusted_ancestor_iter.next() {
-            if !last_ancestor.is_switch_block() {
+            if !last_ancestor.is_switch_block() && !last_ancestor.is_genesis() {
                 return Err(SyncLeapValidationError::MissingAncestorSwitchBlock);
             }
         }

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -10,6 +10,7 @@ use datasize::DataSize;
 use itertools::Itertools;
 use num_rational::Ratio;
 use serde::Serialize;
+use tracing::debug;
 
 use casper_types::{EraId, PublicKey, SecretKey, U512};
 
@@ -109,6 +110,7 @@ impl ValidatorMatrix {
                 validators.validator_weights,
                 validators.finality_threshold_fraction,
             ));
+            debug!("Validator Matrix: Inferred validator weights for Era 0 from weights in Era 1");
         }
         was_present
     }

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -303,22 +303,9 @@ function _step_08()
     done
 
     log "Waiting for all nodes to sync to genesis"
-    TIMEOUT=300
     for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
     do
-        log "Waiting for node $NODE_ID to sync to genesis (timeout=$TIMEOUT sec)"
-        RETRY_COUNT=1
-        LOWEST_AVAILABLE_BLOCK=$(get_node_lowest_available_block "$NODE_ID")
-        while [ -z "$LOWEST_AVAILABLE_BLOCK" ] || [ "$LOWEST_AVAILABLE_BLOCK" -ne 0 ]; do
-            if [ "$RETRY_COUNT" -gt $TIMEOUT ]; then
-                log "ERROR :: NODE-$NODE_ID RETRY :: Failed to sync to genesis within $TIMEOUT seconds; lowest available block $LOWEST_AVAILABLE_BLOCK"
-                exit 1
-            else
-                LOWEST_AVAILABLE_BLOCK=$(get_node_lowest_available_block "$NODE_ID")
-                sleep 1
-                ((RETRY_COUNT=RETRY_COUNT+1))
-            fi
-        done
+        await_node_historical_sync_to_genesis "$NODE_ID" "300"
     done
 }
 

--- a/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test.sh
@@ -52,7 +52,7 @@ function main() {
     # 13. Reset node 1 to sync from scratch.
     do_reset_node_1
     # 14. Wait until node 1 syncs back to genesis.
-    do_await_node_1_historical_sync
+    await_node_historical_sync_to_genesis '1' "$SYNC_TIMEOUT_SEC"
     # 15. Run Health Checks
     # ... restarts=16: due to nodes being stopped and started; node 1 3 times, nodes 2-5 2 times,
     # ................ node 6-10 1 time
@@ -195,24 +195,6 @@ function do_reset_node_1() {
     # use node 7 for the latest block hash
     TRUSTED_HASH=$(get_chain_latest_block_hash "7")
     do_node_start "1" "$TRUSTED_HASH"
-}
-
-function do_await_node_1_historical_sync() {
-    log_step "awaiting node 1 to do historical sync to genesis"
-    local WAIT_TIME_SEC=0
-    local LOWEST="$(get_node_lowest_available_block '1')"
-    local HIGHEST="$(get_node_highest_available_block '1')"
-    while [[ "$LOWEST" != "0" || "$HIGHEST" == "0" ]]; do
-        log "node 1 lowest available block: $LOWEST, highest available block: $HIGHEST"
-        if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
-            log "ERROR: node 1 failed to do historical sync in ${SYNC_TIMEOUT_SEC} seconds"
-            exit 1
-        fi
-        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
-        sleep 1.0
-        LOWEST="$(get_node_lowest_available_block '1')"
-        HIGHEST="$(get_node_highest_available_block '1')"
-    done
 }
 
 function dispatch_native() {

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -151,3 +151,29 @@ function await_until_block_n()
         sleep 10.0
     done
 }
+
+#######################################
+# Awaits for a node to sync to genesis.
+# Arguments:
+#   Node ordinal identifier.
+#######################################
+function await_node_historical_sync_to_genesis() {
+    local NODE_ID=${1}
+    local SYNC_TIMEOUT_SEC=${2}
+
+    log "awaiting node $NODE_ID to do historical sync to genesis"
+    local WAIT_TIME_SEC=0
+    local LOWEST=$(get_node_lowest_available_block "$NODE_ID")
+    local HIGHEST=$(get_node_highest_available_block "$NODE_ID")
+    while [ "$LOWEST" -ne 0 ] || ["$HIGHEST" -eq 0]; do
+        log "node $NODE_ID lowest available block: $LOWEST, highest available block: $HIGHEST"
+        if [ "$WAIT_TIME_SEC" -gt $SYNC_TIMEOUT_SEC ]; then
+            log "ERROR: node 1 failed to do historical sync in ${SYNC_TIMEOUT_SEC} seconds"
+            exit 1
+        fi
+        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
+        sleep 5.0
+        LOWEST=$(get_node_lowest_available_block "$NODE_ID")
+        HIGHEST="$(get_node_highest_available_block "$NODE_ID")"
+    done
+}


### PR DESCRIPTION
* Allow for a sync leap to be returned for era 0 if the it contains the genesis block. Even though the sync leap does not contain a switch block, the block headers will still be included in the response.
* Infer validator weights for era 0 when registering the weights for era 1 since they should be the same given that the weights don't change until the unbonding delay elapsed.
* Change the nctl upgrade test to wait and check that the nodes have synced to genesis.

Fixes: https://github.com/casper-network/casper-node/issues/3631
