### PR TITLE
Avoid unnecessary sync leap

### DIFF
--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -187,6 +187,8 @@ pub(crate) struct MainReactor {
     control_logic_default_delay: TimeDiff,
     sync_to_genesis: bool,
     signature_gossip_tracker: SignatureGossipTracker,
+
+    last_sync_leap_highest_block_hash: Option<BlockHash>,
 }
 
 impl reactor::Reactor for MainReactor {
@@ -390,6 +392,7 @@ impl reactor::Reactor for MainReactor {
             switch_block: None,
             sync_to_genesis: config.node.sync_to_genesis,
             signature_gossip_tracker: SignatureGossipTracker::new(),
+            last_sync_leap_highest_block_hash: Default::default(),
         };
         info!("MainReactor: instantiated");
         let effects = effect_builder

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -26,6 +26,8 @@ use tracing::{debug, error, info, warn};
 
 use casper_types::{EraId, PublicKey, TimeDiff, Timestamp, U512};
 
+#[cfg(test)]
+use crate::testing::network::NetworkedReactor;
 use crate::{
     components::{
         block_accumulator::{self, BlockAccumulator},
@@ -44,7 +46,7 @@ use crate::{
         rpc_server::RpcServer,
         shutdown_trigger::{self, ShutdownTrigger},
         storage::Storage,
-        sync_leaper::SyncLeaper,
+        sync_leaper::{self, SyncLeaper},
         upgrade_watcher::{self, UpgradeWatcher},
         Component, ValidatorBoundComponent,
     },
@@ -70,13 +72,11 @@ use crate::{
     },
     types::{
         Block, BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, Deploy, FinalitySignature,
-        MetaBlock, MetaBlockState, TrieOrChunk, ValidatorMatrix,
+        MetaBlock, MetaBlockState, NodeId, SyncLeapIdentifier, TrieOrChunk, ValidatorMatrix,
     },
     utils::{Source, WithDir},
     NodeRng,
 };
-#[cfg(test)]
-use crate::{testing::network::NetworkedReactor, types::NodeId};
 pub(crate) use config::Config;
 pub(crate) use error::Error;
 pub(crate) use event::MainEvent;
@@ -187,7 +187,6 @@ pub(crate) struct MainReactor {
     control_logic_default_delay: TimeDiff,
     sync_to_genesis: bool,
     signature_gossip_tracker: SignatureGossipTracker,
-
     last_sync_leap_highest_block_hash: Option<BlockHash>,
 }
 
@@ -1173,6 +1172,34 @@ impl reactor::Reactor for MainReactor {
 }
 
 impl MainReactor {
+    fn request_leap_if_not_redundant(
+        &self,
+        sync_leap_identifier: SyncLeapIdentifier,
+        effect_builder: EffectBuilder<MainEvent>,
+        peers_to_ask: Vec<NodeId>,
+    ) -> Effects<MainEvent> {
+        let should_attempt_leap = self.last_sync_leap_highest_block_hash.map_or(
+            true,
+            |last_sync_leap_highest_block_hash| {
+                last_sync_leap_highest_block_hash != sync_leap_identifier.block_hash()
+            },
+        );
+        if should_attempt_leap {
+            effect_builder.immediately().event(move |_| {
+                MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
+                    sync_leap_identifier,
+                    peers_to_ask,
+                })
+            })
+        } else {
+            debug!(
+                state = %self.state,
+                block_hash = %sync_leap_identifier.block_hash(),
+                "successful sync leap for block hash already received, aborting leap attempt");
+            Effects::new()
+        }
+    }
+
     fn update_validator_weights(
         &mut self,
         effect_builder: EffectBuilder<MainEvent>,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1173,7 +1173,7 @@ impl reactor::Reactor for MainReactor {
 
 impl MainReactor {
     fn request_leap_if_not_redundant(
-        &self,
+        &mut self,
         sync_leap_identifier: SyncLeapIdentifier,
         effect_builder: EffectBuilder<MainEvent>,
         peers_to_ask: Vec<NodeId>,
@@ -1185,6 +1185,9 @@ impl MainReactor {
             },
         );
         if should_attempt_leap {
+            // latch accumulator progress to allow sync-leap time to do work
+            self.block_accumulator.reset_last_progress();
+
             effect_builder.immediately().event(move |_| {
                 MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
                     sync_leap_identifier,

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -328,9 +328,6 @@ impl MainReactor {
             );
         }
 
-        // latch accumulator progress to allow sync-leap time to do work
-        self.block_accumulator.reset_last_progress();
-
         let sync_leap_identifier = SyncLeapIdentifier::sync_to_tip(block_hash);
         let effects =
             self.request_leap_if_not_redundant(sync_leap_identifier, effect_builder, peers_to_ask);

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -288,7 +288,7 @@ impl MainReactor {
                 best_available,
                 from_peers,
                 ..
-            } => self.catch_up_leap_received(effect_builder, rng, best_available, from_peers),
+            } => self.catch_up_leap_received(effect_builder, rng, *best_available, from_peers),
             LeapState::Failed { error, .. } => {
                 self.catch_up_leap_failed(effect_builder, rng, block_hash, error)
             }
@@ -333,12 +333,26 @@ impl MainReactor {
         self.block_accumulator.reset_last_progress();
 
         let sync_leap_identifier = SyncLeapIdentifier::sync_to_tip(block_hash);
-        let effects = effect_builder.immediately().event(move |_| {
-            MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
-                sync_leap_identifier,
-                peers_to_ask,
+        let should_attempt_leap = self.last_sync_leap_highest_block_hash.map_or(
+            true,
+            |last_sync_leap_highest_block_hash| {
+                last_sync_leap_highest_block_hash != sync_leap_identifier.block_hash()
+            },
+        );
+        let effects = if should_attempt_leap {
+            effect_builder.immediately().event(move |_| {
+                MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
+                    sync_leap_identifier,
+                    peers_to_ask,
+                })
             })
-        });
+        } else {
+            debug!(
+                state = %self.state,
+                block_hash = %sync_leap_identifier.block_hash(),
+                "successful sync leap for block hash already received, aborting leap attempt");
+            Effects::new()
+        };
         CatchUpInstruction::Do(self.control_logic_default_delay.into(), effects)
     }
 
@@ -346,24 +360,26 @@ impl MainReactor {
         &mut self,
         effect_builder: EffectBuilder<MainEvent>,
         rng: &mut NodeRng,
-        best_available: Box<SyncLeap>,
+        sync_leap: SyncLeap,
         from_peers: Vec<NodeId>,
     ) -> CatchUpInstruction {
-        let block_hash = best_available.highest_block_hash();
-        let block_height = best_available.highest_block_height();
+        let block_hash = sync_leap.highest_block_hash();
+        let block_height = sync_leap.highest_block_height();
         info!(
-            %best_available,
+            %sync_leap,
             %block_height,
             %block_hash,
             "CatchUp: leap received"
         );
+
+        self.last_sync_leap_highest_block_hash = Some(block_hash);
 
         if let Err(msg) = self.update_highest_switch_block() {
             return CatchUpInstruction::Fatal(msg);
         }
 
         for validator_weights in
-            best_available.era_validator_weights(self.validator_matrix.fault_tolerance_threshold())
+            sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold())
         {
             self.validator_matrix
                 .register_era_validator_weights(validator_weights);
@@ -384,7 +400,7 @@ impl MainReactor {
         ));
 
         self.block_synchronizer
-            .register_sync_leap(&best_available, from_peers, true);
+            .register_sync_leap(&sync_leap, from_peers, true);
 
         CatchUpInstruction::Do(self.control_logic_default_delay.into(), effects)
     }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -73,6 +73,7 @@ impl MainReactor {
                 }
                 UpgradingInstruction::CatchUp => {
                     info!("Upgrading: switch to CatchUp");
+                    self.last_sync_leap_highest_block_hash = None;
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())
                 }
@@ -89,6 +90,7 @@ impl MainReactor {
                 CatchUpInstruction::CommitGenesis => match self.commit_genesis(effect_builder) {
                     Ok(effects) => {
                         info!("CatchUp: switch to Validate at genesis");
+                        self.last_sync_leap_highest_block_hash = None;
                         self.state = ReactorState::Validate;
                         (Duration::ZERO, effects)
                     }
@@ -122,6 +124,7 @@ impl MainReactor {
                     }
                     // purge to avoid polluting the status endpoints w/ stale state
                     self.block_synchronizer.purge();
+                    self.last_sync_leap_highest_block_hash = None;
                     info!("CatchUp: switch to KeepUp");
                     self.state = ReactorState::KeepUp;
                     (Duration::ZERO, Effects::new())
@@ -146,6 +149,7 @@ impl MainReactor {
                 }
                 KeepUpInstruction::CatchUp => {
                     self.block_synchronizer.purge();
+                    self.last_sync_leap_highest_block_hash = None;
                     info!("KeepUp: switch to CatchUp");
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -73,7 +73,6 @@ impl MainReactor {
                 }
                 UpgradingInstruction::CatchUp => {
                     info!("Upgrading: switch to CatchUp");
-                    self.last_sync_leap_highest_block_hash = None;
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())
                 }
@@ -90,7 +89,6 @@ impl MainReactor {
                 CatchUpInstruction::CommitGenesis => match self.commit_genesis(effect_builder) {
                     Ok(effects) => {
                         info!("CatchUp: switch to Validate at genesis");
-                        self.last_sync_leap_highest_block_hash = None;
                         self.state = ReactorState::Validate;
                         (Duration::ZERO, effects)
                     }
@@ -124,7 +122,6 @@ impl MainReactor {
                     }
                     // purge to avoid polluting the status endpoints w/ stale state
                     self.block_synchronizer.purge();
-                    self.last_sync_leap_highest_block_hash = None;
                     info!("CatchUp: switch to KeepUp");
                     self.state = ReactorState::KeepUp;
                     (Duration::ZERO, Effects::new())
@@ -149,7 +146,6 @@ impl MainReactor {
                 }
                 KeepUpInstruction::CatchUp => {
                     self.block_synchronizer.purge();
-                    self.last_sync_leap_highest_block_hash = None;
                     info!("KeepUp: switch to CatchUp");
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -479,7 +479,7 @@ impl MainReactor {
                 best_available,
                 from_peers: _,
                 ..
-            } => self.sync_back_leap_received(best_available),
+            } => self.sync_back_leap_received(*best_available),
             LeapState::Failed { error, .. } => {
                 self.sync_back_leap_failed(effect_builder, rng, parent_hash, error)
             }
@@ -526,16 +526,30 @@ impl MainReactor {
             );
         }
         let sync_leap_identifier = SyncLeapIdentifier::sync_to_historical(parent_hash);
-        let effects = effect_builder.immediately().event(move |_| {
-            MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
-                sync_leap_identifier,
-                peers_to_ask,
+        let should_attempt_leap = self.last_sync_leap_highest_block_hash.map_or(
+            true,
+            |last_sync_leap_highest_block_hash| {
+                last_sync_leap_highest_block_hash != sync_leap_identifier.block_hash()
+            },
+        );
+        let effects = if should_attempt_leap {
+            effect_builder.immediately().event(move |_| {
+                MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
+                    sync_leap_identifier,
+                    peers_to_ask,
+                })
             })
-        });
+        } else {
+            debug!(
+                state = %self.state,
+                block_hash = %sync_leap_identifier.block_hash(),
+                "successful sync leap for block hash already received, aborting leap attempt");
+            Effects::new()
+        };
         KeepUpInstruction::Do(offset, effects)
     }
 
-    fn sync_back_leap_received(&mut self, best_available: Box<SyncLeap>) -> KeepUpInstruction {
+    fn sync_back_leap_received(&mut self, sync_leap: SyncLeap) -> KeepUpInstruction {
         // use the leap response to update our recent switch block data (if relevant) and
         // era validator weights. if there are other processes which are holding on discovery
         // of relevant newly-seen era validator weights, they should naturally progress
@@ -543,13 +557,14 @@ impl MainReactor {
         if let Err(msg) = self.update_highest_switch_block() {
             return KeepUpInstruction::Fatal(msg);
         }
-        let block_hash = best_available.highest_block_hash();
-        let block_height = best_available.highest_block_height();
-        info!(%best_available, %block_height, %block_hash, "historical: leap received");
-        debug!(?best_available, %block_height, %block_hash, "historical: best available leap received");
+        let block_hash = sync_leap.highest_block_hash();
+        let block_height = sync_leap.highest_block_height();
+        info!(%sync_leap, %block_height, %block_hash, "historical: leap received");
+
+        self.last_sync_leap_highest_block_hash = Some(block_hash);
 
         let era_validator_weights =
-            best_available.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
+            sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
         for evw in era_validator_weights {
             let era_id = evw.era_id();
             debug!(%era_id, "historical: attempt to register validators for era");


### PR DESCRIPTION
This PR adjusts the sync leap behavior:
1. Upon receiving a successful sync leap response, the block_hash of the highest block is memoized in main reactor
2. When another sync leap is about to be requested, the memoized block hash is compared to the block hash we're about to request a sync leap for
3. If the block hashes match, the sync leap attempt is aborted

Closes #3685 