### PR TITLE
Update error messages of deploy acceptor

### DIFF
--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -9,7 +9,6 @@ use crate::{
     types::{BlockHeader, Deploy},
 };
 
-use casper_hashing::Digest;
 use casper_types::{
     account::{Account, AccountHash},
     Contract, ContractHash, ContractPackage, ContractPackageHash, ContractVersion, Timestamp, U512,
@@ -68,14 +67,14 @@ pub(crate) enum Event {
     /// The result of querying global state for the `Account` associated with the `Deploy`.
     GetAccountResult {
         event_metadata: Box<EventMetadata>,
-        prestate_hash: Digest,
+        block_header: Box<BlockHeader>,
         maybe_account: Option<Account>,
         verification_start_timestamp: Timestamp,
     },
     /// The result of querying the balance of the `Account` associated with the `Deploy`.
     GetBalanceResult {
         event_metadata: Box<EventMetadata>,
-        prestate_hash: Digest,
+        block_header: Box<BlockHeader>,
         maybe_balance_value: Option<U512>,
         account_hash: AccountHash,
         verification_start_timestamp: Timestamp,
@@ -83,7 +82,7 @@ pub(crate) enum Event {
     /// The result of querying global state for a `Contract` to verify the executable logic.
     GetContractResult {
         event_metadata: Box<EventMetadata>,
-        prestate_hash: Digest,
+        block_header: Box<BlockHeader>,
         is_payment: bool,
         contract_hash: ContractHash,
         maybe_contract: Option<Box<Contract>>,
@@ -92,7 +91,7 @@ pub(crate) enum Event {
     /// The result of querying global state for a `ContractPackage` to verify the executable logic.
     GetContractPackageResult {
         event_metadata: Box<EventMetadata>,
-        prestate_hash: Digest,
+        block_header: Box<BlockHeader>,
         is_payment: bool,
         contract_package_hash: ContractPackageHash,
         maybe_package_version: Option<ContractVersion>,
@@ -160,46 +159,46 @@ impl Display for Event {
             Event::GetBlockHeaderResult { event_metadata, .. } => {
                 write!(
                     formatter,
-                    "received highest block from storage to validate deploy with hash: {}.",
+                    "received highest block from storage to validate deploy with hash {}",
                     event_metadata.deploy.hash()
                 )
             }
             Event::GetAccountResult { event_metadata, .. } => {
                 write!(
                     formatter,
-                    "verifying account to validate deploy with hash {}.",
+                    "verifying account to validate deploy with hash {}",
                     event_metadata.deploy.hash()
                 )
             }
             Event::GetBalanceResult { event_metadata, .. } => {
                 write!(
                     formatter,
-                    "verifying account balance to validate deploy with hash {}.",
+                    "verifying account balance to validate deploy with hash {}",
                     event_metadata.deploy.hash()
                 )
             }
             Event::GetContractResult {
                 event_metadata,
-                prestate_hash,
+                block_header,
                 ..
             } => {
                 write!(
                     formatter,
-                    "verifying contract to validate deploy with hash {} with state hash: {}.",
+                    "verifying contract to validate deploy with hash {} with state hash {}",
                     event_metadata.deploy.hash(),
-                    prestate_hash
+                    block_header.state_root_hash()
                 )
             }
             Event::GetContractPackageResult {
                 event_metadata,
-                prestate_hash,
+                block_header,
                 ..
             } => {
                 write!(
                     formatter,
-                    "verifying contract package to validate deploy with hash {} with state hash: {}.",
+                    "verifying contract package to validate deploy with hash {} with state hash {}",
                     event_metadata.deploy.hash(),
-                    prestate_hash
+                    block_header.state_root_hash()
                 )
             }
         }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1881,13 +1881,13 @@ impl<REv> EffectBuilder<REv> {
     /// Retrieves an `Account` from global state if present.
     pub(crate) async fn get_account_from_global_state(
         self,
-        prestate_hash: Digest,
+        state_root_hash: Digest,
         account_key: Key,
     ) -> Option<Account>
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let query_request = QueryRequest::new(prestate_hash, account_key, vec![]);
+        let query_request = QueryRequest::new(state_root_hash, account_key, vec![]);
         match self.query_global_state(query_request).await {
             Ok(QueryResult::Success { value, .. }) => value.as_account().cloned(),
             Ok(_) | Err(_) => None,
@@ -1897,13 +1897,13 @@ impl<REv> EffectBuilder<REv> {
     /// Retrieves the balance of a purse, returns `None` if no purse is present.
     pub(crate) async fn check_purse_balance(
         self,
-        prestate_hash: Digest,
+        state_root_hash: Digest,
         main_purse: URef,
     ) -> Option<U512>
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let balance_request = BalanceRequest::new(prestate_hash, main_purse);
+        let balance_request = BalanceRequest::new(state_root_hash, main_purse);
         match self.get_balance(balance_request).await {
             Ok(balance_result) => {
                 if let Some(motes) = balance_result.motes() {
@@ -1918,14 +1918,14 @@ impl<REv> EffectBuilder<REv> {
     /// Retrieves an `Contract` from global state if present.
     pub(crate) async fn get_contract_for_validation(
         self,
-        prestate_hash: Digest,
+        state_root_hash: Digest,
         query_key: Key,
         path: Vec<String>,
     ) -> Option<Box<Contract>>
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let query_request = QueryRequest::new(prestate_hash, query_key, path);
+        let query_request = QueryRequest::new(state_root_hash, query_key, path);
         match self.query_global_state(query_request).await {
             Ok(QueryResult::Success { value, .. }) => {
                 // TODO: Extending `StoredValue` with an `into_contract` would reduce cloning here.
@@ -1938,14 +1938,14 @@ impl<REv> EffectBuilder<REv> {
     /// Retrieves an `ContractPackage` from global state if present.
     pub(crate) async fn get_contract_package_for_validation(
         self,
-        prestate_hash: Digest,
+        state_root_hash: Digest,
         query_key: Key,
         path: Vec<String>,
     ) -> Option<Box<ContractPackage>>
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let query_request = QueryRequest::new(prestate_hash, query_key, path);
+        let query_request = QueryRequest::new(state_root_hash, query_key, path);
         match self.query_global_state(query_request).await {
             Ok(QueryResult::Success { value, .. }) => {
                 value.as_contract_package().map(|pkg| Box::new(pkg.clone()))


### PR DESCRIPTION
This PR improves the `Display` implementations of many of the `DeployAcceptor`'s error variants, which is important as these are returned to clients as part of the JSON-RPC response in the case that putting a deploy fails.

In particular, the term "prestate hash" has been replaced with "state root hash" for clarity and to be consistent with how this is named elsewhere (e.g. in the block).  Also, for all the `InvalidDeployParameters` variants, the block's hash and height is also reported along with the relevant state root hash, to help users determine whether the node being queried is sufficiently caught up to the tip of the chain.

An example of the change is from:
```
deploy parameter failure: account 229826c53651b4314bcd8e713873b00749654c979c92a0d938d32f406bb9766b does not exist at prestate_hash: 169f..a5a7
```
to
```
account with hash 229826c53651b4314bcd8e713873b00749654c979c92a0d938d32f406bb9766b does not exist at state root hash 169f42d7cfdc1c6910adc57033276a1a8de8fe857144a58497eaaf10f412a5a7 of block d16aded7f240665b7b7c32f76ca64800bc8f04dbe7940fbe55e5159619d33d53 at height 170
```

Other than carrying the block header across various `Event` variants in place of the old `prestate_hash`, there should be no logical changes to the `DeployAcceptor`.