### PR TITLE
Reintroduce max_delegators_per_validator

### DIFF
--- a/execution_engine/src/core/engine_state/engine_config.rs
+++ b/execution_engine/src/core/engine_state/engine_config.rs
@@ -35,6 +35,7 @@ pub struct EngineConfig {
     strict_argument_checking: bool,
     /// Vesting schedule period in milliseconds.
     vesting_schedule_period_millis: u64,
+    max_delegators_per_validator: Option<u32>,
     wasm_config: WasmConfig,
     system_config: SystemConfig,
 }
@@ -48,6 +49,7 @@ impl Default for EngineConfig {
             minimum_delegation_amount: DEFAULT_MINIMUM_DELEGATION_AMOUNT,
             strict_argument_checking: DEFAULT_STRICT_ARGUMENT_CHECKING,
             vesting_schedule_period_millis: DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+            max_delegators_per_validator: None,
             wasm_config: WasmConfig::default(),
             system_config: SystemConfig::default(),
         }
@@ -64,6 +66,7 @@ impl EngineConfig {
         minimum_delegation_amount: u64,
         strict_argument_checking: bool,
         vesting_schedule_period_millis: u64,
+        max_delegators_per_validator: Option<u32>,
         wasm_config: WasmConfig,
         system_config: SystemConfig,
     ) -> EngineConfig {
@@ -74,6 +77,7 @@ impl EngineConfig {
             minimum_delegation_amount,
             strict_argument_checking,
             vesting_schedule_period_millis,
+            max_delegators_per_validator,
             wasm_config,
             system_config,
         }
@@ -112,5 +116,10 @@ impl EngineConfig {
     /// Get the vesting schedule period.
     pub fn vesting_schedule_period_millis(&self) -> u64 {
         self.vesting_schedule_period_millis
+    }
+
+    /// Get the max delegators per validator
+    pub fn max_delegators_per_validator(&self) -> Option<u32> {
+        self.max_delegators_per_validator
     }
 }

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -861,10 +861,17 @@ where
                 let validator = Self::get_named_argument(runtime_args, auction::ARG_VALIDATOR)?;
                 let amount = Self::get_named_argument(runtime_args, auction::ARG_AMOUNT)?;
 
+                let max_delegators_per_validator = self.config.max_delegators_per_validator();
                 let minimum_delegation_amount = self.config.minimum_delegation_amount();
 
                 let result = runtime
-                    .delegate(delegator, validator, amount, minimum_delegation_amount)
+                    .delegate(
+                        delegator,
+                        validator,
+                        amount,
+                        max_delegators_per_validator,
+                        minimum_delegation_amount,
+                    )
                     .map_err(Self::reverter)?;
 
                 CLValue::from_t(result).map_err(Self::reverter)
@@ -916,8 +923,14 @@ where
                 let evicted_validators =
                     Self::get_named_argument(runtime_args, auction::ARG_EVICTED_VALIDATORS)?;
 
+                let max_delegators_per_validator = self.config.max_delegators_per_validator();
+
                 runtime
-                    .run_auction(era_end_timestamp_millis, evicted_validators)
+                    .run_auction(
+                        era_end_timestamp_millis,
+                        evicted_validators,
+                        max_delegators_per_validator,
+                    )
                     .map_err(Self::reverter)?;
 
                 CLValue::from_t(()).map_err(Self::reverter)

--- a/execution_engine/src/system/auction.rs
+++ b/execution_engine/src/system/auction.rs
@@ -207,6 +207,7 @@ pub trait Auction:
         delegator_public_key: PublicKey,
         validator_public_key: PublicKey,
         amount: U512,
+        max_delegators_per_validator: Option<u32>,
         minimum_delegation_amount: u64,
     ) -> Result<U512, ApiError> {
         let provided_account_hash =
@@ -225,6 +226,12 @@ pub trait Auction:
         let validator_account_hash = AccountHash::from(&validator_public_key);
 
         let bid = detail::read_bid_for_validator(self, validator_account_hash)?;
+
+        if let Some(max_delegators_per_validator) = max_delegators_per_validator {
+            if bid.delegators().len() >= max_delegators_per_validator as usize {
+                return Err(Error::ExceededDelegatorSizeLimit.into());
+            }
+        }
 
         if amount < U512::from(minimum_delegation_amount) {
             return Err(Error::DelegationAmountTooSmall.into());
@@ -408,6 +415,7 @@ pub trait Auction:
         &mut self,
         era_end_timestamp_millis: u64,
         evicted_validators: Vec<PublicKey>,
+        max_delegators_per_validator: Option<u32>,
     ) -> Result<(), ApiError> {
         if self.get_caller() != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidCaller.into());
@@ -421,7 +429,7 @@ pub trait Auction:
         let mut bids = detail::get_bids(self)?;
 
         // Process unbond requests
-        detail::process_unbond_requests(self)?;
+        detail::process_unbond_requests(self, max_delegators_per_validator)?;
 
         // Process bids
         let mut bids_modified = false;

--- a/execution_engine/src/system/auction/detail.rs
+++ b/execution_engine/src/system/auction/detail.rs
@@ -503,15 +503,7 @@ fn is_under_max_delegator_cap(
     max_delegators_per_validator: Option<u32>,
     new_validator_delegator_len: usize,
 ) -> bool {
-    if max_delegators_per_validator.is_none() {
-        return true;
-    }
-
-    if let Some(max_delegators) = max_delegators_per_validator {
-        if new_validator_delegator_len >= max_delegators as usize {
-            return false;
-        }
-    }
-
-    true
+    max_delegators_per_validator
+        .map(|limit| new_validator_delegator_len < limit as usize)
+        .unwrap_or(true)
 }

--- a/execution_engine/src/system/auction/detail.rs
+++ b/execution_engine/src/system/auction/detail.rs
@@ -192,6 +192,7 @@ where
 /// This function can be called by the system only.
 pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(
     provider: &mut P,
+    max_delegators_per_validator: Option<u32>,
 ) -> Result<(), ApiError> {
     if provider.get_caller() != PublicKey::System.to_account_hash() {
         return Err(Error::InvalidCaller.into());
@@ -220,15 +221,29 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(
                                         provider,
                                         new_validator.clone().to_account_hash(),
                                     )?;
-                                    handle_delegation(
-                                        provider,
-                                        bid,
-                                        unbonding_purse.unbonder_public_key().clone(),
-                                        new_validator.clone(),
-                                        *unbonding_purse.bonding_purse(),
-                                        *unbonding_purse.amount(),
-                                    )
-                                    .map(|_| ())?
+
+                                    if is_under_max_delegator_cap(
+                                        max_delegators_per_validator,
+                                        new_validator_bid.delegators().len(),
+                                    ) {
+                                        handle_delegation(
+                                            provider,
+                                            bid,
+                                            unbonding_purse.unbonder_public_key().clone(),
+                                            new_validator.clone(),
+                                            *unbonding_purse.bonding_purse(),
+                                            *unbonding_purse.amount(),
+                                        )
+                                        .map(|_| ())?
+                                    } else {
+                                        // Move funds from bid purse to unbonding purse
+                                        provider.unbond(unbonding_purse).map_err(|err| {
+                                            error!(
+                                            "Error unbonding purse {err:?} (delegator cap reached for new validator)"
+                                        );
+                                            ApiError::from(Error::TransferToUnbondingPurse)
+                                        })?
+                                    }
                                 } else {
                                     // Move funds from bid purse to unbonding purse
                                     provider.unbond(unbonding_purse).map_err(|err| {
@@ -482,4 +497,21 @@ pub(crate) fn era_validators_from_snapshot(
             (era_id, validator_weights)
         })
         .collect()
+}
+
+fn is_under_max_delegator_cap(
+    max_delegators_per_validator: Option<u32>,
+    new_validator_delegator_len: usize,
+) -> bool {
+    if max_delegators_per_validator.is_none() {
+        return true;
+    }
+
+    if let Some(max_delegators) = max_delegators_per_validator {
+        if new_validator_delegator_len >= max_delegators as usize {
+            return false;
+        }
+    }
+
+    true
 }

--- a/execution_engine_testing/test_support/src/chainspec_config.rs
+++ b/execution_engine_testing/test_support/src/chainspec_config.rs
@@ -67,6 +67,7 @@ pub struct CoreConfig {
     pub(crate) minimum_delegation_amount: u64,
     /// Enables strict arguments checking when calling a contract.
     pub(crate) strict_argument_checking: bool,
+    pub(crate) max_delegators_per_validator: Option<u32>,
 }
 
 /// This struct can be parsed from a TOML-encoded chainspec file.  It means that as the

--- a/execution_engine_testing/test_support/src/chainspec_config.rs
+++ b/execution_engine_testing/test_support/src/chainspec_config.rs
@@ -67,6 +67,7 @@ pub struct CoreConfig {
     pub(crate) minimum_delegation_amount: u64,
     /// Enables strict arguments checking when calling a contract.
     pub(crate) strict_argument_checking: bool,
+    /// The maximum amount of delegators per validator.
     pub(crate) max_delegators_per_validator: Option<u32>,
 }
 

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -219,6 +219,7 @@ impl InMemoryWasmTestBuilder {
                 .core_config
                 .vesting_schedule_period
                 .millis(),
+            chainspec_config.core_config.max_delegators_per_validator,
             chainspec_config.wasm_config,
             chainspec_config.system_costs_config,
         );
@@ -335,6 +336,7 @@ impl LmdbWasmTestBuilder {
                 .core_config
                 .vesting_schedule_period
                 .millis(),
+            chainspec_config.core_config.max_delegators_per_validator,
             chainspec_config.wasm_config,
             chainspec_config.system_costs_config,
         );

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -287,6 +287,7 @@ fn should_run_ee_966_regression_when_growing_mem_after_upgrade() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         *DOUBLED_WASM_MEMORY_LIMIT,
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/regression/gh_1470.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1470.rs
@@ -81,6 +81,7 @@ fn setup() -> InMemoryWasmTestBuilder {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         strict_argument_checking,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         WasmConfig::default(),
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/regression/gh_2280.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2280.rs
@@ -761,6 +761,7 @@ fn make_engine_config(
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         new_wasm_config,
         new_system_config,
     )

--- a/execution_engine_testing/tests/src/test/regression/gh_3208.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3208.rs
@@ -198,6 +198,7 @@ fn should_immediatelly_unbond_genesis_validator_with_zero_day_vesting_schedule()
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         vesting_schedule_period_millis,
+        None,
         Default::default(),
         Default::default(),
     );
@@ -346,6 +347,7 @@ fn should_immediatelly_unbond_genesis_validator_with_zero_day_vesting_schedule_a
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         vesting_schedule_period_millis,
+        None,
         Default::default(),
         Default::default(),
     );

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -111,6 +111,7 @@ fn should_observe_stack_height_limit() {
             DEFAULT_MINIMUM_DELEGATION_AMOUNT,
             DEFAULT_STRICT_ARGUMENT_CHECKING,
             DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+            None,
             WasmConfig::new(
                 DEFAULT_WASM_MAX_MEMORY,
                 NEW_WASM_STACK_HEIGHT,

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -186,6 +186,7 @@ fn initialize_isolated_storage_costs() -> InMemoryWasmTestBuilder {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         *STORAGE_COSTS_ONLY,
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -4130,3 +4130,325 @@ fn should_allow_delegations_with_minimal_floor_amount() {
 
     builder.exec(delegation_request_2).expect_success().commit();
 }
+
+#[ignore]
+#[test]
+fn should_enforce_max_delegators_per_validator_cap() {
+    let engine_config = EngineConfig::new(
+        DEFAULT_MAX_QUERY_DEPTH,
+        DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+        DEFAULT_STRICT_ARGUMENT_CHECKING,
+        DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        Some(2u32),
+        WasmConfig::default(),
+        SystemConfig::default(),
+    );
+
+    let mut builder = InMemoryWasmTestBuilder::new_with_config(engine_config);
+
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_1_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_2_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_3 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let post_genesis_request = vec![
+        transfer_to_validator_1,
+        transfer_to_delegator_1,
+        transfer_to_delegator_2,
+        transfer_to_delegator_3,
+    ];
+
+    for request in post_genesis_request {
+        builder.exec(request).expect_success().commit();
+    }
+
+    let add_bid_request_1 = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_ADD_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    builder.exec(add_bid_request_1).expect_success().commit();
+
+    for _ in 0..=builder.get_auction_delay() {
+        let step_request = StepRequestBuilder::new()
+            .with_parent_state_hash(builder.get_post_state_hash())
+            .with_protocol_version(ProtocolVersion::V1_0_0)
+            .with_next_era_id(builder.get_era().successor())
+            .with_run_auction(true)
+            .build();
+
+        builder
+            .step(step_request)
+            .expect("must execute step request");
+    }
+
+    let delegation_request_1 = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_1_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK.clone(),
+        },
+    )
+    .build();
+
+    let delegation_request_2 = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_2_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_2_PK.clone(),
+        },
+    )
+    .build();
+
+    let delegation_requests = [delegation_request_1, delegation_request_2];
+
+    for request in delegation_requests {
+        builder.exec(request).expect_success().commit();
+    }
+
+    let delegation_request_3 = ExecuteRequestBuilder::standard(
+        *DELEGATOR_1_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => DELEGATOR_1.clone(),
+        },
+    )
+    .build();
+
+    builder.exec(delegation_request_3).expect_failure();
+
+    let error = builder.get_error().expect("must get error");
+
+    assert!(matches!(
+        error,
+        Error::Exec(execution::Error::Revert(ApiError::AuctionError(auction_error)))
+        if auction_error == AuctionError::ExceededDelegatorSizeLimit as u8));
+}
+
+#[ignore]
+#[test]
+fn should_transfer_to_main_purse_in_case_of_redelegation_past_max_delegation_cap() {
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_2_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_2_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_1_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let transfer_to_delegator_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *BID_ACCOUNT_2_ADDR,
+            ARG_AMOUNT => U512::from(BID_ACCOUNT_1_BALANCE)
+        },
+    )
+    .build();
+
+    let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_ADD_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
+        *NON_FOUNDER_VALIDATOR_2_ADDR,
+        CONTRACT_ADD_BID,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_2_PK.clone(),
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_2),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_1_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK.clone(),
+        },
+    )
+    .build();
+
+    let delegator_1_validator_2_delegate_request = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_2_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_2_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_2_PK.clone(),
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        validator_1_fund_request,
+        validator_2_fund_request,
+        transfer_to_delegator_1,
+        transfer_to_delegator_2,
+        validator_1_add_bid_request,
+        validator_2_add_bid_request,
+        delegator_1_validator_1_delegate_request,
+        delegator_1_validator_2_delegate_request,
+    ];
+
+    let engine_config = EngineConfig::new(
+        DEFAULT_MAX_QUERY_DEPTH,
+        DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+        DEFAULT_STRICT_ARGUMENT_CHECKING,
+        DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        Some(1u32),
+        WasmConfig::default(),
+        SystemConfig::default(),
+    );
+
+    let mut builder = InMemoryWasmTestBuilder::new_with_config(engine_config);
+
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    for request in post_genesis_requests {
+        builder.exec(request).expect_success().commit();
+    }
+
+    builder.advance_eras_by_default_auction_delay(vec![]);
+
+    let delegator_1_main_purse = builder
+        .get_account(*BID_ACCOUNT_1_ADDR)
+        .expect("should have default account")
+        .main_purse();
+
+    let delegator_1_redelegate_request = ExecuteRequestBuilder::standard(
+        *BID_ACCOUNT_1_ADDR,
+        CONTRACT_REDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK.clone(),
+            ARG_NEW_VALIDATOR => NON_FOUNDER_VALIDATOR_2_PK.clone()
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_1_redelegate_request)
+        .commit()
+        .expect_success();
+
+    let after_redelegation = builder
+        .get_unbonds()
+        .get(&NON_FOUNDER_VALIDATOR_1_ADDR)
+        .expect("must have purses")
+        .len();
+
+    assert_eq!(1, after_redelegation);
+
+    let delegator_1_purse_balance_before = builder.get_purse_balance(delegator_1_main_purse);
+
+    let rewards = vec![
+        RewardItem::new(NON_FOUNDER_VALIDATOR_1_PK.clone(), 1),
+        RewardItem::new(NON_FOUNDER_VALIDATOR_2_PK.clone(), 1),
+    ];
+
+    for _ in 0..=DEFAULT_UNBONDING_DELAY {
+        let delegator_1_redelegate_purse_balance =
+            builder.get_purse_balance(delegator_1_main_purse);
+        assert_eq!(
+            delegator_1_purse_balance_before,
+            delegator_1_redelegate_purse_balance
+        );
+
+        builder.advance_era(rewards.clone())
+    }
+
+    let delegator_1_purse_balance_after = builder.get_purse_balance(delegator_1_main_purse);
+
+    assert_eq!(
+        delegator_1_purse_balance_before
+            + U512::from(UNDELEGATE_AMOUNT_1 + DEFAULT_MINIMUM_DELEGATION_AMOUNT),
+        delegator_1_purse_balance_after
+    )
+}

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -2630,6 +2630,7 @@ fn should_release_vfta_holder_stake() {
         NEW_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         WasmConfig::default(),
         SystemConfig::default(),
     );

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -167,6 +167,7 @@ fn should_allow_only_wasm_costs_patch_version() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         new_wasm_config,
         SystemConfig::default(),
     );
