### PR TITLE
block_chain typedef

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -55,9 +55,8 @@ pub(crate) mod diagnostics_port;
 pub(crate) mod event_stream_server;
 pub(crate) mod fetcher;
 pub(crate) mod gossiper;
-// The `in_memory_network` is public for use in doctests.
 #[cfg(test)]
-pub mod in_memory_network;
+pub mod in_memory_network; // The `in_memory_network` is public for use in doctests.
 pub(crate) mod metrics;
 pub(crate) mod network;
 pub(crate) mod rest_server;

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -3,6 +3,7 @@
 pub(crate) mod appendable_block;
 mod available_block_range;
 mod block;
+mod block_chain;
 pub mod chainspec;
 mod chunkable;
 mod deploy;

--- a/node/src/types/block_chain.rs
+++ b/node/src/types/block_chain.rs
@@ -1,0 +1,178 @@
+mod block_chain_entry;
+mod chain_index;
+mod error;
+mod indexed_block_chain;
+mod tests;
+
+use datasize::DataSize;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub(crate) use block_chain_entry::BlockChainEntry;
+
+use crate::types::BlockHash;
+use casper_types::EraId;
+
+use crate::types::{block_chain::indexed_block_chain::IndexedBlockChain, BlockHeader};
+use chain_index::ChainIndex;
+pub(crate) use error::Error;
+
+const POISONED_LOCK: &str = "poisoned lock on chain index";
+
+/// Chain-wise representation of blocks by height and (where known) hash.
+#[derive(DataSize, Debug, Default)]
+pub(crate) struct BlockChain {
+    inner: Arc<RwLock<ChainIndex>>,
+}
+
+// todo!("remove allow unused once integrated");
+#[allow(unused)]
+impl BlockChain {
+    /// Instantiate an instance of BlockChain.
+    pub(crate) fn new() -> Self {
+        BlockChain::default()
+    }
+
+    /// Is index empty?
+    pub(crate) fn is_empty(&self) -> bool {
+        self.read_inner().is_empty()
+    }
+
+    // get write guard
+    fn write_inner(&self) -> RwLockWriteGuard<ChainIndex> {
+        self.inner.write().expect(POISONED_LOCK)
+    }
+
+    // get read guard
+    fn read_inner(&self) -> RwLockReadGuard<ChainIndex> {
+        self.inner.read().expect(POISONED_LOCK)
+    }
+
+    #[cfg(test)]
+    fn register_complete_from_parts(
+        &mut self,
+        block_height: u64,
+        block_hash: BlockHash,
+        era_id: EraId,
+        is_switch_block: bool,
+    ) {
+        self.write_inner().register_complete_from_parts(
+            block_height,
+            block_hash,
+            era_id,
+            is_switch_block,
+        )
+    }
+}
+
+impl IndexedBlockChain for BlockChain {
+    fn remove(&mut self, block_height: u64) -> Option<BlockChainEntry> {
+        self.write_inner().remove(block_height)
+    }
+
+    fn register_proposed(&mut self, block_height: u64) -> Result<(), Error> {
+        self.write_inner().register_proposed(block_height)
+    }
+
+    fn register_finalized(&mut self, block_height: u64, era_id: EraId) -> Result<(), Error> {
+        self.write_inner().register_finalized(block_height, era_id)
+    }
+
+    fn register_incomplete(&mut self, block_height: u64, block_hash: BlockHash, era_id: EraId) {
+        self.write_inner()
+            .register_incomplete(block_height, block_hash, era_id)
+    }
+
+    fn register_complete(&mut self, block_header: &BlockHeader) {
+        self.write_inner().register_complete(block_header)
+    }
+
+    fn by_height(&self, block_height: u64) -> BlockChainEntry {
+        self.read_inner().by_height(block_height)
+    }
+
+    fn by_hash(&self, block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        self.read_inner().by_hash(block_hash)
+    }
+
+    fn by_parent(&self, parent_block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        self.read_inner().by_parent(parent_block_hash)
+    }
+
+    fn by_child(&self, child_block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        self.read_inner().by_child(child_block_hash)
+    }
+
+    fn switch_block_by_era(&self, era_id: EraId) -> Option<BlockChainEntry> {
+        self.read_inner().switch_block_by_era(era_id)
+    }
+
+    fn is_incomplete(&self, block_height: u64) -> bool {
+        self.read_inner().is_incomplete(block_height)
+    }
+
+    fn is_complete(&self, block_height: u64) -> bool {
+        self.read_inner().is_complete(block_height)
+    }
+
+    fn is_switch_block(&self, block_height: u64) -> Option<bool> {
+        self.read_inner().is_switch_block(block_height)
+    }
+
+    fn is_immediate_switch_block(&self, block_height: u64) -> Option<bool> {
+        self.read_inner().is_immediate_switch_block(block_height)
+    }
+
+    fn lowest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().lowest(predicate)
+    }
+
+    fn highest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().highest(predicate)
+    }
+
+    fn higher_by_status<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().higher_by_status(predicate)
+    }
+
+    fn lowest_switch_block(&self) -> Option<BlockChainEntry> {
+        self.read_inner().lowest_switch_block()
+    }
+
+    fn highest_switch_block(&self) -> Option<BlockChainEntry> {
+        self.read_inner().highest_switch_block()
+    }
+
+    fn all_by<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().all_by(predicate)
+    }
+
+    fn lowest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().lowest_sequence(predicate)
+    }
+
+    fn highest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.read_inner().highest_sequence(predicate)
+    }
+
+    fn range(&self, lbound: Option<u64>, ubound: Option<u64>) -> Vec<BlockChainEntry> {
+        self.read_inner().range(lbound, ubound)
+    }
+}

