### PR TITLE
NCTL tests for carrying unbonds across the emergency upgrade

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -148,6 +148,11 @@ function start_upgrade_scenario_9() {
     nctl-exec-upgrade-scenario-9
 }
 
+function start_upgrade_scenario_11() {
+    log "... Starting Upgrade Scenario 11"
+    nctl-exec-upgrade-scenario-11
+}
+
 function start_upgrade_scenario_10() {
     log "... Setting up custom starting version"
     local PATH_TO_STAGE

--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -148,11 +148,6 @@ function start_upgrade_scenario_9() {
     nctl-exec-upgrade-scenario-9
 }
 
-function start_upgrade_scenario_11() {
-    log "... Starting Upgrade Scenario 11"
-    nctl-exec-upgrade-scenario-11
-}
-
 function start_upgrade_scenario_10() {
     log "... Setting up custom starting version"
     local PATH_TO_STAGE
@@ -171,6 +166,11 @@ function start_upgrade_scenario_10() {
 
     log "... Starting Upgrade Scenario 10"
     nctl-exec-upgrade-scenario-10
+}
+
+function start_upgrade_scenario_11() {
+    log "... Starting Upgrade Scenario 11"
+    nctl-exec-upgrade-scenario-11
 }
 
 # ----------------------------------------------------------------

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -74,13 +74,7 @@ function start_run_teardown() {
 
 function run_nightly_upgrade_test() {
     # setup only needed the first time
-    bash -i ./ci/nctl_upgrade.sh test_id=4
-    bash -i ./ci/nctl_upgrade.sh test_id=5 skip_setup=true
-    bash -i ./ci/nctl_upgrade.sh test_id=6 skip_setup=true
-    bash -i ./ci/nctl_upgrade.sh test_id=7 skip_setup=true
-    bash -i ./ci/nctl_upgrade.sh test_id=8 skip_setup=true
-    bash -i ./ci/nctl_upgrade.sh test_id=9 skip_setup=true
-    bash -i ./ci/nctl_upgrade.sh test_id=10 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=11
 }
 
 function run_soundness_test() {
@@ -96,24 +90,6 @@ function run_soundness_test() {
 }
 
 source "$NCTL/sh/staging/set_override_tomls.sh"
-start_run_teardown "client.sh"
-start_run_teardown "itst01.sh"
-start_run_teardown "itst02.sh"
-start_run_teardown "itst06.sh"
-start_run_teardown "itst07.sh"
-start_run_teardown "itst11.sh"
-start_run_teardown "itst13.sh"
-start_run_teardown "itst14.sh"
-start_run_teardown "bond_its.sh"
-start_run_teardown "emergency_upgrade_test.sh"
-start_run_teardown "emergency_upgrade_test_balances.sh"
-start_run_teardown "upgrade_after_emergency_upgrade_test.sh"
-start_run_teardown "sync_test.sh timeout=500"
-start_run_teardown "gov96.sh"
-start_run_teardown "swap_validator_set.sh"
-start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
-# without start_run_teardown - this one performs its own assets setup, network start and teardown
-source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
 
 run_nightly_upgrade_test
 

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -93,4 +93,4 @@ source "$NCTL/sh/staging/set_override_tomls.sh"
 
 run_nightly_upgrade_test
 
-run_soundness_test
+#run_soundness_test

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -74,7 +74,14 @@ function start_run_teardown() {
 
 function run_nightly_upgrade_test() {
     # setup only needed the first time
-    bash -i ./ci/nctl_upgrade.sh test_id=11
+    bash -i ./ci/nctl_upgrade.sh test_id=4
+    bash -i ./ci/nctl_upgrade.sh test_id=5 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=6 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=7 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=8 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=9 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=10 skip_setup=true
+    bash -i ./ci/nctl_upgrade.sh test_id=11 skip_setup=true
 }
 
 function run_soundness_test() {
@@ -90,7 +97,23 @@ function run_soundness_test() {
 }
 
 source "$NCTL/sh/staging/set_override_tomls.sh"
+start_run_teardown "client.sh"
+start_run_teardown "itst01.sh"
+start_run_teardown "itst02.sh"
+start_run_teardown "itst06.sh"
+start_run_teardown "itst07.sh"
+start_run_teardown "itst11.sh"
+start_run_teardown "itst13.sh"
+start_run_teardown "itst14.sh"
+start_run_teardown "bond_its.sh"
+start_run_teardown "emergency_upgrade_test.sh"
+start_run_teardown "emergency_upgrade_test_balances.sh"
+start_run_teardown "upgrade_after_emergency_upgrade_test.sh"
+start_run_teardown "sync_test.sh timeout=500"
+start_run_teardown "gov96.sh"
+start_run_teardown "swap_validator_set.sh"
+start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
 
 run_nightly_upgrade_test
 
-#run_soundness_test
+run_soundness_test

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -113,6 +113,8 @@ start_run_teardown "sync_test.sh timeout=500"
 start_run_teardown "gov96.sh"
 start_run_teardown "swap_validator_set.sh"
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
+# without start_run_teardown - this one performs its own assets setup, network start and teardown
+source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
 
 run_nightly_upgrade_test
 

--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -163,3 +163,4 @@ alias nctl-exec-upgrade-scenario-7='source $NCTL/sh/scenarios-upgrades/upgrade_s
 alias nctl-exec-upgrade-scenario-8='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_08.sh'
 alias nctl-exec-upgrade-scenario-9='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_09.sh'
 alias nctl-exec-upgrade-scenario-10='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_10.sh'
+alias nctl-exec-upgrade-scenario-11='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_11.sh'

--- a/utils/nctl/ci/ci.json
+++ b/utils/nctl/ci/ci.json
@@ -10,6 +10,6 @@
         }
     },
     "nctl_upgrade_tests": {
-        "protocol_1": "1.4.8"
+        "protocol_1": "1.4.13"
     }
 }

--- a/utils/nctl/sh/assets/upgrade.sh
+++ b/utils/nctl/sh/assets/upgrade.sh
@@ -122,6 +122,7 @@ function _generate_global_state_update() {
     local STATE_HASH=${2}
     local STATE_SOURCE=${3:-1}
     local NODE_COUNT=${4:-5}
+    #NOTE ${5} used for params, update accordingly if needed
 
     local PATH_TO_NET=$(get_path_to_net)
 
@@ -136,8 +137,7 @@ function _generate_global_state_update() {
     # First, we supply the path to the directory of the node whose global state we'll use
     # and the trusted hash then we Add the parameters that define the new validators.
     # We're using the reserve validators, from NODE_COUNT+1 to NODE_COUNT*2.
-    local PARAMS
-    PARAMS="generic -d ${STATE_SOURCE_PATH}/storage/$(get_chain_name) -s ${STATE_HASH} $(_validators_state_update_config $NODE_COUNT)"
+    local PARAMS=${5:-"generic -d ${STATE_SOURCE_PATH}/storage/$(get_chain_name) -s ${STATE_HASH} $(_validators_state_update_config $NODE_COUNT)"}
 
     mkdir -p "$PATH_TO_NET"/chainspec/"$PROTOCOL_VERSION"
 
@@ -167,6 +167,7 @@ function _emergency_upgrade_node() {
     local NODE_COUNT=${6:-5}
     local CONFIG_PATH=${7:-""}
     local CHAINSPEC_PATH=${8:-""}
+    local GENERATE_GS_UPDATE=${9:-"true"}
 
     _upgrade_node "$PROTOCOL_VERSION" "$ACTIVATE_ERA" "$NODE_ID" "$CONFIG_PATH" "$CHAINSPEC_PATH"
 
@@ -183,7 +184,9 @@ function _emergency_upgrade_node() {
 
     local PATH_TO_NET=$(get_path_to_net)
 
-    _generate_global_state_update "$PROTOCOL_VERSION" "$STATE_HASH" "$STATE_SOURCE" "$NODE_COUNT"
+    if [ "$GENERATE_GS_UPDATE" == 'true' ]; then
+        _generate_global_state_update "$PROTOCOL_VERSION" "$STATE_HASH" "$STATE_SOURCE" "$NODE_COUNT"
+    fi
 
     cp "$PATH_TO_NET"/chainspec/"$PROTOCOL_VERSION"/global_state.toml \
         "$PATH_TO_NODE"/config/"$PROTOCOL_VERSION"/global_state.toml

--- a/utils/nctl/sh/assets/upgrade.sh
+++ b/utils/nctl/sh/assets/upgrade.sh
@@ -22,6 +22,7 @@ function _upgrade_node() {
 
     local PATH_TO_NET
     local PATH_TO_NODE
+    local CHAIN_NAME
 
 
     PATH_TO_NET=$(get_path_to_net)
@@ -31,12 +32,16 @@ function _upgrade_node() {
     PATH_TO_UPGRADED_CHAINSPEC_FILE="$PATH_TO_NET"/chainspec/"$PROTOCOL_VERSION"/chainspec.toml
     cp "$PATH_TO_CHAINSPEC_FILE" "$PATH_TO_UPGRADED_CHAINSPEC_FILE"
 
+    # Really make sure the chain name stays the same :)
+    CHAIN_NAME=$(get_chain_name)
+
     # Write chainspec contents.
     local SCRIPT=(
         "import toml;"
         "cfg=toml.load('$PATH_TO_CHAINSPEC_FILE');"
         "cfg['protocol']['version']='$PROTOCOL_VERSION'.replace('_', '.');"
         "cfg['protocol']['activation_point']=$ACTIVATE_ERA;"
+        "cfg['network']['name']='$CHAIN_NAME';"
         "toml.dump(cfg, open('$PATH_TO_UPGRADED_CHAINSPEC_FILE', 'w'));"
     )
     python3 -c "${SCRIPT[*]}"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
@@ -5,18 +5,13 @@
 
 # 1. Start v1 running at current mainnet commit.
 # 2. Waits for genesis era to complete.
-# 3. Bonds in a non-genesis validator.
 # 4. Delegates from an unused account.
 # 5. Waits for the auction delay to take effect.
-# 6. Asserts non-genesis validator is in auction info.
 # 7. Asserts delegation is in auction info.
 # 8. Stages the network for upgrade.
 # 9. Assert v2 nodes run & the chain advances (new blocks are generated).
 # 10. Waits 1 era.
-# 11. Unbonds previously bonded non-genesis validator.
-# 12. Undelegates from previously used account
 # 13. Waits for the auction delay to take effect.
-# 14. Asserts non-genesis validator is NO LONGER an active validator.
 # 15. Asserts delegatee is NO LONGER in auction info.
 # 16. Run Health Checks
 # 17. Successful test cleanup.
@@ -208,7 +203,7 @@ function _step_07()
 
 function _step_08()
 {
-    log_step_upgrades 7 "Awaiting Auction_Delay = 1 + 1"
+    log_step_upgrades 8 "Awaiting Auction_Delay = 1 + 1"
     nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='300'
 }
 
@@ -224,7 +219,7 @@ function _step_09()
     HEX=$(cat "$USER_PATH"/public_key_hex | tr '[:upper:]' '[:lower:]')
     AUCTION_INFO_FOR_HEX=$(nctl-view-chain-auction-info | jq --arg node_hex "$HEX" '.auction_state.bids[]| select(.bid.delegators[].public_key | ascii_downcase == $node_hex)')
 
-    log_step_upgrades 8 "Asserting user-$USER_ID is NOT a delegatee"
+    log_step_upgrades 9 "Asserting user-$USER_ID is NOT a delegatee"
 
     if [ ! -z "$AUCTION_INFO_FOR_HEX" ]; then
         log "ERROR: user-$USER_ID found in auction info delegators!"
@@ -236,11 +231,11 @@ function _step_09()
     fi
 }
 
-# Step 16: Run NCTL health checks
-function _step_16()
+# Step 10: Run NCTL health checks
+function _step_10()
 {
     # restarts=6 - Nodes that upgrade
-    log_step_upgrades 16 "running health checks"
+    log_step_upgrades 10 "running health checks"
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='0' \
             equivocators='0' \
@@ -250,10 +245,10 @@ function _step_16()
             ejections=0
 }
 
-# Step 17: Terminate.
-function _step_17()
+# Step 11: Terminate.
+function _step_11()
 {
-    log_step_upgrades 17 "test successful - tidying up"
+    log_step_upgrades 11 "test successful - tidying up"
 
     source "$NCTL/sh/assets/teardown.sh"
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
@@ -53,7 +53,6 @@ function _main()
     _step_09
     _step_10
     _step_11
-    _step_12
 }
 
 function _custom_validators_state_update_config()

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------
+# Synopsis.
+# ----------------------------------------------------------------
+
+# 1. Start v1 running at current mainnet commit.
+# 2. Waits for genesis era to complete.
+# 3. Bonds in a non-genesis validator.
+# 4. Delegates from an unused account.
+# 5. Waits for the auction delay to take effect.
+# 6. Asserts non-genesis validator is in auction info.
+# 7. Asserts delegation is in auction info.
+# 8. Stages the network for upgrade.
+# 9. Assert v2 nodes run & the chain advances (new blocks are generated).
+# 10. Waits 1 era.
+# 11. Unbonds previously bonded non-genesis validator.
+# 12. Undelegates from previously used account
+# 13. Waits for the auction delay to take effect.
+# 14. Asserts non-genesis validator is NO LONGER an active validator.
+# 15. Asserts delegatee is NO LONGER in auction info.
+# 16. Run Health Checks
+# 17. Successful test cleanup.
+
+# ----------------------------------------------------------------
+# Imports.
+# ----------------------------------------------------------------
+
+source "$NCTL/sh/utils/main.sh"
+source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE.sh"
+source "$NCTL/sh/assets/upgrade.sh"
+source "$NCTL/sh/scenarios/common/itst.sh"
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Main entry point.
+function _main()
+{
+    local STAGE_ID=${1}
+
+    if [ ! -d "$(get_path_to_stage "$STAGE_ID")" ]; then
+        log "ERROR :: stage $STAGE_ID has not been built - cannot run scenario"
+        exit 1
+    fi
+
+    _step_01 "$STAGE_ID"
+    _step_02
+
+    # Set initial protocol version for use later.
+    INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
+    _step_03
+    _step_04
+    _step_05
+    _step_06
+    _step_07
+    _step_08
+    _step_09
+    exit 1
+    _step_10
+    _step_11
+    _step_12
+    _step_13
+    _step_14
+    _step_15
+    _step_16
+    _step_17
+}
+
+# Step 01: Start network from pre-built stage.
+function _step_01()
+{
+    local STAGE_ID=${1}
+    local PATH_TO_STAGE
+    local PATH_TO_PROTO1
+
+    PATH_TO_STAGE=$(get_path_to_stage "$STAGE_ID")
+    pushd "$PATH_TO_STAGE"
+    PATH_TO_PROTO1=$(ls -d */ | sort | head -n 1 | tr -d '/')
+    popd
+
+    log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
+
+    source "$NCTL/sh/assets/setup_from_stage.sh" \
+            stage="$STAGE_ID" \
+            accounts_path="$NCTL/overrides/upgrade_scenario_3.pre.accounts.toml"
+    source "$NCTL/sh/node/start.sh" node=all
+}
+
+# Step 02: Await era-id >= 1.
+function _step_02()
+{
+    log_step_upgrades 2 "awaiting genesis era completion"
+
+    do_await_genesis_era_to_complete 'false'
+}
+
+# Step 03: Delegate from a nodes account
+function _step_03()
+{
+    local NODE_ID=${1:-'5'}
+    local ACCOUNT_ID=${2:-'7'}
+    local AMOUNT=${3:-'500000000000'}
+
+    log_step_upgrades 3 "Delegating $AMOUNT from account-$ACCOUNT_ID to validator-$NODE_ID"
+
+    source "$NCTL/sh/contracts-auction/do_delegate.sh" \
+            amount="$AMOUNT" \
+            delegator="$ACCOUNT_ID" \
+            validator="$NODE_ID"
+}
+
+# Step 04: Await 1 era
+function _step_04()
+{
+    log_step_upgrades 4 "Awaiting Auction_Delay = 1 + 1"
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='300'
+}
+
+# Step 05: Assert USER_ID is a delegatee
+function _step_05()
+{
+    local USER_ID=${1:-'7'}
+    local USER_PATH
+    local HEX
+    local AUCTION_INFO_FOR_HEX
+    local TIMEOUT_SEC
+
+    TIMEOUT_SEC='0'
+
+    USER_PATH=$(get_path_to_user "$USER_ID")
+    HEX=$(cat "$USER_PATH"/public_key_hex | tr '[:upper:]' '[:lower:]')
+
+    log_step_upgrades 5 "Asserting user-$USER_ID is a delegatee"
+
+    while [ "$TIMEOUT_SEC" -le "60" ]; do
+        AUCTION_INFO_FOR_HEX=$(nctl-view-chain-auction-info | jq --arg node_hex "$HEX" '.auction_state.bids[]| select(.bid.delegators[].public_key | ascii_downcase == $node_hex)')
+        if [ ! -z "$AUCTION_INFO_FOR_HEX" ]; then
+            log "... user-$USER_ID found in auction info delegators!"
+            log "... public_key_hex: $HEX"
+            echo "$AUCTION_INFO_FOR_HEX"
+            break
+        else
+            TIMEOUT_SEC=$((TIMEOUT_SEC + 1))
+            log "... timeout=$TIMEOUT_SEC: delegatee not yet detected"
+            sleep 1
+            if [ "$TIMEOUT_SEC" = '60' ]; then
+                log "ERROR: Could not find $HEX in auction info delegators!"
+                echo "$(nctl-view-chain-auction-info)"
+                exit 1
+            fi
+        fi
+    done
+}
+
+# Step 06: Undelegate previous user
+function _step_06()
+{
+    local NODE_ID=${1:-'5'}
+    local ACCOUNT_ID=${2:-'7'}
+    local AMOUNT=${3:-'500000000000'}
+
+    log_step_upgrades 6 "Undelegating $AMOUNT to account-$ACCOUNT_ID from validator-$NODE_ID"
+
+    source "$NCTL/sh/contracts-auction/do_delegate_withdraw.sh" \
+            amount="$AMOUNT" \
+            delegator="$ACCOUNT_ID" \
+            validator="$NODE_ID"
+}
+
+# Emergency Restart this bitch with a validator swap
+function _step_07()
+{
+    local ACTIVATE_ERA
+    local ERA_ID
+    local SWITCH_BLOCK
+    local STATE_HASH
+    local TRUSTED_HASH
+    local PROTOCOL_VERSION
+
+    ACTIVATE_ERA="$(get_chain_era)"
+    ERA_ID=$((ACTIVATE_ERA - 1))
+    SWITCH_BLOCK=$(get_switch_block "1" "32" "" "$ERA_ID")
+    STATE_HASH=$(echo "$SWITCH_BLOCK" | jq -r '.header.state_root_hash')
+    TRUSTED_HASH=$(echo "$SWITCH_BLOCK" | jq -r '.hash')
+    PROTOCOL_VERSION='2_0_0'
+
+    log_step_upgrades 7 "Emergency restart with validator swap"
+    log "...emergency upgrade activation era = $ACTIVATE_ERA"
+    log "...state hash = $STATE_HASH"
+    log "...trusted hash = $TRUSTED_HASH"
+    log "...new protocol version = $PROTOCOL_VERSION"
+
+    do_node_stop_all
+
+    for NODE_ID in $(seq 1 "$(get_count_of_nodes)"); do
+        log "...preparing $NODE_ID"
+        _emergency_upgrade_node "$PROTOCOL_VERSION" "$ACTIVATE_ERA" "$NODE_ID" "$STATE_HASH" 1 "$(get_count_of_genesis_nodes)" "$NCTL_CASPER_HOME/resources/local/config.toml" "$NCTL_CASPER_HOME/resources/local/chainspec.toml.in"
+        log "...starting $NODE_ID"
+        #HACK FOR NOW
+        #sed -i 's/\[block_proposer\]//g' $(get_path_to_node_config $NODE_ID)/"$PROTOCOL_VERSION"/config.toml
+        #sed -i 's/max_execution_delay.*//g' $(get_path_to_node_config $NODE_ID)/"$PROTOCOL_VERSION"/config.toml
+        #sed -i 's/max_execution_delay.*//g' $(get_path_to_node_config $NODE_ID)/"$PROTOCOL_VERSION"/config.toml
+        do_node_start "$NODE_ID" "$TRUSTED_HASH"
+    done
+    sleep 10
+}
+
+function _step_08()
+{
+    log_step_upgrades 7 "Awaiting Auction_Delay = 1 + 1"
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='300'
+}
+
+# Step 08: Assert USER_ID is NOT a delegatee
+function _step_09()
+{
+    local USER_ID=${1:-'7'}
+    local USER_PATH
+    local HEX
+    local AUCTION_INFO_FOR_HEX
+
+    USER_PATH=$(get_path_to_user "$USER_ID")
+    HEX=$(cat "$USER_PATH"/public_key_hex | tr '[:upper:]' '[:lower:]')
+    AUCTION_INFO_FOR_HEX=$(nctl-view-chain-auction-info | jq --arg node_hex "$HEX" '.auction_state.bids[]| select(.bid.delegators[].public_key | ascii_downcase == $node_hex)')
+
+    log_step_upgrades 8 "Asserting user-$USER_ID is NOT a delegatee"
+
+    if [ ! -z "$AUCTION_INFO_FOR_HEX" ]; then
+        log "ERROR: user-$USER_ID found in auction info delegators!"
+        log "... public_key_hex: $HEX"
+        echo "$AUCTION_INFO_FOR_HEX"
+        exit 1
+    else
+        log "... Could not find $HEX in auction info delegators! [expected]"
+    fi
+}
+
+# Step 16: Run NCTL health checks
+function _step_16()
+{
+    # restarts=6 - Nodes that upgrade
+    log_step_upgrades 16 "running health checks"
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors='0' \
+            equivocators='0' \
+            doppels='0' \
+            crashes=0 \
+            restarts=6 \
+            ejections=0
+}
+
+# Step 17: Terminate.
+function _step_17()
+{
+    log_step_upgrades 17 "test successful - tidying up"
+
+    source "$NCTL/sh/assets/teardown.sh"
+
+    log_break
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset _STAGE_ID
+unset INITIAL_PROTOCOL_VERSION
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        stage) _STAGE_ID=${VALUE} ;;
+        *)
+    esac
+done
+
+_main "${_STAGE_ID:-1}"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
@@ -168,8 +168,10 @@ function _step_05()
         fi
     done
 
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
 }
 
 # Step 06: Undelegate previous user
@@ -186,11 +188,13 @@ function _step_06()
             delegator="$ACCOUNT_ID" \
             validator="$NODE_ID"
 
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
     nctl-view-chain-auction-info
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
 }
 
 # Emergency Restart this bitch with a validator swap
@@ -238,11 +242,13 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "Awaiting Auction_Delay = 1 + 1"
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
     nctl-view-chain-auction-info
+    echo "CURRENT ERA: $(nctl-view-chain-era)"
 }
 
 # Step 08: Assert USER_ID is NOT a delegatee
@@ -274,14 +280,14 @@ function _step_09()
 # Step 10: Run NCTL health checks
 function _step_10()
 {
-    # restarts=6 - Nodes that upgrade
+    # restarts=5 - Nodes that upgrade
     log_step_upgrades 10 "running health checks"
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='0' \
             equivocators='0' \
             doppels='0' \
             crashes=0 \
-            restarts=6 \
+            restarts=5 \
             ejections=0
 }
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_11.sh
@@ -189,6 +189,8 @@ function _step_06()
     nctl-view-chain-auction-info
     nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
     nctl-view-chain-auction-info
+    nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
+    nctl-view-chain-auction-info
 }
 
 # Emergency Restart this bitch with a validator swap
@@ -236,7 +238,11 @@ function _step_07()
 function _step_08()
 {
     log_step_upgrades 8 "Awaiting Auction_Delay = 1 + 1"
-    nctl-await-n-eras offset='2' sleep_interval='2.0' timeout='300'
+    nctl-view-chain-auction-info
+    nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
+    nctl-view-chain-auction-info
+    nctl-await-n-eras offset='1' sleep_interval='2.0' timeout='300'
+    nctl-view-chain-auction-info
 }
 
 # Step 08: Assert USER_ID is NOT a delegatee

--- a/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_11.accounts.toml.override
+++ b/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_11.accounts.toml.override
@@ -1,0 +1,134 @@
+# FAUCET.
+[[accounts]]
+public_key = "PBK_FAUCET"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 1.
+[[accounts]]
+public_key = "PBK_V1"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 1
+
+# VALIDATOR 2.
+[[accounts]]
+public_key = "PBK_V2"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 2
+
+# VALIDATOR 3.
+[[accounts]]
+public_key = "PBK_V3"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 3
+
+# VALIDATOR 4.
+[[accounts]]
+public_key = "PBK_V4"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 4
+
+# VALIDATOR 5.
+[[accounts]]
+public_key = "PBK_V5"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1"
+delegation_rate = 100
+
+# VALIDATOR 6.
+[[accounts]]
+public_key = "PBK_V6"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 7.
+[[accounts]]
+public_key = "PBK_V7"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 8.
+[[accounts]]
+public_key = "PBK_V8"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 9.
+[[accounts]]
+public_key = "PBK_V9"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 10.
+[[accounts]]
+public_key = "PBK_V10"
+balance = "1000000000000000000000000000000000"
+
+# USER 1.
+[[delegators]]
+validator_public_key = "PBK_V1"
+delegator_public_key = "PBK_U1"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 2.
+[[delegators]]
+validator_public_key = "PBK_V2"
+delegator_public_key = "PBK_U2"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 3.
+[[delegators]]
+validator_public_key = "PBK_V3"
+delegator_public_key = "PBK_U3"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 4.
+[[delegators]]
+validator_public_key = "PBK_V4"
+delegator_public_key = "PBK_U4"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 5.
+[[delegators]]
+validator_public_key = "PBK_V4"
+delegator_public_key = "PBK_U5"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 6.
+[[accounts]]
+public_key = "PBK_U6"
+balance = "1000000000000000000000000000000000"
+
+# USER 7.
+[[accounts]]
+public_key = "PBK_U7"
+balance = "1000000000000000000000000000000000"
+
+# USER 8.
+[[accounts]]
+public_key = "PBK_U8"
+balance = "1000000000000000000000000000000000"
+
+# USER 9.
+[[accounts]]
+public_key = "PBK_U9"
+balance = "1000000000000000000000000000000000"
+
+# USER 10.
+[[accounts]]
+public_key = "PBK_U10"
+balance = "1000000000000000000000000000000000"

--- a/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_11.accounts.toml.override
+++ b/utils/nctl/sh/scenarios/accounts_toml/upgrade_scenario_11.accounts.toml.override
@@ -10,7 +10,7 @@ balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
 bonded_amount = "1"
-delegation_rate = 1
+delegation_rate = 100
 
 # VALIDATOR 2.
 [[accounts]]
@@ -18,8 +18,8 @@ public_key = "PBK_V2"
 balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
-bonded_amount = "1"
-delegation_rate = 2
+bonded_amount = "2"
+delegation_rate = 100
 
 # VALIDATOR 3.
 [[accounts]]
@@ -27,8 +27,8 @@ public_key = "PBK_V3"
 balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
-bonded_amount = "1"
-delegation_rate = 3
+bonded_amount = "3"
+delegation_rate = 100
 
 # VALIDATOR 4.
 [[accounts]]
@@ -36,8 +36,8 @@ public_key = "PBK_V4"
 balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
-bonded_amount = "1"
-delegation_rate = 4
+bonded_amount = "4"
+delegation_rate = 100
 
 # VALIDATOR 5.
 [[accounts]]
@@ -45,7 +45,7 @@ public_key = "PBK_V5"
 balance = "1000000000000000000000000000000000"
 
 [accounts.validator]
-bonded_amount = "1"
+bonded_amount = "5"
 delegation_rate = 100
 
 # VALIDATOR 6.
@@ -103,7 +103,7 @@ delegated_amount = "1"
 
 # USER 5.
 [[delegators]]
-validator_public_key = "PBK_V4"
+validator_public_key = "PBK_V5"
 delegator_public_key = "PBK_U5"
 balance = "1000000000000000000000000000000000"
 delegated_amount = "1"

--- a/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_11.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/upgrade_scenario_11.chainspec.toml.override
@@ -1,0 +1,5 @@
+[core]
+round_seigniorage_rate = [0, 1]
+locked_funds_period = '0days'
+validator_slots = 5
+vesting_schedule_period = '0days'

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -547,3 +547,16 @@ function assert_new_bonded_validator() {
       exit 1
     fi
 }
+
+function delegate_to() {
+    local NODE_ID=${1}
+    local ACCOUNT_ID=${2}
+    local AMOUNT=${3}
+
+    log_step "Delegating $AMOUNT from account-$ACCOUNT_ID to validator-$NODE_ID"
+
+    source "$NCTL/sh/contracts-auction/do_delegate.sh" \
+        amount="$AMOUNT" \
+        delegator="$ACCOUNT_ID" \
+        validator="$NODE_ID"
+}


### PR DESCRIPTION
This PR adds the NCTL tests for carrying unbonds across the emergency upgrade.
Base on the [initial work](https://github.com/casper-network/casper-node/tree/cn-3695) from @TomVasile.

Test executes the following scenario:
```
# 1. Start v1 running at current mainnet commit.
# 2. Wait for genesis era to complete.
# 3. Delegate from an unused account.
# 4. Wait for the auction delay to take effect.
# 5. Asserts delegation is in auction info.
# 6. Undelegate.
# 7. Perform an emergency upgrade and assert validator set has changed.
# 8. Asserts delegatee is NO LONGER in auction info.
# 9. Run health checks.
# 10. Successful test cleanup.
```

Closes #3695 
