### PR TITLE
Fix slashing behaviour in `global_state_update_gen` tool

### DIFF
--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -131,7 +131,9 @@ fn update_auction_state<T: StateReader>(
         slash,
     );
 
-    state.remove_withdraws(&validators_diff.removed);
+    if slash {
+        state.remove_withdraws_and_unbonds(&validators_diff.removed);
+    }
 
     // We need to output the validators for the next era, which are contained in the first entry
     // in the snapshot.

--- a/utils/global-state-update-gen/src/generic/state_reader.rs
+++ b/utils/global-state-update-gen/src/generic/state_reader.rs
@@ -2,7 +2,7 @@ use casper_engine_test_support::LmdbWasmTestBuilder;
 use casper_types::{
     account::{Account, AccountHash},
     system::{
-        auction::{Bids, UnbondingPurses, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY},
+        auction::{Bids, UnbondingPurses, WithdrawPurses, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY},
         mint::TOTAL_SUPPLY_KEY,
     },
     Key, StoredValue,
@@ -18,6 +18,8 @@ pub trait StateReader {
     fn get_account(&mut self, account_hash: AccountHash) -> Option<Account>;
 
     fn get_bids(&mut self) -> Bids;
+
+    fn get_withdraws(&mut self) -> WithdrawPurses;
 
     fn get_unbonds(&mut self) -> UnbondingPurses;
 }
@@ -44,6 +46,10 @@ where
 
     fn get_bids(&mut self) -> Bids {
         T::get_bids(self)
+    }
+
+    fn get_withdraws(&mut self) -> WithdrawPurses {
+        T::get_withdraws(self)
     }
 
     fn get_unbonds(&mut self) -> UnbondingPurses {
@@ -80,6 +86,10 @@ impl StateReader for LmdbWasmTestBuilder {
 
     fn get_bids(&mut self) -> Bids {
         LmdbWasmTestBuilder::get_bids(self)
+    }
+
+    fn get_withdraws(&mut self) -> WithdrawPurses {
+        LmdbWasmTestBuilder::get_withdraw_purses(self)
     }
 
     fn get_unbonds(&mut self) -> UnbondingPurses {


### PR DESCRIPTION
This PR fixes the slashing behaviour in the following ways:
* withdraws and unbonds are only modified when slashing is enabled
* when acquiring the set of withdraws, rather than reading only `StoredValue::Unbonding` values from global state, we now also read `StoredValue::Withdraw` values, since pre-1.5.0 versions will only have the latter
* having acquired the set of withdraws, as well as replacing the values with an empty `Vec` for those related to validators to be slashed, we now also slash the corresponding validator and delegator unbonding purses (i.e. their balances are set to zero)

Closes #3682.
