### PR TITLE
GH-3672: Revert serialization but put restriction in place.

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -209,18 +209,16 @@ impl InMemoryWasmTestBuilder {
         let chainspec_config = ChainspecConfig::from_chainspec_path(chainspec_path)
             .expect("must build chainspec configuration");
 
-        let vesting_schedule_period_millis =
-            humantime::parse_duration(&chainspec_config.core_config.vesting_schedule_period)
-                .expect("should parse a vesting schedule period")
-                .as_millis() as u64;
-
         let engine_config = EngineConfig::new(
             DEFAULT_MAX_QUERY_DEPTH,
             chainspec_config.core_config.max_associated_keys,
             chainspec_config.core_config.max_runtime_call_stack_height,
             chainspec_config.core_config.minimum_delegation_amount,
             chainspec_config.core_config.strict_argument_checking,
-            vesting_schedule_period_millis,
+            chainspec_config
+                .core_config
+                .vesting_schedule_period
+                .millis(),
             chainspec_config.wasm_config,
             chainspec_config.system_costs_config,
         );
@@ -325,10 +323,6 @@ impl LmdbWasmTestBuilder {
     ) -> Self {
         let chainspec_config = ChainspecConfig::from_chainspec_path(chainspec_path)
             .expect("must build chainspec configuration");
-        let vesting_schedule_period_millis =
-            humantime::parse_duration(&chainspec_config.core_config.vesting_schedule_period)
-                .expect("should parse a vesting schedule period")
-                .as_millis() as u64;
 
         let engine_config = EngineConfig::new(
             DEFAULT_MAX_QUERY_DEPTH,
@@ -336,7 +330,10 @@ impl LmdbWasmTestBuilder {
             chainspec_config.core_config.max_runtime_call_stack_height,
             chainspec_config.core_config.minimum_delegation_amount,
             chainspec_config.core_config.strict_argument_checking,
-            vesting_schedule_period_millis,
+            chainspec_config
+                .core_config
+                .vesting_schedule_period
+                .millis(),
             chainspec_config.wasm_config,
             chainspec_config.system_costs_config,
         );

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -14,9 +14,24 @@ use serde::{
 use casper_types::testing::TestRng;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
+    system::auction::VESTING_SCHEDULE_LENGTH_MILLIS,
     TimeDiff,
 };
 use tracing::{error, warn};
+
+fn vesting_schedule_period<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<TimeDiff, D::Error> {
+    let timediff = TimeDiff::deserialize(deserializer)?;
+    if timediff > TimeDiff::from_millis(VESTING_SCHEDULE_LENGTH_MILLIS) {
+        Err(D::Error::custom(format!(
+            "vesting schedule period can't exceed {} milliseconds",
+            VESTING_SCHEDULE_LENGTH_MILLIS
+        )))
+    } else {
+        Ok(timediff)
+    }
+}
 
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
@@ -35,6 +50,7 @@ pub struct CoreConfig {
     /// The period after genesis during which a genesis validator's bid is locked.
     pub(crate) locked_funds_period: TimeDiff,
     /// The period in which genesis validator's bid is released over time after it's unlocked.
+    #[serde(deserialize_with = "vesting_schedule_period")]
     pub(crate) vesting_schedule_period: TimeDiff,
     /// The delay in number of eras for paying out the the unbonding amount.
     pub(crate) unbonding_delay: u64,

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2965,13 +2965,15 @@
                 "minimum": 0.0
               },
               "locked_amounts": {
+                "items": {
+                  "$ref": "#/components/schemas/U512"
+                },
+                "maxItems": 14,
+                "minItems": 14,
                 "type": [
                   "array",
                   "null"
-                ],
-                "items": {
-                  "$ref": "#/components/schemas/U512"
-                }
+                ]
               }
             },
             "additionalProperties": false

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1799,7 +1799,9 @@
           ],
           "items": {
             "$ref": "#/definitions/U512"
-          }
+          },
+          "maxItems": 14,
+          "minItems": 14
         }
       },
       "additionalProperties": false

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -1,6 +1,8 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
+use core::mem::MaybeUninit;
+
 use alloc::vec::Vec;
 
 #[cfg(feature = "datasize")]
