### PR TITLE
Minor cleanups

### DIFF
--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -163,10 +163,15 @@ pub static DEFAULT_GENESIS_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {
 /// Default [`ChainspecRegistry`].
 pub static DEFAULT_CHAINSPEC_REGISTRY: Lazy<ChainspecRegistry> =
     Lazy::new(|| ChainspecRegistry::new_with_genesis(&[1, 2, 3], &[4, 5, 6]));
-// This static constant has been deprecated in favor of the Production counterpart
-// which uses costs tables and values which reflect values used by the Casper Mainnet.
-#[deprecated]
 /// Default [`RunGenesisRequest`].
+///
+/// This has been deprecated in favor of [`PRODUCTION_RUN_GENESIS_REQUEST`] which uses cost tables
+/// matching those used in Casper Mainnet.
+#[deprecated(
+    since = "2.3.0",
+    note = "prefer `PRODUCTION_RUN_GENESIS_REQUEST` as it uses cost tables matching those used in \
+           Casper Mainnet"
+)]
 pub static DEFAULT_RUN_GENESIS_REQUEST: Lazy<RunGenesisRequest> = Lazy::new(|| {
     RunGenesisRequest::new(
         *DEFAULT_GENESIS_CONFIG_HASH,
@@ -176,7 +181,7 @@ pub static DEFAULT_RUN_GENESIS_REQUEST: Lazy<RunGenesisRequest> = Lazy::new(|| {
         DEFAULT_CHAINSPEC_REGISTRY.clone(),
     )
 });
-/// [`RunGenesisRequest`] instantiated using chainspec values.
+/// A [`RunGenesisRequest`] using cost tables matching those used in Casper Mainnet.
 pub static PRODUCTION_RUN_GENESIS_REQUEST: Lazy<RunGenesisRequest> = Lazy::new(|| {
     ChainspecConfig::create_genesis_request_from_production_chainspec(
         DEFAULT_ACCOUNTS.clone(),

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -879,19 +879,6 @@ where
             .cloned()
     }
 
-    /// Gets the transform map that's cached between runs
-    #[deprecated(
-        since = "2.1.0",
-        note = "Use `get_execution_journals` that returns transforms in the order they were created."
-    )]
-    pub fn get_transforms(&self) -> Vec<AdditiveMap<Key, Transform>> {
-        self.transforms
-            .clone()
-            .into_iter()
-            .map(|journal| journal.into_iter().collect())
-            .collect()
-    }
-
     /// Gets `ExecutionJournal`s of all passed runs.
     pub fn get_execution_journals(&self) -> Vec<ExecutionJournal> {
         self.transforms.clone()
@@ -969,23 +956,11 @@ where
         Some(exec_results.iter().map(Rc::clone).collect())
     }
 
-    /// Returns the results of all execs.
-    #[deprecated(since = "2.3.0", note = "use `get_exec_result` instead")]
-    pub fn get_exec_results(&self) -> &Vec<Vec<Rc<ExecutionResult>>> {
-        &self.exec_results
-    }
-
     /// Returns the owned results of a specific exec.
     pub fn get_exec_result_owned(&self, index: usize) -> Option<Vec<Rc<ExecutionResult>>> {
         let exec_results = self.exec_results.get(index)?;
 
         Some(exec_results.iter().map(Rc::clone).collect())
-    }
-
-    /// Returns the results of a specific exec.
-    #[deprecated(since = "2.3.0", note = "use `get_exec_result_owned` instead")]
-    pub fn get_exec_result(&self, index: usize) -> Option<&Vec<Rc<ExecutionResult>>> {
-        self.exec_results.get(index)
     }
 
     /// Returns a count of exec results.
@@ -1283,25 +1258,6 @@ where
         ret
     }
 
-    /// Gets [`UnbondingPurses`].
-    #[deprecated(since = "2.3.0", note = "use `get_withdraw_purses` instead")]
-    pub fn get_withdraws(&mut self) -> UnbondingPurses {
-        let withdraw_purses = self.get_withdraw_purses();
-        let unbonding_purses: UnbondingPurses = withdraw_purses
-            .iter()
-            .map(|(key, withdraw_purse)| {
-                (
-                    key.to_owned(),
-                    withdraw_purse
-                        .iter()
-                        .map(|withdraw_purse| withdraw_purse.to_owned().into())
-                        .collect::<Vec<UnbondingPurse>>(),
-                )
-            })
-            .collect::<BTreeMap<AccountHash, Vec<UnbondingPurse>>>();
-        unbonding_purses
-    }
-
     /// Gets all `[Key::Balance]`s in global state.
     pub fn get_balance_keys(&mut self) -> Vec<Key> {
         let correlation_id = CorrelationId::new();
@@ -1437,7 +1393,7 @@ where
         self.advance_eras_by(auction_delay + 1, reward_items);
     }
 
-    /// Advancess by a single era.
+    /// Advances by a single era.
     pub fn advance_era(&mut self, reward_items: impl IntoIterator<Item = RewardItem>) {
         self.advance_eras_by(1, reward_items);
     }
@@ -1467,5 +1423,52 @@ where
             .config()
             .system_config()
             .handle_payment_costs()
+    }
+
+    /// Gets the transform map that's cached between runs
+    #[deprecated(
+        since = "2.1.0",
+        note = "Use `get_execution_journals` that returns transforms in the order they were created."
+    )]
+    pub fn get_transforms(&self) -> Vec<AdditiveMap<Key, Transform>> {
+        self.transforms
+            .clone()
+            .into_iter()
+            .map(|journal| journal.into_iter().collect())
+            .collect()
+    }
+
+    /// Returns the results of all execs.
+    #[deprecated(
+        since = "2.3.0",
+        note = "use `get_last_exec_results` or `get_exec_result_owned` instead"
+    )]
+    pub fn get_exec_results(&self) -> &Vec<Vec<Rc<ExecutionResult>>> {
+        &self.exec_results
+    }
+
+    /// Returns the results of a specific exec.
+    #[deprecated(since = "2.3.0", note = "use `get_exec_result_owned` instead")]
+    pub fn get_exec_result(&self, index: usize) -> Option<&Vec<Rc<ExecutionResult>>> {
+        self.exec_results.get(index)
+    }
+
+    /// Gets [`UnbondingPurses`].
+    #[deprecated(since = "2.3.0", note = "use `get_withdraw_purses` instead")]
+    pub fn get_withdraws(&mut self) -> UnbondingPurses {
+        let withdraw_purses = self.get_withdraw_purses();
+        let unbonding_purses: UnbondingPurses = withdraw_purses
+            .iter()
+            .map(|(key, withdraw_purse)| {
+                (
+                    key.to_owned(),
+                    withdraw_purse
+                        .iter()
+                        .map(|withdraw_purse| withdraw_purse.to_owned().into())
+                        .collect::<Vec<UnbondingPurse>>(),
+                )
+            })
+            .collect::<BTreeMap<AccountHash, Vec<UnbondingPurse>>>();
+        unbonding_purses
     }
 }

