### PR TITLE
Fix historical sync being stuck on getting strict finality

### DIFF
--- a/node/src/components/fetcher/error.rs
+++ b/node/src/components/fetcher/error.rs
@@ -7,7 +7,7 @@ use crate::{components::fetcher::FetchItem, types::NodeId};
 
 #[derive(Clone, Debug, Error, PartialEq, Eq, Serialize)]
 pub(crate) enum Error<T: FetchItem> {
-    #[error("could not fetch item with id {id:?} from peer {peer:?}")]
+    #[error("item with id {id:?} absent on peer {peer:?}")]
     Absent { id: T::Id, peer: NodeId },
 
     #[error("peer {peer:?} rejected fetch request for item with id {id:?}")]


### PR DESCRIPTION
This PR changes the way how the finality signature to be fetched is selected when we're trying to get the strict finality. It ensures that the requests are randomized, so we eventually cover signatures from all validators.

The process of selecting validators in now unified in the `signatures_from_missing_validators` function and used in both "weak" and "strict" finality flows.

Closes #3747