### PR TITLE
#3704 Avoid sync leap just before upgrade

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -2,6 +2,7 @@ mod block_acceptor;
 mod config;
 mod error;
 mod event;
+mod leap_instruction;
 mod local_tip_identifier;
 mod metrics;
 mod sync_identifier;
@@ -43,12 +44,13 @@ use crate::{
     },
     fatal,
     types::{
-        BlockHash, BlockSignatures, FinalitySignature, MetaBlock, MetaBlockState, NodeId,
-        ValidatorMatrix,
+        ActivationPoint, BlockHash, BlockSignatures, FinalitySignature, MetaBlock, MetaBlockState,
+        NodeId, ValidatorMatrix,
     },
     NodeRng,
 };
 
+use crate::components::block_accumulator::leap_instruction::LeapInstruction;
 pub(crate) use config::Config;
 pub(crate) use error::Error;
 pub(crate) use event::Event;
@@ -85,6 +87,8 @@ pub(crate) struct BlockAccumulator {
     /// and to determine if this node is close enough to the perceived tip of the
     /// network to transition to executing block for itself.
     local_tip: Option<LocalTipIdentifier>,
+    /// Chainspec activation point.
+    activation_point: Option<ActivationPoint>,
     /// Configured setting for how close to perceived tip local tip must be for
     /// this node to attempt block execution for itself.
     attempt_execution_threshold: u64,
@@ -104,6 +108,7 @@ pub(crate) struct BlockAccumulator {
     peer_block_timestamps: BTreeMap<NodeId, VecDeque<(BlockHash, Timestamp)>>,
     /// The minimum time between a block and its child.
     min_block_time: TimeDiff,
+    /// Metrics.
     #[data_size(skip)]
     metrics: Metrics,
 }
@@ -125,6 +130,7 @@ impl BlockAccumulator {
             last_progress: Timestamp::now(),
             purge_interval: config.purge_interval,
             local_tip: None,
+            activation_point: None,
             recent_era_interval,
             peer_block_timestamps: Default::default(),
             min_block_time,
@@ -133,24 +139,20 @@ impl BlockAccumulator {
     }
 
     pub(crate) fn sync_instruction(&mut self, sync_identifier: SyncIdentifier) -> SyncInstruction {
-        let had_no_local_tip = self.local_tip.is_none(); // first time thru, leap
+        let block_hash = sync_identifier.block_hash();
         if let Some((block_height, era_id)) = sync_identifier.block_height_and_era() {
             self.register_local_tip(block_height, era_id);
         }
-        if had_no_local_tip || self.should_leap(self.maybe_block_height(&sync_identifier)) {
-            if had_no_local_tip {
-                debug!("Block Accumulator: leap because accumulator is warming up");
-            }
-            return SyncInstruction::Leap {
-                block_hash: sync_identifier.block_hash(),
-            };
+        let leap_instruction = self.leap_instruction(&sync_identifier);
+        info!(?leap_instruction, %sync_identifier, "Block Accumulator: leap {}", leap_instruction);
+        if leap_instruction.should_leap() {
+            return SyncInstruction::Leap { block_hash };
         }
-        let block_hash = sync_identifier.block_hash();
         match sync_identifier.block_hash_to_sync(self.next_synchable_block_hash(block_hash)) {
-            Some(sync_block_hash) => {
+            Some(block_hash_to_sync) => {
                 self.reset_last_progress();
                 SyncInstruction::BlockSync {
-                    block_hash: sync_block_hash,
+                    block_hash: block_hash_to_sync,
                 }
             }
             None => {
@@ -164,26 +166,14 @@ impl BlockAccumulator {
         }
     }
 
-    fn maybe_block_height(&self, sync_identifier: &SyncIdentifier) -> Option<u64> {
-        // if the sync identifier doesn't have the tip, we may be able
-        // to discover it from one of our acceptors
-        match sync_identifier.block_height() {
-            Some(height) => Some(height),
-            None => {
-                if let Some(block_acceptor) =
-                    self.block_acceptors.get(&sync_identifier.block_hash())
-                {
-                    block_acceptor.block_height()
-                } else {
-                    None
-                }
-            }
-        }
+    /// Register activation point from next protocol version chainspec.
+    pub(crate) fn register_activation_point(&mut self, activation_point: ActivationPoint) {
+        self.activation_point = Some(activation_point);
     }
 
     /// Drops all old block acceptors and tracks new local block height;
     /// subsequent attempts to register a block lower than tip will be rejected.
-    pub(crate) fn register_local_tip(&mut self, height: u64, era_id: EraId) {
+    fn register_local_tip(&mut self, height: u64, era_id: EraId) {
         let new_local_tip = match self.local_tip {
             Some(current) => current.height < height && current.era_id <= era_id,
             None => true,
@@ -487,29 +477,6 @@ impl BlockAccumulator {
         effects
     }
 
-    fn highest_usable_block_height(&self) -> Option<u64> {
-        let mut ret = self.local_tip.map(|local_tip| local_tip.height);
-        for block_acceptor in self.block_acceptors.values() {
-            if false == block_acceptor.has_sufficient_finality() {
-                continue;
-            }
-            match block_acceptor.block_height() {
-                None => {
-                    continue;
-                }
-                Some(acceptor_height) => {
-                    if let Some(curr_height) = ret {
-                        if acceptor_height <= curr_height {
-                            continue;
-                        }
-                    }
-                    ret = Some(acceptor_height);
-                }
-            };
-        }
-        ret
-    }
-
     fn get_peers(&self, block_hash: BlockHash) -> Option<Vec<NodeId>> {
         self.block_acceptors
             .get(&block_hash)
@@ -528,22 +495,58 @@ impl BlockAccumulator {
         self.last_progress = Timestamp::now();
     }
 
-    fn should_leap(&self, maybe_block_height: Option<u64>) -> bool {
-        match (maybe_block_height, self.highest_usable_block_height()) {
-            (None, _) => true,
-            (Some(_), None) => true,
-            (Some(block_height), Some(highest_usable_block_height)) => {
-                let height_diff = highest_usable_block_height.saturating_sub(block_height);
-                if height_diff > self.attempt_execution_threshold {
-                    info!(
-                        height_diff,
-                        attempt_execution_threshold = self.attempt_execution_threshold,
-                        "Block Accumulator: leap because height diff is larger than attempt execution threshold"
-                    );
-                    true
-                } else {
-                    false
-                }
+    fn leap_instruction(&self, sync_identifier: &SyncIdentifier) -> LeapInstruction {
+        let height = match (self.local_tip, sync_identifier.block_height()) {
+            (None, _) => {
+                // if the accumulator is unaware of local tip,
+                // leap to learn more about the network state
+                return LeapInstruction::UnsetLocalTip;
+            }
+            (Some(local_tip_identifier), None) => local_tip_identifier.height,
+            (Some(local_tip_identifier), Some(block_height)) => {
+                local_tip_identifier.height.max(block_height)
+            }
+        };
+        match self
+            .block_acceptors
+            .iter()
+            .filter(|(_, acceptor)| {
+                acceptor.has_sufficient_finality() && acceptor.block_height().is_some()
+            })
+            .max_by(|x, y| x.1.block_height().cmp(&y.1.block_height()))
+            .map(|(_, acceptor)| {
+                (
+                    acceptor.block_height().unwrap_or_default(),
+                    acceptor.is_upgrade_boundary(self.activation_point),
+                )
+            }) {
+            // if we have no usable block acceptors, leap to learn more about the network state
+            None => LeapInstruction::NoUsableBlockAcceptors,
+            Some((acceptor_height, is_upgrade_boundary)) => {
+                // the accumulator has heard about at least one usable block via gossiping
+                // if we've see chatter about a usable higher block, we can determine
+                // if we have local state at or near that highest usable block.
+                // if we have reason to believe we have fallen too far behind the network,
+                // we should switch to catchup mode and start the leap process
+                // otherwise, we should attempt to keep up with the network by
+                // executing our own blocks.
+
+                // This is a special case; if we have heard chatter about the last block
+                // before a protocol upgrade and have enough finality signatures to believe
+                // it, we want to be cautious about leaping, because other nodes on the
+                // network are starting to go down and come back up on the new protocol
+                // version and may or may not respond. Thus, it is best for the node to
+                // continue executing its own blocks to get to the upgrade point on its
+                // own (if able).
+                let is_upgrade_boundary = is_upgrade_boundary == Some(true);
+
+                let distance_from_highest_known_block = acceptor_height.saturating_sub(height);
+
+                LeapInstruction::from_execution_threshold(
+                    self.attempt_execution_threshold,
+                    distance_from_highest_known_block,
+                    is_upgrade_boundary,
+                )
             }
         }
     }

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -2,6 +2,7 @@ mod block_acceptor;
 mod config;
 mod error;
 mod event;
+mod leap_instruction;
 mod local_tip_identifier;
 mod metrics;
 mod sync_identifier;
@@ -43,12 +44,13 @@ use crate::{
     },
     fatal,
     types::{
-        BlockHash, BlockSignatures, FinalitySignature, MetaBlock, MetaBlockState, NodeId,
-        ValidatorMatrix,
+        ActivationPoint, BlockHash, BlockSignatures, FinalitySignature, MetaBlock, MetaBlockState,
+        NodeId, ValidatorMatrix,
     },
     NodeRng,
 };
 
+use crate::components::block_accumulator::leap_instruction::LeapInstruction;
 pub(crate) use config::Config;
 pub(crate) use error::Error;
 pub(crate) use event::Event;
@@ -85,6 +87,8 @@ pub(crate) struct BlockAccumulator {
     /// and to determine if this node is close enough to the perceived tip of the
     /// network to transition to executing block for itself.
     local_tip: Option<LocalTipIdentifier>,
+    /// Chainspec activation point.
+    activation_point: Option<ActivationPoint>,
     /// Configured setting for how close to perceived tip local tip must be for
     /// this node to attempt block execution for itself.
     attempt_execution_threshold: u64,
@@ -106,6 +110,7 @@ pub(crate) struct BlockAccumulator {
     min_block_time: TimeDiff,
     /// The number of validator slots.
     validator_slots: u32,
+    /// Metrics.
     #[data_size(skip)]
     metrics: Metrics,
 }
@@ -128,6 +133,7 @@ impl BlockAccumulator {
             last_progress: Timestamp::now(),
             purge_interval: config.purge_interval,
             local_tip: None,
+            activation_point: None,
             recent_era_interval,
             peer_block_timestamps: Default::default(),
             min_block_time,
@@ -137,24 +143,20 @@ impl BlockAccumulator {
     }
 
     pub(crate) fn sync_instruction(&mut self, sync_identifier: SyncIdentifier) -> SyncInstruction {
-        let had_no_local_tip = self.local_tip.is_none(); // first time thru, leap
+        let block_hash = sync_identifier.block_hash();
         if let Some((block_height, era_id)) = sync_identifier.block_height_and_era() {
             self.register_local_tip(block_height, era_id);
         }
-        if had_no_local_tip || self.should_leap(self.maybe_block_height(&sync_identifier)) {
-            if had_no_local_tip {
-                debug!("Block Accumulator: leap because accumulator is warming up");
-            }
-            return SyncInstruction::Leap {
-                block_hash: sync_identifier.block_hash(),
-            };
+        let leap_instruction = self.leap_instruction(&sync_identifier);
+        info!(?leap_instruction, %sync_identifier, "Block Accumulator: leap {}", leap_instruction);
+        if leap_instruction.should_leap() {
+            return SyncInstruction::Leap { block_hash };
         }
-        let block_hash = sync_identifier.block_hash();
         match sync_identifier.block_hash_to_sync(self.next_synchable_block_hash(block_hash)) {
-            Some(sync_block_hash) => {
+            Some(block_hash_to_sync) => {
                 self.reset_last_progress();
                 SyncInstruction::BlockSync {
-                    block_hash: sync_block_hash,
+                    block_hash: block_hash_to_sync,
                 }
             }
             None => {
@@ -168,26 +170,14 @@ impl BlockAccumulator {
         }
     }
 
-    fn maybe_block_height(&self, sync_identifier: &SyncIdentifier) -> Option<u64> {
-        // if the sync identifier doesn't have the tip, we may be able
-        // to discover it from one of our acceptors
-        match sync_identifier.block_height() {
-            Some(height) => Some(height),
-            None => {
-                if let Some(block_acceptor) =
-                    self.block_acceptors.get(&sync_identifier.block_hash())
-                {
-                    block_acceptor.block_height()
-                } else {
-                    None
-                }
-            }
-        }
+    /// Register activation point from next protocol version chainspec.
+    pub(crate) fn register_activation_point(&mut self, activation_point: ActivationPoint) {
+        self.activation_point = Some(activation_point);
     }
 
     /// Drops all old block acceptors and tracks new local block height;
     /// subsequent attempts to register a block lower than tip will be rejected.
-    pub(crate) fn register_local_tip(&mut self, height: u64, era_id: EraId) {
+    fn register_local_tip(&mut self, height: u64, era_id: EraId) {
         let new_local_tip = match self.local_tip {
             Some(current) => current.height < height && current.era_id <= era_id,
             None => true,
@@ -506,29 +496,6 @@ impl BlockAccumulator {
         effects
     }
 
-    fn highest_usable_block_height(&self) -> Option<u64> {
-        let mut ret = self.local_tip.map(|local_tip| local_tip.height);
-        for block_acceptor in self.block_acceptors.values() {
-            if false == block_acceptor.has_sufficient_finality() {
-                continue;
-            }
-            match block_acceptor.block_height() {
-                None => {
-                    continue;
-                }
-                Some(acceptor_height) => {
-                    if let Some(curr_height) = ret {
-                        if acceptor_height <= curr_height {
-                            continue;
-                        }
-                    }
-                    ret = Some(acceptor_height);
-                }
-            };
-        }
-        ret
-    }
-
     fn get_peers(&self, block_hash: BlockHash) -> Option<Vec<NodeId>> {
         self.block_acceptors
             .get(&block_hash)
@@ -547,22 +514,58 @@ impl BlockAccumulator {
         self.last_progress = Timestamp::now();
     }
 
-    fn should_leap(&self, maybe_block_height: Option<u64>) -> bool {
-        match (maybe_block_height, self.highest_usable_block_height()) {
-            (None, _) => true,
-            (Some(_), None) => true,
-            (Some(block_height), Some(highest_usable_block_height)) => {
-                let height_diff = highest_usable_block_height.saturating_sub(block_height);
-                if height_diff > self.attempt_execution_threshold {
-                    info!(
-                        height_diff,
-                        attempt_execution_threshold = self.attempt_execution_threshold,
-                        "Block Accumulator: leap because height diff is larger than attempt execution threshold"
-                    );
-                    true
-                } else {
-                    false
-                }
+    fn leap_instruction(&self, sync_identifier: &SyncIdentifier) -> LeapInstruction {
+        let height = match (self.local_tip, sync_identifier.block_height()) {
+            (None, _) => {
+                // if the accumulator is unaware of local tip,
+                // leap to learn more about the network state
+                return LeapInstruction::UnsetLocalTip;
+            }
+            (Some(local_tip_identifier), None) => local_tip_identifier.height,
+            (Some(local_tip_identifier), Some(block_height)) => {
+                local_tip_identifier.height.max(block_height)
+            }
+        };
+        match self
+            .block_acceptors
+            .iter()
+            .filter(|(_, acceptor)| {
+                acceptor.has_sufficient_finality() && acceptor.block_height().is_some()
+            })
+            .max_by(|x, y| x.1.block_height().cmp(&y.1.block_height()))
+            .map(|(_, acceptor)| {
+                (
+                    acceptor.block_height().unwrap_or_default(),
+                    acceptor.is_upgrade_boundary(self.activation_point),
+                )
+            }) {
+            // if we have no usable block acceptors, leap to learn more about the network state
+            None => LeapInstruction::NoUsableBlockAcceptors,
+            Some((acceptor_height, is_upgrade_boundary)) => {
+                // the accumulator has heard about at least one usable block via gossiping
+                // if we've see chatter about a usable higher block, we can determine
+                // if we have local state at or near that highest usable block.
+                // if we have reason to believe we have fallen too far behind the network,
+                // we should switch to catchup mode and start the leap process
+                // otherwise, we should attempt to keep up with the network by
+                // executing our own blocks.
+
+                // This is a special case; if we have heard chatter about the last block
+                // before a protocol upgrade and have enough finality signatures to believe
+                // it, we want to be cautious about leaping, because other nodes on the
+                // network are starting to go down and come back up on the new protocol
+                // version and may or may not respond. Thus, it is best for the node to
+                // continue executing its own blocks to get to the upgrade point on its
+                // own (if able).
+                let is_upgrade_boundary = is_upgrade_boundary == Some(true);
+
+                let distance_from_highest_known_block = acceptor_height.saturating_sub(height);
+
+                LeapInstruction::from_execution_threshold(
+                    self.attempt_execution_threshold,
+                    distance_from_highest_known_block,
+                    is_upgrade_boundary,
+                )
             }
         }
     }

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -12,8 +12,8 @@ use crate::{
         fetcher::{EmptyValidationMetadata, FetchItem},
     },
     types::{
-        BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock, NodeId,
-        SignatureWeight,
+        ActivationPoint, BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature,
+        MetaBlock, NodeId, SignatureWeight,
     },
 };
 
@@ -352,6 +352,19 @@ impl BlockAcceptor {
 
     pub(super) fn block_hash(&self) -> BlockHash {
         self.block_hash
+    }
+
+    pub(super) fn is_upgrade_boundary(
+        &self,
+        activation_point: Option<ActivationPoint>,
+    ) -> Option<bool> {
+        match (&self.meta_block, activation_point) {
+            (None, _) => None,
+            (Some(_), None) => Some(false),
+            (Some(meta_block), Some(activation_point)) => {
+                Some(meta_block.is_upgrade_boundary(activation_point))
+            }
+        }
     }
 
     pub(super) fn last_progress(&self) -> Timestamp {

--- a/node/src/components/block_accumulator/block_acceptor.rs
+++ b/node/src/components/block_accumulator/block_acceptor.rs
@@ -12,8 +12,8 @@ use crate::{
         fetcher::{EmptyValidationMetadata, FetchItem},
     },
     types::{
-        BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature, MetaBlock, NodeId,
-        SignatureWeight,
+        ActivationPoint, BlockHash, BlockSignatures, EraValidatorWeights, FinalitySignature,
+        MetaBlock, NodeId, SignatureWeight,
     },
 };
 
@@ -340,6 +340,19 @@ impl BlockAcceptor {
 
     pub(super) fn block_hash(&self) -> BlockHash {
         self.block_hash
+    }
+
+    pub(super) fn is_upgrade_boundary(
+        &self,
+        activation_point: Option<ActivationPoint>,
+    ) -> Option<bool> {
+        match (&self.meta_block, activation_point) {
+            (None, _) => None,
+            (Some(_), None) => Some(false),
+            (Some(meta_block), Some(activation_point)) => {
+                Some(meta_block.is_upgrade_boundary(activation_point))
+            }
+        }
     }
 
     pub(super) fn last_progress(&self) -> Timestamp {

--- a/node/src/components/block_accumulator/leap_instruction.rs
+++ b/node/src/components/block_accumulator/leap_instruction.rs
@@ -1,0 +1,84 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq)]
+pub(super) enum LeapInstruction {
+    // should not leap
+    AtHighestKnownBlock,
+    WithinAttemptExecutionThreshold(u64),
+    TooCloseToUpgradeBoundary(u64),
+
+    // should leap
+    UnsetLocalTip,
+    NoUsableBlockAcceptors,
+    OutsideAttemptExecutionThreshold(u64),
+}
+
+impl LeapInstruction {
+    pub(super) fn from_execution_threshold(
+        attempt_execution_threshold: u64,
+        distance_from_highest_known_block: u64,
+        is_upgrade_boundary: bool,
+    ) -> Self {
+        if distance_from_highest_known_block == 0 {
+            return LeapInstruction::AtHighestKnownBlock;
+        }
+        if is_upgrade_boundary
+            && distance_from_highest_known_block <= attempt_execution_threshold * 2
+        {
+            return LeapInstruction::TooCloseToUpgradeBoundary(distance_from_highest_known_block);
+        }
+        if distance_from_highest_known_block > attempt_execution_threshold {
+            return LeapInstruction::OutsideAttemptExecutionThreshold(
+                distance_from_highest_known_block,
+            );
+        }
+        LeapInstruction::WithinAttemptExecutionThreshold(distance_from_highest_known_block)
+    }
+
+    pub(super) fn should_leap(&self) -> bool {
+        match self {
+            LeapInstruction::AtHighestKnownBlock
+            | LeapInstruction::WithinAttemptExecutionThreshold(_)
+            | LeapInstruction::TooCloseToUpgradeBoundary(_) => false,
+            LeapInstruction::UnsetLocalTip
+            | LeapInstruction::NoUsableBlockAcceptors
+            | LeapInstruction::OutsideAttemptExecutionThreshold(_) => true,
+        }
+    }
+}
+
+impl Display for LeapInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LeapInstruction::AtHighestKnownBlock => {
+                write!(f, "at highest known block")
+            }
+            LeapInstruction::TooCloseToUpgradeBoundary(diff) => {
+                write!(f, "{} blocks away from protocol upgrade", diff)
+            }
+            LeapInstruction::WithinAttemptExecutionThreshold(diff) => {
+                write!(
+                    f,
+                    "within attempt_execution_threshold, {} blocks behind highest known block",
+                    diff
+                )
+            }
+            LeapInstruction::OutsideAttemptExecutionThreshold(diff) => {
+                write!(
+                    f,
+                    "outside attempt_execution_threshold, {} blocks behind highest known block",
+                    diff
+                )
+            }
+            LeapInstruction::UnsetLocalTip => {
+                write!(f, "block accumulator local tip is unset")
+            }
+            LeapInstruction::NoUsableBlockAcceptors => {
+                write!(
+                    f,
+                    "currently have no block acceptor instances with sufficient finality"
+                )
+            }
+        }
+    }
+}

--- a/node/src/components/block_accumulator/sync_identifier.rs
+++ b/node/src/components/block_accumulator/sync_identifier.rs
@@ -1,4 +1,5 @@
 use casper_types::EraId;
+use std::fmt::{Display, Formatter};
 
 use crate::types::BlockHash;
 
@@ -74,6 +75,30 @@ impl SyncIdentifier {
             child_hash
         } else {
             Some(self.block_hash())
+        }
+    }
+}
+
+impl Display for SyncIdentifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyncIdentifier::BlockHash(block_hash) => block_hash.fmt(f),
+            SyncIdentifier::BlockIdentifier(block_hash, block_height) => {
+                write!(
+                    f,
+                    "block_hash: {} block_height: {}",
+                    block_hash, block_height
+                )
+            }
+            SyncIdentifier::SyncedBlockIdentifier(block_hash, block_height, era_id)
+            | SyncIdentifier::ExecutingBlockIdentifier(block_hash, block_height, era_id)
+            | SyncIdentifier::LocalTip(block_hash, block_height, era_id) => {
+                write!(
+                    f,
+                    "block_hash: {} block_height: {} era_id: {}",
+                    block_hash, block_height, era_id
+                )
+            }
         }
     }
 }

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -858,6 +858,12 @@ fn accumulator_should_leap() {
 
     block_accumulator.local_tip = Some(LocalTipIdentifier::new(1, era_id));
 
+    let synced = SyncIdentifier::BlockHash(BlockHash::random(&mut rng));
+    expected_leap_instruction(
+        LeapInstruction::UnknownBlockHeight,
+        block_accumulator.leap_instruction(&synced),
+    );
+
     let synced = SyncIdentifier::SyncedBlockIdentifier(BlockHash::random(&mut rng), 1, era_id);
     expected_leap_instruction(
         LeapInstruction::NoUsableBlockAcceptors,
@@ -1001,6 +1007,7 @@ fn block_acceptor(block: Block) -> BlockAcceptor {
                 ALICE_PUBLIC_KEY.clone(),
             ),
             None,
+            VALIDATOR_SLOTS,
         )
         .unwrap();
 

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -9,18 +9,17 @@ use derive_more::From;
 use num_rational::Ratio;
 use prometheus::Registry;
 use rand::Rng;
-use reactor::ReactorEvent;
 use serde::Serialize;
 use tempfile::TempDir;
 use thiserror::Error as ThisError;
-
-use casper_types::{
-    generate_ed25519_keypair, testing::TestRng, ProtocolVersion, PublicKey, SecretKey, Signature,
-    U512,
-};
 use tokio::time;
 
-use super::*;
+use casper_types::{
+    generate_ed25519_keypair, testing::TestRng, ProtocolVersion, PublicKey, SecretKey, SemVer,
+    Signature, U512,
+};
+use reactor::ReactorEvent;
+
 use crate::{
     components::{
         consensus::tests::utils::{ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID},
@@ -37,6 +36,8 @@ use crate::{
     utils::{Loadable, WithDir},
     NodeRng,
 };
+
+use super::*;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const RECENT_ERA_INTERVAL: u64 = 1;
@@ -751,130 +752,6 @@ fn acceptor_should_store_block() {
 }
 
 #[test]
-fn accumulator_highest_usable_block_height() {
-    let mut rng = TestRng::new();
-    let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
-    let block_accumulator_config = Config::default();
-    let recent_era_interval = 1;
-    let block_time = block_accumulator_config.purge_interval / 2;
-    let mut block_accumulator = BlockAccumulator::new(
-        block_accumulator_config,
-        validator_matrix.clone(),
-        recent_era_interval,
-        block_time,
-        &Registry::default(),
-    )
-    .unwrap();
-
-    // Create 3 parent-child blocks.
-    let block_1 = Arc::new(generate_non_genesis_block(&mut rng));
-    let block_2 = Arc::new(generate_next_block(&mut rng, &block_1));
-    let block_3 = Arc::new(generate_next_block(&mut rng, &block_2));
-
-    // One finality signature from our only validator for block 1.
-    let fin_sig_1 = FinalitySignature::create(
-        *block_1.hash(),
-        block_1.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-    // One finality signature from our only validator for block 2.
-    let fin_sig_2 = FinalitySignature::create(
-        *block_2.hash(),
-        block_2.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-    // One finality signature from our only validator for block 3.
-    let fin_sig_3 = FinalitySignature::create(
-        *block_3.hash(),
-        block_3.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-
-    // Register the eras in the validator matrix so the blocks are valid.
-    {
-        register_evw_for_era(&mut validator_matrix, block_1.header().era_id());
-        register_evw_for_era(&mut validator_matrix, block_2.header().era_id());
-        register_evw_for_era(&mut validator_matrix, block_3.header().era_id());
-    }
-
-    // The accumulator should have no usable block height at inception.
-    assert!(block_accumulator.highest_usable_block_height().is_none());
-
-    // Create an empty acceptor and insert it into the accumulator.
-    let acceptor = BlockAcceptor::new(*block_2.hash(), vec![]);
-    block_accumulator
-        .block_acceptors
-        .insert(*block_2.hash(), acceptor);
-    // An empty acceptor should not count towards the usable block height.
-    assert!(block_accumulator.highest_usable_block_height().is_none());
-
-    {
-        // Insert the second block with sufficient finality.
-        let acceptor = block_accumulator
-            .block_acceptors
-            .get_mut(block_2.hash())
-            .unwrap();
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_2.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_2, None)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-    }
-    // Now we should have a usable block height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_2.height()
-    );
-
-    {
-        // Insert the first block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block_1.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_1.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_1, None)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-        block_accumulator
-            .block_acceptors
-            .insert(*block_1.hash(), acceptor);
-    }
-    // The first block has a lower height than the second, so the highest
-    // usable block height should still be the second block's height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_2.height()
-    );
-
-    {
-        // Insert the third block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block_3.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_3.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_3, None)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-        block_accumulator
-            .block_acceptors
-            .insert(*block_3.hash(), acceptor);
-    }
-    // The third block has a higher height than the second, so the highest
-    // usable block height should now be the third block's height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_3.height()
-    );
-}
-
-#[test]
 fn accumulator_should_leap() {
     let mut rng = TestRng::new();
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
@@ -891,64 +768,180 @@ fn accumulator_should_leap() {
     )
     .unwrap();
 
-    // Create a block.
-    let starting_seed: u64 = rng.gen_range(1..10);
-    let block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        EraId::from(starting_seed),
-        attempt_execution_threshold + starting_seed,
-        ProtocolVersion::V1_0_0,
-        starting_seed % 2 == 0,
-        None,
-    ));
-
-    // One finality signature from our only validator for block 1.
-    let fin_sig = FinalitySignature::create(
-        *block.hash(),
-        block.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
+    let era_id = EraId::from(0);
 
     // Register the era in the validator matrix so the block is valid.
-    register_evw_for_era(&mut validator_matrix, block.header().era_id());
+    register_evw_for_era(&mut validator_matrix, era_id);
 
-    // The accumulator should try to leap at inception, no matter the starting
-    // height.
-    assert!(block_accumulator.should_leap(Some(0)));
-    assert!(block_accumulator.should_leap(Some(block.height().saturating_add(1_000))));
+    assert!(
+        block_accumulator.local_tip.is_none(),
+        "block_accumulator local tip should init null"
+    );
+
+    expected_leap_instruction(
+        LeapInstruction::UnsetLocalTip,
+        block_accumulator.leap_instruction(&SyncIdentifier::BlockIdentifier(
+            BlockHash::random(&mut rng),
+            0,
+        )),
+    );
+
+    block_accumulator.local_tip = Some(LocalTipIdentifier::new(1, era_id));
+
+    let synced = SyncIdentifier::SyncedBlockIdentifier(BlockHash::random(&mut rng), 1, era_id);
+    expected_leap_instruction(
+        LeapInstruction::NoUsableBlockAcceptors,
+        block_accumulator.leap_instruction(&synced),
+    );
 
     // Create an acceptor to change the highest usable block height.
     {
-        // Insert the block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block.clone(), vec![], state);
-        acceptor.register_finality_signature(fin_sig, None).unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
+        let block =
+            Block::random_with_specifics(&mut rng, era_id, 1, ProtocolVersion::V1_0_0, false, None);
+
         block_accumulator
             .block_acceptors
-            .insert(*block.hash(), acceptor);
+            .insert(*block.hash(), block_acceptor(block));
     }
-    // Highest usable block height should have changed.
-    let highest_usable_block_height = block_accumulator.highest_usable_block_height().unwrap();
-    assert_eq!(highest_usable_block_height, block.height());
-    // We should not leap from a height that is greater than our highest usable
-    // block height.
-    assert!(!block_accumulator.should_leap(Some(highest_usable_block_height + 1)));
 
-    // We should leap from a height *lower* than `attempt_execution_threshold`
-    // from the highest usable block height.
-    assert!(!block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold
-    )));
-    assert!(!block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold + 1
-    )));
-    assert!(block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold - 1
-    )));
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&synced),
+    );
+
+    let block_height = attempt_execution_threshold;
+    // Insert an acceptor within execution range
+    {
+        let block = Block::random_with_specifics(
+            &mut rng,
+            era_id,
+            block_height,
+            ProtocolVersion::V1_0_0,
+            false,
+            None,
+        );
+
+        block_accumulator
+            .block_acceptors
+            .insert(*block.hash(), block_acceptor(block));
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::WithinAttemptExecutionThreshold(
+            attempt_execution_threshold.saturating_sub(1),
+        ),
+        block_accumulator.leap_instruction(&synced),
+    );
+
+    let centurion = 100;
+    // Insert an upgrade boundary
+    {
+        let block = Block::random_with_specifics(
+            &mut rng,
+            era_id,
+            centurion,
+            ProtocolVersion::new(SemVer::new(1, 1, 0)),
+            true,
+            None,
+        );
+
+        block_accumulator
+            .block_acceptors
+            .insert(*block.hash(), block_acceptor(block));
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion,
+            era_id,
+        )),
+    );
+    expected_leap_instruction(
+        LeapInstruction::OutsideAttemptExecutionThreshold(attempt_execution_threshold + 1),
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion - attempt_execution_threshold - 1,
+            era_id,
+        )),
+    );
+
+    let offset = centurion.saturating_sub(attempt_execution_threshold);
+    for height in offset..centurion {
+        expected_leap_instruction(
+            LeapInstruction::WithinAttemptExecutionThreshold(centurion.saturating_sub(height)),
+            block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+                BlockHash::random(&mut rng),
+                height,
+                era_id,
+            )),
+        );
+    }
+
+    let upgrade_attempt_execution_threshold = attempt_execution_threshold * 2;
+    block_accumulator.register_activation_point(ActivationPoint::EraId(era_id.successor()));
+    let offset = centurion.saturating_sub(upgrade_attempt_execution_threshold);
+    for height in offset..centurion {
+        expected_leap_instruction(
+            LeapInstruction::TooCloseToUpgradeBoundary(centurion.saturating_sub(height)),
+            block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+                BlockHash::random(&mut rng),
+                height,
+                era_id,
+            )),
+        );
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion,
+            era_id,
+        )),
+    );
+    expected_leap_instruction(
+        LeapInstruction::OutsideAttemptExecutionThreshold(upgrade_attempt_execution_threshold + 1),
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion - upgrade_attempt_execution_threshold - 1,
+            era_id,
+        )),
+    );
+}
+
+fn expected_leap_instruction(expected: LeapInstruction, actual: LeapInstruction) {
+    assert!(
+        expected.eq(&actual),
+        "{}",
+        format!("expected: {} actual: {}", expected, actual)
+    );
+}
+
+fn block_acceptor(block: Block) -> BlockAcceptor {
+    let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
+    // One finality signature from our only validator for block 1.
+    acceptor
+        .register_finality_signature(
+            FinalitySignature::create(
+                *block.hash(),
+                block.header().era_id(),
+                &ALICE_SECRET_KEY,
+                ALICE_PUBLIC_KEY.clone(),
+            ),
+            None,
+        )
+        .unwrap();
+
+    let meta_block = {
+        let mut state = MetaBlockState::new();
+        state.register_has_sufficient_finality();
+        MetaBlock::new(Arc::new(block), vec![], state)
+    };
+    acceptor.register_block(meta_block, None).unwrap();
+
+    acceptor
 }
 
 #[test]

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -9,18 +9,17 @@ use derive_more::From;
 use num_rational::Ratio;
 use prometheus::Registry;
 use rand::Rng;
