### PR TITLE
Reduce `MainEvent` size

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -620,7 +620,7 @@ impl BlockSynchronizer {
                     builder.set_in_flight_latch();
                     results.extend(peers.into_iter().flat_map(|node_id| {
                         effect_builder
-                            .fetch::<ApprovalsHashes>(block_hash, node_id, *block.clone())
+                            .fetch::<ApprovalsHashes>(block_hash, node_id, block.clone())
                             .event(Event::ApprovalsHashesFetched)
                     }))
                 }

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -115,7 +115,7 @@ where
                 validation_metadata,
                 maybe_item,
                 responder,
-            } => match *maybe_item {
+            } => match maybe_item {
                 Some(item) => {
                     self.metrics().found_in_storage.inc();
                     responder

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -21,7 +21,7 @@ pub(crate) enum Event<T: FetchItem> {
         id: T::Id,
         peer: NodeId,
         validation_metadata: T::ValidationMetadata,
-        maybe_item: Box<Option<T>>,
+        maybe_item: Option<Box<T>>,
         responder: FetchResponder<T>,
     },
     /// An announcement from a different component that we have accepted and stored the given item.

--- a/node/src/components/fetcher/fetched_data.rs
+++ b/node/src/components/fetcher/fetched_data.rs
@@ -12,10 +12,8 @@ pub(crate) enum FetchedData<T> {
 }
 
 impl<T> FetchedData<T> {
-    pub(crate) fn from_storage(item: T) -> Self {
-        FetchedData::FromStorage {
-            item: Box::new(item),
-        }
+    pub(crate) fn from_storage(item: Box<T>) -> Self {
+        FetchedData::FromStorage { item }
     }
 
     pub(crate) fn from_peer(item: T, peer: NodeId) -> Self {

--- a/node/src/components/fetcher/item_fetcher.rs
+++ b/node/src/components/fetcher/item_fetcher.rs
@@ -65,7 +65,8 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
             id,
             peer,
             validation_metadata,
-            maybe_item: Box::new(result),
+            // TODO: Change signature of `get_locally` to return boxed item instead of boxing here.
+            maybe_item: result.map(Box::new),
             responder,
         })
     }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -434,13 +434,13 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
     /// the requester.
     fn got_from_storage<REv>(
         effect_builder: EffectBuilder<REv>,
-        item: T,
+        item: Box<T>,
         requester: NodeId,
     ) -> Effects<Event<T>>
     where
         REv: From<NetworkRequest<Message<T>>> + Send,
     {
-        let message = Message::Item(Box::new(item));
+        let message = Message::Item(item);
         effect_builder.send_message(requester, message).ignore()
     }
 

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -54,7 +54,7 @@ pub(crate) enum Event<T: GossipItem> {
     GetFromStorageResult {
         item_id: T::Id,
         requester: NodeId,
-        maybe_item: Option<T>,
+        maybe_item: Option<Box<T>>,
     },
 }
 

--- a/node/src/components/gossiper/item_provider.rs
+++ b/node/src/components/gossiper/item_provider.rs
@@ -13,5 +13,5 @@ pub(super) trait ItemProvider<T: GossipItem> {
     async fn get_from_storage<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: T::Id,
-    ) -> Option<T>;
+    ) -> Option<Box<T>>;
 }

--- a/node/src/components/gossiper/provider_impls/address_provider.rs
+++ b/node/src/components/gossiper/provider_impls/address_provider.rs
@@ -24,7 +24,7 @@ impl ItemProvider<GossipedAddress>
     async fn get_from_storage<REv: Send>(
         _effect_builder: EffectBuilder<REv>,
         item_id: GossipedAddress,
-    ) -> Option<GossipedAddress> {
+    ) -> Option<Box<GossipedAddress>> {
         error!(%item_id, "address gossiper should never try to get from storage");
         None
     }

--- a/node/src/components/gossiper/provider_impls/block_provider.rs
+++ b/node/src/components/gossiper/provider_impls/block_provider.rs
@@ -18,7 +18,11 @@ impl ItemProvider<Block> for Gossiper<{ Block::ID_IS_COMPLETE_ITEM }, Block> {
     async fn get_from_storage<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: BlockHash,
-    ) -> Option<Block> {
-        effect_builder.get_block_from_storage(item_id).await
+    ) -> Option<Box<Block>> {
+        // TODO: Make `get_block_from_storage` return a boxed block instead of boxing here.
+        effect_builder
+            .get_block_from_storage(item_id)
+            .await
+            .map(Box::new)
     }
 }

--- a/node/src/components/gossiper/provider_impls/deploy_provider.rs
+++ b/node/src/components/gossiper/provider_impls/deploy_provider.rs
@@ -18,7 +18,11 @@ impl ItemProvider<Deploy> for Gossiper<{ Deploy::ID_IS_COMPLETE_ITEM }, Deploy> 
     async fn get_from_storage<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: DeployId,
-    ) -> Option<Deploy> {
-        effect_builder.get_stored_deploy(item_id).await
+    ) -> Option<Box<Deploy>> {
+        // TODO: Make `get_stored_deploy` return a boxed value instead of boxing here.
+        effect_builder
+            .get_stored_deploy(item_id)
+            .await
+            .map(Box::new)
     }
 }

--- a/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
+++ b/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
@@ -22,9 +22,11 @@ impl ItemProvider<FinalitySignature>
     async fn get_from_storage<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
         item_id: FinalitySignatureId,
-    ) -> Option<FinalitySignature> {
+    ) -> Option<Box<FinalitySignature>> {
+        // TODO: Make `get_finality_signature_from_storage` return a boxed copy instead.
         effect_builder
             .get_finality_signature_from_storage(item_id.clone())
             .await
+            .map(Box::new)
     }
 }

--- a/node/src/components/sync_leaper/tests.rs
+++ b/node/src/components/sync_leaper/tests.rs
@@ -184,7 +184,7 @@ fn fetch_received_from_storage() {
     let peers_to_ask = vec![peer_1];
     sync_leaper.register_leap_attempt(sync_leap_identifier, peers_to_ask);
 
-    let fetch_result: FetchResult<SyncLeap> = Ok(FetchedData::from_storage(sync_leap));
+    let fetch_result: FetchResult<SyncLeap> = Ok(FetchedData::from_storage(Box::new(sync_leap)));
 
     let actual = sync_leaper
         .fetch_received(sync_leap_identifier, fetch_result)

--- a/node/src/types/block/approvals_hashes.rs
+++ b/node/src/types/block/approvals_hashes.rs
@@ -115,7 +115,7 @@ impl ApprovalsHashes {
 impl FetchItem for ApprovalsHashes {
     type Id = BlockHash;
     type ValidationError = ApprovalsHashesValidationError;
-    type ValidationMetadata = Block;
+    type ValidationMetadata = Box<Block>;
 
     const TAG: Tag = Tag::ApprovalsHashes;
 
@@ -123,7 +123,7 @@ impl FetchItem for ApprovalsHashes {
         self.block_hash
     }
 
-    fn validate(&self, block: &Block) -> Result<(), Self::ValidationError> {
+    fn validate(&self, block: &Box<Block>) -> Result<(), Self::ValidationError> {
         self.is_verified.get_or_init(|| self.verify(block)).clone()
     }
 }


### PR DESCRIPTION
Closes #1959.

This shrinks down the size of `MainEvent` from `824` bytes to `360` by moving a few select types from the stack to the heap. This brings down memory usage by the event queue and reduces stack memory pressure.

An oversight where `Box` and `Option` were combined in the wrong order was also corrected.