### PR TITLE
block_synchronizer: fix determination of signature weight sufficiency

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition_action.rs
+++ b/node/src/components/block_synchronizer/block_acquisition_action.rs
@@ -321,10 +321,7 @@ fn enough_signatures(
     is_checkable: bool,
     is_historical: bool,
 ) -> bool {
-    if is_checkable {
-        // Normal blocks:
-        signature_weight.is_sufficient(false == is_historical)
-    } else {
+    if is_historical && !is_checkable {
         // Legacy blocks:
         matches!((legacy_required_finality, signature_weight), |(
             LegacyRequiredFinality::Any,
@@ -334,6 +331,9 @@ fn enough_signatures(
             SignatureWeight::Weak | SignatureWeight::Strict
         )
             | (LegacyRequiredFinality::Strict, SignatureWeight::Strict))
+    } else {
+        // Normal blocks, either forward or historical
+        signature_weight.is_sufficient(true)
     }
 }
 
@@ -350,7 +350,9 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        // When syncing forward blocks, SignatureWeight::Strict is required
+        // so SignatureWeight::Insufficient is not enough
+        assert!(result == false);
     }
 
     #[test]
@@ -362,7 +364,9 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        // When syncing forward blocks, SignatureWeight::Strict is required
+        // so SignatureWeight::Weak is not enough
+        assert!(result == false);
     }
 
     #[test]
@@ -398,7 +402,9 @@ mod tests {
             false,
         );
 
-        assert!(result == true);
+        // When syncing forward blocks, SignatureWeight::Strict is required
+        // so SignatureWeight::Weak is not enough
+        assert!(result == false);
     }
 
     #[test]
@@ -686,7 +692,9 @@ mod tests {
             true,
         );
 
-        assert!(result == true);
+        // If syncing a historical block that is checkable, SignatureWeight::Strict is required
+        // so SignatureWeight::Weak is not enough
+        assert!(result == false);
     }
 
     #[test]
@@ -722,7 +730,9 @@ mod tests {
             true,
         );
 
-        assert!(result == true);
+        // If syncing a historical block that is checkable, SignatureWeight::Strict is required
+        // so SignatureWeight::Weak is not enough
+        assert!(result == false);
     }
 
     #[test]
@@ -758,7 +768,9 @@ mod tests {
             true,
         );
 
-        assert!(result == true);
+        // If syncing a historical block that is checkable, SignatureWeight::Strict is required
+        // so SignatureWeight::Weak is not enough
+        assert!(result == false);
     }
 
     #[test]


### PR DESCRIPTION
When we try to forward sync a block that doesn’t have deploys, the builder can switch to execute the block even if it doesn’t have strict finality. The bug is exposed by the having_block_body_for_block_without_deploys_requires_only_signatures test in [this PR](https://github.com/casper-network/casper-node/pull/3816). This is because [here](https://github.com/casper-network/casper-node/blob/e5d21032f5590648315787a54546eea6c43e8b5c/node/src/components/block_synchronizer/block_acquisition_action.rs#L324) we don’t first check if this is a forward block and since is_checkable is only set on the historical sync path, we fall through and will report finality based on LegacyRequiredFinality which is not the intended behaviour. Furthermore currently we allow weak finality to be sufficient for checkable blocks when doing a historical sync.

Change determination for `enough_signatures` to fit this criteria:
* Forward blocks -> always require strict finality
* Historical legacy blocks -> determination based on LegacyRequiredFinality
* Historical checkable blocks -> always require strict finality