-use reactor::ReactorEvent;
 use serde::Serialize;
 use tempfile::TempDir;
 use thiserror::Error as ThisError;
-
-use casper_types::{
-    generate_ed25519_keypair, testing::TestRng, ProtocolVersion, PublicKey, SecretKey, Signature,
-    U512,
-};
 use tokio::time;
 
-use super::*;
+use casper_types::{
+    generate_ed25519_keypair, testing::TestRng, ProtocolVersion, PublicKey, SecretKey, SemVer,
+    Signature, U512,
+};
+use reactor::ReactorEvent;
+
 use crate::{
     components::{
         consensus::tests::utils::{ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID},
@@ -37,6 +36,8 @@ use crate::{
     utils::{Loadable, WithDir},
     NodeRng,
 };
+
+use super::*;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const RECENT_ERA_INTERVAL: u64 = 1;
@@ -820,131 +821,6 @@ fn acceptor_signatures_bound_should_not_be_triggered_if_peers_are_different() {
 }
 
 #[test]
-fn accumulator_highest_usable_block_height() {
-    let mut rng = TestRng::new();
-    let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
-    let block_accumulator_config = Config::default();
-    let recent_era_interval = 1;
-    let block_time = block_accumulator_config.purge_interval / 2;
-    let mut block_accumulator = BlockAccumulator::new(
-        block_accumulator_config,
-        validator_matrix.clone(),
-        recent_era_interval,
-        block_time,
-        VALIDATOR_SLOTS,
-        &Registry::default(),
-    )
-    .unwrap();
-
-    // Create 3 parent-child blocks.
-    let block_1 = Arc::new(generate_non_genesis_block(&mut rng));
-    let block_2 = Arc::new(generate_next_block(&mut rng, &block_1));
-    let block_3 = Arc::new(generate_next_block(&mut rng, &block_2));
-
-    // One finality signature from our only validator for block 1.
-    let fin_sig_1 = FinalitySignature::create(
-        *block_1.hash(),
-        block_1.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-    // One finality signature from our only validator for block 2.
-    let fin_sig_2 = FinalitySignature::create(
-        *block_2.hash(),
-        block_2.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-    // One finality signature from our only validator for block 3.
-    let fin_sig_3 = FinalitySignature::create(
-        *block_3.hash(),
-        block_3.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
-
-    // Register the eras in the validator matrix so the blocks are valid.
-    {
-        register_evw_for_era(&mut validator_matrix, block_1.header().era_id());
-        register_evw_for_era(&mut validator_matrix, block_2.header().era_id());
-        register_evw_for_era(&mut validator_matrix, block_3.header().era_id());
-    }
-
-    // The accumulator should have no usable block height at inception.
-    assert!(block_accumulator.highest_usable_block_height().is_none());
-
-    // Create an empty acceptor and insert it into the accumulator.
-    let acceptor = BlockAcceptor::new(*block_2.hash(), vec![]);
-    block_accumulator
-        .block_acceptors
-        .insert(*block_2.hash(), acceptor);
-    // An empty acceptor should not count towards the usable block height.
-    assert!(block_accumulator.highest_usable_block_height().is_none());
-
-    {
-        // Insert the second block with sufficient finality.
-        let acceptor = block_accumulator
-            .block_acceptors
-            .get_mut(block_2.hash())
-            .unwrap();
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_2.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_2, None, VALIDATOR_SLOTS)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-    }
-    // Now we should have a usable block height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_2.height()
-    );
-
-    {
-        // Insert the first block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block_1.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_1.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_1, None, VALIDATOR_SLOTS)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-        block_accumulator
-            .block_acceptors
-            .insert(*block_1.hash(), acceptor);
-    }
-    // The first block has a lower height than the second, so the highest
-    // usable block height should still be the second block's height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_2.height()
-    );
-
-    {
-        // Insert the third block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block_3.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block_3.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig_3, None, VALIDATOR_SLOTS)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
-        block_accumulator
-            .block_acceptors
-            .insert(*block_3.hash(), acceptor);
-    }
-    // The third block has a higher height than the second, so the highest
-    // usable block height should now be the third block's height.
-    assert_eq!(
-        block_accumulator.highest_usable_block_height().unwrap(),
-        block_3.height()
-    );
-}
-
-#[test]
 fn accumulator_should_leap() {
     let mut rng = TestRng::new();
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
@@ -962,66 +838,180 @@ fn accumulator_should_leap() {
     )
     .unwrap();
 
-    // Create a block.
-    let starting_seed: u64 = rng.gen_range(1..10);
-    let block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        EraId::from(starting_seed),
-        attempt_execution_threshold + starting_seed,
-        ProtocolVersion::V1_0_0,
-        starting_seed % 2 == 0,
-        None,
-    ));
-
-    // One finality signature from our only validator for block 1.
-    let fin_sig = FinalitySignature::create(
-        *block.hash(),
-        block.header().era_id(),
-        &ALICE_SECRET_KEY,
-        ALICE_PUBLIC_KEY.clone(),
-    );
+    let era_id = EraId::from(0);
 
     // Register the era in the validator matrix so the block is valid.
-    register_evw_for_era(&mut validator_matrix, block.header().era_id());
+    register_evw_for_era(&mut validator_matrix, era_id);
 
-    // The accumulator should try to leap at inception, no matter the starting
-    // height.
-    assert!(block_accumulator.should_leap(Some(0)));
-    assert!(block_accumulator.should_leap(Some(block.height().saturating_add(1_000))));
+    assert!(
+        block_accumulator.local_tip.is_none(),
+        "block_accumulator local tip should init null"
+    );
+
+    expected_leap_instruction(
+        LeapInstruction::UnsetLocalTip,
+        block_accumulator.leap_instruction(&SyncIdentifier::BlockIdentifier(
+            BlockHash::random(&mut rng),
+            0,
+        )),
+    );
+
+    block_accumulator.local_tip = Some(LocalTipIdentifier::new(1, era_id));
+
+    let synced = SyncIdentifier::SyncedBlockIdentifier(BlockHash::random(&mut rng), 1, era_id);
+    expected_leap_instruction(
+        LeapInstruction::NoUsableBlockAcceptors,
+        block_accumulator.leap_instruction(&synced),
+    );
 
     // Create an acceptor to change the highest usable block height.
     {
-        // Insert the block with sufficient finality.
-        let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
-        let mut state = MetaBlockState::new();
-        state.register_has_sufficient_finality();
-        let meta_block = MetaBlock::new(block.clone(), vec![], state);
-        acceptor
-            .register_finality_signature(fin_sig, None, VALIDATOR_SLOTS)
-            .unwrap();
-        acceptor.register_block(meta_block, None).unwrap();
+        let block =
+            Block::random_with_specifics(&mut rng, era_id, 1, ProtocolVersion::V1_0_0, false, None);
+
         block_accumulator
             .block_acceptors
-            .insert(*block.hash(), acceptor);
+            .insert(*block.hash(), block_acceptor(block));
     }
-    // Highest usable block height should have changed.
-    let highest_usable_block_height = block_accumulator.highest_usable_block_height().unwrap();
-    assert_eq!(highest_usable_block_height, block.height());
-    // We should not leap from a height that is greater than our highest usable
-    // block height.
-    assert!(!block_accumulator.should_leap(Some(highest_usable_block_height + 1)));
 
-    // We should leap from a height *lower* than `attempt_execution_threshold`
-    // from the highest usable block height.
-    assert!(!block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold
-    )));
-    assert!(!block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold + 1
-    )));
-    assert!(block_accumulator.should_leap(Some(
-        highest_usable_block_height - attempt_execution_threshold - 1
-    )));
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&synced),
+    );
+
+    let block_height = attempt_execution_threshold;
+    // Insert an acceptor within execution range
+    {
+        let block = Block::random_with_specifics(
+            &mut rng,
+            era_id,
+            block_height,
+            ProtocolVersion::V1_0_0,
+            false,
+            None,
+        );
+
+        block_accumulator
+            .block_acceptors
+            .insert(*block.hash(), block_acceptor(block));
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::WithinAttemptExecutionThreshold(
+            attempt_execution_threshold.saturating_sub(1),
+        ),
+        block_accumulator.leap_instruction(&synced),
+    );
+
+    let centurion = 100;
+    // Insert an upgrade boundary
+    {
+        let block = Block::random_with_specifics(
+            &mut rng,
+            era_id,
+            centurion,
+            ProtocolVersion::new(SemVer::new(1, 1, 0)),
+            true,
+            None,
+        );
+
+        block_accumulator
+            .block_acceptors
+            .insert(*block.hash(), block_acceptor(block));
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion,
+            era_id,
+        )),
+    );
+    expected_leap_instruction(
+        LeapInstruction::OutsideAttemptExecutionThreshold(attempt_execution_threshold + 1),
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion - attempt_execution_threshold - 1,
+            era_id,
+        )),
+    );
+
+    let offset = centurion.saturating_sub(attempt_execution_threshold);
+    for height in offset..centurion {
+        expected_leap_instruction(
+            LeapInstruction::WithinAttemptExecutionThreshold(centurion.saturating_sub(height)),
+            block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+                BlockHash::random(&mut rng),
+                height,
+                era_id,
+            )),
+        );
+    }
+
+    let upgrade_attempt_execution_threshold = attempt_execution_threshold * 2;
+    block_accumulator.register_activation_point(ActivationPoint::EraId(era_id.successor()));
+    let offset = centurion.saturating_sub(upgrade_attempt_execution_threshold);
+    for height in offset..centurion {
+        expected_leap_instruction(
+            LeapInstruction::TooCloseToUpgradeBoundary(centurion.saturating_sub(height)),
+            block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+                BlockHash::random(&mut rng),
+                height,
+                era_id,
+            )),
+        );
+    }
+
+    expected_leap_instruction(
+        LeapInstruction::AtHighestKnownBlock,
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion,
+            era_id,
+        )),
+    );
+    expected_leap_instruction(
+        LeapInstruction::OutsideAttemptExecutionThreshold(upgrade_attempt_execution_threshold + 1),
+        block_accumulator.leap_instruction(&SyncIdentifier::SyncedBlockIdentifier(
+            BlockHash::random(&mut rng),
+            centurion - upgrade_attempt_execution_threshold - 1,
+            era_id,
+        )),
+    );
+}
+
+fn expected_leap_instruction(expected: LeapInstruction, actual: LeapInstruction) {
+    assert!(
+        expected.eq(&actual),
+        "{}",
+        format!("expected: {} actual: {}", expected, actual)
+    );
+}
+
+fn block_acceptor(block: Block) -> BlockAcceptor {
+    let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
+    // One finality signature from our only validator for block 1.
+    acceptor
+        .register_finality_signature(
+            FinalitySignature::create(
+                *block.hash(),
+                block.header().era_id(),
+                &ALICE_SECRET_KEY,
+                ALICE_PUBLIC_KEY.clone(),
+            ),
+            None,
+        )
+        .unwrap();
+
+    let meta_block = {
+        let mut state = MetaBlockState::new();
+        state.register_has_sufficient_finality();
+        MetaBlock::new(Arc::new(block), vec![], state)
+    };
+    acceptor.register_block(meta_block, None).unwrap();
+
+    acceptor
 }
 
 #[test]

