### PR TITLE
Further reduce event sizes

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -578,11 +578,11 @@ impl BlockSynchronizer {
                     {
                         debug!(%validator, %peer, "attempting to fetch FinalitySignature");
                         builder.register_finality_signature_pending(validator.clone());
-                        let id = FinalitySignatureId {
+                        let id = Box::new(FinalitySignatureId {
                             block_hash,
                             era_id,
                             public_key: validator,
-                        };
+                        });
                         results.extend(
                             effect_builder
                                 .fetch::<FinalitySignature>(id, peer, EmptyValidationMetadata)

--- a/node/src/components/block_synchronizer/trie_accumulator.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator.rs
@@ -250,7 +250,7 @@ impl TrieAccumulator {
                 .merge(old_partial_chunks);
         }
         effect_builder
-            .fetch::<TrieOrChunk>(id, peer, EmptyValidationMetadata)
+            .fetch::<TrieOrChunk>(id, peer, Box::new(EmptyValidationMetadata))
             .event(move |fetch_result| Event::TrieOrChunkFetched { id, fetch_result })
     }
 }

--- a/node/src/components/block_synchronizer/trie_accumulator/tests.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator/tests.rs
@@ -154,7 +154,7 @@ async fn failed_fetch_retriggers_download_with_different_peer() {
 
     // Simulate a fetch error
     let fetch_result: FetchResult<TrieOrChunk> = Err(FetcherError::TimedOut {
-        id: chunk_ids[0],
+        id: Box::new(chunk_ids[0]),
         peer: peers[1],
     });
     let event = Event::TrieOrChunkFetched {

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -408,7 +408,7 @@ where
     async move {
         let deploy_hash: DeployHash = dt_hash.into();
         let deploy = match effect_builder
-            .fetch::<LegacyDeploy>(deploy_hash, sender, EmptyValidationMetadata)
+            .fetch::<LegacyDeploy>(deploy_hash, sender, Box::new(EmptyValidationMetadata))
             .await
         {
             Ok(FetchedData::FromStorage { item }) | Ok(FetchedData::FromPeer { item, .. }) => {

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -68,7 +68,10 @@ impl MockReactor {
             match deploy.into() {
                 None => {
                     responder
-                        .respond(Err(fetcher::Error::Absent { id, peer }))
+                        .respond(Err(fetcher::Error::Absent {
+                            id: Box::new(id),
+                            peer,
+                        }))
                         .await
                 }
                 Some(deploy) => {

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -387,7 +387,7 @@ where
                 self.handle_action(effect_builder, rng, era_id, action_id)
             }
             Event::Incoming(ConsensusMessageIncoming { sender, message }) => {
-                self.handle_message(effect_builder, rng, sender, message)
+                self.handle_message(effect_builder, rng, sender, *message)
             }
             Event::DemandIncoming(ConsensusDemand {
                 sender,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::boxed_local)] // We use boxed locals to pass on event data unchanged.
+
 //! Consensus service is a component that will be communicating with the reactor.
 //! It will receive events (like incoming message event or create new message event)
 //! and propagate them to the underlying consensus protocol.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -676,10 +676,10 @@ impl EraSupervisor {
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         sender: NodeId,
-        request: ConsensusRequestMessage,
+        request: Box<ConsensusRequestMessage>,
         auto_closing_responder: AutoClosingResponder<protocol::Message>,
     ) -> Effects<Event> {
-        let ConsensusRequestMessage { era_id, payload } = request;
+        let ConsensusRequestMessage { era_id, payload } = *request;
         trace!(era = era_id.value(), "received a consensus request");
         match self.open_eras.get_mut(&era_id) {
             None => {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -290,11 +290,12 @@ impl ContractRuntime {
     fn handle_trie_demand(
         &self,
         TrieDemand {
-            request_msg: TrieRequest(ref serialized_id),
+            request_msg,
             auto_closing_responder,
             ..
         }: TrieDemand,
     ) -> Effects<Event> {
+        let TrieRequest(ref serialized_id) = *request_msg;
         let fetch_response = match self.get_trie(serialized_id) {
             Ok(fetch_response) => fetch_response,
             Err(error) => {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -263,14 +263,12 @@ impl ContractRuntime {
     fn handle_trie_request<REv>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        TrieRequestIncoming {
-            sender,
-            message: TrieRequest(ref serialized_id),
-        }: TrieRequestIncoming,
+        TrieRequestIncoming { sender, message }: TrieRequestIncoming,
     ) -> Effects<Event>
     where
         REv: From<NetworkRequest<Message>> + Send,
     {
+        let TrieRequest(ref serialized_id) = *message;
         let fetch_response = match self.get_trie(serialized_id) {
             Ok(fetch_response) => fetch_response,
             Err(error) => {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -254,7 +254,7 @@ impl DeployAcceptor {
             .get_highest_complete_block_header_from_storage()
             .event(move |maybe_block_header| Event::GetBlockHeaderResult {
                 event_metadata: Box::new(EventMetadata::new(deploy, source, maybe_responder)),
-                maybe_block_header: Box::new(maybe_block_header),
+                maybe_block_header: maybe_block_header.map(Box::new),
                 verification_start_timestamp,
             })
     }
@@ -263,7 +263,7 @@ impl DeployAcceptor {
         &mut self,
         effect_builder: EffectBuilder<REv>,
         event_metadata: Box<EventMetadata>,
-        maybe_block_header: Option<BlockHeader>,
+        maybe_block_header: Option<Box<BlockHeader>>,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
         let mut effects = Effects::new();
@@ -946,7 +946,7 @@ impl<REv: ReactorEventT> Component<REv> for DeployAcceptor {
             } => self.handle_get_block_header_result(
                 effect_builder,
                 event_metadata,
-                *maybe_block_header,
+                maybe_block_header,
                 verification_start_timestamp,
             ),
             Event::GetAccountResult {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -226,7 +226,7 @@ impl DeployAcceptor {
             debug!(%deploy, %error, "deploy is incorrectly configured");
             return self.handle_invalid_deploy_result(
                 effect_builder,
-                EventMetadata::new(deploy, source, maybe_responder),
+                Box::new(EventMetadata::new(deploy, source, maybe_responder)),
                 Error::InvalidDeployConfiguration(error),
                 verification_start_timestamp,
             );
@@ -240,7 +240,7 @@ impl DeployAcceptor {
                 debug!(%deploy, "deploy has expired");
                 return self.handle_invalid_deploy_result(
                     effect_builder,
-                    EventMetadata::new(deploy, source, maybe_responder),
+                    Box::new(EventMetadata::new(deploy, source, maybe_responder)),
                     Error::ExpiredDeploy {
                         deploy_expiry_timestamp: time_of_expiry,
                         current_node_timestamp,
@@ -253,7 +253,7 @@ impl DeployAcceptor {
         effect_builder
             .get_highest_complete_block_header_from_storage()
             .event(move |maybe_block_header| Event::GetBlockHeaderResult {
-                event_metadata: EventMetadata::new(deploy, source, maybe_responder),
+                event_metadata: Box::new(EventMetadata::new(deploy, source, maybe_responder)),
                 maybe_block_header: Box::new(maybe_block_header),
                 verification_start_timestamp,
             })
@@ -262,7 +262,7 @@ impl DeployAcceptor {
     fn handle_get_block_header_result<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         maybe_block_header: Option<BlockHeader>,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -305,7 +305,7 @@ impl DeployAcceptor {
     fn handle_get_account_result<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         maybe_account: Option<Account>,
         verification_start_timestamp: Timestamp,
@@ -377,7 +377,7 @@ impl DeployAcceptor {
     fn handle_get_balance_result<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         maybe_balance_value: Option<U512>,
         account_hash: AccountHash,
@@ -436,7 +436,7 @@ impl DeployAcceptor {
     fn verify_payment_logic<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -546,7 +546,7 @@ impl DeployAcceptor {
     fn verify_session_logic<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -648,7 +648,7 @@ impl DeployAcceptor {
     fn handle_get_contract_result<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         is_payment: bool,
         entry_point: String,
@@ -708,7 +708,7 @@ impl DeployAcceptor {
     fn handle_get_contract_package_result<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         is_payment: bool,
         contract_package_hash: ContractPackageHash,
@@ -801,7 +801,7 @@ impl DeployAcceptor {
     fn validate_deploy_cryptography<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
         if let Err(deploy_configuration_failure) = event_metadata.deploy.is_valid() {
@@ -817,7 +817,7 @@ impl DeployAcceptor {
         }
 
         effect_builder
-            .put_deploy_to_storage(Box::new((*event_metadata.deploy).clone()))
+            .put_deploy_to_storage(event_metadata.deploy.clone())
             .event(move |is_new| Event::PutToStorageResult {
                 event_metadata,
                 is_new,
@@ -828,7 +828,7 @@ impl DeployAcceptor {
     fn handle_invalid_deploy_result<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         error: Error,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -836,7 +836,7 @@ impl DeployAcceptor {
             deploy,
             source,
             maybe_responder,
-        } = event_metadata;
+        } = *event_metadata;
         self.metrics.observe_rejected(verification_start_timestamp);
         let mut effects = Effects::new();
         if let Some(responder) = maybe_responder {
@@ -855,7 +855,7 @@ impl DeployAcceptor {
     fn handle_put_to_storage<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         is_new: bool,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -896,7 +896,7 @@ impl DeployAcceptor {
     fn handle_stored_finalized_approvals<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         is_new: bool,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
@@ -905,7 +905,7 @@ impl DeployAcceptor {
             deploy,
             source,
             maybe_responder,
-        } = event_metadata;
+        } = *event_metadata;
         let mut effects = Effects::new();
         if is_new {
             effects.extend(

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::boxed_local)] // We use boxed locals to pass on event data unchanged.
+
 mod event;
 mod metrics;
 mod tests;

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -653,7 +653,7 @@ impl DeployAcceptor {
         is_payment: bool,
         entry_point: String,
         contract_hash: ContractHash,
-        maybe_contract: Option<Contract>,
+        maybe_contract: Option<Box<Contract>>,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
         if let Some(contract) = maybe_contract {
@@ -713,7 +713,7 @@ impl DeployAcceptor {
         is_payment: bool,
         contract_package_hash: ContractPackageHash,
         maybe_package_version: Option<ContractVersion>,
-        maybe_contract_package: Option<ContractPackage>,
+        maybe_contract_package: Option<Box<ContractPackage>>,
         verification_start_timestamp: Timestamp,
     ) -> Effects<Event> {
         match maybe_contract_package {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -161,7 +161,7 @@ impl<REv> ReactorEventT for REv where
 ///     linkStyle 0 stroke-width:0;
 ///
 ///     Start --> A{has valid size?}
-///     A -->|Yes| B{"is compliant with config?<br/>(size, chain name, ttl, etc.)"}    
+///     A -->|Yes| B{"is compliant with config?<br/>(size, chain name, ttl, etc.)"}
 ///     G -->|Yes| ZZ[Accept]
 ///     B -->|Yes| C{is from<br/>client?}
 ///     C -->|Yes| CLIENT{has expired?}

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -48,33 +48,33 @@ pub(crate) enum Event {
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         is_new: bool,
         verification_start_timestamp: Timestamp,
     },
     /// The result of the `DeployAcceptor` storing the approvals from a `Deploy` provided by a
     /// peer.
     StoredFinalizedApprovals {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         is_new: bool,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying the highest available `BlockHeader` from the storage component.
     GetBlockHeaderResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         maybe_block_header: Box<Option<BlockHeader>>,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying global state for the `Account` associated with the `Deploy`.
     GetAccountResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         maybe_account: Option<Account>,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying the balance of the `Account` associated with the `Deploy`.
     GetBalanceResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         maybe_balance_value: Option<U512>,
         account_hash: AccountHash,
@@ -82,7 +82,7 @@ pub(crate) enum Event {
     },
     /// The result of querying global state for a `Contract` to verify the executable logic.
     GetContractResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         is_payment: bool,
         contract_hash: ContractHash,
@@ -91,7 +91,7 @@ pub(crate) enum Event {
     },
     /// The result of querying global state for a `ContractPackage` to verify the executable logic.
     GetContractPackageResult {
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         prestate_hash: Digest,
         is_payment: bool,
         contract_package_hash: ContractPackageHash,

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -62,7 +62,7 @@ pub(crate) enum Event {
     /// The result of querying the highest available `BlockHeader` from the storage component.
     GetBlockHeaderResult {
         event_metadata: Box<EventMetadata>,
-        maybe_block_header: Box<Option<BlockHeader>>,
+        maybe_block_header: Option<Box<BlockHeader>>,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying global state for the `Account` associated with the `Deploy`.

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -86,7 +86,7 @@ pub(crate) enum Event {
         prestate_hash: Digest,
         is_payment: bool,
         contract_hash: ContractHash,
-        maybe_contract: Option<Contract>,
+        maybe_contract: Option<Box<Contract>>,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying global state for a `ContractPackage` to verify the executable logic.
@@ -96,7 +96,7 @@ pub(crate) enum Event {
         is_payment: bool,
         contract_package_hash: ContractPackageHash,
         maybe_package_version: Option<ContractVersion>,
-        maybe_contract_package: Option<ContractPackage>,
+        maybe_contract_package: Option<Box<ContractPackage>>,
         verification_start_timestamp: Timestamp,
     },
 }

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -692,7 +692,7 @@ fn inject_balance_check_for_peer(
     responder: Responder<Result<(), super::Error>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
-        let event_metadata = EventMetadata::new(deploy, source, Some(responder));
+        let event_metadata = Box::new(EventMetadata::new(deploy, source, Some(responder)));
         effect_builder
             .into_inner()
             .schedule(

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -272,7 +272,7 @@ impl DeployBuffer {
         debug!(%deploy_id, "DeployBuffer: registering gossiped deploy");
         effect_builder
             .get_stored_deploy(deploy_id)
-            .event(move |result| Event::StoredDeploy(deploy_id, Box::new(result)))
+            .event(move |result| Event::StoredDeploy(deploy_id, result.map(Box::new)))
     }
 
     /// Update buffer considering new stored deploy.
@@ -629,9 +629,9 @@ where
                     self.register_deploy_gossiped(deploy_id, effect_builder)
                 }
                 Event::StoredDeploy(deploy_id, maybe_deploy) => {
-                    match *maybe_deploy {
+                    match maybe_deploy {
                         Some(deploy) => {
-                            self.register_deploy(deploy);
+                            self.register_deploy(*deploy);
                         }
                         None => {
                             warn!("cannot register un-stored deploy({})", deploy_id);

--- a/node/src/components/deploy_buffer/event.rs
+++ b/node/src/components/deploy_buffer/event.rs
@@ -18,7 +18,7 @@ pub(crate) enum Event {
     #[from]
     Request(DeployBufferRequest),
     ReceiveDeployGossiped(DeployId),
-    StoredDeploy(DeployId, Box<Option<Deploy>>),
+    StoredDeploy(DeployId, Option<Box<Deploy>>),
     BlockProposed(Box<ProposedBlock<ClContext>>),
     Block(Arc<Block>),
     BlockFinalized(Box<FinalizedBlock>),

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -22,7 +22,7 @@ pub enum Event {
     DeploysExpired(Vec<DeployHash>),
     Fault {
         era_id: EraId,
-        public_key: PublicKey,
+        public_key: Box<PublicKey>,
         timestamp: Timestamp,
     },
     FinalitySignature(Box<FinalitySignature>),

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -104,7 +104,7 @@ pub enum SseData {
     /// Generic representation of validator's fault in an era.
     Fault {
         era_id: EraId,
-        public_key: PublicKey,
+        public_key: Box<PublicKey>,
         timestamp: Timestamp,
     },
     /// New finality signature received.
@@ -190,7 +190,7 @@ impl SseData {
     pub(super) fn random_fault(rng: &mut TestRng) -> Self {
         SseData::Fault {
             era_id: EraId::new(rng.gen()),
-            public_key: PublicKey::random(rng),
+            public_key: Box::new(PublicKey::random(rng)),
             timestamp: Timestamp::random(rng),
         }
     }

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -139,15 +139,34 @@ where
             Event::GotInvalidRemotely { .. } => Effects::new(),
             Event::AbsentRemotely { id, peer } => {
                 trace!(TAG=%T::TAG, %id, %peer, "item absent on the remote node");
-                self.signal(id.clone(), Err(Error::Absent { id, peer }), peer)
+                self.signal(
+                    id.clone(),
+                    Err(Error::Absent {
+                        id: Box::new(id),
+                        peer,
+                    }),
+                    peer,
+                )
             }
             Event::RejectedRemotely { id, peer } => {
                 trace!(TAG=%T::TAG, %id, %peer, "peer rejected fetch request");
-                self.signal(id.clone(), Err(Error::Rejected { id, peer }), peer)
+                self.signal(
+                    id.clone(),
+                    Err(Error::Rejected {
+                        id: Box::new(id),
+                        peer,
+                    }),
+                    peer,
+                )
             }
-            Event::TimeoutPeer { id, peer } => {
-                self.signal(id.clone(), Err(Error::TimedOut { id, peer }), peer)
-            }
+            Event::TimeoutPeer { id, peer } => self.signal(
+                id.clone(),
+                Err(Error::TimedOut {
+                    id: Box::new(id),
+                    peer,
+                }),
+                peer,
+            ),
             Event::PutToStorage { item, peer } => {
                 let mut effects =
                     Self::announce_fetched_new_item(effect_builder, (*item).clone(), peer).ignore();

--- a/node/src/components/fetcher/error.rs
+++ b/node/src/components/fetcher/error.rs
@@ -8,23 +8,23 @@ use crate::{components::fetcher::FetchItem, types::NodeId};
 #[derive(Clone, Debug, Error, PartialEq, Eq, Serialize)]
 pub(crate) enum Error<T: FetchItem> {
     #[error("item with id {id:?} absent on peer {peer:?}")]
-    Absent { id: T::Id, peer: NodeId },
+    Absent { id: Box<T::Id>, peer: NodeId },
 
     #[error("peer {peer:?} rejected fetch request for item with id {id:?}")]
-    Rejected { id: T::Id, peer: NodeId },
+    Rejected { id: Box<T::Id>, peer: NodeId },
 
     #[error("timed out getting item with id {id:?} from peer {peer:?}")]
-    TimedOut { id: T::Id, peer: NodeId },
+    TimedOut { id: Box<T::Id>, peer: NodeId },
 
     #[error("could not construct get request for item with id {id:?} for peer {peer:?}")]
-    CouldNotConstructGetRequest { id: T::Id, peer: NodeId },
+    CouldNotConstructGetRequest { id: Box<T::Id>, peer: NodeId },
 
     #[error(
         "ongoing fetch for {id} from {peer} has different validation metadata ({current:?}) to \
         that given in new fetch attempt ({new:?})"
     )]
     ValidationMetadataMismatch {
-        id: T::Id,
+        id: Box<T::Id>,
         peer: NodeId,
         current: Box<T::ValidationMetadata>,
         new: Box<T::ValidationMetadata>,

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -20,7 +20,7 @@ pub(crate) enum Event<T: FetchItem> {
     GetLocallyResult {
         id: T::Id,
         peer: NodeId,
-        validation_metadata: T::ValidationMetadata,
+        validation_metadata: Box<T::ValidationMetadata>,
         maybe_item: Option<Box<T>>,
         responder: FetchResponder<T>,
     },

--- a/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/finality_signature_fetcher.rs
@@ -19,7 +19,8 @@ impl ItemFetcher<FinalitySignature> for Fetcher<FinalitySignature> {
 
     fn item_handles(
         &mut self,
-    ) -> &mut HashMap<FinalitySignatureId, HashMap<NodeId, ItemHandle<FinalitySignature>>> {
+    ) -> &mut HashMap<Box<FinalitySignatureId>, HashMap<NodeId, ItemHandle<FinalitySignature>>>
+    {
         &mut self.item_handles
     }
 
@@ -33,7 +34,7 @@ impl ItemFetcher<FinalitySignature> for Fetcher<FinalitySignature> {
 
     async fn get_locally<REv: From<StorageRequest> + From<BlockAccumulatorRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
-        id: FinalitySignatureId,
+        id: Box<FinalitySignatureId>,
     ) -> Option<FinalitySignature> {
         effect_builder
             .get_signature_from_storage(id.block_hash, id.public_key.clone())

--- a/node/src/components/fetcher/item_fetcher.rs
+++ b/node/src/components/fetcher/item_fetcher.rs
@@ -52,7 +52,7 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
         effect_builder: EffectBuilder<REv>,
         id: T::Id,
         peer: NodeId,
-        validation_metadata: T::ValidationMetadata,
+        validation_metadata: Box<T::ValidationMetadata>,
         responder: FetchResponder<T>,
     ) -> Effects<Event<T>>
     where
@@ -85,7 +85,7 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
         effect_builder: EffectBuilder<REv>,
         id: T::Id,
         peer: NodeId,
-        validation_metadata: T::ValidationMetadata,
+        validation_metadata: Box<T::ValidationMetadata>,
         responder: FetchResponder<T>,
     ) -> Effects<Event<T>>
     where
@@ -98,12 +98,12 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
         match item_handles.entry(id.clone()).or_default().entry(peer) {
             Entry::Occupied(mut entry) => {
                 let handle = entry.get_mut();
-                if *handle.validation_metadata() != validation_metadata {
+                if handle.validation_metadata() != &*validation_metadata {
                     let error = Error::ValidationMetadataMismatch {
                         id,
                         peer,
                         current: Box::new(handle.validation_metadata().clone()),
-                        new: Box::new(validation_metadata),
+                        new: validation_metadata,
                     };
                     error!(%error, "failed to fetch");
                     return responder.respond(Err(error)).ignore();

--- a/node/src/components/fetcher/item_fetcher.rs
+++ b/node/src/components/fetcher/item_fetcher.rs
@@ -100,7 +100,7 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
                 let handle = entry.get_mut();
                 if handle.validation_metadata() != &*validation_metadata {
                     let error = Error::ValidationMetadataMismatch {
-                        id,
+                        id: Box::new(id),
                         peer,
                         current: Box::new(handle.validation_metadata().clone()),
                         new: validation_metadata,
@@ -128,7 +128,10 @@ pub(super) trait ItemFetcher<T: FetchItem + 'static> {
 
                 self.signal(
                     id.clone(),
-                    Err(Error::CouldNotConstructGetRequest { id, peer }),
+                    Err(Error::CouldNotConstructGetRequest {
+                        id: Box::new(id),
+                        peer,
+                    }),
                     peer,
                 )
             }

--- a/node/src/components/fetcher/item_handle.rs
+++ b/node/src/components/fetcher/item_handle.rs
@@ -7,13 +7,13 @@ pub(crate) struct ItemHandle<T>
 where
     T: FetchItem,
 {
-    validation_metadata: T::ValidationMetadata,
+    validation_metadata: Box<T::ValidationMetadata>,
     responders: Vec<FetchResponder<T>>,
 }
 
 impl<T: FetchItem> ItemHandle<T> {
     pub(super) fn new(
-        validation_metadata: T::ValidationMetadata,
+        validation_metadata: Box<T::ValidationMetadata>,
         responder: FetchResponder<T>,
     ) -> Self {
         Self {

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -385,7 +385,7 @@ fn fetch_deploy(
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     move |effect_builder: EffectBuilder<Event>| {
         effect_builder
-            .fetch::<Deploy>(deploy_id, node_id, EmptyValidationMetadata)
+            .fetch::<Deploy>(deploy_id, node_id, Box::new(EmptyValidationMetadata))
             .then(move |deploy| async move {
                 let mut result = fetched.lock().unwrap();
                 result.0 = true;

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -305,7 +305,7 @@ impl Reactor {
         rng: &mut NodeRng,
         response: NetResponseIncoming,
     ) -> Effects<Event> {
-        match response.message {
+        match *response.message {
             NetResponse::Deploy(ref serialized_item) => {
                 let deploy = match bincode::deserialize::<FetchResponse<Deploy, DeployHash>>(
                     serialized_item,

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -597,7 +597,7 @@ where
             Event::CheckGetFromPeerTimeout { item_id, peer } => {
                 self.check_get_from_peer_timeout(effect_builder, item_id, peer)
             }
-            Event::Incoming(GossiperIncoming::<T> { sender, message }) => match message {
+            Event::Incoming(GossiperIncoming::<T> { sender, message }) => match *message {
                 Message::Gossip(item_id) => {
                     Self::is_stored(effect_builder, item_id.clone()).event(move |result| {
                         Event::IsStoredResult {
@@ -700,7 +700,7 @@ where
                 error!(%item_id, %peer, "should not timeout getting small item from peer");
                 Effects::new()
             }
-            Event::Incoming(GossiperIncoming::<T> { sender, message }) => match message {
+            Event::Incoming(GossiperIncoming::<T> { sender, message }) => match *message {
                 Message::Gossip(item_id) => {
                     let target = <T as SmallGossipItem>::id_as_item(&item_id).gossip_target();
                     let action = self.table.new_complete_data(&item_id, Some(sender), target);

--- a/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
+++ b/node/src/components/gossiper/provider_impls/finality_signature_provider.rs
@@ -12,20 +12,18 @@ impl ItemProvider<FinalitySignature>
 {
     async fn is_stored<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
-        item_id: FinalitySignatureId,
+        item_id: Box<FinalitySignatureId>,
     ) -> bool {
-        effect_builder
-            .is_finality_signature_stored(item_id.clone())
-            .await
+        effect_builder.is_finality_signature_stored(item_id).await
     }
 
     async fn get_from_storage<REv: From<StorageRequest> + Send>(
         effect_builder: EffectBuilder<REv>,
-        item_id: FinalitySignatureId,
+        item_id: Box<FinalitySignatureId>,
     ) -> Option<Box<FinalitySignature>> {
         // TODO: Make `get_finality_signature_from_storage` return a boxed copy instead.
         effect_builder
-            .get_finality_signature_from_storage(item_id.clone())
+            .get_finality_signature_from_storage(item_id)
             .await
             .map(Box::new)
     }

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -632,7 +632,7 @@ async fn should_not_gossip_old_stored_item_again() {
         .process_injected_effect_on(&node_0, |effect_builder| {
             let event = Event::DeployGossiperIncoming(GossiperIncoming {
                 sender: node_ids[1],
-                message: Message::Gossip(deploy.gossip_id()),
+                message: Box::new(Message::Gossip(deploy.gossip_id())),
             });
             effect_builder
                 .into_inner()
@@ -704,7 +704,7 @@ async fn should_ignore_unexpected_message(message_type: Unexpected) {
         .process_injected_effect_on(&node_0, |effect_builder| {
             let event = Event::DeployGossiperIncoming(GossiperIncoming {
                 sender: node_ids[1],
-                message,
+                message: Box::new(message),
             });
             effect_builder
                 .into_inner()

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -125,9 +125,10 @@ impl From<ContractRuntimeRequest> for Event {
 impl FromIncoming<Message> for Event {
     fn from_incoming(sender: NodeId, payload: Message) -> Self {
         match payload {
-            Message::AddressGossiper(message) => {
-                Event::AddressGossiperIncoming(GossiperIncoming { sender, message })
-            }
+            Message::AddressGossiper(message) => Event::AddressGossiperIncoming(GossiperIncoming {
+                sender,
+                message: Box::new(message),
+            }),
         }
     }
 }

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -23,12 +23,12 @@ pub(crate) enum Event {
     RpcRequest(RpcRequest),
     GetBlockResult {
         maybe_id: Option<BlockIdentifier>,
-        result: Box<Option<BlockWithMetadata>>,
-        main_responder: Responder<Option<BlockWithMetadata>>,
+        result: Option<Box<BlockWithMetadata>>,
+        main_responder: Responder<Option<Box<BlockWithMetadata>>>,
     },
     GetBlockTransfersResult {
         block_hash: BlockHash,
-        result: Box<Option<Vec<Transfer>>>,
+        result: Option<Vec<Transfer>>,
         main_responder: Responder<Option<Vec<Transfer>>>,
     },
     QueryGlobalStateResult {
@@ -45,8 +45,8 @@ pub(crate) enum Event {
     },
     GetDeployResult {
         hash: DeployHash,
-        result: Box<Option<(Deploy, DeployMetadataExt)>>,
-        main_responder: Responder<Option<(Deploy, DeployMetadataExt)>>,
+        result: Option<Box<(Deploy, DeployMetadataExt)>>,
+        main_responder: Responder<Option<Box<(Deploy, DeployMetadataExt)>>>,
     },
     GetPeersResult {
         peers: BTreeMap<NodeId, String>,

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -438,7 +438,7 @@ pub(super) async fn get_block_with_metadata<REv: ReactorEventT>(
         .await;
 
     if let Some(block_with_metadata) = maybe_result {
-        return Ok(block_with_metadata);
+        return Ok(*block_with_metadata);
     }
 
     // TODO: Potential optimization: We might want to make the `GetBlock` actually return the

--- a/node/src/components/rpc_server/rpcs/info.rs
+++ b/node/src/components/rpc_server/rpcs/info.rs
@@ -141,7 +141,7 @@ impl RpcWithParams for GetDeploy {
             .await;
 
         let (deploy, metadata_ext) = match maybe_deploy_and_metadata {
-            Some((deploy, metadata_ext)) => (deploy, metadata_ext),
+            Some(inner) => (inner.0, inner.1),
             None => {
                 let message = format!(
                     "failed to get {} and metadata from storage",

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -701,7 +701,7 @@ impl Storage {
                 if let Some(item) = opt_item.as_ref() {
                     if item.block_hash != id.block_hash || item.era_id != id.era_id {
                         return Err(GetRequestError::FinalitySignatureIdMismatch {
-                            requested_id: Box::new(id),
+                            requested_id: id,
                             finality_signature: Box::new(item.clone()),
                         });
                     }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -637,7 +637,7 @@ impl Storage {
             }
         }
 
-        match incoming.message {
+        match *(incoming.message) {
             NetRequest::Deploy(ref serialized_id) => {
                 let id = decode_item_id::<Deploy>(serialized_id)?;
                 let opt_item = self.get_deploy(id).map_err(FatalStorageError::from)?;

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -33,10 +33,10 @@ use crate::{
     },
     testing::{ComponentHarness, UnitTestEvent},
     types::{
-        AvailableBlockRange, Block, BlockHash, BlockHashAndHeight, BlockHeader,
-        BlockHeaderWithMetadata, BlockSignatures, Chainspec, ChainspecRawBytes, Deploy, DeployHash,
-        DeployMetadata, DeployMetadataExt, DeployWithFinalizedApprovals, FinalitySignature,
-        LegacyDeploy, SyncLeapIdentifier,
+        sync_leap_validation_metadata::SyncLeapValidationMetaData, AvailableBlockRange, Block,
+        BlockHash, BlockHashAndHeight, BlockHeader, BlockHeaderWithMetadata, BlockSignatures,
+        Chainspec, ChainspecRawBytes, Deploy, DeployHash, DeployMetadata, DeployMetadataExt,
+        DeployWithFinalizedApprovals, FinalitySignature, LegacyDeploy, SyncLeapIdentifier,
     },
     utils::{Loadable, WithDir},
 };
@@ -1558,7 +1558,9 @@ fn should_get_sync_leap() {
         vec![7, 10, 12]
     );
 
-    sync_leap.validate(&chainspec.into()).unwrap();
+    sync_leap
+        .validate(&SyncLeapValidationMetaData::from_chainspec(&chainspec))
+        .unwrap();
 }
 
 #[test]
@@ -1581,7 +1583,9 @@ fn sync_leap_signed_block_headers_should_be_empty_when_asked_for_a_tip() {
     );
     assert!(signed_block_headers_into_heights(&sync_leap.signed_block_headers).is_empty());
 
-    sync_leap.validate(&chainspec.into()).unwrap();
+    sync_leap
+        .validate(&SyncLeapValidationMetaData::from_chainspec(&chainspec))
+        .unwrap();
 }
 
 #[test]
@@ -1604,7 +1608,9 @@ fn sync_leap_should_populate_trusted_ancestor_headers_if_tip_is_a_switch_block()
     );
     assert!(signed_block_headers_into_heights(&sync_leap.signed_block_headers).is_empty());
 
-    sync_leap.validate(&chainspec.into()).unwrap();
+    sync_leap
+        .validate(&SyncLeapValidationMetaData::from_chainspec(&chainspec))
+        .unwrap();
 }
 
 #[test]

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -20,7 +20,10 @@ use crate::{
         Component,
     },
     effect::{requests::FetcherRequest, EffectBuilder, EffectExt, Effects},
-    types::{Chainspec, NodeId, SyncLeap, SyncLeapIdentifier},
+    types::{
+        sync_leap_validation_metadata::SyncLeapValidationMetaData, Chainspec, NodeId, SyncLeap,
+        SyncLeapIdentifier,
+    },
     NodeRng,
 };
 pub(crate) use error::LeapActivityError;
@@ -279,7 +282,9 @@ where
                                 .fetch::<SyncLeap>(
                                     sync_leap_identifier,
                                     peer,
-                                    self.chainspec.as_ref().into(),
+                                    Box::new(SyncLeapValidationMetaData::from_chainspec(
+                                        self.chainspec.as_ref(),
+                                    )),
                                 )
                                 .event(move |fetch_result| Event::FetchedSyncLeapFromPeer {
                                     sync_leap_identifier,

--- a/node/src/components/sync_leaper/tests.rs
+++ b/node/src/components/sync_leaper/tests.rs
@@ -291,7 +291,7 @@ fn fetch_received_peer_rejected() {
     sync_leaper.register_leap_attempt(sync_leap_identifier, peers_to_ask);
 
     let fetch_result: FetchResult<SyncLeap> = Err(fetcher::Error::Rejected {
-        id: sync_leap_identifier,
+        id: Box::new(sync_leap_identifier),
         peer,
     });
 
@@ -314,7 +314,7 @@ fn fetch_received_from_unknown_peer_rejected() {
 
     let unknown_peer = NodeId::random(&mut rng);
     let fetch_result: FetchResult<SyncLeap> = Err(fetcher::Error::Rejected {
-        id: sync_leap_identifier,
+        id: Box::new(sync_leap_identifier),
         peer: unknown_peer,
     });
 
@@ -338,7 +338,7 @@ fn fetch_received_other_error() {
     sync_leaper.register_leap_attempt(sync_leap_identifier, peers_to_ask);
 
     let fetch_result: FetchResult<SyncLeap> = Err(fetcher::Error::TimedOut {
-        id: sync_leap_identifier,
+        id: Box::new(sync_leap_identifier),
         peer,
     });
 
@@ -361,7 +361,7 @@ fn fetch_received_from_unknown_peer_other_error() {
 
     let unknown_peer = NodeId::random(&mut rng);
     let fetch_result: FetchResult<SyncLeap> = Err(fetcher::Error::TimedOut {
-        id: sync_leap_identifier,
+        id: Box::new(sync_leap_identifier),
         peer: unknown_peer,
     });
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1664,7 +1664,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         id: T::Id,
         peer: NodeId,
-        validation_metadata: T::ValidationMetadata,
+        validation_metadata: Box<T::ValidationMetadata>,
     ) -> FetchResult<T>
     where
         REv: From<FetcherRequest<T>>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1602,30 +1602,24 @@ impl<REv> EffectBuilder<REv> {
     /// Gets the requested finality signature from storage.
     pub(crate) async fn get_finality_signature_from_storage(
         self,
-        id: FinalitySignatureId,
+        id: Box<FinalitySignatureId>,
     ) -> Option<FinalitySignature>
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::GetFinalitySignature {
-                id: Box::new(id),
-                responder,
-            },
+            |responder| StorageRequest::GetFinalitySignature { id, responder },
             QueueKind::FromStorage,
         )
         .await
     }
 
-    pub(crate) async fn is_finality_signature_stored(self, id: FinalitySignatureId) -> bool
+    pub(crate) async fn is_finality_signature_stored(self, id: Box<FinalitySignatureId>) -> bool
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::IsFinalitySignatureStored {
-                id: Box::new(id),
-                responder,
-            },
+            |responder| StorageRequest::IsFinalitySignatureStored { id, responder },
             QueueKind::FromStorage,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1921,13 +1921,16 @@ impl<REv> EffectBuilder<REv> {
         prestate_hash: Digest,
         query_key: Key,
         path: Vec<String>,
-    ) -> Option<Contract>
+    ) -> Option<Box<Contract>>
     where
         REv: From<ContractRuntimeRequest>,
     {
         let query_request = QueryRequest::new(prestate_hash, query_key, path);
         match self.query_global_state(query_request).await {
-            Ok(QueryResult::Success { value, .. }) => value.as_contract().cloned(),
+            Ok(QueryResult::Success { value, .. }) => {
+                // TODO: Extending `StoredValue` with an `into_contract` would reduce cloning here.
+                value.as_contract().map(|c| Box::new(c.clone()))
+            }
             Ok(_) | Err(_) => None,
         }
     }
@@ -1938,13 +1941,15 @@ impl<REv> EffectBuilder<REv> {
         prestate_hash: Digest,
         query_key: Key,
         path: Vec<String>,
-    ) -> Option<ContractPackage>
+    ) -> Option<Box<ContractPackage>>
     where
         REv: From<ContractRuntimeRequest>,
     {
         let query_request = QueryRequest::new(prestate_hash, query_key, path);
         match self.query_global_state(query_request).await {
-            Ok(QueryResult::Success { value, .. }) => value.as_contract_package().cloned(),
+            Ok(QueryResult::Success { value, .. }) => {
+                value.as_contract_package().map(|pkg| Box::new(pkg.clone()))
+            }
             Ok(_) | Err(_) => None,
         }
     }

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -40,7 +40,7 @@ pub struct DemandIncoming<M> {
     /// The sender from which the demand originated.
     pub(crate) sender: NodeId,
     /// The wrapped demand.
-    pub(crate) request_msg: M,
+    pub(crate) request_msg: Box<M>,
     /// Responder to send the answer down through.
     pub(crate) auto_closing_responder: AutoClosingResponder<Message>,
 }

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -22,7 +22,7 @@ use super::AutoClosingResponder;
 #[derive(DataSize, Debug, Serialize)]
 pub struct MessageIncoming<M> {
     pub(crate) sender: NodeId,
-    pub(crate) message: M,
+    pub(crate) message: Box<M>,
 }
 
 impl<M> Display for MessageIncoming<M>
@@ -79,7 +79,7 @@ pub(crate) type ConsensusDemand = DemandIncoming<consensus::ConsensusRequestMess
 pub(crate) type TrieResponseIncoming = MessageIncoming<TrieResponse>;
 
 /// A new finality signature arrived over the network.
-pub(crate) type FinalitySignatureIncoming = MessageIncoming<Box<FinalitySignature>>;
+pub(crate) type FinalitySignatureIncoming = MessageIncoming<FinalitySignature>;
 
 /// A request for an object out of storage arrived.
 ///

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1024,7 +1024,7 @@ pub(crate) struct FetcherRequest<T: FetchItem> {
     /// The peer id of the peer to be asked if the item is not held locally
     pub(crate) peer: NodeId,
     /// Metadata used during validation of the fetched item.
-    pub(crate) validation_metadata: T::ValidationMetadata,
+    pub(crate) validation_metadata: Box<T::ValidationMetadata>,
     /// Responder to call with the result.
     pub(crate) responder: Responder<FetchResult<T>>,
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -698,7 +698,7 @@ pub(crate) enum RpcRequest {
         /// retrieve it.
         only_from_available_block_range: bool,
         /// Responder to call with the result.
-        responder: Responder<Option<BlockWithMetadata>>,
+        responder: Responder<Option<Box<BlockWithMetadata>>>,
     },
     /// Return transfers for block by hash (if any).
     GetBlockTransfers {
@@ -751,7 +751,7 @@ pub(crate) enum RpcRequest {
         /// Whether to return finalized approvals.
         finalized_approvals: bool,
         /// Responder to call with the result.
-        responder: Responder<Option<(Deploy, DeployMetadataExt)>>,
+        responder: Responder<Option<Box<(Deploy, DeployMetadataExt)>>>,
     },
     /// Return the connected peers.
     GetPeers {

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -405,7 +405,7 @@ where
             Message::GetRequest { tag, serialized_id } if tag == Tag::TrieOrChunk => {
                 let (ev, fut) = effect_builder.create_request_parts(move |responder| TrieDemand {
                     sender,
-                    request_msg: TrieRequest(serialized_id),
+                    request_msg: Box::new(TrieRequest(serialized_id)),
                     auto_closing_responder: AutoClosingResponder::from_opt_responder(responder),
                 });
 
@@ -415,7 +415,7 @@ where
                 let (ev, fut) =
                     effect_builder.create_request_parts(move |responder| ConsensusDemand {
                         sender,
-                        request_msg,
+                        request_msg: Box::new(request_msg),
                         auto_closing_responder: AutoClosingResponder::from_opt_responder(responder),
                     });
 

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -261,61 +261,79 @@ where
 {
     fn from_incoming(sender: NodeId, payload: Message) -> Self {
         match payload {
-            Message::Consensus(message) => ConsensusMessageIncoming { sender, message }.into(),
+            Message::Consensus(message) => ConsensusMessageIncoming {
+                sender,
+                message: Box::new(message),
+            }
+            .into(),
             Message::ConsensusRequest(_message) => {
                 // TODO: Remove this once from_incoming and try_demand_from_incoming are unified.
                 unreachable!("called from_incoming with a consensus request")
             }
-            Message::BlockGossiper(message) => GossiperIncoming { sender, message }.into(),
-            Message::DeployGossiper(message) => GossiperIncoming { sender, message }.into(),
-            Message::FinalitySignatureGossiper(message) => {
-                GossiperIncoming { sender, message }.into()
+            Message::BlockGossiper(message) => GossiperIncoming {
+                sender,
+                message: Box::new(message),
             }
-            Message::AddressGossiper(message) => GossiperIncoming { sender, message }.into(),
+            .into(),
+            Message::DeployGossiper(message) => GossiperIncoming {
+                sender,
+                message: Box::new(message),
+            }
+            .into(),
+            Message::FinalitySignatureGossiper(message) => GossiperIncoming {
+                sender,
+                message: Box::new(message),
+            }
+            .into(),
+            Message::AddressGossiper(message) => GossiperIncoming {
+                sender,
+                message: Box::new(message),
+            }
+            .into(),
             Message::GetRequest { tag, serialized_id } => match tag {
                 Tag::Deploy => NetRequestIncoming {
                     sender,
-                    message: NetRequest::Deploy(serialized_id),
+                    message: Box::new(NetRequest::Deploy(serialized_id)),
                 }
                 .into(),
                 Tag::LegacyDeploy => NetRequestIncoming {
                     sender,
-                    message: NetRequest::LegacyDeploy(serialized_id),
+                    message: Box::new(NetRequest::LegacyDeploy(serialized_id)),
                 }
                 .into(),
                 Tag::Block => NetRequestIncoming {
                     sender,
-                    message: NetRequest::Block(serialized_id),
+                    message: Box::new(NetRequest::Block(serialized_id)),
                 }
                 .into(),
                 Tag::BlockHeader => NetRequestIncoming {
                     sender,
-                    message: NetRequest::BlockHeader(serialized_id),
+                    message: Box::new(NetRequest::BlockHeader(serialized_id)),
                 }
                 .into(),
                 Tag::TrieOrChunk => TrieRequestIncoming {
                     sender,
-                    message: TrieRequest(serialized_id),
+                    message: Box::new(TrieRequest(serialized_id)),
                 }
                 .into(),
                 Tag::FinalitySignature => NetRequestIncoming {
                     sender,
-                    message: NetRequest::FinalitySignature(serialized_id),
+                    message: Box::new(NetRequest::FinalitySignature(serialized_id)),
                 }
                 .into(),
                 Tag::SyncLeap => NetRequestIncoming {
                     sender,
-                    message: NetRequest::SyncLeap(serialized_id),
+                    message: Box::new(NetRequest::SyncLeap(serialized_id)),
                 }
                 .into(),
                 Tag::ApprovalsHashes => NetRequestIncoming {
                     sender,
-                    message: NetRequest::ApprovalsHashes(serialized_id),
+                    message: Box::new(NetRequest::ApprovalsHashes(serialized_id)),
                 }
                 .into(),
                 Tag::BlockExecutionResults => NetRequestIncoming {
                     sender,
-                    message: NetRequest::BlockExecutionResults(serialized_id),
+                    message: Box::new(NetRequest::BlockExecutionResults(serialized_id)),
                 }
                 .into(),
             },
@@ -325,47 +343,47 @@ where
             } => match tag {
                 Tag::Deploy => NetResponseIncoming {
                     sender,
-                    message: NetResponse::Deploy(serialized_item),
+                    message: Box::new(NetResponse::Deploy(serialized_item)),
                 }
                 .into(),
                 Tag::LegacyDeploy => NetResponseIncoming {
                     sender,
-                    message: NetResponse::LegacyDeploy(serialized_item),
+                    message: Box::new(NetResponse::LegacyDeploy(serialized_item)),
                 }
                 .into(),
                 Tag::Block => NetResponseIncoming {
                     sender,
-                    message: NetResponse::Block(serialized_item),
+                    message: Box::new(NetResponse::Block(serialized_item)),
                 }
                 .into(),
                 Tag::BlockHeader => NetResponseIncoming {
                     sender,
-                    message: NetResponse::BlockHeader(serialized_item),
+                    message: Box::new(NetResponse::BlockHeader(serialized_item)),
                 }
                 .into(),
                 Tag::TrieOrChunk => TrieResponseIncoming {
                     sender,
-                    message: TrieResponse(serialized_item.to_vec()),
+                    message: Box::new(TrieResponse(serialized_item.to_vec())),
                 }
                 .into(),
                 Tag::FinalitySignature => NetResponseIncoming {
                     sender,
-                    message: NetResponse::FinalitySignature(serialized_item),
+                    message: Box::new(NetResponse::FinalitySignature(serialized_item)),
                 }
                 .into(),
                 Tag::SyncLeap => NetResponseIncoming {
                     sender,
-                    message: NetResponse::SyncLeap(serialized_item),
+                    message: Box::new(NetResponse::SyncLeap(serialized_item)),
                 }
                 .into(),
                 Tag::ApprovalsHashes => NetResponseIncoming {
                     sender,
-                    message: NetResponse::ApprovalsHashes(serialized_item),
+                    message: Box::new(NetResponse::ApprovalsHashes(serialized_item)),
                 }
                 .into(),
                 Tag::BlockExecutionResults => NetResponseIncoming {
                     sender,
-                    message: NetResponse::BlockExecutionResults(serialized_item),
+                    message: Box::new(NetResponse::BlockExecutionResults(serialized_item)),
                 }
                 .into(),
             },

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -914,7 +914,7 @@ fn handle_get_response<R>(
     effect_builder: EffectBuilder<<R as Reactor>::Event>,
     rng: &mut NodeRng,
     sender: NodeId,
-    message: NetResponse,
+    message: Box<NetResponse>,
 ) -> Effects<<R as Reactor>::Event>
 where
     R: Reactor,
@@ -931,7 +931,7 @@ where
         + From<block_accumulator::Event>
         + From<PeerBehaviorAnnouncement>,
 {
-    match message {
+    match *message {
         NetResponse::Deploy(ref serialized_item) => handle_fetch_response::<R, Deploy>(
             reactor,
             effect_builder,

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::boxed_local)] // We use boxed locals to pass on event data unchanged.
+
 //! Reactor core.
 //!
 //! Any long running instance of the node application uses an event-dispatch pattern: Events are

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -452,7 +452,7 @@ impl reactor::Reactor for MainReactor {
                         let reactor_event =
                             MainEvent::EventStreamServer(event_stream_server::Event::Fault {
                                 era_id,
-                                public_key: *public_key,
+                                public_key,
                                 timestamp,
                             });
                         self.dispatch_event(effect_builder, rng, reactor_event)

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -1,9 +1,13 @@
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    mem,
+};
 
 use derive_more::From;
 use serde::Serialize;
 
 use casper_types::{system::auction::EraValidators, EraId};
+use static_assertions::const_assert;
 
 use crate::{
     components::{
@@ -46,11 +50,15 @@ use crate::{
     },
 };
 
+// Enforce an upper bound for the `MainEvent` size, which is already quite hefty.
+// 192 is six 256 bit copies, ideally we'd be below, but for now we enforce this as an upper limit.
+// 200 is where the `large_enum_variant` clippy lint draws the line as well.
+const _MAIN_EVENT_SIZE: usize = mem::size_of::<MainEvent>();
+const_assert!(_MAIN_EVENT_SIZE <= 192);
+
 /// Top-level event for the reactor.
 #[derive(Debug, From, Serialize)]
 #[must_use]
-// Note: The large enum size must be reigned in eventually. This is a stopgap for now.
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum MainEvent {
     #[from]
     ControlAnnouncement(ControlAnnouncement),

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -226,17 +226,15 @@ fn has_completed_era(era_id: EraId) -> impl Fn(&Nodes) -> bool {
 }
 
 fn is_ping(event: &MainEvent) -> bool {
-    if let MainEvent::ConsensusMessageIncoming(ConsensusMessageIncoming {
-        message: ConsensusMessage::Protocol { payload, .. },
-        ..
-    }) = event
-    {
-        return matches!(
-            payload.clone().try_into_highway(),
-            Ok(HighwayMessage::<ClContext>::NewVertex(HighwayVertex::Ping(
-                _
-            )))
-        );
+    if let MainEvent::ConsensusMessageIncoming(ConsensusMessageIncoming { message, .. }) = event {
+        if let ConsensusMessage::Protocol { ref payload, .. } = **message {
+            return matches!(
+                payload.clone().try_into_highway(),
+                Ok(HighwayMessage::<ClContext>::NewVertex(HighwayVertex::Ping(
+                    _
+                )))
+            );
+        }
     }
     false
 }

--- a/node/src/reactor/main_reactor/upgrade_shutdown.rs
+++ b/node/src/reactor/main_reactor/upgrade_shutdown.rs
@@ -27,7 +27,7 @@ impl SignatureGossipTracker {
         }
     }
 
-    pub(super) fn register_signature(&mut self, signature_id: FinalitySignatureId) {
+    pub(super) fn register_signature(&mut self, signature_id: Box<FinalitySignatureId>) {
         // ignore the signature if it's from an older era
         if signature_id.era_id < self.era_id {
             return;
@@ -41,7 +41,7 @@ impl SignatureGossipTracker {
         self.finished_gossiping
             .entry(signature_id.block_hash)
             .or_default()
-            .push(signature_id);
+            .push(*signature_id);
     }
 
     fn finished_gossiping_enough(&self, validator_weights: &EraValidatorWeights) -> bool {

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::boxed_local)] // We use boxed locals to pass on event data unchanged.
+
 //! The `FakeDeployAcceptor` behaves as per the real `DeployAcceptor` but without any deploy
 //! verification being performed.
 //!

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -55,7 +55,7 @@ impl FakeDeployAcceptor {
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Effects<Event> {
         let verification_start_timestamp = Timestamp::now();
-        let event_metadata = EventMetadata::new(deploy.clone(), source, maybe_responder);
+        let event_metadata = Box::new(EventMetadata::new(deploy.clone(), source, maybe_responder));
         effect_builder
             .put_deploy_to_storage(Box::new(*deploy))
             .event(move |is_new| Event::PutToStorageResult {
@@ -68,14 +68,14 @@ impl FakeDeployAcceptor {
     fn handle_put_to_storage<REv: ReactorEventT>(
         &self,
         effect_builder: EffectBuilder<REv>,
-        event_metadata: EventMetadata,
+        event_metadata: Box<EventMetadata>,
         is_new: bool,
     ) -> Effects<Event> {
         let EventMetadata {
             deploy,
             source,
             maybe_responder,
-        } = event_metadata;
+        } = *event_metadata;
         let mut effects = Effects::new();
         if is_new {
             effects.extend(

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -15,7 +15,7 @@ mod node_id;
 pub mod peers_map;
 mod status_feed;
 mod sync_leap;
-mod sync_leap_validation_metadata;
+pub(crate) mod sync_leap_validation_metadata;
 mod validator_matrix;
 mod value_or_chunk;
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -2361,18 +2361,21 @@ impl Display for FinalitySignature {
 }
 
 impl FetchItem for FinalitySignature {
-    type Id = FinalitySignatureId;
+    type Id = Box<FinalitySignatureId>;
     type ValidationError = crypto::Error;
     type ValidationMetadata = EmptyValidationMetadata;
 
     const TAG: Tag = Tag::FinalitySignature;
 
     fn fetch_id(&self) -> Self::Id {
-        FinalitySignatureId {
+        // Note: Unfortunately this is somewhat of a mismatch, as finality signature IDs are fairly
+        //       large, while the `FetchItem` trait expects them to be reasonably small (~ 64 bytes
+        //       or less). The included `public_key` bloats these IDs greatly.
+        Box::new(FinalitySignatureId {
             block_hash: self.block_hash,
             era_id: self.era_id,
             public_key: self.public_key.clone(),
-        }
+        })
     }
 
     fn validate(&self, _metadata: &EmptyValidationMetadata) -> Result<(), Self::ValidationError> {
@@ -2381,17 +2384,20 @@ impl FetchItem for FinalitySignature {
 }
 
 impl GossipItem for FinalitySignature {
-    type Id = FinalitySignatureId;
+    type Id = Box<FinalitySignatureId>;
 
     const ID_IS_COMPLETE_ITEM: bool = false;
     const REQUIRES_GOSSIP_RECEIVED_ANNOUNCEMENT: bool = true;
 
     fn gossip_id(&self) -> Self::Id {
-        FinalitySignatureId {
+        // Note: Unfortunately this is somewhat of a mismatch, as finality signature IDs are fairly
+        //       large, while the `GossipItem` trait expects them to be reasonably small (~ 64
+        //       bytes or less). The included `public_key` bloats these IDs greatly.
+        Box::new(FinalitySignatureId {
             block_hash: self.block_hash,
             era_id: self.era_id,
             public_key: self.public_key.clone(),
-        }
+        })
     }
 
     fn gossip_target(&self) -> GossipTarget {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1564,7 +1564,7 @@ impl Block {
             deploys_iter,
         );
         if !validator_weights.is_empty() {
-            finalized_block.era_report = Some(Box::new(EraReport::default()));
+            finalized_block.era_report = Some(Default::default());
         }
         let parent_seed = rng.gen::<[u8; Digest::LENGTH]>().into();
         let next_era_validator_weights = if validator_weights.is_empty() {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1,5 +1,6 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
+#![allow(clippy::boxed_local)] // We use boxed locals to pass on event data unchanged.
 
 mod approvals_hashes;
 mod meta_block;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -428,7 +428,7 @@ pub struct FinalizedBlock {
     transfer_hashes: Vec<DeployHash>,
     timestamp: Timestamp,
     random_bit: bool,
-    era_report: Box<Option<EraReport>>,
+    era_report: Option<Box<EraReport>>,
     era_id: EraId,
     height: u64,
     proposer: Box<PublicKey>,
@@ -448,7 +448,7 @@ impl FinalizedBlock {
             transfer_hashes: block_payload.transfer_hashes().cloned().collect(),
             timestamp,
             random_bit: block_payload.random_bit,
-            era_report: Box::new(era_report),
+            era_report: era_report.map(Box::new),
             era_id,
             height,
             proposer: Box::new(proposer),
@@ -463,7 +463,7 @@ impl FinalizedBlock {
     /// Returns slashing and reward information if this is a switch block, i.e. the last block of
     /// its era.
     pub(crate) fn era_report(&self) -> Option<&EraReport> {
-        (*self.era_report).as_ref()
+        self.era_report.as_deref()
     }
 
     /// Returns the ID of the era this block belongs to.
@@ -594,7 +594,10 @@ impl From<Block> for FinalizedBlock {
             transfer_hashes: block.body.transfer_hashes,
             timestamp: block.header.timestamp,
             random_bit: block.header.random_bit,
-            era_report: Box::new(block.header.era_end.map(|era_end| era_end.era_report)),
+            era_report: block
+                .header
+                .era_end
+                .map(|era_end| Box::new(era_end.era_report)),
             era_id: block.header.era_id,
             height: block.header.height,
             proposer: Box::new(block.body.proposer),
@@ -613,7 +616,7 @@ impl Display for FinalizedBlock {
             self.deploy_hashes.len(),
             self.transfer_hashes.len(),
         )?;
-        if let Some(ee) = *self.era_report.clone() {
+        if let Some(ref ee) = self.era_report {
             write!(formatter, ", era_end: {}", ee)?;
         }
         Ok(())
@@ -1300,10 +1303,10 @@ impl Block {
 
         let body_hash = body.hash();
 
-        let era_end = match (*finalized_block.era_report, next_era_validator_weights) {
+        let era_end = match (finalized_block.era_report, next_era_validator_weights) {
             (None, None) => None,
             (Some(era_report), Some(next_era_validator_weights)) => {
-                Some(EraEnd::new(era_report, next_era_validator_weights))
+                Some(EraEnd::new(*era_report, next_era_validator_weights))
             }
             (maybe_era_report, maybe_next_era_validator_weights) => {
                 return Err(BlockCreationError::CouldNotCreateEraEnd {
@@ -1560,7 +1563,7 @@ impl Block {
             deploys_iter,
         );
         if !validator_weights.is_empty() {
-            finalized_block.era_report = Box::new(Some(EraReport::default()));
+            finalized_block.era_report = Some(Box::new(EraReport::default()));
         }
         let parent_seed = rng.gen::<[u8; Digest::LENGTH]>().into();
         let next_era_validator_weights = if validator_weights.is_empty() {

--- a/node/src/types/block/approvals_hashes.rs
+++ b/node/src/types/block/approvals_hashes.rs
@@ -115,7 +115,7 @@ impl ApprovalsHashes {
 impl FetchItem for ApprovalsHashes {
     type Id = BlockHash;
     type ValidationError = ApprovalsHashesValidationError;
-    type ValidationMetadata = Box<Block>;
+    type ValidationMetadata = Block;
 
     const TAG: Tag = Tag::ApprovalsHashes;
 
@@ -123,7 +123,7 @@ impl FetchItem for ApprovalsHashes {
         self.block_hash
     }
 
-    fn validate(&self, block: &Box<Block>) -> Result<(), Self::ValidationError> {
+    fn validate(&self, block: &Block) -> Result<(), Self::ValidationError> {
         self.is_verified.get_or_init(|| self.verify(block)).clone()
     }
 }

--- a/node/src/types/error.rs
+++ b/node/src/types/error.rs
@@ -26,7 +26,7 @@ pub enum BlockCreationError {
     )]
     CouldNotCreateEraEnd {
         /// An optional `EraReport` we tried to use to construct an `EraEnd`.
-        maybe_era_report: Option<EraReport>,
+        maybe_era_report: Option<Box<EraReport>>,
         /// An optional map of the next era validator weights used to construct an `EraEnd`.
         maybe_next_era_validator_weights: Option<BTreeMap<PublicKey, U512>>,
     },

--- a/node/src/types/sync_leap_validation_metadata.rs
+++ b/node/src/types/sync_leap_validation_metadata.rs
@@ -28,21 +28,8 @@ impl SyncLeapValidationMetaData {
             finality_threshold_fraction,
         }
     }
-}
 
-impl From<Chainspec> for SyncLeapValidationMetaData {
-    fn from(chainspec: Chainspec) -> Self {
-        Self {
-            recent_era_count: chainspec.core_config.recent_era_count(),
-            activation_point: chainspec.protocol_config.activation_point,
-            global_state_update: chainspec.protocol_config.global_state_update.clone(),
-            finality_threshold_fraction: chainspec.core_config.finality_threshold_fraction,
-        }
-    }
-}
-
-impl From<&Chainspec> for SyncLeapValidationMetaData {
-    fn from(chainspec: &Chainspec) -> Self {
+    pub(crate) fn from_chainspec(chainspec: &Chainspec) -> Self {
         Self {
             recent_era_count: chainspec.core_config.recent_era_count(),
             activation_point: chainspec.protocol_config.activation_point,


### PR DESCRIPTION
Closes #3755.

This brings down `MainEvent` to less than 192 bytes, by carefully boxing fields of subevents. The main lift is done by all network messages now being passed boxed, as they have grown over time. Some types abuse the notion of an ID with fairly hefty objects, these have been made to use `Box<T>` as ID. Some other associated types, on the other hand, are moved onto the heap by default.

Additionally, this PR replaces all instances of `Box<Option<T>>` with `Option<Box<T>>`.

Note that a generous `#![allow(clippy::boxed_local)]` is added to some files - I cannot see the value in deboxing/boxing parameters just to pass them on, I prefer to keep the parameters as they come from the event.