@@ -212,6 +213,7 @@ fn should_allow_only_wasm_costs_minor_version() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         new_wasm_config,
         SystemConfig::default(),
     );
@@ -711,6 +713,7 @@ fn should_increase_max_associated_keys_after_upgrade() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         *DEFAULT_WASM_CONFIG,
         new_system_config,
     );

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -213,6 +213,7 @@ fn upgraded_add_bid_and_withdraw_bid_have_expected_costs() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         WasmConfig::default(),
         new_system_config,
     );
@@ -510,6 +511,7 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         WasmConfig::default(),
         new_system_config,
     );
@@ -1026,6 +1028,7 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         new_wasm_config,
         new_system_config,
     );

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -1003,6 +1003,7 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
         DEFAULT_MINIMUM_DELEGATION_AMOUNT,
         DEFAULT_STRICT_ARGUMENT_CHECKING,
         DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
+        None,
         WasmConfig::default(),
         new_system_config,
     );

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -585,6 +585,7 @@ impl ContractRuntime {
         minimum_delegation_amount: u64,
         strict_argument_checking: bool,
         vesting_schedule_period_millis: u64,
+        max_delegators_per_validator: Option<u32>,
         registry: &Registry,
     ) -> Result<Self, ConfigError> {
         // TODO: This is bogus, get rid of this
@@ -616,6 +617,7 @@ impl ContractRuntime {
             minimum_delegation_amount,
             strict_argument_checking,
             vesting_schedule_period_millis,
+            max_delegators_per_validator,
             wasm_config,
             system_config,
         );
@@ -1003,6 +1005,7 @@ mod tests {
             10,
             true,
             1,
+            None,
             &Registry::default(),
         )
         .unwrap();

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1024,6 +1024,7 @@ impl reactor::Reactor for MainReactor {
             chainspec.core_config.minimum_delegation_amount,
             chainspec.core_config.strict_argument_checking,
             chainspec.core_config.vesting_schedule_period.millis(),
+            chainspec.core_config.max_delegators_per_validator,
             registry,
         )?;
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1013,6 +1013,13 @@ impl reactor::Reactor for MainReactor {
             config.node.force_resync,
         )?;
 
+        let max_delegators_per_validator =
+            if chainspec.core_config.max_delegators_per_validator == 0 {
+                None
+            } else {
+                Some(chainspec.core_config.max_delegators_per_validator)
+            };
+
         let contract_runtime = ContractRuntime::new(
             protocol_version,
             storage.root_path(),
@@ -1024,7 +1031,7 @@ impl reactor::Reactor for MainReactor {
             chainspec.core_config.minimum_delegation_amount,
             chainspec.core_config.strict_argument_checking,
             chainspec.core_config.vesting_schedule_period.millis(),
-            chainspec.core_config.max_delegators_per_validator,
+            max_delegators_per_validator,
             registry,
         )?;
 

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -84,6 +84,8 @@ pub struct CoreConfig {
 
     /// Which consensus protocol to use.
     pub consensus_protocol: ConsensusProtocolName,
+
+    pub max_delegators_per_validator: Option<u32>,
 }
 
 impl CoreConfig {
@@ -183,6 +185,7 @@ impl CoreConfig {
             strict_argument_checking,
             simultaneous_peer_requests,
             consensus_protocol,
+            max_delegators_per_validator: None,
         }
     }
 }
@@ -211,6 +214,7 @@ impl ToBytes for CoreConfig {
         buffer.extend(self.strict_argument_checking.to_bytes()?);
         buffer.extend(self.simultaneous_peer_requests.to_bytes()?);
         buffer.extend(self.consensus_protocol.to_bytes()?);
+        buffer.extend(self.max_delegators_per_validator.to_bytes()?);
         Ok(buffer)
     }
 
@@ -235,6 +239,7 @@ impl ToBytes for CoreConfig {
             + self.strict_argument_checking.serialized_length()
             + self.simultaneous_peer_requests.serialized_length()
             + self.consensus_protocol.serialized_length()
+            + self.max_delegators_per_validator.serialized_length()
     }
 }
 
