### PR TITLE
Allow fetching multiple deploys from same fallback peer in BlockValidator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ lint: lint-contracts-rs
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2022-0013 --ignore RUSTSEC-2022-0014
+	$(CARGO) audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2023-0018
 
 .PHONY: doc
 doc:

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -12,10 +12,11 @@ mod keyed_counter;
 mod tests;
 
 use std::{
-    collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap},
     convert::Infallible,
     fmt::Debug,
     hash::Hash,
+    marker::PhantomData,
     sync::Arc,
 };
 
@@ -29,6 +30,7 @@ use crate::{
     components::{
         block_proposer::DeployInfo,
         consensus::{ClContext, ProposedBlock},
+        fetcher::FetchResult,
         Component,
     },
     effect::{
@@ -42,8 +44,6 @@ use crate::{
     NodeRng,
 };
 use keyed_counter::KeyedCounter;
-
-use super::fetcher::FetchResult;
 
 #[derive(DataSize, Debug, Display, Clone, Hash, Eq, PartialEq)]
 pub(crate) enum ValidatingBlock {
@@ -149,7 +149,7 @@ pub(crate) enum Event<I> {
 ///
 /// Tracks whether or not there are deploys still missing and who is interested in the final result.
 #[derive(DataSize, Debug)]
-pub(crate) struct BlockValidationState<I> {
+pub(crate) struct BlockValidationState {
     /// Appendable block ensuring that the deploys satisfy the validity conditions.
     appendable_block: AppendableBlock,
     /// The deploys that have not yet been "crossed off" the list of potential misses.
@@ -158,30 +158,9 @@ pub(crate) struct BlockValidationState<I> {
     missing_deploys: HashMap<DeployOrTransferHash, Option<BTreeSet<Approval>>>,
     /// A list of responders that are awaiting an answer.
     responders: SmallVec<[Responder<bool>; 2]>,
-    /// Peers that should have the data.
-    sources: VecDeque<I>,
 }
 
-impl<I> BlockValidationState<I>
-where
-    I: PartialEq + Eq + 'static,
-{
-    /// Adds alternative source of data.
-    /// Returns true if we already know about the peer.
-    fn add_source(&mut self, peer: I) -> bool {
-        if self.sources.contains(&peer) {
-            true
-        } else {
-            self.sources.push_back(peer);
-            false
-        }
-    }
-
-    /// Returns a peer, if there is any, that we haven't yet tried.
-    fn source(&mut self) -> Option<I> {
-        self.sources.pop_front()
-    }
-
+impl BlockValidationState {
     fn respond<REv>(&mut self, value: bool) -> Effects<REv> {
         self.responders
             .drain(..)
@@ -196,9 +175,10 @@ pub(crate) struct BlockValidator<I> {
     #[data_size(skip)]
     chainspec: Arc<Chainspec>,
     /// State of validation of a specific block.
-    validation_states: HashMap<ValidatingBlock, BlockValidationState<I>>,
+    validation_states: HashMap<ValidatingBlock, BlockValidationState>,
     /// Number of requests for a specific deploy hash still in flight.
     in_flight: KeyedCounter<DeployHash>,
+    _phantom_data: PhantomData<I>,
 }
 
 impl<I> BlockValidator<I>
@@ -211,6 +191,7 @@ where
             chainspec,
             validation_states: HashMap::new(),
             in_flight: KeyedCounter::default(),
+            _phantom_data: PhantomData,
         }
     }
 
@@ -270,43 +251,34 @@ where
                     return responder.respond(false).ignore();
                 }
 
-                match self.validation_states.entry(block) {
-                    Entry::Occupied(mut entry) => {
-                        // The entry already exists.
-                        if entry.get().missing_deploys.is_empty() {
-                            // Block has already been validated successfully, early return to
-                            // caller.
-                            effects.extend(responder.respond(true).ignore());
-                        } else {
-                            // We register ourselves as someone interested in the ultimate
-                            // validation result.
-                            entry.get_mut().responders.push(responder);
-                            // And add an alternative source of data.
-                            entry.get_mut().add_source(sender);
-                        }
-                    }
-                    Entry::Vacant(entry) => {
-                        // Our entry is vacant - create an entry to track the state.
-                        let in_flight = &mut self.in_flight;
-                        effects.extend(entry.key().deploys_and_transfers_iter().flat_map(
-                            |(dt_hash, _)| {
-                                // For every request, increase the number of in-flight...
-                                in_flight.inc(&dt_hash.into());
-                                // ...then request it.
-                                fetch_deploy(effect_builder, dt_hash, sender.clone())
-                            },
-                        ));
-                        let block_timestamp = entry.key().timestamp();
-                        let deploy_config = self.chainspec.deploy_config;
-                        entry.insert(BlockValidationState {
-                            appendable_block: AppendableBlock::new(deploy_config, block_timestamp),
-                            missing_deploys: block_deploys,
-                            responders: smallvec![responder],
-                            sources: VecDeque::new(), /* This is empty b/c we create the first
-                                                       * request using `sender`. */
-                        });
-                    }
+                let block_timestamp = block.timestamp();
+                let state = self
+                    .validation_states
+                    .entry(block)
+                    .or_insert(BlockValidationState {
+                        appendable_block: AppendableBlock::new(
+                            self.chainspec.deploy_config,
+                            block_timestamp,
+                        ),
+                        missing_deploys: block_deploys.clone(),
+                        responders: smallvec![],
+                    });
+
+                if state.missing_deploys.is_empty() {
+                    // Block has already been validated successfully, early return to caller.
+                    return responder.respond(true).ignore();
                 }
+
+                // We register ourselves as someone interested in the ultimate validation result.
+                state.responders.push(responder);
+
+                let in_flight = &mut self.in_flight;
+                effects.extend(block_deploys.into_iter().flat_map(|(dt_hash, _)| {
+                    // For every request, increase the number of in-flight...
+                    in_flight.inc(&dt_hash.into());
+                    // ...then request it.
+                    fetch_deploy(effect_builder, dt_hash, sender.clone())
+                }));
             }
             Event::DeployFound {
                 dt_hash,
@@ -371,43 +343,18 @@ where
                     return Effects::new();
                 }
 
-                // Flag indicating whether we've retried fetching the deploy.
-                let mut retried = false;
-
                 self.validation_states.retain(|key, state| {
                     if !state.missing_deploys.contains_key(&dt_hash) {
                         return true;
                     }
-                    if retried {
-                        // We don't want to retry downloading the same element more than once.
-                        return true;
-                    }
-                    match state.source() {
-                        Some(peer) => {
-                            info!(%dt_hash, ?peer, "trying the next peer");
-                            // There's still hope to download the deploy.
-                            effects.extend(fetch_deploy(effect_builder, dt_hash, peer));
-                            retried = true;
-                            true
-                        }
-                        None => {
-                            // Notify everyone still waiting on it that all is lost.
-                            info!(
-                                block = ?key, %dt_hash,
-                                "could not validate the deploy. block is invalid"
-                            );
-                            // This validation state contains a failed deploy hash, it can never
-                            // succeed.
-                            effects.extend(state.respond(false));
-                            false
-                        }
-                    }
-                });
 
-                if retried {
-                    // If we retried, we need to increase this counter.
-                    self.in_flight.inc(&dt_hash.into());
-                }
+                    // Notify everyone still waiting on it that all is lost.
+                    info!(block = ?key, %dt_hash, "could not validate the deploy. block is invalid");
+                    // This validation state contains a deploy hash we failed to fetch from all
+                    // sources, it can never succeed.
+                    effects.extend(state.respond(false));
+                    false
+                });
             }
             Event::CannotConvertDeploy(dt_hash) => {
                 // Deploy is invalid. There's no point waiting for other in-flight requests to

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -272,10 +272,9 @@ where
                 // We register ourselves as someone interested in the ultimate validation result.
                 state.responders.push(responder);
 
-                let in_flight = &mut self.in_flight;
                 effects.extend(block_deploys.into_iter().flat_map(|(dt_hash, _)| {
                     // For every request, increase the number of in-flight...
-                    in_flight.inc(&dt_hash.into());
+                    self.in_flight.inc(&dt_hash.into());
                     // ...then request it.
                     fetch_deploy(effect_builder, dt_hash, sender.clone())
                 }));

--- a/node/src/components/block_validator/keyed_counter.rs
+++ b/node/src/components/block_validator/keyed_counter.rs
@@ -1,10 +1,6 @@
 //! Tracks positive integers for keys.
 
-use std::{
-    collections::HashMap,
-    hash::Hash,
-    ops::{AddAssign, SubAssign},
-};
+use std::{collections::HashMap, hash::Hash};
 
 use datasize::DataSize;
 
@@ -43,7 +39,7 @@ where
                 1
             }
             Some(value) => {
-                value.add_assign(1);
+                *value += 1;
                 *value
             }
         }
@@ -61,7 +57,7 @@ where
             Some(value) => {
                 assert_ne!(*value, 0, "counter should never be zero in tracker");
 
-                value.sub_assign(1);
+                *value -= 1;
 
                 if *value != 0 {
                     return *value;


### PR DESCRIPTION
This fixes an issue where the BlockValidator would consume `NodeId`s of alternative sources for deploys rather than allowing each source to be queried for multiple deploys.

Now, whenever a new source is learned (via a new `BlockValidation` request) the `BlockValidator` immediately attempts to fetch all deploys from that peer.  The fetcher will take care of not actually generating network traffic for any deploys which are already stored locally.

Closes #3740.