### PR TITLE
Fix `itst13.sh` test

### DIFF
--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -52,21 +52,27 @@ impl MainReactor {
         rng: &mut NodeRng,
     ) -> (Duration, Effects<MainEvent>) {
         match self.state {
-            ReactorState::Initialize => match self.initialize_next_component(effect_builder) {
-                Some(effects) => (self.control_logic_default_delay.into(), effects),
-                None => {
-                    if false == self.net.has_sufficient_fully_connected_peers() {
-                        info!("Initialize: awaiting sufficient fully-connected peers");
-                        return (self.control_logic_default_delay.into(), Effects::new());
+            ReactorState::Initialize => {
+                // We can be more greedy when cranking through the initialization process as the
+                // progress is expected to happen quickly.
+                let initialization_logic_default_delay = self.control_logic_default_delay / 4;
+
+                match self.initialize_next_component(effect_builder) {
+                    Some(effects) => (initialization_logic_default_delay.into(), effects),
+                    None => {
+                        if false == self.net.has_sufficient_fully_connected_peers() {
+                            info!("Initialize: awaiting sufficient fully-connected peers");
+                            return (initialization_logic_default_delay.into(), Effects::new());
+                        }
+                        if let Err(msg) = self.refresh_contract_runtime() {
+                            return (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore());
+                        }
+                        info!("Initialize: switch to CatchUp");
+                        self.state = ReactorState::CatchUp;
+                        (Duration::ZERO, Effects::new())
                     }
-                    if let Err(msg) = self.refresh_contract_runtime() {
-                        return (Duration::ZERO, fatal!(effect_builder, "{}", msg).ignore());
-                    }
-                    info!("Initialize: switch to CatchUp");
-                    self.state = ReactorState::CatchUp;
-                    (Duration::ZERO, Effects::new())
                 }
-            },
+            }
             ReactorState::Upgrading => match self.upgrading_instruction() {
                 UpgradingInstruction::CheckLater(msg, wait) => {
                     debug!("Upgrading: {}", msg);

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -147,6 +147,7 @@ function check_network_sync() {
         for i in $(eval echo "{$FIRST_NODE..$LAST_NODE}")
         do
             ALL_LFBS[$index]=$(do_read_lfb_hash $i)
+            log "got LFB of node $i"
             index=$((index + 1))
         done
 
@@ -156,6 +157,7 @@ function check_network_sync() {
         for i in $(eval echo "{0..$((LFB_COUNT - 1))}")
         do
             if [[ "$BASE_LFB" != "${ALL_LFBS[$i]}" ]]; then
+                log "not all LFBs equal, will try again"
                 ALL_EQUAL=0
                 break
             fi

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -13,6 +13,8 @@ set -e
 #   `timeout=XXX` timeout (in seconds) when syncing.
 #######################################
 function main() {
+    local NODE_STARTUP_ERA
+
     log "------------------------------------------------------------"
     log "Starting Scenario: itst13"
     log "------------------------------------------------------------"
@@ -20,7 +22,7 @@ function main() {
     # Wait for network start up
     do_await_genesis_era_to_complete
     # Verify all nodes are in sync
-    check_network_sync 1  5
+    check_network_sync 1 5
     # Stop the node
     do_stop_node '5'
     # Wait until N+1
@@ -39,10 +41,13 @@ function main() {
     get_switch_block '1' '100'
     # Assert node is marked as inactive
     assert_inactive '5'
+    # Remember current era
+    NODE_STARTUP_ERA=$(check_current_era)
+    log "I'll expect the node to switch to KeepUp within era=$NODE_STARTUP_ERA..."
     # Restart node 5
     do_start_node '5' "$(do_read_lfb_hash '1')"
     # Assert joined within expected era
-    assert_joined_in_era_4 '5'
+    assert_joined_in_era_x '5' '300' $NODE_STARTUP_ERA
     # Assert eviction of node
     do_await_era_change '1'
     # Wait 1 block to avoid missing latest switch block
@@ -78,10 +83,11 @@ function main() {
     log "------------------------------------------------------------"
 }
 
-function assert_joined_in_era_4() {
+function assert_joined_in_era_x() {
     local NODE_ID=${1}
     local NODE_PATH=$(get_path_to_node "$NODE_ID")
     local TIMEOUT=${2:-300}
+    local NODE_STARTUP_ERA=${3}
     local OUTPUT
     local REACTOR_STATE
 
@@ -107,7 +113,7 @@ function assert_joined_in_era_4() {
         fi
     done
 
-    assert_same_era '4' '1'
+    assert_same_era $NODE_STARTUP_ERA '1'
 }
 
 # Checks that a validator gets marked as inactive


### PR DESCRIPTION
This PR changes the following:

1. Fixes the hardcoded era number (`4`) used in the assertion of the joining node. Instead it uses the relative one,
2. Adds more logging to the NCTL function that reads LFB mainly to be able to monitor timing issues (in some runs, it was observed that reading all LFBs took ~4min., while normally it should be as quick as 1 second

Additionally it reduces the control logic delay for the initialization stage of the reactor, because it's ok to be more greedy on this phase in an effort to initialize faster

Partially fixes #3862  
