### PR TITLE
Fix upgrade_scenario_10

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -30,7 +30,7 @@ use std::{
 use num::Zero;
 use num_rational::Ratio;
 use once_cell::sync::Lazy;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use casper_hashing::Digest;
 use casper_types::{
@@ -366,6 +366,7 @@ where
         }
 
         if let Some(new_auction_delay) = upgrade_config.new_auction_delay() {
+            debug!(%new_auction_delay, "Auction delay changed as part of the upgrade");
             let auction_contract = tracking_copy
                 .borrow_mut()
                 .get_contract(correlation_id, *auction_hash)?;
@@ -2086,7 +2087,7 @@ where
             .borrow_mut()
             .get_system_contracts(correlation_id)
             .map_err(|error| {
-                error!(%error, "Failed to retrieve system contract registry");
+                warn!(%error, "Failed to retrieve system contract registry");
                 Error::MissingSystemContractRegistry
             });
         result

--- a/node/src/components/contract_runtime/error.rs
+++ b/node/src/components/contract_runtime/error.rs
@@ -23,9 +23,6 @@ pub(crate) enum ConfigError {
     /// Error initializing metrics.
     #[error("failed to initialize metrics for contract runtime: {0}")]
     Prometheus(#[from] prometheus::Error),
-    /// Error initializing execution engine.
-    #[error("failed to initialize execution engine: {0}")]
-    EngineState(#[from] EngineStateError),
 }
 
 /// An error during block execution.

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -325,7 +325,7 @@ impl MainReactor {
             post_state_hash,
             BlockHash::default(),
             Digest::default(),
-        )?;
+        );
 
         let finalized_block = FinalizedBlock::new(
             BlockPayload::default(),
@@ -385,7 +385,7 @@ impl MainReactor {
                         post_state_hash,
                         previous_block_header.block_hash(),
                         previous_block_header.accumulated_seed(),
-                    )?;
+                    );
 
                     let finalized_block = FinalizedBlock::new(
                         BlockPayload::default(),
@@ -455,7 +455,8 @@ impl MainReactor {
                     *state_root_hash,
                     block_hash,
                     accumulated_seed,
-                )
+                );
+                Ok(())
             }
             Ok(None) => {
                 Ok(()) // noop
@@ -470,7 +471,7 @@ impl MainReactor {
         pre_state_root_hash: Digest,
         parent_hash: BlockHash,
         parent_seed: Digest,
-    ) -> Result<(), String> {
+    ) {
         // a better approach might be to have an announcement for immediate switch block
         // creation, which the contract runtime handles and sets itself into
         // the proper state to handle the unexpected block.
@@ -481,10 +482,7 @@ impl MainReactor {
             parent_hash,
             parent_seed,
         );
-        self.contract_runtime
-            .set_initial_state(initial_pre_state)
-            .map_err(|err| err.to_string())?;
-        Ok(())
+        self.contract_runtime.set_initial_state(initial_pre_state);
     }
 
     pub(super) fn update_last_progress(

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -440,19 +440,15 @@ function setup_asset_node_configs()
 function setup_asset_global_state_toml_for_node() {
     local IDX=${1}
     local TARGET_PROTOCOL_VERSION=${2}
-    local STATE_ROOT_HASH
     local PATH_TO_NET="$(get_path_to_net)"
     local STORAGE_PATH="$PATH_TO_NET/nodes/node-$IDX/storage"
 
-    STATE_ROOT_HASH=$(nctl-view-chain-state-root-hash node=$IDX | awk '{ print $12 }' | tr '[:upper:]' '[:lower:]')
-    log "... state root hash for node $IDX: $STATE_ROOT_HASH"
-
     if [ -f "$STORAGE_PATH/$(get_chain_name)/data.lmdb" ]; then
         GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
-                migrate-into-system-contract-registry -s $STATE_ROOT_HASH -d "$STORAGE_PATH"/"$(get_chain_name)")
+                migrate-into-system-contract-registry -d "$STORAGE_PATH"/"$(get_chain_name)")
     else
         GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
-                migrate-into-system-contract-registry -s $STATE_ROOT_HASH -d "$STORAGE_PATH")
+                migrate-into-system-contract-registry -d "$STORAGE_PATH")
     fi
 
     echo "$GLOBAL_STATE_VALIDATOR_OUTPUT" > "$PATH_TO_NET/nodes/node-$IDX/config/$TARGET_PROTOCOL_VERSION/global_state.toml"


### PR DESCRIPTION
* Fixes invocation of the `global-state-update-gen` in order to correctly generate the missing system contract registry.
* Fixes an issue where the node tries to cache the system contract registry when initializing the contract runtime component, but since the node was not upgraded yet and the previous version didn't have the system contract registry written the initialization would fail. Now caching the system contract registry on initialization will not yield a fatal error and allows it to be created after the upgrade or when needed.

Fixes: https://github.com/casper-network/casper-node/issues/3621