--- a/node/src/types/block_chain/block_chain_entry.rs
+++ b/node/src/types/block_chain/block_chain_entry.rs
@@ -1,0 +1,198 @@
+use crate::types::{BlockHash, BlockHeader, DataSize};
+use casper_types::EraId;
+use std::cmp::Ordering;
+
+/// Lightweight index entry for blocks across relevant lifecycle states.
+#[derive(DataSize, Debug, Copy, Clone, PartialEq)]
+pub enum BlockChainEntry {
+    Vacant {
+        block_height: u64,
+    },
+    Proposed {
+        block_height: u64,
+    },
+    Finalized {
+        block_height: u64,
+        era_id: EraId,
+    },
+    Incomplete {
+        block_height: u64,
+        block_hash: BlockHash,
+        era_id: EraId,
+    },
+    Complete {
+        block_height: u64,
+        block_hash: BlockHash,
+        era_id: EraId,
+        is_switch_block: bool,
+    },
+}
+
+// todo!("remove allow unused once integrated");
+#[allow(unused)]
+impl BlockChainEntry {
+    /// Create a vacant item
+    pub fn vacant(block_height: u64) -> Self {
+        BlockChainEntry::Vacant { block_height }
+    }
+
+    /// Create a new proposed item.
+    pub fn new_proposed(block_height: u64) -> Self {
+        BlockChainEntry::Proposed { block_height }
+    }
+
+    /// Create a new finalize item.
+    pub fn new_finalized(block_height: u64, era_id: EraId) -> Self {
+        BlockChainEntry::Finalized {
+            block_height,
+            era_id,
+        }
+    }
+
+    /// Create a new incomplete item.
+    pub fn new_incomplete(block_height: u64, block_hash: BlockHash, era_id: EraId) -> Self {
+        BlockChainEntry::Incomplete {
+            block_height,
+            block_hash,
+            era_id,
+        }
+    }
+
+    /// Create a new complete item.
+    pub fn new_complete(block_header: &BlockHeader) -> Self {
+        BlockChainEntry::Complete {
+            block_height: block_header.height(),
+            block_hash: block_header.block_hash(),
+            era_id: block_header.era_id(),
+            is_switch_block: block_header.is_switch_block(),
+        }
+    }
+
+    /// Get block height from item
+    pub fn block_height(&self) -> u64 {
+        match self {
+            BlockChainEntry::Vacant { block_height }
+            | BlockChainEntry::Proposed { block_height }
+            | BlockChainEntry::Finalized { block_height, .. }
+            | BlockChainEntry::Incomplete { block_height, .. }
+            | BlockChainEntry::Complete { block_height, .. } => *block_height,
+        }
+    }
+
+    /// Get block hash from item, if present.
+    pub fn block_hash(&self) -> Option<BlockHash> {
+        match self {
+            BlockChainEntry::Vacant { .. }
+            | BlockChainEntry::Proposed { .. }
+            | BlockChainEntry::Finalized { .. } => None,
+            BlockChainEntry::Incomplete { block_hash, .. }
+            | BlockChainEntry::Complete { block_hash, .. } => Some(*block_hash),
+        }
+    }
+
+    /// Get era id from item, if present.
+    pub fn era_id(&self) -> Option<EraId> {
+        match self {
+            BlockChainEntry::Vacant { .. } | BlockChainEntry::Proposed { .. } => None,
+            BlockChainEntry::Finalized { era_id, .. }
+            | BlockChainEntry::Incomplete { era_id, .. }
+            | BlockChainEntry::Complete { era_id, .. } => Some(*era_id),
+        }
+    }
+
+    /// Is this instance finalized or higher and in the imputed era?
+    pub fn is_definitely_in_era(&self, era_id: EraId) -> bool {
+        match self.era_id() {
+            Some(eid) => eid.eq(&era_id),
+            None => false,
+        }
+    }
+
+    /// Is this instance a switch block?
+    pub fn is_switch_block(&self) -> Option<bool> {
+        if let BlockChainEntry::Complete {
+            is_switch_block, ..
+        } = self
+        {
+            Some(*is_switch_block)
+        } else {
+            None
+        }
+    }
+
+    /// Is this instance complete and a switch block?
+    pub fn is_complete_switch_block(&self) -> bool {
+        match self {
+            BlockChainEntry::Vacant { .. }
+            | BlockChainEntry::Proposed { .. }
+            | BlockChainEntry::Finalized { .. }
+            | BlockChainEntry::Incomplete { .. } => false,
+            BlockChainEntry::Complete {
+                is_switch_block, ..
+            } => *is_switch_block,
+        }
+    }
+
+    /// All non-vacant entries.
+    pub fn all_non_vacant(&self) -> bool {
+        match self {
+            BlockChainEntry::Vacant { .. } => false,
+            BlockChainEntry::Proposed { .. }
+            | BlockChainEntry::Finalized { .. }
+            | BlockChainEntry::Incomplete { .. }
+            | BlockChainEntry::Complete { .. } => true,
+        }
+    }
+
+    /// All entries.
+    pub fn all(&self) -> bool {
+        true
+    }
+
+    /// Is this instance the vacant variant?
+    pub fn is_vacant(&self) -> bool {
+        matches!(self, BlockChainEntry::Vacant { .. })
+    }
+
+    /// Is this instance the proposed variant?
+    pub fn is_proposed(&self) -> bool {
+        matches!(self, BlockChainEntry::Proposed { .. })
+    }
+
+    /// Is this instance the finalized variant?
+    pub fn is_finalized(&self) -> bool {
+        matches!(self, BlockChainEntry::Finalized { .. })
+    }
+
+    /// Is this instance the incomplete variant?
+    pub fn is_incomplete(&self) -> bool {
+        matches!(self, BlockChainEntry::Incomplete { .. })
+    }
+
+    /// Is this instance the complete variant?
+    pub fn is_complete(&self) -> bool {
+        matches!(self, BlockChainEntry::Complete { .. })
+    }
+
+    pub fn status(&self) -> u8 {
+        match self {
+            BlockChainEntry::Vacant { .. } => 0,
+            BlockChainEntry::Proposed { .. } => 1,
+            BlockChainEntry::Finalized { .. } => 2,
+            BlockChainEntry::Incomplete { .. } => 3,
+            BlockChainEntry::Complete { .. } => 4,
+        }
+    }
+
+    pub fn higher_status(&self, other: &BlockChainEntry) -> Ordering {
+        self.status().cmp(&other.status())
+    }
+
+    pub fn higher_height_and_status(&self, other: &BlockChainEntry) -> Ordering {
+        let height_order = self.block_height().cmp(&other.block_height());
+        if height_order == Ordering::Greater {
+            return self.status().cmp(&other.status());
+        }
+        height_order
+    }
+}

