### PR TITLE
add balance check to unbond migration

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -495,9 +495,16 @@ where
                     }
 
                     for (unbond_purse_uref, unbond_amount) in balances {
+                        let key = match tracking_copy
+                            .borrow_mut()
+                            .get_purse_balance_key(correlation_id, unbond_purse_uref.into())
+                        {
+                            Ok(key) => key,
+                            Err(_) => return Err(Error::Mint("purse balance not found".into())),
+                        };
                         let current_balance = tracking_copy
                             .borrow_mut()
-                            .get_purse_balance(CorrelationId::new(), Key::URef(unbond_purse_uref))?
+                            .get_purse_balance(CorrelationId::new(), key)?
                             .value();
 
                         if unbond_amount > current_balance {

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -39,10 +39,10 @@ use casper_types::{
     contracts::NamedKeys,
     system::{
         auction::{
-            EraValidators, UnbondingPurse, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_EVICTED_VALIDATORS,
-            ARG_REWARD_FACTORS, ARG_VALIDATOR_PUBLIC_KEYS, AUCTION_DELAY_KEY, ERA_ID_KEY,
-            LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY,
-            VALIDATOR_SLOTS_KEY,
+            EraValidators, UnbondingPurse, WithdrawPurse, ARG_ERA_END_TIMESTAMP_MILLIS,
+            ARG_EVICTED_VALIDATORS, ARG_REWARD_FACTORS, ARG_VALIDATOR_PUBLIC_KEYS,
+            AUCTION_DELAY_KEY, ERA_ID_KEY, LOCKED_FUNDS_PERIOD_KEY,
+            SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
         },
         handle_payment,
         mint::{self, ROUND_SEIGNIORAGE_RATE_KEY},
@@ -474,7 +474,7 @@ where
 
                 // Ensure that sufficient balance exists for all unbond purses that are to be
                 // migrated.
-                fail_upgrade_if_withdraw_purses_lack_sufficient_balance(
+                Self::fail_upgrade_if_withdraw_purses_lack_sufficient_balance(
                     &withdraw_purses,
                     &tracking_copy,
                     correlation_id,
@@ -2197,50 +2197,52 @@ where
             .map_err(Into::into)?;
         maybe_proof.ok_or(Error::MissingChecksumRegistry)
     }
-}
 
-fn fail_upgrade_if_withdraw_purses_lack_sufficient_balance(
-    withdraw_purses: &Vec<casper_types::system::auction::WithdrawPurse>,
-    tracking_copy: &Rc<RefCell<TrackingCopy<<S as StateProvider>::Reader>>>,
-    correlation_id: CorrelationId,
-) -> Result<(), Error> {
-    let mut balances = BTreeMap::new();
-    for purse in withdraw_purses.iter() {
-        match balances.entry(*purse.bonding_purse()) {
-            Entry::Vacant(entry) => {
-                entry.insert(*purse.amount());
-            }
-            Entry::Occupied(mut entry) => {
-                let value = entry.get_mut();
-                let new_val = value.checked_add(*purse.amount()).ok_or_else(|| {
-                    Error::Mint("overflowed a u512 during unbond migration".into())
-                })?;
-                *value = new_val;
+    /// As the name suggests, used to ensure commit_upgrade fails if we lack sufficient balances.
+    fn fail_upgrade_if_withdraw_purses_lack_sufficient_balance(
+        withdraw_purses: &[WithdrawPurse],
+        tracking_copy: &Rc<RefCell<TrackingCopy<<S as StateProvider>::Reader>>>,
+        correlation_id: CorrelationId,
+    ) -> Result<(), Error> {
+        let mut balances = BTreeMap::new();
+        for purse in withdraw_purses.iter() {
+            match balances.entry(*purse.bonding_purse()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(*purse.amount());
+                }
+                Entry::Occupied(mut entry) => {
+                    let value = entry.get_mut();
+                    let new_val = value.checked_add(*purse.amount()).ok_or_else(|| {
+                        Error::Mint("overflowed a u512 during unbond migration".into())
+                    })?;
+                    *value = new_val;
+                }
             }
         }
+        for (unbond_purse_uref, unbond_amount) in balances {
+            let key = match tracking_copy
+                .borrow_mut()
+                .get_purse_balance_key(correlation_id, unbond_purse_uref.into())
+            {
+                Ok(key) => key,
+                Err(_) => return Err(Error::Mint("purse balance not found".into())),
+            };
+            let current_balance = tracking_copy
+                .borrow_mut()
+                .get_purse_balance(CorrelationId::new(), key)?
+                .value();
+
+            if unbond_amount > current_balance {
+                // If we don't have enough balance to migrate, the only thing we can do
+                // is to fail the upgrade.
+                error!(%current_balance, %unbond_purse_uref, %unbond_amount, "commit_upgrade failed during migration - insufficient in purse to unbond");
+                return Err(Error::Mint(
+                    "insufficient balance detected while migrating unbond purses".into(),
+                ));
+            }
+        }
+        Ok(())
     }
-    Ok(for (unbond_purse_uref, unbond_amount) in balances {
-        let key = match tracking_copy
-            .borrow_mut()
-            .get_purse_balance_key(correlation_id, unbond_purse_uref.into())
-        {
-            Ok(key) => key,
-            Err(_) => return Err(Error::Mint("purse balance not found".into())),
-        };
-        let current_balance = tracking_copy
-            .borrow_mut()
-            .get_purse_balance(CorrelationId::new(), key)?
-            .value();
-
-        if unbond_amount > current_balance {
-            // If we don't have enough balance to migrate, the only thing we can do
-            // is to fail the upgrade.
-            error!(%current_balance, %unbond_purse_uref, %unbond_amount, "commit_upgrade failed during migration - insufficient in purse to unbond");
-            return Err(Error::Mint(
-                "insufficient balance detected while migrating unbond purses".into(),
-            ));
-        }
-    })
 }
 
 fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool {

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -478,8 +478,6 @@ where
                 {
                     let balances = BTreeMap::new();
                     for purse in withdraw_purses {
-                        // check for duplicate purses, sum the total so we don't run out of funds
-
                         match balances.entry(*purse.bonding_purse()) {
                             Entry::Vacant(entry) => {
                                 entry.insert(*purse.amount());

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -463,7 +463,7 @@ where
             for key in withdraw_keys {
                 // Transform only those withdraw purses that are still to be
                 // processed in the unbonding queue.
-                let withdraw_purses: Vec<casper_types::system::auction::WithdrawPurse> =
+                let withdraw_purses =
                     tracking_copy
                         .borrow_mut()
                         .read(correlation_id, &key)


### PR DESCRIPTION
This PR adds a balance check to the migration from old unbond purses to the new format. If the purse lacks sufficient balance, we fail the upgrade.

Also adds some logging to `unbond`, to provide rather than eat errors.