### PR TITLE
Improve several nctl functions

### DIFF
--- a/utils/nctl/sh/node/join.sh
+++ b/utils/nctl/sh/node/join.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+source "$NCTL"/sh/utils/infra.sh
 source "$NCTL"/sh/utils/main.sh
 source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
 
@@ -23,18 +24,13 @@ NODE_ID=${NODE_ID:-6}
 BID_AMOUNT=${BID_AMOUNT:-$(get_node_staking_weight "$NODE_ID")}
 BID_DELEGATION_RATE=${BID_DELEGATION_RATE:-2}
 
+
 # ----------------------------------------------------------------
 # MAIN
 # ----------------------------------------------------------------
 
-# Await genesis era to complete.
-if [ "$(get_chain_era)" -lt 1 ]; then
-    log "awaiting genesis era to complete"
-    while [ "$(get_chain_era)" -lt 1 ];
-    do
-        sleep 1.0
-    done
-fi
+log "awaiting genesis era to complete"
+do_await_genesis_era_to_complete false
 
 # Submit auction bid.
 log "dispatching auction bid deploy"

--- a/utils/nctl/sh/node/join.sh
+++ b/utils/nctl/sh/node/join.sh
@@ -28,7 +28,7 @@ BID_DELEGATION_RATE=${BID_DELEGATION_RATE:-2}
 # ----------------------------------------------------------------
 
 # Await genesis era to complete.
