### PR TITLE
Fix detection of sync to ttl

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1283,6 +1283,13 @@ impl Storage {
             .map(|sequence| sequence.high())
     }
 
+    /// Retrieves the height of the lowest complete block (if any).
+    pub(crate) fn lowest_complete_block_height(&self) -> Option<u64> {
+        self.completed_blocks
+            .highest_sequence()
+            .map(|sequence| sequence.low())
+    }
+
     /// Retrieves the highest complete block from the storage, if one exists.
     pub(crate) fn read_highest_complete_block(&self) -> Result<Option<Block>, FatalStorageError> {
         let mut txn = self
@@ -1292,6 +1299,33 @@ impl Storage {
         let maybe_block = self.get_highest_complete_block(&mut txn)?;
         txn.commit().expect("Could not commit transaction");
         Ok(maybe_block)
+    }
+
+    /// Retrieves the lowest complete block header from the storage, if one exists.
+    pub(crate) fn read_lowest_complete_block_header(
+        &self,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let lowest_complete_block_height = match self.lowest_complete_block_height() {
+            Some(height) => height,
+            None => {
+                return Ok(None);
+            }
+        };
+
+        let lowest_complete_block_hash =
+            match self.block_height_index.get(&lowest_complete_block_height) {
+                Some(hash) => hash,
+                None => {
+                    warn!("couldn't find the lowest complete block in block height index");
+                    return Ok(None);
+                }
+            };
+
+        // The `completed_blocks` contains blocks with sufficient finality signatures,
+        // so we don't need to check the sufficiency again.
+        let maybe_lowest_block_header =
+            self.read_block_header_by_hash(lowest_complete_block_hash)?;
+        Ok(maybe_lowest_block_header)
     }
 
     /// Retrieves the contiguous segment of the block chain starting at the highest known switch

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -284,7 +284,7 @@ impl Display for HighestOrphanedBlockResult {
                 f,
                 "orphan, height={}, hash={}",
                 block_header.height(),
-                block_header.height()
+                block_header.block_hash()
             ),
             HighestOrphanedBlockResult::MissingHeader(block_hash) => {
                 write!(f, "missing header for block hash: {}", block_hash)

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -180,7 +180,7 @@ pub(crate) struct MainReactor {
     //   control logic
     state: ReactorState,
     max_attempts: usize,
-    switch_block: Option<BlockHeader>,
+    switch_block_header: Option<BlockHeader>,
 
     last_progress: Timestamp,
     attempts: usize,
@@ -1159,7 +1159,7 @@ impl reactor::Reactor for MainReactor {
             control_logic_default_delay: config.node.control_logic_default_delay,
             trusted_hash,
             validator_matrix,
-            switch_block: None,
+            switch_block_header: None,
             sync_to_genesis: config.node.sync_to_genesis,
             signature_gossip_tracker: SignatureGossipTracker::new(),
         };
@@ -1394,18 +1394,22 @@ impl MainReactor {
                 block.hash(),
             );
             if block.header().is_switch_block() {
-                match self.switch_block.as_ref().map(|header| header.height()) {
+                match self
+                    .switch_block_header
+                    .as_ref()
+                    .map(|header| header.height())
+                {
                     Some(current_height) => {
                         if block.height() > current_height {
-                            self.switch_block = Some(block.header().clone());
+                            self.switch_block_header = Some(block.header().clone());
                         }
                     }
                     None => {
-                        self.switch_block = Some(block.header().clone());
+                        self.switch_block_header = Some(block.header().clone());
                     }
                 }
             } else {
-                self.switch_block = None;
+                self.switch_block_header = None;
             }
         } else {
             error!(

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -108,7 +108,7 @@ impl MainReactor {
                 // trusted block hash to be provided via the config file
                 info!("CatchUp: local tip detected, no trusted hash");
                 if block.header().is_switch_block() {
-                    self.switch_block = Some(block.header().clone());
+                    self.switch_block_header = Some(block.header().clone());
                 }
                 Either::Left(SyncIdentifier::LocalTip(
                     *block.hash(),
@@ -116,7 +116,7 @@ impl MainReactor {
                     block.header().era_id(),
                 ))
             }
-            Ok(None) if self.switch_block.is_none() => {
+            Ok(None) if self.switch_block_header.is_none() => {
                 // no trusted hash, no local block, might be genesis
                 self.catch_up_check_genesis()
             }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -389,7 +389,7 @@ impl MainReactor {
         effect_builder: EffectBuilder<MainEvent>,
     ) -> Result<Effects<MainEvent>, String> {
         info!("{:?}: committing upgrade", self.state);
-        let previous_block_header = match &self.switch_block {
+        let previous_block_header = match &self.switch_block_header {
             None => {
                 return Err("switch_block should be Some".to_string());
             }
@@ -462,7 +462,7 @@ impl MainReactor {
     }
 
     pub(super) fn should_commit_upgrade(&self) -> bool {
-        let highest_switch_block_header = match &self.switch_block {
+        let highest_switch_block_header = match &self.switch_block_header {
             None => {
                 return false;
             }
@@ -552,7 +552,7 @@ impl MainReactor {
                 Ok(highest_switch_block_header) => highest_switch_block_header,
                 Err(err) => return Err(err.to_string()),
             };
-        self.switch_block = maybe_highest_switch_block_header.first().cloned();
+        self.switch_block_header = maybe_highest_switch_block_header.first().cloned();
         Ok(())
     }
 }

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -662,7 +662,12 @@ impl MainReactor {
             return Ok(false);
         }
 
-        if let Some(latest_switch_block_header) = &self.switch_block_header {
+        if let Some(latest_switch_block_header) = self
+            .storage
+            .read_highest_switch_block_headers(1)
+            .map_err(|err| err.to_string())?
+            .last()
+        {
             if let Some(lowest_block_header) = self
                 .storage
                 .read_lowest_complete_block_header()

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -6,7 +6,7 @@ use std::{
 use tracing::{debug, error, info, warn};
 
 use casper_execution_engine::core::engine_state::GetEraValidatorsError;
-use casper_types::{EraId, Timestamp};
+use casper_types::{EraId, TimeDiff, Timestamp};
 
 use crate::{
     components::{
@@ -597,7 +597,7 @@ impl MainReactor {
                 if block_header.is_genesis() {
                     return Ok(Some(SyncBackInstruction::GenesisSynced));
                 }
-                if self.sync_back_is_ttl() {
+                if self.sync_back_is_ttl()? {
                     return Ok(Some(SyncBackInstruction::TtlSynced));
                 }
                 let parent_hash = block_header.parent_hash();
@@ -653,20 +653,102 @@ impl MainReactor {
         }
     }
 
-    fn sync_back_is_ttl(&self) -> bool {
-        if false == self.sync_to_genesis {
-            // if sync to genesis is false, we require sync to ttl; i.e. if the TTL is 12 hours
-            // we require sync back to see a contiguous / unbroken range of at least 12 hours
-            // worth of blocks. note however that we measure from the start of the active era
-            // (for consensus reasons), so this can be up to TTL + era length in practice
-            if let Some(block_header) = &self.switch_block {
-                let diff = self.chainspec.deploy_config.max_ttl;
-                let cutoff = block_header.timestamp().saturating_sub(diff);
-                let block_time = block_header.timestamp();
-                // this node is configured to only sync to ttl, and we may have reached ttl
-                return block_time < cutoff;
+    fn sync_back_is_ttl(&self) -> Result<bool, String> {
+        // if sync to genesis is false, we require sync to ttl; i.e. if the TTL is 12 hours
+        // we require sync back to see a contiguous / unbroken range of at least 12 hours
+        // worth of blocks. note however that we measure from the start of the active era
+        // (for consensus reasons), so this can be up to TTL + era length in practice
+        if self.sync_to_genesis {
+            return Ok(false);
+        }
+
+        if let Some(latest_switch_block_header) = &self.switch_block_header {
+            if let Some(lowest_block_header) = self
+                .storage
+                .read_lowest_complete_block_header()
+                .map_err(|err| err.to_string())?
+            {
+                return Ok(is_at_ttl(
+                    latest_switch_block_header.timestamp(),
+                    lowest_block_header.timestamp(),
+                    self.chainspec.deploy_config.max_ttl,
+                ));
             }
         }
-        false
+
+        Ok(false)
+    }
+}
+
+fn is_at_ttl(
+    latest_switch_block_timestamp: Timestamp,
+    lowest_block_timestamp: Timestamp,
+    max_ttl: TimeDiff,
+) -> bool {
+    lowest_block_timestamp < latest_switch_block_timestamp.saturating_sub(max_ttl)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use casper_types::{TimeDiff, Timestamp};
+
+    use crate::reactor::main_reactor::keep_up::is_at_ttl;
+
+    const TWO_DAYS_SECS: u32 = 60 * 60 * 24 * 2;
+
+    #[test]
+    fn should_be_at_ttl() {
+        let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
+        let lowest_block_timestamp = Timestamp::from_str("2010-06-10 00:00:00.000").unwrap();
+        let max_ttl = TimeDiff::from_seconds(TWO_DAYS_SECS);
+        assert!(is_at_ttl(
+            latest_switch_block_timestamp,
+            lowest_block_timestamp,
+            max_ttl
+        ));
+    }
+
+    #[test]
+    fn should_not_be_at_ttl() {
+        let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
+        let lowest_block_timestamp = Timestamp::from_str("2010-06-14 00:00:00.000").unwrap();
+        let max_ttl = TimeDiff::from_seconds(TWO_DAYS_SECS);
+        assert!(!is_at_ttl(
+            latest_switch_block_timestamp,
+            lowest_block_timestamp,
+            max_ttl
+        ));
+    }
+
+    #[test]
+    fn should_detect_ttl_at_the_boundary() {
+        let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
+        let lowest_block_timestamp = Timestamp::from_str("2010-06-12 23:59:59.999").unwrap();
+        let max_ttl = TimeDiff::from_seconds(TWO_DAYS_SECS);
+        assert!(is_at_ttl(
+            latest_switch_block_timestamp,
+            lowest_block_timestamp,
+            max_ttl
+        ));
+
+        let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
+        let lowest_block_timestamp = Timestamp::from_str("2010-06-13 00:00:00.000").unwrap();
+        let max_ttl = TimeDiff::from_seconds(TWO_DAYS_SECS);
+        assert!(!is_at_ttl(
+            latest_switch_block_timestamp,
+            lowest_block_timestamp,
+            max_ttl
+        ));
+
+        let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
+        let lowest_block_timestamp = Timestamp::from_str("2010-06-13 00:00:00.001").unwrap();
+        let max_ttl = TimeDiff::from_seconds(TWO_DAYS_SECS);
+        assert!(!is_at_ttl(
+            latest_switch_block_timestamp,
+            lowest_block_timestamp,
+            max_ttl
+        ));
     }
 }

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -33,7 +33,7 @@ impl MainReactor {
                 self.control_logic_default_delay.into(),
             );
         }
-        if self.switch_block.is_none() {
+        if self.switch_block_header.is_none() {
             // validate status is only checked at switch blocks
             return ValidateInstruction::NonSwitchBlock;
         }


### PR DESCRIPTION
In this PR
1. Node uses the lowest available block timestamp when calculating if it reached TTL when syncing backwards.
2. TTL detection does not rely on `MainReactor::switch_block_header` (which could be set to `None` when marking block complete), it uses the `switch_block_era_id_index` instead

That introduces some reads from storage when determining if we're synced to TTL, but the performance impact should be negligible.