### PR TITLE
#3791validator matrix retrograde latch

### DIFF
--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -4,6 +4,7 @@ use std::{collections::HashSet, iter, rc::Rc, time::Duration};
 
 use assert_matches::assert_matches;
 use derive_more::From;
+use prometheus::Registry;
 use rand::{seq::IteratorRandom, Rng};
 
 use casper_types::testing::TestRng;
@@ -110,12 +111,13 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     );
 
     // Create a block synchronizer with a maximum of 5 simultaneous peers
+    let metrics_registry = Registry::new();
     let mut block_synchronizer = BlockSynchronizer::new(
         Config::default(),
         Arc::new(Chainspec::random(&mut rng)),
         5,
         validator_matrix,
-        prometheus::default_registry(),
+        &metrics_registry,
     )
     .unwrap();
 
@@ -255,12 +257,13 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
 
     // Create a block synchronizer with a maximum of 5 simultaneous peers.
+    let metrics_registry = Registry::new();
     let mut block_synchronizer = BlockSynchronizer::new(
         Config::default(),
         Arc::new(Chainspec::random(&mut rng)),
         peer_count,
         validator_matrix.clone(),
-        prometheus::default_registry(),
+        &metrics_registry,
     )
     .unwrap();
 

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -125,12 +125,18 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
 
     // Set up the synchronizer for the test block such that the next step is getting global state
     block_synchronizer.register_block_by_hash(*block.hash(), true, true);
-    assert!(block_synchronizer.historical.is_some()); // we only get global state on historical sync
+    assert!(
+        block_synchronizer.historical.is_some(),
+        "we only get global state on historical sync"
+    );
     block_synchronizer.register_peers(*block.hash(), peers.clone());
     let historical_builder = block_synchronizer.historical.as_mut().unwrap();
-    assert!(historical_builder
-        .register_block_header(block.header().clone(), None)
-        .is_ok());
+    assert!(
+        historical_builder
+            .register_block_header(block.header().clone(), None)
+            .is_ok(),
+        "historical builder should register header"
+    );
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
     // Generate a finality signature for the test block and register it
@@ -140,15 +146,26 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
         &Rc::new(ALICE_SECRET_KEY.clone()),
         ALICE_PUBLIC_KEY.clone(),
     );
-    assert!(signature.is_verified().is_ok());
-    assert!(historical_builder
-        .register_finality_signature(signature, None)
-        .is_ok());
-    assert!(historical_builder.register_block(&block, None).is_ok());
+    assert!(signature.is_verified().is_ok(), "signature should be ok");
+    assert!(
+        historical_builder
+            .register_finality_signature(signature, None)
+            .is_ok(),
+        "should register singature"
+    );
+    assert!(
+        historical_builder.register_block(&block, None).is_ok(),
+        "should register block"
+    );
 
     // At this point, the next step the synchronizer takes should be to get global state
     let mut effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert_eq!(effects.len(), 1);
+    assert_eq!(
+        effects.len(),
+        1,
+        "need next should have 1 effect at this step, not {}",
+        effects.len()
+    );
     tokio::spawn(async move { effects.remove(0).await });
     let event = mock_reactor.crank().await;
 
@@ -172,7 +189,12 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     // At this point we expect that another request for the global state would be made,
     // this time with other peers
     let mut effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert_eq!(effects.len(), 1);
+    assert_eq!(
+        effects.len(),
+        1,
+        "need next should still have 1 effect at this step, not {}",
+        effects.len()
+    );
     tokio::spawn(async move { effects.remove(0).await });
     let event = mock_reactor.crank().await;
 
@@ -193,22 +215,33 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
         )),
     );
     let mut effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert_eq!(effects.len(), 1);
+    assert_eq!(
+        effects.len(),
+        1,
+        "need next should still have 1 effect after global state sync'd, not {}",
+        effects.len()
+    );
     tokio::spawn(async move { effects.remove(0).await });
     let event = mock_reactor.crank().await;
 