--- a/execution_engine_testing/tests/src/test/regression/regression_20220204.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220204.rs
@@ -292,7 +292,6 @@ fn regression_20220204_as_session_attenuated() {
     .build();
     builder.exec(exec_request_2).commit();
     let error = builder.get_error().expect("should have returned an error");
-    println!("{:?}", error);
     assert!(
         matches!(
             error,

--- a/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220303.rs
@@ -73,7 +73,6 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32, upgrade_entri
 
     let mut rng = casper_types::testing::TestRng::new();
     if upgrade_entries > 0 {
-        println!("Adding {upgrade_entries} global state update entries");
         for _ in 0..upgrade_entries {
             global_state_update.insert(
                 Key::URef(URef::new(rng.gen(), AccessRights::empty())),
@@ -90,7 +89,6 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32, upgrade_entri
             .with_global_state_update(global_state_update)
             .build()
     };
-    println!("starting upgrade");
     let start = Instant::now();
     builder
         .upgrade_with_upgrade_request_using_scratch(
@@ -105,7 +103,6 @@ fn test_upgrade(major_bump: u32, minor_bump: u32, patch_bump: u32, upgrade_entri
         "upgrade took too long! {} (millis)",
         elapsed.as_millis()
     );
-    println!("upgrade took {} millis", elapsed.as_millis());
     let new_contract = builder
         .get_contract(mint_contract_hash)
         .expect("should have mint contract");

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -120,12 +120,6 @@ impl Digest {
         Digest(result)
     }
 
-    /// Provides the same functionality as [`Digest::hash_merkle_tree`].
-    #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
-    pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
-        Digest::hash_merkle_tree(vec)
-    }
-
     /// Returns the underlying BLAKE2b hash bytes
     pub fn value(&self) -> [u8; Digest::LENGTH] {
         self.0
@@ -237,6 +231,12 @@ impl Digest {
                     .map(Digest::blake2b_hash),
             )
         }
+    }
+
+    /// Provides the same functionality as [`Digest::hash_merkle_tree`].
+    #[deprecated(since = "1.5.0", note = "use `hash_merkle_tree` instead")]
+    pub fn hash_vec_merkle_tree(vec: Vec<Digest>) -> Digest {
+        Digest::hash_merkle_tree(vec)
     }
 }
 

--- a/node/src/components/diagnostics_port/stop_at.rs
+++ b/node/src/components/diagnostics_port/stop_at.rs
@@ -79,14 +79,12 @@ mod tests {
 
         #[test]
         fn string_fuzz_stop_at_spec(input in ".*") {
-            let outcome = StopAtSpec::from_str(&input);
-            println!("{:?}", outcome);
+            let _outcome = StopAtSpec::from_str(&input);
         }
 
         #[test]
         fn prefixed_examples(input in "(era|block):.*") {
-            let outcome = StopAtSpec::from_str(&input);
-            println!("{:?}", outcome);
+            let _outcome = StopAtSpec::from_str(&input);
         }
     }
 


### PR DESCRIPTION
This PR adds a `note` to the deprecation attribute of `DEFAULT_RUN_GENESIS_REQUEST` in order to help users better resolve deprecation warnings caused by it.

It also moves deprecated methods to the foot of impl blocks (as per standard recommendations) to leave the main portion of generated docs uncluttered with deprecated methods.

Finally, it removes some `println!` statements from various tests.