### PR TITLE
Merge release-1.4.15-alt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "casper-contract"
-version = "1.4.4"
+version = "2.0.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "3.1.1"
+version = "4.0.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "3.1.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "casper-hashing"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "assert_matches",
  "base16",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.15"
+version = "1.4.15-alt"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "base16",
  "base64",

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 4.0.0
+
+### Changed
+* Update dependencies (in particular `casper-types` to v2.0.0 due to additional `Key` variant, requiring a major version bump here).
+
+
+
 ## 3.1.1
 
 ### Changed

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "3.1.1" # when updating, also update 'html_root_url' in lib.rs
+version = "4.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -14,8 +14,8 @@ license-file = "../LICENSE"
 anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
-casper-hashing = { version = "1.4.3", path = "../hashing" }
-casper-types = { version = "1.6.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-hashing = { version = "1.4.4", path = "../hashing" }
+casper-types = { version = "2.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 casper-wasm-utils = "1.0.0"
 chrono = "0.4.10"
 datasize = "0.2.4"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/3.1.1")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/4.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,10 +11,17 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 4.0.0
+
+### Changed
+* Update dependencies (in particular `casper-types` to v2.0.0 due to additional `Key` variant, requiring a major version bump here).
+
+
+
 ## 3.1.1
 
 ### Changed
-* Updated chainspec values used in `PRODUCTION_RUN_GENESIS_REQUEST` to match those of Mainnet protocol version 1.4.15.
+* Update chainspec values used in `PRODUCTION_RUN_GENESIS_REQUEST` to match those of Mainnet protocol version 1.4.15.
 
 
 

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "3.1.1" # when updating, also update 'html_root_url' in lib.rs
+version = "4.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-execution-engine = { version = "3.1.1", path = "../../execution_engine", features = ["test-support"] }
-casper-hashing = { version = "1.4.3", path = "../../hashing" }
-casper-types = { version = "1.6.0", path = "../../types" }
+casper-execution-engine = { version = "4.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-hashing = { version = "1.4.4", path = "../../hashing" }
+casper-types = { version = "2.0.0", path = "../../types" }
 humantime = "2"
 filesize = "0.2.0"
 lmdb = "0.8.0"
@@ -27,7 +27,7 @@ toml = "0.5.6"
 tempfile = "3"
 
 [dev-dependencies]
-casper-types = { version = "1.6.0", path = "../../types", features = ["std"] }
+casper-types = { version = "2.0.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [features]

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/3.1.1")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/4.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/hashing/CHANGELOG.md
+++ b/hashing/CHANGELOG.md
@@ -11,7 +11,14 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 1.4.4
+
+### Changed
+* Update dependencies.
+
+
+
+## 1.4.0
 
 ### Added
 * Initial release of crate providing `Digest` type and hashing methods.

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-hashing"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2018"
 description = "A library providing hashing functionality including Merkle Proof utilities."
 readme = "README.md"
@@ -12,7 +12,7 @@ license-file = "../LICENSE"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "1.0.0", path = "../types", features = ["gens"] }
+casper-types = { version = "2.0.0", path = "../types", features = ["gens"] }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library providing hashing functionality including Merkle Proof utilities.
 
-#![doc(html_root_url = "https://docs.rs/casper-hashing/1.4.3")]
+#![doc(html_root_url = "https://docs.rs/casper-hashing/1.4.4")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.15-alt
+
+### Changed
+* Update dependencies (in particular `casper-types` to v2.0.0 due to additional `Key` variant).  Note that publishing `1.4.15-alt` is only to rectify the issue where `casper-types` was published as v1.6.0 despite having a breaking change.  It is expected to only be consumed as a crate; there will be no upgrade of Casper Mainnet, Testnet, etc to protocol version `1.4.15-alt`.
+
+
+
 ## 1.4.15
 
 ### Changed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.15" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.15-alt" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,10 +20,10 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "3.1.1", path = "../execution_engine" }
+casper-execution-engine = { version = "4.0.0", path = "../execution_engine" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }
-casper-hashing = { version = "1.4.3", path = "../hashing" }
-casper-types = { version = "1.6.0", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-hashing = { version = "1.4.4", path = "../hashing" }
+casper-types = { version = "2.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.15")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.15-alt")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 2.0.0
+
+### Changed
+* Update `casper-types` to v2.0.0 due to additional `Key` variant, requiring a major version bump here.
 
 
 

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "1.4.4" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "A library for developing Casper network smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "1.6.0", path = "../../types" }
+casper-types = { version = "2.0.0", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -50,7 +50,7 @@
     all(not(test), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/1.4.4")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/2.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/CHANGELOG.md
+++ b/smart_contracts/contract_as/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.15-alt
+
+### Changed
+* Version bump to match casper-node version.
+
+
+
 ## 1.4.15
 
 ### Changed

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.15",
+  "version": "1.4.15-alt",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.15",
+  "version": "1.4.15-alt",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -11,11 +11,19 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## 1.6.0
+## 2.0.0
+
+### Fixed
+* Republished v1.6.0 as v2.0.0 due to missed breaking change in API (addition of new variant to `Key`).
+
+
+
+## 1.6.0 [YANKED]
 
 ### Added
 * Add `TimeDiff`, `Timestamp` and asymmetric key functionality (moved from `casper-nodes` crate).
 * Add `testing` feature to provide functionality useful for test scenarios.
+* Add new `Key::EraSummary` key variant under which the era summary info is written on each switch block execution.
 
 ### Deprecated
 * Deprecate `gens` feature: its functionality is included in the new `testing` feature.

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "1.6.0" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/1.6.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/2.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR merges changes from `release-1.4.15-alt` to `dev`.

Closes #3943.