### PR TITLE
Merge `release-1.4.15` to `dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.14"
+version = "1.4.15"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -197,6 +197,26 @@ function start_upgrade_scenario_12() {
     nctl-exec-upgrade-scenario-12
 }
 
+function start_upgrade_scenario_13() {
+    log "... Setting up custom starting version"
+    local PATH_TO_STAGE
+
+    PATH_TO_STAGE="$(get_path_to_stage 1)"
+
+    log "... downloading remote for 1.4.13"
+    nctl-stage-set-remotes "1.4.13"
+
+    log "... tearing down old stages"
+    nctl-stage-teardown
+
+    log "... creating new stage"
+    dev_branch_settings "$PATH_TO_STAGE" "1.4.13"
+    build_from_settings_file
+
+    log "... Starting Upgrade Scenario 13"
+    nctl-exec-upgrade-scenario-13
+}
+
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -83,6 +83,7 @@ function run_nightly_upgrade_test() {
     bash -i ./ci/nctl_upgrade.sh test_id=10
     bash -i ./ci/nctl_upgrade.sh test_id=11
     bash -i ./ci/nctl_upgrade.sh test_id=12
+    bash -i ./ci/nctl_upgrade.sh test_id=13
 }
 
 function run_soundness_test() {

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -11,6 +11,22 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 3.1.1
+
+### Changed
+* Update the following constant values to match settings in production chainspec:
+  * `DEFAULT_RET_VALUE_SIZE_WEIGHT`
+  * `DEFAULT_CONTROL_FLOW_CALL_OPCODE`
+  * `DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE`
+  * `DEFAULT_GAS_PER_BYTE_COST`
+  * `DEFAULT_ADD_BID_COST`
+  * `DEFAULT_WITHDRAW_BID_COST`
+  * `DEFAULT_DELEGATE_COST`
+  * `DEFAULT_UNDELEGATE_COST`
+  * `DEFAULT_MAX_STACK_HEIGHT`
+
+
+
 ## 3.1.0
 
 ### Added

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "3.1.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.1.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/3.1.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/3.1.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -19,8 +19,8 @@ const NOT_USED: Cost = 0;
 /// An arbitrary default fixed cost for host functions that were not researched yet.
 const DEFAULT_FIXED_COST: Cost = 200;
 
-const DEFAULT_ADD_ASSOCIATED_KEY_COST: u32 = 9_000;
 const DEFAULT_ADD_COST: u32 = 5_800;
+const DEFAULT_ADD_ASSOCIATED_KEY_COST: u32 = 9_000;
 
 const DEFAULT_CALL_CONTRACT_COST: u32 = 4_500;
 const DEFAULT_CALL_CONTRACT_ARGS_SIZE_WEIGHT: u32 = 420;
@@ -60,7 +60,7 @@ const DEFAULT_REMOVE_KEY_COST: u32 = 61_000;
 const DEFAULT_REMOVE_KEY_NAME_SIZE_WEIGHT: u32 = 3_200;
 
 const DEFAULT_RET_COST: u32 = 23_000;
-const DEFAULT_RET_VALUE_SIZE_WEIGHT: u32 = 420;
+const DEFAULT_RET_VALUE_SIZE_WEIGHT: u32 = 420_000;
 
 const DEFAULT_REVERT_COST: u32 = 500;
 const DEFAULT_SET_ACTION_THRESHOLD_COST: u32 = 74_000;
@@ -86,6 +86,7 @@ pub(crate) const DEFAULT_HOST_FUNCTION_NEW_DICTIONARY: HostFunction<[Cost; 1]> =
 /// The total gas cost is equal to `cost` + sum of each argument weight multiplied by the byte size
 /// of the data.
 #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HostFunction<T> {
     /// How much the user is charged for calling the host function.
     cost: Cost,
@@ -197,6 +198,7 @@ where
 
 /// Definition of a host function cost table.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HostFunctionCosts {
     /// Cost of calling the `read_value` host function.
     pub read_value: HostFunction<[Cost; 3]>,

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -51,23 +51,23 @@ pub const DEFAULT_CONTROL_FLOW_ELSE_OPCODE: u32 = 440;
 /// Default cost of the `end` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_END_OPCODE: u32 = 440;
 /// Default cost of the `br` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 440000;
+pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 440_000;
 /// Default cost of the `br_if` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 440000;
-/// Default fixed cost of the `br_table` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 440000;
-/// Default multiplier for the size of targets in `br_table` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER: u32 = 100;
+pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 440_000;
 /// Default cost of the `return` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_RETURN_OPCODE: u32 = 440;
-/// Default cost of the `call` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 440;
-/// Default cost of the `call_indirect` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 440;
-/// Default cost of the `drop` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_DROP_OPCODE: u32 = 440;
 /// Default cost of the `select` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_SELECT_OPCODE: u32 = 440;
+/// Default cost of the `call` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 140_000;
+/// Default cost of the `call_indirect` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 140_000;
+/// Default cost of the `drop` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_DROP_OPCODE: u32 = 440;
+/// Default fixed cost of the `br_table` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 440_000;
+/// Default multiplier for the size of targets in `br_table` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER: u32 = 100;
 
 /// Definition of a cost table for a Wasm `br_table` opcode.
 ///
@@ -78,6 +78,7 @@ pub const DEFAULT_CONTROL_FLOW_SELECT_OPCODE: u32 = 440;
 /// ```
 // This is done to encourage users to avoid writing code with very long `br_table`s.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct BrTableCost {
     /// Fixed cost charge for `br_table` opcode.
     pub cost: u32,
