### PR TITLE
Make `starting_state_root_hash` required

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project will be documented in this file.  The format
 * Connections to unresponsive nodes will be terminated, based on a watchdog feature.
 
 ### Changed
+* The `starting_state_root_hash` field from the REST and JSON-RPC status endpoints now represents the state root hash of the lowest block in the available block range.
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.
 * Nodes no longer connect to nodes that do not speak the same protocol version by default.
 * Incoming connections from peers are rejected if they are exceeding the default incoming connections per peer limit of 3.
@@ -85,7 +86,6 @@ All notable changes to this project will be documented in this file.  The format
 * Rename `current_era` metric to `consensus_current_era`.
 
 ### Deprecated
-* Deprecate the `starting_state_root_hash` field from the REST and JSON-RPC status endpoints.
 * `null` should no longer be used as a value for `params` in JSON-RPC requests.  Prefer an empty Array or Object.
 * Deprecate the `chain_height` metric in favor of `highest_available_block_height`.
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -213,7 +213,8 @@ where
                                 true,
                             )
                             .await
-                            .map(|header| *header.state_root_hash());
+                            .map(|header| *header.state_root_hash())
+                            .unwrap_or_default();
                         let status_feed = StatusFeed::new(
                             last_added_block,
                             peers,

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -414,7 +414,8 @@ where
                                 true,
                             )
                             .await
-                            .map(|header| *header.state_root_hash());
+                            .map(|header| *header.state_root_hash())
+                            .unwrap_or_default();
                         let status_feed = StatusFeed::new(
                             last_added_block,
                             peers,

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -54,7 +54,7 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         last_progress: Timestamp::from(0),
         available_block_range: AvailableBlockRange::RANGE_0_0,
         block_sync: BlockSynchronizerStatus::doc_example().clone(),
-        starting_state_root_hash: None,
+        starting_state_root_hash: Digest::default(),
     };
     GetStatusResult::new(status_feed, DOCS_EXAMPLE_PROTOCOL_VERSION)
 });
@@ -108,7 +108,7 @@ pub struct StatusFeed {
     /// The status of the block synchronizer builders.
     pub block_sync: BlockSynchronizerStatus,
     /// The state root hash of the lowest block in the available block range.
-    pub starting_state_root_hash: Option<Digest>,
+    pub starting_state_root_hash: Digest,
 }
 
 impl StatusFeed {
@@ -123,7 +123,7 @@ impl StatusFeed {
         last_progress: Timestamp,
         available_block_range: AvailableBlockRange,
         block_sync: BlockSynchronizerStatus,
-        starting_state_root_hash: Option<Digest>,
+        starting_state_root_hash: Digest,
     ) -> Self {
         let (our_public_signing_key, round_length) = match consensus_status {
             Some((public_key, round_length)) => (Some(public_key), round_length),
@@ -185,7 +185,7 @@ pub struct GetStatusResult {
     /// The chainspec name.
     pub chainspec_name: String,
     /// The state root hash of the lowest block in the available block range.
-    pub starting_state_root_hash: Option<Digest>,
+    pub starting_state_root_hash: Digest,
     /// The minimal info of the last block from the linear chain.
     pub last_added_block_info: Option<MinimalBlockInfo>,
     /// Our public signing key.

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -12,6 +12,7 @@
     "last_progress",
     "peers",
     "reactor_state",
+    "starting_state_root_hash",
     "uptime"
   ],
   "properties": {
@@ -37,12 +38,9 @@
     },
     "starting_state_root_hash": {
       "description": "The state root hash of the lowest block in the available block range.",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/Digest"
-        },
-        {
-          "type": "null"
         }
       ]
     },

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -780,6 +780,7 @@
                 "last_progress",
                 "peers",
                 "reactor_state",
+                "starting_state_root_hash",
                 "uptime"
               ],
               "properties": {
@@ -801,14 +802,7 @@
                 },
                 "starting_state_root_hash": {
                   "description": "The state root hash of the lowest block in the available block range.",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/Digest"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/Digest"
                 },
                 "last_added_block_info": {
                   "description": "The minimal info of the last block from the linear chain.",
@@ -894,7 +888,7 @@
                   "api_version": "1.4.8",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
-                  "starting_state_root_hash": null,
+                  "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
                   "last_added_block_info": {
                     "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "timestamp": "2020-11-17T00:39:24.072Z",
@@ -2965,15 +2959,15 @@
                 "minimum": 0.0
               },
               "locked_amounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "$ref": "#/components/schemas/U512"
                 },
                 "maxItems": 14,
-                "minItems": 14,
-                "type": [
-                  "array",
-                  "null"
-                ]
+                "minItems": 14
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
Fixes #3705 

This PR makes the `starting_state_root_hash` field in the REST and JSON-RPC status endpoint responses required and defaulted in case the available block range is empty. It also updates `CHANGELOG.md` to reflect the current state of the status endpoint.
