### PR TITLE
Use casper-wasm-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "num-rational 0.4.0",
  "num-traits",
  "once_cell",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -433,6 +433,7 @@ dependencies = [
  "bincode",
  "casper-hashing",
  "casper-types",
+ "casper-wasm-utils",
  "chrono",
  "criterion",
  "datasize",
@@ -451,9 +452,8 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
- "parity-wasm",
+ "parity-wasm 0.42.2",
  "proptest",
- "pwasm-utils",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "schemars",
@@ -651,6 +651,17 @@ dependencies = [
  "clap",
  "once_cell",
  "regex",
+]
+
+[[package]]
+name = "casper-wasm-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7d5a513000d2d4772800ca7cfce247712553a8363edfb7462b3e0f5db96d02"
+dependencies = [
+ "byteorder",
+ "log",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -2979,6 +2990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,17 +3387,6 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
-]
-
-[[package]]
-name = "pwasm-utils"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm",
 ]
 
 [[package]]
@@ -5220,26 +5226,26 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad7e265153e1010a73e595eef3e2fd2a1fd644ba4e2dd3af4dd6bd7ec692342"
+checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
 dependencies = [
  "downcast-rs",
  "libc",
  "memory_units 0.3.0",
  "num-rational 0.2.4",
  "num-traits",
- "parity-wasm",
+ "parity-wasm 0.42.2",
  "wasmi-validation",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
+checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
 dependencies = [
- "parity-wasm",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "tracing",
  "uint",
  "uuid",
+ "walrus",
  "wasmi",
 ]
 

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,6 +16,7 @@ base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.4.3", path = "../hashing" }
 casper-types = { version = "1.5.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-wasm-utils = "0.1.0"
 chrono = "0.4.10"
 datasize = "0.2.4"
 either = "1.8.1"
@@ -28,14 +29,13 @@ linked-hash-map = "0.5.3"
 lmdb = "0.8"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.4.0", default-features = false }
-num_cpus = "1"
 num-derive = "0.3.0"
 num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
+num_cpus = "1"
 once_cell = "1.5.2"
 parity-wasm = { version = "0.42", default-features = false }
 proptest = { version = "1.0.0", optional = true }
-casper-wasm-utils = "0.1.0"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
 schemars = { version = "=0.8.5", features = ["preserve_order"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -33,9 +33,9 @@ num-derive = "0.3.0"
 num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
 once_cell = "1.5.2"
-parity-wasm = "0.41.0"
+parity-wasm = { version = "0.42", default-features = false }
 proptest = { version = "1.0.0", optional = true }
-pwasm-utils = "0.16.0"
+casper-wasm-utils = "0.1.0"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
 schemars = { version = "=0.8.5", features = ["preserve_order"] }
@@ -46,10 +46,7 @@ thiserror = "1.0.18"
 tracing = "0.1.18"
 uint = "0.9.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-# By depending on wasmi 0.8.0 we are stuck with parity-wasm 0.41.0
-# and pwasm-utils 0.16 as upstream wasmi still depends on 0.41.0.
-# https://github.com/paritytech/wasmi/commit/f5fd480260490ff0de455017229caf7baee68195
-wasmi = "0.8.0"
+wasmi = "0.9.1"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -53,6 +53,7 @@ assert_matches = "1.3.0"
 criterion = "0.3.5"
 proptest = "1.0.0"
 tempfile = "3.1.0"
+walrus = "0.19.0"
 
 [features]
 default = ["gens"]

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -177,8 +177,8 @@ impl From<wasm_prep::PreprocessingError> for Error {
     }
 }
 
-impl From<pwasm_utils::OptimizerError> for Error {
-    fn from(_optimizer_error: pwasm_utils::OptimizerError) -> Self {
+impl From<casper_wasm_utils::OptimizerError> for Error {
+    fn from(_optimizer_error: casper_wasm_utils::OptimizerError) -> Self {
         Error::WasmOptimizer
     }
 }

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -1,9 +1,9 @@
 //! Support for Wasm opcode costs.
 use std::{convert::TryInto, num::NonZeroU32};
 
+use casper_wasm_utils::rules::{MemoryGrowCost, Rules};
 use datasize::DataSize;
 use parity_wasm::elements::Instruction;
-use pwasm_utils::rules::{MemoryGrowCost, Rules};
 use rand::{distributions::Standard, prelude::*, Rng};
 use serde::{Deserialize, Serialize};
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -453,6 +453,7 @@ mod tests {
         builder,
         elements::{CodeSection, Instructions},
     };
+    use walrus::{FunctionBuilder, ModuleConfig, ValType};
 
     use super::*;
 
@@ -604,6 +605,50 @@ mod tests {
         assert!(
             matches!(&error, PreprocessingError::Deserialize(msg)
             if msg == &format!("missing function index {index}", index=u32::MAX)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_accept_multi_value_proposal_wasm() {
+        let module_bytes = {
+            let mut module = walrus::Module::with_config(ModuleConfig::new());
+
+            let _memory_id = module.memories.add_local(false, 11, None);
+
+            // fn func_with_multi_value() -> (i32, i64) {
+
+            let mut func_with_locals =
+                FunctionBuilder::new(&mut module.types, &[], &[ValType::I32, ValType::I64]);
+
+            func_with_locals.func_body().i64_const(0).i32_const(1);
+
+            let func_with_locals = func_with_locals.finish(vec![], &mut module.funcs);
+
+            // }
+
+            // fn call() {
+
+            let mut call_func = FunctionBuilder::new(&mut module.types, &[], &[]);
+
+            // func_with_locals();
+            call_func.func_body().call(func_with_locals);
+
+            let call = call_func.finish(Vec::new(), &mut module.funcs);
+
+            // }
+
+            module.exports.add(DEFAULT_ENTRY_POINT_NAME, call);
+
+            module.emit_wasm()
+        };
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            // TODO: GH-3762 will improve the error message for unsupported wasm proposals.
+            if msg == "Enable the multi_value feature to deserialize more than one function result"),
             "{:?}",
             error,
         );

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -617,8 +617,6 @@ mod tests {
 
             let _memory_id = module.memories.add_local(false, 11, None);
 
-            // fn func_with_multi_value() -> (i32, i64) {
-
             let mut func_with_locals =
                 FunctionBuilder::new(&mut module.types, &[], &[ValType::I32, ValType::I64]);
 
@@ -626,18 +624,11 @@ mod tests {
 
             let func_with_locals = func_with_locals.finish(vec![], &mut module.funcs);
 
-            // }
-
-            // fn call() {
-
             let mut call_func = FunctionBuilder::new(&mut module.types, &[], &[]);
 
-            // func_with_locals();
             call_func.func_body().call(func_with_locals);
 
             let call = call_func.finish(Vec::new(), &mut module.funcs);
-
-            // }
 
             module.exports.add(DEFAULT_ENTRY_POINT_NAME, call);
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,10 +1,10 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
+use casper_wasm_utils::{self, stack_height};
 use parity_wasm::elements::{
     self, External, Instruction, Internal, MemorySection, Module, Section, TableType, Type,
 };
-use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
 use crate::core::execution;
@@ -12,7 +12,7 @@ use crate::core::execution;
 use super::wasm_config::WasmConfig;
 
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
-/// Name of the internal gas function injected by [`pwasm_utils::inject_gas_counter`].
+/// Name of the internal gas function injected by [`casper_wasm_utils::inject_gas_counter`].
 const INTERNAL_GAS_FUNCTION_NAME: &str = "gas";
 
 /// We only allow maximum of 4k function pointers in a table section.
@@ -390,8 +390,8 @@ pub fn preprocess(
     ensure_valid_access(&module)?;
 
     if memory_section(&module).is_none() {
-        // `pwasm_utils::externalize_mem` expects a non-empty memory section to exist in the module,
-        // and panics otherwise.
+        // `casper_wasm_utils::externalize_mem` expects a non-empty memory section to exist in the
+        // module, and panics otherwise.
         return Err(PreprocessingError::MissingMemorySection);
     }
 
@@ -401,8 +401,8 @@ pub fn preprocess(
     ensure_parameter_limit(&module, DEFAULT_MAX_PARAMETER_COUNT)?;
     ensure_valid_imports(&module)?;
 
-    let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
-    let module = pwasm_utils::inject_gas_counter(
+    let module = casper_wasm_utils::externalize_mem(module, None, wasm_config.max_memory);
+    let module = casper_wasm_utils::inject_gas_counter(
         module,
         &wasm_config.opcode_costs(),
         DEFAULT_GAS_MODULE_NAME,
@@ -440,7 +440,7 @@ pub fn get_module_from_entry_points(
     match maybe_missing_name {
         Some(missing_name) => Err(execution::Error::FunctionNotFound(missing_name)),
         None => {
-            pwasm_utils::optimize(&mut module, entry_point_names)?;
+            casper_wasm_utils::optimize(&mut module, entry_point_names)?;
             parity_wasm::serialize(module).map_err(execution::Error::ParityWasm)
         }
     }

--- a/execution_engine_testing/tests/src/test/regression/gov_427.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_427.rs
@@ -19,27 +19,22 @@ fn make_arbitrary_local_count(
 
     let _memory_id = module.memories.add_local(false, 11, None);
 
-    // fn func_with_locals() {
-
     let mut func_with_locals = FunctionBuilder::new(&mut module.types, &[], &[]);
 
     let mut locals = Vec::new();
     for _ in 0..repeat_count {
         for val_type in repeat_pattern {
-            // let local_x;
             let local = module.locals.add(*val_type);
             locals.push((local, *val_type));
         }
     }
 
     for extra_type in extra_types {
-        // let local_x;
         let local = module.locals.add(*extra_type);
         locals.push((local, *extra_type));
     }
 
     for (i, (local, val_type)) in locals.into_iter().enumerate() {
-        // locals[i] = i;
         let value = match val_type {
             ValType::I32 => Value::I32(i.try_into().unwrap()),
             ValType::I64 => Value::I64(i.try_into().unwrap()),
@@ -53,18 +48,11 @@ fn make_arbitrary_local_count(
 
     let func_with_locals = func_with_locals.finish(vec![], &mut module.funcs);
 
-    // }
-
-    // fn call() {
-
     let mut call_func = FunctionBuilder::new(&mut module.types, &[], &[]);
 
-    // func_with_locals();
     call_func.func_body().call(func_with_locals);
 
     let call = call_func.finish(Vec::new(), &mut module.funcs);
-
-    // }
 
     module.exports.add(DEFAULT_ENTRY_POINT_NAME, call);
 
@@ -117,7 +105,10 @@ fn too_many_locals_should_exceed_stack_height() {
     // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
     // restrictive default stack height.
     assert!(
-        matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),
+        matches!(
+            &error,
+            Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")
+        ),
         "{:?}",
         error
     );

--- a/execution_engine_testing/tests/src/test/regression/gov_427.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_427.rs
@@ -1,0 +1,124 @@
+use std::convert::TryInto;
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_WASM_CONFIG,
+    PRODUCTION_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::core::{engine_state::Error, execution};
+use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
+use walrus::{ir::Value, FunctionBuilder, Module, ModuleConfig, ValType};
+
+/// Creates a wasm with a function that contains local section with types in `repeated_pattern`
+/// repeated `repeat_count` times with additional `extra_types` appended at the end of local group.
+fn make_arbitrary_local_count(
+    repeat_count: usize,
+    repeat_pattern: &[ValType],
+    extra_types: &[ValType],
+) -> Vec<u8> {
+    let mut module = Module::with_config(ModuleConfig::new());
+
+    let _memory_id = module.memories.add_local(false, 11, None);
+
+    // fn func_with_locals() {
+
+    let mut func_with_locals = FunctionBuilder::new(&mut module.types, &[], &[]);
+
+    let mut locals = Vec::new();
+    for _ in 0..repeat_count {
+        for val_type in repeat_pattern {
+            // let local_x;
+            let local = module.locals.add(*val_type);
+            locals.push((local, *val_type));
+        }
+    }
+
+    for extra_type in extra_types {
+        // let local_x;
+        let local = module.locals.add(*extra_type);
+        locals.push((local, *extra_type));
+    }
+
+    for (i, (local, val_type)) in locals.into_iter().enumerate() {
+        // locals[i] = i;
+        let value = match val_type {
+            ValType::I32 => Value::I32(i.try_into().unwrap()),
+            ValType::I64 => Value::I64(i.try_into().unwrap()),
+            ValType::F32 => Value::F32(i as f32),
+            ValType::F64 => Value::F64(i as f64),
+            ValType::V128 => Value::V128(i.try_into().unwrap()),
+            ValType::Externref | ValType::Funcref => todo!("{:?}", val_type),
+        };
+        func_with_locals.func_body().const_(value).local_set(local);
+    }
+
+    let func_with_locals = func_with_locals.finish(vec![], &mut module.funcs);
+
+    // }
+
+    // fn call() {
+
+    let mut call_func = FunctionBuilder::new(&mut module.types, &[], &[]);
+
+    // func_with_locals();
+    call_func.func_body().call(func_with_locals);
+
+    let call = call_func.finish(Vec::new(), &mut module.funcs);
+
+    // }
+
+    module.exports.add(DEFAULT_ENTRY_POINT_NAME, call);
+
+    module.emit_wasm()
+}
+
+#[ignore]
+#[test]
+fn too_many_locals_should_exceed_stack_height() {
+    const CALL_COST: usize = 1;
+    let extra_types = [ValType::I32];
+    let repeat_pattern = [ValType::I64];
+    let max_stack_height = DEFAULT_WASM_CONFIG.max_stack_height as usize;
+
+    let success_wasm_bytes: Vec<u8> = make_arbitrary_local_count(
+        max_stack_height - extra_types.len() - CALL_COST - 1,
+        &repeat_pattern,
+        &extra_types,
+    );
+
+    let failing_wasm_bytes: Vec<u8> = make_arbitrary_local_count(
+        max_stack_height - extra_types.len() - CALL_COST,
+        &repeat_pattern,
+        &extra_types,
+    );
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let success_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        success_wasm_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(success_request).expect_success().commit();
+
+    let failing_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        failing_wasm_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(failing_request).expect_failure().commit();
+
+    let error = builder.get_error().expect("should have error");
+
+    // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
+    // restrictive default stack height.
+    assert!(
+        matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),
+        "{:?}",
+        error
+    );
+}

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -38,6 +38,7 @@ mod gh_2280;
 mod gh_2605;
 mod gh_3710;
 mod gov_116;
+pub mod gov_427;
 mod gov_74;
 mod gov_89_regression;
 mod regression_20210707;

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -38,7 +38,7 @@ mod gh_2280;
 mod gh_2605;
 mod gh_3710;
 mod gov_116;
-pub mod gov_427;
+mod gov_427;
 mod gov_74;
 mod gov_89_regression;
 mod regression_20210707;


### PR DESCRIPTION
This PR upgrades the execution engine dependency on the obsolete `pwasm-utils` crate to a forked and maintained crate https://crates.io/crates/casper-wasm-utils. As part of this `parity-wasm` was also upgraded to 0.42.0 and `wasmi` to 0.9.