### PR TITLE
Update nctl dump script to include all nodes' config folders

### DIFF
--- a/utils/nctl/sh/assets/dump.sh
+++ b/utils/nctl/sh/assets/dump.sh
@@ -9,47 +9,32 @@ PATH_TO_NET=$(get_path_to_net)
 PATH_TO_DUMP=$(get_path_to_net_dump)
 
 # Set dump directory.
-if [ -d "$PATH_TO_DUMP" ]; then
-    rm -rf "$PATH_TO_DUMP"
-fi
+rm -rf "$PATH_TO_DUMP"
 mkdir -p "$PATH_TO_DUMP"
-
-# Dump chainspec.
-cp "$PATH_TO_NET"/chainspec/accounts.toml "$PATH_TO_DUMP"/accounts.toml
-cp "$PATH_TO_NET"/chainspec/chainspec.toml "$PATH_TO_DUMP"
 
 # Dump daemon.
 if [ "$NCTL_DAEMON_TYPE" = "supervisord" ]; then
-    cp "$PATH_TO_NET"/daemon/config/supervisord.conf "$PATH_TO_DUMP"/daemon.conf
-    cp "$PATH_TO_NET"/daemon/logs/supervisord.log "$PATH_TO_DUMP"/daemon.log
+    mkdir -p "$PATH_TO_DUMP"/daemon
+    cp -r "$PATH_TO_NET"/daemon/config "$PATH_TO_DUMP"/daemon
+    cp -r "$PATH_TO_NET"/daemon/logs "$PATH_TO_DUMP"/daemon
 fi
 
 # Dump faucet.
-cp "$PATH_TO_NET"/faucet/public_key_hex "$PATH_TO_DUMP"/faucet-public_key_hex
-cp "$PATH_TO_NET"/faucet/public_key.pem "$PATH_TO_DUMP"/faucet-public_key.pem
-cp "$PATH_TO_NET"/faucet/secret_key.pem "$PATH_TO_DUMP"/faucet-secret_key.pem
+cp -r "$PATH_TO_NET"/faucet "$PATH_TO_DUMP"
 
 # Dump nodes.
 for NODE_ID in $(seq 1 "$(get_count_of_started_nodes)")
 do
-    PATH_TO_NODE_KEYS=$(get_path_to_node_keys "$NODE_ID")
-    PATH_TO_NODE_LOGS=$(get_path_to_node_logs "$NODE_ID")
-    PATH_TO_NODE_CFG=$(get_path_to_node_config "$NODE_ID")
-
-    cp "$PATH_TO_NODE_KEYS"/public_key_hex "$PATH_TO_DUMP"/node-"$NODE_ID"-public_key_hex
-    cp "$PATH_TO_NODE_KEYS"/public_key.pem "$PATH_TO_DUMP"/node-"$NODE_ID"-public_key.pem
-    cp "$PATH_TO_NODE_KEYS"/secret_key.pem "$PATH_TO_DUMP"/node-"$NODE_ID"-secret_key.pem
-    cp "$PATH_TO_NODE_LOGS"/stderr.log "$PATH_TO_DUMP"/node-"$NODE_ID"-stderr.log
-    cp "$PATH_TO_NODE_LOGS"/stdout.log "$PATH_TO_DUMP"/node-"$NODE_ID"-stdout.log
+    PATH_TO_NODE_DUMP="$PATH_TO_DUMP/node-$NODE_ID"
+    cp -r $(get_path_to_node_config $NODE_ID) "$PATH_TO_NODE_DUMP"
+    cp -r $(get_path_to_node_keys $NODE_ID) "$PATH_TO_NODE_DUMP"
+    cp -r $(get_path_to_node_logs $NODE_ID) "$PATH_TO_NODE_DUMP"
 done
+
+# Remove socket files which could exist in nodes' config folders.
+find "$PATH_TO_DUMP" -type s -delete
 
 # Dump users.
-for USER_ID in $(seq 1 "$(get_count_of_users)")
-do
-    PATH_TO_USER=$(get_path_to_user "$USER_ID")
-    cp "$PATH_TO_USER"/public_key_hex "$PATH_TO_DUMP"/user-"$USER_ID"-public_key_hex
-    cp "$PATH_TO_USER"/public_key.pem "$PATH_TO_DUMP"/user-"$USER_ID"-public_key.pem
-    cp "$PATH_TO_USER"/secret_key.pem "$PATH_TO_DUMP"/user-"$USER_ID"-secret_key.pem
-done
+cp -r "$PATH_TO_NET"/users/* "$PATH_TO_DUMP"
 
 log "transient asset dump ... complete"


### PR DESCRIPTION
This PR changes the `nctl-assets-dump` command to include all the files from every nodes' `config` folder.

Previously only a single chainspec was included, even for tests which executed one or more upgrades, and no config files were included.  Now all chainspecs are included along with all the individual config files for each node.

It also unflattens the structure of the dump folder to make it more closely match the structure in the assets folder.

Closes #3883.