### PR TITLE
3702 legacy finality threshold

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -17,8 +17,9 @@ use crate::{
         ExecutionResultsAcquisition, ExecutionResultsChecksum,
     },
     types::{
-        ApprovalsHashes, Block, BlockExecutionResultsOrChunk, BlockHash, BlockHeader, DeployHash,
-        DeployId, EraValidatorWeights, FinalitySignature, SignatureWeight,
+        chainspec::LegacyRequiredFinality, ApprovalsHashes, Block, BlockExecutionResultsOrChunk,
+        BlockHash, BlockHeader, DeployHash, DeployId, EraValidatorWeights, FinalitySignature,
+        SignatureWeight,
     },
     NodeRng,
 };
@@ -268,6 +269,7 @@ impl BlockAcquisitionState {
         validator_weights: &EraValidatorWeights,
         rng: &mut NodeRng,
         is_historical: bool,
+        legacy_required_finality: LegacyRequiredFinality,
         max_simultaneous_peers: usize,
     ) -> Result<BlockAcquisitionAction, BlockAcquisitionError> {
         // self is the resting state we are in, ret is the next action that should be taken
@@ -321,6 +323,7 @@ impl BlockAcquisitionState {
                         validator_weights,
                         signatures,
                         is_historical,
+                        legacy_required_finality,
                     ))
                 }
             }
@@ -347,6 +350,7 @@ impl BlockAcquisitionState {
                         validator_weights,
                         signatures,
                         is_historical,
+                        legacy_required_finality,
                     ))
                 }
             }
@@ -371,6 +375,7 @@ impl BlockAcquisitionState {
                         signatures,
                         deploys.needs_deploy(),
                         is_historical,
+                        legacy_required_finality,
                     ))
                 }
             }
@@ -386,6 +391,7 @@ impl BlockAcquisitionState {
                     signatures,
                     deploys.needs_deploy(),
                     is_historical,
+                    legacy_required_finality,
                 ))
             }
             BlockAcquisitionState::HaveAllDeploys(block, signatures) => {
@@ -396,6 +402,7 @@ impl BlockAcquisitionState {
                     validator_weights,
                     signatures,
                     is_historical,
+                    legacy_required_finality,
                 ))
             }
             BlockAcquisitionState::HaveStrictFinalitySignatures(block, ..) => {

--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -11,8 +11,8 @@ use crate::{
         ExecutionResultsAcquisition, ExecutionResultsChecksum,
     },
     types::{
-        Block, BlockExecutionResultsOrChunkId, BlockHash, BlockHeader, DeployHash, DeployId,
-        EraValidatorWeights, NodeId,
+        chainspec::LegacyRequiredFinality, Block, BlockExecutionResultsOrChunkId, BlockHash,
+        BlockHeader, DeployHash, DeployId, EraValidatorWeights, NodeId, SignatureWeight,
     },
     NodeRng,
 };
