### PR TITLE
Remove logging of potentially huge `debug!` messages

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -1010,7 +1010,7 @@ impl BlockSynchronizer {
             }
         };
         debug!(
-            ?maybe_value_or_chunk,
+            has_value_or_chunk = maybe_value_or_chunk.is_some(),
             ?maybe_peer_id,
             "execution_results_fetched"
         );
@@ -1031,6 +1031,10 @@ impl BlockSynchronizer {
                     // to disk here, when the last chunk is collected.
                     // we expect a response back, which will crank the block builder for this block
                     // to the next state.
+                    debug!(
+                        %value_or_chunk,
+                        "execution_results_fetched"
+                    );
                     match builder.register_fetched_execution_results(maybe_peer_id, *value_or_chunk)
                     {
                         Ok(Some(execution_results)) => {

--- a/node/src/components/block_synchronizer/execution_results_acquisition.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::{
     collections::HashMap,
     fmt::{Debug, Display, Formatter},
@@ -199,6 +200,36 @@ pub(super) enum ExecutionResultsAcquisition {
     },
 }
 
+impl Display for ExecutionResultsAcquisition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutionResultsAcquisition::Needed { block_hash } => {
+                write!(f, "Needed: {}", block_hash)
+            }
+            ExecutionResultsAcquisition::Pending {
+                block_hash,
+                checksum: _,
+            } => write!(f, "Pending: {}", block_hash),
+            ExecutionResultsAcquisition::Acquiring {
+                block_hash,
+                checksum: _,
+                chunks: _,
+                chunk_count,
+                next,
+            } => write!(
+                f,
+                "Acquiring: {}, chunk_count={}, next={}",
+                block_hash, chunk_count, next
+            ),
+            ExecutionResultsAcquisition::Complete {
+                block_hash,
+                checksum: _,
+                results: _,
+            } => write!(f, "Complete: {}", block_hash),
+        }
+    }
+}
+
 impl ExecutionResultsAcquisition {
     pub(super) fn needs_value_or_chunk(
         &self,
@@ -248,7 +279,7 @@ impl ExecutionResultsAcquisition {
         let block_hash = *block_execution_results_or_chunk.block_hash();
         let value = block_execution_results_or_chunk.into_value();
 
-        debug!(%block_hash, state=?self, "apply_block_execution_results_or_chunk");
+        debug!(%block_hash, state=%self, "apply_block_execution_results_or_chunk");
 
         let expected_block_hash = self.block_hash();
         if expected_block_hash != block_hash {

--- a/node/src/components/block_synchronizer/execution_results_acquisition.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition.rs
@@ -1,7 +1,6 @@
-use core::fmt;
 use std::{
     collections::HashMap,
-    fmt::{Debug, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
 };
 
 use datasize::DataSize;


### PR DESCRIPTION
This PR removes logging of potentially huge `debug!` messages that may appear if trie chunking is at play.
