### PR TITLE
Deduplicate block header fetching in storage

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1118,13 +1118,9 @@ impl Storage {
                 only_from_available_block_range,
                 responder,
             } => {
-                let mut txn = self.env.begin_ro_txn()?;
-                let result = self.get_block_header_by_height_restricted(
-                    &mut txn,
-                    block_height,
-                    only_from_available_block_range,
-                )?;
-                responder.respond(result).ignore()
+                let maybe_header = self
+                    .read_block_header_by_height(block_height, only_from_available_block_range)?;
+                responder.respond(maybe_header).ignore()
             }
             StorageRequest::PutBlockHeader {
                 block_header,
@@ -1592,22 +1588,7 @@ impl Storage {
     pub fn read_block_header_by_height(
         &self,
         height: u64,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        self.block_height_index
-            .get(&height)
-            .and_then(|block_hash| {
-                self.get_single_block_header(&mut txn, block_hash)
-                    .transpose()
-            })
-            .transpose()
-    }
-
-    /// Retrieves a single block header by height from the available block
-    /// range by looking it up in the index and returning it.
-    pub fn read_complete_block_header_by_height(
-        &self,
-        height: u64,
+        only_from_available_block_range: bool,
     ) -> Result<Option<BlockHeader>, FatalStorageError> {
         let mut txn = self.env.begin_ro_txn()?;
         let res = self
@@ -1618,7 +1599,7 @@ impl Storage {
                     .transpose()
             })
             .transpose();
-        if !(self.should_return_block(height, true)?) {
+        if !(self.should_return_block(height, only_from_available_block_range)?) {
             return Ok(None);
         }
         res
@@ -1996,20 +1977,6 @@ impl Storage {
         }
 
         Ok(Some(result))
-    }
-
-    fn get_block_header_by_height_restricted<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        block_height: u64,
-        only_from_available_block_range: bool,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let block_hash = match self.block_height_index.get(&block_height) {
-            None => return Ok(None),
-            Some(block_hash) => block_hash,
-        };
-
-        self.get_single_block_header_restricted(txn, block_hash, only_from_available_block_range)
     }
 
     /// Retrieves a single block header in a given transaction from storage.

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -449,9 +449,10 @@ impl reactor::Reactor for MainReactor {
                 self.handle_meta_block(effect_builder, rng, meta_block)
             }
             MainEvent::UnexecutedBlockAnnouncement(UnexecutedBlockAnnouncement(block_height)) => {
+                let only_from_available_block_range = true;
                 if let Ok(Some(block_header)) = self
                     .storage
-                    .read_complete_block_header_by_height(block_height)
+                    .read_block_header_by_height(block_height, only_from_available_block_range)
                 {
                     let block_hash = block_header.block_hash();
                     reactor::wrap_effects(


### PR DESCRIPTION
Fixes #3648 

This PR removed code duplication around reading complete block headers in storage.