@@ -10,18 +12,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bytesrepr::{self, FromBytes, ToBytes},
+    bytesrepr::{self, Error, FromBytes, ToBytes},
     U512,
 };
-
-const LOCKED_AMOUNTS_TAG_LENGTH: usize = 1;
-
-/// Uninitialized vesting schedule.
-const UNINITIALIZED_LOCKED_AMOUNTS_TAG: u8 = 0;
-/// Initialized locked amounts for an initialized fixed 91 days (~14 weeks) vesting schedule.
-const INITIALIZED_14W_FIXED_LOCKED_AMOUNTS_TAG: u8 = 1;
-/// Initialized vesting schedule for a configured period of time.
-const VARIABLE_LOCKED_AMOUNTS_LENGTH_TAG: u8 = 2;
 
 const DAY_MILLIS: usize = 24 * 60 * 60 * 1000;
 const DAYS_IN_WEEK: usize = 7;
@@ -33,7 +26,7 @@ const VESTING_SCHEDULE_LENGTH_DAYS: usize = 91;
 pub const VESTING_SCHEDULE_LENGTH_MILLIS: u64 =
     VESTING_SCHEDULE_LENGTH_DAYS as u64 * DAY_MILLIS as u64;
 /// 91 days / 7 days in a week = 13 weeks
