### PR TITLE
better error for 0 balances

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -79,7 +79,7 @@ pub(crate) enum Error {
 #[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Error, Serialize)]
 pub(crate) enum DeployParameterFailure {
     /// Account does not exist.
-    #[error("account {account_hash} does not exist")]
+    #[error("main purse for account {account_hash} does not exist - balance is 0")]
     NonexistentAccount { account_hash: AccountHash },
     /// Nonexistent contract at hash.
     #[error("contract at {contract_hash} does not exist")]


### PR DESCRIPTION
The error "account does not exist at prestate_hash" is misleading to unexperienced Casper developers. This error is usually thrown when there is no transactions for an account at a given state root hash. This can either mean that the node is not synced, the account balance is actually 0 and there is no transaction record, or the srh is outdated.

In each scenario the situation becomes more clear with the new error and it'll help developers identify the most common issue - an unfunded account.

Therefore I propose this literal change.
