### PR TITLE
`pub` our config + chainspec types and fields (in the node)

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -138,12 +138,12 @@ impl BlockAccumulator {
     ) -> Result<Self, prometheus::Error> {
         Ok(Self {
             validator_matrix,
-            attempt_execution_threshold: config.attempt_execution_threshold(),
-            dead_air_interval: config.dead_air_interval(),
+            attempt_execution_threshold: config.attempt_execution_threshold,
+            dead_air_interval: config.dead_air_interval,
             block_acceptors: Default::default(),
             block_children: Default::default(),
             last_progress: Timestamp::now(),
-            purge_interval: config.purge_interval(),
+            purge_interval: config.purge_interval,
             local_tip: None,
             recent_era_interval,
             peer_block_timestamps: Default::default(),

--- a/node/src/components/block_accumulator/config.rs
+++ b/node/src/components/block_accumulator/config.rs
@@ -10,23 +10,12 @@ const DEFAULT_PURGE_INTERVAL_SECS: u32 = 6 * 60 * 60; // Six hours.
 /// Configuration options for the block accumulator.
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
-    attempt_execution_threshold: u64,
-    dead_air_interval: TimeDiff,
-    purge_interval: TimeDiff,
-}
-
-impl Config {
-    pub(crate) fn attempt_execution_threshold(&self) -> u64 {
-        self.attempt_execution_threshold
-    }
-
-    pub(crate) fn dead_air_interval(&self) -> TimeDiff {
-        self.dead_air_interval
-    }
-
-    pub(crate) fn purge_interval(&self) -> TimeDiff {
-        self.purge_interval
-    }
+    /// Attempt execution threshold.
+    pub attempt_execution_threshold: u64,
+    /// Dead air interval.
+    pub dead_air_interval: TimeDiff,
+    /// Purge interval.
+    pub purge_interval: TimeDiff,
 }
 
 impl Default for Config {

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -158,7 +158,7 @@ impl Reactor for MockReactor {
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
         let validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
         let block_accumulator_config = Config::default();
-        let block_time = block_accumulator_config.purge_interval() / 2;
+        let block_time = block_accumulator_config.purge_interval / 2;
 
         let block_accumulator = BlockAccumulator::new(
             block_accumulator_config,
@@ -271,7 +271,7 @@ fn upsert_acceptor() {
     let era0 = EraId::from(0);
     let validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let recent_era_interval = 1;
-    let block_time = config.purge_interval() / 2;
+    let block_time = config.purge_interval / 2;
     let metrics_registry = Registry::new();
     let mut accumulator = BlockAccumulator::new(
         config,
@@ -296,7 +296,7 @@ fn upsert_acceptor() {
     accumulator.register_local_tip(0, EraId::new(0));
 
     let max_block_count =
-        PEER_RATE_LIMIT_MULTIPLIER * ((config.purge_interval() / block_time) as usize);
+        PEER_RATE_LIMIT_MULTIPLIER * ((config.purge_interval / block_time) as usize);
 
     for _ in 0..max_block_count {
         accumulator.upsert_acceptor(
@@ -332,7 +332,7 @@ fn upsert_acceptor() {
         .contains(&ALICE_NODE_ID));
 
     // Modify the timestamp of the acceptor we just added to be too old.
-    let purge_interval = config.purge_interval() * 2;
+    let purge_interval = config.purge_interval * 2;
     let purged_hash = {
         let (hash, timestamp) = accumulator
             .peer_block_timestamps
@@ -756,7 +756,7 @@ fn accumulator_highest_usable_block_height() {
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let block_accumulator_config = Config::default();
     let recent_era_interval = 1;
-    let block_time = block_accumulator_config.purge_interval() / 2;
+    let block_time = block_accumulator_config.purge_interval / 2;
     let mut block_accumulator = BlockAccumulator::new(
         block_accumulator_config,
         validator_matrix.clone(),
@@ -880,8 +880,8 @@ fn accumulator_should_leap() {
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let block_accumulator_config = Config::default();
     let recent_era_interval = 1;
-    let block_time = block_accumulator_config.purge_interval() / 2;
-    let attempt_execution_threshold = block_accumulator_config.attempt_execution_threshold();
+    let block_time = block_accumulator_config.purge_interval / 2;
+    let attempt_execution_threshold = block_accumulator_config.attempt_execution_threshold;
     let mut block_accumulator = BlockAccumulator::new(
         block_accumulator_config,
         validator_matrix.clone(),
@@ -955,8 +955,8 @@ fn accumulator_purge() {
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let block_accumulator_config = Config::default();
     let recent_era_interval = 1;
-    let block_time = block_accumulator_config.purge_interval() / 2;
-    let purge_interval = block_accumulator_config.purge_interval();
+    let block_time = block_accumulator_config.purge_interval / 2;
+    let purge_interval = block_accumulator_config.purge_interval;
     let time_before_insertion = Timestamp::now();
     let mut block_accumulator = BlockAccumulator::new(
         block_accumulator_config,

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -225,7 +225,7 @@ impl BlockSynchronizer {
             validator_matrix,
             forward: None,
             historical: None,
-            global_sync: GlobalStateSynchronizer::new(config.max_parallel_trie_fetches() as usize),
+            global_sync: GlobalStateSynchronizer::new(config.max_parallel_trie_fetches as usize),
             metrics: Metrics::new(registry)?,
         })
     }
@@ -286,7 +286,7 @@ impl BlockSynchronizer {
             should_fetch_execution_state,
             requires_strict_finality,
             self.max_simultaneous_peers,
-            self.config.peer_refresh_interval(),
+            self.config.peer_refresh_interval,
         );
         if should_fetch_execution_state {
             self.historical.replace(builder);
@@ -333,7 +333,7 @@ impl BlockSynchronizer {
                         peers,
                         should_fetch_execution_state,
                         self.max_simultaneous_peers,
-                        self.config.peer_refresh_interval(),
+                        self.config.peer_refresh_interval,
                     );
                     apply_sigs(&mut builder, maybe_sigs);
                     if should_fetch_execution_state {
@@ -517,7 +517,7 @@ impl BlockSynchronizer {
     where
         REv: ReactorEvent + From<FetcherRequest<Block>> + From<BlockCompleteConfirmationRequest>,
     {
-        let need_next_interval = self.config.need_next_interval().into();
+        let need_next_interval = self.config.need_next_interval.into();
         let mut results = Effects::new();
         let max_simultaneous_peers = self.max_simultaneous_peers as usize;
         let mut builder_needs_next = |builder: &mut BlockBuilder| {
@@ -1192,7 +1192,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                         );
                         // start dishonest peer management on initialization
                         effect_builder
-                            .set_timeout(self.config.disconnect_dishonest_peers_interval().into())
+                            .set_timeout(self.config.disconnect_dishonest_peers_interval.into())
                             .event(move |_| {
                                 Event::Request(BlockSynchronizerRequest::DishonestPeers)
                             })
@@ -1259,9 +1259,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                         self.flush_dishonest_peers();
                         effects.extend(
                             effect_builder
-                                .set_timeout(
-                                    self.config.disconnect_dishonest_peers_interval().into(),
-                                )
+                                .set_timeout(self.config.disconnect_dishonest_peers_interval.into())
                                 .event(move |_| {
                                     Event::Request(BlockSynchronizerRequest::DishonestPeers)
                                 }),

--- a/node/src/components/block_synchronizer/config.rs
+++ b/node/src/components/block_synchronizer/config.rs
@@ -14,31 +14,13 @@ const DEFAULT_DISCONNECT_DISHONEST_PEERS_INTERVAL: &str = "10sec";
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// Maximum number of trie nodes to fetch in parallel.
-    max_parallel_trie_fetches: u32,
+    pub max_parallel_trie_fetches: u32,
     /// Time interval for the node to ask for refreshed peers.
-    peer_refresh_interval: TimeDiff,
+    pub peer_refresh_interval: TimeDiff,
     /// Time interval for the node to check what the block synchronizer needs to acquire next.
-    need_next_interval: TimeDiff,
+    pub need_next_interval: TimeDiff,
     /// Time interval for recurring disconnection of dishonest peers.
-    disconnect_dishonest_peers_interval: TimeDiff,
-}
-
-impl Config {
-    pub(crate) fn max_parallel_trie_fetches(&self) -> u32 {
-        self.max_parallel_trie_fetches
-    }
-
-    pub(crate) fn peer_refresh_interval(&self) -> TimeDiff {
-        self.peer_refresh_interval
-    }
-
-    pub(crate) fn need_next_interval(&self) -> TimeDiff {
-        self.need_next_interval
-    }
-
-    pub(crate) fn disconnect_dishonest_peers_interval(&self) -> TimeDiff {
-        self.disconnect_dishonest_peers_interval
-    }
+    pub disconnect_dishonest_peers_interval: TimeDiff,
 }
 
 impl Default for Config {

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -21,18 +21,18 @@ const DEFAULT_MAX_EXECUTION_DELAY: u64 = 3;
 #[derive(DataSize, Debug, Deserialize, Clone)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
-pub(crate) struct Config {
+pub struct Config {
     /// Path to secret key file.
-    pub(crate) secret_key_path: External,
+    pub secret_key_path: External,
     /// The maximum number of blocks by which execution is allowed to lag behind finalization.
     /// If it is more than that, consensus will pause, and resume once the executor has caught up.
     pub max_execution_delay: u64,
     /// Highway-specific node configuration.
     #[serde(default)]
-    pub(crate) highway: HighwayConfig,
+    pub highway: HighwayConfig,
     /// Zug-specific node configuration.
     #[serde(default)]
-    pub(crate) zug: ZugConfig,
+    pub zug: ZugConfig,
 }
 
 impl Default for Config {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -598,9 +598,9 @@ impl ContractRuntime {
 
         let environment = Arc::new(LmdbEnvironment::new(
             storage_dir,
-            contract_runtime_config.max_global_state_size(),
-            contract_runtime_config.max_readers(),
-            contract_runtime_config.manual_sync_enabled(),
+            contract_runtime_config.max_global_state_size_or_default(),
+            contract_runtime_config.max_readers_or_default(),
+            contract_runtime_config.manual_sync_enabled_or_default(),
         )?);
 
         let trie_store = Arc::new(LmdbTrieStore::new(
@@ -611,7 +611,7 @@ impl ContractRuntime {
 
         let global_state = LmdbGlobalState::empty(environment, trie_store)?;
         let engine_config = EngineConfig::new(
-            contract_runtime_config.max_query_depth(),
+            contract_runtime_config.max_query_depth_or_default(),
             max_associated_keys,
             max_runtime_call_stack_height,
             minimum_delegation_amount,

--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -18,23 +18,24 @@ pub struct Config {
     /// Defaults to 805,306,368,000 == 750 GiB.
     ///
     /// The size should be a multiple of the OS page size.
-    max_global_state_size: Option<usize>,
+    pub max_global_state_size: Option<usize>,
     /// The maximum number of readers to use for the global state store.
     ///
     /// Defaults to 512.
-    max_readers: Option<u32>,
+    pub max_readers: Option<u32>,
     /// The limit of depth of recursive global state queries.
     ///
     /// Defaults to 5.
-    max_query_depth: Option<u64>,
+    pub max_query_depth: Option<u64>,
     /// Enable synchronizing to disk only after each block is written.
     ///
     /// Defaults to `false`.
-    enable_manual_sync: Option<bool>,
+    pub enable_manual_sync: Option<bool>,
 }
 
 impl Config {
-    pub(crate) fn max_global_state_size(&self) -> usize {
+    /// Max global state size in bytes.
+    pub fn max_global_state_size_or_default(&self) -> usize {
         let value = self
             .max_global_state_size
             .unwrap_or(DEFAULT_MAX_GLOBAL_STATE_SIZE);
@@ -42,15 +43,18 @@ impl Config {
         value
     }
 
-    pub(crate) fn max_readers(&self) -> u32 {
+    /// Max lmdb readers.
+    pub fn max_readers_or_default(&self) -> u32 {
         self.max_readers.unwrap_or(DEFAULT_MAX_READERS)
     }
 
-    pub(crate) fn max_query_depth(&self) -> u64 {
+    /// Max query depth.
+    pub fn max_query_depth_or_default(&self) -> u64 {
         self.max_query_depth.unwrap_or(DEFAULT_MAX_QUERY_DEPTH)
     }
 
-    pub(crate) fn manual_sync_enabled(&self) -> bool {
+    /// Is manual sync enabled.
+    pub fn manual_sync_enabled_or_default(&self) -> bool {
         self.enable_manual_sync
             .unwrap_or(DEFAULT_MANUAL_SYNC_ENABLED)
     }

--- a/node/src/components/deploy_buffer/config.rs
+++ b/node/src/components/deploy_buffer/config.rs
@@ -7,13 +7,14 @@ const DEFAULT_EXPIRY_CHECK_INTERVAL: &str = "1min";
 
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct Config {
+pub struct Config {
     /// The interval of checking for expired deploys.
-    expiry_check_interval: TimeDiff,
+    pub expiry_check_interval: TimeDiff,
 }
 
 impl Config {
-    pub(crate) fn expiry_check_interval(&self) -> TimeDiff {
+    /// Returns the interval of checking for expired deploys.
+    pub fn expiry_check_interval(&self) -> TimeDiff {
         self.expiry_check_interval
     }
 }

--- a/node/src/components/diagnostics_port.rs
+++ b/node/src/components/diagnostics_port.rs
@@ -41,13 +41,13 @@ const COMPONENT_NAME: &str = "diagnostics_port";
 
 /// Diagnostics port configuration.
 #[derive(Clone, DataSize, Debug, Deserialize)]
-pub(crate) struct Config {
+pub struct Config {
     /// Whether or not the diagnostics port is enabled.
-    enabled: bool,
+    pub enabled: bool,
     /// Path to listen on.
-    socket_path: PathBuf,
+    pub socket_path: PathBuf,
     /// `umask` to apply before creating the socket.
-    socket_umask: u16,
+    pub socket_umask: u16,
 }
 
 impl Default for Config {

--- a/node/src/components/fetcher/config.rs
+++ b/node/src/components/fetcher/config.rs
@@ -14,7 +14,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub(crate) fn get_from_peer_timeout(&self) -> TimeDiff {
+    /// Returns `get_from_peer` timeout.
+    pub fn get_from_peer_timeout(&self) -> TimeDiff {
         self.get_from_peer_timeout
     }
 }

--- a/node/src/components/gossiper/config.rs
+++ b/node/src/components/gossiper/config.rs
@@ -32,7 +32,7 @@ const SMALL_TIMEOUTS_VALIDATE_AND_STORE_TIMEOUT: &str = "1sec";
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// Target number of peers to infect with a given piece of data.
-    infection_target: u8,
+    pub infection_target: u8,
     /// The saturation limit as a percentage, with a maximum value of 99.  Used as a termination
     /// condition.
     ///
@@ -40,22 +40,22 @@ pub struct Config {
     /// don't manage to newly infect 3 peers.  We will stop gossiping once we know of more than 15
     /// holders excluding us since 80% saturation would imply 3 new infections in 15 peers.
     #[serde(deserialize_with = "deserialize_saturation_limit_percent")]
-    saturation_limit_percent: u8,
+    pub saturation_limit_percent: u8,
     /// The maximum duration in seconds for which to keep finished entries.
     ///
     /// The longer they are retained, the lower the likelihood of re-gossiping a piece of data.
     /// However, the longer they are retained, the larger the list of finished entries can grow.
-    finished_entry_duration: TimeDiff,
+    pub finished_entry_duration: TimeDiff,
     /// The timeout duration in seconds for a single gossip request, i.e. for a single gossip
     /// message sent from this node, it will be considered timed out if the expected response from
     /// that peer is not received within this specified duration.
-    gossip_request_timeout: TimeDiff,
+    pub gossip_request_timeout: TimeDiff,
     /// The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered
     /// data from a peer which gossiped information about that data to this node.
-    get_remainder_timeout: TimeDiff,
+    pub get_remainder_timeout: TimeDiff,
     /// The timeout duration for a newly-received, gossiped item to be validated and stored by
     /// another component before the gossiper abandons waiting to gossip the item onwards.
-    validate_and_store_timeout: TimeDiff,
+    pub validate_and_store_timeout: TimeDiff,
 }
 
 impl Config {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2672,23 +2672,23 @@ pub struct Config {
     /// The maximum size of the database to use for the block store.
     ///
     /// The size should be a multiple of the OS page size.
-    max_block_store_size: usize,
+    pub max_block_store_size: usize,
     /// The maximum size of the database to use for the deploy store.
     ///
     /// The size should be a multiple of the OS page size.
-    max_deploy_store_size: usize,
+    pub max_deploy_store_size: usize,
     /// The maximum size of the database to use for the deploy metadata store.
     ///
     /// The size should be a multiple of the OS page size.
-    max_deploy_metadata_store_size: usize,
+    pub max_deploy_metadata_store_size: usize,
     /// The maximum size of the database to use for the component state store.
     ///
     /// The size should be a multiple of the OS page size.
-    max_state_store_size: usize,
+    pub max_state_store_size: usize,
     /// Whether or not memory deduplication is enabled.
-    enable_mem_deduplication: bool,
+    pub enable_mem_deduplication: bool,
     /// How many loads before memory duplication checks for dead references.
-    mem_pool_prune_interval: u16,
+    pub mem_pool_prune_interval: u16,
 }
 
 impl Default for Config {

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -48,7 +48,7 @@ const DEFAULT_UPGRADE_CHECK_INTERVAL: &str = "30sec";
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// How often to scan file system for available upgrades.
-    upgrade_check_interval: TimeDiff,
+    pub upgrade_check_interval: TimeDiff,
 }
 
 impl Default for Config {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) mod components;
 mod config_migration;
 mod data_migration;
 pub(crate) mod effect;
-pub(crate) mod logging;
+pub mod logging;
 pub(crate) mod protocol;
 pub(crate) mod reactor;
 #[cfg(test)]
@@ -40,6 +40,7 @@ pub use components::{
     rpc_server::rpcs,
     storage::{self, Config as StorageConfig},
 };
+pub use reactor::main_reactor::Config as MainReactorConfig;
 pub use utils::WithDir;
 
 use std::sync::{atomic::AtomicUsize, Arc};

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -42,19 +42,19 @@ static RELOAD_HANDLE: OnceCell<ReloadHandle> = OnceCell::new();
 #[serde(deny_unknown_fields)]
 pub struct LoggingConfig {
     /// Output format for log.
-    format: LoggingFormat,
+    pub format: LoggingFormat,
 
     /// Colored output (has no effect if JSON format is enabled).
     ///
     /// If set, the logger will inject ANSI color codes into log messages.  This is useful if
     /// writing out to stdout or stderr on an ANSI terminal, but not so if writing to a logfile.
-    color: bool,
+    pub color: bool,
 
     /// Abbreviate module names (has no effect if JSON format is enabled).
     ///
     /// If set, human-readable formats will abbreviate module names, `foo::bar::baz::bizz` will
     /// turn into `f:b:b:bizz`.
-    abbreviate_modules: bool,
+    pub abbreviate_modules: bool,
 }
 
 impl LoggingConfig {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -77,7 +77,7 @@ use crate::{
 };
 #[cfg(test)]
 use crate::{testing::network::NetworkedReactor, types::NodeId};
-pub(crate) use config::Config;
+pub use config::Config;
 pub(crate) use error::Error;
 pub(crate) use event::MainEvent;
 pub(crate) use reactor_state::ReactorState;

--- a/node/src/reactor/main_reactor/config.rs
+++ b/node/src/reactor/main_reactor/config.rs
@@ -12,22 +12,39 @@ use crate::{
 #[derive(DataSize, Debug, Default, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
-pub(crate) struct Config {
-    pub(crate) node: NodeConfig,
-    pub(crate) logging: LoggingConfig,
-    pub(crate) consensus: ConsensusConfig,
-    pub(crate) network: NetworkConfig,
-    pub(crate) event_stream_server: EventStreamServerConfig,
-    pub(crate) rest_server: RestServerConfig,
-    pub(crate) rpc_server: RpcServerConfig,
-    pub(crate) speculative_exec_server: SpeculativeExecConfig,
-    pub(crate) storage: StorageConfig,
-    pub(crate) gossip: GossipConfig,
-    pub(crate) fetcher: FetcherConfig,
-    pub(crate) contract_runtime: ContractRuntimeConfig,
-    pub(crate) deploy_buffer: DeployBufferConfig,
-    pub(crate) diagnostics_port: DiagnosticsPortConfig,
-    pub(crate) block_accumulator: BlockAccumulatorConfig,
-    pub(crate) block_synchronizer: BlockSynchronizerConfig,
-    pub(crate) upgrade_watcher: UpgradeWatcherConfig,
+pub struct Config {
+    /// Config values for the node.
+    pub node: NodeConfig,
+    /// Config values for logging.
+    pub logging: LoggingConfig,
+    /// Config values for logging.
+    pub consensus: ConsensusConfig,
+    /// Config values for logging.
+    pub network: NetworkConfig,
+    /// Config values for network.
+    pub event_stream_server: EventStreamServerConfig,
+    /// Config values for the REST server.
+    pub rest_server: RestServerConfig,
+    /// Config values for the Json-RPC server.
+    pub rpc_server: RpcServerConfig,
+    /// Config values for speculative execution.
+    pub speculative_exec_server: SpeculativeExecConfig,
+    /// Config values for storage.
+    pub storage: StorageConfig,
+    /// Config values for gossip.
+    pub gossip: GossipConfig,
+    /// Config values for fetchers.
+    pub fetcher: FetcherConfig,
+    /// Config values for the contract runtime.
+    pub contract_runtime: ContractRuntimeConfig,
+    /// Config values for the deploy buffer.
+    pub deploy_buffer: DeployBufferConfig,
+    /// Config values for the diagnostics port.
+    pub diagnostics_port: DiagnosticsPortConfig,
+    /// Config values for the block accumulator.
+    pub block_accumulator: BlockAccumulatorConfig,
+    /// Config values for the block synchronizer.
+    pub block_synchronizer: BlockSynchronizerConfig,
+    /// Config values for the upgrade watcher.
+    pub upgrade_watcher: UpgradeWatcherConfig,
 }

--- a/node/src/reactor/main_reactor/config.rs
+++ b/node/src/reactor/main_reactor/config.rs
@@ -17,11 +17,11 @@ pub struct Config {
     pub node: NodeConfig,
     /// Config values for logging.
     pub logging: LoggingConfig,
-    /// Config values for logging.
+    /// Config values for consensus.
     pub consensus: ConsensusConfig,
-    /// Config values for logging.
-    pub network: NetworkConfig,
     /// Config values for network.
+    pub network: NetworkConfig,
+    /// Config values for the event stream server.
     pub event_stream_server: EventStreamServerConfig,
     /// Config values for the REST server.
     pub rest_server: RestServerConfig,

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -33,15 +33,13 @@ use casper_types::{
     EraId, ProtocolVersion,
 };
 
-#[cfg(test)]
-pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
-pub use self::error::Error;
-pub(crate) use self::{
-    accounts_config::AccountsConfig,
+pub use self::{
+    accounts_config::{AccountConfig, AccountsConfig, ValidatorConfig},
     activation_point::ActivationPoint,
     chainspec_raw_bytes::ChainspecRawBytes,
     core_config::{ConsensusProtocolName, CoreConfig},
     deploy_config::DeployConfig,
+    error::Error,
     global_state_update::GlobalStateUpdate,
     highway_config::HighwayConfig,
     network_config::NetworkConfig,
@@ -56,25 +54,38 @@ pub const CHAINSPEC_FILENAME: &str = "chainspec.toml";
 /// upgrades to basic system functionality occurring after genesis.
 #[derive(DataSize, PartialEq, Eq, Serialize, Debug)]
 pub struct Chainspec {
+    /// Protocol config.
     #[serde(rename = "protocol")]
-    pub(crate) protocol_config: ProtocolConfig,
+    pub protocol_config: ProtocolConfig,
+
+    /// Network config.
     #[serde(rename = "network")]
-    pub(crate) network_config: NetworkConfig,
+    pub network_config: NetworkConfig,
+
+    /// Core config.
     #[serde(rename = "core")]
-    pub(crate) core_config: CoreConfig,
+    pub core_config: CoreConfig,
+
+    /// Highway config.
     #[serde(rename = "highway")]
-    pub(crate) highway_config: HighwayConfig,
+    pub highway_config: HighwayConfig,
+
+    /// Deploy COnfig
     #[serde(rename = "deploys")]
-    pub(crate) deploy_config: DeployConfig,
+    pub deploy_config: DeployConfig,
+
+    /// Wasm config.
     #[serde(rename = "wasm")]
-    pub(crate) wasm_config: WasmConfig,
+    pub wasm_config: WasmConfig,
+
+    /// System costs config.
     #[serde(rename = "system_costs")]
-    pub(crate) system_costs_config: SystemConfig,
+    pub system_costs_config: SystemConfig,
 }
 
 impl Chainspec {
     /// Returns `false` and logs errors if the values set in the config don't make sense.
-    pub(crate) fn is_valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         if (self.network_config.maximum_net_message_size as usize)
             < ChunkWithProof::CHUNK_SIZE_BYTES * 3
         {
@@ -121,7 +132,7 @@ impl Chainspec {
     }
 
     /// Serializes `self` and hashes the resulting bytes.
-    pub(crate) fn hash(&self) -> Digest {
+    pub fn hash(&self) -> Digest {
         let serialized_chainspec = self.to_bytes().unwrap_or_else(|error| {
             error!(%error, "failed to serialize chainspec");
             vec![]
@@ -130,13 +141,13 @@ impl Chainspec {
     }
 
     /// Returns the protocol version of the chainspec.
-    pub(crate) fn protocol_version(&self) -> ProtocolVersion {
+    pub fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_config.version
     }
 
     /// Returns the era ID of where we should reset back to.  This means stored blocks in that and
     /// subsequent eras are deleted from storage.
-    pub(crate) fn hard_reset_to_start_of_era(&self) -> Option<EraId> {
+    pub fn hard_reset_to_start_of_era(&self) -> Option<EraId> {
         self.protocol_config
             .hard_reset
             .then(|| self.protocol_config.activation_point.era_id())

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -70,7 +70,7 @@ pub struct Chainspec {
     #[serde(rename = "highway")]
     pub highway_config: HighwayConfig,
 
-    /// Deploy COnfig
+    /// Deploy Config.
     #[serde(rename = "deploys")]
     pub deploy_config: DeployConfig,
 

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -34,6 +34,7 @@ where
     Ok(vec)
 }
 
+/// Configuration values associated with accounts.toml
 #[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Clone)]
 pub struct AccountsConfig {
     #[serde(deserialize_with = "sorted_vec_deserializer")]
@@ -43,6 +44,7 @@ pub struct AccountsConfig {
 }
 
 impl AccountsConfig {
+    /// Creates a new `AccountsConfig.
     pub fn new(accounts: Vec<AccountConfig>, delegators: Vec<DelegatorConfig>) -> Self {
         Self {
             accounts,
@@ -50,14 +52,17 @@ impl AccountsConfig {
         }
     }
 
+    /// Accounts.
     pub fn accounts(&self) -> &[AccountConfig] {
         &self.accounts
     }
 
+    /// Delegators.
     pub fn delegators(&self) -> &[DelegatorConfig] {
         &self.delegators
     }
 
+    /// Account.
     pub fn account(&self, public_key: &PublicKey) -> Option<&AccountConfig> {
         self.accounts
             .iter()

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -44,7 +44,7 @@ pub struct AccountsConfig {
 }
 
 impl AccountsConfig {
-    /// Creates a new `AccountsConfig.
+    /// Creates a new `AccountsConfig`.
     pub fn new(accounts: Vec<AccountConfig>, delegators: Vec<DelegatorConfig>) -> Self {
         Self {
             accounts,

--- a/node/src/types/chainspec/accounts_config/account_config.rs
+++ b/node/src/types/chainspec/accounts_config/account_config.rs
@@ -14,6 +14,7 @@ use casper_types::{testing::TestRng, SecretKey, U512};
 
 use super::ValidatorConfig;
 
+/// Configuration of an individial account in accounts.toml
 #[derive(PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize, DataSize, Debug, Clone)]
 pub struct AccountConfig {
     pub(super) public_key: PublicKey,
@@ -22,6 +23,7 @@ pub struct AccountConfig {
 }
 
 impl AccountConfig {
+    /// Creates a new `AccountConfig`.
     pub fn new(public_key: PublicKey, balance: Motes, validator: Option<ValidatorConfig>) -> Self {
         Self {
             public_key,
@@ -30,14 +32,17 @@ impl AccountConfig {
         }
     }
 
+    /// Public key.
     pub fn public_key(&self) -> PublicKey {
         self.public_key.clone()
     }
 
+    /// Balance.
     pub fn balance(&self) -> Motes {
         self.balance
     }
 
+    /// Bonded amount.
     pub fn bonded_amount(&self) -> Motes {
         match self.validator {
             Some(validator_config) => validator_config.bonded_amount(),
@@ -45,6 +50,7 @@ impl AccountConfig {
         }
     }
 
+    /// Is this a genesis validator?
     pub fn is_genesis_validator(&self) -> bool {
         self.validator.is_some()
     }

--- a/node/src/types/chainspec/accounts_config/validator_config.rs
+++ b/node/src/types/chainspec/accounts_config/validator_config.rs
@@ -13,6 +13,7 @@ use casper_types::{
 #[cfg(test)]
 use casper_types::{testing::TestRng, U512};
 
+/// Validator account configuration.
 #[derive(PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
 pub struct ValidatorConfig {
     bonded_amount: Motes,
@@ -21,6 +22,7 @@ pub struct ValidatorConfig {
 }
 
 impl ValidatorConfig {
+    /// Creates a new `ValidatorConfig`.
     pub fn new(bonded_amount: Motes, delegation_rate: DelegationRate) -> Self {
         Self {
             bonded_amount,
@@ -28,10 +30,12 @@ impl ValidatorConfig {
         }
     }
 
+    /// Delegation rate.
     pub fn delegation_rate(&self) -> DelegationRate {
         self.delegation_rate
     }
 
+    /// Bonded amount.
     pub fn bonded_amount(&self) -> Motes {
         self.bonded_amount
     }

--- a/node/src/types/chainspec/activation_point.rs
+++ b/node/src/types/chainspec/activation_point.rs
@@ -23,7 +23,9 @@ const GENESIS_TAG: u8 = 1;
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(untagged)]
 pub enum ActivationPoint {
+    /// Era id.
     EraId(EraId),
+    /// Genesis timestamp.
     Genesis(Timestamp),
 }
 

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -19,53 +19,74 @@ use casper_types::{
 };
 use tracing::{error, warn};
 
+/// Configuration values associated with the core protocol.
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct CoreConfig {
-    pub(crate) era_duration: TimeDiff,
-    pub(crate) minimum_era_height: u64,
-    pub(crate) minimum_block_time: TimeDiff,
-    pub(crate) validator_slots: u32,
+    /// Duration of an era.
+    pub era_duration: TimeDiff,
+
+    /// Minimum era height.
+    pub minimum_era_height: u64,
+
+    /// Minimum block time.
+    pub minimum_block_time: TimeDiff,
+
+    /// Validator slots.
+    pub validator_slots: u32,
+
+    /// Finality threshold fraction.
     #[data_size(skip)]
-    pub(crate) finality_threshold_fraction: Ratio<u64>,
+    pub finality_threshold_fraction: Ratio<u64>,
+
     /// Number of eras before an auction actually defines the set of validators.
     /// If you bond with a sufficient bid in era N, you will be a validator in era N +
     /// auction_delay + 1
-    pub(crate) auction_delay: u64,
+    pub auction_delay: u64,
+
     /// The period after genesis during which a genesis validator's bid is locked.
-    pub(crate) locked_funds_period: TimeDiff,
+    pub locked_funds_period: TimeDiff,
+
     /// The period in which genesis validator's bid is released over time after it's unlocked.
-    pub(crate) vesting_schedule_period: TimeDiff,
+    pub vesting_schedule_period: TimeDiff,
+
     /// The delay in number of eras for paying out the the unbonding amount.
-    pub(crate) unbonding_delay: u64,
+    pub unbonding_delay: u64,
+
     /// Round seigniorage rate represented as a fractional number.
     #[data_size(skip)]
-    pub(crate) round_seigniorage_rate: Ratio<u64>,
+    pub round_seigniorage_rate: Ratio<u64>,
+
     /// Maximum number of associated keys for a single account.
-    pub(crate) max_associated_keys: u32,
+    pub max_associated_keys: u32,
+
     /// Maximum height of contract runtime call stack.
-    pub(crate) max_runtime_call_stack_height: u32,
+    pub max_runtime_call_stack_height: u32,
+
     /// The minimum bound of motes that can be delegated to a validator.
-    pub(crate) minimum_delegation_amount: u64,
+    pub minimum_delegation_amount: u64,
+
     /// Enables strict arguments checking when calling a contract.
-    pub(crate) strict_argument_checking: bool,
+    pub strict_argument_checking: bool,
+
     /// How many peers to simultaneously ask when sync leaping.
-    pub(crate) simultaneous_peer_requests: u32,
+    pub simultaneous_peer_requests: u32,
+
     /// Which consensus protocol to use.
-    pub(crate) consensus_protocol: ConsensusProtocolName,
+    pub consensus_protocol: ConsensusProtocolName,
 }
 
 impl CoreConfig {
     /// The number of eras that have already started and whose validators are still bonded.
-    pub(crate) fn recent_era_count(&self) -> u64 {
+    pub fn recent_era_count(&self) -> u64 {
         // Safe to use naked `-` operation assuming `CoreConfig::is_valid()` has been checked.
         self.unbonding_delay - self.auction_delay
     }
 
     /// Returns `false` if unbonding delay is not greater than auction delay to ensure
     /// that `recent_era_count()` yields a value of at least 1.
-    pub(super) fn is_valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         if self.unbonding_delay <= self.auction_delay {
             warn!(
                 unbonding_delay = self.unbonding_delay,
@@ -234,9 +255,12 @@ impl FromBytes for CoreConfig {
     }
 }
 
+/// Consensus protocol name.
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Debug)]
-pub(crate) enum ConsensusProtocolName {
+pub enum ConsensusProtocolName {
+    /// Highway.
     Highway,
+    /// Zug.
     Zug,
 }
 

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -17,6 +17,7 @@ use casper_types::{
     Motes, TimeDiff, U512,
 };
 
+/// Configuration values associated with deploys.
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]

--- a/node/src/types/chainspec/highway_config.rs
+++ b/node/src/types/chainspec/highway_config.rs
@@ -12,21 +12,22 @@ use casper_types::{
     TimeDiff,
 };
 
+/// Configuration values relevant to Highway consensus.
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
-pub(crate) struct HighwayConfig {
+pub struct HighwayConfig {
     /// The upper limit for Highway round lengths.
-    pub(crate) maximum_round_length: TimeDiff,
+    pub maximum_round_length: TimeDiff,
     /// The factor by which rewards for a round are multiplied if the greatest summit has ≤50%
     /// quorum, i.e. no finality.
     #[data_size(skip)]
-    pub(crate) reduced_reward_multiplier: Ratio<u64>,
+    pub reduced_reward_multiplier: Ratio<u64>,
 }
 
 impl HighwayConfig {
     /// Checks whether the values set in the config make sense and returns `false` if they don't.
-    pub(super) fn is_valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         if self.reduced_reward_multiplier > Ratio::new(1, 1) {
             error!(
                 rrm = %self.reduced_reward_multiplier,

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -9,16 +9,17 @@ use casper_types::testing::TestRng;
 
 use super::AccountsConfig;
 
+/// Configuration values associated with the network.
 #[derive(Clone, DataSize, PartialEq, Eq, Serialize, Debug)]
 pub struct NetworkConfig {
     /// The network name.
-    pub(crate) name: String,
+    pub name: String,
     /// The maximum size of an accepted network message, in bytes.
-    pub(crate) maximum_net_message_size: u32,
+    pub maximum_net_message_size: u32,
     /// Validator accounts specified in the chainspec.
     // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
     // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
-    pub(crate) accounts_config: AccountsConfig,
+    pub accounts_config: AccountsConfig,
 }
 
 #[cfg(test)]

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -18,6 +18,7 @@ use casper_types::{
 use super::{ActivationPoint, GlobalStateUpdate};
 use crate::types::BlockHeader;
 
+/// Configuration values associated with the protocol.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug)]
 pub struct ProtocolConfig {
     #[data_size(skip)]

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -21,16 +21,17 @@ use crate::types::BlockHeader;
 /// Configuration values associated with the protocol.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug)]
 pub struct ProtocolConfig {
+    /// Protocol version.
     #[data_size(skip)]
-    pub(crate) version: ProtocolVersion,
+    pub version: ProtocolVersion,
     /// Whether we need to clear latest blocks back to the switch block just before the activation
     /// point or not.
-    pub(crate) hard_reset: bool,
+    pub hard_reset: bool,
     /// This protocol config applies starting at the era specified in the activation point.
-    pub(crate) activation_point: ActivationPoint,
+    pub activation_point: ActivationPoint,
     /// Any arbitrary updates we might want to make to the global state at the start of the era
     /// specified in the activation point.
-    pub(crate) global_state_update: Option<GlobalStateUpdate>,
+    pub global_state_update: Option<GlobalStateUpdate>,
 }
 
 impl ProtocolConfig {
@@ -53,7 +54,7 @@ impl ProtocolConfig {
 
     /// Returns whether the block header belongs to the last block before the upgrade to the
     /// current protocol version.
-    pub(crate) fn is_last_block_before_activation(&self, block_header: &BlockHeader) -> bool {
+    pub fn is_last_block_before_activation(&self, block_header: &BlockHeader) -> bool {
         block_header.protocol_version() < self.version
             && block_header.is_switch_block()
             && ActivationPoint::EraId(block_header.next_block_era_id()) == self.activation_point

--- a/node/src/utils/external.rs
+++ b/node/src/utils/external.rs
@@ -45,7 +45,7 @@ pub static RESOURCES_PATH: Lazy<PathBuf> =
 /// used instead.
 #[derive(Clone, DataSize, Eq, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
-pub(crate) enum External {
+pub enum External {
     /// Value that should be loaded from an external path.
     Path(PathBuf),
     /// The value has not been specified, but a default has been requested.

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -248,10 +248,20 @@
       "description": "The first era to which the associated protocol version applies.",
       "anyOf": [
         {
-          "$ref": "#/definitions/EraId"
+          "description": "Era id.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EraId"
+            }
+          ]
         },
         {
-          "$ref": "#/definitions/Timestamp"
+          "description": "Genesis timestamp.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            }
+          ]
         }
       ]
     },

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2965,15 +2965,15 @@
                 "minimum": 0.0
               },
               "locked_amounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "$ref": "#/components/schemas/U512"
                 },
                 "maxItems": 14,
-                "minItems": 14,
-                "type": [
-                  "array",
-                  "null"
-                ]
+                "minItems": 14
               }
             },
             "additionalProperties": false
@@ -4127,10 +4127,20 @@
             "description": "The first era to which the associated protocol version applies.",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/EraId"
+                "description": "Era id.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EraId"
+                  }
+                ]
               },
               {
-                "$ref": "#/components/schemas/Timestamp"
+                "description": "Genesis timestamp.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Timestamp"
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
We need to `pub` all the fields and parsing of `chainspec.toml`, `config.toml`, and `accounts.toml` for anyone who wants to read/write config files that the node can understand. While not officially "public", they are still effectively already and implicitly part of our public api, and therefore a source of endless pitfalls for anyone trying to generate this information or configure things programmatically. AND we already have this code.

Where we had getters, but no setters, the getters have been removed and replaced with inline field accessors.

While this is a large changeset, it should -not- change any behavior. We are merely exposing through the `casper-node` crate types and fields that were previously not pub.

