### PR TITLE
bugfix: completed blocks write anomaly

### DIFF
--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use datasize::DataSize;
 use itertools::Itertools;
@@ -15,8 +12,8 @@ use crate::{
         fetcher::{EmptyValidationMetadata, FetchItem},
     },
     types::{
-        Block, BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock,
-        NodeId, SignatureWeight,
+        BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock, NodeId,
+        SignatureWeight,
     },
 };
 
@@ -61,18 +58,6 @@ impl BlockAcceptor {
 
     pub(super) fn peers(&self) -> &BTreeSet<NodeId> {
         &self.peers
-    }
-
-    pub(super) fn block(&self) -> Option<Arc<Block>> {
-        self.meta_block
-            .as_ref()
-            .map(|meta_block| Arc::clone(&meta_block.block))
-    }
-
-    pub(super) fn finality_signature(&self, public_key: &PublicKey) -> Option<FinalitySignature> {
-        self.signatures
-            .get(public_key)
-            .map(|(finality_signature, _peer)| finality_signature.clone())
     }
 
     pub(super) fn register_peer(&mut self, peer: NodeId) {

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -51,20 +51,6 @@ impl Display for Event {
                     block_hash
                 )
             }
-            Event::Request(BlockAccumulatorRequest::GetBlock { block_hash, .. }) => {
-                write!(f, "block accumulator block request for {}", block_hash)
-            }
-            Event::Request(BlockAccumulatorRequest::GetFinalitySignature {
-                block_hash,
-                public_key,
-                ..
-            }) => {
-                write!(
-                    f,
-                    "block accumulator signature request of {} for {}",
-                    public_key, block_hash
-                )
-            }
             Event::RegisterPeer {
                 block_hash, sender, ..
             } => {

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -53,8 +53,9 @@ use crate::{
     rpcs::docs::DocExample,
     types::{
         ApprovalsHashes, Block, BlockExecutionResultsOrChunk, BlockHash, BlockHeader,
-        BlockSignatures, Deploy, FinalitySignature, FinalitySignatureId, LegacyDeploy, MetaBlock,
-        MetaBlockState, NodeId, SyncLeap, TrieOrChunk, ValidatorMatrix,
+        BlockSignatures, Chainspec, Deploy, FinalitySignature, FinalitySignatureId, LegacyDeploy,
+        MetaBlock, MetaBlockState, NodeId, SyncLeap, SyncLeapIdentifier, TrieOrChunk,
+        ValidatorMatrix,
     },
     NodeRng,
 };
@@ -116,6 +117,7 @@ pub(crate) trait ReactorEvent:
     + From<FetcherRequest<FinalitySignature>>
     + From<FetcherRequest<TrieOrChunk>>
     + From<FetcherRequest<BlockExecutionResultsOrChunk>>
+    + From<FetcherRequest<SyncLeap>>
     + From<BlockAccumulatorRequest>
     + From<PeerBehaviorAnnouncement>
     + From<StorageRequest>
@@ -140,6 +142,7 @@ impl<REv> ReactorEvent for REv where
         + From<FetcherRequest<FinalitySignature>>
         + From<FetcherRequest<TrieOrChunk>>
         + From<FetcherRequest<BlockExecutionResultsOrChunk>>
+        + From<FetcherRequest<SyncLeap>>
         + From<BlockAccumulatorRequest>
         + From<PeerBehaviorAnnouncement>
         + From<StorageRequest>
@@ -198,6 +201,7 @@ impl DocExample for BlockSynchronizerStatus {
 pub(crate) struct BlockSynchronizer {
     state: ComponentState,
     config: Config,
+    chainspec: Arc<Chainspec>,
     max_simultaneous_peers: u32,
     validator_matrix: ValidatorMatrix,
 
@@ -214,6 +218,7 @@ pub(crate) struct BlockSynchronizer {
 impl BlockSynchronizer {
     pub(crate) fn new(
         config: Config,
+        chainspec: Arc<Chainspec>,
         max_simultaneous_peers: u32,
         validator_matrix: ValidatorMatrix,
         registry: &Registry,
@@ -221,6 +226,7 @@ impl BlockSynchronizer {
         Ok(BlockSynchronizer {
             state: ComponentState::Uninitialized,
             config,
+            chainspec,
             max_simultaneous_peers,
             validator_matrix,
             forward: None,
@@ -320,10 +326,12 @@ impl BlockSynchronizer {
             (Some(builder), _) | (_, Some(builder))
                 if builder.block_hash() == block_header.block_hash() =>
             {
+                debug!(%builder, "BlockSynchronizer: register_sync_leap update builder");
                 apply_sigs(builder, maybe_sigs);
                 builder.register_peers(peers);
             }
             _ => {
+                debug!("BlockSynchronizer: register_sync_leap update validator_matrix");
                 let era_id = block_header.era_id();
                 if let Some(validator_weights) = self.validator_matrix.validator_weights(era_id) {
                     let mut builder = BlockBuilder::new_from_sync_leap(
@@ -520,7 +528,7 @@ impl BlockSynchronizer {
         let need_next_interval = self.config.need_next_interval.into();
         let mut results = Effects::new();
         let max_simultaneous_peers = self.max_simultaneous_peers as usize;
-        let mut builder_needs_next = |builder: &mut BlockBuilder| {
+        let mut builder_needs_next = |builder: &mut BlockBuilder, chainspec: Arc<Chainspec>| {
             if builder.in_flight_latch().is_some() || builder.is_finished() {
                 return;
             }
@@ -688,20 +696,25 @@ impl BlockSynchronizer {
                         "BlockSynchronizer: does not have era_validators for era_id: {}",
                         era_id
                     );
-                    results.extend(
+                    builder.set_in_flight_latch();
+                    results.extend(peers.into_iter().flat_map(|node_id| {
                         effect_builder
-                            .set_timeout(need_next_interval)
-                            .event(|_| Event::Request(BlockSynchronizerRequest::NeedNext)),
-                    )
+                            .fetch::<SyncLeap>(
+                                SyncLeapIdentifier::sync_to_historical(builder.block_hash()),
+                                node_id,
+                                chainspec.clone(),
+                            )
+                            .event(Event::SyncLeapFetched)
+                    }))
                 }
             }
         };
 
         if let Some(builder) = &mut self.forward {
-            builder_needs_next(builder);
+            builder_needs_next(builder, Arc::clone(&self.chainspec));
         }
         if let Some(builder) = &mut self.historical {
-            builder_needs_next(builder);
+            builder_needs_next(builder, Arc::clone(&self.chainspec));
         }
         results
     }
@@ -890,6 +903,55 @@ impl BlockSynchronizer {
                             warn!(%error, "BlockSynchronizer: failed to apply finality signature");
                         }
                     }
+                }
+            }
+            _ => {
+                trace!(%block_hash, "BlockSynchronizer: not currently synchronizing block");
+            }
+        }
+    }
+
+    fn sync_leap_fetched(&mut self, result: Result<FetchedData<SyncLeap>, FetcherError<SyncLeap>>) {
+        let (block_hash, maybe_sync_leap, maybe_peer_id): (
+            BlockHash,
+            Option<Box<SyncLeap>>,
+            Option<NodeId>,
+        ) = match result {
+            Ok(FetchedData::FromPeer { item, peer }) => {
+                debug!(
+                    "BlockSynchronizer: fetched sync leap {:?} from peer {}",
+                    item.fetch_id().block_hash(),
+                    peer
+                );
+
+                (item.fetch_id().block_hash(), Some(item), Some(peer))
+            }
+            Ok(FetchedData::FromStorage { item }) => {
+                (item.fetch_id().block_hash(), Some(item), None)
+            }
+            Err(err) => {
+                debug!(%err, "BlockSynchronizer: failed to fetch sync leap");
+                if err.is_peer_fault() {
+                    (err.id().block_hash(), None, Some(*err.peer()))
+                } else {
+                    (err.id().block_hash(), None, None)
+                }
+            }
+        };
+        let demote_peer = maybe_sync_leap.is_none();
+        if let Some(sync_leap) = maybe_sync_leap {
+            let era_validator_weights =
+                sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
+            for evw in era_validator_weights {
+                self.validator_matrix.register_era_validator_weights(evw);
+            }
+        }
+        match (&mut self.forward, &mut self.historical) {
+            (Some(builder), _) | (_, Some(builder)) if builder.block_hash() == block_hash => {
+                if demote_peer {
+                    builder.demote_peer(maybe_peer_id);
+                } else {
+                    builder.register_era_validator_weights(&self.validator_matrix);
                 }
             }
             _ => {
@@ -1207,6 +1269,7 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                     | Event::BlockFetched(_)
                     | Event::ApprovalsHashesFetched(_)
                     | Event::FinalitySignatureFetched(_)
+                    | Event::SyncLeapFetched(_)
                     | Event::GlobalStateSynced { .. }
                     | Event::GotExecutionResultsChecksum { .. }
                     | Event::DeployFetched { .. }
@@ -1372,6 +1435,10 @@ impl<REv: ReactorEvent> Component<REv> for BlockSynchronizer {
                 // for the deploys they contain
                 Event::ApprovalsHashesFetched(result) => {
                     self.approvals_hashes_fetched(result);
+                    self.need_next(effect_builder, rng)
+                }
+                Event::SyncLeapFetched(result) => {
+                    self.sync_leap_fetched(result);
                     self.need_next(effect_builder, rng)
                 }
                 // we use the existence of n execution results checksum as an expedient way to

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -927,7 +927,8 @@ impl BlockSynchronizer {
                 (item.fetch_id().block_hash(), Some(item), Some(peer))
             }
             Ok(FetchedData::FromStorage { item }) => {
-                (item.fetch_id().block_hash(), Some(item), None)
+                error!(%item, "BlockSynchronizer: sync leap should never come from storage");
+                (item.fetch_id().block_hash(), None, None) // maybe_sync_leap None will demote peer
             }
             Err(err) => {
                 debug!(%err, "BlockSynchronizer: failed to fetch sync leap");
@@ -951,6 +952,7 @@ impl BlockSynchronizer {
                 if demote_peer {
                     builder.demote_peer(maybe_peer_id);
                 } else {
+                    builder.promote_peer(maybe_peer_id);
                     builder.register_era_validator_weights(&self.validator_matrix);
                 }
             }

--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -214,12 +214,11 @@ impl BlockAcquisitionAction {
         }
     }
 
-    pub(super) fn era_validators(era_id: EraId) -> Self {
-        let peers_to_ask = Default::default();
-        let need_next = NeedNext::EraValidators(era_id);
+    pub(super) fn era_validators(peer_list: &PeerList, rng: &mut NodeRng, era_id: EraId) -> Self {
+        let peers_to_ask = peer_list.qualified_peers(rng);
         BlockAcquisitionAction {
             peers_to_ask,
-            need_next,
+            need_next: NeedNext::EraValidators(era_id),
         }
     }
 

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -370,15 +370,21 @@ impl BlockBuilder {
         }
         let era_id = match self.era_id {
             None => {
+                // if we don't have the era_id, we only have block_hash, thus get block_header
                 return BlockAcquisitionAction::block_header(&self.peer_list, rng, self.block_hash);
             }
             Some(era_id) => era_id,
         };
         let validator_weights = match &self.validator_weights {
             None => {
-                return BlockAcquisitionAction::era_validators(era_id);
+                return BlockAcquisitionAction::era_validators(&self.peer_list, rng, era_id);
             }
-            Some(validator_weights) => validator_weights,
+            Some(validator_weights) => {
+                if validator_weights.is_empty() {
+                    return BlockAcquisitionAction::era_validators(&self.peer_list, rng, era_id);
+                }
+                validator_weights
+            }
         };
         match self.acquisition_state.next_action(
             &self.peer_list,

--- a/node/src/components/block_synchronizer/event.rs
+++ b/node/src/components/block_synchronizer/event.rs
@@ -16,7 +16,7 @@ use crate::{
     effect::requests::BlockSynchronizerRequest,
     types::{
         ApprovalsHashes, Block, BlockExecutionResultsOrChunk, BlockHash, BlockHeader, Deploy,
-        FinalitySignature, FinalizedBlock, LegacyDeploy, NodeId,
+        FinalitySignature, FinalizedBlock, LegacyDeploy, NodeId, SyncLeap,
     },
 };
 
@@ -45,6 +45,8 @@ pub(crate) enum Event {
     ApprovalsHashesFetched(FetchResult<ApprovalsHashes>),
     #[from]
     FinalitySignatureFetched(FetchResult<FinalitySignature>),
+    #[from]
+    SyncLeapFetched(FetchResult<SyncLeap>),
     GlobalStateSynced {
         block_hash: BlockHash,
         #[serde(skip_serializing)]
@@ -118,6 +120,12 @@ impl Display for Event {
                 write!(f, "{}", fetched_item)
             }
             Event::FinalitySignatureFetched(Err(fetcher_error)) => {
+                write!(f, "{}", fetcher_error)
+            }
+            Event::SyncLeapFetched(Ok(fetched_item)) => {
+                write!(f, "{}", fetched_item)
+            }
+            Event::SyncLeapFetched(Err(fetcher_error)) => {
                 write!(f, "{}", fetcher_error)
             }
             Event::GlobalStateSynced {

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -40,12 +40,6 @@ impl From<FetcherRequest<ApprovalsHashes>> for MockReactorEvent {
     }
 }
 
-// impl From<FetcherRequest<SyncLeap>> for MockReactorEvent {
-//     fn from(_req: FetcherRequest<SyncLeap>) -> MockReactorEvent {
-//         unreachable!()
-//     }
-// }
-
 struct MockReactor {
     scheduler: &'static Scheduler<MockReactorEvent>,
     effect_builder: EffectBuilder<MockReactorEvent>,

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -22,6 +22,7 @@ enum MockReactorEvent {
     FinalitySignatureFetcherRequest(FetcherRequest<FinalitySignature>),
     TrieOrChunkFetcherRequest(FetcherRequest<TrieOrChunk>),
     BlockExecutionResultsOrChunkFetcherRequest(FetcherRequest<BlockExecutionResultsOrChunk>),
+    SyncLeapFetcherRequest(FetcherRequest<SyncLeap>),
     NetworkInfoRequest(NetworkInfoRequest),
     BlockAccumulatorRequest(BlockAccumulatorRequest),
     PeerBehaviorAnnouncement(PeerBehaviorAnnouncement),
@@ -38,6 +39,12 @@ impl From<FetcherRequest<ApprovalsHashes>> for MockReactorEvent {
         unreachable!()
     }
 }
+
+// impl From<FetcherRequest<SyncLeap>> for MockReactorEvent {
+//     fn from(_req: FetcherRequest<SyncLeap>) -> MockReactorEvent {
+//         unreachable!()
+//     }
+// }
 
 struct MockReactor {
     scheduler: &'static Scheduler<MockReactorEvent>,
@@ -109,6 +116,7 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     // Create a block synchronizer with a maximum of 5 simultaneous peers
     let mut block_synchronizer = BlockSynchronizer::new(
         Config::default(),
+        Arc::new(Chainspec::random(&mut rng)),
         5,
         validator_matrix,
         prometheus::default_registry(),

--- a/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/block_fetcher.rs
@@ -33,13 +33,7 @@ impl ItemFetcher<Block> for Fetcher<Block> {
         effect_builder: EffectBuilder<REv>,
         id: BlockHash,
     ) -> Option<Block> {
-        if let Some(block) = effect_builder.get_block_from_storage(id).await {
-            return Some(block);
-        }
-        effect_builder
-            .get_block_from_block_accumulator(id)
-            .await
-            .map(|block| (*block).clone())
+        effect_builder.get_block_from_storage(id).await
     }
 
     fn put_to_storage<'a, REv: From<StorageRequest> + Send>(

--- a/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
@@ -35,14 +35,8 @@ impl ItemFetcher<FinalitySignature> for Fetcher<FinalitySignature> {
         effect_builder: EffectBuilder<REv>,
         id: FinalitySignatureId,
     ) -> Option<FinalitySignature> {
-        if let Some(finality_signature) = effect_builder
-            .get_signature_from_storage(id.block_hash, id.public_key.clone())
-            .await
-        {
-            return Some(finality_signature);
-        }
         effect_builder
-            .get_signature_from_block_accumulator(id.block_hash, id.public_key.clone())
+            .get_signature_from_storage(id.block_hash, id.public_key.clone())
             .await
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -2221,42 +2221,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    pub(crate) async fn get_block_from_block_accumulator(
-        self,
-        block_hash: BlockHash,
-    ) -> Option<Arc<Block>>
-    where
-        REv: From<BlockAccumulatorRequest>,
-    {
-        self.make_request(
-            |responder| BlockAccumulatorRequest::GetBlock {
-                block_hash,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    pub(crate) async fn get_signature_from_block_accumulator(
-        self,
-        block_hash: BlockHash,
-        public_key: PublicKey,
-    ) -> Option<FinalitySignature>
-    where
-        REv: From<BlockAccumulatorRequest>,
-    {
-        self.make_request(
-            |responder| BlockAccumulatorRequest::GetFinalitySignature {
-                block_hash,
-                public_key,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Set a new stopping point for the node.
     ///
     /// Returns a potentially previously set stop-at spec.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1150,15 +1150,6 @@ pub(crate) enum BlockAccumulatorRequest {
         block_hash: BlockHash,
         responder: Responder<Option<Vec<NodeId>>>,
     },
-    GetBlock {
-        block_hash: BlockHash,
-        responder: Responder<Option<Arc<Block>>>,
-    },
-    GetFinalitySignature {
-        block_hash: BlockHash,
-        public_key: PublicKey,
-        responder: Responder<Option<FinalitySignature>>,
-    },
 }
 
 impl Display for BlockAccumulatorRequest {
@@ -1166,20 +1157,6 @@ impl Display for BlockAccumulatorRequest {
         match self {
             BlockAccumulatorRequest::GetPeersForBlock { block_hash, .. } => {
                 write!(f, "get peers for {}", block_hash)
-            }
-            BlockAccumulatorRequest::GetBlock { block_hash, .. } => {
-                write!(f, "get block for {}", block_hash)
-            }
-            BlockAccumulatorRequest::GetFinalitySignature {
-                block_hash,
-                public_key,
-                ..
-            } => {
-                write!(
-                    f,
-                    "get finality signature of {} for {}",
-                    public_key, block_hash
-                )
             }
         }
     }

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -46,7 +46,7 @@ use crate::{
         rpc_server::RpcServer,
         shutdown_trigger::{self, ShutdownTrigger},
         storage::Storage,
-        sync_leaper::{self, SyncLeaper},
+        sync_leaper::SyncLeaper,
         upgrade_watcher::{self, UpgradeWatcher},
         Component, ValidatorBoundComponent,
     },
@@ -72,7 +72,7 @@ use crate::{
     },
     types::{
         Block, BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, Deploy, FinalitySignature,
-        MetaBlock, MetaBlockState, NodeId, SyncLeapIdentifier, TrieOrChunk, ValidatorMatrix,
+        MetaBlock, MetaBlockState, TrieOrChunk, ValidatorMatrix,
     },
     utils::{Source, WithDir},
     NodeRng,
@@ -187,224 +187,12 @@ pub(crate) struct MainReactor {
     control_logic_default_delay: TimeDiff,
     sync_to_genesis: bool,
     signature_gossip_tracker: SignatureGossipTracker,
-    last_sync_leap_highest_block_hash: Option<BlockHash>,
 }
 
 impl reactor::Reactor for MainReactor {
     type Event = MainEvent;
     type Config = WithDir<Config>;
     type Error = Error;
-
-    fn new(
-        config: Self::Config,
-        chainspec: Arc<Chainspec>,
-        chainspec_raw_bytes: Arc<ChainspecRawBytes>,
-        network_identity: NetworkIdentity,
-        registry: &Registry,
-        event_queue: EventQueueHandle<Self::Event>,
-        _rng: &mut NodeRng,
-    ) -> Result<(Self, Effects<MainEvent>), Error> {
-        let node_startup_instant = Instant::now();
-
-        let effect_builder = EffectBuilder::new(event_queue);
-
-        let metrics = Metrics::new(registry.clone());
-        let memory_metrics = MemoryMetrics::new(registry.clone())?;
-        let event_queue_metrics = EventQueueMetrics::new(registry.clone(), event_queue)?;
-
-        let protocol_version = chainspec.protocol_config.version;
-
-        let trusted_hash = config.value().node.trusted_hash;
-        let (root_dir, config) = config.into_parts();
-        let (our_secret_key, our_public_key) = config.consensus.load_keys(&root_dir)?;
-        let validator_matrix = ValidatorMatrix::new(
-            chainspec.core_config.finality_threshold_fraction,
-            chainspec
-                .protocol_config
-                .global_state_update
-                .as_ref()
-                .and_then(|global_state_update| global_state_update.validators.clone()),
-            chainspec.protocol_config.activation_point.era_id(),
-            our_secret_key.clone(),
-            our_public_key.clone(),
-            chainspec.core_config.auction_delay,
-        );
-
-        let storage_config = WithDir::new(&root_dir, config.storage.clone());
-
-        let hard_reset_to_start_of_era = chainspec.hard_reset_to_start_of_era();
-        let storage = Storage::new(
-            &storage_config,
-            hard_reset_to_start_of_era,
-            protocol_version,
-            &chainspec.network_config.name,
-            chainspec.deploy_config.max_ttl,
-            chainspec.core_config.recent_era_count(),
-            Some(registry),
-            config.node.force_resync,
-        )?;
-
-        let contract_runtime = ContractRuntime::new(
-            protocol_version,
-            storage.root_path(),
-            &config.contract_runtime,
-            chainspec.wasm_config,
-            chainspec.system_costs_config,
-            chainspec.core_config.max_associated_keys,
-            chainspec.core_config.max_runtime_call_stack_height,
-            chainspec.core_config.minimum_delegation_amount,
-            chainspec.core_config.strict_argument_checking,
-            chainspec.core_config.vesting_schedule_period.millis(),
-            registry,
-        )?;
-
-        let network = Network::new(
-            config.network.clone(),
-            network_identity,
-            Some((our_secret_key.clone(), our_public_key.clone())),
-            registry,
-            chainspec.as_ref(),
-            validator_matrix.clone(),
-        )?;
-
-        let address_gossiper = Gossiper::<{ GossipedAddress::ID_IS_COMPLETE_ITEM }, _>::new(
-            "address_gossiper",
-            config.gossip,
-            registry,
-        )?;
-
-        let rpc_server = RpcServer::new(
-            config.rpc_server.clone(),
-            config.speculative_exec_server.clone(),
-            protocol_version,
-            chainspec.network_config.name.clone(),
-            node_startup_instant,
-        );
-        let rest_server = RestServer::new(
-            config.rest_server.clone(),
-            protocol_version,
-            chainspec.network_config.name.clone(),
-            node_startup_instant,
-        );
-        let event_stream_server = EventStreamServer::new(
-            config.event_stream_server.clone(),
-            storage.root_path().to_path_buf(),
-            protocol_version,
-        );
-        let diagnostics_port =
-            DiagnosticsPort::new(WithDir::new(&root_dir, config.diagnostics_port));
-        let shutdown_trigger = ShutdownTrigger::new();
-
-        // local / remote data management
-        let sync_leaper = SyncLeaper::new(chainspec.clone(), registry)?;
-        let fetchers = Fetchers::new(&config.fetcher, registry)?;
-
-        // gossipers
-        let block_gossiper = Gossiper::<{ Block::ID_IS_COMPLETE_ITEM }, _>::new(
-            "block_gossiper",
-            config.gossip,
-            registry,
-        )?;
-        let deploy_gossiper = Gossiper::<{ Deploy::ID_IS_COMPLETE_ITEM }, _>::new(
-            "deploy_gossiper",
-            config.gossip,
-            registry,
-        )?;
-        let finality_signature_gossiper =
-            Gossiper::<{ FinalitySignature::ID_IS_COMPLETE_ITEM }, _>::new(
-                "finality_signature_gossiper",
-                config.gossip,
-                registry,
-            )?;
-
-        // consensus
-        let consensus = EraSupervisor::new(
-            storage.root_path(),
-            our_secret_key,
-            our_public_key,
-            config.consensus,
-            chainspec.clone(),
-            registry,
-        )?;
-
-        // chain / deploy management
-
-        let block_accumulator = BlockAccumulator::new(
-            config.block_accumulator,
-            validator_matrix.clone(),
-            chainspec.core_config.unbonding_delay,
-            chainspec.core_config.minimum_block_time,
-            registry,
-        )?;
-        let block_synchronizer = BlockSynchronizer::new(
-            config.block_synchronizer,
-            chainspec.core_config.simultaneous_peer_requests,
-            validator_matrix.clone(),
-            registry,
-        )?;
-        let block_validator = BlockValidator::new(Arc::clone(&chainspec));
-        let upgrade_watcher =
-            UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;
-        let deploy_acceptor = DeployAcceptor::new(chainspec.as_ref(), registry)?;
-        let deploy_buffer =
-            DeployBuffer::new(chainspec.deploy_config, config.deploy_buffer, registry)?;
-
-        let reactor = MainReactor {
-            chainspec,
-            chainspec_raw_bytes,
-            storage,
-            contract_runtime,
-            upgrade_watcher,
-            net: network,
-            address_gossiper,
-
-            rpc_server,
-            rest_server,
-            event_stream_server,
-            deploy_acceptor,
-            fetchers,
-
-            block_gossiper,
-            deploy_gossiper,
-            finality_signature_gossiper,
-            sync_leaper,
-            deploy_buffer,
-            consensus,
-            block_validator,
-            block_accumulator,
-            block_synchronizer,
-            diagnostics_port,
-            shutdown_trigger,
-
-            metrics,
-            memory_metrics,
-            event_queue_metrics,
-
-            state: ReactorState::Initialize {},
-            attempts: 0,
-            last_progress: Timestamp::now(),
-            max_attempts: config.node.max_attempts,
-            idle_tolerance: config.node.idle_tolerance,
-            control_logic_default_delay: config.node.control_logic_default_delay,
-            trusted_hash,
-            validator_matrix,
-            switch_block: None,
-            sync_to_genesis: config.node.sync_to_genesis,
-            signature_gossip_tracker: SignatureGossipTracker::new(),
-            last_sync_leap_highest_block_hash: Default::default(),
-        };
-        info!("MainReactor: instantiated");
-        let effects = effect_builder
-            .immediately()
-            .event(|()| MainEvent::ReactorCrank);
-        Ok((reactor, effects))
-    }
-
-    fn update_metrics(&mut self, event_queue_handle: EventQueueHandle<Self::Event>) {
-        self.memory_metrics.estimate(self);
-        self.event_queue_metrics
-            .record_event_queue_counts(&event_queue_handle)
-    }
 
     fn dispatch_event(
         &mut self,
@@ -1169,40 +957,220 @@ impl reactor::Reactor for MainReactor {
                 .dispatch_fetcher_event(effect_builder, rng, event),
         }
     }
+
+    fn new(
+        config: Self::Config,
+        chainspec: Arc<Chainspec>,
+        chainspec_raw_bytes: Arc<ChainspecRawBytes>,
+        network_identity: NetworkIdentity,
+        registry: &Registry,
+        event_queue: EventQueueHandle<Self::Event>,
+        _rng: &mut NodeRng,
+    ) -> Result<(Self, Effects<MainEvent>), Error> {
+        let node_startup_instant = Instant::now();
+
+        let effect_builder = EffectBuilder::new(event_queue);
+
+        let metrics = Metrics::new(registry.clone());
+        let memory_metrics = MemoryMetrics::new(registry.clone())?;
+        let event_queue_metrics = EventQueueMetrics::new(registry.clone(), event_queue)?;
+
+        let protocol_version = chainspec.protocol_config.version;
+
+        let trusted_hash = config.value().node.trusted_hash;
+        let (root_dir, config) = config.into_parts();
+        let (our_secret_key, our_public_key) = config.consensus.load_keys(&root_dir)?;
+        let validator_matrix = ValidatorMatrix::new(
+            chainspec.core_config.finality_threshold_fraction,
+            chainspec
+                .protocol_config
+                .global_state_update
+                .as_ref()
+                .and_then(|global_state_update| global_state_update.validators.clone()),
+            chainspec.protocol_config.activation_point.era_id(),
+            our_secret_key.clone(),
+            our_public_key.clone(),
+            chainspec.core_config.auction_delay,
+        );
+
+        let storage_config = WithDir::new(&root_dir, config.storage.clone());
+
+        let hard_reset_to_start_of_era = chainspec.hard_reset_to_start_of_era();
+        let storage = Storage::new(
+            &storage_config,
+            hard_reset_to_start_of_era,
+            protocol_version,
+            &chainspec.network_config.name,
+            chainspec.deploy_config.max_ttl,
+            chainspec.core_config.recent_era_count(),
+            Some(registry),
+            config.node.force_resync,
+        )?;
+
+        let contract_runtime = ContractRuntime::new(
+            protocol_version,
+            storage.root_path(),
+            &config.contract_runtime,
+            chainspec.wasm_config,
+            chainspec.system_costs_config,
+            chainspec.core_config.max_associated_keys,
+            chainspec.core_config.max_runtime_call_stack_height,
+            chainspec.core_config.minimum_delegation_amount,
+            chainspec.core_config.strict_argument_checking,
+            chainspec.core_config.vesting_schedule_period.millis(),
+            registry,
+        )?;
+
+        let network = Network::new(
+            config.network.clone(),
+            network_identity,
+            Some((our_secret_key.clone(), our_public_key.clone())),
+            registry,
+            chainspec.as_ref(),
+            validator_matrix.clone(),
+        )?;
+
+        let address_gossiper = Gossiper::<{ GossipedAddress::ID_IS_COMPLETE_ITEM }, _>::new(
+            "address_gossiper",
+            config.gossip,
+            registry,
+        )?;
+
+        let rpc_server = RpcServer::new(
+            config.rpc_server.clone(),
+            config.speculative_exec_server.clone(),
+            protocol_version,
+            chainspec.network_config.name.clone(),
+            node_startup_instant,
+        );
+        let rest_server = RestServer::new(
+            config.rest_server.clone(),
+            protocol_version,
+            chainspec.network_config.name.clone(),
+            node_startup_instant,
+        );
+        let event_stream_server = EventStreamServer::new(
+            config.event_stream_server.clone(),
+            storage.root_path().to_path_buf(),
+            protocol_version,
+        );
+        let diagnostics_port =
+            DiagnosticsPort::new(WithDir::new(&root_dir, config.diagnostics_port));
+        let shutdown_trigger = ShutdownTrigger::new();
+
+        // local / remote data management
+        let sync_leaper = SyncLeaper::new(chainspec.clone(), registry)?;
+        let fetchers = Fetchers::new(&config.fetcher, registry)?;
+
+        // gossipers
+        let block_gossiper = Gossiper::<{ Block::ID_IS_COMPLETE_ITEM }, _>::new(
+            "block_gossiper",
+            config.gossip,
+            registry,
+        )?;
+        let deploy_gossiper = Gossiper::<{ Deploy::ID_IS_COMPLETE_ITEM }, _>::new(
+            "deploy_gossiper",
+            config.gossip,
+            registry,
+        )?;
+        let finality_signature_gossiper =
+            Gossiper::<{ FinalitySignature::ID_IS_COMPLETE_ITEM }, _>::new(
+                "finality_signature_gossiper",
+                config.gossip,
+                registry,
+            )?;
+
+        // consensus
+        let consensus = EraSupervisor::new(
+            storage.root_path(),
+            our_secret_key,
+            our_public_key,
+            config.consensus,
+            chainspec.clone(),
+            registry,
+        )?;
+
+        // chain / deploy management
+
+        let block_accumulator = BlockAccumulator::new(
+            config.block_accumulator,
+            validator_matrix.clone(),
+            chainspec.core_config.unbonding_delay,
+            chainspec.core_config.minimum_block_time,
+            registry,
+        )?;
+        let block_synchronizer = BlockSynchronizer::new(
+            config.block_synchronizer,
+            chainspec.clone(),
+            chainspec.core_config.simultaneous_peer_requests,
+            validator_matrix.clone(),
+            registry,
+        )?;
+        let block_validator = BlockValidator::new(Arc::clone(&chainspec));
+        let upgrade_watcher =
+            UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;
+        let deploy_acceptor = DeployAcceptor::new(chainspec.as_ref(), registry)?;
+        let deploy_buffer =
+            DeployBuffer::new(chainspec.deploy_config, config.deploy_buffer, registry)?;
+
+        let reactor = MainReactor {
+            chainspec,
+            chainspec_raw_bytes,
+            storage,
+            contract_runtime,
+            upgrade_watcher,
+            net: network,
+            address_gossiper,
+
+            rpc_server,
+            rest_server,
+            event_stream_server,
+            deploy_acceptor,
+            fetchers,
+
+            block_gossiper,
+            deploy_gossiper,
+            finality_signature_gossiper,
+            sync_leaper,
+            deploy_buffer,
+            consensus,
+            block_validator,
+            block_accumulator,
+            block_synchronizer,
+            diagnostics_port,
+            shutdown_trigger,
+
+            metrics,
+            memory_metrics,
+            event_queue_metrics,
+
+            state: ReactorState::Initialize {},
+            attempts: 0,
+            last_progress: Timestamp::now(),
+            max_attempts: config.node.max_attempts,
+            idle_tolerance: config.node.idle_tolerance,
+            control_logic_default_delay: config.node.control_logic_default_delay,
+            trusted_hash,
+            validator_matrix,
+            switch_block: None,
+            sync_to_genesis: config.node.sync_to_genesis,
+            signature_gossip_tracker: SignatureGossipTracker::new(),
+        };
+        info!("MainReactor: instantiated");
+        let effects = effect_builder
+            .immediately()
+            .event(|()| MainEvent::ReactorCrank);
+        Ok((reactor, effects))
+    }
+
+    fn update_metrics(&mut self, event_queue_handle: EventQueueHandle<Self::Event>) {
+        self.memory_metrics.estimate(self);
+        self.event_queue_metrics
+            .record_event_queue_counts(&event_queue_handle)
+    }
 }
 
 impl MainReactor {
-    fn request_leap_if_not_redundant(
-        &mut self,
-        sync_leap_identifier: SyncLeapIdentifier,
-        effect_builder: EffectBuilder<MainEvent>,
-        peers_to_ask: Vec<NodeId>,
-    ) -> Effects<MainEvent> {
-        let should_attempt_leap = self.last_sync_leap_highest_block_hash.map_or(
-            true,
-            |last_sync_leap_highest_block_hash| {
-                last_sync_leap_highest_block_hash != sync_leap_identifier.block_hash()
-            },
-        );
-        if should_attempt_leap {
-            // latch accumulator progress to allow sync-leap time to do work
-            self.block_accumulator.reset_last_progress();
-
-            effect_builder.immediately().event(move |_| {
-                MainEvent::SyncLeaper(sync_leaper::Event::AttemptLeap {
-                    sync_leap_identifier,
-                    peers_to_ask,
-                })
-            })
-        } else {
-            debug!(
-                state = %self.state,
-                block_hash = %sync_leap_identifier.block_hash(),
-                "successful sync leap for block hash already received, aborting leap attempt");
-            Effects::new()
-        }
-    }
-
     fn update_validator_weights(
         &mut self,
         effect_builder: EffectBuilder<MainEvent>,
@@ -1515,7 +1483,7 @@ impl MainReactor {
 
 #[cfg(test)]
 impl NetworkedReactor for MainReactor {
-    fn node_id(&self) -> NodeId {
+    fn node_id(&self) -> crate::types::NodeId {
         self.net.node_id()
     }
 }


### PR DESCRIPTION
bug fixes: due to an interaction between the block & finality signature fetchers, the accumulator, and the block synchronizer, it was possible for a block to get marked complete before it was actually stored, which would result in a later unrecoverable error if anything else attempted to read back the supposedly complete block data from storage prior to it actually being stored. this was an edge condition, but when it did occur a node's completed block record was left in an unrecoverable state.

separately, removed a risky optimization added recently that suppressed sync leaps considered to be redundant, which did not consider that other nodes' responses to a request for the same block_hash can differ over time; also, on a larger network with more peers it is healthy to get a broader response. 

finally, added logic to the block synchronizer to actively acquire era validator weights if needed rather than wait for them to potentially be provided which could be a terminal condition if the needed weights were not acquired by other means. 