### PR TITLE
GH-3231: Default vesting schedule

### DIFF
--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -41,16 +41,14 @@ pub use step_request_builder::StepRequestBuilder;
 pub use upgrade_request_builder::UpgradeRequestBuilder;
 pub use wasm_test_builder::{InMemoryWasmTestBuilder, LmdbWasmTestBuilder, WasmTestBuilder};
 
-const DAY_MILLIS: u64 = 24 * 60 * 60 * 1000;
-
 /// Default number of validator slots.
 pub const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 /// Default auction delay.
 pub const DEFAULT_AUCTION_DELAY: u64 = 1;
-/// Default lock-in period of 90 days
-pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
-/// Default length of total vesting schedule of 91 days.
-pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+/// Default lock-in period is currently zero.
+pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 0;
+/// Default length of total vesting schedule is currently zero.
+pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 0;
 
 /// Default number of eras that need to pass to be able to withdraw unbonded funds.
 pub const DEFAULT_UNBONDING_DELAY: u64 = 7;

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -41,9 +41,9 @@ finality_threshold_fraction = [1, 3]
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1
 # The period after genesis during which a genesis validator's bid is locked.
-locked_funds_period = '90days'
+locked_funds_period = '0 days'
 # The period in which genesis validator's bid is released over time after it's unlocked.
-vesting_schedule_period = '13 weeks'
+vesting_schedule_period = '0 weeks'
 # Default number of eras that need to pass to be able to withdraw unbonded funds.
 unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.


### PR DESCRIPTION
Closes #3231 

This PR defaults the locked funds period to 0 days and the vesting schedule to 0 days. Only the tests relevant to Casper network's main net tests are set to 91 days locked period and 90 days of the vesting schedule. All other tests start with unlocked genesis balances.