--- a/node/src/types/block_chain/chain_index.rs
+++ b/node/src/types/block_chain/chain_index.rs
@@ -1,0 +1,339 @@
+use crate::types::{
+    block_chain::{indexed_block_chain::IndexedBlockChain, BlockChainEntry, Error},
+    BlockHash, BlockHeader, DataSize,
+};
+use casper_types::EraId;
+use itertools::Itertools;
+use std::collections::{btree_map::Entry, hash_map::Entry as HashEntry, BTreeMap, HashMap};
+
+/// Block index by height and reverse lookup (where known) by hash.
+#[derive(DataSize, Debug, Default)]
+pub(crate) struct ChainIndex {
+    chain: BTreeMap<u64, BlockChainEntry>,
+    index: HashMap<BlockHash, u64>,
+}
+
+impl ChainIndex {
+    /// Are the chain and by height index both empty?
+    pub(crate) fn is_empty(&self) -> bool {
+        self.chain.is_empty() && self.index.is_empty()
+    }
+
+    fn register(&mut self, item: BlockChainEntry) {
+        // don't waste mem on actual vacant entries
+        if item.is_vacant() {
+            return;
+        }
+        let block_height = item.block_height();
+        // maintain the reverse lookup by block_hash where able
+        if let Some(block_hash) = item.block_hash() {
+            match self.index.entry(block_hash) {
+                HashEntry::Occupied(entry) => {
+                    let val = entry.get();
+                    debug_assert!(
+                        val.eq(&block_height),
+                        "BlockChain: register existing block_height {} should match {}",
+                        val,
+                        block_height
+                    );
+                }
+                HashEntry::Vacant(vacant) => {
+                    vacant.insert(block_height);
+                }
+            }
+        }
+        // maintain the chain representation overlay
+        match self.chain.entry(block_height) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(item);
+            }
+            Entry::Occupied(mut entry) => {
+                let val = entry.get_mut();
+                *val = item;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn register_complete_from_parts(
+        &mut self,
+        block_height: u64,
+        block_hash: BlockHash,
+        era_id: EraId,
+        is_switch_block: bool,
+    ) {
+        let entry = BlockChainEntry::Complete {
+            block_height,
+            block_hash,
+            era_id,
+            is_switch_block,
+        };
+        self.register(entry);
+    }
+}
+
+impl IndexedBlockChain for ChainIndex {
+    fn remove(&mut self, block_height: u64) -> Option<BlockChainEntry> {
+        if let Some(entry) = self.chain.remove(&block_height) {
+            if let Some(block_hash) = entry.block_hash() {
+                let _ = self.index.remove(&block_hash);
+            }
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    fn register_proposed(&mut self, block_height: u64) -> Result<(), Error> {
+        if let Some(highest) = self.highest(BlockChainEntry::all_non_vacant) {
+            if false == highest.is_proposed() {
+                return Err(Error::AttemptToProposeAboveTail);
+            }
+        }
+        self.register(BlockChainEntry::new_proposed(block_height));
+        Ok(())
+    }
+
+    fn register_finalized(&mut self, block_height: u64, era_id: EraId) -> Result<(), Error> {
+        if self
+            .higher_by_status(BlockChainEntry::all_non_vacant)
+            .is_some()
+        {
+            return Err(Error::AttemptToFinalizeAboveTail);
+        }
+        self.register(BlockChainEntry::new_finalized(block_height, era_id));
+        Ok(())
+    }
+
+    fn register_incomplete(&mut self, block_height: u64, block_hash: BlockHash, era_id: EraId) {
+        self.register(BlockChainEntry::new_incomplete(
+            block_height,
+            block_hash,
+            era_id,
+        ));
+    }
+
+    fn register_complete(&mut self, block_header: &BlockHeader) {
+        self.register(BlockChainEntry::new_complete(block_header));
+    }
+
+    fn by_height(&self, block_height: u64) -> BlockChainEntry {
+        *self
+            .chain
+            .get(&block_height)
+            .unwrap_or(&BlockChainEntry::vacant(block_height))
+    }
+
+    fn by_hash(&self, block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        if let Some(height) = self.index.get(block_hash) {
+            return Some(self.by_height(*height));
+        }
+        None
+    }
+
+    fn by_parent(&self, parent_block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        if let Some(height) = self.index.get(parent_block_hash) {
+            return Some(self.by_height(height + 1));
+        }
+        None
+    }
+
+    fn by_child(&self, child_block_hash: &BlockHash) -> Option<BlockChainEntry> {
+        if let Some(height) = self.index.get(child_block_hash) {
+            if height.eq(&0) {
+                // genesis cannot have a parent
+                return None;
+            }
+            return Some(self.by_height(height.saturating_sub(1)));
+        }
+        None
+    }
+
+    fn switch_block_by_era(&self, era_id: EraId) -> Option<BlockChainEntry> {
+        self.chain
+            .values()
+            .find_or_first(|x| x.is_switch_block().unwrap_or(false) && x.era_id() == Some(era_id))
+            .cloned()
+    }
+
+    fn is_incomplete(&self, block_height: u64) -> bool {
+        self.chain
+            .get(&block_height)
+            .map(|b| b.is_incomplete())
+            .unwrap_or(false)
+    }
+
+    fn is_complete(&self, block_height: u64) -> bool {
+        self.chain
+            .get(&block_height)
+            .map(|b| b.is_complete())
+            .unwrap_or(false)
+    }
+
+    fn is_switch_block(&self, block_height: u64) -> Option<bool> {
+        self.chain
+            .get(&block_height)
+            .map(|b| b.is_switch_block())
+            .unwrap_or(None)
+    }
+
+    fn is_immediate_switch_block(&self, block_height: u64) -> Option<bool> {
+        if let Some(switch) = self.is_switch_block(block_height) {
+            if block_height == 0 {
+                // on legacy chains, first block is not a switch block,
+                // on post 1.5 chains it is, and is considered to be an
+                // immediate switch block though it has no parent as
+                // it is the head of the chain
+                return Some(true);
+            }
+            return if switch {
+                // immediate switch block == block @ height is switch && parent is also switch
+                self.is_switch_block(block_height.saturating_sub(1))
+            } else {
+                Some(false)
+            };
+        }
+        None
+    }
+
+    fn lowest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.chain
+            .values()
+            .filter(|x| predicate(x))
+            .min_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .cloned()
+    }
+
+    fn highest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.chain
+            .values()
+            .filter(|x| predicate(x))
+            .max_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .cloned()
+    }
+
+    fn higher_by_status<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.chain
+            .values()
+            .filter(|x| predicate(x))
+            .max_by(|x, y| x.higher_height_and_status(y))
+            .cloned()
+    }
+
+    fn lowest_switch_block(&self) -> Option<BlockChainEntry> {
+        self.chain
+            .values()
+            .filter(|x| x.is_complete() && x.is_switch_block().unwrap_or(false))
+            .min_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .cloned()
+    }
+
+    fn highest_switch_block(&self) -> Option<BlockChainEntry> {
+        self.chain
+            .values()
+            .filter(|x| x.is_complete() && x.is_switch_block().unwrap_or(false))
+            .max_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .cloned()
+    }
+
+    fn all_by<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        self.chain
+            .values()
+            .filter(|x| predicate(x))
+            .cloned()
+            .collect_vec()
+    }
+
+    fn lowest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        match self
+            .chain
+            .values()
+            .filter(|x| predicate(x))
+            .min_by(|x, y| x.block_height().cmp(&y.block_height()))
+        {
+            None => {
+                vec![]
+            }
+            Some(entry) => {
+                let mut ret = vec![*entry];
+                let mut idx = entry.block_height() + 1;
+                loop {
+                    let item = self.by_height(idx);
+                    if predicate(&item) {
+                        ret.push(item);
+                        idx += 1;
+                    } else {
+                        break;
+                    }
+                }
+                ret
+            }
+        }
+    }
+
+    fn highest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool,
+    {
+        match self
+            .chain
+            .values()
+            .filter(|x| predicate(x))
+            .max_by(|x, y| x.block_height().cmp(&y.block_height()))
+        {
+            None => {
+                vec![]
+            }
+            Some(entry) => {
+                let mut ret = vec![*entry];
+                let mut idx = entry.block_height() - 1;
+                loop {
+                    let item = self.by_height(idx);
+                    if predicate(&item) {
+                        ret.push(item);
+                        idx -= 1;
+                    } else {
+                        break;
+                    }
+                }
+                ret
+            }
+        }
+    }
+
+    fn range(&self, lbound: Option<u64>, ubound: Option<u64>) -> Vec<BlockChainEntry> {
+        let mut ret = vec![];
+        if self.chain.is_empty() {
+            return ret;
+        }
+        let low = lbound.unwrap_or(0);
+        let hi = ubound.unwrap_or(*self.chain.keys().max().unwrap_or(&0));
+        if low > hi {
+            return ret;
+        }
+        for height in low..=hi {
+            match self.chain.get(&height) {
+                None => {
+                    ret.push(BlockChainEntry::vacant(height));
+                }
+                Some(entry) => ret.push(*entry),
+            }
+        }
+        ret
+    }
+}

