### PR TITLE
NCTL: Allow filtering certain error messages when doing health checks

### DIFF
--- a/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
+++ b/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
@@ -62,10 +62,10 @@ function main() {
     # 15. Run Health Checks
     # ... restarts=26: due to nodes being stopped and started; node 1 3 times, nodes 2-5 2 times,
     # ................ node 6-10 3 times (start at 1.4.8, restart to 1.4.7 for sync, then 2 upgrades)
-    # ... errors=ignore: disabled due to non-deterministic error messages "could not send response
+    # ... errors: ignore pattern due to non-deterministic error messages "could not send response
     # .................. to request down oneshot channel"
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
-            errors='ignore' \
+            errors='0;ignore:to request down oneshot channel' \
             equivocators=0 \
             doppels=0 \
             crashes=0 \

--- a/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
+++ b/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
@@ -226,7 +226,14 @@ function do_prepare_upgrade() {
 function do_restart_network() {
     log_step "restarting the network: starting both old and new validators"
     # start the network
-    for NODE_ID in $(seq 1 "$(get_count_of_nodes)"); do
+    # do not pass the trusted hash to the original validators - they already have all the blocks
+    # and will simply pick up at the upgrade point
+    for NODE_ID in $(seq 1 5); do
+        do_node_start "$NODE_ID"
+    done
+    # the new validators need the trusted hash in order to be able to sync to the network, as they
+    # don't have any blocks at this point
+    for NODE_ID in $(seq 6 "$(get_count_of_nodes)"); do
         do_node_start "$NODE_ID" "$TRUSTED_HASH"
     done
 }

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -165,7 +165,7 @@ function await_node_historical_sync_to_genesis() {
     local WAIT_TIME_SEC=0
     local LOWEST=$(get_node_lowest_available_block "$NODE_ID")
     local HIGHEST=$(get_node_highest_available_block "$NODE_ID")
-    while [ $LOWEST -ne 0 ] || [ $HIGHEST -eq 0 ]; do
+    while [ -z $HIGHEST ] || [ -z $LOWEST ] || [ $LOWEST -ne 0 ] || [ $HIGHEST -eq 0 ]; do
         log "node $NODE_ID lowest available block: $LOWEST, highest available block: $HIGHEST"
         if [ $WAIT_TIME_SEC -gt $SYNC_TIMEOUT_SEC ]; then
             log "ERROR: node 1 failed to do historical sync in ${SYNC_TIMEOUT_SEC} seconds"


### PR DESCRIPTION
Fixes: https://github.com/casper-network/casper-node/issues/3804

Also fixes a bug in the function that waits for the node to do a full historical sync.
