### PR TITLE
Bump rust version to 1.67.1 and satisfy updated clippy

### DIFF
--- a/ci/casper_updater/src/chainspec.rs
+++ b/ci/casper_updater/src/chainspec.rs
@@ -47,8 +47,8 @@ impl Chainspec {
                 .to_string()
         };
 
-        let protocol_version = find_value(&*regex_data::chainspec_protocol_version::REGEX);
-        let current_activation_point = find_value(&*regex_data::chainspec_activation_point::REGEX);
+        let protocol_version = find_value(&regex_data::chainspec_protocol_version::REGEX);
+        let current_activation_point = find_value(&regex_data::chainspec_activation_point::REGEX);
         let current_protocol_version = SemVer::try_from(protocol_version.as_str())
             .expect("should parse current protocol version");
 

--- a/ci/casper_updater/src/main.rs
+++ b/ci/casper_updater/src/main.rs
@@ -20,7 +20,6 @@
     clippy::all
 )]
 #![forbid(
-    const_err,
     arithmetic_overflow,
     invalid_type_param_default,
     macro_expanded_macro_exports_accessed_by_absolute_paths,
@@ -232,39 +231,39 @@ fn get_args() -> Args {
 }
 
 fn main() {
-    let types = Package::cargo("types", &*regex_data::types::DEPENDENT_FILES);
+    let types = Package::cargo("types", &regex_data::types::DEPENDENT_FILES);
     types.update();
 
-    let hashing = Package::cargo("hashing", &*regex_data::hashing::DEPENDENT_FILES);
+    let hashing = Package::cargo("hashing", &regex_data::hashing::DEPENDENT_FILES);
     hashing.update();
 
     let execution_engine = Package::cargo(
         "execution_engine",
-        &*regex_data::execution_engine::DEPENDENT_FILES,
+        &regex_data::execution_engine::DEPENDENT_FILES,
     );
     execution_engine.update();
 
-    let json_rpc = Package::cargo("json_rpc", &*regex_data::json_rpc::DEPENDENT_FILES);
+    let json_rpc = Package::cargo("json_rpc", &regex_data::json_rpc::DEPENDENT_FILES);
     json_rpc.update();
 
-    let node = Package::cargo("node", &*regex_data::node::DEPENDENT_FILES);
+    let node = Package::cargo("node", &regex_data::node::DEPENDENT_FILES);
     node.update();
 
     let smart_contracts_contract = Package::cargo(
         "smart_contracts/contract",
-        &*regex_data::smart_contracts_contract::DEPENDENT_FILES,
+        &regex_data::smart_contracts_contract::DEPENDENT_FILES,
     );
     smart_contracts_contract.update();
 
     let smart_contracts_contract_as = Package::assembly_script(
         "smart_contracts/contract_as",
-        &*regex_data::smart_contracts_contract_as::DEPENDENT_FILES,
+        &regex_data::smart_contracts_contract_as::DEPENDENT_FILES,
     );
     smart_contracts_contract_as.update();
 
     let execution_engine_testing_test_support = Package::cargo(
         "execution_engine_testing/test_support",
-        &*regex_data::execution_engine_testing_test_support::DEPENDENT_FILES,
+        &regex_data::execution_engine_testing_test_support::DEPENDENT_FILES,
     );
     execution_engine_testing_test_support.update();
 

--- a/ci/casper_updater/src/package.rs
+++ b/ci/casper_updater/src/package.rs
@@ -42,11 +42,11 @@ impl PackageConsts for CargoPackage {
     const MANIFEST: &'static str = "Cargo.toml";
 
     fn name_regex() -> &'static Regex {
-        &*MANIFEST_NAME_REGEX
+        &MANIFEST_NAME_REGEX
     }
 
     fn version_regex() -> &'static Regex {
-        &*MANIFEST_VERSION_REGEX
+        &MANIFEST_VERSION_REGEX
     }
 }
 
@@ -56,11 +56,11 @@ impl PackageConsts for AssemblyScriptPackage {
     const MANIFEST: &'static str = "package.json";
 
     fn name_regex() -> &'static Regex {
-        &*PACKAGE_JSON_NAME_REGEX
+        &PACKAGE_JSON_NAME_REGEX
     }
 
     fn version_regex() -> &'static Regex {
-        &*PACKAGE_JSON_VERSION_REGEX
+        &PACKAGE_JSON_VERSION_REGEX
     }
 }
 