--- a/node/src/types/block_chain/error.rs
+++ b/node/src/types/block_chain/error.rs
@@ -1,0 +1,6 @@
+/// BlockChain errors.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    AttemptToProposeAboveTail,
+    AttemptToFinalizeAboveTail,
+}

--- a/node/src/types/block_chain/indexed_block_chain.rs
+++ b/node/src/types/block_chain/indexed_block_chain.rs
@@ -1,0 +1,67 @@
+use crate::types::{
+    block_chain::{BlockChainEntry, Error},
+    BlockHash, BlockHeader,
+};
+use casper_types::EraId;
+
+/// API for a block chain representation with block_height indexed lookup.
+pub trait IndexedBlockChain {
+    /// Remove an item by block height.
+    fn remove(&mut self, block_height: u64) -> Option<BlockChainEntry>;
+    /// Register a block that is proposed.
+    fn register_proposed(&mut self, block_height: u64) -> Result<(), Error>;
+    /// Register a block that is finalized.
+    fn register_finalized(&mut self, block_height: u64, era_id: EraId) -> Result<(), Error>;
+    /// Register a block that is not yet complete.
+    fn register_incomplete(&mut self, block_height: u64, block_hash: BlockHash, era_id: EraId);
+    /// Register a block that has been marked complete.
+    fn register_complete(&mut self, block_header: &BlockHeader);
+    /// Returns entry by height, if present.
+    fn by_height(&self, block_height: u64) -> BlockChainEntry;
+    /// Return entry by hash, if present.
+    fn by_hash(&self, block_hash: &BlockHash) -> Option<BlockChainEntry>;
+    /// Returns entry of child, if present.
+    fn by_parent(&self, parent_block_hash: &BlockHash) -> Option<BlockChainEntry>;
+    /// Returns entry of parent, if present.
+    fn by_child(&self, child_block_hash: &BlockHash) -> Option<BlockChainEntry>;
+    /// Is switch block and is in imputed era?
+    fn switch_block_by_era(&self, era_id: EraId) -> Option<BlockChainEntry>;
+    /// Is block at height incomplete?
+    fn is_incomplete(&self, block_height: u64) -> bool;
+    /// Is block at height complete?
+    fn is_complete(&self, block_height: u64) -> bool;
+    /// Is block at height a switch block?
+    fn is_switch_block(&self, block_height: u64) -> Option<bool>;
+    /// Is block at height an immediate switch block?
+    fn is_immediate_switch_block(&self, block_height: u64) -> Option<bool>;
+    /// Returns the lowest entry (by block height) where the predicate is true, if any.
+    fn lowest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns the highest entry (by block height) where the predicate is true, if any.
+    fn highest<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns the highest entry (by block height) where the predicate is true, if any.
+    fn higher_by_status<F>(&self, predicate: F) -> Option<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns the lowest switch block entry, if any.
+    fn lowest_switch_block(&self) -> Option<BlockChainEntry>;
+    /// Returns the highest switch block entry, if any.
+    fn highest_switch_block(&self) -> Option<BlockChainEntry>;
+    /// Returns all actual entries where the predicate is true, if any.
+    fn all_by<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns the highest entry (by block height) where the predicate is true, if any.
+    fn lowest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns the highest entry (by block height) where the predicate is true, if any.
+    fn highest_sequence<F>(&self, predicate: F) -> Vec<BlockChainEntry>
+    where
+        F: Fn(&BlockChainEntry) -> bool;
+    /// Returns a range, including vacancies.
+    fn range(&self, lbound: Option<u64>, ubound: Option<u64>) -> Vec<BlockChainEntry>;
+}

