### PR TITLE
Remove `unregister_metric!`

### DIFF
--- a/node/src/components/block_accumulator/metrics.rs
+++ b/node/src/components/block_accumulator/metrics.rs
@@ -1,44 +1,32 @@
 use prometheus::{IntGauge, Registry};
 
-use crate::unregister_metric;
+use crate::utils::registered_metric::{RegisteredMetric, RegistryExt};
 
 /// Metrics for the block accumulator component.
 #[derive(Debug)]
 pub(super) struct Metrics {
     /// Total number of BlockAcceptors contained in the BlockAccumulator.
-    pub(super) block_acceptors: IntGauge,
+    pub(super) block_acceptors: RegisteredMetric<IntGauge>,
     /// Number of child block hashes that we know of and that will be used in order to request next
     /// blocks.
-    pub(super) known_child_blocks: IntGauge,
-    registry: Registry,
+    pub(super) known_child_blocks: RegisteredMetric<IntGauge>,
 }
 
 impl Metrics {
     /// Creates a new instance of the block accumulator metrics, using the given prefix.
     pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let block_acceptors = IntGauge::new(
+        let block_acceptors = registry.new_int_gauge(
             "block_accumulator_block_acceptors".to_string(),
             "number of block acceptors in the Block Accumulator".to_string(),
         )?;
-        let known_child_blocks = IntGauge::new(
+        let known_child_blocks = registry.new_int_gauge(
             "block_accumulator_known_child_blocks".to_string(),
             "number of blocks received by the Block Accumulator for which we know the hash of the child block".to_string(),
         )?;
 
-        registry.register(Box::new(block_acceptors.clone()))?;
-        registry.register(Box::new(known_child_blocks.clone()))?;
-
         Ok(Metrics {
             block_acceptors,
             known_child_blocks,
-            registry: registry.clone(),
         })
-    }
-}
-
-impl Drop for Metrics {
-    fn drop(&mut self) {
-        unregister_metric!(self.registry, self.block_acceptors);
-        unregister_metric!(self.registry, self.known_child_blocks);
     }
 }

--- a/node/src/components/deploy_buffer/metrics.rs
+++ b/node/src/components/deploy_buffer/metrics.rs
@@ -1,52 +1,38 @@
 use prometheus::{IntGauge, Registry};
 
-use crate::unregister_metric;
+use crate::utils::registered_metric::{RegisteredMetric, RegistryExt};
 
 /// Metrics for the deploy_buffer component.
 #[derive(Debug)]
 pub(super) struct Metrics {
     /// Total number of deploys contained in the deploy buffer.
-    pub(super) total_deploys: IntGauge,
+    pub(super) total_deploys: RegisteredMetric<IntGauge>,
     /// Number of deploys contained in in-flight proposed blocks.
-    pub(super) held_deploys: IntGauge,
+    pub(super) held_deploys: RegisteredMetric<IntGauge>,
     /// Number of deploys that should not be included in future proposals ever again.
-    pub(super) dead_deploys: IntGauge,
-    registry: Registry,
+    pub(super) dead_deploys: RegisteredMetric<IntGauge>,
 }
 
 impl Metrics {
     /// Creates a new instance of the block accumulator metrics, using the given prefix.
     pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let total_deploys = IntGauge::new(
+        let total_deploys = registry.new_int_gauge(
             "deploy_buffer_total_deploys".to_string(),
             "total number of deploys contained in the deploy buffer.".to_string(),
         )?;
-        let held_deploys = IntGauge::new(
+        let held_deploys = registry.new_int_gauge(
             "deploy_buffer_held_deploys".to_string(),
             "number of deploys included in in-flight proposed blocks.".to_string(),
         )?;
-        let dead_deploys = IntGauge::new(
+        let dead_deploys = registry.new_int_gauge(
             "deploy_buffer_dead_deploys".to_string(),
             "number of deploys that should not be included in future proposals.".to_string(),
         )?;
-
-        registry.register(Box::new(total_deploys.clone()))?;
-        registry.register(Box::new(held_deploys.clone()))?;
-        registry.register(Box::new(dead_deploys.clone()))?;
 
         Ok(Metrics {
             total_deploys,
             held_deploys,
             dead_deploys,
-            registry: registry.clone(),
         })
-    }
-}
-
-impl Drop for Metrics {
-    fn drop(&mut self) {
-        unregister_metric!(self.registry, self.total_deploys);
-        unregister_metric!(self.registry, self.held_deploys);
-        unregister_metric!(self.registry, self.dead_deploys);
     }
 }

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -1,50 +1,48 @@
 use prometheus::{IntCounter, IntGauge, Registry};
 
-use crate::unregister_metric;
+use crate::utils::registered_metric::{RegisteredMetric, RegistryExt};
 
 /// Metrics for the gossiper component.
 #[derive(Debug)]
 pub(super) struct Metrics {
     /// Total number of items received by the gossiper.
-    pub(super) items_received: IntCounter,
+    pub(super) items_received: RegisteredMetric<IntCounter>,
     /// Total number of gossip requests sent to peers.
-    pub(super) times_gossiped: IntCounter,
+    pub(super) times_gossiped: RegisteredMetric<IntCounter>,
     /// Number of times the process had to pause due to running out of peers.
-    pub(super) times_ran_out_of_peers: IntCounter,
+    pub(super) times_ran_out_of_peers: RegisteredMetric<IntCounter>,
     /// Number of items in the gossip table that are currently being gossiped.
-    pub(super) table_items_current: IntGauge,
+    pub(super) table_items_current: RegisteredMetric<IntGauge>,
     /// Number of items in the gossip table that are finished.
-    pub(super) table_items_finished: IntGauge,
-    /// Reference to the registry for unregistering.
-    registry: Registry,
+    pub(super) table_items_finished: RegisteredMetric<IntGauge>,
 }
 
 impl Metrics {
     /// Creates a new instance of gossiper metrics, using the given prefix.
     pub fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
-        let items_received = IntCounter::new(
+        let items_received = registry.new_int_counter(
             format!("{}_items_received", name),
             format!("number of items received by the {}", name),
         )?;
-        let times_gossiped = IntCounter::new(
+        let times_gossiped = registry.new_int_counter(
             format!("{}_times_gossiped", name),
             format!("number of times the {} sent gossip requests to peers", name),
         )?;
-        let times_ran_out_of_peers = IntCounter::new(
+        let times_ran_out_of_peers = registry.new_int_counter(
             format!("{}_times_ran_out_of_peers", name),
             format!(
                 "number of times the {} ran out of peers and had to pause",
                 name
             ),
         )?;
-        let table_items_current = IntGauge::new(
+        let table_items_current = registry.new_int_gauge(
             format!("{}_table_items_current", name),
             format!(
                 "number of items in the gossip table of {} in state current",
                 name
             ),
         )?;
-        let table_items_finished = IntGauge::new(
+        let table_items_finished = registry.new_int_gauge(
             format!("{}_table_items_finished", name),
             format!(
                 "number of items in the gossip table of {} in state finished",
@@ -52,29 +50,12 @@ impl Metrics {
             ),
         )?;
 
-        registry.register(Box::new(items_received.clone()))?;
-        registry.register(Box::new(times_gossiped.clone()))?;
-        registry.register(Box::new(times_ran_out_of_peers.clone()))?;
-        registry.register(Box::new(table_items_current.clone()))?;
-        registry.register(Box::new(table_items_finished.clone()))?;
-
         Ok(Metrics {
             items_received,
             times_gossiped,
             times_ran_out_of_peers,
             table_items_current,
             table_items_finished,
-            registry: registry.clone(),
         })
-    }
-}
-
-impl Drop for Metrics {
-    fn drop(&mut self) {
-        unregister_metric!(self.registry, self.items_received);
-        unregister_metric!(self.registry, self.times_gossiped);
-        unregister_metric!(self.registry, self.times_ran_out_of_peers);
-        unregister_metric!(self.registry, self.table_items_current);
-        unregister_metric!(self.registry, self.table_items_finished);
     }
 }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -255,13 +255,19 @@ where
 
         let outgoing_limiter = Limiter::new(
             cfg.max_outgoing_byte_rate_non_validators,
-            net_metrics.accumulated_outgoing_limiter_delay.clone(),
+            net_metrics
+                .accumulated_outgoing_limiter_delay
+                .inner()
+                .clone(),
             validator_matrix.clone(),
         );
 
         let incoming_limiter = Limiter::new(
             cfg.max_incoming_message_rate_non_validators,
-            net_metrics.accumulated_incoming_limiter_delay.clone(),
+            net_metrics
+                .accumulated_incoming_limiter_delay
+                .inner()
+                .clone(),
             validator_matrix,
         );
 
@@ -506,7 +512,7 @@ where
             };
             trace!(%msg, encoded_size=payload.len(), %channel, "enqueing message for sending");
 
-            let send_token = TokenizedCount::new(self.net_metrics.queued_messages.clone());
+            let send_token = TokenizedCount::new(self.net_metrics.queued_messages.inner().clone());
 
             if let Err(refused_message) =
                 sender.send(EncodedMessage::new(payload, opt_responder, send_token))

--- a/node/src/components/network/metrics.rs
+++ b/node/src/components/network/metrics.rs
@@ -4,10 +4,7 @@ use prometheus::{Counter, IntCounter, IntGauge, Registry};
 use tracing::debug;
 
 use super::{outgoing::OutgoingMetrics, MessageKind};
-use crate::{
-    unregister_metric,
-    utils::registered_metric::{RegisteredMetric, RegistryExt},
-};
+use crate::utils::registered_metric::{RegisteredMetric, RegistryExt};
 
 /// Network-type agnostic networking metrics.
 #[derive(Debug)]
@@ -17,389 +14,336 @@ pub(super) struct Metrics {
     /// How often a request to send a message directly to a peer was made.
     pub(super) direct_message_requests: RegisteredMetric<IntCounter>,
     /// Number of messages still waiting to be sent out (broadcast and direct).
-    pub(super) queued_messages: IntGauge,
+    pub(super) queued_messages: RegisteredMetric<IntGauge>,
     /// Number of connected peers.
-    pub(super) peers: IntGauge,
+    pub(super) peers: RegisteredMetric<IntGauge>,
 
     /// Count of outgoing messages that are protocol overhead.
-    pub(super) out_count_protocol: IntCounter,
+    pub(super) out_count_protocol: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with consensus payload.
-    pub(super) out_count_consensus: IntCounter,
+    pub(super) out_count_consensus: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with deploy gossiper payload.
-    pub(super) out_count_deploy_gossip: IntCounter,
-    pub(super) out_count_block_gossip: IntCounter,
-    pub(super) out_count_finality_signature_gossip: IntCounter,
+    pub(super) out_count_deploy_gossip: RegisteredMetric<IntCounter>,
+    pub(super) out_count_block_gossip: RegisteredMetric<IntCounter>,
+    pub(super) out_count_finality_signature_gossip: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with address gossiper payload.
-    pub(super) out_count_address_gossip: IntCounter,
+    pub(super) out_count_address_gossip: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with deploy request/response payload.
-    pub(super) out_count_deploy_transfer: IntCounter,
+    pub(super) out_count_deploy_transfer: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with block request/response payload.
-    pub(super) out_count_block_transfer: IntCounter,
+    pub(super) out_count_block_transfer: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with trie request/response payload.
-    pub(super) out_count_trie_transfer: IntCounter,
+    pub(super) out_count_trie_transfer: RegisteredMetric<IntCounter>,
     /// Count of outgoing messages with other payload.
-    pub(super) out_count_other: IntCounter,
+    pub(super) out_count_other: RegisteredMetric<IntCounter>,
 
     /// Volume in bytes of outgoing messages that are protocol overhead.
-    pub(super) out_bytes_protocol: IntCounter,
+    pub(super) out_bytes_protocol: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with consensus payload.
-    pub(super) out_bytes_consensus: IntCounter,
+    pub(super) out_bytes_consensus: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with deploy gossiper payload.
-    pub(super) out_bytes_deploy_gossip: IntCounter,
-    pub(super) out_bytes_block_gossip: IntCounter,
-    pub(super) out_bytes_finality_signature_gossip: IntCounter,
+    pub(super) out_bytes_deploy_gossip: RegisteredMetric<IntCounter>,
+    /// Volume in bytes of outgoing messages with block gossiper payload.
+    pub(super) out_bytes_block_gossip: RegisteredMetric<IntCounter>,
+    /// Volume in bytes of outgoing messages with finality signature payload.
+    pub(super) out_bytes_finality_signature_gossip: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with address gossiper payload.
-    pub(super) out_bytes_address_gossip: IntCounter,
+    pub(super) out_bytes_address_gossip: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with deploy request/response payload.
-    pub(super) out_bytes_deploy_transfer: IntCounter,
+    pub(super) out_bytes_deploy_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with block request/response payload.
-    pub(super) out_bytes_block_transfer: IntCounter,
+    pub(super) out_bytes_block_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with block request/response payload.
-    pub(super) out_bytes_trie_transfer: IntCounter,
+    pub(super) out_bytes_trie_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of outgoing messages with other payload.
-    pub(super) out_bytes_other: IntCounter,
+    pub(super) out_bytes_other: RegisteredMetric<IntCounter>,
 
     /// Number of outgoing connections in connecting state.
-    pub(super) out_state_connecting: IntGauge,
+    pub(super) out_state_connecting: RegisteredMetric<IntGauge>,
     /// Number of outgoing connections in waiting state.
-    pub(super) out_state_waiting: IntGauge,
+    pub(super) out_state_waiting: RegisteredMetric<IntGauge>,
     /// Number of outgoing connections in connected state.
-    pub(super) out_state_connected: IntGauge,
+    pub(super) out_state_connected: RegisteredMetric<IntGauge>,
     /// Number of outgoing connections in blocked state.
-    pub(super) out_state_blocked: IntGauge,
+    pub(super) out_state_blocked: RegisteredMetric<IntGauge>,
     /// Number of outgoing connections in loopback state.
-    pub(super) out_state_loopback: IntGauge,
+    pub(super) out_state_loopback: RegisteredMetric<IntGauge>,
 
     /// Volume in bytes of incoming messages that are protocol overhead.
-    pub(super) in_bytes_protocol: IntCounter,
+    pub(super) in_bytes_protocol: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with consensus payload.
-    pub(super) in_bytes_consensus: IntCounter,
+    pub(super) in_bytes_consensus: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with deploy gossiper payload.
-    pub(super) in_bytes_deploy_gossip: IntCounter,
-    pub(super) in_bytes_block_gossip: IntCounter,
-    pub(super) in_bytes_finality_signature_gossip: IntCounter,
+    pub(super) in_bytes_deploy_gossip: RegisteredMetric<IntCounter>,
+    /// Volume in bytes of incoming messages with block gossiper payload.
+    pub(super) in_bytes_block_gossip: RegisteredMetric<IntCounter>,
+    /// Volume in bytes of incoming messages with finality signature gossiper payload.
+    pub(super) in_bytes_finality_signature_gossip: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with address gossiper payload.
-    pub(super) in_bytes_address_gossip: IntCounter,
+    pub(super) in_bytes_address_gossip: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with deploy request/response payload.
-    pub(super) in_bytes_deploy_transfer: IntCounter,
+    pub(super) in_bytes_deploy_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with block request/response payload.
-    pub(super) in_bytes_block_transfer: IntCounter,
+    pub(super) in_bytes_block_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with block request/response payload.
-    pub(super) in_bytes_trie_transfer: IntCounter,
+    pub(super) in_bytes_trie_transfer: RegisteredMetric<IntCounter>,
     /// Volume in bytes of incoming messages with other payload.
-    pub(super) in_bytes_other: IntCounter,
+    pub(super) in_bytes_other: RegisteredMetric<IntCounter>,
 
     /// Count of incoming messages that are protocol overhead.
-    pub(super) in_count_protocol: IntCounter,
+    pub(super) in_count_protocol: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with consensus payload.
-    pub(super) in_count_consensus: IntCounter,
+    pub(super) in_count_consensus: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with deploy gossiper payload.
-    pub(super) in_count_deploy_gossip: IntCounter,
-    pub(super) in_count_block_gossip: IntCounter,
-    pub(super) in_count_finality_signature_gossip: IntCounter,
+    pub(super) in_count_deploy_gossip: RegisteredMetric<IntCounter>,
+    /// Count of incoming messages with block gossiper payload.
+    pub(super) in_count_block_gossip: RegisteredMetric<IntCounter>,
+    /// Count of incoming messages with finality signature gossiper payload.
+    pub(super) in_count_finality_signature_gossip: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with address gossiper payload.
-    pub(super) in_count_address_gossip: IntCounter,
+    pub(super) in_count_address_gossip: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with deploy request/response payload.
-    pub(super) in_count_deploy_transfer: IntCounter,
+    pub(super) in_count_deploy_transfer: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with block request/response payload.
-    pub(super) in_count_block_transfer: IntCounter,
+    pub(super) in_count_block_transfer: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with trie request/response payload.
-    pub(super) in_count_trie_transfer: IntCounter,
+    pub(super) in_count_trie_transfer: RegisteredMetric<IntCounter>,
     /// Count of incoming messages with other payload.
-    pub(super) in_count_other: IntCounter,
+    pub(super) in_count_other: RegisteredMetric<IntCounter>,
 
     /// Number of trie requests accepted for processing.
-    pub(super) requests_for_trie_accepted: IntCounter,
+    pub(super) requests_for_trie_accepted: RegisteredMetric<IntCounter>,
     /// Number of trie requests finished (successful or unsuccessful).
-    pub(super) requests_for_trie_finished: IntCounter,
+    pub(super) requests_for_trie_finished: RegisteredMetric<IntCounter>,
 
     /// Total time spent delaying outgoing traffic to non-validators due to limiter, in seconds.
-    pub(super) accumulated_outgoing_limiter_delay: Counter,
+    pub(super) accumulated_outgoing_limiter_delay: RegisteredMetric<Counter>,
     /// Total time spent delaying incoming traffic from non-validators due to limiter, in seconds.
-    pub(super) accumulated_incoming_limiter_delay: Counter,
-
-    /// Registry instance.
-    registry: Registry,
+    pub(super) accumulated_incoming_limiter_delay: RegisteredMetric<Counter>,
 }
 
 impl Metrics {
     /// Creates a new instance of networking metrics.
     pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let queued_messages = IntGauge::new(
+        let broadcast_requests = registry
+            .new_int_counter("net_broadcast_requests", "number of broadcasting requests")?;
+        let direct_message_requests = registry.new_int_counter(
+            "net_direct_message_requests",
+            "number of requests to send a message directly to a peer",
+        )?;
+
+        let queued_messages = registry.new_int_gauge(
             "net_queued_direct_messages",
             "number of messages waiting to be sent out",
         )?;
-        let peers = IntGauge::new("peers", "number of connected peers")?;
+        let peers = registry.new_int_gauge("peers", "number of connected peers")?;
 
-        let out_count_protocol = IntCounter::new(
+        let out_count_protocol = registry.new_int_counter(
             "net_out_count_protocol",
             "count of outgoing messages that are protocol overhead",
         )?;
-        let out_count_consensus = IntCounter::new(
+        let out_count_consensus = registry.new_int_counter(
             "net_out_count_consensus",
             "count of outgoing messages with consensus payload",
         )?;
-        let out_count_deploy_gossip = IntCounter::new(
+        let out_count_deploy_gossip = registry.new_int_counter(
             "net_out_count_deploy_gossip",
             "count of outgoing messages with deploy gossiper payload",
         )?;
-        let out_count_block_gossip = IntCounter::new(
+        let out_count_block_gossip = registry.new_int_counter(
             "net_out_count_block_gossip",
             "count of outgoing messages with block gossiper payload",
         )?;
-        let out_count_finality_signature_gossip = IntCounter::new(
+        let out_count_finality_signature_gossip = registry.new_int_counter(
             "net_out_count_finality_signature_gossip",
             "count of outgoing messages with finality signature gossiper payload",
         )?;
-        let out_count_address_gossip = IntCounter::new(
+        let out_count_address_gossip = registry.new_int_counter(
             "net_out_count_address_gossip",
             "count of outgoing messages with address gossiper payload",
         )?;
-        let out_count_deploy_transfer = IntCounter::new(
+        let out_count_deploy_transfer = registry.new_int_counter(
             "net_out_count_deploy_transfer",
             "count of outgoing messages with deploy request/response payload",
         )?;
-        let out_count_block_transfer = IntCounter::new(
+        let out_count_block_transfer = registry.new_int_counter(
             "net_out_count_block_transfer",
             "count of outgoing messages with block request/response payload",
         )?;
-        let out_count_trie_transfer = IntCounter::new(
+        let out_count_trie_transfer = registry.new_int_counter(
             "net_out_count_trie_transfer",
             "count of outgoing messages with trie payloads",
         )?;
-        let out_count_other = IntCounter::new(
+        let out_count_other = registry.new_int_counter(
             "net_out_count_other",
             "count of outgoing messages with other payload",
         )?;
 
-        let out_bytes_protocol = IntCounter::new(
+        let out_bytes_protocol = registry.new_int_counter(
             "net_out_bytes_protocol",
             "volume in bytes of outgoing messages that are protocol overhead",
         )?;
-        let out_bytes_consensus = IntCounter::new(
+        let out_bytes_consensus = registry.new_int_counter(
             "net_out_bytes_consensus",
             "volume in bytes of outgoing messages with consensus payload",
         )?;
-        let out_bytes_deploy_gossip = IntCounter::new(
+        let out_bytes_deploy_gossip = registry.new_int_counter(
             "net_out_bytes_deploy_gossip",
             "volume in bytes of outgoing messages with deploy gossiper payload",
         )?;
-        let out_bytes_block_gossip = IntCounter::new(
+        let out_bytes_block_gossip = registry.new_int_counter(
             "net_out_bytes_block_gossip",
             "volume in bytes of outgoing messages with block gossiper payload",
         )?;
-        let out_bytes_finality_signature_gossip = IntCounter::new(
+        let out_bytes_finality_signature_gossip = registry.new_int_counter(
             "net_out_bytes_finality_signature_gossip",
             "volume in bytes of outgoing messages with finality signature gossiper payload",
         )?;
-        let out_bytes_address_gossip = IntCounter::new(
+        let out_bytes_address_gossip = registry.new_int_counter(
             "net_out_bytes_address_gossip",
             "volume in bytes of outgoing messages with address gossiper payload",
         )?;
-        let out_bytes_deploy_transfer = IntCounter::new(
+        let out_bytes_deploy_transfer = registry.new_int_counter(
             "net_out_bytes_deploy_transfer",
             "volume in bytes of outgoing messages with deploy request/response payload",
         )?;
-        let out_bytes_block_transfer = IntCounter::new(
+        let out_bytes_block_transfer = registry.new_int_counter(
             "net_out_bytes_block_transfer",
             "volume in bytes of outgoing messages with block request/response payload",
         )?;
-        let out_bytes_trie_transfer = IntCounter::new(
+        let out_bytes_trie_transfer = registry.new_int_counter(
             "net_out_bytes_trie_transfer",
             "volume in bytes of outgoing messages with trie payloads",
         )?;
-        let out_bytes_other = IntCounter::new(
+        let out_bytes_other = registry.new_int_counter(
             "net_out_bytes_other",
             "volume in bytes of outgoing messages with other payload",
         )?;
 
-        let out_state_connecting = IntGauge::new(
+        let out_state_connecting = registry.new_int_gauge(
             "out_state_connecting",
             "number of connections in the connecting state",
         )?;
-        let out_state_waiting = IntGauge::new(
+        let out_state_waiting = registry.new_int_gauge(
             "out_state_waiting",
             "number of connections in the waiting state",
         )?;
-        let out_state_connected = IntGauge::new(
+        let out_state_connected = registry.new_int_gauge(
             "out_state_connected",
             "number of connections in the connected state",
         )?;
-        let out_state_blocked = IntGauge::new(
+        let out_state_blocked = registry.new_int_gauge(
             "out_state_blocked",
             "number of connections in the blocked state",
         )?;
-        let out_state_loopback = IntGauge::new(
+        let out_state_loopback = registry.new_int_gauge(
             "out_state_loopback",
             "number of connections in the loopback state",
         )?;
 
-        let in_count_protocol = IntCounter::new(
+        let in_count_protocol = registry.new_int_counter(
             "net_in_count_protocol",
             "count of incoming messages that are protocol overhead",
         )?;
-        let in_count_consensus = IntCounter::new(
+        let in_count_consensus = registry.new_int_counter(
             "net_in_count_consensus",
             "count of incoming messages with consensus payload",
         )?;
-        let in_count_deploy_gossip = IntCounter::new(
+        let in_count_deploy_gossip = registry.new_int_counter(
             "net_in_count_deploy_gossip",
             "count of incoming messages with deploy gossiper payload",
         )?;
-        let in_count_block_gossip = IntCounter::new(
+        let in_count_block_gossip = registry.new_int_counter(
             "net_in_count_block_gossip",
             "count of incoming messages with block gossiper payload",
         )?;
-        let in_count_finality_signature_gossip = IntCounter::new(
+        let in_count_finality_signature_gossip = registry.new_int_counter(
             "net_in_count_finality_signature_gossip",
             "count of incoming messages with finality signature gossiper payload",
         )?;
-        let in_count_address_gossip = IntCounter::new(
+        let in_count_address_gossip = registry.new_int_counter(
             "net_in_count_address_gossip",
             "count of incoming messages with address gossiper payload",
         )?;
-        let in_count_deploy_transfer = IntCounter::new(
+        let in_count_deploy_transfer = registry.new_int_counter(
             "net_in_count_deploy_transfer",
             "count of incoming messages with deploy request/response payload",
         )?;
-        let in_count_block_transfer = IntCounter::new(
+        let in_count_block_transfer = registry.new_int_counter(
             "net_in_count_block_transfer",
             "count of incoming messages with block request/response payload",
         )?;
-        let in_count_trie_transfer = IntCounter::new(
+        let in_count_trie_transfer = registry.new_int_counter(
             "net_in_count_trie_transfer",
             "count of incoming messages with trie payloads",
         )?;
-        let in_count_other = IntCounter::new(
+        let in_count_other = registry.new_int_counter(
             "net_in_count_other",
             "count of incoming messages with other payload",
         )?;
 
-        let in_bytes_protocol = IntCounter::new(
+        let in_bytes_protocol = registry.new_int_counter(
             "net_in_bytes_protocol",
             "volume in bytes of incoming messages that are protocol overhead",
         )?;
-        let in_bytes_consensus = IntCounter::new(
+        let in_bytes_consensus = registry.new_int_counter(
             "net_in_bytes_consensus",
             "volume in bytes of incoming messages with consensus payload",
         )?;
-        let in_bytes_deploy_gossip = IntCounter::new(
+        let in_bytes_deploy_gossip = registry.new_int_counter(
             "net_in_bytes_deploy_gossip",
             "volume in bytes of incoming messages with deploy gossiper payload",
         )?;
-        let in_bytes_block_gossip = IntCounter::new(
+        let in_bytes_block_gossip = registry.new_int_counter(
             "net_in_bytes_block_gossip",
             "volume in bytes of incoming messages with block gossiper payload",
         )?;
-        let in_bytes_finality_signature_gossip = IntCounter::new(
+        let in_bytes_finality_signature_gossip = registry.new_int_counter(
             "net_in_bytes_finality_signature_gossip",
             "volume in bytes of incoming messages with finality signature gossiper payload",
         )?;
-        let in_bytes_address_gossip = IntCounter::new(
+        let in_bytes_address_gossip = registry.new_int_counter(
             "net_in_bytes_address_gossip",
             "volume in bytes of incoming messages with address gossiper payload",
         )?;
-        let in_bytes_deploy_transfer = IntCounter::new(
+        let in_bytes_deploy_transfer = registry.new_int_counter(
             "net_in_bytes_deploy_transfer",
             "volume in bytes of incoming messages with deploy request/response payload",
         )?;
-        let in_bytes_block_transfer = IntCounter::new(
+        let in_bytes_block_transfer = registry.new_int_counter(
             "net_in_bytes_block_transfer",
             "volume in bytes of incoming messages with block request/response payload",
         )?;
-        let in_bytes_trie_transfer = IntCounter::new(
+        let in_bytes_trie_transfer = registry.new_int_counter(
             "net_in_bytes_trie_transfer",
             "volume in bytes of incoming messages with trie payloads",
         )?;
-        let in_bytes_other = IntCounter::new(
+        let in_bytes_other = registry.new_int_counter(
             "net_in_bytes_other",
             "volume in bytes of incoming messages with other payload",
         )?;
 
-        let requests_for_trie_accepted = IntCounter::new(
+        let requests_for_trie_accepted = registry.new_int_counter(
             "requests_for_trie_accepted",
             "number of trie requests accepted for processing",
         )?;
-        let requests_for_trie_finished = IntCounter::new(
+        let requests_for_trie_finished = registry.new_int_counter(
             "requests_for_trie_finished",
             "number of trie requests finished, successful or not",
         )?;
 
-        let accumulated_outgoing_limiter_delay = Counter::new(
+        let accumulated_outgoing_limiter_delay = registry.new_counter(
             "accumulated_outgoing_limiter_delay",
             "seconds spent delaying outgoing traffic to non-validators due to limiter, in seconds",
         )?;
-        let accumulated_incoming_limiter_delay = Counter::new(
+        let accumulated_incoming_limiter_delay = registry.new_counter(
             "accumulated_incoming_limiter_delay",
             "seconds spent delaying incoming traffic from non-validators due to limiter, in seconds."
         )?;
 
-        registry.register(Box::new(queued_messages.clone()))?;
-        registry.register(Box::new(peers.clone()))?;
-
-        registry.register(Box::new(out_count_protocol.clone()))?;
-        registry.register(Box::new(out_count_consensus.clone()))?;
-        registry.register(Box::new(out_count_deploy_gossip.clone()))?;
-        registry.register(Box::new(out_count_block_gossip.clone()))?;
-        registry.register(Box::new(out_count_finality_signature_gossip.clone()))?;
-        registry.register(Box::new(out_count_address_gossip.clone()))?;
-        registry.register(Box::new(out_count_deploy_transfer.clone()))?;
-        registry.register(Box::new(out_count_block_transfer.clone()))?;
-        registry.register(Box::new(out_count_trie_transfer.clone()))?;
-        registry.register(Box::new(out_count_other.clone()))?;
-
-        registry.register(Box::new(out_bytes_protocol.clone()))?;
-        registry.register(Box::new(out_bytes_consensus.clone()))?;
-        registry.register(Box::new(out_bytes_deploy_gossip.clone()))?;
-        registry.register(Box::new(out_bytes_block_gossip.clone()))?;
-        registry.register(Box::new(out_bytes_finality_signature_gossip.clone()))?;
-        registry.register(Box::new(out_bytes_address_gossip.clone()))?;
-        registry.register(Box::new(out_bytes_deploy_transfer.clone()))?;
-        registry.register(Box::new(out_bytes_block_transfer.clone()))?;
-        registry.register(Box::new(out_bytes_trie_transfer.clone()))?;
-        registry.register(Box::new(out_bytes_other.clone()))?;
-
-        registry.register(Box::new(out_state_connecting.clone()))?;
-        registry.register(Box::new(out_state_waiting.clone()))?;
-        registry.register(Box::new(out_state_connected.clone()))?;
-        registry.register(Box::new(out_state_blocked.clone()))?;
-        registry.register(Box::new(out_state_loopback.clone()))?;
-
-        registry.register(Box::new(in_count_protocol.clone()))?;
-        registry.register(Box::new(in_count_consensus.clone()))?;
-        registry.register(Box::new(in_count_deploy_gossip.clone()))?;
-        registry.register(Box::new(in_count_block_gossip.clone()))?;
-        registry.register(Box::new(in_count_finality_signature_gossip.clone()))?;
-        registry.register(Box::new(in_count_address_gossip.clone()))?;
-        registry.register(Box::new(in_count_deploy_transfer.clone()))?;
-        registry.register(Box::new(in_count_block_transfer.clone()))?;
-        registry.register(Box::new(in_count_trie_transfer.clone()))?;
-        registry.register(Box::new(in_count_other.clone()))?;
-
-        registry.register(Box::new(in_bytes_protocol.clone()))?;
-        registry.register(Box::new(in_bytes_consensus.clone()))?;
-        registry.register(Box::new(in_bytes_deploy_gossip.clone()))?;
-        registry.register(Box::new(in_bytes_block_gossip.clone()))?;
-        registry.register(Box::new(in_bytes_finality_signature_gossip.clone()))?;
-        registry.register(Box::new(in_bytes_address_gossip.clone()))?;
-        registry.register(Box::new(in_bytes_deploy_transfer.clone()))?;
-        registry.register(Box::new(in_bytes_block_transfer.clone()))?;
-        registry.register(Box::new(in_bytes_trie_transfer.clone()))?;
-        registry.register(Box::new(in_bytes_other.clone()))?;
-
-        registry.register(Box::new(requests_for_trie_accepted.clone()))?;
-        registry.register(Box::new(requests_for_trie_finished.clone()))?;
-
-        registry.register(Box::new(accumulated_outgoing_limiter_delay.clone()))?;
-        registry.register(Box::new(accumulated_incoming_limiter_delay.clone()))?;
-
         Ok(Metrics {
-            broadcast_requests: registry
-                .new_int_counter("net_broadcast_requests", "number of broadcasting requests")?,
-            direct_message_requests: registry.new_int_counter(
-                "net_direct_message_requests",
-                "number of requests to send a message directly to a peer",
-            )?,
+            broadcast_requests,
+            direct_message_requests,
             queued_messages,
             peers,
             out_count_protocol,
@@ -451,7 +395,6 @@ impl Metrics {
             requests_for_trie_finished,
             accumulated_outgoing_limiter_delay,
             accumulated_incoming_limiter_delay,
-            registry: registry.clone(),
         })
     }
 
@@ -561,11 +504,11 @@ impl Metrics {
     /// Creates a set of outgoing metrics that is connected to this set of metrics.
     pub(super) fn create_outgoing_metrics(&self) -> OutgoingMetrics {
         OutgoingMetrics {
-            out_state_connecting: self.out_state_connecting.clone(),
-            out_state_waiting: self.out_state_waiting.clone(),
-            out_state_connected: self.out_state_connected.clone(),
-            out_state_blocked: self.out_state_blocked.clone(),
-            out_state_loopback: self.out_state_loopback.clone(),
+            out_state_connecting: self.out_state_connecting.inner().clone(),
+            out_state_waiting: self.out_state_waiting.inner().clone(),
+            out_state_connected: self.out_state_connected.inner().clone(),
+            out_state_blocked: self.out_state_blocked.inner().clone(),
+            out_state_loopback: self.out_state_loopback.inner().clone(),
         }
     }
 
@@ -588,68 +531,5 @@ impl Metrics {
         } else {
             debug!("not recording metrics, component already shut down");
         }
-    }
-}
-
-impl Drop for Metrics {
-    fn drop(&mut self) {
-        unregister_metric!(self.registry, self.queued_messages);
-        unregister_metric!(self.registry, self.peers);
-
-        unregister_metric!(self.registry, self.out_count_protocol);
-        unregister_metric!(self.registry, self.out_count_consensus);
-        unregister_metric!(self.registry, self.out_count_deploy_gossip);
-        unregister_metric!(self.registry, self.out_count_block_gossip);
-        unregister_metric!(self.registry, self.out_count_finality_signature_gossip);
-        unregister_metric!(self.registry, self.out_count_address_gossip);
-        unregister_metric!(self.registry, self.out_count_deploy_transfer);
-        unregister_metric!(self.registry, self.out_count_block_transfer);
-        unregister_metric!(self.registry, self.out_count_trie_transfer);
-        unregister_metric!(self.registry, self.out_count_other);
-
-        unregister_metric!(self.registry, self.out_bytes_protocol);
-        unregister_metric!(self.registry, self.out_bytes_consensus);
-        unregister_metric!(self.registry, self.out_bytes_deploy_gossip);
-        unregister_metric!(self.registry, self.out_bytes_block_gossip);
-        unregister_metric!(self.registry, self.out_bytes_finality_signature_gossip);
-        unregister_metric!(self.registry, self.out_bytes_address_gossip);
-        unregister_metric!(self.registry, self.out_bytes_deploy_transfer);
-        unregister_metric!(self.registry, self.out_bytes_block_transfer);
-        unregister_metric!(self.registry, self.out_bytes_trie_transfer);
-        unregister_metric!(self.registry, self.out_bytes_other);
-
-        unregister_metric!(self.registry, self.out_state_connecting);
-        unregister_metric!(self.registry, self.out_state_waiting);
-        unregister_metric!(self.registry, self.out_state_connected);
-        unregister_metric!(self.registry, self.out_state_blocked);
-        unregister_metric!(self.registry, self.out_state_loopback);
-
-        unregister_metric!(self.registry, self.in_count_protocol);
-        unregister_metric!(self.registry, self.in_count_consensus);
-        unregister_metric!(self.registry, self.in_count_deploy_gossip);
-        unregister_metric!(self.registry, self.in_count_block_gossip);
-        unregister_metric!(self.registry, self.in_count_finality_signature_gossip);
-        unregister_metric!(self.registry, self.in_count_address_gossip);
-        unregister_metric!(self.registry, self.in_count_deploy_transfer);
-        unregister_metric!(self.registry, self.in_count_block_transfer);
-        unregister_metric!(self.registry, self.in_count_trie_transfer);
-        unregister_metric!(self.registry, self.in_count_other);
-
-        unregister_metric!(self.registry, self.in_bytes_protocol);
-        unregister_metric!(self.registry, self.in_bytes_consensus);
-        unregister_metric!(self.registry, self.in_bytes_deploy_gossip);
-        unregister_metric!(self.registry, self.in_bytes_block_gossip);
-        unregister_metric!(self.registry, self.in_bytes_finality_signature_gossip);
-        unregister_metric!(self.registry, self.in_bytes_address_gossip);
-        unregister_metric!(self.registry, self.in_bytes_deploy_transfer);
-        unregister_metric!(self.registry, self.in_bytes_block_transfer);
-        unregister_metric!(self.registry, self.in_bytes_trie_transfer);
-        unregister_metric!(self.registry, self.in_bytes_other);
-
-        unregister_metric!(self.registry, self.requests_for_trie_accepted);
-        unregister_metric!(self.registry, self.requests_for_trie_finished);
-
-        unregister_metric!(self.registry, self.accumulated_outgoing_limiter_delay);
-        unregister_metric!(self.registry, self.accumulated_incoming_limiter_delay);
     }
 }

--- a/node/src/components/network/metrics.rs
+++ b/node/src/components/network/metrics.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 use super::{outgoing::OutgoingMetrics, MessageKind};
 use crate::{
     unregister_metric,
-    utils::{RegisteredMetric, RegistryExt},
+    utils::registered_metric::{RegisteredMetric, RegistryExt},
 };
 
 /// Network-type agnostic networking metrics.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -47,7 +47,7 @@ use datasize::DataSize;
 use erased_serde::Serialize as ErasedSerialize;
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
-use prometheus::{self, Histogram, HistogramOpts, IntCounter, IntGauge, Registry};
+use prometheus::{self, Histogram, IntCounter, IntGauge, Registry};
 use quanta::{Clock, IntoNanoseconds};
 use serde::Serialize;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
@@ -72,9 +72,9 @@ use crate::{
         ChainspecRawBytes, Deploy, ExitCode, FinalitySignature, LegacyDeploy, NodeId, SyncLeap,
         TrieOrChunk,
     },
-    unregister_metric,
     utils::{
         self,
+        registered_metric::{RegisteredMetric, RegistryExt},
         rlimit::{Limit, OpenFiles, ResourceLimit},
         Fuse, SharedFuse, WeightedRoundRobin,
     },
@@ -361,34 +361,30 @@ where
 #[derive(Debug)]
 struct RunnerMetrics {
     /// Total number of events processed.
-    events: IntCounter,
+    events: RegisteredMetric<IntCounter>,
     /// Histogram of how long it took to dispatch an event.
-    event_dispatch_duration: Histogram,
+    event_dispatch_duration: RegisteredMetric<Histogram>,
     /// Total allocated RAM in bytes, as reported by stats_alloc.
-    allocated_ram_bytes: IntGauge,
+    allocated_ram_bytes: RegisteredMetric<IntGauge>,
     /// Total consumed RAM in bytes, as reported by sys-info.
-    consumed_ram_bytes: IntGauge,
+    consumed_ram_bytes: RegisteredMetric<IntGauge>,
     /// Total system RAM in bytes, as reported by sys-info.
-    total_ram_bytes: IntGauge,
-    /// Handle to the metrics registry, in case we need to unregister.
-    registry: Registry,
+    total_ram_bytes: RegisteredMetric<IntGauge>,
 }
 
 impl RunnerMetrics {
     /// Create and register new runner metrics.
     fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        let events = IntCounter::new(
+        let events = registry.new_int_counter(
             "runner_events",
             "running total count of events handled by this reactor",
         )?;
 
         // Create an event dispatch histogram, putting extra emphasis on the area between 1-10 us.
-        let event_dispatch_duration = Histogram::with_opts(
-            HistogramOpts::new(
-                "event_dispatch_duration",
-                "time in nanoseconds to dispatch an event",
-            )
-            .buckets(vec![
+        let event_dispatch_duration = registry.new_histogram(
+            "event_dispatch_duration",
+            "time in nanoseconds to dispatch an event",
+            vec![
                 100.0,
                 500.0,
                 1_000.0,
@@ -408,39 +404,23 @@ impl RunnerMetrics {
                 1_000_000.0,
                 2_000_000.0,
                 5_000_000.0,
-            ]),
+            ],
         )?;
 
         let allocated_ram_bytes =
-            IntGauge::new("allocated_ram_bytes", "total allocated ram in bytes")?;
+            registry.new_int_gauge("allocated_ram_bytes", "total allocated ram in bytes")?;
         let consumed_ram_bytes =
-            IntGauge::new("consumed_ram_bytes", "total consumed ram in bytes")?;
-        let total_ram_bytes = IntGauge::new("total_ram_bytes", "total system ram in bytes")?;
-
-        registry.register(Box::new(events.clone()))?;
-        registry.register(Box::new(event_dispatch_duration.clone()))?;
-        registry.register(Box::new(allocated_ram_bytes.clone()))?;
-        registry.register(Box::new(consumed_ram_bytes.clone()))?;
-        registry.register(Box::new(total_ram_bytes.clone()))?;
+            registry.new_int_gauge("consumed_ram_bytes", "total consumed ram in bytes")?;
+        let total_ram_bytes =
+            registry.new_int_gauge("total_ram_bytes", "total system ram in bytes")?;
 
         Ok(RunnerMetrics {
             events,
             event_dispatch_duration,
-            registry: registry.clone(),
             allocated_ram_bytes,
             consumed_ram_bytes,
             total_ram_bytes,
         })
-    }
-}
-
-impl Drop for RunnerMetrics {
-    fn drop(&mut self) {
-        unregister_metric!(self.registry, self.events);
-        unregister_metric!(self.registry, self.event_dispatch_duration);
-        unregister_metric!(self.registry, self.allocated_ram_bytes);
-        unregister_metric!(self.registry, self.consumed_ram_bytes);
-        unregister_metric!(self.registry, self.total_ram_bytes);
     }
 }
 

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -318,19 +318,6 @@ where
     (numerator + denominator / T::from(2)) / denominator
 }
 
-/// Creates a prometheus Histogram and registers it.
-pub(crate) fn register_histogram_metric(
-    registry: &Registry,
-    metric_name: &str,
-    metric_help: &str,
-    buckets: Vec<f64>,
-) -> Result<Histogram, prometheus::Error> {
-    let histogram_opts = HistogramOpts::new(metric_name, metric_help).buckets(buckets);
-    let histogram = Histogram::with_opts(histogram_opts)?;
-    registry.register(Box::new(histogram.clone()))?;
-    Ok(histogram)
-}
-
 /// Unregisters a metric from the Prometheus registry.
 #[macro_export]
 macro_rules! unregister_metric {

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -32,7 +32,7 @@ use fs2::FileExt;
 use futures::future::Either;
 use hyper::server::{conn::AddrIncoming, Builder, Server};
 
-use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
+use prometheus::{self, IntGauge};
 use serde::Serialize;
 use thiserror::Error;
 use tracing::{error, warn};
@@ -316,21 +316,6 @@ where
     T: Add<Output = T> + Div<Output = T> + From<u8> + Copy,
 {
     (numerator + denominator / T::from(2)) / denominator
-}
-
-/// Unregisters a metric from the Prometheus registry.
-#[macro_export]
-macro_rules! unregister_metric {
-    ($registry:expr, $metric:expr) => {
-        $registry
-            .unregister(Box::new($metric.clone()))
-            .unwrap_or_else(|_| {
-                tracing::error!(
-                    "unregistering {} failed: was not registered",
-                    stringify!($metric)
-                )
-            });
-    };
 }
 
 /// XORs two byte sequences.

--- a/node/src/utils/registered_metric.rs
+++ b/node/src/utils/registered_metric.rs
@@ -1,0 +1,106 @@
+//! Self registereing and deregistering metrics support.
+
+use prometheus::{
+    core::{Atomic, Collector, GenericCounter},
+    IntCounter, IntGauge, Registry,
+};
+
+/// A metric wrapper that will deregister the metric from a given registry on drop.
+#[derive(Debug)]
+pub(crate) struct RegisteredMetric<T>
+where
+    T: Collector + 'static,
+{
+    metric: Option<Box<T>>,
+    registry: Registry,
+}
+
+impl<T> RegisteredMetric<T>
+where
+    T: Collector + 'static,
+{
+    /// Creates a new self-deregistering metric.
+    pub(crate) fn new(registry: Registry, metric: T) -> Result<Self, prometheus::Error>
+    where
+        T: Clone,
+    {
+        let boxed_metric = Box::new(metric);
+        registry.register(boxed_metric.clone())?;
+
+        Ok(RegisteredMetric {
+            metric: Some(boxed_metric),
+            registry,
+        })
+    }
+
+    /// Returns a reference to the inner metric.
+    #[inline]
+    fn inner(&self) -> &T {
+        self.metric.as_ref().expect("metric disappeared")
+    }
+}
+
+impl<P> RegisteredMetric<GenericCounter<P>>
+where
+    P: Atomic,
+{
+    /// Increment the counter.
+    #[inline]
+    pub(crate) fn inc(&self) {
+        self.inner().inc()
+    }
+}
+
+impl<T> Drop for RegisteredMetric<T>
+where
+    T: Collector + 'static,
+{
+    fn drop(&mut self) {
+        if let Some(boxed_metric) = self.metric.take() {
+            let desc = boxed_metric
+                .desc()
+                .iter()
+                .next()
+                .map(|desc| desc.fq_name.clone())
+                .unwrap_or_default();
+            self.registry.unregister(boxed_metric).unwrap_or_else(|_| {
+                tracing::error!("unregistering {} failed: was not registered", desc)
+            })
+        }
+    }
+}
+
+/// Extension trait for [`Registry`] instances.
+pub(crate) trait RegistryExt {
+    /// Creates a new [`IntCounter`] registered to this registry.
+    fn new_int_counter<S1: Into<String>, S2: Into<String>>(
+        &self,
+        name: S1,
+        help: S2,
+    ) -> Result<RegisteredMetric<IntCounter>, prometheus::Error>;
+
+    /// Creates a new [`IntGauge`] registered to this registry.
+    fn new_int_gauge<S1: Into<String>, S2: Into<String>>(
+        &self,
+        name: S1,
+        help: S2,
+    ) -> Result<RegisteredMetric<IntGauge>, prometheus::Error>;
+}
+
+impl RegistryExt for Registry {
+    fn new_int_counter<S1: Into<String>, S2: Into<String>>(
+        &self,
+        name: S1,
+        help: S2,
+    ) -> Result<RegisteredMetric<IntCounter>, prometheus::Error> {
+        RegisteredMetric::new(self.clone(), IntCounter::new(name, help)?)
+    }
+
+    fn new_int_gauge<S1: Into<String>, S2: Into<String>>(
+        &self,
+        name: S1,
+        help: S2,
+    ) -> Result<RegisteredMetric<IntGauge>, prometheus::Error> {
+        RegisteredMetric::new(self.clone(), IntGauge::new(name, help)?)
+    }
+}

--- a/node/src/utils/registered_metric.rs
+++ b/node/src/utils/registered_metric.rs
@@ -109,8 +109,7 @@ where
         if let Some(boxed_metric) = self.metric.take() {
             let desc = boxed_metric
                 .desc()
-                .iter()
-                .next()
+                .first()
                 .map(|desc| desc.fq_name.clone())
                 .unwrap_or_default();
             self.registry.unregister(boxed_metric).unwrap_or_else(|_| {

--- a/node/src/utils/registered_metric.rs
+++ b/node/src/utils/registered_metric.rs
@@ -2,7 +2,7 @@
 
 use prometheus::{
     core::{Atomic, Collector, GenericCounter, GenericGauge},
-    Counter, Gauge, Histogram, HistogramOpts, IntCounter, IntGauge, Registry,
+    Counter, Gauge, Histogram, HistogramOpts, HistogramTimer, IntCounter, IntGauge, Registry,
 };
 
 /// A metric wrapper that will deregister the metric from a given registry on drop.
@@ -92,6 +92,12 @@ impl RegisteredMetric<Histogram> {
     #[inline]
     pub(crate) fn observe(&self, v: f64) {
         self.inner().observe(v)
+    }
+
+    /// Creates a new histogram timer.
+    #[inline]
+    pub(crate) fn start_timer(&self) -> HistogramTimer {
+        self.inner().start_timer()
     }
 }
 

--- a/node/src/utils/registered_metric.rs
+++ b/node/src/utils/registered_metric.rs
@@ -1,4 +1,4 @@
-//! Self registereing and deregistering metrics support.
+//! Self registering and deregistering metrics support.
 
 use prometheus::{
     core::{Atomic, Collector, GenericCounter, GenericGauge},

--- a/node/src/utils/registered_metric.rs
+++ b/node/src/utils/registered_metric.rs
@@ -121,7 +121,7 @@ where
 
 /// Extension trait for [`Registry`] instances.
 pub(crate) trait RegistryExt {
-    /// Creates a new [`IntCounter`] registered to this registry.
+    /// Creates a new [`Counter`] registered to this registry.
     fn new_counter<S1: Into<String>, S2: Into<String>>(
         &self,
         name: S1,


### PR DESCRIPTION
Closes #3774.

This removes the `unregister_metric!` macro by creating a new `RegisteredMetric` wrapper type that registers a metric on construction and deregisters it on drop. A `RegistryExt` macro is added for convenience to create these and the wrapper has the used methods of all metrics implemented in specialized `impl` blocks for each type.

This greatly reduces the code needed for setting up metrics and reduces potential errors, at the cost of keeping additional copies of `Arc`s around in the form of `Registry`.