### PR TITLE
block_synchronizer/tests: enable sync stall tests

### DIFF
--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -9,7 +9,9 @@ use std::{
     time::Duration,
 };
 
-use casper_types::{AccessRights, CLValue, EraId, PublicKey, SecretKey, StoredValue, URef, U512};
+use casper_types::{
+    AccessRights, CLValue, EraId, PublicKey, SecretKey, StoredValue, TimeDiff, URef, U512,
+};
 use derive_more::From;
 use rand::{seq::IteratorRandom, Rng};
 
@@ -28,6 +30,8 @@ use crate::{
 };
 
 const MAX_SIMULTANEOUS_PEERS: usize = 5;
+const TEST_LATCH_RESET_INTERVAL_MILLIS: u64 = 5;
+const TEST_SYNCHRONIZER_STALL_LIMIT_MILLIS: u64 = 150;
 
 /// Event for the mock reactor.
 #[derive(Debug, From)]
@@ -212,10 +216,15 @@ fn register_multiple_signatures<'a, I: IntoIterator<Item = &'a Arc<SecretKey>>>(
 }
 
 impl BlockSynchronizer {
-    // Create an initialized block synchronizer with default config and MAX_SIMULTANEOUS_PEERS peers
-    fn new_initialized(rng: &mut TestRng, validator_matrix: ValidatorMatrix) -> BlockSynchronizer {
+    // Create an initialized block synchronizer
+    // with a specified config and MAX_SIMULTANEOUS_PEERS peers
+    fn new_initialized(
+        rng: &mut TestRng,
+        validator_matrix: ValidatorMatrix,
+        config: Config,
+    ) -> BlockSynchronizer {
         let mut block_synchronizer = BlockSynchronizer::new(
-            Config::default(),
+            config,
             Arc::new(Chainspec::random(rng)),
             MAX_SIMULTANEOUS_PEERS as u32,
             validator_matrix,
@@ -255,7 +264,12 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let cfg = Config {
+        latch_reset_interval: TimeDiff::from_millis(TEST_LATCH_RESET_INTERVAL_MILLIS),
+        ..Default::default()
+    };
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, cfg);
 
     // Set up the synchronizer for the test block such that the next step is getting global state
     block_synchronizer.register_block_by_hash(*block.hash(), true);
@@ -311,7 +325,7 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     check_sync_global_state_event(event, block);
 
     // Wait for the latch to reset
-    std::thread::sleep(Duration::from_secs(6));
+    tokio::time::sleep(Duration::from_millis(TEST_LATCH_RESET_INTERVAL_MILLIS * 2)).await;
 
     // Simulate an error form the global_state_synchronizer;
     // make it seem that the `TrieAccumulator` did not find the required tries on any of the peers
@@ -338,7 +352,7 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
     check_sync_global_state_event(event, block);
 
     // Wait for the latch to reset
-    std::thread::sleep(Duration::from_secs(6));
+    tokio::time::sleep(Duration::from_millis(TEST_LATCH_RESET_INTERVAL_MILLIS * 2)).await;
 
     // Simulate a successful global state sync;
     // Although the request was successful, some peers did not have the data.
@@ -392,7 +406,7 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
     // Set up an empty validator matrix.
     let mut validator_matrix = ValidatorMatrix::new_with_validator(ALICE_SECRET_KEY.clone());
     let mut block_synchronizer =
-        BlockSynchronizer::new_initialized(&mut rng, validator_matrix.clone());
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix.clone(), Config::default());
 
     // Set up the synchronizer for the test block such that the next step is getting era validators.
     block_synchronizer.register_block_by_hash(*block.hash(), true);
@@ -464,7 +478,8 @@ fn duplicate_register_block_not_allowed_if_builder_is_not_failed() {
     let test_env = TestEnv::random(&mut rng);
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for forward sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -489,7 +504,8 @@ async fn historical_sync_gets_peers_form_both_connected_peers_and_accumulator() 
     let test_env = TestEnv::random(&mut rng);
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for historical sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), true));
@@ -531,7 +547,8 @@ async fn fwd_sync_gets_peers_only_from_accumulator() {
     let test_env = TestEnv::random(&mut rng);
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for forward sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -565,7 +582,8 @@ async fn sync_starts_with_header_fetch() {
     let block = test_env.block();
     let peers = test_env.peers();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -594,8 +612,6 @@ async fn sync_starts_with_header_fetch() {
     }
 }
 
-//TODO: remove this ignore when the synchronizer can recover from the stall
-#[ignore]
 #[tokio::test]
 async fn fwd_sync_is_not_blocked_by_failed_header_fetch_within_latch_interval() {
     let mut rng = TestRng::new();
@@ -604,7 +620,12 @@ async fn fwd_sync_is_not_blocked_by_failed_header_fetch_within_latch_interval() 
     let block = test_env.block();
     let peers = test_env.peers();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let cfg = Config {
+        stall_limit: TimeDiff::from_millis(TEST_SYNCHRONIZER_STALL_LIMIT_MILLIS),
+        ..Default::default()
+    };
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, cfg);
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -650,8 +671,25 @@ async fn fwd_sync_is_not_blocked_by_failed_header_fetch_within_latch_interval() 
         generated_effects.extend(effects);
     }
 
