### PR TITLE
Fix nctl upgrade test script

### DIFF
--- a/utils/nctl/sh/assets/upgrade.sh
+++ b/utils/nctl/sh/assets/upgrade.sh
@@ -18,12 +18,12 @@ function _upgrade_node() {
     local ACTIVATE_ERA=${2}
     local NODE_ID=${3}
     local CONFIG_PATH=${4}
+    local PATH_TO_NET
+    PATH_TO_NET=$(get_path_to_net)
     local PATH_TO_CHAINSPEC_FILE=${5:-"$PATH_TO_NET/chainspec/chainspec.toml"}
 
-    local PATH_TO_NET
     local PATH_TO_NODE
     local CHAIN_NAME
-
 
     PATH_TO_NET=$(get_path_to_net)
 


### PR DESCRIPTION
This fixes an issue in the nctl `upgrade.sh` script causing at least Upgrade Scenario 6 to fail in nightlies.