### PR TITLE
Update openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,9 +2834,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2875,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+## 1.4.14
+
+### Changed
+* Update `openssl` and `openssl-sys` to latest versions.
+
+### Fixed
+* Fix issue in BlockValidator inhibiting the use of fallback peers to fetch missing deploys.
+
+
 
 ## 1.4.13
  


### PR DESCRIPTION
This PR updates `openssl` and `openssl-sys` in response to the latest security advisories ([RUSTSEC-2023-0022](https://rustsec.org/advisories/RUSTSEC-2023-0022.html), [RUSTSEC-2023-0023](https://rustsec.org/advisories/RUSTSEC-2023-0023.html) and [RUSTSEC-2023-0024](https://rustsec.org/advisories/RUSTSEC-2023-0024.html)).

Closes #3786.
