### PR TITLE
Version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.13"
+version = "1.4.14"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "base16",
  "base64",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "casper-wasm-utils"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7d5a513000d2d4772800ca7cfce247712553a8363edfb7462b3e0f5db96d02"
+checksum = "8e9c4208106e8a95a83ab3cb5f4e800114bfc101df9e7cb8c2160c7e298c6397"
 dependencies = [
  "byteorder",
  "log",

--- a/ci/casper_updater/src/chainspec.rs
+++ b/ci/casper_updater/src/chainspec.rs
@@ -25,10 +25,11 @@ impl Chainspec {
         let chainspec_path = crate::root_dir().join("resources/production/chainspec.toml");
 
         let chainspec = &regex_data::chainspec_protocol_version::DEPENDENT_FILES[0];
+        let contents = chainspec.contents();
 
         let find_value = |regex: &Regex| {
             regex
-                .captures(chainspec.contents())
+                .captures(&contents)
                 .unwrap_or_else(|| {
                     panic!(
                         "should find protocol version and activation point in {}",

--- a/ci/casper_updater/src/main.rs
+++ b/ci/casper_updater/src/main.rs
@@ -232,29 +232,28 @@ fn get_args() -> Args {
 }
 
 fn main() {
-    let types = Package::cargo("types", &*regex_data::types::DEPENDENT_FILES);
-    types.update();
+    let rust_packages = [
+        Package::cargo("types", &*regex_data::types::DEPENDENT_FILES),
+        Package::cargo(
+            "execution_engine",
+            &*regex_data::execution_engine::DEPENDENT_FILES,
+        ),
+        Package::cargo("hashing", &*regex_data::hashing::DEPENDENT_FILES),
+        Package::cargo("node_macros", &*regex_data::node_macros::DEPENDENT_FILES),
+        Package::cargo("node", &*regex_data::node::DEPENDENT_FILES),
+        Package::cargo(
+            "smart_contracts/contract",
+            &*regex_data::smart_contracts_contract::DEPENDENT_FILES,
+        ),
+        Package::cargo(
+            "execution_engine_testing/test_support",
+            &*regex_data::execution_engine_testing_test_support::DEPENDENT_FILES,
+        ),
+    ];
 
-    let hashing = Package::cargo("hashing", &*regex_data::hashing::DEPENDENT_FILES);
-    hashing.update();
-
-    let execution_engine = Package::cargo(
-        "execution_engine",
-        &*regex_data::execution_engine::DEPENDENT_FILES,
-    );
-    execution_engine.update();
-
-    let node_macros = Package::cargo("node_macros", &*regex_data::node_macros::DEPENDENT_FILES);
-    node_macros.update();
-
-    let node = Package::cargo("node", &*regex_data::node::DEPENDENT_FILES);
-    node.update();
-
-    let smart_contracts_contract = Package::cargo(
-        "smart_contracts/contract",
-        &*regex_data::smart_contracts_contract::DEPENDENT_FILES,
-    );
-    smart_contracts_contract.update();
+    for rust_package in &rust_packages {
+        rust_package.update()
+    }
 
     let smart_contracts_contract_as = Package::assembly_script(
         "smart_contracts/contract_as",
@@ -262,23 +261,22 @@ fn main() {
     );
     smart_contracts_contract_as.update();
 
-    let execution_engine_testing_test_support = Package::cargo(
-        "execution_engine_testing/test_support",
-        &*regex_data::execution_engine_testing_test_support::DEPENDENT_FILES,
-    );
-    execution_engine_testing_test_support.update();
-
     let chainspec = Chainspec::new();
     chainspec.update();
 
     // Update Cargo.lock if this isn't a dry run.
     if !is_dry_run() {
-        let status = Command::new(env!("CARGO"))
-            .arg("generate-lockfile")
-            .arg("--offline")
+        let mut command = Command::new(env!("CARGO"));
+        let _ = command
             .current_dir(root_dir())
+            .arg("update")
+            .arg("--offline");
+        for rust_package in &rust_packages {
+            let _ = command.arg("--package").arg(rust_package.name());
+        }
+        let status = command
             .status()
-            .expect("Failed to execute 'cargo generate-lockfile'");
+            .unwrap_or_else(|error| panic!("Failed to execute '{:?}': {}", command, error));
         assert!(status.success(), "Failed to update Cargo.lock");
     }
 }

--- a/ci/casper_updater/src/package.rs
+++ b/ci/casper_updater/src/package.rs
@@ -82,6 +82,10 @@ impl Package {
         package
     }
 
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     fn new<P: AsRef<Path>, T: PackageConsts>(
         relative_path: P,
         dependent_files: &'static Vec<DependentFile>,
@@ -98,10 +102,11 @@ impl Package {
                     relative_path.as_ref().display()
                 )
             });
+        let contents = manifest.contents();
 
         let find_value = |regex: &Regex| {
             regex
-                .captures(manifest.contents())
+                .captures(&contents)
                 .unwrap_or_else(|| {
                     panic!(
                         "should find package name and version in {}",

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -11,6 +11,16 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 3.1.0
+
+### Added
+* Add `commit_prune` functionality to support pruning of entries in global storage.
+
+### Changed
+* Update to use `casper-wasm-utils`; a patched fork of the archived `wasm-utils`.
+
+
+
 ## 3.0.0
 
 ### Changed

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -15,8 +15,8 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.4.3", path = "../hashing" }
-casper-types = { version = "1.5.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
-casper-wasm-utils = "0.1.0"
+casper-types = { version = "1.6.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-wasm-utils = "1.0.0"
 chrono = "0.4.10"
 datasize = "0.2.4"
 either = "1.8.1"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/3.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 3.1.0
+
+### Added
+* Add support for `commit_prune` of `casper-execution-engine`.
+
+
+
 ## 3.0.0
 
 ### Changed

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-execution-engine = { version = "3.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "3.1.0", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
-casper-types = { version = "1.5.0", path = "../../types" }
+casper-types = { version = "1.6.0", path = "../../types" }
 humantime = "2"
 filesize = "0.2.0"
 lmdb = "0.8.0"

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,10 +10,20 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+
 ## 1.4.14
 
+### Added
+* Node executes new prune process after executing each block, whereby entries under `Key::EraInfo` are removed in batches of size defined by the new chainspec option `[core.prune_batch_size]`.
+* After executing a switch block, information about that era is stored to global state under a new static key `Key::EraSummary`.
+* Add a new JSON-RPC endpoint `chain_get_era_summary` to retrieve the information stored under `Key::EraSummary`.
+
 ### Changed
+* Rather than storing an ever-increasing collection of era information after executing a switch block under `Key::EraInfo`, the node now stores only the information relevant to that era under `Key::EraSummary`.
 * Update `openssl` and `openssl-sys` to latest versions.
+
+### Removed
+* Remove `TimeDiff`, `Timestamp` and asymmetric key functionality (moved to `casper-types` crate).
 
 ### Fixed
 * Fix issue in BlockValidator inhibiting the use of fallback peers to fetch missing deploys.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.13" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.14" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,10 +20,10 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "3.0.0", path = "../execution_engine" }
+casper-execution-engine = { version = "3.1.0", path = "../execution_engine" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }
 casper-hashing = { version = "1.4.3", path = "../hashing" }
-casper-types = { version = "1.5.0", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-types = { version = "1.6.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 13);
+    ProtocolVersion::from_parts(1, 4, 14);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.13")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.14")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -56,7 +56,7 @@ max_stored_value_size = 8_388_608
 # Minimum allowed delegation amount in motes
 minimum_delegation_amount = 500_000_000_000
 # Global state prune batch size (0 = this feature is off)
-prune_batch_size = 1
+prune_batch_size = 50
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.13'
+version = '1.4.14'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.
@@ -59,7 +59,7 @@ max_stored_value_size = 8_388_608
 # Minimum allowed delegation amount in motes
 minimum_delegation_amount = 500_000_000_000
 # Global state prune batch size (0 = this feature is off)
-prune_batch_size = 1
+prune_batch_size = 50
 
 [highway]
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -5,7 +5,7 @@
     {
       "openrpc": "1.0.0-rc1",
       "info": {
-        "version": "1.4.13",
+        "version": "1.4.14",
         "title": "Client API of Casper Node",
         "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
         "contact": {
@@ -120,7 +120,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -195,7 +195,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "deploy": {
                     "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                     "header": {
@@ -413,7 +413,7 @@
               "result": {
                 "name": "state_get_account_info_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "account": {
                     "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                     "named_keys": [],
@@ -509,7 +509,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "stored_value": {
                     "CLValue": {
@@ -617,7 +617,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block_header": {
                     "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
                     "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
@@ -715,7 +715,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "peers": [
                     {
                       "node_id": "tls:0101..0101",
@@ -824,7 +824,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "chainspec_name": "casper-example",
                   "starting_state_root_hash": "0202020202020202020202020202020202020202020202020202020202020202",
                   "peers": [
@@ -890,7 +890,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -962,7 +962,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block": {
                     "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "header": {
@@ -1090,7 +1090,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -1164,7 +1164,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -1253,7 +1253,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "stored_value": {
                     "CLValue": {
                       "cl_type": "U64",
@@ -1331,7 +1331,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -1394,7 +1394,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -1474,7 +1474,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "auction_state": {
                     "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                     "block_height": 10,
@@ -1556,7 +1556,7 @@
               "result": {
                 "name": "chain_get_era_summary_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.13"
+        "version": "1.4.14"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.13",
+                  "api_version": "1.4.14",
                   "auction_state": {
                     "bids": [
                       {

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "1.5.0", path = "../../types" }
+casper-types = { version = "1.6.0", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/smart_contracts/contract_as/CHANGELOG.md
+++ b/smart_contracts/contract_as/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.14
+
+### Changed
+* Version bump to match casper-node version.
+
+
+
 ## 1.4.13
 
 ### Changed

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -11,7 +11,14 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 1.6.0
+
+### Added
+* Add `TimeDiff`, `Timestamp` and asymmetric key functionality (moved from `casper-nodes` crate).
+* Add `testing` feature to provide functionality useful for test scenarios.
+
+### Deprecated
+* Deprecate `gens` feature: its functionality is included in the new `testing` feature.
 
 
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "1.5.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.6.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/1.6.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR provides version bumps in preparation for the v1.4.14 node release.

It also sets the `prune_batch_size` to 50 in the two chainspec files and bumps the execution-engine dependency `casper-wasm-utils` to 1.0.0.

Finally, there is a small change to the casper-updater tool to avoid it from calling `cargo generate-lockfile`.  This would cause all dependencies to be updated in the Cargo.lock file, not just the casper crates.  Now the tool calls `cargo update`, specifying each casper crate individually and hence avoiding the mass dependency update.
