### PR TITLE
Unify sync to ttl check

### DIFF
--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -36,8 +36,8 @@ use crate::{
     types::{
         appendable_block::{AddError, AppendableBlock},
         chainspec::DeployConfig,
-        Approval, Block, BlockHeader, Deploy, DeployFootprint, DeployHash, DeployHashWithApprovals,
-        DeployId, FinalizedBlock,
+        Approval, Block, Deploy, DeployFootprint, DeployHash, DeployHashWithApprovals, DeployId,
+        FinalizedBlock,
     },
     utils::DisplayIter,
     NodeRng,
@@ -72,13 +72,6 @@ pub(crate) struct DeployBuffer {
     hold: BTreeMap<Timestamp, HashSet<DeployHash>>,
     // deploy_hashes that should not be proposed, ever
     dead: HashSet<DeployHash>,
-    // block_height and block_time of blocks added to the local chain needed to ensure we have seen
-    // sufficient blocks to allow consensus to proceed safely without risking duplicating deploys.
-    //
-    // if we have gaps in block_height, we do NOT have full TTL awareness.
-    // if we have no block_height gaps but our earliest block_time is less than now - ttl,
-    // we do NOT have full TTL awareness.
-    chain_index: BTreeMap<u64, Timestamp>,
     // deploy buffer metrics
     #[data_size(skip)]
     metrics: Metrics,
@@ -98,7 +91,6 @@ impl DeployBuffer {
             buffer: HashMap::new(),
             hold: BTreeMap::new(),
             dead: HashSet::new(),
-            chain_index: BTreeMap::new(),
             metrics: Metrics::new(registry)?,
         })
     }
@@ -152,63 +144,6 @@ impl DeployBuffer {
             );
         }
         None
-    }
-
-    /// Returns `true` if we have enough information to participate in consensus in the era after
-    /// the `switch block`.
-    ///
-    /// To validate and propose blocks we need to be able to avoid and detect deploy replays.
-    /// Each block in the new era E will have a timestamp greater or equal to E's start time T,
-    /// which is the switch block's timestamp. A deploy D in a block B cannot have timed out as of
-    /// B's timestamp, so it cannot be older than T - ttl, where ttl is the maximum deploy
-    /// time-to-live. So if D were also in an earlier block C, then C's timestamp would be at
-    /// least T - ttl. Thus to prevent replays, we need all blocks with a timestamp between
-    /// T - ttl and T.
-    ///
-    /// Note that we don't need to already have any blocks from E itself, since the consensus
-    /// protocol will announce all proposed and finalized blocks in E anyway.
-    pub(crate) fn have_full_ttl_of_deploys(&self, switch_block: &BlockHeader) -> bool {
-        let from_height = switch_block.height();
-        let earliest_needed = switch_block
-            .timestamp()
-            .saturating_sub(self.deploy_config.max_ttl);
-        debug!(
-            ?self.chain_index, %earliest_needed,
-            "DeployBuffer: chain_index check from_height: {}", from_height
-        );
-        let mut current = match self.chain_index.get(&from_height) {
-            None => {
-                debug!("DeployBuffer: not in chain_index: {}", from_height);
-                return false;
-            }
-            Some(timestamp) => (from_height, timestamp),
-        };
-
-        // genesis special case
-        if from_height == 0 && self.chain_index.contains_key(&from_height) {
-            return true;
-        }
-
-        // note the .rev() at the end (we go backwards)
-        // I only mention it as it seems to keep tripping people up. Not YOU of course, but people.
-        for (height, timestamp) in self.chain_index.range(..from_height).rev() {
-            // gap detection; any gaps in the chain index means we do not have full ttl awareness
-            // for instance, for block_height 6 in set [0,1,2,4,5,6] block 3 is missing
-            // therefore, we can't possibly have ttl
-            let contiguous_next = height.saturating_add(1);
-            if contiguous_next != current.0 {
-                debug!("DeployBuffer: missing block at height: {}", contiguous_next);
-                return false;
-            }
-
-            // if we've reached genesis via an unbroken sequence, we're good
-            // if we've seen a full ttl period of blocks, we're good
-            if *height == 0 || *timestamp < earliest_needed {
-                return true;
-            }
-            current = (*height, timestamp);
-        }
-        false
     }
 
     /// Manages cache ejection.