-const LOCKED_AMOUNTS_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEEK) + 1;
+const LOCKED_AMOUNTS_MAX_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEEK) + 1;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
@@ -41,7 +34,7 @@ const LOCKED_AMOUNTS_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEE
 #[serde(deny_unknown_fields)]
 pub struct VestingSchedule {
     initial_release_timestamp_millis: u64,
-    locked_amounts: Option<Vec<U512>>,
+    locked_amounts: Option<[U512; LOCKED_AMOUNTS_MAX_LENGTH]>,
 }
 
 fn vesting_schedule_period_to_weeks(vesting_schedule_period_millis: u64) -> u64 {
@@ -74,23 +67,31 @@ impl VestingSchedule {
         let locked_amounts_length =
             vesting_schedule_period_to_weeks(vesting_schedule_period_millis);
 
+        if locked_amounts_length as usize >= LOCKED_AMOUNTS_MAX_LENGTH {
+            // We will not initialize a vesting schedule if the genesis configuration is incorrect.
+            // There are restrictions put in place in the chainspec config to make sure we will not
+            // hit this case.
+            //
+            // This is done to avoid breaking changes in the serialization format.
+            return false;
+        }
+
         if locked_amounts_length == 0 || vesting_schedule_period_millis == 0 {
             // Zero weeks means instant unlock of staked amount.
-            self.locked_amounts = Some(vec![U512::zero()]);
+            self.locked_amounts = Some(Default::default());
             return true;
         }
 
         let release_period: U512 = U512::from(locked_amounts_length + 1);
         let weekly_release = staked_amount / release_period;
 
-        let mut locked_amounts = Vec::with_capacity(locked_amounts_length as usize + 1);
+        let mut locked_amounts = [U512::zero(); LOCKED_AMOUNTS_MAX_LENGTH];
         let mut remaining_locked = staked_amount;
 
-        for _ in 0..locked_amounts_length {
+        for i in 0..locked_amounts_length {
             remaining_locked -= weekly_release;
-            locked_amounts.push(remaining_locked);
+            locked_amounts[i as usize] = remaining_locked;
         }
-        locked_amounts.push(U512::zero());
 
         self.locked_amounts = Some(locked_amounts);
         true
@@ -107,8 +108,9 @@ impl VestingSchedule {
         self.initial_release_timestamp_millis
     }
 
-    pub fn locked_amounts(&self) -> Option<&Vec<U512>> {
-        self.locked_amounts.as_ref()
+    pub fn locked_amounts(&self) -> Option<&[U512]> {
+        let locked_amounts = self.locked_amounts.as_ref()?;
+        Some(locked_amounts.as_slice())
     }
 
     pub fn locked_amount(&self, timestamp_millis: u64) -> Option<U512> {
@@ -151,79 +153,66 @@ impl VestingSchedule {
     }
 }
 
+impl ToBytes for [U512; LOCKED_AMOUNTS_MAX_LENGTH] {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let mut result = bytesrepr::allocate_buffer(self)?;
+        for item in self.iter() {
+            result.append(&mut item.to_bytes()?);
+        }
+        Ok(result)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.iter().map(ToBytes::serialized_length).sum::<usize>()
+    }
+}
+
+impl FromBytes for [U512; LOCKED_AMOUNTS_MAX_LENGTH] {
+    fn from_bytes(mut bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let mut result: MaybeUninit<[U512; LOCKED_AMOUNTS_MAX_LENGTH]> = MaybeUninit::uninit();
+        let result_ptr = result.as_mut_ptr() as *mut U512;
+        for i in 0..LOCKED_AMOUNTS_MAX_LENGTH {
+            let (t, remainder) = match FromBytes::from_bytes(bytes) {
+                Ok(success) => success,
+                Err(error) => {
+                    for j in 0..i {
+                        unsafe { result_ptr.add(j).drop_in_place() }
+                    }
+                    return Err(error);
+                }
+            };
+            unsafe { result_ptr.add(i).write(t) };
+            bytes = remainder;
+        }
+        Ok((unsafe { result.assume_init() }, bytes))
+    }
+}
+
 impl ToBytes for VestingSchedule {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        self.write_bytes(&mut result)?;
+        result.append(&mut self.initial_release_timestamp_millis.to_bytes()?);
+        result.append(&mut self.locked_amounts.to_bytes()?);
         Ok(result)
     }
 
     fn serialized_length(&self) -> usize {
         self.initial_release_timestamp_millis.serialized_length()
-            + LOCKED_AMOUNTS_TAG_LENGTH
-            + match &self.locked_amounts {
-                Some(locked_amounts) => locked_amounts.serialized_length(),
-                None => 0,
-            }
-    }
-
-    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        self.initial_release_timestamp_millis.write_bytes(writer)?;
-        match &self.locked_amounts {
-            None => {
-                UNINITIALIZED_LOCKED_AMOUNTS_TAG.write_bytes(writer)?;
-            }
-            Some(locked_amounts) => {
-                VARIABLE_LOCKED_AMOUNTS_LENGTH_TAG.write_bytes(writer)?;
-                locked_amounts.write_bytes(writer)?;
-            }
-        }
-        Ok(())
+            + self.locked_amounts.serialized_length()
     }
 }
 
 impl FromBytes for VestingSchedule {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (initial_release_timestamp_millis, bytes) = FromBytes::from_bytes(bytes)?;
-        let (locked_amounts_tag, mut bytes): (u8, _) = FromBytes::from_bytes(bytes)?;
-
-        match locked_amounts_tag {
-            UNINITIALIZED_LOCKED_AMOUNTS_TAG => Ok((
-                VestingSchedule {
-                    initial_release_timestamp_millis,
-                    locked_amounts: None,
-                },
-                bytes,
-            )),
-            INITIALIZED_14W_FIXED_LOCKED_AMOUNTS_TAG => {
-                let mut locked_amounts = Vec::new();
-
-                for _ in 0..LOCKED_AMOUNTS_LENGTH {
-                    let (locked_amount, rem) = FromBytes::from_bytes(bytes)?;
-                    bytes = rem;
-                    locked_amounts.push(locked_amount);
-                }
-
-                Ok((
-                    VestingSchedule {
-                        initial_release_timestamp_millis,
-                        locked_amounts: Some(locked_amounts),
-                    },
-                    bytes,
-                ))
-            }
-            VARIABLE_LOCKED_AMOUNTS_LENGTH_TAG => {
-                let (locked_amounts, bytes) = FromBytes::from_bytes(bytes)?;
-                Ok((
-                    VestingSchedule {
-                        initial_release_timestamp_millis,
-                        locked_amounts: Some(locked_amounts),
-                    },
-                    bytes,
-                ))
-            }
-            _ => Err(bytesrepr::Error::Formatting),
-        }
+        let (locked_amounts, bytes) = FromBytes::from_bytes(bytes)?;
+        Ok((
+            VestingSchedule {
+                initial_release_timestamp_millis,
+                locked_amounts,
+            },
+            bytes,
+        ))
     }
 }
 