@@ -150,43 +150,45 @@ impl BlockAcquisitionAction {
         validator_weights: &EraValidatorWeights,
         signature_acquisition: &SignatureAcquisition,
         is_historical: bool,
+        legacy_required_finality: LegacyRequiredFinality,
     ) -> Self {
         let block_hash = block_header.block_hash();
-
-        let requires_strict_finality =
-            signature_acquisition.requires_strict_finality(is_historical);
         let validator_keys = signature_acquisition.have_signatures();
-        if validator_weights
-            .signature_weight(validator_keys)
-            .is_sufficient(requires_strict_finality)
-        {
+        let signature_weight = validator_weights.signature_weight(validator_keys);
+
+        if enough_signatures(
+            signature_weight,
+            legacy_required_finality,
+            signature_acquisition.is_checkable(),
+            is_historical,
+        ) {
             if is_historical {
                 // we have enough signatures; need to make sure we've stored the necessary bits
-                return BlockAcquisitionAction {
+                BlockAcquisitionAction {
                     peers_to_ask: vec![],
                     need_next: NeedNext::BlockMarkedComplete(block_hash, block_header.height()),
-                };
+                }
+            } else {
+                BlockAcquisitionAction {
+                    peers_to_ask: vec![],
+                    need_next: NeedNext::EnqueueForExecution(block_hash, block_header.height()),
+                }
             }
-
-            return BlockAcquisitionAction {
-                peers_to_ask: vec![],
-                need_next: NeedNext::EnqueueForExecution(block_hash, block_header.height()),
-            };
-        }
-
-        let peers_to_ask = peer_list.qualified_peers(rng);
-        let era_id = block_header.era_id();
-        // need more signatures
-        BlockAcquisitionAction {
-            peers_to_ask,
-            need_next: NeedNext::FinalitySignatures(
-                block_hash,
-                era_id,
-                validator_weights
-                    .missing_validators(signature_acquisition.have_signatures())
-                    .cloned()
-                    .collect(),
-            ),
+        } else {
+            let peers_to_ask = peer_list.qualified_peers(rng);
+            let era_id = block_header.era_id();
+            // need more signatures
+            BlockAcquisitionAction {
+                peers_to_ask,
+                need_next: NeedNext::FinalitySignatures(
+                    block_hash,
+                    era_id,
+                    validator_weights
+                        .missing_validators(signature_acquisition.have_signatures())
+                        .cloned()
+                        .collect(),
+                ),
+            }
         }
     }
 
@@ -269,6 +271,7 @@ impl BlockAcquisitionAction {
         signatures: &SignatureAcquisition,
         needs_deploy: Option<DeployIdentifier>,
         is_historical: bool,
+        legacy_required_finality: LegacyRequiredFinality,
     ) -> Self {
         match needs_deploy {
             Some(DeployIdentifier::ById(deploy_id)) => {
@@ -296,7 +299,193 @@ impl BlockAcquisitionAction {
                 validator_weights,
                 signatures,
                 is_historical,
+                legacy_required_finality,
             ),
         }
     }
+}
+
+fn enough_signatures(
+    signature_weight: SignatureWeight,
+    legacy_required_finality: LegacyRequiredFinality,
+    is_checkable: bool,
+    is_historical: bool,
+) -> bool {
+    let requires_strict = if is_historical { is_checkable } else { true };
+
+    signature_weight.is_sufficient(requires_strict)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! build_test {
+        ( $name:ident (
+            $signature_weight:path,
+            $legacy_required_finality:path,
+            is_checkable: $is_checkable:expr,
+            is_historical: $is_historical:expr $(,)?
+        ) => $result:expr ) => {
+            #[test]
+            fn $name() {
+                let result = enough_signatures(
+                    $signature_weight,
+                    $legacy_required_finality,
+                    $is_checkable,
+                    $is_historical,
+                );
+
+                assert_eq!(result, $result)
+            }
+        };
+    }
+
+    // Historical false
+
+    build_test!(enough_signatures_params_insufficient_any_false_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Any, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_any_false_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Any, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_any_false_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Any, is_checkable: false, is_historical: false,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_weak_false_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_weak_false_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_weak_false_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: false,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_strict_false_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_strict_false_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_strict_false_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: false,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_any_true_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Any, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_any_true_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Any, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_any_true_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Any, is_checkable: true, is_historical: false,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_weak_true_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_weak_true_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_weak_true_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: false,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_strict_true_false(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_strict_true_false(
+        SignatureWeight::Weak, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: false,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_strict_true_false(
+        SignatureWeight::Strict, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: false,
+    ) => true);
+
+    // Historical true
+
+    build_test!(enough_signatures_params_insufficient_any_false_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Any, is_checkable: false, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_any_false_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Any, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_strict_any_false_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Any, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_weak_false_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_weak_false_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_strict_weak_false_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Weak, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_strict_false_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_strict_false_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_strict_strict_false_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Strict, is_checkable: false, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_any_true_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Any, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_any_true_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Any, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_any_true_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Any, is_checkable: true, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_weak_true_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_weak_true_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_weak_true_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Weak, is_checkable: true, is_historical: true,
+    ) => true);
+
+    build_test!(enough_signatures_params_insufficient_strict_true_true(
+        SignatureWeight::Insufficient, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_weak_strict_true_true(
+        SignatureWeight::Weak, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: true,
+    ) => false);
+
+    build_test!(enough_signatures_params_strict_strict_true_true(
+        SignatureWeight::Strict, LegacyRequiredFinality::Strict, is_checkable: true, is_historical: true,
+    ) => true);
 }

--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -342,7 +342,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -366,7 +366,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -378,7 +378,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -390,7 +390,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -438,7 +438,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -450,7 +450,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -462,7 +462,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -474,7 +474,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -486,7 +486,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -498,7 +498,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -510,7 +510,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -522,7 +522,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -534,7 +534,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -546,7 +546,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -558,7 +558,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -570,7 +570,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -582,7 +582,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -594,7 +594,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -606,7 +606,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -618,7 +618,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -630,7 +630,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -642,7 +642,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -654,7 +654,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -666,7 +666,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -678,7 +678,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -690,7 +690,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -702,7 +702,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -714,7 +714,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -726,7 +726,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 
     #[test]
@@ -738,7 +738,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -750,7 +750,7 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, false);
+        assert!(result == false);
     }
 
     #[test]
@@ -762,6 +762,6 @@ mod tests {
             true,
         );
 
-        assert_eq!(result, true);
+        assert!(result == true);
     }
 }

