### PR TITLE
Fix network_soundness.py test

### DIFF
--- a/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
+++ b/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
@@ -28,8 +28,10 @@ function main()
     local CP1_SECRET_KEY
     local CP1_ACCOUNT_KEY
     local CP2_ACCOUNT_KEY
-    local DISPATCHED
+    local DISPATCH_ATTEMPTS
+    local SUCCESSFUL_DISPATCH_COUNT
     local DISPATCH_NODE_ADDRESS
+    local OUTPUT
 
     CHAIN_NAME=$(get_chain_name)
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
@@ -54,14 +56,15 @@ function main()
         log "... transfer interval=$INTERVAL (s)"
         log "... counter-party 1 public key=$CP1_ACCOUNT_KEY"
         log "... counter-party 2 public key=$CP2_ACCOUNT_KEY"
-        log "... dispatched deploys:"    
+        log "... dispatched deploys:"
     fi
 
-    DISPATCHED=0
-    while [ $DISPATCHED -lt "$TRANSFERS" ];
-    do
+    DISPATCH_ATTEMPTS=0
+    SUCCESSFUL_DISPATCH_COUNT=0
+    while [ $DISPATCH_ATTEMPTS -lt "$TRANSFERS" ]; do
+        DISPATCH_ATTEMPTS=$((DISPATCH_ATTEMPTS + 1))
         DISPATCH_NODE_ADDRESS=${NODE_ADDRESS:-$(get_node_address_rpc)}
-        DEPLOY_HASH=$(
+        OUTPUT=$(
             $PATH_TO_CLIENT transfer \
                 --chain-name "$CHAIN_NAME" \
                 --node-address "$DISPATCH_NODE_ADDRESS" \
@@ -70,19 +73,24 @@ function main()
                 --secret-key "$CP1_SECRET_KEY" \
                 --amount "$AMOUNT" \
                 --target-account "$CP2_ACCOUNT_KEY" \
-                --transfer-id $((DISPATCHED + 1)) \
-                | jq '.result.deploy_hash' \
-                | sed -e 's/^"//' -e 's/"$//'
+                --transfer-id $((DISPATCHED + 1))
             )
-        DISPATCHED=$((DISPATCHED + 1))
-        if [ $VERBOSE == true ]; then
-            log "... #$DISPATCHED :: $DISPATCH_NODE_ADDRESS :: $DEPLOY_HASH"
+        if [[ $? -eq 0 ]]; then
+            SUCCESSFUL_DISPATCH_COUNT=$((SUCCESSFUL_DISPATCH_COUNT + 1))
+            DEPLOY_HASH=$(echo $OUTPUT | jq '.result.deploy_hash' | sed -e 's/^"//' -e 's/"$//')
+            if [ $VERBOSE == true ]; then
+                log "... #$DISPATCH_ATTEMPTS :: $DISPATCH_NODE_ADDRESS :: $DEPLOY_HASH"
+            fi
+        else
+            if [ $VERBOSE == true ]; then
+                log "... #$DISPATCH_ATTEMPTS :: $DISPATCH_NODE_ADDRESS :: FAILED to send"
+            fi
         fi
         sleep "$INTERVAL"
     done
 
     if [ $VERBOSE == true ]; then
-        log "dispatched $TRANSFERS native transfers"
+        log "successfully dispatched $SUCCESSFUL_DISPATCH_COUNT of $DISPATCH_ATTEMPTS native transfers"
     fi
 }
 
@@ -104,7 +112,7 @@ do
     case "$KEY" in
         amount) AMOUNT=${VALUE} ;;
         interval) INTERVAL=${VALUE} ;;
-        node) NODE_ID=${VALUE} ;;        
+        node) NODE_ID=${VALUE} ;;
         transfers) TRANSFERS=${VALUE} ;;
         user) USER_ID=${VALUE} ;;
         verbose) VERBOSE=${VALUE} ;;

--- a/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
+++ b/utils/nctl/sh/contracts-transfers/do_dispatch_native.sh
@@ -73,7 +73,7 @@ function main()
                 --secret-key "$CP1_SECRET_KEY" \
                 --amount "$AMOUNT" \
                 --target-account "$CP2_ACCOUNT_KEY" \
-                --transfer-id $((DISPATCHED + 1))
+                --transfer-id $((DISPATCH_ATTEMPTS + 1))
             )
         if [[ $? -eq 0 ]]; then
             SUCCESSFUL_DISPATCH_COUNT=$((SUCCESSFUL_DISPATCH_COUNT + 1))


### PR DESCRIPTION
This PR fixes the issue of chunking not being detected in the network_soundness.py test.

The cause was simply the `block_gas_limit` being too low in the chainspec to support executing the huge deploy.  The test now increases that value before starting the nctl network.

Also, the `run_health_checks` function now accesses all nodes' logs rather than just those of nodes 1..[current running count], which could possibly exclude the single set of logs containing the "chunk" lines.

There are also a couple of changes to avoid generating error messages when invoking `nctl-transfer-native` or `nctl-transfer-wasm` where the specified node is not running.  These messages were polluting the output of this test (at least, the `nctl-transfer-wasm` ones were).

Closes #3905.