### PR TITLE
nctl: allow override of the NCTL base URL for remote assets

### DIFF
--- a/utils/nctl/sh/staging/set_remote.sh
+++ b/utils/nctl/sh/staging/set_remote.sh
@@ -13,7 +13,7 @@ source "$NCTL/sh/utils/main.sh"
 # ----------------------------------------------------------------
 
 # Base URL: nctl.
-_BASE_URL="http://nctl.casperlabs.io.s3-website.us-east-2.amazonaws.com"
+_BASE_URL=${NCTL_REMOTE_BASE_URL:-"http://nctl.casperlabs.io.s3-website.us-east-2.amazonaws.com"}
 
 # Set of remote files.
 _REMOTE_FILES=(


### PR DESCRIPTION
The remote assets are only compiled for x86-64 which prevents running the tests on other platforms (like ARM aarch64).
Add ability to override the base URL so that users can run the tests using assets from a different location, or locally cached assets by specifying a `file://<local_directory>` URL.
