### PR TITLE
3818: Test asserting the type and size of the largest message specimen

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -85,8 +85,8 @@ pub(crate) use self::{
     identity::Identity,
     insights::NetworkInsights,
     message::{
-        generate_largest_message, EstimatorWeights, FromIncoming, Message, MessageKind,
-        NetworkMessageEstimator, Payload,
+        generate_largest_serialized_message, EstimatorWeights, FromIncoming, Message, MessageKind,
+        Payload,
     },
 };
 use self::{

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -941,4 +941,21 @@ mod tests {
     fn bincode_roundtrip_certificate() {
         roundtrip_certificate(false)
     }
+
+    #[test]
+    fn assert_the_largest_specimen_type_and_size() {
+        let (chainspec, _) = crate::utils::Loadable::from_resources("production");
+        let estimator = NetworkMessageEstimator::new(&chainspec);
+        let mut cache = Cache::default();
+        let specimen = Message::largest_specimen(&estimator, &mut cache);
+
+        assert_matches::assert_matches!(
+            specimen,
+            Message::Payload(protocol::Message::GetResponse { .. })
+        );
+
+        let serialized = serialize_net_message(&specimen);
+
+        assert_eq!(serialized.len(), 8_388_736);
+    }
 }

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -45,10 +45,7 @@ pub use self::{
     network_config::NetworkConfig,
     protocol_config::ProtocolConfig,
 };
-use crate::{
-    components::network::{generate_largest_message, NetworkMessageEstimator},
-    utils::{specimen::Cache, Loadable},
-};
+use crate::{components::network::generate_largest_serialized_message, utils::Loadable};
 
 /// The name of the chainspec file on disk.
 pub const CHAINSPEC_FILENAME: &str = "chainspec.toml";
@@ -96,9 +93,7 @@ impl Chainspec {
         info!("begin chainspec validation");
         // Ensure the size of the largest message generated under these chainspec settings does not
         // exceed the configured message size limit.
-        let estimator = NetworkMessageEstimator::new(self);
-        let mut cache = Cache::default();
-        let serialized = generate_largest_message(&estimator, &mut cache);
+        let serialized = generate_largest_serialized_message(self);
 
         if serialized.len() + CHAINSPEC_NETWORK_MESSAGE_SAFETY_MARGIN
             > self.network_config.maximum_net_message_size as usize


### PR DESCRIPTION
A test is added which:
- Verify that the largest specimen is of type `Message::GetResponse`,
- Verify that its size is `8_388_736` bytes.