### PR TITLE
3776: Added tests for signature acquisition

### DIFF
--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -109,3 +109,317 @@ impl SignatureAcquisition {
         self.signature_weight
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, fmt::Debug};
+
+    use super::*;
+    use crate::types::BlockHash;
+    use assert_matches::assert_matches;
+    use casper_types::{testing::TestRng, EraId, SecretKey, U512};
+    use itertools::Itertools;
+    use num_rational::Ratio;
+    use rand::Rng;
+
+    fn validators(rng: &mut TestRng, n: usize) -> Vec<(PublicKey, SecretKey)> {
+        (0..n)
+            .map(|_| {
+                let secret = SecretKey::random(rng);
+                let public = PublicKey::from(&secret);
+
+                (public, secret)
+            })
+            .collect()
+    }
+
+    fn assert_equal<T: Ord + Debug>(
+        left: impl IntoIterator<Item = T>,
+        right: impl IntoIterator<Item = T>,
+    ) {
+        let left: BTreeSet<_> = left.into_iter().collect();
+        let right: BTreeSet<_> = right.into_iter().collect();
+
+        itertools::assert_equal(left, right);
+    }
+
+    #[test]
+    fn apply_signature_has_the_expected_behavior_highway_finality() {
+        let rng = &mut TestRng::new();
+        let validators = validators(rng, 4);
+        let block_hash = BlockHash::random(rng);
+        let era_id = EraId::new(rng.gen());
+        let weights = EraValidatorWeights::new(
+            era_id,
+            validators
+                .iter()
+                .enumerate()
+                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
+                .collect(),
+            Ratio::new(1, 3), // Highway finality
+        );
+        assert_eq!(U512::from(10), weights.get_total_weight());
+        let mut signature_acquisition =
+            SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
+
+        // Signature for the validator #0 weighting 1:
+        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(signature_acquisition.have_signatures(), [public_0]);
+        assert_equal(signature_acquisition.not_vacant(), [public_0]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Insufficient
+        );
+
+        // Signature for the validator #2 weighting 3:
+        let (public_2, secret_2) = validators.iter().nth(2).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2],
+        );
+        assert_equal(signature_acquisition.not_vacant(), [public_0, public_2]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 4/10, which is higher than 1/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Weak
+        );
+
+        // Signature for the validator #3 weighting 4:
+        let (public_3, secret_3) = validators.iter().nth(3).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2, public_3],
+        );
+        assert_equal(
+            signature_acquisition.not_vacant(),
+            [public_0, public_2, public_3],
+        );
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 8/10, which is higher than 2/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Strict
+        );
+    }
+
+    #[test]
+    fn apply_signature_has_the_expected_behavior_low_finality() {
+        let rng = &mut TestRng::new();
+        let validators = validators(rng, 4);
+        let block_hash = BlockHash::random(rng);
+        let era_id = EraId::new(rng.gen());
+        let weights = EraValidatorWeights::new(
+            era_id,
+            validators
+                .iter()
+                .enumerate()
+                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
+                .collect(),
+            Ratio::new(1, 10), // Low finality threshold
+        );
+        assert_eq!(U512::from(10), weights.get_total_weight());
+        let mut signature_acquisition =
+            SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
+
+        // Signature for the validator #0 weighting 1:
+        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(signature_acquisition.have_signatures(), [public_0]);
+        assert_equal(signature_acquisition.not_vacant(), [public_0]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // We get the 1/10 needed:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Weak
+        );
+
+        // Signature for the validator #2 weighting 3:
+        let (public_2, secret_2) = validators.iter().nth(2).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2],
+        );
+        assert_equal(signature_acquisition.not_vacant(), [public_0, public_2]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 4/10, which is higher than 1/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Weak
+        );
+
+        // Signature for the validator #3 weighting 4:
+        let (public_3, secret_3) = validators.iter().nth(3).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2, public_3],
+        );
+        assert_equal(
+            signature_acquisition.not_vacant(),
+            [public_0, public_2, public_3],
+        );
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 8/10, which is higher than 2/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Strict
+        );
+    }
+
+    #[test]
+    fn register_pending_has_the_expected_behavior() {
+        let rng = &mut TestRng::new();
+        let validators = validators(rng, 4);
+        let era_id = EraId::new(rng.gen());
+        let block_hash = BlockHash::random(rng);
+        let weights = EraValidatorWeights::new(
+            era_id,
+            validators
+                .iter()
+                .enumerate()
+                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
+                .collect(),
+            Ratio::new(1, 10), // Low finality threshold
+        );
+        assert_eq!(U512::from(10), weights.get_total_weight());
+        let mut signature_acquisition =
+            SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
+
+        // Set the validator #0 weighting 1 as pending:
+        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        signature_acquisition.register_pending(public_0.clone());
+        assert_equal(signature_acquisition.have_signatures(), []);
+        assert_equal(signature_acquisition.not_vacant(), [public_0]);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().skip(1).map(|(p, _s)| p).collect_vec(),
+        );
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Insufficient
+        );
+
+        // Sign it:
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_equal(signature_acquisition.have_signatures(), [public_0]);
+        assert_equal(signature_acquisition.not_vacant(), [public_0]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_equal(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Weak
+        );
+    }
+
+    /*
+    #[test]
+    fn invalid_signature_does_not_apply() {
+        let rng = &mut TestRng::new();
+        let validators = validators(rng, 4);
+        let block_hash = BlockHash::random(rng);
+        let era_id = EraId::new(rng.gen());
+        let weights = EraValidatorWeights::new(
+            era_id,
+            validators
+                .iter()
+                .enumerate()
+                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
+                .collect(),
+            Ratio::new(1, 10), // Low finality threshold
+        );
+        assert_eq!(U512::from(10), weights.get_total_weight());
+        let mut signature_acquisition =
+            SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
+
+        let (public_0, _secret_0) = validators.iter().nth(0).unwrap();
+        let (_public_1, secret_1) = validators.iter().nth(1).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_1, public_0.clone());
+
+        // This should panic because of the secret/public mismatch:
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        //panic!(
+        //    "{:?}",
+        //    signature_acquisition.have_signatures().collect_vec()
+        //);
+        //assert_equal(signature_acquisition.have_signatures(), []);
+
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Insufficient
+        );
+    }
+    */
+}

