### PR TITLE
Version bump casper-engine-test-support to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "2.3.0"
+version = "3.0.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,7 +11,14 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## 2.3.0
+## 3.0.0
+
+### Changed
+* Version bump only to match major version bump of `casper-execution-engine` dependency.
+
+
+
+## 2.3.0 [YANKED]
 
 ### Added
 * Add `ChainspecConfig` to support parsing a chainspec.

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "2.3.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/2.3.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
Closes #3739.