--- a/execution_engine/benches/trie_bench.rs
+++ b/execution_engine/benches/trie_bench.rs
@@ -27,14 +27,14 @@ fn deserialize_trie_leaf(b: &mut Bencher) {
 
 fn serialize_trie_node(b: &mut Bencher) {
     let node = Trie::<Key, StoredValue>::Node {
-        pointer_block: Box::new(PointerBlock::default()),
+        pointer_block: Box::<PointerBlock>::default(),
     };
     b.iter(|| ToBytes::to_bytes(black_box(&node)));
 }
 
 fn deserialize_trie_node(b: &mut Bencher) {
     let node = Trie::<Key, StoredValue>::Node {
-        pointer_block: Box::new(PointerBlock::default()),
+        pointer_block: Box::<PointerBlock>::default(),
     };
     let node_bytes = node.to_bytes().unwrap();
 
@@ -44,7 +44,7 @@ fn deserialize_trie_node(b: &mut Bencher) {
 fn serialize_trie_node_pointer(b: &mut Bencher) {
     let node = Trie::<Key, StoredValue>::Extension {
         affix: (0..255).collect(),
-        pointer: Pointer::NodePointer(Digest::hash(&[0; 32])),
+        pointer: Pointer::NodePointer(Digest::hash([0; 32])),
     };
 
     b.iter(|| ToBytes::to_bytes(black_box(&node)));
@@ -53,7 +53,7 @@ fn serialize_trie_node_pointer(b: &mut Bencher) {
 fn deserialize_trie_node_pointer(b: &mut Bencher) {
     let node = Trie::<Key, StoredValue>::Extension {
         affix: (0..255).collect(),
-        pointer: Pointer::NodePointer(Digest::hash(&[0; 32])),
+        pointer: Pointer::NodePointer(Digest::hash([0; 32])),
     };
     let node_bytes = node.to_bytes().unwrap();
 

--- a/execution_engine/src/core/engine_state/checksum_registry.rs
+++ b/execution_engine/src/core/engine_state/checksum_registry.rs
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn bytesrepr_roundtrip() {
         let mut checksum_registry = ChecksumRegistry::new();
-        checksum_registry.insert("a", Digest::hash(&[9; 100]));
+        checksum_registry.insert("a", Digest::hash([9; 100]));
         bytesrepr::test_serialization_roundtrip(&checksum_registry);
     }
 }

--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -146,9 +146,9 @@ impl From<mint::Error> for Error {
     }
 }
 
-impl From<GenesisError> for Error {
-    fn from(genesis_error: GenesisError) -> Self {
-        Self::Genesis(Box::new(genesis_error))
+impl From<Box<GenesisError>> for Error {
+    fn from(genesis_error: Box<GenesisError>) -> Self {
+        Self::Genesis(genesis_error)
     }
 }
 

--- a/execution_engine/src/core/engine_state/execute_request.rs
+++ b/execution_engine/src/core/engine_state/execute_request.rs
@@ -56,7 +56,7 @@ impl Default for ExecuteRequest {
             SecretKey::ed25519_from_bytes([0; SecretKey::ED25519_LENGTH]).unwrap();
         let proposer = PublicKey::from(&proposer_secret_key);
         Self {
-            parent_state_hash: Digest::hash(&[]),
+            parent_state_hash: Digest::hash([]),
             block_time: 0,
             deploys: vec![],
             protocol_version: Default::default(),

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -149,7 +149,7 @@ impl EngineState<LmdbGlobalState> {
         }
     }
 
-    /// Writes state cached in an EngineState<ScratchEngineState> to LMDB.
+    /// Writes state cached in an `EngineState<ScratchEngineState>` to LMDB.
     pub fn write_scratch_to_db(
         &self,
         state_root_hash: Digest,

--- a/execution_engine/src/core/engine_state/run_genesis_request.rs
+++ b/execution_engine/src/core/engine_state/run_genesis_request.rs
@@ -65,7 +65,7 @@ impl RunGenesisRequest {
 impl Distribution<RunGenesisRequest> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> RunGenesisRequest {
         let input: [u8; 32] = rng.gen();
-        let genesis_config_hash = Digest::hash(&input);
+        let genesis_config_hash = Digest::hash(input);
         let protocol_version = ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen());
         let ee_config = rng.gen();
 

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -883,7 +883,7 @@ where
                     [in_ptr, in_size, out_ptr, out_size],
                 )?;
                 let input: Vec<u8> = self.bytes_from_mem(in_ptr, in_size as usize)?;
-                let digest = crypto::blake2b(&input);
+                let digest = crypto::blake2b(input);
 
                 let result = if digest.len() != out_size as usize {
                     Err(ApiError::BufferTooSmall)

--- a/execution_engine/src/core/tracking_copy/tests.rs
+++ b/execution_engine/src/core/tracking_copy/tests.rs
@@ -698,7 +698,7 @@ fn validate_query_proof_should_work() {
     // Bad proof hash
     assert_eq!(
         crate::core::validate_query_proof(
-            &Digest::hash(&[]),
+            &Digest::hash([]),
             &proofs,
             &main_account_key,
             path,

--- a/execution_engine/src/storage/global_state/in_memory.rs
+++ b/execution_engine/src/storage/global_state/in_memory.rs
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn checkout_fails_if_unknown_hash_is_given() {
         let (state, _) = create_test_state();
-        let fake_hash = Digest::hash(&[1, 2, 3]);
+        let fake_hash = Digest::hash([1, 2, 3]);
         let result = state.checkout(fake_hash).unwrap();
         assert!(result.is_none());
     }

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -343,7 +343,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let environment = Arc::new(
             LmdbEnvironment::new(
-                &temp_dir.path(),
+                temp_dir.path(),
                 DEFAULT_TEST_MAX_DB_SIZE,
                 DEFAULT_TEST_MAX_READERS,
                 true,
@@ -395,7 +395,7 @@ mod tests {
     #[test]
     fn checkout_fails_if_unknown_hash_is_given() {
         let (state, _) = create_test_state(create_test_pairs);
-        let fake_hash: Digest = Digest::hash(&[1u8; 32]);
+        let fake_hash: Digest = Digest::hash([1u8; 32]);
         let result = state.checkout(fake_hash).unwrap();
         assert!(result.is_none());
     }

--- a/execution_engine/src/storage/global_state/scratch.rs
+++ b/execution_engine/src/storage/global_state/scratch.rs
@@ -406,7 +406,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let environment = Arc::new(
             LmdbEnvironment::new(
-                &temp_dir.path(),
+                temp_dir.path(),
                 DEFAULT_TEST_MAX_DB_SIZE,
                 DEFAULT_TEST_MAX_READERS,
                 true,

--- a/execution_engine/src/storage/trie/gens.rs
+++ b/execution_engine/src/storage/trie/gens.rs
@@ -9,7 +9,7 @@ use casper_types::{
 use super::{Pointer, PointerBlock, Trie};
 
 pub fn blake2b_hash_arb() -> impl Strategy<Value = Digest> {
-    vec(any::<u8>(), 0..1000).prop_map(|b| Digest::hash(&b))
+    vec(any::<u8>(), 0..1000).prop_map(Digest::hash)
 }
 
 pub fn trie_pointer_arb() -> impl Strategy<Value = Pointer> {

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -301,7 +301,7 @@ impl core::ops::Index<core::ops::Range<usize>> for PointerBlock {
 
     #[inline]
     fn index(&self, index: core::ops::Range<usize>) -> &[PointerBlockValue] {
-        let &PointerBlock(ref dat) = self;
+        let PointerBlock(dat) = self;
         &dat[index]
     }
 }
@@ -311,7 +311,7 @@ impl core::ops::Index<core::ops::RangeTo<usize>> for PointerBlock {
 
     #[inline]
     fn index(&self, index: core::ops::RangeTo<usize>) -> &[PointerBlockValue] {
-        let &PointerBlock(ref dat) = self;
+        let PointerBlock(dat) = self;
         &dat[index]
     }
 }
@@ -321,7 +321,7 @@ impl core::ops::Index<core::ops::RangeFrom<usize>> for PointerBlock {
 
     #[inline]
     fn index(&self, index: core::ops::RangeFrom<usize>) -> &[PointerBlockValue] {
-        let &PointerBlock(ref dat) = self;
+        let PointerBlock(dat) = self;
         &dat[index]
     }
 }
@@ -331,7 +331,7 @@ impl core::ops::Index<core::ops::RangeFull> for PointerBlock {
 
     #[inline]
     fn index(&self, index: core::ops::RangeFull) -> &[PointerBlockValue] {
-        let &PointerBlock(ref dat) = self;
+        let PointerBlock(dat) = self;
         &dat[index]
     }
 }
@@ -599,6 +599,6 @@ pub(crate) mod operations {
             pointer_block: Default::default(),
         };
         let root_bytes: Vec<u8> = root.to_bytes()?;
-        Ok((Digest::hash(&root_bytes), root))
+        Ok((Digest::hash(root_bytes), root))
     }
 }

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -99,7 +99,7 @@ struct HashedTrie<K, V> {
 impl<K: ToBytes, V: ToBytes> HashedTrie<K, V> {
     pub fn new(trie: Trie<K, V>) -> Result<Self, bytesrepr::Error> {
         let trie_bytes = trie.to_bytes()?;
-        let hash = Digest::hash(&trie_bytes);
+        let hash = Digest::hash(trie_bytes);
         Ok(HashedTrie { hash, trie })
     }
 }
@@ -523,7 +523,7 @@ impl LmdbTestContext {
     {
         let _temp_dir = tempdir()?;
         let environment = LmdbEnvironment::new(
-            &_temp_dir.path(),
+            _temp_dir.path(),
             DEFAULT_TEST_MAX_DB_SIZE,
             DEFAULT_TEST_MAX_READERS,
             true,

--- a/execution_engine/src/storage/trie_store/tests/concurrent.rs
+++ b/execution_engine/src/storage/trie_store/tests/concurrent.rs
@@ -22,7 +22,7 @@ fn lmdb_writer_mutex_does_not_collide_with_readers() {
     let dir = tempdir().unwrap();
     let env = Arc::new(
         LmdbEnvironment::new(
-            &dir.path(),
+            dir.path(),
             DEFAULT_TEST_MAX_DB_SIZE,
             DEFAULT_TEST_MAX_READERS,
             true,

--- a/execution_engine/src/storage/trie_store/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/tests/mod.rs
@@ -30,9 +30,9 @@ fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         value: Bytes::from(b"val_3".to_vec()),
     };
 
-    let leaf_1_hash = Digest::hash(&leaf_1.to_bytes().unwrap());
-    let leaf_2_hash = Digest::hash(&leaf_2.to_bytes().unwrap());
-    let leaf_3_hash = Digest::hash(&leaf_3.to_bytes().unwrap());
+    let leaf_1_hash = Digest::hash(leaf_1.to_bytes().unwrap());
+    let leaf_2_hash = Digest::hash(leaf_2.to_bytes().unwrap());
+    let leaf_3_hash = Digest::hash(leaf_3.to_bytes().unwrap());
 
     let node_2: Trie<Bytes, Bytes> = {
         let mut pointer_block = PointerBlock::new();
@@ -42,7 +42,7 @@ fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         Trie::Node { pointer_block }
     };
 
-    let node_2_hash = Digest::hash(&node_2.to_bytes().unwrap());
+    let node_2_hash = Digest::hash(node_2.to_bytes().unwrap());
 
     let ext_node: Trie<Bytes, Bytes> = {
         let affix = vec![1u8, 0];
@@ -53,7 +53,7 @@ fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         }
     };
 
-    let ext_node_hash = Digest::hash(&ext_node.to_bytes().unwrap());
+    let ext_node_hash = Digest::hash(ext_node.to_bytes().unwrap());
 
     let node_1: Trie<Bytes, Bytes> = {
         let mut pointer_block = PointerBlock::new();
@@ -63,7 +63,7 @@ fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         Trie::Node { pointer_block }
     };
 
-    let node_1_hash = Digest::hash(&node_1.to_bytes().unwrap());
+    let node_1_hash = Digest::hash(node_1.to_bytes().unwrap());
 
     vec![
         TestData(leaf_1_hash, leaf_1),

--- a/execution_engine/src/storage/trie_store/tests/proptests.rs
+++ b/execution_engine/src/storage/trie_store/tests/proptests.rs
@@ -40,7 +40,7 @@ fn in_memory_roundtrip_succeeds(inputs: Vec<Trie<Key, StoredValue>>) -> bool {
 
     let inputs: BTreeMap<Digest, Trie<Key, StoredValue>> = inputs
         .into_iter()
-        .map(|trie| (Digest::hash(&trie.to_bytes().unwrap()), trie))
+        .map(|trie| (Digest::hash(trie.to_bytes().unwrap()), trie))
         .collect();
 
     store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap()
@@ -53,7 +53,7 @@ fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, StoredValue>>) -> bool {
 
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &tmp_dir.path(),
+        tmp_dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -63,7 +63,7 @@ fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, StoredValue>>) -> bool {
 
     let inputs: BTreeMap<Digest, Trie<Key, StoredValue>> = inputs
         .into_iter()
-        .map(|trie| (Digest::hash(&trie.to_bytes().unwrap()), trie))
+        .map(|trie| (Digest::hash(trie.to_bytes().unwrap()), trie))
         .collect();
 
     let ret = store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap();

--- a/execution_engine/src/storage/trie_store/tests/simple.rs
+++ b/execution_engine/src/storage/trie_store/tests/simple.rs
@@ -48,7 +48,7 @@ fn in_memory_put_succeeds() {
 fn lmdb_put_succeeds() {
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &tmp_dir.path(),
+        tmp_dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -106,7 +106,7 @@ fn in_memory_put_get_succeeds() {
 fn lmdb_put_get_succeeds() {
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &tmp_dir.path(),
+        tmp_dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -151,7 +151,7 @@ fn in_memory_put_get_many_succeeds() {
 fn lmdb_put_get_many_succeeds() {
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &tmp_dir.path(),
+        tmp_dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -222,7 +222,7 @@ fn in_memory_uncommitted_read_write_txn_does_not_persist() {
 fn lmdb_uncommitted_read_write_txn_does_not_persist() {
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &tmp_dir.path(),
+        tmp_dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -271,7 +271,7 @@ fn in_memory_read_write_transaction_does_not_block_read_transaction() {
 fn lmdb_read_write_transaction_does_not_block_read_transaction() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -328,7 +328,7 @@ fn in_memory_reads_are_isolated() {
 fn lmdb_reads_are_isolated() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -390,7 +390,7 @@ fn in_memory_reads_are_isolated_2() {
 fn lmdb_reads_are_isolated_2() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -458,7 +458,7 @@ fn in_memory_dbs_are_isolated() {
 fn lmdb_dbs_are_isolated() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -522,7 +522,7 @@ fn in_memory_transactions_can_be_used_across_sub_databases() {
 fn lmdb_transactions_can_be_used_across_sub_databases() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,
@@ -590,7 +590,7 @@ fn in_memory_uncommitted_transactions_across_sub_databases_do_not_persist() {
 fn lmdb_uncommitted_transactions_across_sub_databases_do_not_persist() {
     let dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(
-        &dir.path(),
+        dir.path(),
         DEFAULT_TEST_MAX_DB_SIZE,
         DEFAULT_TEST_MAX_READERS,
         true,

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -378,7 +378,7 @@ pub fn generate_public_keys(key_count: usize) -> Vec<PublicKey> {
     let mut ret = Vec::with_capacity(key_count);
     for _ in 0..key_count {
         let bytes: [u8; SecretKey::ED25519_LENGTH] = rand::random();
-        let secret_key = SecretKey::ed25519_from_bytes(&bytes).unwrap();
+        let secret_key = SecretKey::ed25519_from_bytes(bytes).unwrap();
         let public_key = PublicKey::from(&secret_key);
         ret.push(public_key);
     }

--- a/execution_engine_testing/tests/benches/auction_bench.rs
+++ b/execution_engine_testing/tests/benches/auction_bench.rs
@@ -226,7 +226,7 @@ fn generate_public_keys(key_count: usize) -> Vec<PublicKey> {
     let mut ret = Vec::with_capacity(key_count);
     for _ in 0..key_count {
         let bytes: [u8; SecretKey::ED25519_LENGTH] = rand::random();
-        let secret_key = SecretKey::ed25519_from_bytes(&bytes).unwrap();
+        let secret_key = SecretKey::ed25519_from_bytes(bytes).unwrap();
         let public_key = PublicKey::from(&secret_key);
         ret.push(public_key);
     }

--- a/execution_engine_testing/tests/src/lmdb_fixture.rs
+++ b/execution_engine_testing/tests/src/lmdb_fixture.rs
@@ -72,7 +72,7 @@ pub fn builder_from_global_state_fixture(
 
     let path_to_state = to.path().join(fixture_name).join(STATE_JSON_FILE);
     let lmdb_fixture_state: LmdbFixtureState =
-        serde_json::from_reader(File::open(&path_to_state).unwrap()).unwrap();
+        serde_json::from_reader(File::open(path_to_state).unwrap()).unwrap();
     let path_to_gs = to.path().join(fixture_name);
 
     (
@@ -123,7 +123,7 @@ pub fn generate_fixture(
 
     let path_to_state_file = fixture_root.join(STATE_JSON_FILE);
 
-    let mut f = File::create(&path_to_state_file)?;
+    let mut f = File::create(path_to_state_file)?;
     f.write_all(serialized_state.as_bytes())?;
     Ok(())
 }

--- a/execution_engine_testing/tests/src/test/chainspec_registry.rs
+++ b/execution_engine_testing/tests/src/test/chainspec_registry.rs
@@ -31,8 +31,8 @@ fn should_commit_chainspec_registry_during_genesis() {
     let mut rng = rand::thread_rng();
     let chainspec_bytes = rng.gen::<[u8; 32]>();
     let genesis_account = rng.gen::<[u8; 32]>();
-    let chainspec_bytes_hash = Digest::hash(&chainspec_bytes);
-    let genesis_account_hash = Digest::hash(&genesis_account);
+    let chainspec_bytes_hash = Digest::hash(chainspec_bytes);
+    let genesis_account_hash = Digest::hash(genesis_account);
 
     let chainspec_registry =
         ChainspecRegistry::new_with_genesis(&chainspec_bytes, &genesis_account);
@@ -108,13 +108,13 @@ fn should_upgrade_chainspec_registry(cfg: TestConfig) {
 
     let chainspec_bytes = rng.gen::<[u8; 32]>();
     let global_state_bytes = rng.gen::<[u8; 32]>();
-    let chainspec_bytes_hash = Digest::hash(&chainspec_bytes);
-    let global_state_bytes_hash = Digest::hash(&global_state_bytes);
+    let chainspec_bytes_hash = Digest::hash(chainspec_bytes);
+    let global_state_bytes_hash = Digest::hash(global_state_bytes);
 
     let upgraded_chainspec_registry = ChainspecRegistry::new_with_optional_global_state(
         &chainspec_bytes,
         cfg.with_global_state_bytes
-            .then(|| global_state_bytes.as_slice()),
+            .then_some(global_state_bytes.as_slice()),
     );
 
     let mut upgrade_request = {

--- a/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/list_authorization_keys.rs
@@ -21,13 +21,13 @@ const CONTRACT_LIST_AUTHORIZATION_KEYS: &str = "list_authorization_keys.wasm";
 const ARG_EXPECTED_AUTHORIZATION_KEYS: &str = "expected_authorization_keys";
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());
 static ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_1_SECRET_KEY));
 static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_1_PUBLIC_KEY.to_account_hash());
 
 static ACCOUNT_2_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[243u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([243u8; 32]).unwrap());
 static ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_2_SECRET_KEY));
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_2_PUBLIC_KEY.to_account_hash());

--- a/execution_engine_testing/tests/src/test/contract_api/runtime.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/runtime.rs
@@ -126,7 +126,7 @@ fn should_hash() {
         builder.exec(exec_request).commit().expect_success();
 
         let digest = get_value::<BLAKE2B_DIGEST_LENGTH>(&builder, HASH_RESULT);
-        let expected_digest = crypto::blake2b(&input);
+        let expected_digest = crypto::blake2b(input);
         assert_eq!(digest, expected_digest);
     }
 }

--- a/execution_engine_testing/tests/src/test/contract_api/transfer.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer.rs
@@ -29,13 +29,13 @@ static ACCOUNT_1_INITIAL_BALANCE: Lazy<U512> =
     Lazy::new(|| U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE));
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());
 static ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_1_SECRET_KEY));
 static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_1_PUBLIC_KEY.to_account_hash());
 
 static ACCOUNT_2_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[210u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([210u8; 32]).unwrap());
 static ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_2_SECRET_KEY));
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_2_PUBLIC_KEY.to_account_hash());

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
@@ -17,13 +17,13 @@ use tempfile::TempDir;
 static TRANSFER_AMOUNT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());
 static ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_1_SECRET_KEY));
 static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_1_PUBLIC_KEY.to_account_hash());
 
 static ACCOUNT_2_SECRET_KEY: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[210u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([210u8; 32]).unwrap());
 static ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> =
     Lazy::new(|| PublicKey::from(&*ACCOUNT_2_SECRET_KEY));
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_2_PUBLIC_KEY.to_account_hash());

--- a/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
@@ -91,7 +91,7 @@ fn should_exec_non_stored_code() {
         let deploy = DeployItemBuilder::new()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
-                &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
+                format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
                 runtime_args! {
                     ARG_TARGET => account_1_account_hash,
                     ARG_AMOUNT => U512::from(transferred_amount)
@@ -172,7 +172,7 @@ fn should_fail_if_calling_non_existent_entry_point() {
     let exec_request_stored_payment = {
         let deploy = DeployItemBuilder::new()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_session_code(&format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
+            .with_session_code(format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
             .with_stored_payment_hash(
                 stored_payment_contract_hash.into(),
                 "electric-boogaloo",
@@ -235,7 +235,7 @@ fn should_exec_stored_code_by_hash() {
             let deploy = DeployItemBuilder::new()
                 .with_address(*DEFAULT_ACCOUNT_ADDR)
                 .with_session_code(
-                    &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
+                    format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
                     runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => U512::from(transferred_amount) },
                 )
                 .with_stored_versioned_payment_contract_by_hash(
@@ -305,7 +305,7 @@ fn should_not_transfer_above_balance_using_stored_payment_code_by_hash() {
         let deploy = DeployItemBuilder::new()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
-                &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
+                format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
                 runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => transferred_amount },
             )
             .with_stored_versioned_payment_contract_by_hash(
@@ -378,7 +378,7 @@ fn should_empty_account_using_stored_payment_code_by_hash() {
             let deploy = DeployItemBuilder::new()
                 .with_address(*DEFAULT_ACCOUNT_ADDR)
                 .with_session_code(
-                    &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
+                    format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
                     runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => transferred_amount },
                 )
                 .with_stored_versioned_payment_contract_by_hash(
@@ -471,7 +471,7 @@ fn should_exec_stored_code_by_named_hash() {
             let deploy = DeployItemBuilder::new()
                 .with_address(*DEFAULT_ACCOUNT_ADDR)
                 .with_session_code(
-                    &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
+                    format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
                     runtime_args! { ARG_TARGET => account_1_account_hash, ARG_AMOUNT => U512::from(transferred_amount) },
                 )
                 .with_stored_versioned_payment_contract_by_name(
@@ -571,7 +571,7 @@ fn should_fail_payment_stored_at_named_key_with_incompatible_major_version() {
     let exec_request_stored_payment = {
         let deploy = DeployItemBuilder::new()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_session_code(&format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
+            .with_session_code(format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
             .with_stored_payment_named_key(
                 STORED_PAYMENT_CONTRACT_HASH_NAME,
                 PAY_ENTRYPOINT,
@@ -654,7 +654,7 @@ fn should_fail_payment_stored_at_hash_with_incompatible_major_version() {
     let exec_request_stored_payment = {
         let deploy = DeployItemBuilder::new()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_session_code(&format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
+            .with_session_code(format!("{}.wasm", DO_NOTHING_NAME), RuntimeArgs::default())
             .with_stored_payment_hash(
                 stored_payment_contract_hash.into(),
                 PAY_ENTRYPOINT,

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -430,7 +430,7 @@ fn should_not_fund_once_exhausted() {
             .new_faucet_fund_request_builder()
             .with_user_account(user_account)
             .with_arg_fund_amount(user_fund_amount)
-            .with_block_time(1000 + i as u64)
+            .with_block_time(1000 + i)
             .with_payment_amount(U512::from(payment_amount))
             .build();
 

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -85,7 +85,7 @@ fn get_balance_should_work() {
         Err(ValidationError::UnexpectedKey)
     );
 
-    let bogus_hash = Digest::hash(&[5u8; 32]);
+    let bogus_hash = Digest::hash([5u8; 32]);
     assert_eq!(
         core::validate_balance_proof(
             &bogus_hash,
@@ -170,7 +170,7 @@ fn get_balance_using_public_key_should_work() {
         Err(ValidationError::UnexpectedKey)
     );
 
-    let bogus_hash = Digest::hash(&[5u8; 32]);
+    let bogus_hash = Digest::hash([5u8; 32]);
     assert_eq!(
         core::validate_balance_proof(
             &bogus_hash,

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -184,7 +184,7 @@ fn should_run_ee_1129_underfunded_add_bid_call() {
 fn should_run_ee_1129_underfunded_mint_contract_call() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -232,7 +232,7 @@ fn should_run_ee_1129_underfunded_mint_contract_call() {
 fn should_not_panic_when_calling_session_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -280,7 +280,7 @@ fn should_not_panic_when_calling_session_contract_by_uref() {
 fn should_not_panic_when_calling_payment_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -326,7 +326,7 @@ fn should_not_panic_when_calling_payment_contract_by_uref() {
 fn should_not_panic_when_calling_contract_package_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -379,7 +379,7 @@ fn should_not_panic_when_calling_contract_package_by_uref() {
 fn should_not_panic_when_calling_payment_versioned_contract_by_uref() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -446,7 +446,7 @@ fn do_nothing_without_memory() -> Vec<u8> {
 fn should_not_panic_when_calling_module_without_memory() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()

--- a/execution_engine_testing/tests/src/test/regression/ee_1160.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1160.rs
@@ -26,7 +26,7 @@ fn ee_1160_wasmless_transfer_should_empty_account() {
         U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE) - wasmless_transfer_cost.value();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -80,7 +80,7 @@ fn ee_1160_transfer_larger_than_balance_should_fail() {
         + U512::one();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -141,7 +141,7 @@ fn ee_1160_large_wasmless_transfer_should_avoid_overflow() {
     let transfer_amount = U512::max_value();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/execution_engine_testing/tests/src/test/regression/ee_1163.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1163.rs
@@ -21,7 +21,7 @@ const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     builder
 }
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1174.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1174.rs
@@ -21,7 +21,7 @@ fn should_run_ee_1174_delegation_rate_too_high() {
     let bid_amount = U512::one();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let auction = builder.get_auction_contract_hash();
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1225.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1225.rs
@@ -14,7 +14,7 @@ const DO_NOTHING_CONTRACT: &str = "do_nothing.wasm";
 #[test]
 fn should_run_ee_1225_verify_finalize_payment_invariants() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -100,7 +100,7 @@ fn should_run_ee_966_with_zero_min_and_zero_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -114,7 +114,7 @@ fn should_run_ee_966_cant_have_too_much_initial_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -135,7 +135,7 @@ fn should_run_ee_966_should_request_exactly_maximum() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -149,7 +149,7 @@ fn should_run_ee_966_should_request_exactly_maximum_as_initial() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit().expect_success();
 }
@@ -166,7 +166,7 @@ fn should_run_ee_966_cant_have_too_much_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -189,7 +189,7 @@ fn should_run_ee_966_cant_have_way_too_much_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -210,7 +210,7 @@ fn should_run_ee_966_cant_have_larger_initial_than_max_memory() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -233,7 +233,7 @@ fn should_run_ee_966_regression_fail_when_growing_mem_past_max() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request).commit();
 
@@ -256,7 +256,7 @@ fn should_run_ee_966_regression_when_growing_mem_after_upgrade() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     builder.exec(exec_request_1).commit();
 

--- a/execution_engine_testing/tests/src/test/regression/gh_1470.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1470.rs
@@ -46,7 +46,7 @@ const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gh_1688.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1688.rs
@@ -17,7 +17,7 @@ const CONTRACT_HASH_KEY: &str = "contract_hash";
 
 fn setup() -> (InMemoryWasmTestBuilder, ContractPackageHash, ContractHash) {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_contract_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gh_1902.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1902.rs
@@ -29,7 +29,7 @@ static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCO
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let id: Option<u64> = None;
     let transfer_args_1 = runtime_args! {
         mint::ARG_TARGET => *ACCOUNT_1_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/gh_2280.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2280.rs
@@ -713,7 +713,7 @@ struct TestContext {
 
 fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let session_args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),

--- a/execution_engine_testing/tests/src/test/regression/gov_116.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_116.rs
@@ -35,11 +35,11 @@ const DELEGATION_RATE: DelegationRate = 0;
 /// run_auction call.
 const VESTING_WEEKS: [u64; 3] = [
     // Passes the vesting schedule (aka initial lockup + schedule length)
-    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64,
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS,
     // One week after
-    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64 + WEEK_MILLIS,
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS + WEEK_MILLIS,
     // Two weeks after
-    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64 + (2 * WEEK_MILLIS),
+    VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS + (2 * WEEK_MILLIS),
 ];
 
 static GENESIS_VALIDATOR_PUBLIC_KEYS: Lazy<BTreeSet<PublicKey>> = Lazy::new(|| {
@@ -286,10 +286,7 @@ fn should_retain_genesis_validator_slot_protection() {
     assert_eq!(next_validator_set_3, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
 
     // After 13 weeks ~ 91 days lowest stake validator is dropped and replaced with higher bid
-    builder.run_auction(
-        VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS as u64,
-        Vec::new(),
-    );
+    builder.run_auction(VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS, Vec::new());
 
     let era_validators_4: EraValidators = builder.get_era_validators();
     let (last_era_4, weights_4) = era_validators_4.iter().last().unwrap();

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -45,7 +45,7 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
 
 fn initialize_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     builder
 }
 

--- a/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
+++ b/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
@@ -147,7 +147,7 @@ fn host_function_metrics_has_acceptable_gas_cost() {
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder
-        .run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST)
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .exec(create_account_exec_request(ACCOUNT0_ADDR))
         .expect_success()
         .commit()

--- a/execution_engine_testing/tests/src/test/regression/regression_20210707.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210707.rs
@@ -92,7 +92,7 @@ fn assert_forged_uref_error(error: CoreError, forged_uref: URef) {
 fn should_transfer_funds_from_contract_to_new_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -130,7 +130,7 @@ fn should_transfer_funds_from_contract_to_new_account() {
 fn should_transfer_funds_from_contract_to_existing_account() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -173,7 +173,7 @@ fn should_transfer_funds_from_contract_to_existing_account() {
 fn should_not_transfer_funds_from_forged_purse_to_account_native_transfer() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -213,7 +213,7 @@ fn should_not_transfer_funds_from_forged_purse_to_account_native_transfer() {
 fn should_not_transfer_funds_from_forged_purse_to_owned_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -263,7 +263,7 @@ fn should_not_transfer_funds_from_forged_purse_to_owned_purse() {
 fn should_not_transfer_funds_into_bob_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -306,7 +306,7 @@ fn should_not_transfer_funds_into_bob_purse() {
 fn should_not_transfer_from_hardcoded_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -345,7 +345,7 @@ fn should_not_transfer_from_hardcoded_purse() {
 fn should_not_refund_to_bob_and_charge_alice() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -401,7 +401,7 @@ fn should_not_refund_to_bob_and_charge_alice() {
 fn should_not_charge_alice_for_execution() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 
@@ -457,7 +457,7 @@ fn should_not_charge_alice_for_execution() {
 fn should_not_charge_for_execution_from_hardcoded_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let store_request = setup_regression_contract();
 

--- a/execution_engine_testing/tests/src/test/regression/regression_20220119.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220119.rs
@@ -10,7 +10,7 @@ const REGRESSION_20220119_CONTRACT: &str = "regression_20220119.wasm";
 #[test]
 fn should_create_purse() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220207.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220207.rs
@@ -17,7 +17,7 @@ const UNAPPROVED_SPENDING_AMOUNT_ERR: Error = Error::Exec(ExecError::Revert(ApiE
 #[test]
 fn should_not_transfer_above_approved_limit() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(1000u64), // What we approved.
@@ -38,7 +38,7 @@ fn should_not_transfer_above_approved_limit() {
 #[test]
 fn should_transfer_within_approved_limit() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         mint::ARG_AMOUNT => U512::from(1000u64),
@@ -57,7 +57,7 @@ fn should_transfer_within_approved_limit() {
 #[test]
 fn should_fail_without_amount_arg() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let args = runtime_args! {
         // If `amount` arg is absent, host assumes that limit is 0.

--- a/execution_engine_testing/tests/src/test/regression/regression_20220208.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220208.rs
@@ -18,7 +18,7 @@ const UNAPPROVED_SPENDING_AMOUNT_ERR: Error = Error::Exec(ExecError::Revert(ApiE
 #[test]
 fn should_transfer_within_approved_limit_multiple_transfers() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let part_1 = U512::from(100u64);
     let part_2 = U512::from(100u64);
@@ -42,7 +42,7 @@ fn should_transfer_within_approved_limit_multiple_transfers() {
 #[test]
 fn should_not_transfer_above_approved_limit_multiple_transfers() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let part_1 = U512::from(100u64);
     let part_2 = U512::from(100u64);

--- a/execution_engine_testing/tests/src/test/regression/regression_20220217.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220217.rs
@@ -240,7 +240,7 @@ fn regression_20220217_should_not_transfer_funds_on_unrelated_purses() {
 
 fn setup() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let fund_account_1_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,
@@ -383,7 +383,7 @@ fn mint_by_hash_transfer_should_fail_because_lack_of_target_uref_access() {
     // TODO create two named purses and verify we can pass source and target known non-main purses
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/execution_engine_testing/tests/src/test/regression/regression_20220221.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220221.rs
@@ -36,7 +36,7 @@ fn generate_secret_keys() -> impl Iterator<Item = SecretKey> {
         let u256 = U256::from(i);
         let mut u256_bytes = [0u8; 32];
         u256.to_big_endian(&mut u256_bytes);
-        SecretKey::ed25519_from_bytes(&u256_bytes).expect("should create secret key")
+        SecretKey::ed25519_from_bytes(u256_bytes).expect("should create secret key")
     })
 }
 
@@ -63,7 +63,7 @@ fn regression_20220221_should_distribute_to_many_validators() {
     .build();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_request = UpgradeRequestBuilder::default()
         .with_new_validator_slots(DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT + 1)

--- a/execution_engine_testing/tests/src/test/regression/regression_20220222.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220222.rs
@@ -11,7 +11,7 @@ const ALICE_ADDR: AccountHash = AccountHash::new([42; 32]);
 #[test]
 fn regression_20220222_escalate() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request = ExecuteRequestBuilder::transfer(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220224.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220224.rs
@@ -12,7 +12,7 @@ const CONTRACT_REVERT: &str = "revert.wasm";
 #[test]
 fn should_not_transfer_above_approved_limit_in_payment_code() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let account_hash = *DEFAULT_ACCOUNT_ADDR;

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -58,7 +58,7 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 #[test]
 fn should_not_oom() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let initial_size_exceeded = vec![OOM_INIT, FAILURE_ONE_ABOVE_LIMIT];
 
@@ -117,7 +117,7 @@ fn should_not_oom() {
 #[test]
 fn should_pass_table_validation() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
 
@@ -191,7 +191,7 @@ fn test_element_section(
     // )
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut wat = String::new();
 
@@ -248,7 +248,7 @@ fn test_element_section(
 #[test]
 fn should_not_allow_more_than_one_table() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
 
@@ -381,7 +381,7 @@ fn should_allow_large_br_table() {
         .expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -400,7 +400,7 @@ fn should_not_allow_large_br_table() {
         make_arbitrary_br_table(FAILING_BR_TABLE_SIZE).expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -470,7 +470,7 @@ fn should_allow_multiple_globals() {
         make_arbitrary_global(DEFAULT_MAX_GLOBALS as usize).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -489,7 +489,7 @@ fn should_not_allow_too_many_globals() {
         make_arbitrary_global(FAILING_GLOBALS_SIZE).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -521,7 +521,7 @@ fn should_verify_max_param_count() {
             .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -546,7 +546,7 @@ fn should_verify_max_param_count() {
         wasm_utils::make_n_arg_call_bytes(100, "i32").expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -565,7 +565,7 @@ fn should_not_allow_too_many_params() {
         .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -601,7 +601,7 @@ fn should_not_allow_to_import_gas_function() {
     .unwrap();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -736,7 +736,7 @@ fn should_not_set_non_existing_global_above_declared_range() {
 fn test_non_existing_global(module_wat: &str, index: u32) {
     let module_bytes = wat::parse_str(module_wat).unwrap();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -401,7 +401,7 @@ fn should_measure_unisolated_gas_cost_for_storage_usage_write() {
     let cost_per_byte = U512::from(StorageCosts::default().gas_per_byte());
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -627,7 +627,7 @@ fn should_measure_unisolated_gas_cost_for_storage_usage_add() {
     let cost_per_byte = U512::from(StorageCosts::default().gas_per_byte());
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -3075,7 +3075,7 @@ fn check_validator_slots_for_accounts(accounts: usize) {
             let secret_key = {
                 let mut secret_key_bytes = [0; 32];
                 count.to_big_endian(&mut secret_key_bytes);
-                SecretKey::ed25519_from_bytes(&secret_key_bytes).expect("should create ed25519 key")
+                SecretKey::ed25519_from_bytes(secret_key_bytes).expect("should create ed25519 key")
             };
 
             let public_key = PublicKey::from(&secret_key);
@@ -3945,7 +3945,7 @@ fn should_transfer_to_main_purse_when_validator_is_no_longer_active() {
 fn should_enforce_minimum_delegation_amount() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -4026,7 +4026,7 @@ fn should_enforce_minimum_delegation_amount() {
 fn should_allow_delegations_with_minimal_floor_amount() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -86,7 +86,7 @@ const ARG_AMOUNT: &str = "amount";
 fn add_bid_and_withdraw_bid_have_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let system_contract_hashes_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -221,7 +221,7 @@ fn upgraded_add_bid_and_withdraw_bid_have_expected_costs() {
     );
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
@@ -673,7 +673,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
 fn mint_transfer_has_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -740,7 +740,7 @@ fn mint_transfer_has_expected_costs() {
 fn should_charge_for_erroneous_system_contract_calls() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let auction_hash = builder.get_auction_contract_hash();
     let mint_hash = builder.get_mint_contract_hash();
@@ -872,7 +872,7 @@ fn should_charge_for_erroneous_system_contract_calls() {
 fn should_verify_do_nothing_charges_only_for_standard_payment() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
@@ -912,7 +912,7 @@ fn should_verify_do_nothing_charges_only_for_standard_payment() {
 fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let new_opcode_costs = OpcodeCosts {
         bit: 0,

--- a/execution_engine_testing/tests/src/test/tutorial/counter.rs
+++ b/execution_engine_testing/tests/src/test/tutorial/counter.rs
@@ -13,7 +13,7 @@ const COUNTER_KEY: &str = "counter";
 #[test]
 fn should_run_counter_example() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let install_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/tutorial/hello_world.rs
+++ b/execution_engine_testing/tests/src/test/tutorial/hello_world.rs
@@ -13,7 +13,7 @@ const MESSAGE_VALUE: &str = "Hello, world!";
 #[test]
 fn should_run_hello_world() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = {
         let session_args = runtime_args! {

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -130,7 +130,7 @@ fn should_upgrade_do_nothing_to_do_something_version_hash_call() {
 fn should_upgrade_do_nothing_to_do_something_contract_call() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     // Create contract package and store contract ver: 1.0.0
     {

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -43,12 +43,12 @@ const ARG_PURSE_NAME: &str = "purse_name";
 const ARG_UREF_NAME: &str = "uref_name";
 
 static ACCOUNT_1_SK: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[234u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());
 static ACCOUNT_1_PK: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&*ACCOUNT_1_SK));
 static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_1_PK.to_account_hash());
 
 static ACCOUNT_2_SK: Lazy<SecretKey> =
-    Lazy::new(|| SecretKey::secp256k1_from_bytes(&[210u8; 32]).unwrap());
+    Lazy::new(|| SecretKey::secp256k1_from_bytes([210u8; 32]).unwrap());
 static ACCOUNT_2_PK: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&*ACCOUNT_2_SK));
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| ACCOUNT_2_PK.to_account_hash());
 
@@ -1015,7 +1015,7 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
     );
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
     let default_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/hashing/src/chunk_with_proof.rs
+++ b/hashing/src/chunk_with_proof.rs
@@ -63,7 +63,7 @@ impl ChunkWithProof {
     pub fn new(data: &[u8], index: u64) -> Result<Self, MerkleConstructionError> {
         Ok(if data.is_empty() {
             ChunkWithProof {
-                proof: IndexedMerkleProof::new([Digest::blake2b_hash(&[])], index)?,
+                proof: IndexedMerkleProof::new([Digest::blake2b_hash([])], index)?,
                 chunk: Bytes::new(),
             }
         } else {

--- a/hashing/src/indexed_merkle_proof.rs
+++ b/hashing/src/indexed_merkle_proof.rs
@@ -94,7 +94,7 @@ impl IndexedMerkleProof {
                 }
             })
             .tree_fold1(|x, y| match (x, y) {
-                (Hash(hash_x), Hash(hash_y)) => Hash(Digest::hash_pair(&hash_x, &hash_y)),
+                (Hash(hash_x), Hash(hash_y)) => Hash(Digest::hash_pair(hash_x, hash_y)),
                 (Hash(hash), Proof(mut proof)) | (Proof(mut proof), Hash(hash)) => {
                     proof.push(hash);
                     Proof(proof)
@@ -156,9 +156,9 @@ impl IndexedMerkleProof {
                 // Compute the raw Merkle root by hashing the proof from leaf hash up.
                 hashes.fold(leaf_hash, |acc, hash| {
                     let digest = if (path & 1) == 1 {
-                        Digest::hash_pair(hash, &acc)
+                        Digest::hash_pair(hash, acc)
                     } else {
-                        Digest::hash_pair(&acc, hash)
+                        Digest::hash_pair(acc, hash)
                     };
                     path >>= 1;
                     digest
@@ -382,11 +382,11 @@ mod tests {
             let last = proof.len() - 1;
             if index < half {
                 let left = compute_raw_root_from_proof(index, half, &proof[..last]);
-                Digest::hash_pair(&left, &proof[last])
+                Digest::hash_pair(left, proof[last])
             } else {
                 let right =
                     compute_raw_root_from_proof(index - half, leaf_count - half, &proof[..last]);
-                Digest::hash_pair(&proof[last], &right)
+                Digest::hash_pair(proof[last], right)
             }
         }
 

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -105,7 +105,8 @@ impl Digest {
         let mut hasher = PAIR_PREFIX_HASHER
             .get_or_init(|| {
                 let mut hasher = VarBlake2b::new(Digest::LENGTH).unwrap();
-                hasher.update([0u8; ChunkWithProof::CHUNK_SIZE_BYTES]);
+                #[allow(clippy::needless_borrow)]
+                hasher.update(&[0u8; ChunkWithProof::CHUNK_SIZE_BYTES]);
                 hasher
             })
             .clone();

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -47,6 +47,8 @@ pub use indexed_merkle_proof::IndexedMerkleProof;
 #[schemars(with = "String", description = "Hex-encoded hash digest.")]
 pub struct Digest(#[schemars(skip, with = "String")] [u8; Digest::LENGTH]);
 
+const CHUNK_DATA_ZEROED: &[u8] = &[0u8; ChunkWithProof::CHUNK_SIZE_BYTES];
+
 impl Digest {
     /// The number of bytes in a `Digest`.
     pub const LENGTH: usize = 32;
@@ -105,8 +107,7 @@ impl Digest {
         let mut hasher = PAIR_PREFIX_HASHER
             .get_or_init(|| {
                 let mut hasher = VarBlake2b::new(Digest::LENGTH).unwrap();
-                #[allow(clippy::needless_borrow)]
-                hasher.update(&[0u8; ChunkWithProof::CHUNK_SIZE_BYTES]);
+                hasher.update(CHUNK_DATA_ZEROED);
                 hasher
             })
             .clone();

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -105,7 +105,7 @@ impl Digest {
         let mut hasher = PAIR_PREFIX_HASHER
             .get_or_init(|| {
                 let mut hasher = VarBlake2b::new(Digest::LENGTH).unwrap();
-                hasher.update(&[0u8; ChunkWithProof::CHUNK_SIZE_BYTES]);
+                hasher.update([0u8; ChunkWithProof::CHUNK_SIZE_BYTES]);
                 hasher
             })
             .clone();
@@ -180,8 +180,8 @@ impl Digest {
         let mut kv_hashes: Vec<Digest> = Vec::with_capacity(btree_map.len());
         for (key, value) in btree_map.iter() {
             kv_hashes.push(Digest::hash_pair(
-                &Digest::hash(key.to_bytes()?),
-                &Digest::hash(value.to_bytes()?),
+                Digest::hash(key.to_bytes()?),
+                Digest::hash(value.to_bytes()?),
             ))
         }
         Ok(Self::hash_merkle_tree(kv_hashes))
@@ -212,7 +212,7 @@ impl Digest {
     pub fn hash_slice_with_proof(slice: &[Digest], proof: Digest) -> Digest {
         slice
             .iter()
-            .rfold(proof, |prev, next| Digest::hash_pair(next, &prev))
+            .rfold(proof, |prev, next| Digest::hash_pair(next, prev))
     }
 
     /// Returns a `Digest` parsed from a hex-encoded `Digest`.
@@ -343,7 +343,7 @@ impl Serialize for Digest {
         } else {
             // This is to keep backwards compatibility with how HexForm encodes
             // byte arrays. HexForm treats this like a slice.
-            (&self.0[..]).serialize(serializer)
+            self.0[..].serialize(serializer)
         }
     }
 }
@@ -503,7 +503,7 @@ mod tests {
         let hash1 = Digest([1u8; 32]);
         let hash2 = Digest([2u8; 32]);
 
-        let hash = Digest::hash_pair(&hash1, &hash2);
+        let hash = Digest::hash_pair(hash1, hash2);
         let hash_lower_hex = format!("{:x}", hash);
 
         assert_eq!(
@@ -675,7 +675,7 @@ mod tests {
             190, 67, 244, 169, 31, 95,
         ];
         assert_eq!(
-            Digest::blake2b_hash(&expected_final_hash_input),
+            Digest::blake2b_hash(expected_final_hash_input),
             long_data_hash
         );
 

--- a/json_rpc/src/filters.rs
+++ b/json_rpc/src/filters.rs
@@ -80,7 +80,7 @@ async fn handle_body(
     handlers: RequestHandlers,
     allow_unknown_fields: bool,
 ) -> Result<Response, Rejection> {
-    let response = match serde_json::from_slice::<Map<String, Value>>(&*body) {
+    let response = match serde_json::from_slice::<Map<String, Value>>(&body) {
         Ok(unvalidated_request) => match Request::new(unvalidated_request, allow_unknown_fields) {
             Ok(request) => handlers.handle_request(request).await,
             Err(ErrorOrRejection::Error { id, error }) => {

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -37,6 +37,7 @@ static ALLOC: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
 #[structopt(version = crate::VERSION_STRING_COLOR.as_str())]
+#[allow(rustdoc::invalid_html_tags)]
 /// Casper blockchain node.
 pub enum Cli {
     /// Run the node in standard mode.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -250,7 +250,7 @@ impl Cli {
             .unwrap_or_else(|| "/".into());
 
         // The app supports running without a config file, using default values.
-        let encoded_config = fs::read_to_string(&config)
+        let encoded_config = fs::read_to_string(config)
             .context("could not read configuration file")
             .with_context(|| config.display().to_string())?;
 

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -190,7 +190,7 @@ impl BlockSynchronizerStatus {
 
 impl DocExample for BlockSynchronizerStatus {
     fn doc_example() -> &'static Self {
-        &*BLOCK_SYNCHRONIZER_STATUS
+        &BLOCK_SYNCHRONIZER_STATUS
     }
 }
 

--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -633,7 +633,7 @@ impl BlockAcquisitionState {
                 return Ok(None)
             }
         };
-        let ret = currently_acquiring_sigs.then(|| acceptance);
+        let ret = currently_acquiring_sigs.then_some(acceptance);
         info!(
             signature=%cloned_sig,
             ?ret,

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -289,13 +289,13 @@ where
                             DeployOrTransferHash::Deploy(hash) => {
                                 state.appendable_block.add_deploy(
                                     DeployHashWithApprovals::new(hash, approvals.clone()),
-                                    &*deploy_info,
+                                    &deploy_info,
                                 )
                             }
                             DeployOrTransferHash::Transfer(hash) => {
                                 state.appendable_block.add_transfer(
                                     DeployHashWithApprovals::new(hash, approvals.clone()),
-                                    &*deploy_info,
+                                    &deploy_info,
                                 )
                             }
                         };

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -109,10 +109,7 @@ impl Era {
             .drain()
             .partition(|(_, validation_state)| validation_state.is_complete());
         self.validation_states = incomplete;
-        complete
-            .into_iter()
-            .map(|(proposed_block, _)| proposed_block)
-            .collect()
+        complete.into_keys().collect()
     }
 
     /// Marks the block payload as valid or invalid. Returns `false` if the block was not present

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -230,16 +230,16 @@ impl<C: Context + 'static> Synchronizer<C> {
     // Every pending vertex is counted once, even if it has multiple senders.
     fn vertices_to_be_added_later_len(&self) -> u64 {
         self.vertices_to_be_added_later
-            .iter()
-            .map(|(_, pv)| pv.len())
+            .values()
+            .map(|pv| pv.len())
             .sum()
     }
 
     // Returns number of elements in `vertex_deps` queue.
     fn vertices_awaiting_deps_len(&self) -> u64 {
         self.vertices_awaiting_deps
-            .iter()
-            .map(|(_, pv)| pv.len())
+            .values()
+            .map(|pv| pv.len())
             .sum()
     }
 

--- a/node/src/components/consensus/leader_sequence.rs
+++ b/node/src/components/consensus/leader_sequence.rs
@@ -38,7 +38,7 @@ impl LeaderSequence {
         );
         let cumulative_w_leaders = weights
             .enumerate()
-            .map(|(idx, weight)| leaders[idx].then(|| *weight).unwrap_or(Weight(0)))
+            .map(|(idx, weight)| if leaders[idx] { *weight } else { Weight(0) })
             .fold(vec![], sums)
             .into();
         LeaderSequence {

--- a/node/src/components/consensus/protocols/common.rs
+++ b/node/src/components/consensus/protocols/common.rs
@@ -17,7 +17,7 @@ pub(crate) fn validators<C: Context>(
     inactive: &HashSet<C::ValidatorId>,
     validator_stakes: BTreeMap<C::ValidatorId, U512>,
 ) -> Validators<C::ValidatorId> {
-    let sum_stakes: U512 = validator_stakes.iter().map(|(_, stake)| *stake).sum();
+    let sum_stakes: U512 = validator_stakes.values().copied().sum();
     // We use u64 weights. Scale down by sum / u64::MAX, rounded up.
     // If we round up the divisor, the resulting sum is guaranteed to be less than
     // u64::MAX.

--- a/node/src/components/consensus/protocols/zug/wal.rs
+++ b/node/src/components/consensus/protocols/zug/wal.rs
@@ -69,7 +69,7 @@ impl<C: Context> WriteWal<C> {
         let file = OpenOptions::new()
             .append(true)
             .create(true)
-            .open(&wal_path)
+            .open(wal_path)
             .map_err(WriteWalError::FileCouldntBeOpened)?;
         Ok(WriteWal {
             writer: BufWriter::new(file),
@@ -117,7 +117,7 @@ impl<C: Context> ReadWal<C> {
             .create(true)
             .read(true)
             .write(true)
-            .open(&wal_path)
+            .open(wal_path)
             .map_err(|err| ReadWalError::FileCouldntBeCreated(wal_path.clone(), err))?;
         Ok(ReadWal {
             reader: BufReader::new(file),

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -600,7 +600,7 @@ where
                     responder,
                 }) => responder.respond(self.appendable_block(timestamp)).ignore(),
                 Event::BlockFinalized(finalized_block) => {
-                    self.register_block_finalized(&*finalized_block);
+                    self.register_block_finalized(&finalized_block);
                     Effects::new()
                 }
                 Event::Block(block) => {

--- a/node/src/components/diagnostics_port.rs
+++ b/node/src/components/diagnostics_port.rs
@@ -224,7 +224,7 @@ fn setup_listener<P: AsRef<Path>>(path: P, socket_umask: umask::Mode) -> io::Res
     // check-then-delete :).
     if socket_path.exists() {
         debug!(socket_path=%socket_path.display(), "found stale socket file, trying to remove");
-        match fs::remove_file(&socket_path) {
+        match fs::remove_file(socket_path) {
             Ok(_) => {
                 debug!("stale socket file removed");
             }

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -241,7 +241,7 @@ where
                 }
                 Event::BlockAdded(block) => self.broadcast(SseData::BlockAdded {
                     block_hash: *block.hash(),
-                    block: Box::new(JsonBlock::new(&*block, None)),
+                    block: Box::new(JsonBlock::new(&block, None)),
                 }),
                 Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted {
                     deploy: Arc::new(*deploy),

--- a/node/src/components/network/counting_format.rs
+++ b/node/src/components/network/counting_format.rs
@@ -251,7 +251,7 @@ impl ConnectionId {
         utils::xor(&mut buffer[4..12], &count.to_ne_bytes());
 
         // Hash again and truncate.
-        let full_hash = Digest::hash(&buffer);
+        let full_hash = Digest::hash(buffer);
 
         // Safe to expect here, as we assert earlier that `Digest` is at least 12 bytes.
         let truncated = TryFrom::try_from(&full_hash.value()[0..8]).expect("buffer size mismatch");

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -109,16 +109,18 @@ impl<P: Payload> Message<P> {
         self,
         effect_builder: EffectBuilder<REv>,
         sender: NodeId,
-    ) -> Result<(REv, BoxFuture<'static, Option<P>>), Self>
+    ) -> Result<(REv, BoxFuture<'static, Option<P>>), Box<Self>>
     where
         REv: FromIncoming<P> + Send,
     {
         match self {
-            Message::Handshake { .. } | Message::Ping { .. } | Message::Pong { .. } => Err(self),
+            Message::Handshake { .. } | Message::Ping { .. } | Message::Pong { .. } => {
+                Err(self.into())
+            }
             Message::Payload(payload) => {
                 // Note: For now, the wrapping/unwrap of the payload is a bit unfortunate here.
                 REv::try_demand_from_incoming(effect_builder, sender, payload)
-                    .map_err(Message::Payload)
+                    .map_err(|err| Message::Payload(err).into())
             }
         }
     }

--- a/node/src/components/network/tasks.rs
+++ b/node/src/components/network/tasks.rs
@@ -758,7 +758,7 @@ where
                                 .schedule(
                                     Event::IncomingMessage {
                                         peer_id: Box::new(peer_id),
-                                        msg: Box::new(msg),
+                                        msg,
                                         span: span.clone(),
                                     },
                                     queue_kind,

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -305,7 +305,7 @@ fn network_is_complete(
     for (node_id, node) in nodes {
         let net = &node.reactor().inner().net;
         // TODO: Ensure the connections are symmetrical.
-        let peers: HashSet<_> = net.peers().into_iter().map(|(k, _)| k).collect();
+        let peers: HashSet<_> = net.peers().into_keys().collect();
 
         let mut missing = expected.difference(&peers);
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -14,9 +14,9 @@
 //!
 //! Currently this component supports two endpoints, each of which takes no arguments:
 //! /status : a human readable JSON equivalent of the info-get-status rpc method.
-//!     example: curl -X GET 'http://<ip>:8888/status'
+//!     example: curl -X GET 'http://IP:8888/status'
 //! /metrics : time series data collected from the internals of the node being queried.
-//!     example: curl -X GET 'http://<ip>:8888/metrics'
+//!     example: curl -X GET 'http://IP:8888/metrics'
 
 mod config;
 mod event;

--- a/node/src/components/rpc_server/rpcs/account.rs
+++ b/node/src/components/rpc_server/rpcs/account.rs
@@ -42,7 +42,7 @@ pub struct PutDeployParams {
 
 impl DocExample for PutDeployParams {
     fn doc_example() -> &'static Self {
-        &*PUT_DEPLOY_PARAMS
+        &PUT_DEPLOY_PARAMS
     }
 }
 
@@ -59,7 +59,7 @@ pub struct PutDeployResult {
 
 impl DocExample for PutDeployResult {
     fn doc_example() -> &'static Self {
-        &*PUT_DEPLOY_RESULT
+        &PUT_DEPLOY_RESULT
     }
 }
 

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -117,7 +117,7 @@ pub struct GetBlockParams {
 
 impl DocExample for GetBlockParams {
     fn doc_example() -> &'static Self {
-        &*GET_BLOCK_PARAMS
+        &GET_BLOCK_PARAMS
     }
 }
 
@@ -134,7 +134,7 @@ pub struct GetBlockResult {
 
 impl DocExample for GetBlockResult {
     fn doc_example() -> &'static Self {
-        &*GET_BLOCK_RESULT
+        &GET_BLOCK_RESULT
     }
 }
 
@@ -187,7 +187,7 @@ pub struct GetBlockTransfersParams {
 
 impl DocExample for GetBlockTransfersParams {
     fn doc_example() -> &'static Self {
-        &*GET_BLOCK_TRANSFERS_PARAMS
+        &GET_BLOCK_TRANSFERS_PARAMS
     }
 }
 
@@ -221,7 +221,7 @@ impl GetBlockTransfersResult {
 
 impl DocExample for GetBlockTransfersResult {
     fn doc_example() -> &'static Self {
-        &*GET_BLOCK_TRANSFERS_RESULT
+        &GET_BLOCK_TRANSFERS_RESULT
     }
 }
 
@@ -278,7 +278,7 @@ pub struct GetStateRootHashParams {
 
 impl DocExample for GetStateRootHashParams {
     fn doc_example() -> &'static Self {
-        &*GET_STATE_ROOT_HASH_PARAMS
+        &GET_STATE_ROOT_HASH_PARAMS
     }
 }
 
@@ -295,7 +295,7 @@ pub struct GetStateRootHashResult {
 
 impl DocExample for GetStateRootHashResult {
     fn doc_example() -> &'static Self {
-        &*GET_STATE_ROOT_HASH_RESULT
+        &GET_STATE_ROOT_HASH_RESULT
     }
 }
 
@@ -344,7 +344,7 @@ pub struct GetEraInfoParams {
 
 impl DocExample for GetEraInfoParams {
     fn doc_example() -> &'static Self {
-        &*GET_ERA_INFO_PARAMS
+        &GET_ERA_INFO_PARAMS
     }
 }
 
@@ -361,7 +361,7 @@ pub struct GetEraInfoResult {
 
 impl DocExample for GetEraInfoResult {
     fn doc_example() -> &'static Self {
-        &*GET_ERA_INFO_RESULT
+        &GET_ERA_INFO_RESULT
     }
 }
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -430,7 +430,7 @@ pub struct ListRpcsResult {
 
 impl DocExample for ListRpcsResult {
     fn doc_example() -> &'static Self {
-        &*LIST_RPCS_RESULT
+        &LIST_RPCS_RESULT
     }
 }
 
@@ -468,7 +468,7 @@ mod doc_example_impls {
 
     impl DocExample for Timestamp {
         fn doc_example() -> &'static Self {
-            &*TIMESTAMP_EXAMPLE
+            &TIMESTAMP_EXAMPLE
         }
     }
 }

--- a/node/src/components/rpc_server/rpcs/info.rs
+++ b/node/src/components/rpc_server/rpcs/info.rs
@@ -77,7 +77,7 @@ fn finalized_approvals_default() -> bool {
 
 impl DocExample for GetDeployParams {
     fn doc_example() -> &'static Self {
-        &*GET_DEPLOY_PARAMS
+        &GET_DEPLOY_PARAMS
     }
 }
 
@@ -110,7 +110,7 @@ pub struct GetDeployResult {
 
 impl DocExample for GetDeployResult {
     fn doc_example() -> &'static Self {
-        &*GET_DEPLOY_RESULT
+        &GET_DEPLOY_RESULT
     }
 }
 
@@ -190,7 +190,7 @@ pub struct GetPeersResult {
 
 impl DocExample for GetPeersResult {
     fn doc_example() -> &'static Self {
-        &*GET_PEERS_RESULT
+        &GET_PEERS_RESULT
     }
 }
 
@@ -326,7 +326,7 @@ impl GetValidatorChangesResult {
 
 impl DocExample for GetValidatorChangesResult {
     fn doc_example() -> &'static Self {
-        &*GET_VALIDATOR_CHANGES_RESULT
+        &GET_VALIDATOR_CHANGES_RESULT
     }
 }
 
@@ -369,7 +369,7 @@ impl GetChainspecResult {
 
 impl DocExample for GetChainspecResult {
     fn doc_example() -> &'static Self {
-        &*GET_CHAINSPEC_RESULT
+        &GET_CHAINSPEC_RESULT
     }
 }
 

--- a/node/src/components/rpc_server/rpcs/speculative_exec.rs
+++ b/node/src/components/rpc_server/rpcs/speculative_exec.rs
@@ -48,7 +48,7 @@ pub struct SpeculativeExecParams {
 
 impl DocExample for SpeculativeExecParams {
     fn doc_example() -> &'static Self {
-        &*SPECULATIVE_EXEC_PARAMS
+        &SPECULATIVE_EXEC_PARAMS
     }
 }
 
@@ -67,7 +67,7 @@ pub struct SpeculativeExecResult {
 
 impl DocExample for SpeculativeExecResult {
     fn doc_example() -> &'static Self {
-        &*SPECULATIVE_EXEC_RESULT
+        &SPECULATIVE_EXEC_RESULT
     }
 }
 
@@ -127,14 +127,14 @@ impl RpcWithParams for SpeculativeExec {
                 let rpc_error = match error {
                     EngineStateError::RootNotFound(_) => Error::new(ErrorCode::NoSuchStateRoot, ""),
                     EngineStateError::WasmPreprocessing(error) => {
-                        Error::new(ErrorCode::InvalidDeploy, &format!("{}", error))
+                        Error::new(ErrorCode::InvalidDeploy, format!("{}", error))
                     }
                     EngineStateError::InvalidDeployItemVariant(error) => {
-                        Error::new(ErrorCode::InvalidDeploy, &error)
+                        Error::new(ErrorCode::InvalidDeploy, error)
                     }
                     EngineStateError::InvalidProtocolVersion(_) => Error::new(
                         ErrorCode::InvalidDeploy,
-                        &format!("deploy used invalid protocol version {}", error),
+                        format!("deploy used invalid protocol version {}", error),
                     ),
                     EngineStateError::Deploy => Error::new(ErrorCode::InvalidDeploy, ""),
                     EngineStateError::Genesis(_)
@@ -158,11 +158,11 @@ impl RpcWithParams for SpeculativeExec {
                     | EngineStateError::FailedToGetWithdrawPurses
                     | EngineStateError::FailedToRetrieveUnbondingDelay
                     | EngineStateError::FailedToRetrieveEraId => {
-                        Error::new(ReservedErrorCode::InternalError, &format!("{}", error))
+                        Error::new(ReservedErrorCode::InternalError, format!("{}", error))
                     }
                     _ => Error::new(
                         ReservedErrorCode::InternalError,
-                        &format!("Unhandled engine state error: {}", error),
+                        format!("Unhandled engine state error: {}", error),
                     ),
                 };
                 Err(rpc_error)

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -143,7 +143,7 @@ pub struct GetItemParams {
 
 impl DocExample for GetItemParams {
     fn doc_example() -> &'static Self {
-        &*GET_ITEM_PARAMS
+        &GET_ITEM_PARAMS
     }
 }
 
@@ -162,7 +162,7 @@ pub struct GetItemResult {
 
 impl DocExample for GetItemResult {
     fn doc_example() -> &'static Self {
-        &*GET_ITEM_RESULT
+        &GET_ITEM_RESULT
     }
 }
 
@@ -221,7 +221,7 @@ pub struct GetBalanceParams {
 
 impl DocExample for GetBalanceParams {
     fn doc_example() -> &'static Self {
-        &*GET_BALANCE_PARAMS
+        &GET_BALANCE_PARAMS
     }
 }
 
@@ -240,7 +240,7 @@ pub struct GetBalanceResult {
 
 impl DocExample for GetBalanceResult {
     fn doc_example() -> &'static Self {
-        &*GET_BALANCE_RESULT
+        &GET_BALANCE_RESULT
     }
 }
 
@@ -333,7 +333,7 @@ pub struct GetAuctionInfoParams {
 
 impl DocExample for GetAuctionInfoParams {
     fn doc_example() -> &'static Self {
-        &*GET_AUCTION_INFO_PARAMS
+        &GET_AUCTION_INFO_PARAMS
     }
 }
 
@@ -350,7 +350,7 @@ pub struct GetAuctionInfoResult {
 
 impl DocExample for GetAuctionInfoResult {
     fn doc_example() -> &'static Self {
-        &*GET_AUCTION_INFO_RESULT
+        &GET_AUCTION_INFO_RESULT
     }
 }
 
@@ -478,7 +478,7 @@ pub struct GetAccountInfoParams {
 
 impl DocExample for GetAccountInfoParams {
     fn doc_example() -> &'static Self {
-        &*GET_ACCOUNT_INFO_PARAMS
+        &GET_ACCOUNT_INFO_PARAMS
     }
 }
 
@@ -497,7 +497,7 @@ pub struct GetAccountInfoResult {
 
 impl DocExample for GetAccountInfoResult {
     fn doc_example() -> &'static Self {
-        &*GET_ACCOUNT_INFO_RESULT
+        &GET_ACCOUNT_INFO_RESULT
     }
 }
 
@@ -675,7 +675,7 @@ pub struct GetDictionaryItemParams {
 
 impl DocExample for GetDictionaryItemParams {
     fn doc_example() -> &'static Self {
-        &*GET_DICTIONARY_ITEM_PARAMS
+        &GET_DICTIONARY_ITEM_PARAMS
     }
 }
 
@@ -696,7 +696,7 @@ pub struct GetDictionaryItemResult {
 
 impl DocExample for GetDictionaryItemResult {
     fn doc_example() -> &'static Self {
-        &*GET_DICTIONARY_ITEM_RESULT
+        &GET_DICTIONARY_ITEM_RESULT
     }
 }
 
@@ -784,7 +784,7 @@ pub struct QueryGlobalStateParams {
 
 impl DocExample for QueryGlobalStateParams {
     fn doc_example() -> &'static Self {
-        &*QUERY_GLOBAL_STATE_PARAMS
+        &QUERY_GLOBAL_STATE_PARAMS
     }
 }
 
@@ -805,7 +805,7 @@ pub struct QueryGlobalStateResult {
 
 impl DocExample for QueryGlobalStateResult {
     fn doc_example() -> &'static Self {
-        &*QUERY_GLOBAL_STATE_RESULT
+        &QUERY_GLOBAL_STATE_RESULT
     }
 }
 
@@ -875,7 +875,7 @@ pub struct QueryBalanceParams {
 
 impl DocExample for QueryBalanceParams {
     fn doc_example() -> &'static Self {
-        &*QUERY_BALANCE_PARAMS
+        &QUERY_BALANCE_PARAMS
     }
 }
 
@@ -891,7 +891,7 @@ pub struct QueryBalanceResult {
 
 impl DocExample for QueryBalanceResult {
     fn doc_example() -> &'static Self {
-        &*QUERY_BALANCE_RESULT
+        &QUERY_BALANCE_RESULT
     }
 }
 
@@ -1001,7 +1001,7 @@ pub struct GetTrieParams {
 
 impl DocExample for GetTrieParams {
     fn doc_example() -> &'static Self {
-        &*GET_TRIE_PARAMS
+        &GET_TRIE_PARAMS
     }
 }
 
@@ -1022,7 +1022,7 @@ pub struct GetTrieResult {
 
 impl DocExample for GetTrieResult {
     fn doc_example() -> &'static Self {
-        &*GET_TRIE_RESULT
+        &GET_TRIE_RESULT
     }
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -699,7 +699,7 @@ impl Storage {
                 if let Some(item) = opt_item.as_ref() {
                     if item.block_hash != id.block_hash || item.era_id != id.era_id {
                         return Err(GetRequestError::FinalitySignatureIdMismatch {
-                            requested_id: id,
+                            requested_id: Box::new(id),
                             finality_signature: Box::new(item.clone()),
                         });
                     }
@@ -761,7 +761,7 @@ impl Storage {
         // average the actual execution time will be very low.
         Ok(match req {
             StorageRequest::PutBlock { block, responder } => {
-                responder.respond(self.write_block(&*block)?).ignore()
+                responder.respond(self.write_block(&block)?).ignore()
             }
             StorageRequest::PutApprovalsHashes {
                 approvals_hashes,
@@ -769,7 +769,7 @@ impl Storage {
             } => {
                 let env = Rc::clone(&self.env);
                 let mut txn = env.begin_rw_txn()?;
-                let result = self.write_approvals_hashes(&mut txn, &*approvals_hashes)?;
+                let result = self.write_approvals_hashes(&mut txn, &approvals_hashes)?;
                 txn.commit()?;
                 responder.respond(result).ignore()
             }
@@ -829,7 +829,7 @@ impl Storage {
                     .ignore()
             }
             StorageRequest::PutDeploy { deploy, responder } => {
-                responder.respond(self.put_deploy(&*deploy)?).ignore()
+                responder.respond(self.put_deploy(&deploy)?).ignore()
             }
             StorageRequest::GetDeploys {
                 deploy_hashes,
@@ -868,7 +868,7 @@ impl Storage {
                     None => None,
                     Some(deploy_with_finalized_approvals) => {
                         let deploy = deploy_with_finalized_approvals.into_naive();
-                        (deploy.fetch_id() == deploy_id).then(|| deploy)
+                        (deploy.fetch_id() == deploy_id).then_some(deploy)
                     }
                 };
                 responder.respond(maybe_deploy).ignore()
@@ -897,7 +897,7 @@ impl Storage {
             } => {
                 let env = Rc::clone(&self.env);
                 let mut txn = env.begin_rw_txn()?;
-                self.write_execution_results(&mut txn, &*block_hash, execution_results)?;
+                self.write_execution_results(&mut txn, &block_hash, execution_results)?;
                 txn.commit()?;
                 responder.respond(()).ignore()
             }

--- a/node/src/components/storage/error.rs
+++ b/node/src/components/storage/error.rs
@@ -174,6 +174,12 @@ impl From<lmdb::Error> for FatalStorageError {
     }
 }
 
+impl From<Box<BlockValidationError>> for FatalStorageError {
+    fn from(err: Box<BlockValidationError>) -> Self {
+        Self::BlockValidation(*err)
+    }
+}
+
 /// An error that may occur when handling a get request.
 ///
 /// Wraps a fatal error, callers should check whether the variant is of the fatal or non-fatal kind.
@@ -192,7 +198,7 @@ pub(super) enum GetRequestError {
     )]
     FinalitySignatureIdMismatch {
         // the ID requested
-        requested_id: FinalitySignatureId,
+        requested_id: Box<FinalitySignatureId>,
         // the finality signature read from storage
         finality_signature: Box<FinalitySignature>,
     },

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -359,7 +359,7 @@ struct UpgradePoint {
 impl UpgradePoint {
     /// Parses a chainspec file at the given path as an `UpgradePoint`.
     fn from_chainspec_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let bytes = file_utils::read_file(path.as_ref().join(&CHAINSPEC_FILENAME))
+        let bytes = file_utils::read_file(path.as_ref().join(CHAINSPEC_FILENAME))
             .map_err(Error::LoadUpgradePoint)?;
         Ok(toml::from_slice(&bytes)?)
     }

--- a/node/src/data_migration.rs
+++ b/node/src/data_migration.rs
@@ -232,7 +232,7 @@ mod tests {
         let info_path = tempdir.path().join(POST_MIGRATION_STATE_HASH_FILENAME);
 
         let mut rng = crate::new_rng();
-        let state_hash = Digest::hash(&[rng.gen()]);
+        let state_hash = Digest::hash([rng.gen()]);
         let protocol_version = ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen());
         let secret_key = SecretKey::random(&mut rng);
 
@@ -260,7 +260,7 @@ mod tests {
         assert!(maybe_hash.is_none());
 
         // Create the info file and check we can read it.
-        let state_hash = Digest::hash(&[rng.gen()]);
+        let state_hash = Digest::hash([rng.gen()]);
         write_post_migration_info(state_hash, protocol_version, &secret_key, info_path.clone())
             .unwrap();
         assert!(
@@ -293,7 +293,7 @@ mod tests {
 
         // Should return `Err` if the signature is invalid.
         let other_secret_key = SecretKey::random(&mut rng);
-        let state_hash = Digest::hash(&[rng.gen()]);
+        let state_hash = Digest::hash([rng.gen()]);
         write_post_migration_info(
             state_hash,
             protocol_version,

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -556,11 +556,11 @@ where
         let event_desc = event.description();
 
         // Create another span for tracing the processing of one event.
-        Span::current().record("ev", &self.current_event_id);
+        Span::current().record("ev", self.current_event_id);
 
         // If we know the ancestor of an event, record it.
         if let Some(ancestor) = ancestor {
-            Span::current().record("a", &ancestor.get());
+            Span::current().record("a", ancestor.get());
         }
 
         // Dispatch the event, then execute the resulting effect.

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -384,7 +384,7 @@ impl MainReactor {
         ));
 
         self.block_synchronizer
-            .register_sync_leap(&*best_available, from_peers, true);
+            .register_sync_leap(&best_available, from_peers, true);
 
         CatchUpInstruction::Do(self.control_logic_default_delay.into(), effects)
     }

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -702,15 +702,15 @@ async fn should_store_finalized_approvals() {
     let mut deploy_alice_bob_charlie = deploy_alice_bob.clone();
     let mut deploy_bob_alice = deploy_alice_bob.clone();
 
-    deploy_alice_bob.sign(&*alice_secret_key);
-    deploy_alice_bob.sign(&*bob_secret_key);
+    deploy_alice_bob.sign(&alice_secret_key);
+    deploy_alice_bob.sign(&bob_secret_key);
 
-    deploy_alice_bob_charlie.sign(&*alice_secret_key);
-    deploy_alice_bob_charlie.sign(&*bob_secret_key);
-    deploy_alice_bob_charlie.sign(&*charlie_secret_key);
+    deploy_alice_bob_charlie.sign(&alice_secret_key);
+    deploy_alice_bob_charlie.sign(&bob_secret_key);
+    deploy_alice_bob_charlie.sign(&charlie_secret_key);
 
-    deploy_bob_alice.sign(&*bob_secret_key);
-    deploy_bob_alice.sign(&*alice_secret_key);
+    deploy_bob_alice.sign(&bob_secret_key);
+    deploy_bob_alice.sign(&alice_secret_key);
 
     // We will be testing the correct sequence of approvals against the deploy signed by Bob and
     // Alice.

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -588,7 +588,7 @@ pub(crate) fn key_fingerprint(ec_key: EcKey<Public>) -> Result<KeyFingerprint, V
             &mut big_num_context,
         )
         .map_err(ValidationError::PublicKeyEncodingFailed)?;
-    let key_fingerprint = KeyFingerprint(Sha512::new(&buf));
+    let key_fingerprint = KeyFingerprint(Sha512::new(buf));
     Ok(key_fingerprint)
 }
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -416,7 +416,7 @@ impl FromBytes for EraReport {
 
 impl DocExample for EraReport {
     fn doc_example() -> &'static Self {
-        &*ERA_REPORT
+        &ERA_REPORT
     }
 }
 
@@ -583,7 +583,7 @@ impl FinalizedBlock {
 
 impl DocExample for FinalizedBlock {
     fn doc_example() -> &'static Self {
-        &*FINALIZED_BLOCK
+        &FINALIZED_BLOCK
     }
 }
 
@@ -797,7 +797,7 @@ impl Display for EraEnd {
 
 impl DocExample for EraEnd {
     fn doc_example() -> &'static Self {
-        &*ERA_END
+        &ERA_END
     }
 }
 
@@ -910,7 +910,7 @@ impl BlockHeader {
         *self.block_hash.get_or_init(|| {
             let serialized_header = Self::serialize(self)
                 .unwrap_or_else(|error| panic!("should serialize block header: {}", error));
-            BlockHash::new(Digest::hash(&serialized_header))
+            BlockHash::new(Digest::hash(serialized_header))
         })
     }
 
@@ -1135,7 +1135,7 @@ impl BlockBody {
             let serialized_body = self
                 .to_bytes()
                 .unwrap_or_else(|error| panic!("should serialize block body: {}", error));
-            Digest::hash(&serialized_body)
+            Digest::hash(serialized_body)
         })
     }
 }
@@ -1339,7 +1339,7 @@ impl Block {
     pub(crate) fn new_from_header_and_body(
         header: BlockHeader,
         body: BlockBody,
-    ) -> Result<Self, BlockValidationError> {
+    ) -> Result<Self, Box<BlockValidationError>> {
         let hash = header.block_hash();
         let block = Block { hash, header, body };
         block.verify()?;
@@ -1410,6 +1410,7 @@ impl Block {
     }
 
     /// Check the integrity of a block by hashing its body and header
+    #[allow(clippy::result_large_err)]
     pub fn verify(&self) -> Result<(), BlockValidationError> {
         let actual_block_header_hash = self.header().block_hash();
         if *self.hash() != actual_block_header_hash {
@@ -1566,7 +1567,7 @@ impl Block {
 
 impl DocExample for Block {
     fn doc_example() -> &'static Self {
-        &*BLOCK
+        &BLOCK
     }
 }
 
@@ -2040,7 +2041,7 @@ pub(crate) mod json_compatibility {
 
     impl DocExample for JsonBlockHeader {
         fn doc_example() -> &'static Self {
-            &*JSON_BLOCK_HEADER
+            &JSON_BLOCK_HEADER
         }
     }
 
@@ -2119,7 +2120,7 @@ pub(crate) mod json_compatibility {
 
     impl DocExample for JsonBlock {
         fn doc_example() -> &'static Self {
-            &*JSON_BLOCK
+            &JSON_BLOCK
         }
     }
 
@@ -2468,7 +2469,7 @@ mod tests {
         let mut rng = TestRng::new();
 
         let mut random_block = Block::random(&mut rng);
-        let bogus_block_body_hash = Digest::hash(&[0xde, 0xad, 0xbe, 0xef]);
+        let bogus_block_body_hash = Digest::hash([0xde, 0xad, 0xbe, 0xef]);
         random_block.header.body_hash = bogus_block_body_hash;
         random_block.hash = random_block.header.block_hash();
         let bogus_block_hash = random_block.hash;
@@ -2489,7 +2490,7 @@ mod tests {
         let mut rng = TestRng::new();
 
         let mut random_block = Block::random(&mut rng);
-        let bogus_block_hash: BlockHash = Digest::hash(&[0xde, 0xad, 0xbe, 0xef]).into();
+        let bogus_block_hash: BlockHash = Digest::hash([0xde, 0xad, 0xbe, 0xef]).into();
         random_block.hash = bogus_block_hash;
 
         // No Eq trait for BlockValidationError, so pattern match

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -126,7 +126,7 @@ impl Chainspec {
             error!(%error, "failed to serialize chainspec");
             vec![]
         });
-        Digest::hash(&serialized_chainspec)
+        Digest::hash(serialized_chainspec)
     }
 
     /// Returns the protocol version of the chainspec.

--- a/node/src/types/json_compatibility.rs
+++ b/node/src/types/json_compatibility.rs
@@ -12,7 +12,7 @@ pub use auction_state::AuctionState;
 pub use contracts::{Contract, ContractPackage};
 pub use stored_value::StoredValue;
 
-/// A helper function to change NamedKeys into a Vec<NamedKey>
+/// A helper function to change NamedKeys into a `Vec<NamedKey>`
 pub fn vectorize(keys: &NamedKeys) -> Vec<NamedKey> {
     let named_keys = keys
         .iter()

--- a/node/src/types/json_compatibility/account.rs
+++ b/node/src/types/json_compatibility/account.rs
@@ -94,6 +94,6 @@ impl From<&ExecutionEngineAccount> for Account {
 
 impl DocExample for Account {
     fn doc_example() -> &'static Self {
-        &*ACCOUNT
+        &ACCOUNT
     }
 }

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -197,18 +197,18 @@ impl AuctionState {
 
 impl DocExample for AuctionState {
     fn doc_example() -> &'static Self {
-        &*AUCTION_INFO
+        &AUCTION_INFO
     }
 }
 
 impl DocExample for EraValidators {
     fn doc_example() -> &'static Self {
-        &*ERA_VALIDATORS
+        &ERA_VALIDATORS
     }
 }
 
 impl DocExample for Bids {
     fn doc_example() -> &'static Self {
-        &*BIDS
+        &BIDS
     }
 }

--- a/node/src/types/node_id.rs
+++ b/node/src/types/node_id.rs
@@ -78,7 +78,7 @@ static NODE_ID: Lazy<NodeId> =
 
 impl DocExample for NodeId {
     fn doc_example() -> &'static Self {
-        &*NODE_ID
+        &NODE_ID
     }
 }
 

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -69,7 +69,7 @@ pub struct ChainspecInfo {
 
 impl DocExample for ChainspecInfo {
     fn doc_example() -> &'static Self {
-        &*CHAINSPEC_INFO
+        &CHAINSPEC_INFO
     }
 }
 
@@ -235,6 +235,6 @@ impl GetStatusResult {
 
 impl DocExample for GetStatusResult {
     fn doc_example() -> &'static Self {
-        &*GET_STATUS_RESULT
+        &GET_STATUS_RESULT
     }
 }

--- a/node/src/types/value_or_chunk.rs
+++ b/node/src/types/value_or_chunk.rs
@@ -137,7 +137,7 @@ impl Display for HashingTrieRaw {
 
 impl HashingTrieRaw {
     fn hash(&self) -> Digest {
-        *self.hash.get_or_init(|| Digest::hash(&self.inner.inner()))
+        *self.hash.get_or_init(|| Digest::hash(self.inner.inner()))
     }
 
     pub fn inner(&self) -> &TrieRaw {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.63"
+channel = "1.67.1"

--- a/types/src/bytesrepr/bytes.rs
+++ b/types/src/bytesrepr/bytes.rs
@@ -135,7 +135,7 @@ impl Index<Range<usize>> for Bytes {
     type Output = [u8];
 
     fn index(&self, index: Range<usize>) -> &[u8] {
-        let &Bytes(ref dat) = self;
+        let Bytes(dat) = self;
         &dat[index]
     }
 }
@@ -144,7 +144,7 @@ impl Index<RangeTo<usize>> for Bytes {
     type Output = [u8];
 
     fn index(&self, index: RangeTo<usize>) -> &[u8] {
-        let &Bytes(ref dat) = self;
+        let Bytes(dat) = self;
         &dat[index]
     }
 }
@@ -153,7 +153,7 @@ impl Index<RangeFrom<usize>> for Bytes {
     type Output = [u8];
 
     fn index(&self, index: RangeFrom<usize>) -> &[u8] {
-        let &Bytes(ref dat) = self;
+        let Bytes(dat) = self;
         &dat[index]
     }
 }
@@ -162,7 +162,7 @@ impl Index<RangeFull> for Bytes {
     type Output = [u8];
 
     fn index(&self, _: RangeFull) -> &[u8] {
-        let &Bytes(ref dat) = self;
+        let Bytes(dat) = self;
         &dat[..]
     }
 }
@@ -278,7 +278,7 @@ impl<'de> Deserialize<'de> for Bytes {
     {
         if deserializer.is_human_readable() {
             let hex_string = String::deserialize(deserializer)?;
-            checksummed_hex::decode(&hex_string)
+            checksummed_hex::decode(hex_string)
                 .map(Bytes)
                 .map_err(SerdeError::custom)
         } else {

--- a/types/src/checksummed_hex.rs
+++ b/types/src/checksummed_hex.rs
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn should_decode_empty_input() {
         let input = String::new();
-        let actual = decode(&input).unwrap();
+        let actual = decode(input).unwrap();
         assert!(actual.is_empty());
     }
 
@@ -163,14 +163,14 @@ mod tests {
         assert!(decode("A1a2").is_err());
 
         let large_encoded = format!("A1{}", small_encoded);
-        assert!(decode(&large_encoded).is_ok());
+        assert!(decode(large_encoded).is_ok());
     }
 
     #[proptest]
     fn hex_roundtrip(input: Vec<u8>) {
         prop_assert_eq!(
             input.clone(),
-            decode(&encode_iter(&input).collect::<String>()).expect("Failed to decode input.")
+            decode(encode_iter(&input).collect::<String>()).expect("Failed to decode input.")
         );
     }
 
@@ -219,7 +219,7 @@ mod tests {
     #[proptest]
     fn hex_roundtrip_sanity(input: Vec<u8>) {
         prop_assert!(matches!(
-            decode(&encode_iter(&input).collect::<String>()),
+            decode(encode_iter(&input).collect::<String>()),
             Ok(_)
         ))
     }
@@ -227,18 +227,18 @@ mod tests {
     #[proptest]
     fn is_same_case_uppercase(input: String) {
         let input = input.to_uppercase();
-        prop_assert!(string_is_same_case(&input));
+        prop_assert!(string_is_same_case(input));
     }
 
     #[proptest]
     fn is_same_case_lowercase(input: String) {
         let input = input.to_lowercase();
-        prop_assert!(string_is_same_case(&input));
+        prop_assert!(string_is_same_case(input));
     }
 
     #[proptest]
     fn is_not_same_case(input: String) {
         let input = format!("aA{}", input);
-        prop_assert!(!string_is_same_case(&input));
+        prop_assert!(!string_is_same_case(input));
     }
 }

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -1027,7 +1027,7 @@ impl EntryPoints {
 
     /// Takes all entry points.
     pub fn take_entry_points(self) -> Vec<EntryPoint> {
-        self.0.into_iter().map(|(_name, value)| value).collect()
+        self.0.into_values().collect()
     }
 
     /// Returns the length of the entry points

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -143,8 +143,8 @@ where
 
         let (tag_hex, key_hex) = input.as_ref().split_at(2);
 
-        let tag = checksummed_hex::decode(&tag_hex)?;
-        let key_bytes = checksummed_hex::decode(&key_hex)?;
+        let tag = checksummed_hex::decode(tag_hex)?;
+        let key_bytes = checksummed_hex::decode(key_hex)?;
 
         match tag[0] {
             SYSTEM_TAG => {
@@ -439,7 +439,7 @@ impl SecretKey {
 
     /// Returns an example value for documentation purposes.
     pub fn doc_example() -> &'static Self {
-        &*ED25519_SECRET_KEY
+        &ED25519_SECRET_KEY
     }
 }
 
@@ -666,7 +666,7 @@ impl PublicKey {
 
     /// Returns an example value for documentation purposes.
     pub fn doc_example() -> &'static Self {
-        &*ED25519_PUBLIC_KEY
+        &ED25519_PUBLIC_KEY
     }
 }
 

--- a/types/src/crypto/asymmetric_key/tests.rs
+++ b/types/src/crypto/asymmetric_key/tests.rs
@@ -848,7 +848,7 @@ fn should_construct_secp256k1_from_uncompressed_bytes() {
         base16::encode_lower(secp256k1_public_key.to_encoded_point(false).as_bytes())
             .to_lowercase()
     );
-    let from_uncompressed_hex = PublicKey::from_hex(&uncompressed_hex).unwrap();
+    let from_uncompressed_hex = PublicKey::from_hex(uncompressed_hex).unwrap();
     assert_eq!(public_key, from_uncompressed_hex);
 }
 

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -183,7 +183,7 @@ impl ExecutionResult {
     #[doc(hidden)]
     #[cfg(feature = "json-schema")]
     pub fn example() -> &'static Self {
-        &*EXECUTION_RESULT
+        &EXECUTION_RESULT
     }
 
     fn tag(&self) -> ExecutionResultTag {

--- a/types/src/system/auction/bid.rs
+++ b/types/src/system/auction/bid.rs
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn should_initialize_delegators_different_timestamps() {
-        const TIMESTAMP_MILLIS: u64 = WEEK_MILLIS as u64;
+        const TIMESTAMP_MILLIS: u64 = WEEK_MILLIS;
 
         let validator_pk: PublicKey = (&SecretKey::ed25519_from_bytes([42; 32]).unwrap()).into();
 

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -47,7 +47,7 @@ pub struct VestingSchedule {
 fn vesting_schedule_period_to_weeks(vesting_schedule_period_millis: u64) -> u64 {
     debug_assert_ne!(DAY_MILLIS, 0);
     debug_assert_ne!(DAYS_IN_WEEK, 0);
-    vesting_schedule_period_millis as u64 / (DAY_MILLIS as u64) / (DAYS_IN_WEEK as u64)
+    vesting_schedule_period_millis / (DAY_MILLIS as u64) / (DAYS_IN_WEEK as u64)
 }
 
 impl VestingSchedule {
@@ -507,7 +507,7 @@ mod tests {
             prop_assert!(vested_amounts_match_initial_stake(
                 stake,
                 DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
-                DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS as u64,
+                DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS,
             ))
         }
 

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -165,9 +165,9 @@ function await_node_historical_sync_to_genesis() {
     local WAIT_TIME_SEC=0
     local LOWEST=$(get_node_lowest_available_block "$NODE_ID")
     local HIGHEST=$(get_node_highest_available_block "$NODE_ID")
-    while [ "$LOWEST" -ne 0 ] || ["$HIGHEST" -eq 0]; do
+    while [ $LOWEST -ne 0 ] || [ $HIGHEST -eq 0 ]; do
         log "node $NODE_ID lowest available block: $LOWEST, highest available block: $HIGHEST"
-        if [ "$WAIT_TIME_SEC" -gt $SYNC_TIMEOUT_SEC ]; then
+        if [ $WAIT_TIME_SEC -gt $SYNC_TIMEOUT_SEC ]; then
             log "ERROR: node 1 failed to do historical sync in ${SYNC_TIMEOUT_SEC} seconds"
             exit 1
         fi


### PR DESCRIPTION
This PR bumps the pinned rust version to 1.67.1 and satisfies updated Clippy.

Node built from this branch was tested with `casper-test` and all tests are passing, in particular, the test that verifies trie chunking mechanism.