### PR TITLE
adjustment for non-validating nodes who join network prior to genesis

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -906,7 +906,7 @@ where
                     nonce,
                     span,
                 } => span.in_scope(|| {
-                    debug!("enqueuing ping to be sent");
+                    trace!("enqueuing ping to be sent");
                     self.send_message(peer_id, Arc::new(Message::Ping { nonce }), None);
                 }),
             }

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -558,7 +558,7 @@ where
         span.clone()
             .in_scope(move || match self.outgoing.entry(addr) {
                 Entry::Occupied(_) => {
-                    debug!("ignoring already known address");
+                    trace!("ignoring already known address");
                     None
                 }
                 Entry::Vacant(_vacant) => {
@@ -789,7 +789,7 @@ where
                             // Nothing to do.
                         }
                         HealthCheckOutcome::SendPing(nonce) => {
-                            debug!(%nonce, "sending ping");
+                            trace!(%nonce, "sending ping");
                             to_ping.push((peer_id, addr, nonce));
                         }
                         HealthCheckOutcome::GiveUp => {

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -288,18 +288,18 @@ impl MainReactor {
         rng: &mut NodeRng,
     ) -> Option<KeepUpInstruction> {
         let sync_back_progress = self.block_synchronizer.historical_progress();
-        debug!(?sync_back_progress, "historical: sync back progress");
+        debug!(?sync_back_progress, "KeepUp: historical sync back progress");
         self.update_last_progress(&sync_back_progress, true);
         match self.sync_back_instruction(&sync_back_progress) {
             Ok(Some(sync_back_instruction)) => match sync_back_instruction {
                 SyncBackInstruction::TtlSynced | SyncBackInstruction::GenesisSynced => {
                     // we don't need to sync any historical blocks currently
-                    debug!("historical: synced to TTL or Genesis");
+                    debug!("KeepUp: synced to TTL or Genesis");
                     self.block_synchronizer.purge_historical();
                     None
                 }
                 SyncBackInstruction::Syncing => {
-                    debug!("historical: syncing; checking later");
+                    debug!("KeepUp: syncing historical; checking later");
                     Some(KeepUpInstruction::CheckLater(
                         format!("historical {}", SyncBackInstruction::Syncing),
                         self.control_logic_default_delay.into(),
@@ -310,7 +310,7 @@ impl MainReactor {
                     maybe_parent_metadata,
                     era_id,
                 } => {
-                    debug!(%parent_hash, ?era_id, validator_matrix_eras=?self.validator_matrix.eras(), "historical: sync back instruction");
+                    debug!(%parent_hash, ?era_id, validator_matrix_eras=?self.validator_matrix.eras(), "KeepUp: historical sync back instruction");
                     match (
                         self.validator_matrix.has_era(&era_id),
                         maybe_parent_metadata,
@@ -447,16 +447,23 @@ impl MainReactor {
         // may or may not know the validator set for that era to validate finality
         // signatures against. we use the leaper to gain awareness of the necessary
         // trusted ancestors to our earliest contiguous block to do necessary validation.
-        let leap_status = self.sync_leaper.leap_status();
-        info!(%parent_hash, %leap_status, "historical status");
-        debug!(?parent_hash, ?leap_status, "historical sync back state");
-        match leap_status {
+        let sync_back_status = self.sync_leaper.leap_status();
+        info!(
+            "KeepUp: historical sync back status {} {}",
+            parent_hash, sync_back_status
+        );
+        debug!(
+            ?parent_hash,
+            ?sync_back_status,
+            "KeepUp: historical sync back status"
+        );
+        match sync_back_status {
             LeapState::Idle => {
-                debug!("historical: sync leaper idle");
+                debug!("KeepUp: historical sync back idle");
                 self.sync_back_leaper_idle(effect_builder, rng, parent_hash, Duration::ZERO)
             }
             LeapState::Awaiting { .. } => KeepUpInstruction::CheckLater(
-                "historical sync leaper is awaiting response".to_string(),
+                "KeepUp: historical sync back is awaiting response".to_string(),
                 self.control_logic_default_delay.into(),
             ),
             LeapState::Received {
@@ -479,7 +486,7 @@ impl MainReactor {
     ) -> KeepUpInstruction {
         warn!(
             %error,
-            "historical: failed leap",
+            "KeepUp: failed historical sync back",
         );
         self.sync_back_leaper_idle(
             effect_builder,
@@ -532,20 +539,20 @@ impl MainReactor {
         }
         let block_hash = sync_leap.highest_block_hash();
         let block_height = sync_leap.highest_block_height();
-        info!(%sync_leap, %block_height, %block_hash, "historical: leap received");
+        info!(%sync_leap, %block_height, %block_hash, "KeepUp: historical sync_back received");
 
         let era_validator_weights =
             sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
         for evw in era_validator_weights {
             let era_id = evw.era_id();
-            debug!(%era_id, "historical: attempt to register validators for era");
+            debug!(%era_id, "KeepUp: attempt to register historical validators for era");
             if self.validator_matrix.register_era_validator_weights(evw) {
-                info!(%era_id, "historical: got era");
+                info!("KeepUp: got historical era {}", era_id);
             } else {
-                debug!(%era_id, "historical: era already present or is not relevant");
+                debug!(%era_id, "KeepUp: historical era already present or is not relevant");
             }
         }
-        KeepUpInstruction::CheckLater("historical sync leap received".to_string(), Duration::ZERO)
+        KeepUpInstruction::CheckLater("historical sync back received".to_string(), Duration::ZERO)
     }
 
     fn sync_back_register(
@@ -567,7 +574,7 @@ impl MainReactor {
                 self.chainspec.core_config.simultaneous_peer_requests as usize,
             );
             debug!(
-                "historical: register_block_by_hash: {} peers count: {:?}",
+                "KeepUp: historical register_block_by_hash: {} peers count: {:?}",
                 parent_hash,
                 peers_to_ask.len()
             );
@@ -595,7 +602,7 @@ impl MainReactor {
             block_synchronizer_progress,
             BlockSynchronizerProgress::Syncing(_, _, _)
         ) {
-            debug!("historical: still syncing");
+            debug!("KeepUp: still syncing historical block");
             return Ok(Some(SyncBackInstruction::Syncing));
         }
         // in this flow there is no significant difference between Idle & Synced, as unlike in
@@ -612,7 +619,7 @@ impl MainReactor {
                     return Ok(Some(SyncBackInstruction::TtlSynced));
                 }
                 let parent_hash = block_header.parent_hash();
-                debug!(?block_header, %parent_hash, "historical: highest orphaned block");
+                debug!(?block_header, %parent_hash, "KeepUp: highest orphaned historical block");
                 match self.storage.read_block_header(parent_hash) {
                     Ok(Some(parent_block_header)) => {
                         // even if we don't have a complete block (all parts and dependencies)
@@ -643,7 +650,7 @@ impl MainReactor {
                         debug!(
                             ?parent_block_header,
                             ?maybe_parent_metadata,
-                            "historical: found parent block header in storage"
+                            "KeepUp: found parent block header for historical block in storage"
                         );
                         Ok(Some(SyncBackInstruction::Sync {
                             parent_hash: parent_block_header.block_hash(),
@@ -652,7 +659,7 @@ impl MainReactor {
                         }))
                     }
                     Ok(None) => {
-                        debug!(%parent_hash, "historical: did not find block header in storage");
+                        debug!(%parent_hash, "KeepUp: did not find historical block header in storage");
                         let era_id = match block_header.era_id().predecessor() {
                             None => EraId::from(0),
                             Some(predecessor) => {
@@ -675,15 +682,15 @@ impl MainReactor {
                 }
             }
             HighestOrphanedBlockResult::MissingFromBlockHeightIndex(block_height) => Err(format!(
-                "historical: storage is missing block height index entry {}",
+                "KeepUp: storage is missing historical block height index entry {}",
                 block_height
             )),
             HighestOrphanedBlockResult::MissingHeader(block_hash) => Err(format!(
-                "historical: storage is missing block header for {}",
+                "KeepUp: storage is missing historical block header for {}",
                 block_hash
             )),
             HighestOrphanedBlockResult::MissingHighestSequence => {
-                Err("historical: storage is missing highest block sequence".to_string())
+                Err("KeepUp: storage is missing historical highest block sequence".to_string())
             }
         }
     }

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -82,11 +82,10 @@ impl MainReactor {
             Some(header) => header,
         };
         debug!(
-            state = %self.state,
             era = highest_switch_block_header.era_id().value(),
             block_hash = %highest_switch_block_header.block_hash(),
             height = highest_switch_block_header.height(),
-            "highest_switch_block_header"
+            "{}: highest_switch_block_header", self.state
         );
 
         if let Some(current_era) = self.consensus.current_era() {
@@ -108,7 +107,10 @@ impl MainReactor {
             Some(weights) => weights,
         };
         if !highest_era_weights.contains_key(self.consensus.public_key()) {
-            info!(state = %self.state,"highest_era_weights does not contain signing_public_key");
+            info!(
+                "{}: highest_era_weights does not contain signing_public_key",
+                self.state
+            );
             return Ok(None);
         }
 
@@ -116,15 +118,22 @@ impl MainReactor {
             .deploy_buffer
             .have_full_ttl_of_deploys(highest_switch_block_header)
         {
-            debug!(state = %self.state,"sufficient deploy TTL awareness to safely participate in consensus");
+            debug!(%self.state,"{}: sufficient deploy TTL awareness to safely participate in consensus", self.state);
         } else {
-            info!(state = %self.state,"insufficient deploy TTL awareness to safely participate in consensus");
+            info!(
+                "{}: insufficient deploy TTL awareness to safely participate in consensus",
+                self.state
+            );
             return Ok(None);
         }
 
         let era_id = highest_switch_block_header.era_id();
         if self.upgrade_watcher.should_upgrade_after(era_id) {
-            info!(state = %self.state, era_id = era_id.value(), "upgrade required after given era");
+            info!(
+                "{}: upgrade required after era {}",
+                self.state,
+                era_id.value()
+            );
             return Ok(None);
         }
 

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -10,7 +10,7 @@ use datasize::DataSize;
 use itertools::Itertools;
 use num_rational::Ratio;
 use serde::Serialize;
-use tracing::debug;
+use tracing::info;
 
 use casper_types::{EraId, PublicKey, SecretKey, U512};
 
@@ -110,7 +110,7 @@ impl ValidatorMatrix {
                 validators.validator_weights,
                 validators.finality_threshold_fraction,
             ));
-            debug!("Validator Matrix: Inferred validator weights for Era 0 from weights in Era 1");
+            info!("ValidatorMatrix: Inferred validator weights for Era 0 from weights in Era 1");
         }
         was_present
     }


### PR DESCRIPTION
non-validating nodes present prior to the genesis timestamp should go to CatchUp, not KeepUp after committing genesis immediate switch block. also, tuning log noise. 