-    // If the effects are empty at this point, then the synchronizer gets stuck
-    assert!(!generated_effects.is_empty());
+    assert_matches!(
+        block_synchronizer.forward_progress(),
+        BlockSynchronizerProgress::Syncing(block_hash, _, _) if block_hash == *block.hash()
+    );
+
+    // The effects are empty at this point and the synchronizer is stuck
+    assert!(generated_effects.is_empty());
+
+    // Wait for the stall detection time to pass
+    tokio::time::sleep(Duration::from_millis(
+        TEST_SYNCHRONIZER_STALL_LIMIT_MILLIS * 2,
+    ))
+    .await;
+
+    // Check if the forward builder is reported as stalled so that the control logic can recover
+    assert_matches!(
+        block_synchronizer.forward_progress(),
+        BlockSynchronizerProgress::Stalled(block_hash, _, _) if block_hash == *block.hash()
+    );
 }
 
 #[tokio::test]
@@ -662,7 +700,8 @@ async fn registering_header_successfully_triggers_signatures_fetch_for_weak_fina
     let peers = test_env.peers();
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -736,7 +775,8 @@ async fn fwd_more_signatures_are_requested_if_weak_finality_is_not_reached() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -851,8 +891,6 @@ async fn fwd_more_signatures_are_requested_if_weak_finality_is_not_reached() {
     }
 }
 
-//TODO: remove this ignore when the synchronizer can recover from the stall
-#[ignore]
 #[tokio::test]
 async fn fwd_sync_is_not_blocked_by_failed_signatures_fetch_within_latch_interval() {
     let mut rng = TestRng::new();
@@ -862,7 +900,12 @@ async fn fwd_sync_is_not_blocked_by_failed_signatures_fetch_within_latch_interva
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let num_validators = test_env.validator_keys().len();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let cfg = Config {
+        stall_limit: TimeDiff::from_millis(TEST_SYNCHRONIZER_STALL_LIMIT_MILLIS),
+        ..Default::default()
+    };
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, cfg);
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -933,8 +976,25 @@ async fn fwd_sync_is_not_blocked_by_failed_signatures_fetch_within_latch_interva
         generated_effects.extend(effects);
     }
 
-    // If the effects are empty at this point, then the synchronizer gets stuck
-    assert!(!generated_effects.is_empty());
+    assert_matches!(
+        block_synchronizer.forward_progress(),
+        BlockSynchronizerProgress::Syncing(block_hash, _, _) if block_hash == *block.hash()
+    );
+
+    // The effects are empty at this point and the synchronizer is stuck
+    assert!(generated_effects.is_empty());
+
+    // Wait for the stall detection time to pass
+    tokio::time::sleep(Duration::from_millis(
+        TEST_SYNCHRONIZER_STALL_LIMIT_MILLIS * 2,
+    ))
+    .await;
+
+    // Check if the forward builder is reported as stalled so that the control logic can recover
+    assert_matches!(
+        block_synchronizer.forward_progress(),
+        BlockSynchronizerProgress::Stalled(block_hash, _, _) if block_hash == *block.hash()
+    );
 }
 
 #[tokio::test]
@@ -946,7 +1006,8 @@ async fn next_action_for_have_weak_finality_is_fetching_block_body() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1011,7 +1072,8 @@ async fn registering_block_body_transitions_builder_to_have_block_state() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1090,7 +1152,8 @@ async fn fwd_having_block_body_for_block_without_deploys_requires_only_signature
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1152,7 +1215,8 @@ async fn fwd_having_block_body_for_block_with_deploys_requires_approvals_hashes(
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1222,7 +1286,8 @@ async fn fwd_registering_approvals_hashes_triggers_fetch_for_deploys() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1306,7 +1371,8 @@ async fn fwd_have_block_body_without_deploys_and_strict_finality_transitions_sta
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1366,7 +1432,8 @@ async fn fwd_have_block_with_strict_finality_requires_creation_of_finalized_bloc
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1436,7 +1503,8 @@ async fn fwd_have_strict_finality_requests_enqueue_when_finalized_block_is_creat
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1525,7 +1593,8 @@ async fn fwd_builder_status_is_executing_when_block_is_enqueued_for_execution() 
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1596,7 +1665,8 @@ async fn fwd_sync_is_finished_when_block_is_marked_as_executed() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1663,7 +1733,8 @@ async fn historical_sync_announces_meta_block() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for historical sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), true));
@@ -1761,7 +1832,8 @@ fn builders_are_purged_when_requested() {
     let test_env = TestEnv::random(&mut rng);
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for forward sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
@@ -1802,7 +1874,8 @@ async fn synchronizer_halts_if_block_cannot_be_made_executable() {
     let block = test_env.block();
     let validator_matrix = test_env.gen_validator_matrix();
     let validators_secret_keys = test_env.validator_keys();
-    let mut block_synchronizer = BlockSynchronizer::new_initialized(&mut rng, validator_matrix);
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, Config::default());
 
     // Register block for fwd sync
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));


### PR DESCRIPTION
Because we now have the ability to determine block synchronizer stalls, re-enable the tests that check for stalls.

Also now that the latch interval is configurable, we can adjust the tests that require to wait for the latch to be reset such that the test run takes a reasonable amount of time.