--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -121,32 +121,132 @@ mod tests {
     use itertools::Itertools;
     use num_rational::Ratio;
     use rand::Rng;
+    use std::iter::repeat_with;
 
-    fn validators(rng: &mut TestRng, n: usize) -> Vec<(PublicKey, SecretKey)> {
-        (0..n)
-            .map(|_| {
-                let secret = SecretKey::random(rng);
-                let public = PublicKey::from(&secret);
+    fn keypair(rng: &mut TestRng) -> (PublicKey, SecretKey) {
+        let secret = SecretKey::random(rng);
+        let public = PublicKey::from(&secret);
 
-                (public, secret)
-            })
-            .collect()
+        (public, secret)
     }
 
-    fn assert_equal<T: Ord + Debug>(
-        left: impl IntoIterator<Item = T>,
-        right: impl IntoIterator<Item = T>,
-    ) {
-        let left: BTreeSet<_> = left.into_iter().collect();
-        let right: BTreeSet<_> = right.into_iter().collect();
+    /// Asserts that 2 iterators iterate over the same set of items.
+    macro_rules! assert_iter_equal {
+        ( $left:expr, $right:expr $(,)? ) => {{
+            fn to_btreeset<T: Ord + Debug>(
+                left: impl IntoIterator<Item = T>,
+                right: impl IntoIterator<Item = T>,
+            ) -> (BTreeSet<T>, BTreeSet<T>) {
+                (left.into_iter().collect(), right.into_iter().collect())
+            }
 
-        itertools::assert_equal(left, right);
+            let (left, right) = to_btreeset($left, $right);
+            assert_eq!(left, right);
+        }};
+    }
+
+    fn test_finality_with_ratio(finality_threshold: Ratio<u64>, first_weight: SignatureWeight) {
+        let rng = &mut TestRng::new();
+        let validators = repeat_with(|| keypair(rng)).take(4).collect_vec();
+        let block_hash = BlockHash::random(rng);
+        let era_id = EraId::new(rng.gen());
+        let weights = EraValidatorWeights::new(
+            era_id,
+            validators
+                .iter()
+                .enumerate()
+                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
+                .collect(),
+            finality_threshold,
+        );
+        assert_eq!(U512::from(10), weights.get_total_weight());
+        let mut signature_acquisition =
+            SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
+
+        // Signature for the validator #0 weighting 1:
+        let (public_0, secret_0) = validators.get(0).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_iter_equal!(signature_acquisition.have_signatures(), [public_0]);
+        assert_iter_equal!(signature_acquisition.not_vacant(), [public_0]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_iter_equal!(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+
+        assert_eq!(signature_acquisition.signature_weight(), first_weight);
+
+        // Signature for the validator #2 weighting 3:
+        let (public_2, secret_2) = validators.get(2).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_iter_equal!(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2],
+        );
+        assert_iter_equal!(signature_acquisition.not_vacant(), [public_0, public_2]);
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_iter_equal!(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 4/10, which is higher than 1/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Weak
+        );
+
+        // Signature for the validator #3 weighting 4:
+        let (public_3, secret_3) = validators.get(3).unwrap();
+        let finality_signature =
+            FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
+        assert_matches!(
+            signature_acquisition.apply_signature(finality_signature, &weights),
+            Acceptance::NeededIt
+        );
+        assert_iter_equal!(
+            signature_acquisition.have_signatures(),
+            [public_0, public_2, public_3],
+        );
+        assert_iter_equal!(
+            signature_acquisition.not_vacant(),
+            [public_0, public_2, public_3],
+        );
+        assert!(signature_acquisition.have_no_vacant() == false);
+        assert_iter_equal!(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _)| p),
+        );
+        // The total signed weight is 8/10, which is higher than 2/3:
+        assert_eq!(
+            signature_acquisition.signature_weight(),
+            SignatureWeight::Strict
+        );
     }
 
     #[test]
-    fn apply_signature_has_the_expected_behavior_highway_finality() {
+    fn should_return_insufficient_when_weight_1_and_1_3_is_required() {
+        test_finality_with_ratio(Ratio::new(1, 3), SignatureWeight::Insufficient)
+    }
+
+    #[test]
+    fn should_return_weak_when_weight_1_and_1_10_is_required() {
+        test_finality_with_ratio(Ratio::new(1, 10), SignatureWeight::Weak)
+    }
+
+    #[test]
+    fn adding_a_not_already_stored_validator_signature_works() {
         let rng = &mut TestRng::new();
-        let validators = validators(rng, 4);
+        let validators = repeat_with(|| keypair(rng)).take(4).collect_vec();
         let block_hash = BlockHash::random(rng);
         let era_id = EraId::new(rng.gen());
         let weights = EraValidatorWeights::new(
@@ -162,82 +262,28 @@ mod tests {
         let mut signature_acquisition =
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
-        // Signature for the validator #0 weighting 1:
-        let (public_0, secret_0) = validators.get(0).unwrap();
+        // Signature for an already stored validator:
+        let (public_0, secret_0) = validators.first().unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
         assert_matches!(
             signature_acquisition.apply_signature(finality_signature, &weights),
             Acceptance::NeededIt
         );
-        assert_equal(signature_acquisition.have_signatures(), [public_0]);
-        assert_equal(signature_acquisition.not_vacant(), [public_0]);
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Insufficient
-        );
 
-        // Signature for the validator #2 weighting 3:
-        let (public_2, secret_2) = validators.get(2).unwrap();
-        let finality_signature =
-            FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
+        // Signature for an unknown validator:
+        let (public, secret) = keypair(rng);
+        let finality_signature = FinalitySignature::create(block_hash, era_id, &secret, public);
         assert_matches!(
             signature_acquisition.apply_signature(finality_signature, &weights),
             Acceptance::NeededIt
-        );
-        assert_equal(
-            signature_acquisition.have_signatures(),
-            [public_0, public_2],
-        );
-        assert_equal(signature_acquisition.not_vacant(), [public_0, public_2]);
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        // The total signed weight is 4/10, which is higher than 1/3:
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Weak
-        );
-
-        // Signature for the validator #3 weighting 4:
-        let (public_3, secret_3) = validators.get(3).unwrap();
-        let finality_signature =
-            FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
-        assert_matches!(
-            signature_acquisition.apply_signature(finality_signature, &weights),
-            Acceptance::NeededIt
-        );
-        assert_equal(
-            signature_acquisition.have_signatures(),
-            [public_0, public_2, public_3],
-        );
-        assert_equal(
-            signature_acquisition.not_vacant(),
-            [public_0, public_2, public_3],
-        );
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        // The total signed weight is 8/10, which is higher than 2/3:
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Strict
         );
     }
 
     #[test]
-    fn apply_signature_has_the_expected_behavior_low_finality() {
+    fn signing_twice_does_nothing() {
         let rng = &mut TestRng::new();
-        let validators = validators(rng, 4);
+        let validators = repeat_with(|| keypair(rng)).take(4).collect_vec();
         let block_hash = BlockHash::random(rng);
         let era_id = EraId::new(rng.gen());
         let weights = EraValidatorWeights::new(
@@ -247,89 +293,35 @@ mod tests {
                 .enumerate()
                 .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
                 .collect(),
-            Ratio::new(1, 10), // Low finality threshold
+            Ratio::new(1, 3), // Highway finality
         );
         assert_eq!(U512::from(10), weights.get_total_weight());
         let mut signature_acquisition =
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
-        // Signature for the validator #0 weighting 1:
-        let (public_0, secret_0) = validators.get(0).unwrap();
+        let (public_0, secret_0) = validators.first().unwrap();
+
+        // Signature for an already stored validator:
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
         assert_matches!(
             signature_acquisition.apply_signature(finality_signature, &weights),
             Acceptance::NeededIt
         );
-        assert_equal(signature_acquisition.have_signatures(), [public_0]);
-        assert_equal(signature_acquisition.not_vacant(), [public_0]);
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        // We get the 1/10 needed:
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Weak
-        );
 
-        // Signature for the validator #2 weighting 3:
-        let (public_2, secret_2) = validators.get(2).unwrap();
+        // Signing again returns `HadIt`:
         let finality_signature =
-            FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
+            FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
         assert_matches!(
             signature_acquisition.apply_signature(finality_signature, &weights),
-            Acceptance::NeededIt
-        );
-        assert_equal(
-            signature_acquisition.have_signatures(),
-            [public_0, public_2],
-        );
-        assert_equal(signature_acquisition.not_vacant(), [public_0, public_2]);
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        // The total signed weight is 4/10, which is higher than 1/3:
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Weak
-        );
-
-        // Signature for the validator #3 weighting 4:
-        let (public_3, secret_3) = validators.get(3).unwrap();
-        let finality_signature =
-            FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
-        assert_matches!(
-            signature_acquisition.apply_signature(finality_signature, &weights),
-            Acceptance::NeededIt
-        );
-        assert_equal(
-            signature_acquisition.have_signatures(),
-            [public_0, public_2, public_3],
-        );
-        assert_equal(
-            signature_acquisition.not_vacant(),
-            [public_0, public_2, public_3],
-        );
-        assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
-            signature_acquisition.not_pending(),
-            validators.iter().map(|(p, _)| p),
-        );
-        // The total signed weight is 8/10, which is higher than 2/3:
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Strict
+            Acceptance::HadIt
         );
     }
 
     #[test]
     fn register_pending_has_the_expected_behavior() {
         let rng = &mut TestRng::new();
-        let validators = validators(rng, 4);
+        let validators = repeat_with(|| keypair(rng)).take(4).collect_vec();
         let era_id = EraId::new(rng.gen());
         let block_hash = BlockHash::random(rng);
         let weights = EraValidatorWeights::new(
@@ -348,9 +340,9 @@ mod tests {
         // Set the validator #0 weighting 1 as pending:
         let (public_0, secret_0) = validators.get(0).unwrap();
         signature_acquisition.register_pending(public_0.clone());
-        assert_equal(signature_acquisition.have_signatures(), []);
-        assert_equal(signature_acquisition.not_vacant(), [public_0]);
-        assert_equal(
+        assert_iter_equal!(signature_acquisition.have_signatures(), []);
+        assert_iter_equal!(signature_acquisition.not_vacant(), [public_0]);
+        assert_iter_equal!(
             signature_acquisition.not_pending(),
             validators.iter().skip(1).map(|(p, _s)| p).collect_vec(),
         );
@@ -367,10 +359,10 @@ mod tests {
             signature_acquisition.apply_signature(finality_signature, &weights),
             Acceptance::NeededIt
         );
-        assert_equal(signature_acquisition.have_signatures(), [public_0]);
-        assert_equal(signature_acquisition.not_vacant(), [public_0]);
+        assert_iter_equal!(signature_acquisition.have_signatures(), [public_0]);
+        assert_iter_equal!(signature_acquisition.not_vacant(), [public_0]);
         assert!(signature_acquisition.have_no_vacant() == false);
-        assert_equal(
+        assert_iter_equal!(
             signature_acquisition.not_pending(),
             validators.iter().map(|(p, _)| p),
         );
@@ -380,46 +372,22 @@ mod tests {
         );
     }
 
-    /*
     #[test]
-    fn invalid_signature_does_not_apply() {
+    fn register_pending_an_unknown_validator_works() {
         let rng = &mut TestRng::new();
-        let validators = validators(rng, 4);
-        let block_hash = BlockHash::random(rng);
-        let era_id = EraId::new(rng.gen());
-        let weights = EraValidatorWeights::new(
-            era_id,
-            validators
-                .iter()
-                .enumerate()
-                .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
-                .collect(),
-            Ratio::new(1, 10), // Low finality threshold
-        );
-        assert_eq!(U512::from(10), weights.get_total_weight());
+        let validators = repeat_with(|| keypair(rng)).take(4).collect_vec();
         let mut signature_acquisition =
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
-        let (public_0, _secret_0) = validators.get(0).unwrap();
-        let (_public_1, secret_1) = validators.get(1).unwrap();
-        let finality_signature =
-            FinalitySignature::create(block_hash, era_id, secret_1, public_0.clone());
-
-        // This should panic because of the secret/public mismatch:
-        assert_matches!(
-            signature_acquisition.apply_signature(finality_signature, &weights),
-            Acceptance::NeededIt
+        // Set a new validator as pending:
+        let (public, _secret) = keypair(rng);
+        signature_acquisition.register_pending(public.clone());
+        assert_iter_equal!(signature_acquisition.have_signatures(), []);
+        assert_iter_equal!(signature_acquisition.not_vacant(), [&public]);
+        assert_iter_equal!(
+            signature_acquisition.not_pending(),
+            validators.iter().map(|(p, _s)| p),
         );
-        //panic!(
-        //    "{:?}",
-        //    signature_acquisition.have_signatures().collect_vec()
-        //);
-        //assert_equal(signature_acquisition.have_signatures(), []);
-
-        assert_eq!(
-            signature_acquisition.signature_weight(),
-            SignatureWeight::Insufficient
-        );
+        assert!(signature_acquisition.have_no_vacant() == false);
     }
-    */
 }

--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -163,7 +163,7 @@ mod tests {
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
         // Signature for the validator #0 weighting 1:
-        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        let (public_0, secret_0) = validators.get(0).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
         assert_matches!(
@@ -183,7 +183,7 @@ mod tests {
         );
 
         // Signature for the validator #2 weighting 3:
-        let (public_2, secret_2) = validators.iter().nth(2).unwrap();
+        let (public_2, secret_2) = validators.get(2).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
         assert_matches!(
@@ -207,7 +207,7 @@ mod tests {
         );
 
         // Signature for the validator #3 weighting 4:
-        let (public_3, secret_3) = validators.iter().nth(3).unwrap();
+        let (public_3, secret_3) = validators.get(3).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
         assert_matches!(
@@ -254,7 +254,7 @@ mod tests {
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
         // Signature for the validator #0 weighting 1:
-        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        let (public_0, secret_0) = validators.get(0).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_0, public_0.clone());
         assert_matches!(
@@ -275,7 +275,7 @@ mod tests {
         );
 
         // Signature for the validator #2 weighting 3:
-        let (public_2, secret_2) = validators.iter().nth(2).unwrap();
+        let (public_2, secret_2) = validators.get(2).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_2, public_2.clone());
         assert_matches!(
@@ -299,7 +299,7 @@ mod tests {
         );
 
         // Signature for the validator #3 weighting 4:
-        let (public_3, secret_3) = validators.iter().nth(3).unwrap();
+        let (public_3, secret_3) = validators.get(3).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_3, public_3.clone());
         assert_matches!(
@@ -346,7 +346,7 @@ mod tests {
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
         // Set the validator #0 weighting 1 as pending:
-        let (public_0, secret_0) = validators.iter().nth(0).unwrap();
+        let (public_0, secret_0) = validators.get(0).unwrap();
         signature_acquisition.register_pending(public_0.clone());
         assert_equal(signature_acquisition.have_signatures(), []);
         assert_equal(signature_acquisition.not_vacant(), [public_0]);
@@ -400,8 +400,8 @@ mod tests {
         let mut signature_acquisition =
             SignatureAcquisition::new(validators.iter().map(|(p, _)| p.clone()).collect());
 
-        let (public_0, _secret_0) = validators.iter().nth(0).unwrap();
-        let (_public_1, secret_1) = validators.iter().nth(1).unwrap();
+        let (public_0, _secret_0) = validators.get(0).unwrap();
+        let (_public_1, secret_1) = validators.get(1).unwrap();
         let finality_signature =
             FinalitySignature::create(block_hash, era_id, secret_1, public_0.clone());
 


### PR DESCRIPTION
This commit adds tests for the `signature_acquisition` module. They check the behavior of `apply_signature`, `register_pending` and `signature_weight` mainly.