### PR TITLE
Include rpc_schema_hashing.json in casper-updater

### DIFF
--- a/ci/casper_updater/src/dependent_file.rs
+++ b/ci/casper_updater/src/dependent_file.rs
@@ -41,7 +41,7 @@ impl DependentFile {
         let contents = self.contents();
         let updated_contents = self
             .regex
-            .replace(&contents, (self.replacement)(updated_version).as_str());
+            .replace_all(&contents, (self.replacement)(updated_version).as_str());
         fs::write(&self.path, updated_contents.as_ref())
             .unwrap_or_else(|error| panic!("should write {}: {:?}", self.path.display(), error));
     }

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -259,6 +259,11 @@ pub mod chainspec_protocol_version {
                 Regex::new(r#"(?m)(DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =\s*ProtocolVersion::from_parts)\((\d+,\s*\d+,\s*\d+)\)"#).unwrap(),
                 rpcs_docs_rs_replacement,
             ),
+            DependentFile::new(
+                "resources/test/rpc_schema_hashing.json",
+                Regex::new(r#"(?m)("version":\s*|"api_version":\s*)"([^"]+)"#).unwrap(),
+                replacement,
+            ),
         ]
     });
 


### PR DESCRIPTION
This PR just updates the `casper-updater` tool (used to prepare version bump PRs) to include rpc_schema_hashing.json in the set of files changed when version bumping the chainspec's protocol version.