### PR TITLE
Fix latch issue in BlockSynchronizer

### DIFF
--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -408,6 +408,7 @@ impl BlockBuilder {
         if let Some(era_id) = self.era_id {
             if let Some(evw) = validator_matrix.validator_weights(era_id) {
                 self.validator_weights = Some(evw);
+                self.touch();
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where historical syncing would stall due to not releasing the in-flight latch after needing era validator weights.

Closes #3784.