@@ -259,6 +264,7 @@ impl FromBytes for CoreConfig {
         let (strict_argument_checking, remainder) = bool::from_bytes(remainder)?;
         let (simultaneous_peer_requests, remainder) = u32::from_bytes(remainder)?;
         let (consensus_protocol, remainder) = ConsensusProtocolName::from_bytes(remainder)?;
+        let (max_delegators_per_validator, remainder) = FromBytes::from_bytes(remainder)?;
         let config = CoreConfig {
             era_duration,
             minimum_era_height,
@@ -278,6 +284,7 @@ impl FromBytes for CoreConfig {
             strict_argument_checking,
             simultaneous_peer_requests,
             consensus_protocol,
+            max_delegators_per_validator,
         };
         Ok((config, remainder))
     }

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -86,7 +86,8 @@ pub struct CoreConfig {
     pub consensus_protocol: ConsensusProtocolName,
 
     /// The maximum amount of delegators per validator.
-    pub max_delegators_per_validator: Option<u32>,
+    /// if the value is 0, there is no maximum capacity.
+    pub max_delegators_per_validator: u32,
 }
 
 impl CoreConfig {
@@ -186,7 +187,7 @@ impl CoreConfig {
             strict_argument_checking,
             simultaneous_peer_requests,
             consensus_protocol,
-            max_delegators_per_validator: None,
+            max_delegators_per_validator: 0,
         }
     }
 }

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -85,6 +85,7 @@ pub struct CoreConfig {
     /// Which consensus protocol to use.
     pub consensus_protocol: ConsensusProtocolName,
 
+    /// The maximum amount of delegators per validator.
     pub max_delegators_per_validator: Option<u32>,
 }
 

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -69,6 +69,8 @@ strict_argument_checking = false
 simultaneous_peer_requests = 5
 # The consensus protocol to use. Options are "Zug" and "Highway".
 consensus_protocol = 'Highway'
+# The maximum amount of delegators per validator. if the value is 0, there is no maximum capacity.
+max_delegators_per_validator = 0
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -76,6 +76,8 @@ strict_argument_checking = false
 simultaneous_peer_requests = 5
 # The consensus protocol to use. Options are "Zug" and "Highway".
 consensus_protocol = 'Highway'
+# The maximum amount of delegators per validator. if the value is 0, there is no maximum capacity.
+max_delegators_per_validator = 1200
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.


### PR DESCRIPTION
CHANGELOG:

- Added a new optional chainspec setting called `max_delegators_per_validator` which enforces a delegator cap per validator
- Reworked the redelegation implementation to transfer redelegated tokens back to the Account's main purse
- Added tests to assert the newly modified behavior
