### PR TITLE
Fix purge of builder before validating

### DIFF
--- a/node/src/components/block_synchronizer/block_synchronizer_progress.rs
+++ b/node/src/components/block_synchronizer/block_synchronizer_progress.rs
@@ -11,6 +11,16 @@ pub(crate) enum BlockSynchronizerProgress {
     Synced(BlockHash, u64, EraId),
 }
 
+impl BlockSynchronizerProgress {
+    pub(crate) fn is_active(&self) -> bool {
+        match self {
+            BlockSynchronizerProgress::Idle | BlockSynchronizerProgress::Synced(_, _, _) => false,
+            BlockSynchronizerProgress::Syncing(_, _, _)
+            | BlockSynchronizerProgress::Executing(_, _, _) => true,
+        }
+    }
+}
+
 impl Display for BlockSynchronizerProgress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::*;
 use crate::{
     reactor::{EventQueueHandle, QueueKind, Scheduler},
@@ -152,6 +154,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
         Responder::without_shutdown(oneshot::channel().0),
     );
     let trie_hash = request.state_root_hash;
+    tokio::time::sleep(Duration::from_millis(5)).await;
     let mut effects = global_state_synchronizer.handle_request(request, reactor.effect_builder());
     assert_eq!(effects.len(), 1);
     assert!(global_state_synchronizer.request_state.is_some());
@@ -182,7 +185,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
     reactor.expect_trie_accumulator_request(&trie_hash).await;
 
     // sleep a bit so that the next progress timestamp is different
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    tokio::time::sleep(Duration::from_millis(2)).await;
     // simulate the fetch returning a trie
     let effects = global_state_synchronizer.handle_fetched_trie(
         TrieHash(trie_hash),
@@ -199,7 +202,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
     progress = global_state_synchronizer.last_progress().unwrap();
 
     // sleep a bit so that the next progress timestamp is different
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    tokio::time::sleep(Duration::from_millis(2)).await;
     // simulate synchronizer processing the fetched trie
     let effects = global_state_synchronizer.handle_put_trie_result(
         TrieHash(trie_hash),

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -142,6 +142,12 @@ impl MainReactor {
                 return None;
             }
         }
+
+        if self.block_synchronizer.forward_progress().is_active() {
+            debug!("KeepUp: still syncing a block");
+            return None;
+        }
+
         let queue_depth = self.contract_runtime.queue_depth();
         if queue_depth > 0 {
             debug!("KeepUp: should_validate queue_depth {}", queue_depth);
@@ -172,8 +178,8 @@ impl MainReactor {
             }
             BlockSynchronizerProgress::Synced(block_hash, block_height, era_id) => {
                 // for a synced forward block -> we have header, body, any referenced deploys,
-                // and sufficient finality (by weight) of signatures. this node will ultimately
-                // attempt to execute this block to produce global state and execution effects.
+                // sufficient finality (by weight) of signatures, associated global state and
+                // execution effects.
                 Either::Left(self.keep_up_synced(block_hash, block_height, era_id))
             }
         }


### PR DESCRIPTION
Fixes #3733 #3738 

This PR introduces a fix to the bug seen in the `swap_validators` test scenario.

The nodes which should become validators in the upcoming era and were previously keeping up are synchronizing the switch block, but before getting to execute it, the associated builder would get purged by the switch to `Validate` mode, triggered by `keep_up_should_validate` into `create_required_eras`. `ContractRuntime` would therefore miss the switch block and we would have a gap which would prevent the node from executing the next blocks.

Another bug which surfaced in this test scenario was that the nodes which were validating and then were supposed to swap places with other nodes in the upcoming era would stall instead of keeping up. From preliminary observations, it seems they switch from `Validate` to `KeepUp` and then to `CatchUp` with a `Leap` instruction because of stale gossip, trying to leap to the same block they just executed before transitioning from `Validate`. The block builder is never doing any `need_next` action, and the synchronizer is stuck. The node fixes itself at some point in the future through a `Leap` when it falls too much behind the actual tip of the chain.
