### PR TITLE
Ensure nodes are historically synced before walking back blocks

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -40,6 +40,8 @@ function main() {
     local AFTER_EVICTION_HASH=$(do_read_lfb_hash '1')
     # 10. Wait 3 eras to see if the node ends up proposing
     do_await_era_change "3"
+    # Node 6 must be synced to genesis in case it's selected for walkback
+    await_node_historical_sync_to_genesis '6' '300'
     # 11. Assert node didn't propose since being unbonded
     assert_no_proposal_walkback '6' "$AFTER_EVICTION_HASH"
     # 12. Run Health Checks

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -51,6 +51,8 @@ function main() {
     get_switch_block '1' '100'
     # Assert node 5 was evicted
     assert_eviction '5'
+    # Node 5 must be synced to genesis in case it's selected for walkback
+    await_node_historical_sync_to_genesis '5' '300'
     # Assert node didn't propose since being shutdown
     assert_no_proposal_walkback '5' "$RESTART_HASH"
     # Re-bid shutdown node


### PR DESCRIPTION
This PR fix the flakiness in `bond_its.sh` and `itst13.sh`.

The potential problem is that at some point these tests execute the block walkback process and, if by any chance they (randomly) decide to query the node that is not synced back to genesis, `casper-client` will return non-zero exit code and the test will immediately fail.

To overcome that, the tests have been updated to wait until the nodes that rejoin the network are fully synced historically.

**Partially** fixes https://github.com/casper-network/casper-node/issues/3862