--- a/node/src/types/block_chain/tests.rs
+++ b/node/src/types/block_chain/tests.rs
@@ -1,0 +1,600 @@
+//! Tests for the `block_chain` type.
+#![cfg(test)]
+
+use crate::types::{
+    block_chain::{
+        block_chain_entry::BlockChainEntry, indexed_block_chain::IndexedBlockChain, BlockChain,
+        Error,
+    },
+    Block, BlockHash,
+};
+use casper_types::{testing::TestRng, EraId};
+use num_traits::FromPrimitive;
+use std::collections::HashMap;
+
+#[test]
+fn should_construct_empty() {
+    let block_chain = BlockChain::new();
+    assert!(block_chain.is_empty(), "should ctor with empty chain");
+}
+
+#[test]
+fn should_be_vacant() {
+    let block_chain = BlockChain::new();
+    assert_eq!(
+        block_chain.by_height(0),
+        BlockChainEntry::vacant(0),
+        "should be vacant"
+    );
+}
+
+#[test]
+fn should_be_proposed() {
+    let mut block_chain = BlockChain::new();
+    assert!(
+        block_chain.register_proposed(0).is_ok(),
+        "should register proposed"
+    );
+    assert_eq!(
+        block_chain.by_height(0),
+        BlockChainEntry::new_proposed(0),
+        "should be proposed"
+    );
+}
+
+#[test]
+fn should_be_finalized() {
+    let mut block_chain = BlockChain::new();
+    assert!(
+        block_chain.register_finalized(0, EraId::new(0)).is_ok(),
+        "should register finalized"
+    );
+    assert_eq!(
+        block_chain.by_height(0),
+        BlockChainEntry::new_finalized(0, EraId::new(0)),
+        "should be finalized"
+    );
+}
+
+#[test]
+fn should_be_incomplete() {
+    let mut block_chain = BlockChain::new();
+    let block_hash = BlockHash::default();
+    block_chain.register_incomplete(0, block_hash, EraId::new(0));
+    assert_eq!(
+        block_chain.by_height(0),
+        BlockChainEntry::new_incomplete(0, block_hash, EraId::new(0)),
+        "should be incomplete"
+    );
+}
+
+#[test]
+fn should_be_complete() {
+    let mut block_chain = BlockChain::new();
+    let mut rng = TestRng::new();
+    let block_header = {
+        let tmp = Block::random(&mut rng);
+        tmp.header().clone()
+    };
+    block_chain.register_complete(&block_header);
+    assert_eq!(
+        block_chain.by_height(block_header.height()),
+        BlockChainEntry::new_complete(&block_header),
+        "should be complete"
+    );
+}
+
+#[test]
+fn should_recognize_higher_status() {
+    let mut entries = HashMap::new();
+    let mut inserter = |bce: BlockChainEntry| {
+        entries.insert(bce.status(), bce);
+    };
+    inserter(BlockChainEntry::vacant(0));
+    inserter(BlockChainEntry::new_proposed(0));
+    inserter(BlockChainEntry::new_finalized(0, EraId::new(0)));
+
+    let mut rng = TestRng::new();
+    let block_header = {
+        let tmp = Block::random(&mut rng);
+        tmp.header().clone()
+    };
+    inserter(BlockChainEntry::new_incomplete(
+        block_header.height(),
+        block_header.block_hash(),
+        EraId::new(0),
+    ));
+    inserter(BlockChainEntry::new_complete(&block_header));
+    let max = entries.keys().max().expect("should have entries");
+    for key in entries.keys() {
+        if key == max {
+            break;
+        }
+        let x = entries.get(key).expect("x should exist");
+        let y = entries.get(&(key + 1)).expect("y should exist");
+        assert!(x.status() < y.status(), "should be lower status");
+    }
+}
+
+#[test]
+fn should_find_by_hash() {
+    let mut block_chain = BlockChain::new();
+    let mut rng = TestRng::new();
+    let block_header1 = {
+        let tmp = Block::random(&mut rng);
+        tmp.header().clone()
+    };
+    block_chain.register_complete(&block_header1);
+    assert_eq!(
+        block_chain.by_hash(&block_header1.block_hash()),
+        Some(BlockChainEntry::new_complete(&block_header1)),
+        "should find complete block by hash"
+    );
+    let block_header2 = {
+        let tmp = Block::random(&mut rng);
+        tmp.header().clone()
+    };
+    block_chain.register_incomplete(
+        block_header2.height(),
+        block_header2.block_hash(),
+        EraId::new(0),
+    );
+    assert_eq!(
+        block_chain.by_hash(&block_header2.block_hash()),
+        Some(BlockChainEntry::new_incomplete(
+            block_header2.height(),
+            block_header2.block_hash(),
+            EraId::new(0)
+        )),
+        "should find incomplete block by hash"
+    );
+}
+
+#[test]
+fn should_not_find_by_hash() {
+    let mut block_chain = BlockChain::new();
+    let block_hash = BlockHash::default();
+    assert!(block_chain.register_proposed(0).is_ok(), "should be ok");
+    assert_eq!(
+        block_chain.by_hash(&block_hash),
+        None,
+        "proposed should not be indexed by hash"
+    );
+    let _ = block_chain.register_finalized(1, EraId::new(1));
+    assert_eq!(
+        block_chain.by_hash(&block_hash),
+        None,
+        "finalized should not be indexed by hash"
+    );
+}
+
+#[test]
+fn should_remove() {
+    let mut block_chain = BlockChain::new();
+    let block_height = 0;
+    assert!(
+        block_chain.remove(block_height).is_none(),
+        "nothing to remove"
+    );
+    assert!(
+        block_chain.register_proposed(block_height).is_ok(),
+        "should be ok"
+    );
+    assert!(false == block_chain.is_empty(), "chain should not be empty");
+    let removed = block_chain.remove(block_height).expect("should exist");
+    assert_eq!(removed.block_height(), block_height, "removed wrong item");
+    assert!(block_chain.is_empty(), "chain should be empty");
+}
+
+#[test]
+fn should_remove_index() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let block_height = 0;
+    block_chain.register_complete_from_parts(
+        block_height,
+        BlockHash::random(&mut rng),
+        EraId::from(0),
+        false,
+    );
+    assert!(false == block_chain.is_empty(), "chain should not be empty");
+    let removed = block_chain.remove(block_height).expect("should exist");
+    assert_eq!(removed.block_height(), block_height, "removed wrong item");
+    assert!(block_chain.is_empty(), "chain should be empty");
+}
+
+fn irregular_sequence(lbound: u64, ubound: u64, start_break: u64, end_break: u64) -> BlockChain {
+    let mut block_chain = BlockChain::new();
+    for height in lbound..=ubound {
+        if height >= start_break && height <= end_break {
+            let _ = block_chain.register_finalized(height, EraId::new(0));
+            continue;
+        }
+        assert!(
+            block_chain.register_proposed(height).is_ok(),
+            "should be ok {}",
+            height
+        );
+    }
+    block_chain
+}
+
+#[test]
+fn should_find_low_sequence() {
+    let lbound = 0;
+    let ubound = 14;
+    let start_break = 5;
+    let block_chain = irregular_sequence(lbound, ubound, start_break, ubound - start_break);
+    let low = block_chain.lowest_sequence(BlockChainEntry::is_proposed);
+    assert!(false == low.is_empty(), "sequence should not be empty");
+    assert_eq!(
+        low.iter()
+            .min_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .expect("should have entry")
+            .block_height(),
+        lbound,
+        "expected first entry by predicate"
+    );
+    assert_eq!(
+        low.iter()
+            .max_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .expect("should have entry")
+            .block_height(),
+        start_break - 1,
+        "expected last entry by predicate"
+    );
+}
+
+#[test]
+fn should_find_high_sequence() {
+    let lbound = 0;
+    let ubound = 14;
+    let start_break = 5;
+    let block_chain = irregular_sequence(lbound, ubound, start_break, ubound - start_break);
+    let hi = block_chain.highest_sequence(BlockChainEntry::is_proposed);
+    assert!(false == hi.is_empty(), "sequence should not be empty");
+    assert_eq!(
+        hi.iter()
+            .min_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .expect("should have entry")
+            .block_height(),
+        ubound - start_break + 1,
+        "expected first entry by predicate"
+    );
+    assert_eq!(
+        hi.iter()
+            .max_by(|x, y| x.block_height().cmp(&y.block_height()))
+            .expect("should have entry")
+            .block_height(),
+        ubound,
+        "expected last entry by predicate"
+    );
+}
+
+fn complete_with_switches<F>(
+    start: u64,
+    end: u64,
+    blocks_per_era: u64,
+    is_switch_block: F,
+) -> BlockChain
+where
+    F: FnOnce(u64) -> bool + Copy,
+{
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let mut era_id = EraId::new(start / blocks_per_era);
+    let mut change_era = false;
+    for height in start..=end {
+        if change_era {
+            era_id = era_id.successor();
+        }
+        let switch = is_switch_block(height);
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            switch,
+        );
+        change_era = switch;
+    }
+    block_chain
+}
+
+#[test]
+fn should_find_switch_blocks() {
+    let (start, end, blocks_per_era) = (0, 10, 5);
+    let block_chain = complete_with_switches(start, end, blocks_per_era, |h: u64| {
+        h == start || h % blocks_per_era == 0
+    });
+    assert_eq!(
+        block_chain
+            .lowest(BlockChainEntry::is_complete_switch_block)
+            .expect("should have switch blocks")
+            .block_height(),
+        start,
+        "block at height {} should be lowest switch",
+        start
+    );
+    assert_eq!(
+        block_chain
+            .highest(BlockChainEntry::is_complete_switch_block)
+            .expect("should have switch blocks")
+            .block_height(),
+        end,
+        "block at height {} should be highest switch",
+        end
+    );
+    let actual: u64 = u64::from_usize(
+        block_chain
+            .all_by(BlockChainEntry::is_complete_switch_block)
+            .len(),
+    )
+    .expect("should have value");
+    let expected = end / blocks_per_era + 1;
+    assert_eq!(actual, expected, "unexpected number of switch blocks");
+}
+
+#[test]
+fn should_find_immediate_switch_blocks() {
+    let (start, end, blocks_per_era) = (0, 10, 5);
+    let block_chain = complete_with_switches(start, end, blocks_per_era, |h: u64| {
+        h == 0 || h % blocks_per_era == 0 || h - 1 % blocks_per_era == 0
+    });
+    for height in start..=end {
+        let expected = Some(height == 0 || height - 1 % blocks_per_era == 0);
+        let actual = block_chain.is_immediate_switch_block(height);
+        assert_eq!(
+            expected, actual,
+            "at height {} expected: {:?} actual: {:?}",
+            height, expected, actual
+        );
+    }
+}
+
+#[test]
+fn should_find_switch_block_by_era() {
+    let (start, end, blocks_per_era) = (0, 15, 5);
+    let block_chain = complete_with_switches(start, end, blocks_per_era, |h: u64| {
+        h == start || h % blocks_per_era == 0
+    });
+    let all_switch_blocks = block_chain.all_by(BlockChainEntry::is_complete_switch_block);
+    let expected_era_count = end / blocks_per_era + 1;
+    let actual_era_count: u64 = u64::from_usize(all_switch_blocks.len()).expect("should convert");
+    assert_eq!(
+        expected_era_count, actual_era_count,
+        "should have {} switch blocks but found {}",
+        expected_era_count, actual_era_count
+    );
+    for era_id in start..=expected_era_count {
+        assert!(
+            block_chain
+                .switch_block_by_era(EraId::new(era_id))
+                .is_some(),
+            "should have era entry for {}",
+            era_id
+        );
+    }
+}
+
+#[test]
+fn should_find_blocks_by_era() {
+    let (start, end, blocks_per_era) = (0, 15, 5);
+    let block_chain = complete_with_switches(start, end, blocks_per_era, |h: u64| {
+        h == start || h % blocks_per_era == 0
+    });
+    let expected_era_count = end / blocks_per_era;
+    // era 0 only has genesis
+    for era_id in 1..=expected_era_count {
+        let all_in_era = block_chain.all_by(|bce| bce.is_definitely_in_era(EraId::new(era_id)));
+        let actual = u64::from_usize(all_in_era.len()).expect("should have value");
+        assert_eq!(
+            blocks_per_era, actual,
+            "should have {} blocks per era but found {}",
+            blocks_per_era, actual
+        );
+    }
+}
+
+#[test]
+fn should_find_by_parent() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    for height in 0..5 {
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    for height in 0..4 {
+        let parent = block_chain.by_height(height);
+        assert!(parent.is_complete(), "should be complete");
+        let child = block_chain
+            .by_parent(&parent.block_hash().expect("should have block_hash"))
+            .expect("should have child");
+        assert_eq!(
+            child.block_height().saturating_sub(1),
+            parent.block_height(),
+            "invalid child detected"
+        )
+    }
+}
+
+#[test]
+fn should_find_by_child() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    for height in 0..5 {
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    for height in (1..5).rev() {
+        let child = block_chain.by_height(height);
+        assert!(child.is_complete(), "should be complete");
+        let parent = block_chain
+            .by_child(&child.block_hash().expect("should have block_hash"))
+            .expect("should have child");
+        assert_eq!(
+            parent.block_height() + 1,
+            child.block_height(),
+            "invalid child detected"
+        )
+    }
+}
+
+#[test]
+fn should_have_childless_tail() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    for height in 0..5 {
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    let highest = block_chain
+        .highest(BlockChainEntry::all_non_vacant)
+        .expect("should have some");
+    let child = block_chain
+        .by_parent(&highest.block_hash().expect("should have block_hash"))
+        .expect("should return vacant entry");
+    assert!(child.is_vacant(), "tail should not have child");
+}
+
+#[test]
+fn should_have_parentless_head() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    for height in 0..5 {
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    let lowest = block_chain
+        .lowest(BlockChainEntry::all_non_vacant)
+        .expect("should have some");
+    let parent = block_chain.by_child(&lowest.block_hash().expect("should have block_hash"));
+    assert!(parent.is_none(), "head should not have parent");
+}
+
+#[test]
+fn should_not_allow_proposed_with_higher_status_descendants() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    let block_to_skip = 3;
+    for height in 0..5 {
+        if height == block_to_skip {
+            continue;
+        }
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    let result = block_chain.register_proposed(block_to_skip);
+    assert_eq!(
+        Err(Error::AttemptToProposeAboveTail),
+        result,
+        "should detect non-tail proposal"
+    )
+}
+
+#[test]
+fn should_not_allow_finalized_with_higher_status_descendants() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let era_id = EraId::new(0);
+    let block_to_skip = 3;
+    for height in 0..5 {
+        if height == block_to_skip {
+            continue;
+        }
+        block_chain.register_complete_from_parts(
+            height,
+            BlockHash::random(&mut rng),
+            era_id,
+            false,
+        );
+    }
+    let result = block_chain.register_finalized(block_to_skip, era_id);
+    assert_eq!(
+        Err(Error::AttemptToFinalizeAboveTail),
+        result,
+        "should detect non-tail finalization"
+    )
+}
+
+#[test]
+fn should_find_all_actual_entries() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let mut expected = vec![];
+    for height in 5..15 {
+        if (8..10).contains(&height) {
+            continue;
+        }
+        let block_hash = BlockHash::random(&mut rng);
+        block_chain.register_incomplete(height, block_hash, EraId::new(0));
+        expected.push(BlockChainEntry::new_incomplete(
+            height,
+            block_hash,
+            EraId::new(0),
+        ));
+    }
+    let all = block_chain.all_by(BlockChainEntry::all);
+    assert_eq!(expected, all, "should have actual entries only");
+}
+
+#[test]
+fn should_find_all_virtual_entries() {
+    let mut rng = TestRng::new();
+    let mut block_chain = BlockChain::new();
+    let mut expected = vec![];
+    let lbound = 0;
+    let ubound = 14;
+    for height in lbound..=ubound {
+        if height == 0 || height % 2 == 0 {
+            expected.push(BlockChainEntry::Vacant {
+                block_height: height,
+            });
+            continue;
+        }
+        let block_hash = BlockHash::random(&mut rng);
+        block_chain.register_incomplete(height, block_hash, EraId::new(0));
+        expected.push(BlockChainEntry::new_incomplete(
+            height,
+            block_hash,
+            EraId::new(0),
+        ));
+    }
+    let all = block_chain.all_by(BlockChainEntry::all);
+    let range = block_chain.range(Some(lbound), Some(ubound));
+    assert!(all.len() < range.len(), "all should not include vacancies");
+    assert_ne!(all, range, "range should include vacancies");
+    assert_eq!(expected, range, "should have entire range");
+    let range = block_chain.range(None, Some(ubound));
+    assert_eq!(expected, range, "should have entire range default lbound");
+
+    expected.pop(); // get rid of tail vacancy
+    let range = block_chain.range(Some(lbound), None);
+    assert_eq!(expected, range, "should have entire range default ubound");
+    let range = block_chain.range(None, None);
+    assert_eq!(expected, range, "should have entire range unbounded");
+}


### PR DESCRIPTION
Initial def for a block_chain representation meant to be shared between relevant components (similar to validator_matrix), with tests. Interface will likely evolve further for edge cases encountered while integrating w/ components but I think I've captured the obvious / known behaviors sufficiently to stop cutting bait and start fishing (i.e. begin integration).