### PR TITLE
Simplify `sync_to_ttl` code and `BlockCompleteConfirmationRequest` rename

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -40,7 +40,7 @@ use crate::{
             BlockAccumulatorAnnouncement, FatalAnnouncement, MetaBlockAnnouncement,
             PeerBehaviorAnnouncement,
         },
-        requests::{BlockAccumulatorRequest, BlockCompleteConfirmationRequest, StorageRequest},
+        requests::{BlockAccumulatorRequest, MarkBlockCompletedRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
     fatal,
@@ -266,7 +266,7 @@ impl BlockAccumulator {
     where
         REv: From<StorageRequest>
             + From<PeerBehaviorAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
+            + From<MarkBlockCompletedRequest>
             + From<FatalAnnouncement>
             + Send,
     {
@@ -370,7 +370,7 @@ impl BlockAccumulator {
     where
         REv: From<StorageRequest>
             + From<PeerBehaviorAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
+            + From<MarkBlockCompletedRequest>
             + From<FatalAnnouncement>
             + Send,
     {
@@ -482,7 +482,7 @@ impl BlockAccumulator {
     ) -> Effects<Event>
     where
         REv: From<BlockAccumulatorAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
+            + From<MarkBlockCompletedRequest>
             + From<MetaBlockAnnouncement>
             + Send,
     {
@@ -672,7 +672,7 @@ impl BlockAccumulator {
     where
         REv: From<PeerBehaviorAnnouncement>
             + From<StorageRequest>
-            + From<BlockCompleteConfirmationRequest>
+            + From<MarkBlockCompletedRequest>
             + Send,
         I: IntoIterator<Item = (NodeId, Error)>,
     {
@@ -758,7 +758,7 @@ pub(crate) trait ReactorEvent:
     From<StorageRequest>
     + From<PeerBehaviorAnnouncement>
     + From<BlockAccumulatorAnnouncement>
-    + From<BlockCompleteConfirmationRequest>
+    + From<MarkBlockCompletedRequest>
     + From<MetaBlockAnnouncement>
     + From<FatalAnnouncement>
     + Send
@@ -770,7 +770,7 @@ impl<REv> ReactorEvent for REv where
     REv: From<StorageRequest>
         + From<PeerBehaviorAnnouncement>
         + From<BlockAccumulatorAnnouncement>
-        + From<BlockCompleteConfirmationRequest>
+        + From<MarkBlockCompletedRequest>
         + From<MetaBlockAnnouncement>
         + From<FatalAnnouncement>
         + Send

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     effect::{
         announcements::ControlAnnouncement,
-        requests::{BlockCompleteConfirmationRequest, ContractRuntimeRequest, NetworkRequest},
+        requests::{ContractRuntimeRequest, MarkBlockCompletedRequest, NetworkRequest},
     },
     protocol::Message,
     reactor::{self, EventQueueHandle, QueueKind, Reactor, Runner, TryCrankOutcome},
@@ -85,8 +85,8 @@ enum Event {
     NetworkPeerBehaviorAnnouncement(PeerBehaviorAnnouncement),
 }
 
-impl From<BlockCompleteConfirmationRequest> for Event {
-    fn from(request: BlockCompleteConfirmationRequest) -> Self {
+impl From<MarkBlockCompletedRequest> for Event {
+    fn from(request: MarkBlockCompletedRequest) -> Self {
         Event::Storage(storage::Event::MarkBlockCompletedRequest(request))
     }
 }

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -43,9 +43,9 @@ use crate::{
     effect::{
         announcements::{MetaBlockAnnouncement, PeerBehaviorAnnouncement},
         requests::{
-            BlockAccumulatorRequest, BlockCompleteConfirmationRequest, BlockSynchronizerRequest,
-            ContractRuntimeRequest, FetcherRequest, MakeBlockExecutableRequest, NetworkInfoRequest,
-            StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
+            BlockAccumulatorRequest, BlockSynchronizerRequest, ContractRuntimeRequest,
+            FetcherRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest,
+            NetworkInfoRequest, StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
         },
         EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
@@ -124,7 +124,7 @@ pub(crate) trait ReactorEvent:
     + From<TrieAccumulatorRequest>
     + From<ContractRuntimeRequest>
     + From<SyncGlobalStateRequest>
-    + From<BlockCompleteConfirmationRequest>
+    + From<MarkBlockCompletedRequest>
     + From<MakeBlockExecutableRequest>
     + From<MetaBlockAnnouncement>
     + Send
@@ -149,7 +149,7 @@ impl<REv> ReactorEvent for REv where
         + From<TrieAccumulatorRequest>
         + From<ContractRuntimeRequest>
         + From<SyncGlobalStateRequest>
-        + From<BlockCompleteConfirmationRequest>
+        + From<MarkBlockCompletedRequest>
         + From<MakeBlockExecutableRequest>
         + From<MetaBlockAnnouncement>
         + Send
@@ -461,7 +461,7 @@ impl BlockSynchronizer {
     where
         REv: From<StorageRequest>
             + From<MetaBlockAnnouncement>
-            + From<BlockCompleteConfirmationRequest>
+            + From<MarkBlockCompletedRequest>
             + Send,
     {
         if let Some(builder) = &self.forward {
@@ -545,7 +545,7 @@ impl BlockSynchronizer {
         rng: &mut NodeRng,
     ) -> Effects<Event>
     where
-        REv: ReactorEvent + From<FetcherRequest<Block>> + From<BlockCompleteConfirmationRequest>,
+        REv: ReactorEvent + From<FetcherRequest<Block>> + From<MarkBlockCompletedRequest>,
     {
         let need_next_interval = self.config.need_next_interval.into();
         let mut results = Effects::new();

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -32,7 +32,7 @@ const MAX_SIMULTANEOUS_PEERS: usize = 5;
 /// Event for the mock reactor.
 #[derive(Debug, From)]
 enum MockReactorEvent {
-    BlockCompleteConfirmationRequest(BlockCompleteConfirmationRequest),
+    MarkBlockCompletedRequest(MarkBlockCompletedRequest),
     BlockFetcherRequest(FetcherRequest<Block>),
     BlockHeaderFetcherRequest(FetcherRequest<BlockHeader>),
     LegacyDeployFetcherRequest(FetcherRequest<LegacyDeploy>),

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -38,7 +38,7 @@ use crate::{
     effect::{
         announcements::{ControlAnnouncement, DeployAcceptorAnnouncement},
         requests::{
-            BlockCompleteConfirmationRequest, ContractRuntimeRequest, MakeBlockExecutableRequest,
+            ContractRuntimeRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest,
             NetworkRequest,
         },
         Responder,
@@ -86,8 +86,8 @@ impl From<MakeBlockExecutableRequest> for Event {
     }
 }
 
-impl From<BlockCompleteConfirmationRequest> for Event {
-    fn from(request: BlockCompleteConfirmationRequest) -> Self {
+impl From<MarkBlockCompletedRequest> for Event {
+    fn from(request: MarkBlockCompletedRequest) -> Self {
         Event::Storage(storage::Event::MarkBlockCompletedRequest(request))
     }
 }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -32,7 +32,7 @@ use crate::{
             NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
             TrieResponseIncoming,
         },
-        requests::BlockCompleteConfirmationRequest,
+        requests::MarkBlockCompletedRequest,
         Responder,
     },
     fatal,
@@ -120,7 +120,7 @@ enum Event {
     #[from]
     BlocklistAnnouncement(PeerBehaviorAnnouncement),
     #[from]
-    MarkBlockCompletedRequest(BlockCompleteConfirmationRequest),
+    MarkBlockCompletedRequest(MarkBlockCompletedRequest),
     #[from]
     TrieDemand(TrieDemand),
     #[from]

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -83,8 +83,7 @@ use crate::{
         announcements::FatalAnnouncement,
         incoming::{NetRequest, NetRequestIncoming},
         requests::{
-            BlockCompleteConfirmationRequest, MakeBlockExecutableRequest, NetworkRequest,
-            StorageRequest,
+            MakeBlockExecutableRequest, MarkBlockCompletedRequest, NetworkRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -224,9 +223,9 @@ pub(crate) enum Event {
     StorageRequest(Box<StorageRequest>),
     /// Incoming net request.
     NetRequestIncoming(Box<NetRequestIncoming>),
-    /// Block completion announcement.
+    /// Mark block completed request.
     #[from]
-    MarkBlockCompletedRequest(BlockCompleteConfirmationRequest),
+    MarkBlockCompletedRequest(MarkBlockCompletedRequest),
     /// Make block executable request.
     #[from]
     MakeBlockExecutableRequest(Box<MakeBlockExecutableRequest>),
@@ -1183,10 +1182,10 @@ impl Storage {
     /// Handles a [`BlockCompletedAnnouncement`].
     fn handle_mark_block_completed_request(
         &mut self,
-        BlockCompleteConfirmationRequest {
+        MarkBlockCompletedRequest {
             block_height,
             responder,
-        }: BlockCompleteConfirmationRequest,
+        }: MarkBlockCompletedRequest,
     ) -> Result<Effects<Event>, FatalStorageError> {
         let is_new = self.mark_block_complete(block_height)?;
         Ok(responder.respond(is_new).ignore())

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -24,7 +24,7 @@ use super::{
 use crate::{
     components::fetcher::{FetchItem, FetchResponse},
     effect::{
-        requests::{BlockCompleteConfirmationRequest, StorageRequest},
+        requests::{MarkBlockCompletedRequest, StorageRequest},
         Multiple,
     },
     storage::{
@@ -417,7 +417,7 @@ fn put_complete_block(
     });
     assert!(harness.is_idle());
     harness.send_request(storage, move |responder| {
-        BlockCompleteConfirmationRequest {
+        MarkBlockCompletedRequest {
             block_height,
             responder,
         }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -165,11 +165,10 @@ use announcements::{
 };
 use diagnostics_port::DumpConsensusStateRequest;
 use requests::{
-    BeginGossipRequest, BlockAccumulatorRequest, BlockCompleteConfirmationRequest,
-    BlockSynchronizerRequest, BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest,
-    FetcherRequest, MakeBlockExecutableRequest, NetworkInfoRequest, NetworkRequest,
-    ReactorStatusRequest, StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
-    UpgradeWatcherRequest,
+    BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest, BlockValidationRequest,
+    ChainspecRawBytesRequest, ConsensusRequest, FetcherRequest, MakeBlockExecutableRequest,
+    MarkBlockCompletedRequest, NetworkInfoRequest, NetworkRequest, ReactorStatusRequest,
+    StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
 };
 
 use self::{
@@ -907,10 +906,10 @@ impl<REv> EffectBuilder<REv> {
     /// global state.
     pub(crate) async fn mark_block_completed(self, block_height: u64) -> bool
     where
-        REv: From<BlockCompleteConfirmationRequest>,
+        REv: From<MarkBlockCompletedRequest>,
     {
         self.make_request(
-            |responder| BlockCompleteConfirmationRequest {
+            |responder| MarkBlockCompletedRequest {
                 block_height,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -636,10 +636,6 @@ impl Display for MakeBlockExecutableRequest {
 /// * the block header and the actual block are persisted in storage,
 /// * all of its deploys are persisted in storage, and
 /// * the global state root the block refers to has no missing dependencies locally.
-
-// Note - this is a request rather than an announcement as the chain synchronizer needs to ensure
-// the request has been completed before it can exit, i.e. it awaits the response. Otherwise, the
-// reactor might exit before handling the announcement and it would go un-actioned.
 #[derive(Debug, Serialize)]
 pub(crate) struct MarkBlockCompletedRequest {
     pub block_height: u64,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -639,15 +639,15 @@ impl Display for MakeBlockExecutableRequest {
 
 // Note - this is a request rather than an announcement as the chain synchronizer needs to ensure
 // the request has been completed before it can exit, i.e. it awaits the response. Otherwise, the
-// joiner reactor might exit before handling the announcement and it would go un-actioned.
+// reactor might exit before handling the announcement and it would go un-actioned.
 #[derive(Debug, Serialize)]
-pub(crate) struct BlockCompleteConfirmationRequest {
+pub(crate) struct MarkBlockCompletedRequest {
     pub block_height: u64,
     /// Responds `true` if the block was not previously marked complete.
     pub responder: Responder<bool>,
 }
 
-impl Display for BlockCompleteConfirmationRequest {
+impl Display for MarkBlockCompletedRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "block completed: height {}", self.block_height)
     }

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -856,7 +856,7 @@ impl reactor::Reactor for MainReactor {
                 MainEvent::Storage,
                 self.storage.handle_event(effect_builder, rng, req.into()),
             ),
-            MainEvent::BlockCompleteConfirmationRequest(req) => reactor::wrap_effects(
+            MainEvent::MarkBlockCompletedRequest(req) => reactor::wrap_effects(
                 MainEvent::Storage,
                 self.storage.handle_event(effect_builder, rng, req.into()),
             ),

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -34,12 +34,13 @@ use crate::{
             TrieResponseIncoming,
         },
         requests::{
-            BeginGossipRequest, BlockAccumulatorRequest, BlockCompleteConfirmationRequest,
-            BlockSynchronizerRequest, BlockValidationRequest, ChainspecRawBytesRequest,
-            ConsensusRequest, ContractRuntimeRequest, DeployBufferRequest, FetcherRequest,
-            MakeBlockExecutableRequest, MetricsRequest, NetworkInfoRequest, NetworkRequest,
-            ReactorStatusRequest, RestRequest, RpcRequest, SetNodeStopRequest, StorageRequest,
-            SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
+            BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest,
+            BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest,
+            ContractRuntimeRequest, DeployBufferRequest, FetcherRequest,
+            MakeBlockExecutableRequest, MarkBlockCompletedRequest, MetricsRequest,
+            NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, RestRequest, RpcRequest,
+            SetNodeStopRequest, StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
+            UpgradeWatcherRequest,
         },
     },
     protocol::Message,
@@ -165,7 +166,7 @@ pub(crate) enum MainEvent {
     #[from]
     MakeBlockExecutableRequest(MakeBlockExecutableRequest),
     #[from]
-    BlockCompleteConfirmationRequest(BlockCompleteConfirmationRequest),
+    MarkBlockCompletedRequest(MarkBlockCompletedRequest),
     #[from]
     FinalitySignatureIncoming(FinalitySignatureIncoming),
     #[from]
@@ -311,7 +312,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::ChainspecRawBytesRequest(_) => "ChainspecRawBytesRequest",
             MainEvent::UpgradeWatcherRequest(_) => "UpgradeWatcherRequest",
             MainEvent::StorageRequest(_) => "StorageRequest",
-            MainEvent::BlockCompleteConfirmationRequest(_) => "BlockCompleteConfirmationRequest",
+            MainEvent::MarkBlockCompletedRequest(_) => "MarkBlockCompletedRequest",
             MainEvent::DumpConsensusStateRequest(_) => "DumpConsensusStateRequest",
             MainEvent::ControlAnnouncement(_) => "ControlAnnouncement",
             MainEvent::FatalAnnouncement(_) => "FatalAnnouncement",
@@ -439,7 +440,7 @@ impl Display for MainEvent {
                 write!(f, "upgrade watcher request: {}", req)
             }
             MainEvent::StorageRequest(req) => write!(f, "storage request: {}", req),
-            MainEvent::BlockCompleteConfirmationRequest(req) => {
+            MainEvent::MarkBlockCompletedRequest(req) => {
                 write!(f, "mark block completed request: {}", req)
             }
             MainEvent::BlockHeaderFetcherRequest(request) => {

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -637,13 +637,11 @@ impl MainReactor {
                         .map_err(|err| err.to_string())?
                         .last()
                     {
-                        if !self.sync_to_genesis
-                            && synced_to_ttl(
-                                highest_switch_block_header,
-                                &highest_orphaned_block_header,
-                                self.chainspec.deploy_config.max_ttl,
-                            )?
-                        {
+                        if synced_to_ttl(
+                            highest_switch_block_header,
+                            &highest_orphaned_block_header,
+                            self.chainspec.deploy_config.max_ttl,
+                        )? {
                             return Ok(Some(SyncBackInstruction::TtlSynced));
                         }
                     }

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -21,7 +21,6 @@ use crate::{
         requests::BlockSynchronizerRequest, EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     reactor::main_reactor::{MainEvent, MainReactor},
-    storage::Storage,
     types::{
         ActivationPoint, BlockHash, BlockHeader, GlobalStatesMetadata, SyncLeap, SyncLeapIdentifier,
     },
@@ -616,32 +615,40 @@ impl MainReactor {
         // on an old block. in either case we will attempt to get the next needed block (if any).
         // note: for a synced historical block we have header, body, global state, any execution
         // effects, any referenced deploys, & sufficient finality (by weight) of signatures.
-        let highest_orphaned_block_header = self.storage.get_highest_orphaned_block_header();
-        match highest_orphaned_block_header {
-            HighestOrphanedBlockResult::Orphan(block_header) => {
+        match self.storage.get_highest_orphaned_block_header() {
+            HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) => {
                 // set a latch on the validator matrix to prevent it from purging validator weights
                 // of interstitial eras which we have not yet historically sync'd
                 self.validator_matrix
-                    .register_retrograde_latch(Some(block_header.era_id()));
-                if block_header.is_genesis() {
+                    .register_retrograde_latch(Some(highest_orphaned_block_header.era_id()));
+                if highest_orphaned_block_header.is_genesis() {
                     return Ok(Some(SyncBackInstruction::GenesisSynced));
                 }
-                // if sync to genesis is false, we require sync to ttl; i.e. if the TTL is 12 hours
-                // we require sync back to see a contiguous / unbroken range of at least 12 hours
-                // worth of blocks. note however that we measure from the start of the active era
-                // (for consensus reasons), so this can be up to TTL + era length in practice
-                if !self.sync_to_genesis
-                    && synced_to_ttl(
-                        None,
-                        Some(&block_header),
-                        &self.storage,
-                        self.chainspec.deploy_config.max_ttl,
-                    )?
+
+                if let Some(highest_switch_block_header) = self
+                    .storage
+                    .read_highest_switch_block_headers(1)
+                    .map_err(|err| err.to_string())?
+                    .last()
                 {
-                    return Ok(Some(SyncBackInstruction::TtlSynced));
+                    // if sync to genesis is false, we require sync to ttl; i.e. if the TTL is 12
+                    // hours we require sync back to see a contiguous / unbroken
+                    // range of at least 12 hours worth of blocks. note however
+                    // that we measure from the start of the active era
+                    // (for consensus reasons), so this can be up to TTL + era length in practice
+                    if !self.sync_to_genesis
+                        && synced_to_ttl(
+                            highest_switch_block_header,
+                            &highest_orphaned_block_header,
+                            self.chainspec.deploy_config.max_ttl,
+                        )?
+                    {
+                        return Ok(Some(SyncBackInstruction::TtlSynced));
+                    }
                 }
-                let parent_hash = block_header.parent_hash();
-                debug!(?block_header, %parent_hash, "KeepUp: highest orphaned historical block");
+
+                let parent_hash = highest_orphaned_block_header.parent_hash();
+                debug!(?highest_orphaned_block_header, %parent_hash, "KeepUp: highest orphaned historical block");
                 match self.storage.read_block_header(parent_hash) {
                     Ok(Some(parent_block_header)) => {
                         // even if we don't have a complete block (all parts and dependencies)
@@ -659,7 +666,7 @@ impl MainReactor {
                     }
                     Ok(None) => {
                         debug!(%parent_hash, "KeepUp: did not find historical block header in storage");
-                        let era_id = match block_header.era_id().predecessor() {
+                        let era_id = match highest_orphaned_block_header.era_id().predecessor() {
                             None => EraId::from(0),
                             Some(predecessor) => {
                                 // we do not have the parent header and thus don't know what era
@@ -695,54 +702,13 @@ impl MainReactor {
 }
 
 pub(crate) fn synced_to_ttl(
-    maybe_latest_switch_block_header: Option<&BlockHeader>,
-    maybe_highest_orphaned_block_header: Option<&BlockHeader>,
-    storage: &Storage,
+    latest_switch_block_header: &BlockHeader,
+    highest_orphaned_block_header: &BlockHeader,
     max_ttl: TimeDiff,
 ) -> Result<bool, String> {
-    let switch_block_header = match maybe_latest_switch_block_header {
-        Some(switch_block_header) => switch_block_header.clone(),
-        None => {
-            // If latest switch block header is not provided, we try to get it from storage.
-            if let Some(latest_switch_block_header) = storage
-                .read_highest_switch_block_headers(1)
-                .map_err(|err| err.to_string())?
-                .last()
-            {
-                latest_switch_block_header.clone()
-            } else {
-                // No latest switch block header is known, we assume that we're not synced to
-                // TTL.
-                info!(
-                    "KeepUp: unable to get latest switch block header (this problem should be transient), \
-                    assuming not synced to ttl");
-                return Ok(false);
-            }
-        }
-    };
-
-    let highest_orphaned_block_header = match maybe_highest_orphaned_block_header {
-        Some(highest_orphaned_block_header) => highest_orphaned_block_header.clone(),
-        None => {
-            // If highest orphaned block header is not provided, we try to get it from storage.
-            if let HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) =
-                storage.get_highest_orphaned_block_header()
-            {
-                highest_orphaned_block_header
-            } else {
-                // No highest orphaned block header is known, we assume that we're not synced to
-                // TTL.
-                info!(
-                    "KeepUp: unable to get highest orphaned block header (this problem should be transient), \
-                    assuming not synced to ttl");
-                return Ok(false);
-            }
-        }
-    };
-
     Ok(highest_orphaned_block_header.height() == 0
         || is_timestamp_at_ttl(
-            switch_block_header.timestamp(),
+            latest_switch_block_header.timestamp(),
             highest_orphaned_block_header.timestamp(),
             max_ttl,
         ))
@@ -760,14 +726,11 @@ fn is_timestamp_at_ttl(
 mod tests {
     use std::str::FromStr;
 
-    use casper_types::{ProtocolVersion, TimeDiff, Timestamp};
+    use casper_types::{testing::TestRng, ProtocolVersion, TimeDiff, Timestamp};
 
     use crate::{
         reactor::main_reactor::keep_up::{is_timestamp_at_ttl, synced_to_ttl},
-        storage::Storage,
-        testing::{ComponentHarness, UnitTestEvent},
         types::Block,
-        WithDir,
     };
 
     const TWO_DAYS_SECS: u32 = 60 * 60 * 24 * 2;
@@ -827,35 +790,12 @@ mod tests {
         ));
     }
 
-    pub(crate) fn make_mock_storage(harness: &ComponentHarness<UnitTestEvent>) -> Storage {
-        const RECENT_ERA_COUNT: u64 = 7;
-
-        Storage::new(
-            &WithDir::new(
-                harness.tmp.path(),
-                crate::components::storage::Config {
-                    path: harness.tmp.path().join("storage"),
-                    ..Default::default()
-                },
-            ),
-            None,
-            ProtocolVersion::default(),
-            "test",
-            MAX_TTL,
-            RECENT_ERA_COUNT,
-            None,
-            false,
-        )
-        .expect("could not create storage component fixture")
-    }
-
     #[test]
     fn should_detect_ttl_at_genesis() {
-        let mut harness = ComponentHarness::default();
-        let storage = make_mock_storage(&harness);
+        let mut rng = TestRng::new();
 
         let latest_switch_block = Block::random_with_specifics(
-            &mut harness.rng,
+            &mut rng,
             100.into(),
             1000,
             ProtocolVersion::default(),
@@ -864,7 +804,7 @@ mod tests {
         );
 
         let latest_orphaned_block = Block::random_with_specifics(
-            &mut harness.rng,
+            &mut rng,
             0.into(),
             0,
             ProtocolVersion::default(),
@@ -875,9 +815,8 @@ mod tests {
         assert_eq!(latest_orphaned_block.height(), 0);
         assert_eq!(
             synced_to_ttl(
-                Some(latest_switch_block.header()),
-                Some(latest_orphaned_block.header()),
-                &storage,
+                latest_switch_block.header(),
+                latest_orphaned_block.header(),
                 MAX_TTL
             ),
             Ok(true)


### PR DESCRIPTION
This PR renames the `BlockCompleteConfirmationRequest` to `MarkBlockCompletedRequest` and it simplifies the code around calculations for `sync_to_ttl()`.

It's a response to the comments from the previously merged PR: https://github.com/casper-network/casper-node/pull/3855