### PR TITLE
Share info about blocks and finality signatures between BlockAccumulator and fetchers

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -816,7 +816,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 Effects::new()
             }
             Event::ReceivedBlock { block, sender } => {
-                let meta_block = MetaBlock::new(Arc::new(*block), vec![], MetaBlockState::new());
+                let meta_block = MetaBlock::new(block, vec![], MetaBlockState::new());
                 self.register_block(effect_builder, meta_block, Some(sender))
             }
             Event::CreatedFinalitySignature { finality_signature } => {

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use datasize::DataSize;
 use itertools::Itertools;
@@ -12,8 +15,8 @@ use crate::{
         fetcher::{EmptyValidationMetadata, FetchItem},
     },
     types::{
-        BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock, NodeId,
-        SignatureWeight,
+        Block, BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock,
+        NodeId, SignatureWeight,
     },
 };
 
@@ -58,6 +61,18 @@ impl BlockAcceptor {
 
     pub(super) fn peers(&self) -> &BTreeSet<NodeId> {
         &self.peers
+    }
+
+    pub(super) fn block(&self) -> Option<Arc<Block>> {
+        self.meta_block
+            .as_ref()
+            .map(|meta_block| Arc::clone(&meta_block.block))
+    }
+
+    pub(super) fn finality_signature(&self, public_key: &PublicKey) -> Option<FinalitySignature> {
+        self.signatures
+            .get(public_key)
+            .map(|(finality_signature, _peer)| finality_signature.clone())
     }
 
     pub(super) fn register_peer(&mut self, peer: NodeId) {

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use derive_more::From;
 
@@ -19,7 +22,7 @@ pub(crate) enum Event {
         sender: NodeId,
     },
     ReceivedBlock {
-        block: Box<Block>,
+        block: Arc<Block>,
         sender: NodeId,
     },
     CreatedFinalitySignature {

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -48,6 +48,20 @@ impl Display for Event {
                     block_hash
                 )
             }
+            Event::Request(BlockAccumulatorRequest::GetBlock { block_hash, .. }) => {
+                write!(f, "block accumulator block request for {}", block_hash)
+            }
+            Event::Request(BlockAccumulatorRequest::GetFinalitySignature {
+                block_hash,
+                public_key,
+                ..
+            }) => {
+                write!(
+                    f,
+                    "block accumulator signature request of {} for {}",
+                    public_key, block_hash
+                )
+            }
             Event::RegisterPeer {
                 block_hash, sender, ..
             } => {

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1228,7 +1228,7 @@ async fn block_accumulator_reactor_flow() {
         runner
             .process_injected_effects(|effect_builder| {
                 let event = super::Event::ReceivedBlock {
-                    block: Box::new(block_1.clone()),
+                    block: Arc::new(block_1.clone()),
                     sender: peer_2,
                 };
                 effect_builder
@@ -1268,7 +1268,7 @@ async fn block_accumulator_reactor_flow() {
 
         let block_accumulator = &mut reactor.block_accumulator;
         let event = super::Event::ReceivedBlock {
-            block: Box::new(block_2.clone()),
+            block: Arc::new(block_2.clone()),
             sender: peer_2,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
@@ -1470,7 +1470,7 @@ async fn block_accumulator_reactor_flow() {
 
         let block_accumulator = &mut reactor.block_accumulator;
         let event = super::Event::ReceivedBlock {
-            block: Box::new(older_block.clone()),
+            block: Arc::new(older_block.clone()),
             sender: peer_1,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -17,7 +17,7 @@ pub(crate) enum Event<T: FetchItem> {
     Fetch(FetcherRequest<T>),
     /// The result of the `Fetcher` getting a item from the storage component.  If the
     /// result is `None`, the item should be requested from the peer.
-    GetFromStorageResult {
+    GetLocallyResult {
         id: T::Id,
         peer: NodeId,
         validation_metadata: T::ValidationMetadata,
@@ -93,7 +93,7 @@ impl<T: FetchItem> Display for Event<T> {
             Event::Fetch(FetcherRequest { id, .. }) => {
                 write!(formatter, "request to fetch item at hash {}", id)
             }
-            Event::GetFromStorageResult { id, maybe_item, .. } => {
+            Event::GetLocallyResult { id, maybe_item, .. } => {
                 if maybe_item.is_some() {
                     write!(formatter, "got {} from storage", id)
                 } else {

--- a/node/src/components/fetcher/fetcher_impls/approvals_hashes_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/approvals_hashes_fetcher.rs
@@ -45,4 +45,11 @@ impl ItemFetcher<ApprovalsHashes> for Fetcher<ApprovalsHashes> {
                 .boxed(),
         )
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: ApprovalsHashes,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/approvals_hashes_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/approvals_hashes_fetcher.rs
@@ -27,7 +27,7 @@ impl ItemFetcher<ApprovalsHashes> for Fetcher<ApprovalsHashes> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
     ) -> Option<ApprovalsHashes> {

--- a/node/src/components/fetcher/fetcher_impls/block_execution_results_or_chunk_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_execution_results_or_chunk_fetcher.rs
@@ -29,7 +29,7 @@ impl ItemFetcher<BlockExecutionResultsOrChunk> for Fetcher<BlockExecutionResults
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: BlockExecutionResultsOrChunkId,
     ) -> Option<BlockExecutionResultsOrChunk> {

--- a/node/src/components/fetcher/fetcher_impls/block_execution_results_or_chunk_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_execution_results_or_chunk_fetcher.rs
@@ -45,4 +45,11 @@ impl ItemFetcher<BlockExecutionResultsOrChunk> for Fetcher<BlockExecutionResults
         // Stored by the BlockSynchronizer once all chunks are fetched.
         StoringState::WontStore(item)
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: BlockExecutionResultsOrChunk,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
@@ -5,7 +5,10 @@ use futures::FutureExt;
 
 use crate::{
     components::fetcher::{metrics::Metrics, Fetcher, ItemFetcher, ItemHandle, StoringState},
-    effect::{requests::StorageRequest, EffectBuilder},
+    effect::{
+        requests::{BlockAccumulatorRequest, StorageRequest},
+        EffectBuilder,
+    },
     types::{Block, BlockHash, NodeId},
 };
 
@@ -25,11 +28,17 @@ impl ItemFetcher<Block> for Fetcher<Block> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + From<BlockAccumulatorRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
     ) -> Option<Block> {
-        effect_builder.get_block_from_storage(id).await
+        if let Some(block) = effect_builder.get_block_from_storage(id).await {
+            return Some(block);
+        }
+        effect_builder
+            .get_block_from_block_accumulator(id)
+            .await
+            .map(|block| (*block).clone())
     }
 
     fn put_to_storage<'a, REv: From<StorageRequest> + Send>(

--- a/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
@@ -6,6 +6,7 @@ use futures::FutureExt;
 use crate::{
     components::fetcher::{metrics::Metrics, Fetcher, ItemFetcher, ItemHandle, StoringState},
     effect::{
+        announcements::FetchedNewBlockAnnouncement,
         requests::{BlockAccumulatorRequest, StorageRequest},
         EffectBuilder,
     },
@@ -51,5 +52,15 @@ impl ItemFetcher<Block> for Fetcher<Block> {
                 .map(|_| ())
                 .boxed(),
         )
+    }
+
+    async fn announce_fetched_new_item<REv: From<FetchedNewBlockAnnouncement> + Send>(
+        effect_builder: EffectBuilder<REv>,
+        item: Block,
+        peer: NodeId,
+    ) {
+        effect_builder
+            .announce_fetched_new_block(Arc::new(item), peer)
+            .await
     }
 }

--- a/node/src/components/fetcher/fetcher_impls/block_header_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_header_fetcher.rs
@@ -27,7 +27,7 @@ impl ItemFetcher<BlockHeader> for Fetcher<BlockHeader> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
     ) -> Option<BlockHeader> {

--- a/node/src/components/fetcher/fetcher_impls/block_header_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_header_fetcher.rs
@@ -49,4 +49,11 @@ impl ItemFetcher<BlockHeader> for Fetcher<BlockHeader> {
                 .boxed(),
         )
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: BlockHeader,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
@@ -25,7 +25,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: DeployId,
     ) -> Option<Deploy> {

--- a/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
@@ -56,4 +56,11 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
             .boxed(),
         )
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: Deploy,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
@@ -6,6 +6,7 @@ use futures::FutureExt;
 use crate::{
     components::fetcher::{metrics::Metrics, Fetcher, ItemFetcher, ItemHandle, StoringState},
     effect::{
+        announcements::FetchedNewFinalitySignatureAnnouncement,
         requests::{BlockAccumulatorRequest, StorageRequest},
         EffectBuilder,
     },
@@ -55,5 +56,17 @@ impl ItemFetcher<FinalitySignature> for Fetcher<FinalitySignature> {
                 .map(|_| ())
                 .boxed(),
         )
+    }
+
+    async fn announce_fetched_new_item<REv>(
+        effect_builder: EffectBuilder<REv>,
+        item: FinalitySignature,
+        peer: NodeId,
+    ) where
+        REv: From<FetchedNewFinalitySignatureAnnouncement> + Send,
+    {
+        effect_builder
+            .announce_fetched_new_finality_signature(Box::new(item.clone()), peer)
+            .await
     }
 }

--- a/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
@@ -45,4 +45,11 @@ impl ItemFetcher<LegacyDeploy> for Fetcher<LegacyDeploy> {
                 .boxed(),
         )
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: LegacyDeploy,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
@@ -27,7 +27,7 @@ impl ItemFetcher<LegacyDeploy> for Fetcher<LegacyDeploy> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<StorageRequest> + Send>(
+    async fn get_locally<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: DeployHash,
     ) -> Option<LegacyDeploy> {

--- a/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
@@ -31,7 +31,7 @@ impl ItemFetcher<SyncLeap> for Fetcher<SyncLeap> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: Send>(
+    async fn get_locally<REv: Send>(
         _effect_builder: EffectBuilder<REv>,
         _id: SyncLeapIdentifier,
     ) -> Option<SyncLeap> {

--- a/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
@@ -63,4 +63,11 @@ impl ItemFetcher<SyncLeap> for Fetcher<SyncLeap> {
             .boxed(),
         )
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: SyncLeap,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/fetcher_impls/trie_or_chunk_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/trie_or_chunk_fetcher.rs
@@ -27,7 +27,7 @@ impl ItemFetcher<TrieOrChunk> for Fetcher<TrieOrChunk> {
         self.get_from_peer_timeout
     }
 
-    async fn get_from_storage<REv: From<ContractRuntimeRequest> + Send>(
+    async fn get_locally<REv: From<ContractRuntimeRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         id: TrieOrChunkId,
     ) -> Option<TrieOrChunk> {

--- a/node/src/components/fetcher/fetcher_impls/trie_or_chunk_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/trie_or_chunk_fetcher.rs
@@ -44,4 +44,11 @@ impl ItemFetcher<TrieOrChunk> for Fetcher<TrieOrChunk> {
         // Stored by the GlobalStateSynchronizer once all chunks are fetched.
         StoringState::WontStore(item)
     }
+
+    async fn announce_fetched_new_item<REv: Send>(
+        _effect_builder: EffectBuilder<REv>,
+        _item: TrieOrChunk,
+        _peer: NodeId,
+    ) {
+    }
 }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -104,6 +104,8 @@ enum Event {
     #[from]
     FetcherRequestDeploy(FetcherRequest<Deploy>),
     #[from]
+    BlockAccumulatorRequest(BlockAccumulatorRequest),
+    #[from]
     DeployAcceptorAnnouncement(DeployAcceptorAnnouncement),
     #[from]
     RpcServerAnnouncement(RpcServerAnnouncement),
@@ -238,6 +240,7 @@ impl ReactorTrait for Reactor {
             ),
             Event::TrieDemand(_)
             | Event::ContractRuntimeRequest(_)
+            | Event::BlockAccumulatorRequest(_)
             | Event::BlocklistAnnouncement(_)
             | Event::GossiperIncomingDeploy(_)
             | Event::GossiperIncomingBlock(_)

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -110,6 +110,10 @@ enum Event {
     #[from]
     RpcServerAnnouncement(RpcServerAnnouncement),
     #[from]
+    FetchedNewFinalitySignatureAnnouncement(FetchedNewFinalitySignatureAnnouncement),
+    #[from]
+    FetchedNewBlockAnnouncement(FetchedNewBlockAnnouncement),
+    #[from]
     NetRequestIncoming(NetRequestIncoming),
     #[from]
     NetResponseIncoming(NetResponseIncoming),
@@ -251,6 +255,8 @@ impl ReactorTrait for Reactor {
             | Event::ConsensusMessageIncoming(_)
             | Event::ConsensusDemandIncoming(_)
             | Event::FinalitySignatureIncoming(_)
+            | Event::FetchedNewBlockAnnouncement(_)
+            | Event::FetchedNewFinalitySignatureAnnouncement(_)
             | Event::ControlAnnouncement(_)
             | Event::FatalAnnouncement(_) => panic!("unexpected: {}", event),
         }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -2186,6 +2186,42 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    pub(crate) async fn get_block_from_block_accumulator(
+        self,
+        block_hash: BlockHash,
+    ) -> Option<Arc<Block>>
+    where
+        REv: From<BlockAccumulatorRequest>,
+    {
+        self.make_request(
+            |responder| BlockAccumulatorRequest::GetBlock {
+                block_hash,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    pub(crate) async fn get_signature_from_block_accumulator(
+        self,
+        block_hash: BlockHash,
+        public_key: PublicKey,
+    ) -> Option<FinalitySignature>
+    where
+        REv: From<BlockAccumulatorRequest>,
+    {
+        self.make_request(
+            |responder| BlockAccumulatorRequest::GetFinalitySignature {
+                block_hash,
+                public_key,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Set a new stopping point for the node.
     ///
     /// Returns a potentially previously set stop-at spec.

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -7,6 +7,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Display, Formatter},
     fs::File,
+    sync::Arc,
 };
 
 use datasize::DataSize;
@@ -20,12 +21,13 @@ use crate::{
         consensus::{ClContext, ProposedBlock},
         deploy_acceptor::Error,
         diagnostics_port::FileSerializer,
+        fetcher::FetchItem,
         gossiper::GossipItem,
         network::blocklist::BlocklistJustification,
         upgrade_watcher::NextUpgrade,
     },
     effect::Responder,
-    types::{Deploy, DeployHash, FinalitySignature, FinalizedBlock, MetaBlock, NodeId},
+    types::{Block, Deploy, DeployHash, FinalitySignature, FinalizedBlock, MetaBlock, NodeId},
     utils::Source,
 };
 
@@ -417,5 +419,41 @@ impl Display for BlockAccumulatorAnnouncement {
                 )
             }
         }
+    }
+}
+
+/// A block which wasn't previously stored on this node has been fetched and stored.
+#[derive(Debug, Serialize)]
+pub(crate) struct FetchedNewBlockAnnouncement {
+    pub(crate) block: Arc<Block>,
+    pub(crate) peer: NodeId,
+}
+
+impl Display for FetchedNewBlockAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "new block {} fetched from {}",
+            self.block.fetch_id(),
+            self.peer
+        )
+    }
+}
+
+/// A finality signature which wasn't previously stored on this node has been fetched and stored.
+#[derive(Debug, Serialize)]
+pub(crate) struct FetchedNewFinalitySignatureAnnouncement {
+    pub(crate) finality_signature: Box<FinalitySignature>,
+    pub(crate) peer: NodeId,
+}
+
+impl Display for FetchedNewFinalitySignatureAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "new finality signature {} fetched from {}",
+            self.finality_signature.fetch_id(),
+            self.peer
+        )
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1144,16 +1144,44 @@ impl Display for ReactorStatusRequest {
 }
 
 #[derive(Debug, Serialize)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum BlockAccumulatorRequest {
     GetPeersForBlock {
         block_hash: BlockHash,
         responder: Responder<Option<Vec<NodeId>>>,
     },
+    GetBlock {
+        block_hash: BlockHash,
+        responder: Responder<Option<Arc<Block>>>,
+    },
+    GetFinalitySignature {
+        block_hash: BlockHash,
+        public_key: PublicKey,
+        responder: Responder<Option<FinalitySignature>>,
+    },
 }
 
 impl Display for BlockAccumulatorRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "block accumulator request")
+        match self {
+            BlockAccumulatorRequest::GetPeersForBlock { block_hash, .. } => {
+                write!(f, "get peers for {}", block_hash)
+            }
+            BlockAccumulatorRequest::GetBlock { block_hash, .. } => {
+                write!(f, "get block for {}", block_hash)
+            }
+            BlockAccumulatorRequest::GetFinalitySignature {
+                block_hash,
+                public_key,
+                ..
+            } => {
+                write!(
+                    f,
+                    "get finality signature of {} for {}",
+                    public_key, block_hash
+                )
+            }
+        }
     }
 }
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -102,7 +102,7 @@ pub(crate) use reactor_state::ReactorState;
 ///
 ///     I -->|"❌<br/>Never get<br/>SyncLeap<br/>from storage"| H
 ///     linkStyle 0 fill:none,stroke:red,color:red
-///     
+///
 ///     A -->|"Execute block<br/>(genesis or upgrade)"| B
 ///
 ///     G -->|Peers| C
@@ -1250,6 +1250,13 @@ impl MainReactor {
                             finality_signature: Box::new(finality_signature.clone()),
                         },
                     ),
+                ));
+
+                effects.extend(reactor::wrap_effects(
+                    MainEvent::Storage,
+                    effect_builder
+                        .put_finality_signature_to_storage(finality_signature.clone())
+                        .ignore(),
                 ));
 
                 let era_id = finality_signature.era_id;

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -18,7 +18,8 @@ use crate::{
         announcements::{
             BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
             ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
-            FatalAnnouncement, GossiperAnnouncement, MetaBlockAnnouncement,
+            FatalAnnouncement, FetchedNewBlockAnnouncement,
+            FetchedNewFinalitySignatureAnnouncement, GossiperAnnouncement, MetaBlockAnnouncement,
             PeerBehaviorAnnouncement, RpcServerAnnouncement, UnexecutedBlockAnnouncement,
             UpgradeWatcherAnnouncement,
         },
@@ -152,6 +153,8 @@ pub(crate) enum MainEvent {
     #[from]
     BlockFetcherRequest(#[serde(skip_serializing)] FetcherRequest<Block>),
     #[from]
+    BlockFetcherAnnouncement(#[serde(skip_serializing)] FetchedNewBlockAnnouncement),
+    #[from]
     MakeBlockExecutableRequest(MakeBlockExecutableRequest),
     #[from]
     BlockCompleteConfirmationRequest(BlockCompleteConfirmationRequest),
@@ -169,6 +172,10 @@ pub(crate) enum MainEvent {
     FinalitySignatureFetcher(#[serde(skip_serializing)] fetcher::Event<FinalitySignature>),
     #[from]
     FinalitySignatureFetcherRequest(#[serde(skip_serializing)] FetcherRequest<FinalitySignature>),
+    #[from]
+    FinalitySignatureFetcherAnnouncement(
+        #[serde(skip_serializing)] FetchedNewFinalitySignatureAnnouncement,
+    ),
     #[from]
     DeployAcceptor(#[serde(skip_serializing)] deploy_acceptor::Event),
     #[from]
@@ -309,6 +316,9 @@ impl ReactorEvent for MainEvent {
             MainEvent::UpgradeWatcherAnnouncement(_) => "UpgradeWatcherAnnouncement",
             MainEvent::NetworkPeerBehaviorAnnouncement(_) => "BlocklistAnnouncement",
             MainEvent::DeployBufferAnnouncement(_) => "DeployBufferAnnouncement",
+            MainEvent::FinalitySignatureFetcherAnnouncement(_) => {
+                "FinalitySignatureFetcherAnnouncement"
+            }
             MainEvent::AddressGossiperCrank(_) => "BeginAddressGossipRequest",
             MainEvent::ConsensusMessageIncoming(_) => "ConsensusMessageIncoming",
             MainEvent::ConsensusDemand(_) => "ConsensusDemand",
@@ -335,6 +345,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::BlockGossiperAnnouncement(_) => "BlockGossiperAnnouncement",
             MainEvent::BlockFetcher(_) => "BlockFetcher",
             MainEvent::BlockFetcherRequest(_) => "BlockFetcherRequest",
+            MainEvent::BlockFetcherAnnouncement(_) => "BlockFetcherAnnouncement",
             MainEvent::SetNodeStopRequest(_) => "SetNodeStopRequest",
             MainEvent::MainReactorRequest(_) => "MainReactorRequest",
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
@@ -496,6 +507,9 @@ impl Display for MainEvent {
             MainEvent::NetworkPeerBehaviorAnnouncement(ann) => {
                 write!(f, "blocklist announcement: {}", ann)
             }
+            MainEvent::FinalitySignatureFetcherAnnouncement(ann) => {
+                write!(f, "finality signature fetcher announcement: {}", ann)
+            }
             MainEvent::ConsensusMessageIncoming(inner) => Display::fmt(inner, f),
             MainEvent::ConsensusDemand(inner) => Display::fmt(inner, f),
             MainEvent::DeployGossiperIncoming(inner) => Display::fmt(inner, f),
@@ -513,6 +527,7 @@ impl Display for MainEvent {
             MainEvent::BlockGossiperAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::BlockFetcher(inner) => Display::fmt(inner, f),
             MainEvent::BlockFetcherRequest(inner) => Display::fmt(inner, f),
+            MainEvent::BlockFetcherAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::SetNodeStopRequest(inner) => Display::fmt(inner, f),
             MainEvent::MainReactorRequest(inner) => Display::fmt(inner, f),
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),


### PR DESCRIPTION
This PR increases the ability of the `BlockFetcher` and `FinalitySignatureFetcher` to fetch locally by querying the `BlockAccumulator` after a failure to fetch from `Storage` before sending a request to peers.

It also adds an announcement for these two fetchers to emit once they retrieve an item from a peer and store it.  The announcements cause the `BlockAccumulator` to be notified of the newly-fetched block or finality signature, using the existing events for handling incoming gossiped items.

Closes #3612.