--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -263,6 +263,7 @@ impl BlockAcquisitionAction {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn maybe_needs_deploy(
         block_header: &BlockHeader,
         peer_list: &PeerList,

--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -312,21 +312,19 @@ fn enough_signatures(
     is_checkable: bool,
     is_historical: bool,
 ) -> bool {
-    use SignatureWeight::*;
-
     if is_checkable {
         // Normal blocks:
-        signature_weight.is_sufficient(is_historical)
+        signature_weight.is_sufficient(false == is_historical)
     } else {
         // Legacy blocks:
         matches!((legacy_required_finality, signature_weight), |(
             LegacyRequiredFinality::Any,
-            Insufficient | Weak | Strict,
+            SignatureWeight::Insufficient | SignatureWeight::Weak | SignatureWeight::Strict,
         )| (
             LegacyRequiredFinality::Weak,
-            Weak | Strict
+            SignatureWeight::Weak | SignatureWeight::Strict
         )
-            | (LegacyRequiredFinality::Strict, Strict))
+            | (LegacyRequiredFinality::Strict, SignatureWeight::Strict))
     }
 }
 
@@ -463,7 +461,7 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        assert!(result == false);
     }
 
     #[test]
@@ -499,7 +497,7 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        assert!(result == false);
     }
 
     #[test]
@@ -535,7 +533,7 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        assert!(result == false);
     }
 
     #[test]
@@ -679,7 +677,7 @@ mod tests {
             true,
         );
 
-        assert!(result == false);
+        assert!(result == true);
     }
 
     #[test]
@@ -715,7 +713,7 @@ mod tests {
             true,
         );
 
-        assert!(result == false);
+        assert!(result == true);
     }
 
     #[test]
@@ -751,7 +749,7 @@ mod tests {
             true,
         );
 
-        assert!(result == false);
+        assert!(result == true);
     }
 
     #[test]

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -20,9 +20,9 @@ use super::{
 };
 use crate::{
     types::{
-        ApprovalsHashes, Block, BlockExecutionResultsOrChunk, BlockHash, BlockHeader,
-        BlockSignatures, DeployHash, DeployId, EraValidatorWeights, FinalitySignature, NodeId,
-        ValidatorMatrix,
+        chainspec::LegacyRequiredFinality, ApprovalsHashes, Block, BlockExecutionResultsOrChunk,
+        BlockHash, BlockHeader, BlockSignatures, DeployHash, DeployId, EraValidatorWeights,
+        FinalitySignature, NodeId, ValidatorMatrix,
     },
     NodeRng,
 };