--- a/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/sync_leap_fetcher.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
-use tracing::debug;
 
 use crate::{
     components::fetcher::{metrics::Metrics, Fetcher, ItemFetcher, ItemHandle, StoringState},
@@ -43,10 +42,6 @@ impl ItemFetcher<SyncLeap> for Fetcher<SyncLeap> {
         effect_builder: EffectBuilder<REv>,
         item: SyncLeap,
     ) -> StoringState<'a, SyncLeap> {
-        debug!(
-            ?item,
-            "SyncLeapFetcher: Attempted to put sync leap to storage"
-        );
         StoringState::Enqueued(
             async move {
                 for header in item.headers() {

--- a/node/src/components/network/limiter.rs
+++ b/node/src/components/network/limiter.rs
@@ -381,8 +381,8 @@ mod tests {
             handle.request_allowance(1).await;
             let elapsed = start.elapsed();
 
-            assert!(elapsed >= Duration::from_secs(9));
-            assert!(elapsed <= Duration::from_secs(10));
+            assert!(elapsed >= Duration::from_secs(9), "flip");
+            assert!(elapsed <= Duration::from_secs(10), "flop");
         }
     }
 

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Instant};
 use datasize::DataSize;
 use prometheus::Registry;
 use thiserror::Error;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     components::{
@@ -161,12 +161,15 @@ impl SyncLeaper {
                 .collect();
 
             return if peers_not_asked_yet.is_empty() {
+                debug!(%sync_leap_identifier, "peers_not_asked_yet.is_empty()");
                 RegisterLeapAttemptOutcome::DoNothing
             } else {
+                debug!(%sync_leap_identifier, "fetching sync leap from {} peers not asked yet", peers_not_asked_yet.len());
                 RegisterLeapAttemptOutcome::FetchSyncLeapFromPeers(peers_not_asked_yet)
             };
         }
 
+        debug!(%sync_leap_identifier, "fetching sync leap from {} peers", peers_to_ask.len());
         self.leap_activity = Some(LeapActivity::new(
             sync_leap_identifier,
             peers_to_ask

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -140,6 +140,10 @@ impl NextUpgrade {
             protocol_version,
         }
     }
+
+    pub(crate) fn activation_point(&self) -> ActivationPoint {
+        self.activation_point
+    }
 }
 
 impl From<ProtocolConfig> for NextUpgrade {

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -13,9 +13,10 @@ use crate::{
     effect::{EffectBuilder, EffectExt, Effects},
     fatal,
     reactor::main_reactor::{
-        catch_up::CatchUpInstruction, keep_up::KeepUpInstruction,
-        upgrade_shutdown::UpgradeShutdownInstruction, upgrading_instruction::UpgradingInstruction,
-        utils, validate::ValidateInstruction, MainEvent, MainReactor, ReactorState,
+        catch_up::CatchUpInstruction, genesis_instruction::GenesisInstruction,
+        keep_up::KeepUpInstruction, upgrade_shutdown::UpgradeShutdownInstruction,
+        upgrading_instruction::UpgradingInstruction, utils, validate::ValidateInstruction,
+        MainEvent, MainReactor, ReactorState,
     },
     types::{BlockHash, BlockPayload, FinalizedBlock, MetaBlockState},
     NodeRng,
@@ -87,12 +88,17 @@ impl MainReactor {
                     (Duration::ZERO, Effects::new())
                 }
                 CatchUpInstruction::CommitGenesis => match self.commit_genesis(effect_builder) {
-                    Ok(effects) => {
+                    GenesisInstruction::Validator(duration, effects) => {
                         info!("CatchUp: switch to Validate at genesis");
                         self.state = ReactorState::Validate;
-                        (Duration::ZERO, effects)
+                        (duration, effects)
                     }
-                    Err(msg) => (
+                    GenesisInstruction::NonValidator(duration, effects) => {
+                        info!("CatchUp: switch to KeepUp at genesis");
+                        self.state = ReactorState::KeepUp;
+                        (duration, effects)
+                    }
+                    GenesisInstruction::Fatal(msg) => (
                         Duration::ZERO,
                         fatal!(effect_builder, "failed to commit genesis: {}", msg).ignore(),
                     ),
@@ -286,17 +292,14 @@ impl MainReactor {
         None
     }
 
-    fn commit_genesis(
-        &mut self,
-        effect_builder: EffectBuilder<MainEvent>,
-    ) -> Result<Effects<MainEvent>, String> {
+    fn commit_genesis(&mut self, effect_builder: EffectBuilder<MainEvent>) -> GenesisInstruction {
         let post_state_hash = match self.contract_runtime.commit_genesis(
             self.chainspec.clone().as_ref(),
             self.chainspec_raw_bytes.clone().as_ref(),
         ) {
             Ok(success) => success.post_state_hash,
             Err(error) => {
-                return Err(error.to_string());
+                return GenesisInstruction::Fatal(error.to_string());
             }
         };
 
@@ -307,7 +310,7 @@ impl MainReactor {
             .genesis_timestamp()
         {
             None => {
-                return Err("must have genesis timestamp".to_string());
+                return GenesisInstruction::Fatal("must have genesis timestamp".to_string());
             }
             Some(timestamp) => timestamp,
         };
@@ -336,13 +339,24 @@ impl MainReactor {
             PublicKey::System,
         );
 
-        Ok(effect_builder
+        let effects = effect_builder
             .enqueue_block_for_execution(
                 finalized_block,
                 vec![],
                 MetaBlockState::new_not_to_be_gossiped(),
             )
-            .ignore())
+            .ignore();
+
+        if self
+            .chainspec
+            .network_config
+            .accounts_config
+            .is_genesis_validator(self.validator_matrix.public_signing_key())
+        {
+            GenesisInstruction::Validator(Duration::ZERO, effects)
+        } else {
+            GenesisInstruction::NonValidator(Duration::ZERO, effects)
+        }
     }
 
     fn upgrading_instruction(&self) -> UpgradingInstruction {

--- a/node/src/reactor/main_reactor/genesis_instruction.rs
+++ b/node/src/reactor/main_reactor/genesis_instruction.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+use crate::{effect::Effects, reactor::main_reactor::MainEvent};
+
+pub(super) enum GenesisInstruction {
+    Validator(Duration, Effects<MainEvent>),
+    NonValidator(Duration, Effects<MainEvent>),
+    Fatal(String),
+}

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -477,10 +477,8 @@ impl MainReactor {
         parent_hash: BlockHash,
         error: LeapActivityError,
     ) -> KeepUpInstruction {
-        self.attempts += 1;
         warn!(
             %error,
-            remaining_attempts = %self.max_attempts.saturating_sub(self.attempts),
             "historical: failed leap",
         );
         self.sync_back_leaper_idle(

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -656,8 +656,8 @@ async fn dont_upgrade_without_switch_block() {
             .expect("failed to read from storage")
             .expect("missing switch block")
             .take_header();
-        assert_eq!(EraId::from(1), header.era_id());
-        assert!(header.is_switch_block());
+        assert_eq!(EraId::from(1), header.era_id(), "era should be 1");
+        assert!(header.is_switch_block(), "header should be switch block");
     }
 }
 
@@ -896,7 +896,11 @@ async fn empty_block_validation_regression() {
     let switch_blocks = SwitchBlocks::collect(net.nodes(), 2);
 
     // Nobody actually double-signed. The accusations should have had no effect.
-    assert_eq!(switch_blocks.equivocators(0), []);
+    assert_eq!(
+        switch_blocks.equivocators(0),
+        [],
+        "expected no equivocators"
+    );
     // If the malicious validator was the first proposer, all their Highway units might be invalid,
     // because they all refer to the invalid proposal, so they might get flagged as inactive. No
     // other validators should be considered inactive.

--- a/node/src/types/block/meta_block.rs
+++ b/node/src/types/block/meta_block.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use casper_types::ExecutionResult;
 
-use crate::types::{Block, DeployHash, DeployHeader};
+use crate::types::{ActivationPoint, Block, DeployHash, DeployHeader};
 
 pub(crate) use merge_mismatch_error::MergeMismatchError;
 pub(crate) use state::State;
@@ -58,6 +58,21 @@ impl MetaBlock {
         self.state = self.state.merge(other.state)?;
 
         Ok(self)
+    }
+
+    /// Is this a switch block?
+    pub(crate) fn is_switch_block(&self) -> bool {
+        self.block.header.is_switch_block()
+    }
+
+    /// Is this the last block before a protocol version upgrade?
+    pub(crate) fn is_upgrade_boundary(&self, activation_point: ActivationPoint) -> bool {
+        match activation_point {
+            ActivationPoint::EraId(era_id) => {
+                self.is_switch_block() && self.block.header.era_id.successor() == era_id
+            }
+            ActivationPoint::Genesis(_) => false,
+        }
     }
 }
 

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -69,6 +69,13 @@ impl AccountsConfig {
             .find(|account| &account.public_key == public_key)
     }
 
+    pub(crate) fn is_genesis_validator(&self, public_key: &PublicKey) -> bool {
+        match self.account(public_key) {
+            None => false,
+            Some(account_config) => account_config.is_genesis_validator(),
+        }
+    }
+
     /// Returns `Self` and the raw bytes of the file.
     ///
     /// If the file doesn't exist, returns `Ok` with an empty `AccountsConfig` and `None` bytes.

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -204,6 +204,10 @@ impl ValidatorMatrix {
         }
     }
 
+    pub(crate) fn public_signing_key(&self) -> &PublicKey {
+        &self.public_signing_key
+    }
+
     /// Returns whether `pub_key` is the ID of a validator in this era, or `None` if the validator
     /// information for that era is missing.
     pub(crate) fn is_self_validator_in_era(&self, era_id: EraId) -> Option<bool> {

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -237,13 +237,23 @@ function _step_08()
     local NX_PROTOCOL_VERSION
     local NX_STATE_ROOT_HASH
     local RETRY_COUNT
+    local NODE_COUNT
 
     log_step_upgrades 8 "asserting joined nodes are running upgrade"
 
+    NODE_COUNT=$(get_count_of_nodes)
+    # Status refresh.
+    for NODE_ID in $(seq 1 $NODE_COUNT)
+    do
+        source "$NCTL"/sh/node/status.sh node="$NODE_ID"
+    done
+
     # Assert all nodes are live.
-    for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
+    for NODE_ID in $(seq 1 $NODE_COUNT)
     do
         if [ $(get_node_is_up "$NODE_ID") == false ]; then
+            log "node-$NODE_ID not up"
+            log "NODE_COUNT_UP: $(get_count_of_up_nodes)"
             log "ERROR :: protocol upgrade failure - >= 1 nodes not live"
             exit 1
         fi


### PR DESCRIPTION
also fixed an incorrect state change to validate mode for non-validators present at genesis which was revealed by tighter leap instruction tracking and testing, and adjusted logging