-if [ "$(get_chain_era)" -eq 0 ]; then
+if [ "$(get_chain_era)" -lt 1 ]; then
     log "awaiting genesis era to complete"
     while [ "$(get_chain_era)" -lt 1 ];
     do

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -70,7 +70,7 @@ function do_background_wasmless_transfers() {
 function check_transfer_inclusion() {
     local NODE_ID=${1}
     local WALKBACK=${2}
-    local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d')
+    local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d' | sed '/FAILED to send/d')
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
     log_step "Checking transfer inclusion..."

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -69,7 +69,7 @@ function do_background_wasm_transfers() {
 function check_wasm_inclusion() {
     local NODE_ID=${1}
     local WALKBACK=${2}
-    local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d')
+    local TRANSFER_HASHES=$(cat "$DEPLOY_LOG" | awk -F'::' '{print $4}' | sed 's/^[ \t]*//' | sed '/^[[:space:]]*$/d' | sed '/FAILED to send/d')
     local TRANSFER_COUNT=$(echo "$TRANSFER_HASHES" | wc -l)
     local HASH
     log_step "Checking wasm inclusion..."

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -3,9 +3,11 @@
 #######################################
 # Awaits for the chain to proceed N eras.
 # Arguments:
-#   Network ordinal identifier.
-#   Node ordinal identifier.
 #   Future era offset to apply.
+#   Whether to log progress or not.
+#   Sleep interval.
+#   Node ordinal identifier.
+#   Timeout for function.
 #######################################
 function await_n_eras()
 {
@@ -18,7 +20,8 @@ function await_n_eras()
     local FUTURE
     local LOG_OUTPUT
 
-    CURRENT=$(get_chain_era "$NODE_ID")
+    # 60 second retry period to allow for network upgrades.
+    CURRENT=$(get_chain_era "$NODE_ID" 60)
     while [ "$CURRENT" -lt 0 ];
     do
         LOG_OUTPUT="current era = $CURRENT :: sleeping $SLEEP_INTERVAL seconds"
@@ -43,7 +46,7 @@ function await_n_eras()
             fi
         fi
 
-        CURRENT=$(get_chain_era "$NODE_ID")
+        CURRENT=$(get_chain_era "$NODE_ID" 60)
     done
 
     FUTURE=$((CURRENT + OFFSET))
@@ -73,7 +76,7 @@ function await_n_eras()
             fi
         fi
 
-        CURRENT=$(get_chain_era "$NODE_ID")
+        CURRENT=$(get_chain_era "$NODE_ID" 60)
     done
 
     if [ "$EMIT_LOG" = true ]; then
@@ -84,9 +87,9 @@ function await_n_eras()
 #######################################
 # Awaits for the chain to proceed N blocks.
 # Arguments:
-#   Network ordinal identifier.
-#   Node ordinal identifier.
 #   Future block height offset to apply.
+#   Whether to log progress or not.
+#   Node ordinal identifier.
 #######################################
 function await_n_blocks()
 {
@@ -97,7 +100,12 @@ function await_n_blocks()
     local CURRENT
     local FUTURE
 
-    CURRENT=$(get_chain_height "$NODE_ID")
+    # 60 second retry period to allow for network upgrades.
+    CURRENT=$(get_chain_height "$NODE_ID" 60)
+    if [ "$CURRENT" == "N/A" ]; then
+        log "unable to get current block height using node $NODE_ID"
+        exit 1
+    fi
     FUTURE=$((CURRENT + OFFSET))
 
     while [ "$CURRENT" -lt "$FUTURE" ];
@@ -106,7 +114,11 @@ function await_n_blocks()
             log "current block height = $CURRENT :: future height = $FUTURE ... sleeping 2 seconds"
         fi
         sleep 2.0
-        CURRENT=$(get_chain_height "$NODE_ID")
+        CURRENT=$(get_chain_height "$NODE_ID" 60)
+        if [ "$CURRENT" == "N/A" ]; then
+            log "unable to get current block height using node $NODE_ID"
+            exit 1
+        fi
     done
 
     if [ "$EMIT_LOG" = true ]; then
@@ -117,17 +129,16 @@ function await_n_blocks()
 #######################################
 # Awaits for the chain to proceed N eras.
 # Arguments:
-#   Network ordinal identifier.
-#   Node ordinal identifier.
 #   Future era offset to apply.
+#   Whether to log progress or not.
 #######################################
 function await_until_era_n()
 {
     local ERA=${1}
     local EMIT_LOG=${2:-false}
 
-    while [ "$(get_chain_era)" -lt "$ERA" ];
-    do
+    # 60 second retry period to allow for network upgrades.
+    while [ "$(get_chain_era '' 60)" -lt "$ERA" ]; do
         if [ "$EMIT_LOG" = true ]; then
             log "waiting for future era = $ERA ... sleeping 2 seconds"
         fi
@@ -138,16 +149,14 @@ function await_until_era_n()
 #######################################
 # Awaits for the chain to proceed N blocks.
 # Arguments:
-#   Network ordinal identifier.
-#   Node ordinal identifier.
 #   Future block offset to apply.
 #######################################
 function await_until_block_n()
 {
     local HEIGHT=${1}
 
-    while [ "$HEIGHT" -lt "$(get_chain_height)" ];
-    do
+    # 60 second retry period to allow for network upgrades.
+    while [ "$HEIGHT" -lt "$(get_chain_height '' 60)" ]; do
         sleep 10.0
     done
 }
@@ -156,6 +165,7 @@ function await_until_block_n()
 # Awaits for a node to sync to genesis.
 # Arguments:
 #   Node ordinal identifier.
+#   Timeout for function.
 #######################################
 function await_node_historical_sync_to_genesis() {
     local NODE_ID=${1}

--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -10,7 +10,7 @@
 function get_bootstrap_known_address()
 {
     local NODE_ID=${1}
-    local NET_ID=${NET_ID:-1}    
+    local NET_ID=${NET_ID:-1}
     local NODE_PORT=$((NCTL_BASE_PORT_NETWORK + (NET_ID * 100) + NODE_ID))
 
     echo "'127.0.0.1:$NODE_PORT'"
@@ -37,7 +37,7 @@ function get_count_of_genesis_nodes()
 # Returns count of all network nodes.
 #######################################
 function get_count_of_nodes()
-{    
+{
     find "$(get_path_to_net)"/nodes/* -maxdepth 0 -type d | wc -l
 }
 
@@ -54,7 +54,7 @@ function get_count_of_up_nodes()
         if [ "$(get_node_is_up "$NODE_ID")" == true ]; then
             COUNT=$((COUNT + 1))
         fi
-    done    
+    done
 
     echo $COUNT
 }
@@ -63,7 +63,7 @@ function get_count_of_up_nodes()
 # Returns count of test users.
 #######################################
 function get_count_of_users()
-{    
+{
     find "$(get_path_to_net)"/users/* -maxdepth 0 -type d | wc -l
 }
 
@@ -76,7 +76,7 @@ function get_network_bind_address()
 {
     local NODE_ID=${1}
 
-    echo "0.0.0.0:$(get_node_port "$NCTL_BASE_PORT_NETWORK" "$NODE_ID")"   
+    echo "0.0.0.0:$(get_node_port "$NCTL_BASE_PORT_NETWORK" "$NODE_ID")"
 }
 
 #######################################
@@ -113,7 +113,7 @@ function get_network_known_addresses()
 #######################################
 function get_node_address_event()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     echo "http://localhost:$(get_node_port "$NCTL_BASE_PORT_SSE" "$NODE_ID")"
 }
@@ -125,7 +125,7 @@ function get_node_address_event()
 #######################################
 function get_node_address_rest()
 {
-    local NODE_ID=${1}   
+    local NODE_ID=${1}
 
     echo "http://localhost:$(get_node_port "$NCTL_BASE_PORT_REST" "$NODE_ID")"
 }
@@ -137,7 +137,7 @@ function get_node_address_rest()
 #######################################
 function get_node_address_rpc()
 {
-    local NODE_ID=${1}      
+    local NODE_ID=${1}
 
     echo "http://localhost:$(get_node_port "$NCTL_BASE_PORT_RPC" "$NODE_ID")"
 }
@@ -149,7 +149,7 @@ function get_node_address_rpc()
 #######################################
 function get_node_address_rpc_for_curl()
 {
-    local NODE_ID=${1}   
+    local NODE_ID=${1}
 
     echo "$(get_node_address_rpc "$NODE_ID")/rpc"
 }
@@ -177,9 +177,9 @@ function get_node_for_dispatch()
 #######################################
 function get_node_is_up()
 {
-    local NODE_ID=${1}  
-    local NODE_PORT  
-    
+    local NODE_ID=${1}
+    local NODE_PORT
+
     NODE_PORT=$(get_node_port_rpc "$NODE_ID")
 
     if grep -q "$NODE_PORT (LISTEN)" <<< "$(lsof -i -P -n)"; then
@@ -197,9 +197,9 @@ function get_node_is_up()
 #######################################
 function get_node_port()
 {
-    local BASE_PORT=${1}    
-    local NODE_ID=${2:-$(get_node_for_dispatch)}    
-    local NET_ID=${NET_ID:-1}    
+    local BASE_PORT=${1}
+    local NODE_ID=${2:-$(get_node_for_dispatch)}
+    local NET_ID=${NET_ID:-1}
 
     # TODO: Need to handle case of more than 99 nodes.
     echo $((BASE_PORT + (NET_ID * 100) + NODE_ID))
@@ -212,7 +212,7 @@ function get_node_port()
 #######################################
 function get_node_port_speculative_exec()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     get_node_port "$NCTL_BASE_PORT_SPEC_EXEC" "$NODE_ID"
 }
@@ -224,7 +224,7 @@ function get_node_port_speculative_exec()
 #######################################
 function get_node_port_rest()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     get_node_port "$NCTL_BASE_PORT_REST" "$NODE_ID"
 }
@@ -236,7 +236,7 @@ function get_node_port_rest()
 #######################################
 function get_node_port_rpc()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     get_node_port "$NCTL_BASE_PORT_RPC" "$NODE_ID"
 }
@@ -248,7 +248,7 @@ function get_node_port_rpc()
 #######################################
 function get_node_port_sse()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     get_node_port "$NCTL_BASE_PORT_SSE" "$NODE_ID"
 }
@@ -260,7 +260,7 @@ function get_node_port_sse()
 #######################################
 function get_node_staking_weight()
 {
-    local NODE_ID=${1}    
+    local NODE_ID=${1}
 
     echo $((NCTL_VALIDATOR_BASE_WEIGHT + NODE_ID))
 }
@@ -280,11 +280,11 @@ function get_process_group_members()
     if [ "$PROCESS_GROUP" == "$NCTL_PROCESS_GROUP_1" ]; then
         SEQ_START=1
         SEQ_END=$(get_count_of_bootstrap_nodes)
-    
+
     elif [ "$PROCESS_GROUP" == "$NCTL_PROCESS_GROUP_2" ]; then
         SEQ_START=$(($(get_count_of_bootstrap_nodes) + 1))
         SEQ_END=$(get_count_of_genesis_nodes)
-    
+
     elif [ "$PROCESS_GROUP" == "$NCTL_PROCESS_GROUP_3" ]; then
         SEQ_START=$(($(get_count_of_genesis_nodes) + 1))
         SEQ_END=$(get_count_of_nodes)
@@ -311,9 +311,9 @@ function get_process_group_members()
 #######################################
 function get_process_name_of_node()
 {
-    local NODE_ID=${1} 
-    local NET_ID=${NET_ID:-1}    
-    
+    local NODE_ID=${1}
+    local NET_ID=${NET_ID:-1}
+
     echo "casper-net-$NET_ID-node-$NODE_ID"
 }
 
@@ -324,13 +324,13 @@ function get_process_name_of_node()
 #######################################
 function get_process_name_of_node_in_group()
 {
-    local NODE_ID=${1} 
+    local NODE_ID=${1}
     local NODE_PROCESS_NAME
     local PROCESS_GROUP_NAME
 
     NODE_PROCESS_NAME=$(get_process_name_of_node "$NODE_ID")
     PROCESS_GROUP_NAME=$(get_process_name_of_node_group "$NODE_ID")
-    
+
     echo "$PROCESS_GROUP_NAME:$NODE_PROCESS_NAME"
 }
 
@@ -342,8 +342,8 @@ function get_process_name_of_node_in_group()
 #######################################
 function get_process_name_of_node_group()
 {
-    local NODE_ID=${1} 
-    
+    local NODE_ID=${1}
+
     if [ "$NODE_ID" -le "$(get_count_of_bootstrap_nodes)" ]; then
         echo "$NCTL_PROCESS_GROUP_1"
     elif [ "$NODE_ID" -le "$(get_count_of_genesis_nodes)" ]; then
@@ -379,7 +379,7 @@ function do_await_genesis_era_to_complete() {
         CURRENT_ERA=$(get_chain_era)
         if [ "$CURRENT_ERA" -ge "2" ]
         then
-            log_step "genesis reached, era=$CURRENT_ERA"
+            log "genesis reached, era=$CURRENT_ERA"
             return
         fi
         TIMEOUT=$((TIMEOUT-1))

--- a/utils/nctl/sh/views/view_chain_era.sh
+++ b/utils/nctl/sh/views/view_chain_era.sh
@@ -6,18 +6,20 @@ source "$NCTL"/sh/utils/main.sh
 # Renders chain era at specified node(s).
 # Arguments:
 #   Node ordinal identifier.
+#   Duration for which to retry once per second in the case the node is not responding.
 #######################################
 function main()
 {
     local NODE_ID=${1}
+    local TIMEOUT_SEC=${2}
 
     if [ "$NODE_ID" = "all" ]; then
         for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
         do
-            log "chain era @ node-$NODE_ID = $(get_chain_era "$NODE_ID")"
+            log "chain era @ node-$NODE_ID = $(get_chain_era "$NODE_ID" "$TIMEOUT_SEC")"
         done
     else
-        log "chain era @ node-$NODE_ID = $(get_chain_era "$NODE_ID")"
+        log "chain era @ node-$NODE_ID = $(get_chain_era "$NODE_ID" "$TIMEOUT_SEC")"
     fi
 }
 
@@ -26,6 +28,7 @@ function main()
 # ----------------------------------------------------------------
 
 unset NODE_ID
+unset TIMEOUT_SEC
 
 for ARGUMENT in "$@"
 do
@@ -33,8 +36,9 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in
         node) NODE_ID=${VALUE} ;;
+        timeout) TIMEOUT_SEC=${VALUE} ;;
         *)
     esac
 done
 
-main "${NODE_ID:-"all"}"
+main "${NODE_ID:-"all"}" "${TIMEOUT_SEC:-"0"}"

--- a/utils/nctl/sh/views/view_chain_height.sh
+++ b/utils/nctl/sh/views/view_chain_height.sh
@@ -6,18 +6,20 @@ source "$NCTL"/sh/utils/main.sh
 # Renders chain height at specified node(s).
 # Arguments:
 #   Node ordinal identifier.
+#   Duration for which to retry once per second in the case the node is not responding.
 #######################################
 function main()
 {
     local NODE_ID=${1}
+    local TIMEOUT_SEC=${2:-0}
 
     if [ "$NODE_ID" = "all" ]; then
         for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
         do
-            log "chain height @ node-$NODE_ID = $(get_chain_height "$NODE_ID")"
+            log "chain height @ node-$NODE_ID = $(get_chain_height "$NODE_ID" "$TIMEOUT_SEC")"
         done
     else
-        log "chain height @ node-$NODE_ID = $(get_chain_height "$NODE_ID")"
+        log "chain height @ node-$NODE_ID = $(get_chain_height "$NODE_ID" "$TIMEOUT_SEC")"
     fi
 }
 
@@ -26,6 +28,7 @@ function main()
 # ----------------------------------------------------------------
 
 unset NODE_ID
+unset TIMEOUT_SEC
 
 for ARGUMENT in "$@"
 do
@@ -33,8 +36,9 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in
         node) NODE_ID=${VALUE} ;;
+        timeout) TIMEOUT_SEC=${VALUE} ;;
         *)
     esac
 done
 
-main "${NODE_ID:-"all"}"
+main "${NODE_ID:-"all"}" "${TIMEOUT_SEC:-"0"}"


### PR DESCRIPTION
This PR makes the blocking nctl functions more robust in that they should be successful across a network upgrade.  It resolves the issue of `bash: N/A: division by 0 (error token is "A")` causing upgrade scenario 6 to fail (see [this comment](https://github.com/casper-network/casper-node/issues/3862#issuecomment-1529566944) for details of the issue).

To achieve this, several of the functions in queries.sh were updated to use a new common function which attempts (with retries) to get a specific field from the status REST response of a given node.

The PR also removes a small number of unused functions from queries.rs.

Note that this PR merged with #3907 passed the full nightly test suite locally.

Closes #3862.
