### PR TITLE
Fix `upgrade_after_emergency_upgrade_test`

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -570,10 +570,10 @@ impl BlockAcquisitionState {
             }
             BlockAcquisitionState::HaveBlock(block, acquired_signatures, acquired_deploys) => {
                 maybe_block_hash = Some(*block.hash());
-                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 currently_acquiring_sigs = !is_historical
                     && acquired_deploys.needs_deploy().is_none()
                     && acquired_signatures.signature_weight() != SignatureWeight::Strict;
+                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 None
             }
             BlockAcquisitionState::HaveGlobalState(
@@ -588,9 +588,9 @@ impl BlockAcquisitionState {
                 acquired_deploys,
             ) => {
                 maybe_block_hash = Some(*block.hash());
-                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 currently_acquiring_sigs = acquired_deploys.needs_deploy().is_none()
                     && acquired_signatures.signature_weight() != SignatureWeight::Strict;
+                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 None
             }
             BlockAcquisitionState::HaveAllExecutionResults(
@@ -600,17 +600,17 @@ impl BlockAcquisitionState {
                 ..,
             ) => {
                 maybe_block_hash = Some(*block.hash());
-                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 currently_acquiring_sigs = !acquired_signatures.is_checkable()
                     && acquired_deploys.needs_deploy().is_none()
                     && acquired_signatures.signature_weight() != SignatureWeight::Strict;
+                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 None
             }
             BlockAcquisitionState::HaveAllDeploys(block, acquired_signatures) => {
                 maybe_block_hash = Some(*block.hash());
-                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 currently_acquiring_sigs =
                     acquired_signatures.signature_weight() != SignatureWeight::Strict;
+                acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 None
             }
             BlockAcquisitionState::HaveStrictFinalitySignatures(block, acquired_signatures) => {


### PR DESCRIPTION
The acceptance was not reported correctly for a signature that was received in a state where only one signature was missing to achieve strict finality.
This happens because we report it only if we should be currently acquiring signatures. This determination was made however after we applied the new signature, making it appear that we should not have acquired signatures which lead to the acceptance not being reported and the latch not being properly reset. This makes the sinchronizer stall making it impossible to transition to the next state.

Fixed by moving the determination of whether the synchronizer is currently acquiring signatures before the new signature is applied
