### PR TITLE
Fix the `request_evidence` implementation.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -194,7 +194,6 @@ pub(crate) enum ProtocolOutcome<C: Context> {
     CreatedGossipMessage(EraMessage<C>),
     CreatedTargetedMessage(EraMessage<C>, NodeId),
     CreatedMessageToRandomPeer(EraMessage<C>),
-    CreatedTargetedRequest(EraRequest<C>, NodeId),
     CreatedRequestToRandomPeer(EraRequest<C>),
     ScheduleTimer(Timestamp, TimerId),
     QueueAction(ActionId),

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -305,7 +305,7 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
     fn mark_faulty(&mut self, vid: &C::ValidatorId);
 
     /// Sends evidence for a faulty of validator `vid` to the `sender` of the request.
-    fn request_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C>;
+    fn send_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C>;
 
     /// Sets the pause status: While paused we don't create consensus messages other than pings.
     fn set_paused(&mut self, paused: bool, now: Timestamp) -> ProtocolOutcomes<C>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -928,10 +928,6 @@ impl EraSupervisor {
                 }
                 .ignore()
             }
-            ProtocolOutcome::CreatedTargetedRequest(payload, to) => {
-                let message = ConsensusRequestMessage { era_id, payload };
-                effect_builder.enqueue_message(to, message.into()).ignore()
-            }
             ProtocolOutcome::CreatedRequestToRandomPeer(payload) => {
                 let message = ConsensusRequestMessage { era_id, payload };
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -662,7 +662,7 @@ impl EraSupervisor {
                     self.iter_past(era_id, PAST_EVIDENCE_ERAS)
                         .flat_map(|e_id| {
                             self.delegate_to_era(effect_builder, rng, e_id, |consensus, _| {
-                                consensus.request_evidence(sender, &pub_key)
+                                consensus.send_evidence(sender, &pub_key)
                             })
                         })
                         .collect()
@@ -1127,7 +1127,7 @@ impl EraSupervisor {
                 .iter_past_other(era_id, PAST_EVIDENCE_ERAS)
                 .flat_map(|e_id| {
                     self.delegate_to_era(effect_builder, rng, e_id, |consensus, _| {
-                        consensus.request_evidence(sender, &pub_key)
+                        consensus.send_evidence(sender, &pub_key)
                     })
                 })
                 .collect(),

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -1003,7 +1003,7 @@ where
         self.highway.mark_faulty(vid);
     }
 
-    fn request_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
+    fn send_evidence(&self, sender: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
         self.highway
             .validators()
             .get_index(vid)

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -1332,7 +1332,6 @@ impl<C: Context + 'static> Zug<C> {
                             | ProtocolOutcome::CreatedGossipMessage(_)
                             | ProtocolOutcome::CreatedTargetedMessage(_, _)
                             | ProtocolOutcome::CreatedMessageToRandomPeer(_)
-                            | ProtocolOutcome::CreatedTargetedRequest(_, _)
                             | ProtocolOutcome::CreatedRequestToRandomPeer(_)
                             | ProtocolOutcome::ScheduleTimer(_, _)
                             | ProtocolOutcome::QueueAction(_)

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -2192,7 +2192,7 @@ where
         }
     }
 
-    fn request_evidence(&self, peer: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
+    fn send_evidence(&self, peer: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
         self.validators
             .get_index(vid)
             .and_then(|idx| self.faults.get(&idx))

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -2199,7 +2199,7 @@ where
             .map(|fault| match fault {
                 Fault::Direct(msg, content, sign) => {
                     vec![ProtocolOutcome::CreatedTargetedMessage(
-                        Message::Evidence(msg.clone(), content.clone(), sign.clone()).into(),
+                        Message::Evidence(msg.clone(), content.clone(), *sign).into(),
                         peer,
                     )]
                 }

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -2194,15 +2194,19 @@ where
     }
 
     fn request_evidence(&self, peer: NodeId, vid: &C::ValidatorId) -> ProtocolOutcomes<C> {
-        if let Some(v_idx) = self.validators.get_index(vid) {
-            // Send the peer a sync message, so they will send us evidence we are missing.
-            let round_id = self.current_round;
-            let payload = self.create_sync_request(v_idx, round_id).into();
-            vec![ProtocolOutcome::CreatedTargetedRequest(payload, peer)]
-        } else {
-            error!(?vid, "unknown validator ID");
-            vec![]
-        }
+        self.validators
+            .get_index(vid)
+            .and_then(|idx| self.faults.get(&idx))
+            .map(|fault| match fault {
+                Fault::Direct(msg, content, sign) => {
+                    vec![ProtocolOutcome::CreatedTargetedMessage(
+                        Message::Evidence(msg.clone(), content.clone(), sign.clone()).into(),
+                        peer,
+                    )]
+                }
+                _ => vec![],
+            })
+            .unwrap_or_default()
     }
 
     fn set_paused(&mut self, paused: bool, now: Timestamp) -> ProtocolOutcomes<C> {


### PR DESCRIPTION
The `request_evidence` has a placeholder implementation: this commit fixes that implementation to use a correct one.