### PR TITLE
Have sync leap response composed of only complete blocks' headers

### DIFF
--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -171,7 +171,6 @@ impl Reactor for MockReactor {
 
         let storage = Storage::new(
             &storage_withdir,
-            Ratio::new(1, 3),
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             "test",

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -12,7 +12,6 @@ use futures::{
     channel::oneshot::{self, Sender},
     FutureExt,
 };
-use num_rational::Ratio;
 use prometheus::Registry;
 use reactor::ReactorEvent;
 use serde::Serialize;
@@ -440,7 +439,6 @@ impl reactor::Reactor for Reactor {
 
         let storage = Storage::new(
             &storage_withdir,
-            Ratio::new(1, 3),
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             "test",

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -266,7 +266,6 @@ impl ReactorTrait for Reactor {
 
         let storage = Storage::new(
             &WithDir::new(cfg.temp_dir.path(), cfg.storage_config),
-            chainspec.core_config.finality_threshold_fraction,
             chainspec.hard_reset_to_start_of_era(),
             chainspec.protocol_config.version,
             &chainspec.network_config.name,

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use derive_more::{Display, From};
-use num_rational::Ratio;
 use prometheus::Registry;
 use rand::Rng;
 use reactor::ReactorEvent;
@@ -161,7 +160,6 @@ impl reactor::Reactor for Reactor {
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
         let storage = Storage::new(
             &storage_withdir,
-            Ratio::new(1, 3),
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             "test",

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -102,7 +102,7 @@ pub(crate) use reactor_state::ReactorState;
 ///
 ///     I -->|"❌<br/>Never get<br/>SyncLeap<br/>from storage"| H
 ///     linkStyle 0 fill:none,stroke:red,color:red
-///     
+///
 ///     A -->|"Execute block<br/>(genesis or upgrade)"| B
 ///
 ///     G -->|Peers| C
@@ -233,7 +233,6 @@ impl reactor::Reactor for MainReactor {
         let hard_reset_to_start_of_era = chainspec.hard_reset_to_start_of_era();
         let storage = Storage::new(
             &storage_config,
-            chainspec.core_config.finality_threshold_fraction,
             hard_reset_to_start_of_era,
             protocol_version,
             &chainspec.network_config.name,


### PR DESCRIPTION
This PR changes the way in which a sync leap response is created.

Previously there was an explicit check for sufficient signatures on each block header in the `signed_block_headers`.  This had an issue where validator-changing upgrades were not handled correctly and hence the validator set expected to have signed an immediate switch block might not be the correct one, causing the sync leap response to contain no `signed_block_headers` after or including such an immediate switch block.

Rather than fixing the signature checking, we now use the available block range as an inclusion criterion.  This criterion is now also applied to the `trusted_ancestor_headers` where previously no sufficiency check was done.

Closes #3643.