@@ -144,6 +145,7 @@ impl FromBytes for BrTableCost {
 
 /// Definition of a cost table for a Wasm control flow opcodes.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct ControlFlowCosts {
     /// Cost for `block` opcode.
     pub block: u32,
@@ -324,6 +326,7 @@ impl Distribution<ControlFlowCosts> for Standard {
 ///
 /// This is taken (partially) from parity-ethereum.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct OpcodeCosts {
     /// Bit operations multiplier.
     pub bit: u32,

--- a/execution_engine/src/shared/storage_costs.rs
+++ b/execution_engine/src/shared/storage_costs.rs
@@ -9,10 +9,11 @@ use casper_types::{
 };
 
 /// Default gas cost per byte stored.
-pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 625_000;
+pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 630_000;
 
 /// Represents a cost table for storage costs.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct StorageCosts {
     /// Gas charged per byte stored in the global state.
     gas_per_byte: u32,

--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 100_000_000;
 /// This structure contains the costs of all the system contract's entry points and, additionally,
 /// it defines a wasmless transfer cost.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct SystemConfig {
     /// Wasmless transfer cost expressed in gas.
     wasmless_transfer_cost: u32,

--- a/execution_engine/src/shared/system_config/auction_costs.rs
+++ b/execution_engine/src/shared/system_config/auction_costs.rs
@@ -9,13 +9,13 @@ pub const DEFAULT_GET_ERA_VALIDATORS_COST: u32 = 10_000;
 /// Default cost of the `read_seigniorage_recipients` auction entry point.
 pub const DEFAULT_READ_SEIGNIORAGE_RECIPIENTS_COST: u32 = 10_000;
 /// Default cost of the `add_bid` auction entry point.
-pub const DEFAULT_ADD_BID_COST: u32 = 10_000;
+pub const DEFAULT_ADD_BID_COST: u32 = 2_500_000_000;
 /// Default cost of the `withdraw_bid` auction entry point.
-pub const DEFAULT_WITHDRAW_BID_COST: u32 = 10_000;
+pub const DEFAULT_WITHDRAW_BID_COST: u32 = 2_500_000_000;
 /// Default cost of the `delegate` auction entry point.
-pub const DEFAULT_DELEGATE_COST: u32 = 10_000;
+pub const DEFAULT_DELEGATE_COST: u32 = 2_500_000_000;
 /// Default cost of the `undelegate` auction entry point.
-pub const DEFAULT_UNDELEGATE_COST: u32 = 10_000;
+pub const DEFAULT_UNDELEGATE_COST: u32 = 2_500_000_000;
 /// Default cost of the `run_auction` auction entry point.
 pub const DEFAULT_RUN_AUCTION_COST: u32 = 10_000;
 /// Default cost of the `slash` auction entry point.
@@ -33,6 +33,7 @@ pub const DEFAULT_ACTIVATE_BID_COST: u32 = 10_000;
 
 /// Description of the costs of calling auction entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct AuctionCosts {
     /// Cost of calling the `get_era_validators` entry point.
     pub get_era_validators: u32,

--- a/execution_engine/src/shared/system_config/handle_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/handle_payment_costs.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 
 /// Description of the costs of calling `handle_payment` entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HandlePaymentCosts {
     /// Cost of calling the `get_payment_purse` entry point.
     pub get_payment_purse: u32,

--- a/execution_engine/src/shared/system_config/mint_costs.rs
+++ b/execution_engine/src/shared/system_config/mint_costs.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
 
 /// Description of the costs of calling mint entry points.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct MintCosts {
     /// Cost of calling the `mint` entry point.
     pub mint: u32,

--- a/execution_engine/src/shared/system_config/standard_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/standard_payment_costs.rs
@@ -9,6 +9,7 @@ const DEFAULT_PAY_COST: u32 = 10_000;
 
 /// Description of the costs of calling standard payment entry points.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct StandardPaymentCosts {
     /// Cost of calling the `pay` entry point.
     pub pay: u32,

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -12,13 +12,14 @@ use super::{
 /// Default maximum number of pages of the Wasm memory.
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 /// Default maximum stack height.
-pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 188;
+pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 200;
 
 /// Configuration of the Wasm execution environment.
 ///
 /// This structure contains various Wasm execution configuration options, such as memory limits,
 /// stack limits and costs.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct WasmConfig {
     /// Maximum amount of heap memory (represented in 64kB pages) each contract can use.
     pub max_memory: u32,

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 3.1.1
+
+### Changed
+* Updated chainspec values used in `PRODUCTION_RUN_GENESIS_REQUEST` to match those of Mainnet protocol version 1.4.15.
+
+
+
 ## 3.1.0
 
 ### Added

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "3.1.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.1.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-execution-engine = { version = "3.1.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "3.1.1", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.6.0", path = "../../types" }
 humantime = "2"

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.5.6"
 tempfile = "3"
 
 [dev-dependencies]
+casper-types = { version = "1.6.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [features]

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -74,7 +74,7 @@ pub fn run_blocks_with_transfers_and_step(
         &validator_keys,
         delegator_keys
             .iter()
-            .map(|pk| pk.to_account_hash())
+            .map(|public_key| public_key.to_account_hash())
             .collect::<Vec<_>>(),
         U512::from(TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE),
     );
@@ -342,7 +342,7 @@ pub fn create_delegate_request(
     let deploy = DeployItemBuilder::new()
         .with_address(delegator_account_hash)
         .with_stored_session_hash(contract_hash, entry_point, args)
-        .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(100_000_000), })
+        .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(2_500_000_000_u64) })
         .with_authorization_keys(&[delegator_account_hash])
         .with_deploy_hash(deploy_hash)
         .build();

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -198,14 +198,11 @@ pub static SYSTEM_ADDR: Lazy<AccountHash> = Lazy::new(|| PublicKey::System.to_ac
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
 
     #[test]
     fn defaults_should_match_production_chainspec_values() {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/chainspec.toml");
-        let production = ChainspecConfig::from_chainspec_path(path).unwrap();
+        let production = ChainspecConfig::from_chainspec_path(&*PRODUCTION_PATH).unwrap();
         // No need to test `CoreConfig::validator_slots`.
         assert_eq!(production.core_config.auction_delay, DEFAULT_AUCTION_DELAY);
         assert_eq!(

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.1.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.1.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.15
+
+### Changed
+* Modified JSON-RPCs `chain_get_era_info_by_switch_block` and `chain_get_era_summary` to use either `Key::EraInfo` or `Key::EraSummary` as appropriate in order to provide useful responses.
+
+
+
 ## 1.4.14
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.14" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.15" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,7 +20,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "3.1.0", path = "../execution_engine" }
+casper-execution-engine = { version = "3.1.1", path = "../execution_engine" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }
 casper-hashing = { version = "1.4.3", path = "../hashing" }
 casper-types = { version = "1.6.0", path = "../types", features = ["datasize", "json-schema", "std"] }

--- a/node/src/components/rpc_server/rpcs/common.rs
+++ b/node/src/components/rpc_server/rpcs/common.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use casper_execution_engine::storage::trie::merkle_proof::TrieMerkleProof;
 use casper_hashing::Digest;
 use casper_json_rpc::{ErrorCodeT, ReservedErrorCode};
 use casper_types::{bytesrepr::ToBytes, Key};
@@ -47,7 +48,19 @@ pub(super) async fn run_query_and_encode<REv: ReactorEventT>(
     path: Vec<String>,
 ) -> Result<(StoredValue, String), Error> {
     let (value, proofs) = state::run_query(effect_builder, state_root_hash, base_key, path).await?;
+    encode_query_success(value, proofs)
+}
 
+/// Converts the result of a successful global state query to a tuple of the JSON-compatible stored
+/// value and Merkle proof of the value.
+///
+/// The proof is bytesrepr-encoded, and then hex-encoded.
+///
+/// On error, a `warp_json_rpc::Error` is returned suitable for sending as a JSON-RPC response.
+pub(super) fn encode_query_success(
+    value: casper_types::StoredValue,
+    proofs: Vec<TrieMerkleProof<Key, casper_types::StoredValue>>,
+) -> Result<(StoredValue, String), Error> {
     let value_compat = match StoredValue::try_from(value) {
         Ok(value_compat) => value_compat,
         Err(error) => {

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 14);
+    ProtocolVersion::from_parts(1, 4, 15);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -9,10 +9,10 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use casper_execution_engine::{
-    core::engine_state::{BalanceResult, GetBidsResult, QueryResult},
+    core::engine_state::{self, BalanceResult, GetBidsResult, QueryResult},
     storage::trie::merkle_proof::TrieMerkleProof,
 };
 use casper_hashing::Digest;
@@ -1088,6 +1088,16 @@ pub(super) async fn run_query<REv: ReactorEventT>(
         )
         .await;
 
+    handle_query_result(effect_builder, state_root_hash, query_result).await
+}
+
+/// Converts the result of running a global state query into a type suitable for including in a
+/// JSON-RPC response.
+pub(super) async fn handle_query_result<REv: ReactorEventT>(
+    effect_builder: EffectBuilder<REv>,
+    state_root_hash: Digest,
+    query_result: Result<QueryResult, engine_state::Error>,
+) -> Result<QuerySuccess, Error> {
     match query_result {
         Ok(QueryResult::Success { value, proofs }) => Ok((*value, proofs)),
         Ok(QueryResult::RootNotFound) => {
@@ -1101,7 +1111,7 @@ pub(super) async fn run_query<REv: ReactorEventT>(
             Err(error)
         }
         Ok(query_result) => {
-            info!(?query_result, "query failed");
+            debug!(?query_result, "query failed");
             Err(Error::new(
                 ErrorCode::QueryFailed,
                 format!("{:?}", query_result),

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.14")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.15")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -105,7 +105,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 188
+max_stack_height = 200
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.
@@ -142,6 +142,8 @@ nop = 200
 current_memory = 290
 # Grow memory cost, per page (64kb).
 grow_memory = 240_000
+# Regular opcode cost.
+regular = 210
 
 # Control flow operations multiplier.
 [wasm.opcode_costs.control_flow]
@@ -154,8 +156,8 @@ br = 440_000
 br_if = 440_000
 return = 440
 select = 440
-call = 440
-call_indirect = 440
+call = 140_000
+call_indirect = 140_000
 drop = 440
 
 [wasm.opcode_costs.control_flow.br_table]

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -142,8 +142,6 @@ nop = 200
 current_memory = 290
 # Grow memory cost, per page (64kb).
 grow_memory = 240_000
-# Regular opcode cost.
-regular = 210
 
 # Control flow operations multiplier.
 [wasm.opcode_costs.control_flow]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.15'
+version = '1.4.14'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -145,8 +145,6 @@ nop = 200
 current_memory = 290
 # Grow memory cost, per page (64kb).
 grow_memory = 240_000
-# Regular opcode cost.
-regular = 210
 
 # Control flow operations multiplier.
 [wasm.opcode_costs.control_flow]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.14'
+version = '1.4.15'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.
@@ -11,7 +11,7 @@ hard_reset = true
 # in contract-runtime for computing genesis post-state hash.
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
-activation_point = 5900
+activation_point = 9100
 # Optional era ID in which the last emergency restart happened.
 #last_emergency_restart = 0
 
@@ -108,7 +108,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 188
+max_stack_height = 200
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.
@@ -159,8 +159,8 @@ br = 440_000
 br_if = 440_000
 return = 440
 select = 440
-call = 440
-call_indirect = 440
+call = 140_000
+call_indirect = 140_000
 drop = 440
 
 [wasm.opcode_costs.control_flow.br_table]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.14'
+version = '1.4.15'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -5,7 +5,7 @@
     {
       "openrpc": "1.0.0-rc1",
       "info": {
-        "version": "1.4.14",
+        "version": "1.4.15",
         "title": "Client API of Casper Node",
         "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
         "contact": {
@@ -120,7 +120,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -195,7 +195,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "deploy": {
                     "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                     "header": {
@@ -413,7 +413,7 @@
               "result": {
                 "name": "state_get_account_info_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "account": {
                     "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                     "named_keys": [],
@@ -509,7 +509,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "stored_value": {
                     "CLValue": {
@@ -617,7 +617,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block_header": {
                     "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
                     "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
@@ -715,7 +715,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "peers": [
                     {
                       "node_id": "tls:0101..0101",
@@ -824,7 +824,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "chainspec_name": "casper-example",
                   "starting_state_root_hash": "0202020202020202020202020202020202020202020202020202020202020202",
                   "peers": [
@@ -890,7 +890,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -962,7 +962,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block": {
                     "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "header": {
@@ -1090,7 +1090,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -1164,7 +1164,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -1253,7 +1253,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "stored_value": {
                     "CLValue": {
                       "cl_type": "U64",
@@ -1331,7 +1331,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -1394,7 +1394,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -1474,7 +1474,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "auction_state": {
                     "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                     "block_height": 10,
@@ -1556,7 +1556,7 @@
               "result": {
                 "name": "chain_get_era_summary_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -2717,7 +2717,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.14"
+        "version": "1.4.15"
       },
       "methods": [
         {
@@ -2782,7 +2782,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -2836,7 +2836,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "deploy": {
                     "approvals": [
                       {
@@ -3006,7 +3006,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3089,7 +3089,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3179,7 +3179,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
@@ -3322,7 +3322,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3367,7 +3367,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -3494,7 +3494,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -3554,7 +3554,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block": {
                     "body": {
                       "deploy_hashes": [
@@ -3672,7 +3672,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                   "transfers": [
                     {
@@ -3756,7 +3756,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -3826,7 +3826,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -3916,7 +3916,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -3986,7 +3986,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "era_summary": {
                     "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
                     "era_id": 42,
@@ -4072,7 +4072,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.14",
+                  "api_version": "1.4.15",
                   "auction_state": {
                     "bids": [
                       {

--- a/smart_contracts/contract_as/CHANGELOG.md
+++ b/smart_contracts/contract_as/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.15
+
+### Changed
+* Version bump to match casper-node version.
+
+
+
 ## 1.4.14
 
 ### Changed

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -165,3 +165,4 @@ alias nctl-exec-upgrade-scenario-9='source $NCTL/sh/scenarios-upgrades/upgrade_s
 alias nctl-exec-upgrade-scenario-10='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_10.sh'
 alias nctl-exec-upgrade-scenario-11='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_11.sh'
 alias nctl-exec-upgrade-scenario-12='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_12.sh'
+alias nctl-exec-upgrade-scenario-13='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_13.sh'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_13.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_13.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------
+# Synopsis.
+# ----------------------------------------------------------------
+
+# Step 01: Start network from pre-built stage.
+# Step 02: Await era-id >= 2.
+# Step 03: Stage nodes 1-5 and upgrade.
+# Step 04: Assert upgraded nodes 1-5.
+# Step 05: Assert nodes 1-5 didn't stall.
+# Step 06: Await 2 eras.
+# Step 07: Check rpc backwards compatibility for the
+#          chain_get_era_info_by_switch_block and chain_get_era_summary RPC endpoints
+# Step 08: Terminate.
+
+# ----------------------------------------------------------------
+# Imports.
+# ----------------------------------------------------------------
+
+source "$NCTL/sh/utils/main.sh"
+source "$NCTL/sh/views/utils.sh"
+source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Main entry point.
+function _main()
+{
+    local STAGE_ID=${1}
+    local INITIAL_PROTOCOL_VERSION
+    local ACTIVATION_POINT
+    local UPGRADE_HASH
+
+    if [ ! -d "$(get_path_to_stage "$STAGE_ID")" ]; then
+        log "ERROR :: stage $STAGE_ID has not been built - cannot run scenario"
+        exit 1
+    fi
+
+    _step_01 "$STAGE_ID"
+    _step_02
+
+    # Set initial protocol version for use later.
+    INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
+    # Establish consistent activation point for use later.
+    ACTIVATION_POINT="$(get_chain_era)"
+
+    _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
+    _step_04 "$INITIAL_PROTOCOL_VERSION"
+    _step_05
+    _step_06
+    _step_07
+    _step_08
+}
+
+# Step 01: Start network from pre-built stage.
+function _step_01()
+{
+    local STAGE_ID=${1}
+
+    log_step_upgrades 0 "Begin upgrade_scenario_13"
+    log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
+
+    source "$NCTL/sh/assets/setup_from_stage.sh" \
+            stage="$STAGE_ID" \
+    log "... Starting 5 validators"
+    source "$NCTL/sh/node/start.sh" node=all
+}
+
+# Step 02: Await era-id >= 2.
+function _step_02()
+{
+    log_step_upgrades 2 "awaiting until era 2"
+    await_until_era_n 2
+}
+
+# Step 03: Stage nodes 1-5 and upgrade.
+function _step_03()
+{
+    local STAGE_ID=${1}
+    local ACTIVATION_POINT=${2}
+
+    log_step_upgrades 3 "upgrading 1 thru 5 from stage ($STAGE_ID)"
+
+    log "... setting upgrade assets"
+
+    for i in $(seq 1 5); do
+        log "... staging upgrade on validator node-$i"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        echo ""
+    done
+
+    log "... awaiting 2 eras + 1 block"
+    await_n_eras '2' 'true' '5.0' '2'
+    await_n_blocks '1' 'true' '2'
+}
+
+# Step 04: Assert upgraded nodes 1-5.
+function _step_04()
+{
+    local PROTOCOL_VERSION_INITIAL=${1}
+    local NX_PROTOCOL_VERSION
+    local NODE_ID
+
+    log_step_upgrades 4 "Asserting nodes 1 thru 5 upgraded"
+
+    # Assert nodes are running same protocol version.
+    for NODE_ID in $(seq 1 5)
+    do
+        NX_PROTOCOL_VERSION=$(get_node_protocol_version "$NODE_ID")
+        if [ "$NX_PROTOCOL_VERSION" = "$PROTOCOL_VERSION_INITIAL" ]; then
+            log "ERROR :: upgrade failure :: nodes are not all running same protocol version"
+            log "... Node $NODE_ID: $NX_PROTOCOL_VERSION = $PROTOCOL_VERSION_INITIAL"
+            exit 1
+        else
+            log "Node $NODE_ID upgraded successfully: $PROTOCOL_VERSION_INITIAL -> $NX_PROTOCOL_VERSION"
+        fi
+    done
+}
+
+# Step 05: Assert nodes 1-5 didn't stall.
+function _step_05()
+{
+    local HEIGHT_1
+    local HEIGHT_2
+    local NODE_ID
+
+    log_step_upgrades 5 "Asserting nodes 1 thru 5 didn't stall"
+
+    HEIGHT_1=$(get_chain_height 2)
+    await_n_blocks '5' 'true' '2'
+    for NODE_ID in $(seq 1 5)
+    do
+        HEIGHT_2=$(get_chain_height "$NODE_ID")
+        if [ "$HEIGHT_2" != "N/A" ] && [ "$HEIGHT_2" -le "$HEIGHT_1" ]; then
+            log "ERROR :: upgrade failure :: node-$NODE_ID has stalled"
+            log " ... node-$NODE_ID : $HEIGHT_2 <= $HEIGHT_1"
+            exit 1
+        else
+            log " ... no stall detected on node-$NODE_ID: $HEIGHT_2 > $HEIGHT_1 [expected]"
+        fi
+    done
+}
+
+# Step 06: Await 2 eras.
+function _step_06()
+{
+    log_step_upgrades 6 "awaiting 2 eras"
+    await_n_eras '2' 'true' '5.0' '2'
+}
+
+function _compare_era_summary()
+{
+    local BLOCK_HASH=${1}
+    local NODE_ADDRESS_CURL=$(get_node_address_rpc_for_curl "1")
+
+    local ERA_SUMMARY_RPC_RESPONSE=$(
+        curl -s --header 'Content-Type: application/json' \
+            --request POST "$NODE_ADDRESS_CURL" \
+            --data-raw "{
+                \"jsonrpc\": \"2.0\",
+                \"method\": \"chain_get_era_summary\",
+                \"params\": {
+                    \"block_identifier\": {
+                        \"Hash\": $BLOCK_HASH
+                    }
+                },
+                \"id\": 1
+            }" | jq '.result.era_summary'
+    )
+
+    local ERA_INFO_RPC_RESPONSE=$(
+        curl -s --header 'Content-Type: application/json' \
+            --request POST "$NODE_ADDRESS_CURL" \
+            --data-raw "{
+                \"jsonrpc\": \"2.0\",
+                \"method\": \"chain_get_era_info_by_switch_block\",
+                \"params\": {
+                    \"block_identifier\": {
+                        \"Hash\": $BLOCK_HASH
+                    }
+                },
+                \"id\": 1
+            }" | jq '.result.era_summary'
+    )
+
+    if [ "$ERA_SUMMARY_RPC_RESPONSE" != "$ERA_INFO_RPC_RESPONSE" ]; then
+        log "ERROR :: era summary does not match for block hash $LATEST_SWITCH_BLOCK_HASH"
+        exit 1
+    fi
+}
+
+# Check rpc backwards compatibility for the chain_get_era_info_by_switch_block RPC
+function _step_07()
+{
+    log_step_upgrades 7 "comparing era summary obtained through chain_get_era_info_by_switch_block and chain_get_era_summary"
+
+    local LATEST_SWITCH_BLOCK=$(get_switch_block "1" "32" "" "")
+    local LATEST_SWITCH_BLOCK_HASH=$(echo $LATEST_SWITCH_BLOCK | jq '.hash')
+    _compare_era_summary $LATEST_SWITCH_BLOCK_HASH
+
+    # check that chain_get_era_info_by_switch_block still works for blocks before the upgrade
+    local SWITCH_BLOCK_BEFORE_UPGRADE=$(get_switch_block "1" "150" "" "2")
+    local SWITCH_BLOCK_BEFORE_UPGRADE_HASH=$(echo $SWITCH_BLOCK_BEFORE_UPGRADE | jq '.hash')
+    _compare_era_summary $SWITCH_BLOCK_BEFORE_UPGRADE_HASH
+}
+
+# Step 09: Terminate.
+function _step_08()
+{
+    log_step_upgrades 8 "upgrade_scenario_13 successful - tidying up"
+
+    source "$NCTL/sh/assets/teardown.sh"
+
+    log_break
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset _STAGE_ID
+unset INITIAL_PROTOCOL_VERSION
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        stage) _STAGE_ID=${VALUE} ;;
+        *)
+    esac
+done
+
+_main "${_STAGE_ID:-1}"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_13.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_13.sh
@@ -186,8 +186,18 @@ function _compare_era_summary()
             }" | jq '.result.era_summary'
     )
 
+    if [ "$ERA_SUMMARY_RPC_RESPONSE" = "null" ]; then
+        log "ERROR :: chain_get_era_summary failed with block hash $BLOCK_HASH"
+        exit 1
+    fi
+
+    if [ "$ERA_INFO_RPC_RESPONSE" = "null" ]; then
+        log "ERROR :: chain_get_era_info_by_switch_block failed with block hash $BLOCK_HASH"
+        exit 1
+    fi
+
     if [ "$ERA_SUMMARY_RPC_RESPONSE" != "$ERA_INFO_RPC_RESPONSE" ]; then
-        log "ERROR :: era summary does not match for block hash $LATEST_SWITCH_BLOCK_HASH"
+        log "ERROR :: era summary does not match for block hash $BLOCK_HASH"
         exit 1
     fi
 }
@@ -201,13 +211,13 @@ function _step_07()
     local LATEST_SWITCH_BLOCK_HASH=$(echo $LATEST_SWITCH_BLOCK | jq '.hash')
     _compare_era_summary $LATEST_SWITCH_BLOCK_HASH
 
-    # check that chain_get_era_info_by_switch_block still works for blocks before the upgrade
+    # check both RPCs still work for switch blocks before the upgrade
     local SWITCH_BLOCK_BEFORE_UPGRADE=$(get_switch_block "1" "150" "" "2")
     local SWITCH_BLOCK_BEFORE_UPGRADE_HASH=$(echo $SWITCH_BLOCK_BEFORE_UPGRADE | jq '.hash')
     _compare_era_summary $SWITCH_BLOCK_BEFORE_UPGRADE_HASH
 }
 
-# Step 09: Terminate.
+# Step 08: Terminate.
 function _step_08()
 {
     log_step_upgrades 8 "upgrade_scenario_13 successful - tidying up"


### PR DESCRIPTION
This PR brings over the changes from `release-1.4.15` to `dev`.

The final commit fixes the issue of keeping the JSON-RPCs `chain_get_era_summary` and `chain_get_era_info_by_switch_block` functional for data before and after the 1.4.15 upgrade, where the `Key` variant for era summaries changed.

Tested locally with an nctl network upgraded from 1.4.13 to this code.

The PR also now includes an nctl test for this (upgrade_scenario_13.sh) proved by @alsrdn.

Closes #3899.