### PR TITLE
Add a faster way to check if nodes 1 to 5 are in sync

### DIFF
--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -18,7 +18,7 @@ function main() {
     # 1. Allow the chain to progress
     do_await_era_change 1
     # 2. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3. Submit bid for node 6
     do_submit_auction_bids "6"
     do_read_lfb_hash "5"

--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -18,7 +18,7 @@ function main() {
     # 1. Allow the chain to progress
     do_await_era_change 1
     # 2. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3. Submit bid for node 6
     do_submit_auction_bids "6"
     do_read_lfb_hash "5"

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -129,6 +129,35 @@ function get_reactor_state() {
     echo "$REACTOR_STATE"
 }
 
+function check_nodes_1_to_5_sync_fast() {
+    local ALL_HASHES
+    local UNIQUE_HASH_COUNT
+    local TIMEOUT_SEC=${1-300}
+    local ATTEMPTS=0
+    
+    while [ "$ATTEMPTS" -le "$TIMEOUT_SEC" ]; do
+        ALL_HASHES=$(get_chain_latest_block_hash 1 & \
+                     get_chain_latest_block_hash 2 & \
+                     get_chain_latest_block_hash 3 & \
+                     get_chain_latest_block_hash 4 & \
+                     get_chain_latest_block_hash 5 & \
+                     wait)
+        log "All hashes:\n$ALL_HASHES"
+        UNIQUE_HASH_COUNT=$(echo $ALL_HASHES | sort | uniq | wc -l)
+        log "Unique hashes count: $UNIQUE_HASH_COUNT"
+        if [ "$UNIQUE_HASH_COUNT" -eq 1 ]; then
+            log "nodes 1 to 5 in sync, proceeding..."
+            nctl-view-chain-height
+            break
+        fi
+        ATTEMPTS=$((ATTEMPTS + 1))
+        if [ "$ATTEMPTS" -lt "$TIMEOUT_SEC" ]; then
+            sleep 1
+            log "attempt $ATTEMPTS out of $TIMEOUT_SEC..."
+        fi
+    done
+}
+
 function check_network_sync() {
     local WAIT_TIME_SEC=0
     local FIRST_NODE=${1:-1}

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -129,7 +129,7 @@ function get_reactor_state() {
     echo "$REACTOR_STATE"
 }
 
-function check_nodes_1_to_5_sync_fast() {
+function parallel_check_nodes_1_to_5_sync() {
     local ALL_HASHES
     local UNIQUE_HASH_COUNT
     local TIMEOUT_SEC=${1-300}

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -27,7 +27,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3-6. Stop four nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -46,11 +46,11 @@ function main() {
     do_start_node "3" "$STALLED_LFB"
     do_start_node "2" "$STALLED_LFB"
     # 13. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 14. Ensure era proceeds after restart
     do_await_era_change "2"
     # 15. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 16-17. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -27,7 +27,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3-6. Stop four nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -46,11 +46,11 @@ function main() {
     do_start_node "3" "$STALLED_LFB"
     do_start_node "2" "$STALLED_LFB"
     # 13. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 14. Ensure era proceeds after restart
     do_await_era_change "2"
     # 15. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 16-17. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst01.sh
+++ b/utils/nctl/sh/scenarios/itst01.sh
@@ -40,9 +40,9 @@ function main() {
     # wait 1 era, and then check they are still in sync.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     do_await_era_change
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 9. Run Closing Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst01.sh
+++ b/utils/nctl/sh/scenarios/itst01.sh
@@ -40,9 +40,9 @@ function main() {
     # wait 1 era, and then check they are still in sync.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     do_await_era_change
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 9. Run Closing Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -24,7 +24,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3-5. Stop three nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -36,11 +36,11 @@ function main() {
     do_start_node "4" "$STALLED_LFB"
     do_start_node "3" "$STALLED_LFB"
     # 10. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 11. Ensure era proceeds after restart
     do_await_era_change "2"
     # 12. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 13-15. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -24,7 +24,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3-5. Stop three nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -36,11 +36,11 @@ function main() {
     do_start_node "4" "$STALLED_LFB"
     do_start_node "3" "$STALLED_LFB"
     # 10. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 11. Ensure era proceeds after restart
     do_await_era_change "2"
     # 12. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 13-15. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasmless_transfers '5'
     # 4. Stop node being sent transfers
@@ -34,7 +34,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasmless_transfers '5'
     # 4. Stop node being sent transfers
@@ -34,7 +34,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -21,7 +21,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasm_transfers '5'
     # 4. Stop node being sent transfers
@@ -33,7 +33,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -21,7 +21,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasm_transfers '5'
     # 4. Stop node being sent transfers
@@ -33,7 +33,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3. Create the doppelganger
     create_doppelganger '5' '6'
     # 4. Get LFB Hash

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3. Create the doppelganger
     create_doppelganger '5' '6'
     # 4. Get LFB Hash

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -22,7 +22,7 @@ function main() {
     # Wait for network start up
     do_await_genesis_era_to_complete
     # Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # Stop the node
     do_stop_node '5'
     # Wait until N+1

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -22,7 +22,7 @@ function main() {
     # Wait for network start up
     do_await_genesis_era_to_complete
     # Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # Stop the node
     do_stop_node '5'
     # Wait until N+1

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks "5"
     # 2. Verify network is in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 3a. Get era
     STOPPED_ERA=$(check_current_era)
     # 3b. Stop node
@@ -34,11 +34,11 @@ function main() {
     do_read_lfb_hash 1
     do_start_node "5" "$LFB_HASH"
     # 6. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 7. Verify network is creating blocks post-restart
     do_await_n_blocks "5"
     # 8. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 9. Verify node proposed a block
     assert_node_proposed '5' '180'
     # 10. Verify we are in the same era
@@ -46,7 +46,7 @@ function main() {
     # 11. Wait an era
     do_await_era_change
     # 12. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
     # 13. Run Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks "5"
     # 2. Verify network is in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 3a. Get era
     STOPPED_ERA=$(check_current_era)
     # 3b. Stop node
@@ -34,11 +34,11 @@ function main() {
     do_read_lfb_hash 1
     do_start_node "5" "$LFB_HASH"
     # 6. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 7. Verify network is creating blocks post-restart
     do_await_n_blocks "5"
     # 8. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 9. Verify node proposed a block
     assert_node_proposed '5' '180'
     # 10. Verify we are in the same era
@@ -46,7 +46,7 @@ function main() {
     # 11. Wait an era
     do_await_era_change
     # 12. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
     # 13. Run Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -22,7 +22,7 @@ function main() {
     PRE_SWAP_HASH=$(do_read_lfb_hash 1)
 
     # 2. Verify all nodes are in sync
-    check_network_sync 1 5
+    check_nodes_1_to_5_sync_fast
 
     # 3. Send some wasm to all running nodes
     log_step "sending wasm trandfers to validators"

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -22,7 +22,7 @@ function main() {
     PRE_SWAP_HASH=$(do_read_lfb_hash 1)
 
     # 2. Verify all nodes are in sync
-    check_nodes_1_to_5_sync_fast
+    parallel_check_nodes_1_to_5_sync
 
     # 3. Send some wasm to all running nodes
     log_step "sending wasm trandfers to validators"


### PR DESCRIPTION
This test provides a faster way to check if nodes 1 to 5 are in sync. It achieves that by querying nodes in parallel and also skipping the check for RPC port availability, which previously was done by a call to `lsof`.

The previous, slower function has been kept intact, since it is still used in few tests that need to check for a different number of nodes (the new one is hardcoded to 1-5 for simplicity).

Partially fixes #3862 