### PR TITLE
block_synchronizer: add a time threshold for detecting stalled builders

### DIFF
--- a/node/src/components/block_synchronizer/block_synchronizer_progress.rs
+++ b/node/src/components/block_synchronizer/block_synchronizer_progress.rs
@@ -9,12 +9,15 @@ pub(crate) enum BlockSynchronizerProgress {
     Syncing(BlockHash, Option<u64>, Timestamp),
     Executing(BlockHash, u64, EraId),
     Synced(BlockHash, u64, EraId),
+    Stalled(BlockHash, Option<u64>, Timestamp),
 }
 
 impl BlockSynchronizerProgress {
     pub(crate) fn is_active(&self) -> bool {
         match self {
-            BlockSynchronizerProgress::Idle | BlockSynchronizerProgress::Synced(_, _, _) => false,
+            BlockSynchronizerProgress::Idle
+            | BlockSynchronizerProgress::Synced(_, _, _)
+            | BlockSynchronizerProgress::Stalled(_, _, _) => false,
             BlockSynchronizerProgress::Syncing(_, _, _)
             | BlockSynchronizerProgress::Executing(_, _, _) => true,
         }
@@ -44,6 +47,13 @@ impl Display for BlockSynchronizerProgress {
                     f,
                     "block_height: {} block_hash: {} era_id: {}",
                     block_height, block_hash, era_id
+                )
+            }
+            BlockSynchronizerProgress::Stalled(block_hash, block_height, timestamp) => {
+                write!(
+                    f,
+                    "block_height: {:?} timestamp: {} block_hash: {}",
+                    block_height, timestamp, block_hash
                 )
             }
         }

--- a/node/src/components/block_synchronizer/config.rs
+++ b/node/src/components/block_synchronizer/config.rs
@@ -9,6 +9,7 @@ const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 5000;
 const DEFAULT_PEER_REFRESH_INTERVAL: &str = "90sec";
 const DEFAULT_NEED_NEXT_INTERVAL: &str = "1sec";
 const DEFAULT_DISCONNECT_DISHONEST_PEERS_INTERVAL: &str = "10sec";
+const DEFAULT_PROGRESS_STALL_THRESHOLD_INTERVAL: &str = "120sec";
 
 /// Configuration options for fetching.
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -21,6 +22,9 @@ pub struct Config {
     pub need_next_interval: TimeDiff,
     /// Time interval for recurring disconnection of dishonest peers.
     pub disconnect_dishonest_peers_interval: TimeDiff,
+    /// Time interval after which synchronization is considered stalled if no successful sync
+    /// activity happened.
+    pub progress_stall_threshold_interval: TimeDiff,
 }
 
 impl Default for Config {
@@ -31,6 +35,10 @@ impl Default for Config {
             need_next_interval: TimeDiff::from_str(DEFAULT_NEED_NEXT_INTERVAL).unwrap(),
             disconnect_dishonest_peers_interval: TimeDiff::from_str(
                 DEFAULT_DISCONNECT_DISHONEST_PEERS_INTERVAL,
+            )
+            .unwrap(),
+            progress_stall_threshold_interval: TimeDiff::from_str(
+                DEFAULT_PROGRESS_STALL_THRESHOLD_INTERVAL,
             )
             .unwrap(),
         }

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -95,6 +95,19 @@ impl MainReactor {
                 // effects, any referenced deploys, & sufficient finality (by weight) of signatures
                 SyncIdentifier::SyncedBlockIdentifier(block_hash, block_height, era_id),
             ),
+            BlockSynchronizerProgress::Stalled(block_hash, _, last_progress_time) => {
+                // working on syncing a block
+                warn!(
+                    %block_hash,
+                    %last_progress_time,
+                    "CatchUp: block synchronizer stalled while syncing block; purging historical builder"
+                );
+                self.block_synchronizer.purge_historical();
+                match self.trusted_hash {
+                    Some(trusted_hash) => self.catch_up_trusted_hash(trusted_hash),
+                    None => self.catch_up_no_trusted_hash(),
+                }
+            }
         }
     }
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -463,6 +463,10 @@ need_next_interval = '1sec'
 # Time interval for recurring disconnection of dishonest peers.
 disconnect_dishonest_peers_interval = '10sec'
 
+# Time interval after which synchronization is considered stalled if no successful sync
+# activity happened.
+progress_stall_threshold_interval = '120sec'
+
 
 # ==================================
 # Configuration options for fetchers

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -463,6 +463,10 @@ need_next_interval = '1sec'
 # Time interval for recurring disconnection of dishonest peers.
 disconnect_dishonest_peers_interval = '10sec'
 
+# Time interval after which synchronization is considered stalled if no successful sync
+# activity happened.
+progress_stall_threshold_interval = '120sec'
+
 
 # ==================================
 # Configuration options for fetchers


### PR DESCRIPTION
Because there are situations where the block synchronizer can get stuck, added a new config parameter to compare against to check if the synchronizer didn’t make any progress.
So if a builder did not receive data successfully and updated its progress for the configured amount of time, we flag it as stalled and the control logic should purge it and try again.

Fixes: https://github.com/casper-network/casper-node/issues/3815