@@ -345,6 +345,7 @@ impl BlockBuilder {
         &mut self,
         rng: &mut NodeRng,
         max_simultaneous_peers: usize,
+        legacy_required_finality: LegacyRequiredFinality,
     ) -> BlockAcquisitionAction {
         match self.peer_list.need_peers() {
             PeersStatus::Sufficient => {
@@ -388,6 +389,7 @@ impl BlockBuilder {
             validator_weights,
             rng,
             self.should_fetch_execution_state,
+            legacy_required_finality,
             max_simultaneous_peers,
         ) {
             Ok(ret) => ret,

--- a/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
@@ -7,6 +7,7 @@ use crate::{
 use casper_types::{bytesrepr::Bytes, testing::TestRng};
 use futures::channel::oneshot;
 use rand::Rng;
+use std::time::Duration;
 
 /// Event for the mock reactor.
 #[derive(Debug)]
@@ -152,6 +153,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
         Responder::without_shutdown(oneshot::channel().0),
     );
     let trie_hash = request.state_root_hash;
+    tokio::time::sleep(Duration::from_millis(5)).await;
     let mut effects = global_state_synchronizer.handle_request(request, reactor.effect_builder());
     assert_eq!(effects.len(), 1);
     assert!(global_state_synchronizer.request_state.is_some());
@@ -182,7 +184,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
     reactor.expect_trie_accumulator_request(&trie_hash).await;
 
     // sleep a bit so that the next progress timestamp is different
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    tokio::time::sleep(Duration::from_millis(2)).await;
     // simulate the fetch returning a trie
     let effects = global_state_synchronizer.handle_fetched_trie(
         TrieHash(trie_hash),
@@ -199,7 +201,7 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
     progress = global_state_synchronizer.last_progress().unwrap();
 
     // sleep a bit so that the next progress timestamp is different
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    tokio::time::sleep(Duration::from_millis(2)).await;
     // simulate synchronizer processing the fetched trie
     let effects = global_state_synchronizer.handle_put_trie_result(
         TrieHash(trie_hash),

--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -105,14 +105,6 @@ impl SignatureAcquisition {
         self.maybe_is_checkable.unwrap_or(false)
     }
 
-    pub(super) fn requires_strict_finality(&self, is_recent_block: bool) -> bool {
-        if is_recent_block {
-            return true;
-        }
-
-        self.maybe_is_checkable.unwrap_or(false)
-    }
-
     pub(super) fn signature_weight(&self) -> SignatureWeight {
         self.signature_weight
     }

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -110,7 +110,6 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
         Config::default(),
         Arc::new(Chainspec::random(&mut rng)),
         5,
-        LegacyRequiredFinality::Any,
         validator_matrix,
         prometheus::default_registry(),
     )

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -110,6 +110,7 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
         Config::default(),
         Arc::new(Chainspec::random(&mut rng)),
         5,
+        LegacyRequiredFinality::Any,
         validator_matrix,
         prometheus::default_registry(),
     )

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -37,7 +37,7 @@ pub use self::{
     accounts_config::{AccountConfig, AccountsConfig, ValidatorConfig},
     activation_point::ActivationPoint,
     chainspec_raw_bytes::ChainspecRawBytes,
-    core_config::{ConsensusProtocolName, CoreConfig},
+    core_config::{ConsensusProtocolName, CoreConfig, LegacyRequiredFinality},
     deploy_config::DeployConfig,
     error::Error,
     global_state_update::GlobalStateUpdate,

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -335,10 +335,14 @@ impl Distribution<ConsensusProtocolName> for Standard {
     }
 }
 
+/// Which finality a legacy block needs during a fast sync.
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Debug)]
-pub(crate) enum LegacyRequiredFinality {
+pub enum LegacyRequiredFinality {
+    /// Strict finality: more than 2/3rd of validators.
     Strict,
+    /// Weak finality: more than 1/3rd of validators.
     Weak,
+    /// Finality always valid.
     Any,
 }
 

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -40,6 +40,9 @@ pub struct CoreConfig {
     #[data_size(skip)]
     pub finality_threshold_fraction: Ratio<u64>,
 
+    /// Which finality is required for legacy blocks.
+    pub legacy_required_finality: LegacyRequiredFinality,
+
     /// Number of eras before an auction actually defines the set of validators.
     /// If you bond with a sufficient bid in era N, you will be a validator in era N +
     /// auction_delay + 1
@@ -137,6 +140,7 @@ impl CoreConfig {
         let minimum_block_time = TimeDiff::from_seconds(rng.gen_range(1..60));
         let validator_slots = rng.gen_range(1..10_000);
         let finality_threshold_fraction = Ratio::new(rng.gen_range(1..100), 100);
+        let legacy_required_finality = rng.gen();
         let auction_delay = rng.gen_range(1..5);
         let locked_funds_period = TimeDiff::from_seconds(rng.gen_range(600..604_800));
         let vesting_schedule_period = TimeDiff::from_seconds(rng.gen_range(600..604_800));
@@ -158,6 +162,7 @@ impl CoreConfig {
             minimum_block_time,
             validator_slots,
             finality_threshold_fraction,
+            legacy_required_finality,
             auction_delay,
             locked_funds_period,
             vesting_schedule_period,
@@ -181,6 +186,7 @@ impl ToBytes for CoreConfig {
         buffer.extend(self.minimum_block_time.to_bytes()?);
         buffer.extend(self.validator_slots.to_bytes()?);
         buffer.extend(self.finality_threshold_fraction.to_bytes()?);
+        buffer.extend(self.legacy_required_finality.to_bytes()?);
         buffer.extend(self.auction_delay.to_bytes()?);
         buffer.extend(self.locked_funds_period.to_bytes()?);
         buffer.extend(self.vesting_schedule_period.to_bytes()?);
@@ -222,6 +228,7 @@ impl FromBytes for CoreConfig {
         let (minimum_block_time, remainder) = TimeDiff::from_bytes(remainder)?;
         let (validator_slots, remainder) = u32::from_bytes(remainder)?;
         let (finality_threshold_fraction, remainder) = Ratio::<u64>::from_bytes(remainder)?;
+        let (legacy_required_finality, remainder) = LegacyRequiredFinality::from_bytes(remainder)?;
         let (auction_delay, remainder) = u64::from_bytes(remainder)?;
         let (locked_funds_period, remainder) = TimeDiff::from_bytes(remainder)?;
         let (vesting_schedule_period, remainder) = TimeDiff::from_bytes(remainder)?;
@@ -239,6 +246,7 @@ impl FromBytes for CoreConfig {
             minimum_block_time,
             validator_slots,
             finality_threshold_fraction,
+            legacy_required_finality,
             auction_delay,
             locked_funds_period,
             vesting_schedule_period,
@@ -323,6 +331,81 @@ impl Distribution<ConsensusProtocolName> for Standard {
             ConsensusProtocolName::Highway
         } else {
             ConsensusProtocolName::Zug
+        }
+    }
+}
+
+#[derive(Copy, Clone, DataSize, PartialEq, Eq, Debug)]
+pub(crate) enum LegacyRequiredFinality {
+    Strict,
+    Weak,
+    Any,
+}
+
+impl Serialize for LegacyRequiredFinality {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            LegacyRequiredFinality::Strict => "Strict",
+            LegacyRequiredFinality::Weak => "Weak",
+            LegacyRequiredFinality::Any => "Any",
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LegacyRequiredFinality {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match String::deserialize(deserializer)?.to_lowercase().as_str() {
+            "strict" => Ok(LegacyRequiredFinality::Strict),
+            "weak" => Ok(LegacyRequiredFinality::Weak),
+            "any" => Ok(LegacyRequiredFinality::Any),
+            _ => Err(DeError::custom("unknown legacy required finality")),
+        }
+    }
+}
+
+const LEGACY_REQUIRED_FINALITY_STRICT_TAG: u8 = 0;
+const LEGACY_REQUIRED_FINALITY_WEAK_TAG: u8 = 1;
+const LEGACY_REQUIRED_FINALITY_ANY_TAG: u8 = 2;
+
+impl ToBytes for LegacyRequiredFinality {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let tag = match self {
+            LegacyRequiredFinality::Strict => LEGACY_REQUIRED_FINALITY_STRICT_TAG,
+            LegacyRequiredFinality::Weak => LEGACY_REQUIRED_FINALITY_WEAK_TAG,
+            LegacyRequiredFinality::Any => LEGACY_REQUIRED_FINALITY_ANY_TAG,
+        };
+        Ok(vec![tag])
+    }
+
+    fn serialized_length(&self) -> usize {
+        1
+    }
+}
+
+impl FromBytes for LegacyRequiredFinality {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            LEGACY_REQUIRED_FINALITY_STRICT_TAG => Ok((LegacyRequiredFinality::Strict, remainder)),
+            LEGACY_REQUIRED_FINALITY_WEAK_TAG => Ok((LegacyRequiredFinality::Weak, remainder)),
+            LEGACY_REQUIRED_FINALITY_ANY_TAG => Ok((LegacyRequiredFinality::Any, remainder)),
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Distribution<LegacyRequiredFinality> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> LegacyRequiredFinality {
+        match rng.gen_range(0..3) {
+            0 => LegacyRequiredFinality::Strict,
+            1 => LegacyRequiredFinality::Weak,
+            2 => LegacyRequiredFinality::Any,
+            _not_in_range => unreachable!(),
         }
     }
 }

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -207,6 +207,7 @@ impl ToBytes for CoreConfig {
             + self.minimum_block_time.serialized_length()
             + self.validator_slots.serialized_length()
             + self.finality_threshold_fraction.serialized_length()
+            + self.legacy_required_finality.serialized_length()
             + self.auction_delay.serialized_length()
             + self.locked_funds_period.serialized_length()
             + self.vesting_schedule_period.serialized_length()

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -37,6 +37,8 @@ validator_slots = 7
 # finalized: A higher value F makes it safer to rely on finalized blocks.  It also makes it more difficult to finalize
 # blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly.
 finality_threshold_fraction = [1, 3]
+# Which finality is required for legacy blocks. Options are 'Strict', 'Weak' and 'Any'.
+legacy_required_finality = 'Strict'
 # Number of eras before an auction actually defines the set of validators.  If you bond with a sufficient bid in era N,
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -37,6 +37,8 @@ validator_slots = 100
 # finalized: A higher value F makes it safer to rely on finalized blocks.  It also makes it more difficult to finalize
 # blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly.
 finality_threshold_fraction = [1, 3]
+# Which finality is required for legacy blocks. Options are 'Strict', 'Weak' and 'Any'.
+legacy_required_finality = 'Strict'
 # Number of eras before an auction actually defines the set of validators.  If you bond with a sufficient bid in era N,
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1


### PR DESCRIPTION
Modifies the legacy finality thresthold during a fast sync:
- Adds a new chainspec parameter that tells how legacy blocks finality behave;
- Fix the logic to take this parameter into account.