@@ -338,11 +273,9 @@ impl DeployBuffer {
 
     fn register_deploys<'a>(
         &mut self,
-        block_height: u64,
         timestamp: Timestamp,
         deploy_hashes: impl Iterator<Item = &'a DeployHash>,
     ) {
-        self.chain_index.insert(block_height, timestamp);
         let expiry_timestamp = timestamp.saturating_add(self.deploy_config.max_ttl);
 
         for deploy_hash in deploy_hashes {
@@ -364,7 +297,7 @@ impl DeployBuffer {
         let block_height = block.header().height();
         let timestamp = block.timestamp();
         debug!(%timestamp, "DeployBuffer: register_block({}) timestamp finalized", block_height);
-        self.register_deploys(block_height, timestamp, block.deploy_and_transfer_hashes());
+        self.register_deploys(timestamp, block.deploy_and_transfer_hashes());
     }
 
     /// Update buffer and holds considering new finalized block.
@@ -372,11 +305,7 @@ impl DeployBuffer {
         let block_height = finalized_block.height();
         let timestamp = finalized_block.timestamp();
         debug!(%timestamp, "DeployBuffer: register_block_finalized({}) timestamp finalized", block_height);
-        self.register_deploys(
-            block_height,
-            timestamp,
-            finalized_block.deploy_and_transfer_hashes(),
-        );
+        self.register_deploys(timestamp, finalized_block.deploy_and_transfer_hashes());
     }
 
     /// Returns eligible deploys that are buffered and not held or dead.

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -311,7 +311,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::ChainspecRawBytesRequest(_) => "ChainspecRawBytesRequest",
             MainEvent::UpgradeWatcherRequest(_) => "UpgradeWatcherRequest",
             MainEvent::StorageRequest(_) => "StorageRequest",
-            MainEvent::BlockCompleteConfirmationRequest(_) => "MarkBlockCompletedRequest",
+            MainEvent::BlockCompleteConfirmationRequest(_) => "BlockCompleteConfirmationRequest",
             MainEvent::DumpConsensusStateRequest(_) => "DumpConsensusStateRequest",
             MainEvent::ControlAnnouncement(_) => "ControlAnnouncement",
             MainEvent::FatalAnnouncement(_) => "FatalAnnouncement",

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -115,10 +115,7 @@ impl MainReactor {
             return Ok(None);
         }
 
-        if self
-            .deploy_buffer
-            .have_full_ttl_of_deploys(highest_switch_block_header)
-        {
+        if self.synced_to_ttl(Some(highest_switch_block_header))? {
             if let HighestOrphanedBlockResult::Orphan(header) =
                 self.storage.get_highest_orphaned_block_header()
             {

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -115,7 +115,7 @@ impl MainReactor {
             return Ok(None);
         }
 
-        if self.synced_to_ttl(Some(highest_switch_block_header))? {
+        if self.synced_to_ttl(Some(highest_switch_block_header), None)? {
             if let HighestOrphanedBlockResult::Orphan(header) =
                 self.storage.get_highest_orphaned_block_header()
             {

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -4,8 +4,10 @@ use tracing::{debug, info, warn};
 use crate::{
     components::consensus::ChainspecConsensusExt,
     effect::{EffectBuilder, Effects},
-    reactor,
-    reactor::main_reactor::{MainEvent, MainReactor},
+    reactor::{
+        self,
+        main_reactor::{keep_up::synced_to_ttl, MainEvent, MainReactor},
+    },
     storage::HighestOrphanedBlockResult,
     NodeRng,
 };
@@ -115,7 +117,12 @@ impl MainReactor {
             return Ok(None);
         }
 
-        if self.synced_to_ttl(Some(highest_switch_block_header), None)? {
+        if synced_to_ttl(
+            Some(highest_switch_block_header),
+            None,
+            &self.storage,
+            self.chainspec.deploy_config.max_ttl,
+        )? {
             if let HighestOrphanedBlockResult::Orphan(header) =
                 self.storage.get_highest_orphaned_block_header()
             {

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -75,8 +75,8 @@ impl MainReactor {
         let highest_switch_block_header = match recent_switch_block_headers.last() {
             None => {
                 debug!(
-                    state = %self.state,
-                    "create_required_eras: recent_switch_block_headers is empty"
+                    "{}: create_required_eras: recent_switch_block_headers is empty",
+                    self.state
                 );
                 return Ok(None);
             }
@@ -92,7 +92,7 @@ impl MainReactor {
         if let Some(current_era) = self.consensus.current_era() {
             debug!(state = %self.state,
                 era = current_era.value(),
-                "consensus current_era");
+                "{}: consensus current_era", self.state);
             if highest_switch_block_header.next_block_era_id() <= current_era {
                 return Ok(Some(Effects::new()));
             }


### PR DESCRIPTION
This PR makes the validate flow to reuse the "is synced to ttl?" calculation from keep-up flow, making the `DeployBuffer::chain_index` no longer needed.

Closes https://github.com/casper-network/casper-node/issues/3858