### PR TITLE
Fix activation points in nctl upgrade tests

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -51,7 +51,7 @@ function _main()
     # Set initial protocol version for use later.
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
-    ACTIVATION_POINT="$(get_chain_era)"
+    ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
     _step_04 "$INITIAL_PROTOCOL_VERSION"
@@ -130,7 +130,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -267,7 +267,7 @@ function _step_09()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+            era="$ACTIVATION_POINT"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -51,7 +51,7 @@ function _main()
     # Set initial protocol version for use later.
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
-    ACTIVATION_POINT="$(get_chain_era)"
+    ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
     _step_04 "$INITIAL_PROTOCOL_VERSION"
@@ -130,7 +130,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -267,7 +267,7 @@ function _step_09()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+            era="$ACTIVATION_POINT"
         echo ""
         # add hash to upgrades config
         PATH_TO_NODE_CONFIG_UPGRADE="$(get_path_to_node_config $i)/$N2_PROTO_VERSION/config.toml"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_08.sh
@@ -35,7 +35,7 @@ function _main()
 
     # Set initial protocol version for use later.
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
-    local ACTIVATION_POINT="$(get_chain_era)"
+    local ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
     _step_04 "6"
@@ -84,7 +84,7 @@ function _step_03()
         stage="$STAGE_ID" \
         verbose=false \
         node="6" \
-        era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))" \
+        era="$ACTIVATION_POINT" \
         chainspec_path="$NCTL_CASPER_HOME/resources/local/chainspec.toml.in"
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -47,7 +47,7 @@ function _main()
     # Set initial protocol version for use later.
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
-    ACTIVATION_POINT="$(get_chain_era)"
+    ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
     PRE_UPGRADE_BLOCK_HASH="$($(get_path_to_client) get-block --node-address "$(get_node_address_rpc '2')" | jq -r '.result.block.hash')"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
@@ -107,7 +107,7 @@ function _step_03()
             stage="$STAGE_ID" \
             verbose=false \
             node="$i" \
-            era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+            era="$ACTIVATION_POINT"
         echo ""
     done
 
@@ -207,7 +207,7 @@ function _stage_node_with_trusted_hash()
         stage="$STAGE_ID" \
         verbose=false \
         node="$NODE_ID" \
-        era="$((ACTIVATION_POINT + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+        era="$ACTIVATION_POINT"
     echo ""
 
     source "$NCTL/sh/node/start.sh" node="$NODE_ID" hash="$BLOCK_HASH"


### PR DESCRIPTION
Some of the nctl upgrade tests called `upgrade_from_stage_single_node.sh` inside a loop where a local variable `ACTIVATION_POINT` was in scope.  `upgrade_from_stage_single_node.sh` was being called with `era="$((ACTIVATION_POINT + 2))"`.  Inside that script however, it was setting `ACTIVATION_POINT` to the value of `era`, and this change permeated back to the calling script.  This meant that every node was being given a chainspec with a different activation point, causing the upgrade to fail.

This PR changes that flow to avoid incrementing the activation point within the loops.