### PR TITLE
Fix `EraValidatorWeights::signature_weight` in `validator_matrix.rs`

### DIFF
--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -279,7 +279,12 @@ mod tests {
 
     #[test]
     fn should_return_weak_when_weight_1_and_1_10_is_required() {
-        test_finality_with_ratio(Ratio::new(1, 10), SignatureWeight::Weak)
+        test_finality_with_ratio(Ratio::new(1, 10), SignatureWeight::Insufficient)
+    }
+
+    #[test]
+    fn should_return_weak_when_weight_1_and_1_11_is_required() {
+        test_finality_with_ratio(Ratio::new(1, 11), SignatureWeight::Weak)
     }
 
     #[test]
@@ -374,7 +379,7 @@ mod tests {
                 .enumerate()
                 .map(|(i, (public, _))| (public.clone(), (i + 1).into()))
                 .collect(),
-            Ratio::new(1, 10), // Low finality threshold
+            Ratio::new(1, 11), // Low finality threshold
         );
         assert_eq!(U512::from(10), weights.get_total_weight());
         let mut signature_acquisition = SignatureAcquisition::new(

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -248,7 +248,7 @@ impl BlockSynchronizer {
 
 /// Returns the number of validators that need a signature for a weak finality of 1/3.
 fn weak_finality_threshold(n: usize) -> usize {
-    n / 3 + if n % 3 == 0 { 0 } else { 1 }
+    n / 3 + 1
 }
 
 #[tokio::test]

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -383,12 +383,12 @@ impl EraValidatorWeights {
 
         let signature_weight = self.signed_weight(validator_keys);
         if signature_weight * U512::from(*strict.denom())
-            >= total_era_weight * U512::from(*strict.numer())
+            > total_era_weight * U512::from(*strict.numer())
         {
             return SignatureWeight::Strict;
         }
         if signature_weight * U512::from(*finality_threshold_fraction.denom())
-            >= total_era_weight * U512::from(*finality_threshold_fraction.numer())
+            > total_era_weight * U512::from(*finality_threshold_fraction.numer())
         {
             return SignatureWeight::Weak;
         }


### PR DESCRIPTION
Fixes #3908 

This PR fixes the `EraValidatorWeights` structure allowing exactly `1/3` and `2/3` of the total weight to pass as weak and strict finality respectively. It was also the root cause of some tests failing when the test environment would generate 3 validators. There are new tests for this specific function and also other tests which were failing after the fix were adjusted.
