### PR TITLE
Fix duplicate block execution enquement in block synchronizer

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -654,14 +654,11 @@ impl BlockSynchronizer {
                 NeedNext::EnqueueForExecution(block_hash, _) => {
                     if false == builder.should_fetch_execution_state() {
                         builder.set_in_flight_latch();
-                        results.extend(
-                            effect_builder
-                                .make_block_executable(block_hash)
-                                .event(move |result| Event::MadeFinalizedBlock {
-                                    block_hash,
-                                    result,
-                                }),
-                        )
+                        if builder.execution_unattempted() {
+                            results.extend(effect_builder.make_block_executable(block_hash).event(
+                                move |result| Event::MadeFinalizedBlock { block_hash, result },
+                            ))
+                        }
                     }
                 }
                 NeedNext::BlockMarkedComplete(block_hash, block_height) => {

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -250,6 +250,10 @@ impl BlockBuilder {
         matches!(self.execution_progress, ExecutionProgress::Started)
     }
 
+    pub(super) fn execution_unattempted(&self) -> bool {
+        matches!(self.execution_progress, ExecutionProgress::Idle)
+    }
+
     pub(super) fn register_block_execution_not_enqueued(&mut self) {
         warn!("failed to enqueue block for execution");
         // reset latch and try again
@@ -264,21 +268,19 @@ impl BlockBuilder {
             error!(%error, "register block execution enqueued failed");
             self.abort()
         } else {
-            match (
-                self.should_fetch_execution_state,
-                self.execution_progress.start(),
-            ) {
-                (true, _) => {
+            if self.should_fetch_execution_state {
+                let block_hash = self.block_hash();
+                error!(%block_hash, "invalid attempt to start block execution on historical block");
+                self.abort();
+                return;
+            }
+
+            match self.execution_progress.start() {
+                None => {
                     let block_hash = self.block_hash();
-                    error!(%block_hash, "invalid attempt to start block execution on historical block");
-                    self.abort();
+                    warn!(%block_hash, "invalid attempt to start block execution");
                 }
-                (false, None) => {
-                    let block_hash = self.block_hash();
-                    error!(%block_hash, "invalid attempt to start block execution");
-                    self.abort();
-                }
-                (false, Some(executing_progress)) => {
+                Some(executing_progress) => {
                     self.touch();
                     self.execution_progress = executing_progress;
                 }
@@ -287,21 +289,18 @@ impl BlockBuilder {
     }
 
     pub(super) fn register_block_executed(&mut self) {
-        match (
-            self.should_fetch_execution_state,
-            self.execution_progress.finish(),
-        ) {
-            (true, _) => {
+        if self.should_fetch_execution_state {
+            let block_hash = self.block_hash();
+            error!(%block_hash, "invalid attempt to finish block execution on historical block");
+            self.abort();
+        }
+
+        match self.execution_progress.finish() {
+            None => {
                 let block_hash = self.block_hash();
-                error!(%block_hash, "invalid attempt to finish block execution on historical block");
-                self.abort();
+                warn!(%block_hash, "invalid attempt to finish block execution");
             }
-            (false, None) => {
-                let block_hash = self.block_hash();
-                error!(%block_hash, "invalid attempt to finish block execution");
-                self.abort();
-            }
-            (false, Some(executing_progress)) => {
+            Some(executing_progress) => {
                 self.touch();
                 self.execution_progress = executing_progress;
             }


### PR DESCRIPTION
Fixes #3759 

This PR fixes a bug in the block synchronizer block execution flow. The bug scenario is:
- the synchronizer reaches a state where it wants to execute the block
- `need_next` returns `NeedNext::EnqueueForExecution`
- the synchronizer then sets the in flight latch, initiates the event through which a finalized block is created and sent for execution
- if another `register` type of event happens, in this case a finality signature arriving and triggering a `register_finality_signature` and `touch` is called, the in flight latch is reset
- the following `need_next` will still be `NeedNext::EnqueueForExecution`, which leads to multiple attempts to enqueue the block for execution

This scenario is not a fatal bug and the synchronizer will complete the block, therefore this PR downgrades the log to a `warn` in case of double enqueuement and also actively prevents it by leveraging the `ExecutionProgress` state to not enqueue a block which has already been enqueued.