@@ -231,7 +220,7 @@ impl FromBytes for VestingSchedule {
 #[cfg(test)]
 mod gens {
     use proptest::{
-        collection, option,
+        array, option,
         prelude::{Arbitrary, Strategy},
     };
 
@@ -239,16 +228,12 @@ mod gens {
     use crate::gens::u512_arb;
 
     pub fn vesting_schedule_arb() -> impl Strategy<Value = VestingSchedule> {
-        (
-            <u64>::arbitrary(),
-            option::of(collection::vec(u512_arb(), 0..20)),
+        (<u64>::arbitrary(), option::of(array::uniform14(u512_arb()))).prop_map(
+            |(initial_release_timestamp_millis, locked_amounts)| VestingSchedule {
+                initial_release_timestamp_millis,
+                locked_amounts,
+            },
         )
-            .prop_map(|(initial_release_timestamp_millis, locked_amounts)| {
-                VestingSchedule {
-                    initial_release_timestamp_millis,
-                    locked_amounts,
-                }
-            })
     }
 }
 
@@ -266,14 +251,26 @@ mod tests {
         U512,
     };
 
+    use super::*;
+
     /// Default lock-in period of 90 days
-    const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * 24 * 60 * 60 * 1000;
+    const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS as u64;
     const RELEASE_TIMESTAMP: u64 = DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
     const STAKE: u64 = 140;
 
-    const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * 24 * 60 * 60 * 1000;
+    const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS as u64;
     const LOCKED_AMOUNTS_LENGTH: usize =
         (DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS as usize / WEEK_MILLIS) + 1;
+
+    #[test]
+    fn test_vesting_schedule_exceeding_the_maximum_should_not_panic() {
+        let future_date = 91 * DAY_MILLIS as u64;
+        let mut vesting_schedule = VestingSchedule::new(RELEASE_TIMESTAMP);
+        vesting_schedule.initialize_with_schedule(U512::from(STAKE), future_date);
+
+        assert_eq!(vesting_schedule.locked_amount(0), None);
+        assert_eq!(vesting_schedule.locked_amount(RELEASE_TIMESTAMP - 1), None);
+    }
 
     #[test]
     fn test_locked_amount_check_should_not_panic() {
@@ -491,7 +488,7 @@ mod tests {
 
     #[test]
     fn should_calculate_vesting_schedule_period_to_weeks() {
-        let thirteen_weeks_millis = 13 * 7 * 24 * 60 * 60 * 1000;
+        let thirteen_weeks_millis = 13 * 7 * DAY_MILLIS as u64;
         assert_eq!(vesting_schedule_period_to_weeks(thirteen_weeks_millis), 13,);
 
         assert_eq!(vesting_schedule_period_to_weeks(0), 0);


### PR DESCRIPTION
Closes #3672

This reverts bytesrepr and bincode (and serde in general) serialization formats back to before #3219 was merged. But to satisfy the new requirement of configurable vesting schedules, a restriction is put in place so the length would not exceed fixed-sized slots of 14 weeks.