### PR TITLE
Create acceptors when local tip is unknown

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -258,12 +258,13 @@ impl BlockAccumulator {
             btree_map::Entry::Vacant(entry) => entry,
         };
 
-        // The acceptor doesn't exist. Don't create it if the item's era is not provided, the local
-        // tip doesn't have an era or the item's era is older than the local tip era by more than
-        // `recent_era_interval`.
+        // The acceptor doesn't exist. Don't create it if the item's era is not
+        // provided or the item's era is older than the local tip era by more
+        // than `recent_era_interval`.
         match (maybe_era_id, self.local_tip) {
             (Some(era_id), Some(local_tip))
                 if era_id >= local_tip.era_id.saturating_sub(self.recent_era_interval) => {}
+            (Some(_), None) => {}
             _ => {
                 // If we created the event, it's safe to create the acceptor.
                 if maybe_sender.is_some() {

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -282,6 +282,17 @@ fn upsert_acceptor() {
     )
     .unwrap();
 
+    let random_block_hash = BlockHash::random(&mut rng);
+    accumulator.upsert_acceptor(random_block_hash, Some(era0), Some(*ALICE_NODE_ID));
+    assert!(accumulator
+        .block_acceptors
+        .remove(&random_block_hash)
+        .is_some());
+    assert!(accumulator
+        .peer_block_timestamps
+        .remove(&ALICE_NODE_ID)
+        .is_some());
+
     accumulator.register_local_tip(0, EraId::new(0));
 
     let max_block_count =


### PR DESCRIPTION
Fixes #3683 

This PR introduces a change that relaxes the requirements for creating new block acceptors in `BlockAccumulator::upsert_acceptor`. Previously acceptors would not be created when the accumulator had no local tip, but we decided that this behavior is too restrictive and should be changed.
