### PR TITLE
Never purge the local tip's acceptor in the block accumulator

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -58,19 +58,14 @@ const COMPONENT_NAME: &str = "block_accumulator";
 const PEER_RATE_LIMIT_MULTIPLIER: usize = 2;
 
 #[derive(Clone, Copy, DataSize, Debug, Eq, PartialEq)]
-pub(crate) struct LocalTipIdentifier {
-    block_hash: BlockHash,
+struct LocalTipIdentifier {
     height: u64,
     era_id: EraId,
 }
 
 impl LocalTipIdentifier {
-    fn new(block_hash: BlockHash, height: u64, era_id: EraId) -> Self {
-        Self {
-            block_hash,
-            height,
-            era_id,
-        }
+    fn new(height: u64, era_id: EraId) -> Self {
+        Self { height, era_id }
     }
 }
 
@@ -230,14 +225,14 @@ impl BlockAccumulator {
 
     /// Drops all old block acceptors and tracks new local block height;
     /// subsequent attempts to register a block lower than tip will be rejected.
-    pub(crate) fn register_local_tip(&mut self, block_hash: BlockHash, height: u64, era_id: EraId) {
+    pub(crate) fn register_local_tip(&mut self, height: u64, era_id: EraId) {
         let new_local_tip = match self.local_tip {
             Some(current) => current.height < height && current.era_id <= era_id,
             None => true,
         };
         if new_local_tip {
             self.purge();
-            self.local_tip = Some(LocalTipIdentifier::new(block_hash, height, era_id));
+            self.local_tip = Some(LocalTipIdentifier::new(height, era_id));
             info!(local_tip=?self.local_tip, "new local tip detected");
         }
     }
@@ -586,19 +581,17 @@ impl BlockAccumulator {
 
     fn maybe_new_local_tip(&self, sync_identifier: &SyncIdentifier) -> Option<LocalTipIdentifier> {
         match (sync_identifier.maybe_local_tip_identifier(), self.local_tip) {
-            (Some(new_local_tip_identifier), Some(local_tip)) => {
-                if local_tip.height < new_local_tip_identifier.height
-                    && local_tip.era_id <= new_local_tip_identifier.era_id
-                {
+            (Some((block_height, era_id)), Some(local_tip)) => {
+                if local_tip.height < block_height && local_tip.era_id <= era_id {
                     debug!(
                         "new block({}) higher than local tip({})",
-                        new_local_tip_identifier.height, local_tip.height
+                        block_height, local_tip.height
                     );
-                    return Some(new_local_tip_identifier);
+                    return Some(LocalTipIdentifier::new(block_height, era_id));
                 }
             }
-            (Some(new_local_tip_identifier), None) => {
-                return Some(new_local_tip_identifier);
+            (Some((block_height, era_id)), None) => {
+                return Some(LocalTipIdentifier::new(block_height, era_id));
             }
             (None, _) => (),
         }
@@ -619,10 +612,17 @@ impl BlockAccumulator {
         let now = Timestamp::now();
         let mut purged = vec![];
         let purge_interval = self.purge_interval;
-        let maybe_local_tip_block_hash = self.local_tip.map(|local_tip| local_tip.block_hash);
+        let maybe_local_tip_height = self.local_tip.map(|local_tip| local_tip.height);
+        let attempt_execution_threshold = self.attempt_execution_threshold;
         self.block_acceptors.retain(|k, v| {
-            if Some(*k) == maybe_local_tip_block_hash {
-                return true;
+            if let (Some(acceptor_height), Some(local_tip_height)) =
+                (v.block_height(), maybe_local_tip_height)
+            {
+                if acceptor_height >= local_tip_height.saturating_sub(attempt_execution_threshold)
+                    && acceptor_height <= local_tip_height
+                {
+                    return true;
+                }
             }
             let expired = now.saturating_diff(v.last_progress()) > purge_interval;
             if expired {
@@ -813,10 +813,9 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
                 self.register_finality_signature(effect_builder, *finality_signature, Some(sender))
             }
             Event::ExecutedBlock { meta_block } => {
-                let block_hash = meta_block.block.header().block_hash();
                 let height = meta_block.block.header().height();
                 let era_id = meta_block.block.header().era_id();
-                self.register_local_tip(block_hash, height, era_id);
+                self.register_local_tip(height, era_id);
                 self.register_block(effect_builder, meta_block, None)
             }
             Event::Stored {

--- a/node/src/components/block_accumulator/sync_identifier.rs
+++ b/node/src/components/block_accumulator/sync_identifier.rs
@@ -2,6 +2,8 @@ use casper_types::EraId;
 
 use crate::types::BlockHash;
 
+use super::LocalTipIdentifier;
+
 #[derive(Clone, Debug)]
 pub(crate) enum SyncIdentifier {
     // all we know about the block is its hash;
@@ -53,14 +55,16 @@ impl SyncIdentifier {
         }
     }
 
-    pub(crate) fn maybe_local_tip_identifier(&self) -> Option<(u64, EraId)> {
+    pub(crate) fn maybe_local_tip_identifier(&self) -> Option<LocalTipIdentifier> {
         match self {
             SyncIdentifier::BlockHash(_)
             | SyncIdentifier::BlockIdentifier(_, _)
             | SyncIdentifier::ExecutingBlockIdentifier(_, _, _) => None,
 
-            SyncIdentifier::SyncedBlockIdentifier(_, block_height, era_id)
-            | SyncIdentifier::LocalTip(_, block_height, era_id) => Some((*block_height, *era_id)),
+            SyncIdentifier::SyncedBlockIdentifier(block_hash, block_height, era_id)
+            | SyncIdentifier::LocalTip(block_hash, block_height, era_id) => {
+                Some(LocalTipIdentifier::new(*block_hash, *block_height, *era_id))
+            }
         }
     }
 }

--- a/node/src/components/block_accumulator/sync_identifier.rs
+++ b/node/src/components/block_accumulator/sync_identifier.rs
@@ -2,8 +2,6 @@ use casper_types::EraId;
 
 use crate::types::BlockHash;
 
-use super::LocalTipIdentifier;
-
 #[derive(Clone, Debug)]
 pub(crate) enum SyncIdentifier {
     // all we know about the block is its hash;
@@ -55,16 +53,14 @@ impl SyncIdentifier {
         }
     }
 
-    pub(crate) fn maybe_local_tip_identifier(&self) -> Option<LocalTipIdentifier> {
+    pub(crate) fn maybe_local_tip_identifier(&self) -> Option<(u64, EraId)> {
         match self {
             SyncIdentifier::BlockHash(_)
             | SyncIdentifier::BlockIdentifier(_, _)
             | SyncIdentifier::ExecutingBlockIdentifier(_, _, _) => None,
 
-            SyncIdentifier::SyncedBlockIdentifier(block_hash, block_height, era_id)
-            | SyncIdentifier::LocalTip(block_hash, block_height, era_id) => {
-                Some(LocalTipIdentifier::new(*block_hash, *block_height, *era_id))
-            }
+            SyncIdentifier::SyncedBlockIdentifier(_, block_height, era_id)
+            | SyncIdentifier::LocalTip(_, block_height, era_id) => Some((*block_height, *era_id)),
         }
     }
 }


### PR DESCRIPTION
Fixes #3661 

This PR forbids purging of the local tip in the block accumulator. The old `block_timestamps` entries are, however, still purged. If there is new information received on the local tip's acceptor, new `block_timestamps` entries will be created.
