### PR TITLE
Remove stray line in nightly CI test script

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -112,7 +112,6 @@ start_run_teardown "sync_test.sh timeout=500"
 start_run_teardown "gov96.sh"
 start_run_teardown "swap_validator_set.sh"
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
-start_run_teardown "network_soundness.sh"
 
 run_nightly_upgrade_test
 


### PR DESCRIPTION
This removes a line which was accidentally left in the nightly-test.sh file.