### PR TITLE
use scratch trie for commit_upgrade

### DIFF
--- a/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 
 use casper_engine_test_support::{LmdbWasmTestBuilder, UpgradeRequestBuilder};
 use casper_execution_engine::core::engine_state::SystemContractRegistry;
@@ -7,6 +10,7 @@ use casper_types::{
     system::{self, mint},
     AccessRights, CLValue, EraId, Key, ProtocolVersion, StoredValue, URef,
 };
+use rand::Rng;
 
 use crate::lmdb_fixture::{self, CONTRACT_REGISTRY_SPECIAL_ADDRESS};
 
@@ -15,22 +19,28 @@ const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 #[ignore]
 #[test]
 fn should_update_contract_metadata_at_upgrade_with_major_bump() {
-    test_upgrade(1, 0, 0);
+    test_upgrade(1, 0, 0, 0);
 }
 
 #[ignore]
 #[test]
 fn should_update_contract_metadata_at_upgrade_with_minor_bump() {
-    test_upgrade(0, 1, 0);
+    test_upgrade(0, 1, 0, 0);
 }
 
 #[ignore]
 #[test]
 fn should_update_contract_metadata_at_upgrade_with_patch_bump() {
-    test_upgrade(0, 0, 1);
+    test_upgrade(0, 0, 1, 0);
 }
 
-fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32) {
+#[ignore]
+#[test]
+fn test_upgrade_with_global_state_update_entries() {
+    test_upgrade(0, 0, 1, 20000);
+}
+
+fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32, upgrade_entries: u32) {
     let (mut builder, lmdb_fixture_state, _temp_dir) =
         lmdb_fixture::builder_from_global_state_fixture(lmdb_fixture::RELEASE_1_3_1);
     let mint_contract_hash = {
@@ -58,8 +68,20 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32) {
         old_protocol_version.value().minor + minor_bump,
         old_protocol_version.value().patch + patch_bump,
     );
-    let global_state_update =
+    let mut global_state_update =
         apply_global_state_update(&builder, lmdb_fixture_state.post_state_hash);
+
+    let mut rng = casper_types::testing::TestRng::new();
+    if upgrade_entries > 0 {
+        println!("Adding {upgrade_entries} global state update entries");
+        for _ in 0..upgrade_entries {
+            global_state_update.insert(
+                Key::URef(URef::new(rng.gen(), AccessRights::empty())),
+                StoredValue::CLValue(CLValue::from_t(rng.gen::<u64>()).unwrap()),
+            );
+        }
+    }
+
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(old_protocol_version)
@@ -68,9 +90,22 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32) {
             .with_global_state_update(global_state_update)
             .build()
     };
+    println!("starting upgrade");
+    let start = Instant::now();
     builder
-        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
+        .upgrade_with_upgrade_request_using_scratch(
+            //.upgrade_with_upgrade_request(
+            *builder.get_engine_state().config(),
+            &mut upgrade_request,
+        )
         .expect_upgrade_success();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "upgrade took too long! {} (millis)",
+        elapsed.as_millis()
+    );
+    println!("upgrade took {} millis", elapsed.as_millis());
     let new_contract = builder
         .get_contract(mint_contract_hash)
         .expect("should have mint contract");

--- a/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
@@ -101,7 +101,7 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32, upgrade_entri
         .expect_upgrade_success();
     let elapsed = start.elapsed();
     assert!(
-        elapsed < Duration::from_secs(1),
+        elapsed < Duration::from_secs(20),
         "upgrade took too long! {} (millis)",
         elapsed.as_millis()
     );


### PR DESCRIPTION
We should use the scratch trie for `commit_upgrade`. Addresses existing perf issue.