-    // Synchronizer should have progressed
-    assert!(false == matches!(event, MockReactorEvent::SyncGlobalStateRequest { .. }));
+    assert!(
+        false == matches!(event, MockReactorEvent::SyncGlobalStateRequest { .. }),
+        "synchronizer should have progressed"
+    );
 
     // Check if the peers returned by the `GlobalStateSynchronizer` in the response were marked
     // unreliable.
     for peer in unreliable_peers.iter() {
-        assert!(block_synchronizer
-            .historical
-            .as_ref()
-            .unwrap()
-            .peer_list()
-            .is_peer_unreliable(peer));
+        assert!(
+            block_synchronizer
+                .historical
+                .as_ref()
+                .unwrap()
+                .peer_list()
+                .is_peer_unreliable(peer),
+            "{} should be marked unreliable",
+            peer
+        );
     }
 }
 
@@ -249,7 +282,11 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
 
     // At this point, the next step the synchronizer takes should be to get era validators.
     let effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert_eq!(effects.len(), peer_count as usize);
+    assert_eq!(
+        effects.len(),
+        peer_count as usize,
+        "need next should have an effect per peer when needing peers"
+    );
     for effect in effects {
         tokio::spawn(async move { effect.await });
         let event = mock_reactor.crank().await;
@@ -261,7 +298,10 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
 
     // Ensure the in-flight latch has been set, i.e. that `need_next` returns nothing.
     let effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert!(effects.is_empty());
+    assert!(
+        effects.is_empty(),
+        "should not have need next while latched"
+    );
 
     // Update the validator matrix to now have an entry for the era of our random block.
     validator_matrix.register_validator_weights(
@@ -277,7 +317,11 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
 
     // Ensure the in-flight latch has been released, i.e. that `need_next` returns something.
     let mut effects = block_synchronizer.need_next(mock_reactor.effect_builder(), &mut rng);
-    assert_eq!(effects.len(), 1);
+    assert_eq!(
+        effects.len(),
+        1,
+        "need next should produce 1 effect now that we have peers and the latch is removed"
+    );
     tokio::spawn(async move { effects.remove(0).await });
     let event = mock_reactor.crank().await;
     assert_matches!(

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -333,6 +333,13 @@ impl MainReactor {
             Digest::default(),
         );
 
+        let era_id = EraId::default();
+
+        // as this is a genesis validator, there is no historical syncing necessary
+        // thus, the retrograde latch is immediately set
+        self.validator_matrix
+            .register_retrograde_latch(Some(era_id));
+
         // new networks will create a switch block at genesis to
         // surface the genesis validators. older networks did not
         // have this behavior.
@@ -340,7 +347,7 @@ impl MainReactor {
             BlockPayload::default(),
             Some(EraReport::default()),
             genesis_timestamp,
-            EraId::default(),
+            era_id,
             genesis_block_height,
             PublicKey::System,
         );

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -612,6 +612,10 @@ impl MainReactor {
         // effects, any referenced deploys, & sufficient finality (by weight) of signatures.
         match self.storage.get_highest_orphaned_block_header() {
             HighestOrphanedBlockResult::Orphan(block_header) => {
+                // set a latch on the validator matrix to prevent it from purging validator weights
+                // of interstitial eras which we have not yet historically sync'd
+                self.validator_matrix
+                    .register_retrograde_latch(Some(block_header.era_id()));
                 if block_header.is_genesis() {
                     return Ok(Some(SyncBackInstruction::GenesisSynced));
                 }

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -10,6 +10,7 @@ use datasize::DataSize;
 use itertools::Itertools;
 use num_rational::Ratio;
 use serde::Serialize;
+use static_assertions::const_assert;
 use tracing::info;
 
 use casper_types::{EraId, PublicKey, SecretKey, U512};
@@ -17,6 +18,7 @@ use casper_types::{EraId, PublicKey, SecretKey, U512};
 use super::{BlockHeader, FinalitySignature};
 
 const MAX_VALIDATOR_MATRIX_ENTRIES: usize = 6;
+const_assert!(MAX_VALIDATOR_MATRIX_ENTRIES % 2 == 0);
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, DataSize)]
 pub(crate) enum SignatureWeight {
@@ -504,5 +506,109 @@ mod tests {
         );
         let new_state: Vec<EraId> = validator_matrix.read_inner().keys().copied().collect();
         assert_eq!(old_state, new_state, "state should be unchanged");
+    }
+
+    #[test]
+    fn register_validator_weights_latched_pruning() {
+        // Create a validator matrix and saturate it with entries.
+        let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
+        // Set the retrograde latch to 10 so we can register all eras lower or
+        // equal to 10.
+        validator_matrix.register_retrograde_latch(Some(EraId::from(10)));
+        let mut era_validator_weights = vec![validator_matrix.validator_weights(0.into()).unwrap()];
+        era_validator_weights.extend(
+            (1..=MAX_VALIDATOR_MATRIX_ENTRIES as u64)
+                .into_iter()
+                .map(EraId::from)
+                .map(empty_era_validator_weights),
+        );
+        for evw in era_validator_weights
+            .iter()
+            .take(MAX_VALIDATOR_MATRIX_ENTRIES + 1)
+            .skip(1)
+            .cloned()
+        {
+            assert!(
+                validator_matrix.register_era_validator_weights(evw),
+                "register_era_validator_weights"
+            );
+        }
+
+        // Register eras [7, 8, 9].
+        era_validator_weights.extend(
+            (7..=9)
+                .into_iter()
+                .map(EraId::from)
+                .map(empty_era_validator_weights),
+        );
+        for evw in era_validator_weights.iter().rev().take(3).cloned() {
+            assert!(
+                validator_matrix.register_era_validator_weights(evw),
+                "register_era_validator_weights"
+            );
+        }
+
+        // Set the retrograde latch to era 5.
+        validator_matrix.register_retrograde_latch(Some(EraId::from(5)));
+        // Add era 10 to the weights.
+        era_validator_weights.push(empty_era_validator_weights(EraId::from(10)));
+        assert_eq!(era_validator_weights.len(), 11);
+        // As the current weights in the matrix are [0, ..., 9], register era
+        // 10. This should succeed anyway since it's the highest weight.
+        assert!(
+            validator_matrix.register_era_validator_weights(era_validator_weights[10].clone()),
+            "register_era_validator_weights"
+        );
+        // The latch was previously set to 5, so now all weights which are
+        // neither the lowest 3, highest 3 or higher than the latched era
+        // should have been purged.
+        // Given we had weights [0, ..., 10] and the latch is 5, we should
+        // be left with [0, 1, 2, 3, 4, 5, 8, 9, 10].
+        for era in 0..=5 {
+            assert!(validator_matrix.has_era(&EraId::from(era)));
+        }
+        for era in 6..=7 {
+            assert!(!validator_matrix.has_era(&EraId::from(era)));
+        }
+        for era in 8..=10 {
+            assert!(validator_matrix.has_era(&EraId::from(era)));
+        }
+
+        // Make sure era 6, which was previously purged, is not registered as
+        // it is greater than the latch, which is 5.
+        assert!(
+            !validator_matrix.register_era_validator_weights(era_validator_weights[6].clone()),
+            "register_era_validator_weights"
+        );
+
+        // Set the retrograde latch to era 6.
+        validator_matrix.register_retrograde_latch(Some(EraId::from(6)));
+        // Make sure era 6 is now registered.
+        assert!(
+            validator_matrix.register_era_validator_weights(era_validator_weights[6].clone()),
+            "register_era_validator_weights"
+        );
+
+        // Set the retrograde latch to era 1.
+        validator_matrix.register_retrograde_latch(Some(EraId::from(1)));
+        // Register era 10 again to drive the purging mechanism.
+        assert!(
+            !validator_matrix.register_era_validator_weights(era_validator_weights[10].clone()),
+            "register_era_validator_weights"
+        );
+        // The latch was previously set to 1, so now all weights which are
+        // neither the lowest 3, highest 3 or higher than the latched era
+        // should have been purged.
+        // Given we had weights [0, 1, 2, 3, 4, 5, 6, 8, 9, 10] and the latch
+        // is 1, we should be left with [0, 1, 2, 8, 9, 10].
+        for era in 0..=2 {
+            assert!(validator_matrix.has_era(&EraId::from(era)));
+        }
+        for era in 3..=7 {
+            assert!(!validator_matrix.has_era(&EraId::from(era)));
+        }
+        for era in 8..=10 {
+            assert!(validator_matrix.has_era(&EraId::from(era)));
+        }
     }
 }


### PR DESCRIPTION
Sets retrograde latch on validator matrix to prevent premature removal of historical era validator weights which are still needed for historical syncing.
