### PR TITLE
Revert consensus encoding changes

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -59,9 +59,7 @@ use traits::Context;
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
-pub(crate) use era_supervisor::{
-    debug::EraDump, deserialize_payload, serialize_payload, EraSupervisor,
-};
+pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor, SerializedMessage};
 #[cfg(test)]
 pub(crate) use highway_core::highway::Vertex as HighwayVertex;
 pub(crate) use leader_sequence::LeaderSequence;
@@ -80,11 +78,16 @@ mod relaxed {
     use serde::{Deserialize, Serialize};
     use strum::EnumDiscriminants;
 
+    use super::era_supervisor::SerializedMessage;
+
     #[derive(DataSize, Clone, Serialize, Deserialize, EnumDiscriminants)]
     #[strum_discriminants(derive(strum::EnumIter))]
     pub(crate) enum ConsensusMessage {
         /// A protocol message, to be handled by the instance in the specified era.
-        Protocol { era_id: EraId, payload: Vec<u8> },
+        Protocol {
+            era_id: EraId,
+            payload: SerializedMessage,
+        },
         /// A request for evidence against the specified validator, from any era that is still
         /// bonded in `era_id`.
         EvidenceRequest { era_id: EraId, pub_key: PublicKey },
@@ -105,8 +108,7 @@ where
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub(crate) struct ConsensusRequestMessage {
     era_id: EraId,
-    // payload: EraRequest<ClContext>,
-    payload: Vec<u8>,
+    payload: SerializedMessage,
 }
 
 /// An ID to distinguish different timers. What they are used for is specific to each consensus

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -59,9 +59,7 @@ use traits::Context;
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
-#[cfg(test)]
-pub(crate) use era_supervisor::deserialize_payload;
-pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor};
+pub(crate) use era_supervisor::{debug::EraDump, deserialize_payload, EraSupervisor};
 #[cfg(test)]
 pub(crate) use highway_core::highway::Vertex as HighwayVertex;
 pub(crate) use leader_sequence::LeaderSequence;
@@ -80,7 +78,7 @@ mod relaxed {
     use serde::{Deserialize, Serialize};
     use strum::EnumDiscriminants;
 
-    use super::{protocols, traits::Context, ClContext, HighwayMessage};
+    use super::{protocols, traits::Context, HighwayMessage};
 
     /// A message to be handled by the consensus protocol instance in a particular era.
     #[derive(DataSize, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, EnumDiscriminants)]
@@ -111,25 +109,6 @@ pub(crate) use relaxed::{
     ConsensusMessage, ConsensusMessageDiscriminants, EraMessage, EraMessageDiscriminants,
 };
 
-impl<C: Context> EraMessage<C> {
-    /// Returns the message for the Zug protocol, or an error if it is for a different protocol.
-    fn try_into_zug(self) -> Result<protocols::zug::Message<C>, Self> {
-        match self {
-            EraMessage::Zug(msg) => Ok(*msg),
-            other => Err(other),
-        }
-    }
-
-    /// Returns the message for the Highway protocol, or an error if it is for a different
-    /// protocol.
-    pub(crate) fn try_into_highway(self) -> Result<HighwayMessage<C>, Self> {
-        match self {
-            EraMessage::Highway(msg) => Ok(*msg),
-            other => Err(other),
-        }
-    }
-}
-
 impl<C: Context> From<protocols::zug::Message<C>> for EraMessage<C> {
     fn from(msg: protocols::zug::Message<C>) -> EraMessage<C> {
         EraMessage::Zug(Box::new(msg))
@@ -149,15 +128,6 @@ where
     C: Context,
 {
     Zug(protocols::zug::SyncRequest<C>),
-}
-
-impl<C: Context> EraRequest<C> {
-    /// Returns the request for the Zug protocol, or an error if it is for a different protocol.
-    fn try_into_zug(self) -> Result<protocols::zug::SyncRequest<C>, Self> {
-        match self {
-            EraRequest::Zug(msg) => Ok(msg),
-        }
-    }
 }
 
 /// A protocol request message, to be handled by the instance in the specified era.

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -64,6 +64,8 @@ pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor, SerializedMessage
 pub(crate) use highway_core::highway::Vertex as HighwayVertex;
 pub(crate) use leader_sequence::LeaderSequence;
 pub(crate) use protocols::highway::max_rounds_per_era;
+#[cfg(test)]
+pub(crate) use protocols::highway::HighwayMessage;
 pub(crate) use validator_change::ValidatorChange;
 
 const COMPONENT_NAME: &str = "consensus";

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -59,6 +59,8 @@ use traits::Context;
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
+#[cfg(test)]
+pub(crate) use era_supervisor::deserialize_payload;
 pub(crate) use era_supervisor::{debug::EraDump, EraSupervisor};
 #[cfg(test)]
 pub(crate) use highway_core::highway::Vertex as HighwayVertex;
@@ -97,7 +99,8 @@ mod relaxed {
         /// A protocol message, to be handled by the instance in the specified era.
         Protocol {
             era_id: EraId,
-            payload: EraMessage<ClContext>,
+            //payload: EraMessage<ClContext>,
+            payload: Vec<u8>,
         },
         /// A request for evidence against the specified validator, from any era that is still
         /// bonded in `era_id`.
@@ -161,7 +164,8 @@ impl<C: Context> EraRequest<C> {
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub(crate) struct ConsensusRequestMessage {
     era_id: EraId,
-    payload: EraRequest<ClContext>,
+    // payload: EraRequest<ClContext>,
+    payload: Vec<u8>,
 }
 
 /// An ID to distinguish different timers. What they are used for is specific to each consensus
@@ -396,7 +400,7 @@ mod specimen_support {
                 match variant {
                     ConsensusMessageDiscriminants::Protocol => ConsensusMessage::Protocol {
                         era_id: LargestSpecimen::largest_specimen(estimator, cache),
-                        payload: LargestSpecimen::largest_specimen(estimator, cache),
+                        payload: todo!(), //LargestSpecimen::largest_specimen(estimator, cache),
                     },
                     ConsensusMessageDiscriminants::EvidenceRequest => {
                         ConsensusMessage::EvidenceRequest {
@@ -413,7 +417,7 @@ mod specimen_support {
         fn largest_specimen<E: SizeEstimator>(estimator: &E, cache: &mut Cache) -> Self {
             ConsensusRequestMessage {
                 era_id: LargestSpecimen::largest_specimen(estimator, cache),
-                payload: LargestSpecimen::largest_specimen(estimator, cache),
+                payload: todo!(), //LargestSpecimen::largest_specimen(estimator, cache),
             }
         }
     }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -59,7 +59,9 @@ use traits::Context;
 pub(crate) use cl_context::ClContext;
 pub(crate) use config::{ChainspecConsensusExt, Config};
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
-pub(crate) use era_supervisor::{debug::EraDump, deserialize_payload, EraSupervisor};
+pub(crate) use era_supervisor::{
+    debug::EraDump, deserialize_payload, serialize_payload, EraSupervisor,
+};
 #[cfg(test)]
 pub(crate) use highway_core::highway::Vertex as HighwayVertex;
 pub(crate) use leader_sequence::LeaderSequence;

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -17,6 +17,8 @@ use crate::{
     NodeRng,
 };
 
+use super::era_supervisor::SerializedMessage;
+
 /// Information about the context in which a new block is created.
 #[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
 pub struct BlockContext<C>
@@ -191,10 +193,10 @@ pub(crate) type ProtocolOutcomes<C> = Vec<ProtocolOutcome<C>>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ProtocolOutcome<C: Context> {
-    CreatedGossipMessage(Vec<u8>),
-    CreatedTargetedMessage(Vec<u8>, NodeId),
-    CreatedMessageToRandomPeer(Vec<u8>),
-    CreatedRequestToRandomPeer(Vec<u8>),
+    CreatedGossipMessage(SerializedMessage),
+    CreatedTargetedMessage(SerializedMessage, NodeId),
+    CreatedMessageToRandomPeer(SerializedMessage),
+    CreatedRequestToRandomPeer(SerializedMessage),
     ScheduleTimer(Timestamp, TimerId),
     QueueAction(ActionId),
     /// Request deploys for a new block, providing the necessary context.
@@ -243,7 +245,7 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
         &mut self,
         rng: &mut NodeRng,
         sender: NodeId,
-        msg: Vec<u8>,
+        msg: SerializedMessage,
         now: Timestamp,
     ) -> ProtocolOutcomes<C>;
 
@@ -252,9 +254,9 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
         &mut self,
         rng: &mut NodeRng,
         sender: NodeId,
-        msg: Vec<u8>,
+        msg: SerializedMessage,
         now: Timestamp,
-    ) -> (ProtocolOutcomes<C>, Option<Vec<u8>>);
+    ) -> (ProtocolOutcomes<C>, Option<SerializedMessage>);
 
     /// Current instance of consensus protocol is latest era.
     fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<C>;

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -12,7 +12,7 @@ use casper_hashing::Digest;
 use casper_types::{bytesrepr::ToBytes, TimeDiff, Timestamp};
 
 use crate::{
-    components::consensus::{traits::Context, ActionId, EraMessage, TimerId},
+    components::consensus::{traits::Context, ActionId, TimerId},
     types::NodeId,
     NodeRng,
 };
@@ -254,7 +254,7 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
         sender: NodeId,
         msg: Vec<u8>,
         now: Timestamp,
-    ) -> (ProtocolOutcomes<C>, Option<EraMessage<C>>);
+    ) -> (ProtocolOutcomes<C>, Option<Vec<u8>>);
 
     /// Current instance of consensus protocol is latest era.
     fn handle_is_current(&self, now: Timestamp) -> ProtocolOutcomes<C>;

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -243,7 +243,7 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
         &mut self,
         rng: &mut NodeRng,
         sender: NodeId,
-        msg: EraMessage<C>,
+        msg: Vec<u8>,
         now: Timestamp,
     ) -> ProtocolOutcomes<C>;
 
@@ -252,7 +252,7 @@ pub(crate) trait ConsensusProtocol<C: Context>: Send {
         &mut self,
         rng: &mut NodeRng,
         sender: NodeId,
-        msg: EraRequest<C>,
+        msg: Vec<u8>,
         now: Timestamp,
     ) -> (ProtocolOutcomes<C>, Option<EraMessage<C>>);
 

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -12,7 +12,7 @@ use casper_hashing::Digest;
 use casper_types::{bytesrepr::ToBytes, TimeDiff, Timestamp};
 
 use crate::{
-    components::consensus::{traits::Context, ActionId, EraMessage, EraRequest, TimerId},
+    components::consensus::{traits::Context, ActionId, EraMessage, TimerId},
     types::NodeId,
     NodeRng,
 };
@@ -191,10 +191,10 @@ pub(crate) type ProtocolOutcomes<C> = Vec<ProtocolOutcome<C>>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ProtocolOutcome<C: Context> {
-    CreatedGossipMessage(EraMessage<C>),
-    CreatedTargetedMessage(EraMessage<C>, NodeId),
-    CreatedMessageToRandomPeer(EraMessage<C>),
-    CreatedRequestToRandomPeer(EraRequest<C>),
+    CreatedGossipMessage(Vec<u8>),
+    CreatedTargetedMessage(Vec<u8>, NodeId),
+    CreatedMessageToRandomPeer(Vec<u8>),
+    CreatedRequestToRandomPeer(Vec<u8>),
     ScheduleTimer(Timestamp, TimerId),
     QueueAction(ActionId),
     /// Request deploys for a new block, providing the necessary context.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1208,6 +1208,11 @@ impl SerializedMessage {
     pub(crate) fn into_raw(self) -> Vec<u8> {
         self.0
     }
+
+    /// Returns a reference to the inner raw bytes.
+    pub(crate) fn as_raw(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 async fn get_deploys<REv>(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -701,13 +701,7 @@ impl EraSupervisor {
                 if let Some(payload) = response {
                     effects.extend(
                         auto_closing_responder
-                            .respond(
-                                ConsensusMessage::Protocol {
-                                    era_id,
-                                    payload: serialize_payload(&payload),
-                                }
-                                .into(),
-                            )
+                            .respond(ConsensusMessage::Protocol { era_id, payload }.into())
                             .ignore(),
                     );
                 } else {
@@ -920,26 +914,17 @@ impl EraSupervisor {
                 }
             }
             ProtocolOutcome::CreatedGossipMessage(payload) => {
-                let message = ConsensusMessage::Protocol {
-                    era_id,
-                    payload: serialize_payload(&payload),
-                };
+                let message = ConsensusMessage::Protocol { era_id, payload };
                 effect_builder
                     .broadcast_message_to_validators(message.into(), era_id)
                     .ignore()
             }
             ProtocolOutcome::CreatedTargetedMessage(payload, to) => {
-                let message = ConsensusMessage::Protocol {
-                    era_id,
-                    payload: serialize_payload(&payload),
-                };
+                let message = ConsensusMessage::Protocol { era_id, payload };
                 effect_builder.enqueue_message(to, message.into()).ignore()
             }
             ProtocolOutcome::CreatedMessageToRandomPeer(payload) => {
-                let message = ConsensusMessage::Protocol {
-                    era_id,
-                    payload: serialize_payload(&payload),
-                };
+                let message = ConsensusMessage::Protocol { era_id, payload };
 
                 async move {
                     let peers = effect_builder.get_fully_connected_peers(1).await;
@@ -950,10 +935,7 @@ impl EraSupervisor {
                 .ignore()
             }
             ProtocolOutcome::CreatedRequestToRandomPeer(payload) => {
-                let message = ConsensusRequestMessage {
-                    era_id,
-                    payload: serialize_payload(&payload),
-                };
+                let message = ConsensusRequestMessage { era_id, payload };
 
                 async move {
                     let peers = effect_builder.get_fully_connected_peers(1).await;
@@ -1189,7 +1171,7 @@ impl EraSupervisor {
 }
 
 /// Serializes a payload with the fixed encoding scheme for consensus messages.
-fn serialize_payload<T>(_payload: &T) -> Vec<u8> {
+pub(crate) fn serialize_payload<T>(_payload: &T) -> Vec<u8> {
     todo!()
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1193,7 +1193,7 @@ impl SerializedMessage {
     where
         T: ConsensusNetworkMessage + Serialize,
     {
-        todo!()
+        SerializedMessage(bincode::serialize(msg).expect("should serialize message"))
     }
 
     /// Attempt to deserialize a given type from incoming raw bytes.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1203,6 +1203,11 @@ impl SerializedMessage {
     {
         todo!()
     }
+
+    /// Returns the inner raw bytes.
+    pub(crate) fn into_raw(self) -> Vec<u8> {
+        self.0
+    }
 }
 
 async fn get_deploys<REv>(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1177,7 +1177,7 @@ impl EraSupervisor {
 /// double-serialization of network messages, or serialization of unsuitable types.
 ///
 /// Note that this type fixates the encoding for all consensus implementations to one scheme.
-#[derive(Clone, DataSize, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 #[repr(transparent)]
 pub(crate) struct SerializedMessage(Vec<u8>);
@@ -1212,6 +1212,51 @@ impl SerializedMessage {
     /// Returns a reference to the inner raw bytes.
     pub(crate) fn as_raw(&self) -> &[u8] {
         &self.0
+    }
+}
+
+#[cfg(test)]
+impl SerializedMessage {
+    // /// Deserializes a message into a [`zug::Message<C>`].
+    // ///
+    // /// # Panics
+    // ///
+    // /// Will panic if deserialization fails.
+    // #[track_caller]
+    // pub(crate) fn expect_zug_message<C>(&self) -> super::protocols::zug::Message<C>
+    // where
+    //     C: super::traits::Context,
+    // {
+    //     self.deserialize_incoming()
+    //         .expect("could not deserialize valid zug message from serialized message")
+    // }
+
+    // /// Deserializes a message into a [`zug::Message<C>`].
+    // ///
+    // /// # Panics
+    // ///
+    // /// Will panic if deserialization fails.
+    // #[track_caller]
+    // pub(crate) fn expect_zug_sync_request<C>(&self) -> super::protocols::zug::SyncRequest<C>
+    // where
+    //     C: super::traits::Context,
+    // {
+    //     self.deserialize_incoming()
+    //         .expect("could not deserialize valid zug message from serialized message")
+    // }
+
+    /// Deserializes a message into a the given value.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if deserialization fails.
+    #[track_caller]
+    pub(crate) fn deserialize_expect<T>(&self) -> T
+    where
+        T: ConsensusNetworkMessage + DeserializeOwned,
+    {
+        self.deserialize_incoming()
+            .expect("could not deserialize valid zug message from serialized message")
     }
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1217,34 +1217,6 @@ impl SerializedMessage {
 
 #[cfg(test)]
 impl SerializedMessage {
-    // /// Deserializes a message into a [`zug::Message<C>`].
-    // ///
-    // /// # Panics
-    // ///
-    // /// Will panic if deserialization fails.
-    // #[track_caller]
-    // pub(crate) fn expect_zug_message<C>(&self) -> super::protocols::zug::Message<C>
-    // where
-    //     C: super::traits::Context,
-    // {
-    //     self.deserialize_incoming()
-    //         .expect("could not deserialize valid zug message from serialized message")
-    // }
-
-    // /// Deserializes a message into a [`zug::Message<C>`].
-    // ///
-    // /// # Panics
-    // ///
-    // /// Will panic if deserialization fails.
-    // #[track_caller]
-    // pub(crate) fn expect_zug_sync_request<C>(&self) -> super::protocols::zug::SyncRequest<C>
-    // where
-    //     C: super::traits::Context,
-    // {
-    //     self.deserialize_incoming()
-    //         .expect("could not deserialize valid zug message from serialized message")
-    // }
-
     /// Deserializes a message into a the given value.
     ///
     /// # Panics

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1197,11 +1197,11 @@ impl SerializedMessage {
     }
 
     /// Attempt to deserialize a given type from incoming raw bytes.
-    pub(crate) fn deserialize_incoming<T>(&self) -> Result<T, &'static str>
+    pub(crate) fn deserialize_incoming<T>(&self) -> Result<T, bincode::Error>
     where
         T: ConsensusNetworkMessage + DeserializeOwned,
     {
-        todo!()
+        bincode::deserialize(&self.0)
     }
 
     /// Returns the inner raw bytes.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -63,8 +63,6 @@ use crate::{
 pub use self::era::Era;
 use crate::components::consensus::error::CreateNewEraError;
 
-use super::EraMessage;
-
 /// The delay in milliseconds before we shutdown after the number of faulty validators exceeded the
 /// fault tolerance threshold.
 const FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS: u64 = 60 * 1000;
@@ -1191,12 +1189,12 @@ impl EraSupervisor {
 }
 
 /// Serializes a payload with the fixed encoding scheme for consensus messages.
-fn serialize_payload<T>(payload: &T) -> Vec<u8> {
+fn serialize_payload<T>(_payload: &T) -> Vec<u8> {
     todo!()
 }
 
 /// Deserializes a payload with the fixed decoding scheme for consensus messages.
-pub(crate) fn deserialize_payload<T>(payload: &[u8]) -> Result<T, &'static str> {
+pub(crate) fn deserialize_payload<T>(_payload: &[u8]) -> Result<T, &'static str> {
     todo!()
 }
 

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -15,6 +15,7 @@ use crate::{
     components::consensus::{
         consensus_protocol::{ProposedBlock, ProtocolOutcome, ProtocolOutcomes},
         protocols::highway::{HighwayMessage, ACTION_ID_VERTEX},
+        serialize_payload,
         traits::Context,
         utils::ValidatorMap,
     },
@@ -434,7 +435,10 @@ impl<C: Context + 'static> Synchronizer<C> {
                 let uuid = thread_rng().next_u64();
                 debug!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let msg = HighwayMessage::RequestDependency(uuid, transitive_dependency);
-                outcomes.push(ProtocolOutcome::CreatedTargetedMessage(msg.into(), sender));
+                outcomes.push(ProtocolOutcome::CreatedTargetedMessage(
+                    serialize_payload(&msg),
+                    sender,
+                ));
                 continue;
             }
             // We found the next vertex to add.

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -14,8 +14,8 @@ use casper_types::Timestamp;
 use crate::{
     components::consensus::{
         consensus_protocol::{ProposedBlock, ProtocolOutcome, ProtocolOutcomes},
+        era_supervisor::SerializedMessage,
         protocols::highway::{HighwayMessage, ACTION_ID_VERTEX},
-        serialize_payload,
         traits::Context,
         utils::ValidatorMap,
     },
@@ -436,7 +436,7 @@ impl<C: Context + 'static> Synchronizer<C> {
                 debug!(?uuid, dependency = ?transitive_dependency, %sender, "requesting dependency");
                 let msg = HighwayMessage::RequestDependency(uuid, transitive_dependency);
                 outcomes.push(ProtocolOutcome::CreatedTargetedMessage(
-                    serialize_payload(&msg),
+                    SerializedMessage::from_message(&msg),
                     sender,
                 ));
                 continue;

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -317,26 +317,28 @@ fn transitive_proposal_dependency() {
         sync.pop_vertex_to_add(&highway, &Default::default(), max_requests_for_vertex);
     assert!(maybe_pv.is_none());
     match &*outcomes {
-        [ProtocolOutcome::CreatedTargetedMessage(SerializedMessage::from_message(msg0), p0), ProtocolOutcome::CreatedTargetedMessage(SerializedMessage::from_message(msg1), p1)] =>
+        [ProtocolOutcome::CreatedTargetedMessage(msg0_serialized, p0), ProtocolOutcome::CreatedTargetedMessage(msg1_serialized, p1)] =>
         {
+            let msg0: HighwayMessage<TestContext> = msg0_serialized.deserialize_expect();
+            let msg1: HighwayMessage<TestContext> = msg1_serialized.deserialize_expect();
             assert_eq!(
                 vec![&peer0, &peer1],
                 vec![p0, p1].into_iter().sorted().collect_vec(),
                 "expected to request dependency from exactly two different peers",
             );
 
-            match (&**msg0, &**msg1) {
+            match (msg0, msg1) {
                 (
                     HighwayMessage::RequestDependency(_, dep0),
                     HighwayMessage::RequestDependency(_, dep1),
                 ) => {
                     assert_eq!(
-                        *dep0,
+                        dep0,
                         Dependency::Unit(c0),
                         "unexpected dependency requested"
                     );
                     assert_eq!(
-                        *dep0, *dep1,
+                        dep0, dep1,
                         "we should have requested the same dependency from two different peers"
                     );
                 }

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -367,9 +367,7 @@ fn assert_targeted_message(
     match outcome {
         ProtocolOutcome::CreatedTargetedMessage(raw_msg, peer0) => {
             assert_eq!(peer, peer0);
-            let msg = raw_msg
-                .deserialize_incoming()
-                .expect("failed to deserialize message");
+            let msg = raw_msg.deserialize_expect();
             match msg {
                 HighwayMessage::RequestDependency(_, got) => assert_eq!(got, expected),
                 other => panic!("unexpected variant: {:?}", other),

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -441,11 +441,14 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         info!(?participation, "validator participation");
     }
 
-    /// Logs the vertex' serialized size.
+    /// Logs the vertex' (network) serialized size.
     fn log_unit_size(&self, vertex: &Vertex<C>, log_msg: &str) {
         if self.config.log_unit_sizes {
             if let Some(hash) = vertex.unit_hash() {
-                let size = HighwayMessage::NewVertex(vertex.clone()).serialize().len();
+                let size =
+                    SerializedMessage::from_message(&HighwayMessage::NewVertex(vertex.clone()))
+                        .into_raw()
+                        .len();
                 info!(size, %hash, "{}", log_msg);
             }
         }
@@ -732,12 +735,6 @@ mod specimen_support {
                 }
             })
         }
-    }
-}
-
-impl<C: Context> HighwayMessage<C> {
-    pub(crate) fn serialize(&self) -> Vec<u8> {
-        bincode::serialize(self).expect("should serialize message")
     }
 }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -753,7 +753,7 @@ where
     ) -> ProtocolOutcomes<C> {
         match msg.deserialize_incoming() {
             Err(err) => {
-                warn!(?err, "could not desrialize highway message");
+                warn!(?err, "could not deserialize highway message");
                 vec![ProtocolOutcome::Disconnect(sender)]
             }
             Ok(HighwayMessage::NewVertex(v))

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -39,7 +39,7 @@ use crate::{
         protocols, serialize_payload,
         traits::{ConsensusValueT, Context},
         utils::ValidatorIndex,
-        ActionId, EraMessage, TimerId,
+        ActionId, TimerId,
     },
     types::{Chainspec, NodeId},
     NodeRng,
@@ -916,7 +916,7 @@ where
         sender: NodeId,
         _msg: Vec<u8>,
         _now: Timestamp,
-    ) -> (ProtocolOutcomes<C>, Option<EraMessage<C>>) {
+    ) -> (ProtocolOutcomes<C>, Option<Vec<u8>>) {
         info!(?sender, "invalid incoming request");
         (vec![ProtocolOutcome::Disconnect(sender)], None)
     }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -22,6 +22,7 @@ use crate::{
         },
         traits::Context,
         utils::{ValidatorIndex, Weight},
+        SerializedMessage,
     },
     types::BlockPayload,
 };
@@ -124,7 +125,7 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
     ));
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
     let sender = *ALICE_NODE_ID;
-    let msg = highway_message.into();
+    let msg = SerializedMessage::from_message(&highway_message);
     let outcomes = highway_protocol.handle_message(&mut rng, sender.to_owned(), msg, now);
     assert_eq!(&*outcomes, [ProtocolOutcome::Disconnect(sender)]);
 }
@@ -155,7 +156,7 @@ fn send_a_valid_wire_unit() {
 
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
     let sender = *ALICE_NODE_ID;
-    let msg = highway_message.into();
+    let msg = SerializedMessage::from_message(&highway_message);
 
     let mut outcomes = highway_protocol.handle_message(&mut rng, sender, msg, now);
     while let Some(outcome) = outcomes.pop() {
@@ -205,7 +206,7 @@ fn detect_doppelganger() {
     let _ = highway_protocol.activate_validator(ALICE_PUBLIC_KEY.clone(), alice_keypair, now, None);
     assert!(highway_protocol.is_active());
     let sender = *ALICE_NODE_ID;
-    let msg = highway_message.into();
+    let msg = SerializedMessage::from_message(&highway_message);
     // "Send" a message created by ALICE to an instance of Highway where she's an active validator.
     // An incoming unit, created by the same validator, should be properly detected as a
     // doppelganger.

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -91,7 +91,7 @@ use crate::{
         deserialize_payload, protocols, serialize_payload,
         traits::{ConsensusValueT, Context},
         utils::{ValidatorIndex, ValidatorMap, Validators, Weight},
-        ActionId, EraMessage, LeaderSequence, TimerId,
+        ActionId, LeaderSequence, TimerId,
     },
     types::{Chainspec, NodeId},
     utils, NodeRng,
@@ -720,7 +720,7 @@ impl<C: Context + 'static> Zug<C> {
         &self,
         sync_request: SyncRequest<C>,
         sender: NodeId,
-    ) -> (ProtocolOutcomes<C>, Option<EraMessage<C>>) {
+    ) -> (ProtocolOutcomes<C>, Option<Vec<u8>>) {
         let SyncRequest {
             round_id,
             mut proposal_hash,
@@ -862,7 +862,10 @@ impl<C: Context + 'static> Zug<C> {
             evidence,
             instance_id,
         };
-        (outcomes, Some(Message::SyncResponse(sync_response).into()))
+        (
+            outcomes,
+            Some(serialize_payload(&Message::SyncResponse(sync_response))),
+        )
     }
 
     /// The response containing the parts from the sender's protocol state that we were missing.
@@ -2004,7 +2007,7 @@ where
         sender: NodeId,
         msg: Vec<u8>,
         _now: Timestamp,
-    ) -> (ProtocolOutcomes<C>, Option<EraMessage<C>>) {
+    ) -> (ProtocolOutcomes<C>, Option<Vec<u8>>) {
         match deserialize_payload::<SyncRequest<C>>(&msg) {
             Err(err) => {
                 warn!(

--- a/node/src/components/consensus/protocols/zug/des_testing.rs
+++ b/node/src/components/consensus/protocols/zug/des_testing.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         traits::{ConsensusValueT, Context, ValidatorSecret},
         utils::{Validators, Weight},
-        ActionId, BlockContext, EraMessage, EraRequest, TimerId,
+        ActionId, BlockContext, EraRequest, TimerId,
     },
     types::NodeId,
     NodeRng,

--- a/node/src/components/consensus/protocols/zug/des_testing.rs
+++ b/node/src/components/consensus/protocols/zug/des_testing.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         traits::{ConsensusValueT, Context, ValidatorSecret},
         utils::{Validators, Weight},
-        ActionId, BlockContext, EraRequest, TimerId,
+        ActionId, BlockContext, SerializedMessage, TimerId,
     },
     types::NodeId,
     NodeRng,
@@ -61,10 +61,10 @@ pub(crate) const TEST_INSTANCE_ID: u64 = 42;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 enum ZugMessage {
-    GossipMessage(EraMessage<TestContext>),
-    TargetedMessage(EraMessage<TestContext>, NodeId),
-    MessageToRandomPeer(EraMessage<TestContext>),
-    RequestToRandomPeer(EraRequest<TestContext>),
+    GossipMessage(SerializedMessage),
+    TargetedMessage(SerializedMessage, NodeId),
+    MessageToRandomPeer(SerializedMessage),
+    RequestToRandomPeer(SerializedMessage),
     Timer(Timestamp, TimerId),
     QueueAction(ActionId),
     RequestNewBlock(BlockContext<TestContext>),
@@ -81,16 +81,20 @@ enum ZugMessage {
 
 impl ZugMessage {
     fn is_signed_gossip_message(&self) -> bool {
-        if let ZugMessage::GossipMessage(EraMessage::Zug(msg)) = self {
-            matches!(**msg, ZugProtocolMessage::Signed(_))
+        if let ZugMessage::GossipMessage(raw) = self {
+            let deserialized: super::Message<TestContext> =
+                raw.deserialize_incoming().expect("message not valid");
+            matches!(deserialized, ZugProtocolMessage::Signed(_))
         } else {
             false
         }
     }
 
     fn is_proposal(&self) -> bool {
-        if let ZugMessage::GossipMessage(EraMessage::Zug(msg)) = self {
-            matches!(**msg, ZugProtocolMessage::Proposal { .. })
+        if let ZugMessage::GossipMessage(raw) = self {
+            let deserialized: super::Message<TestContext> =
+                raw.deserialize_incoming().expect("message not valid");
+            matches!(deserialized, ZugProtocolMessage::Proposal { .. })
         } else {
             false
         }
@@ -295,21 +299,25 @@ impl ZugValidator {
                 }
             }
             Some(DesFault::Equivocate) => match msg {
-                ZugMessage::GossipMessage(EraMessage::Zug(ref zug_msg)) => match &**zug_msg {
-                    ZugProtocolMessage::Signed(signed_msg @ SignedMessage { content, .. }) => {
-                        match content {
+                ZugMessage::GossipMessage(ref serialized_msg) => {
+                    match serialized_msg.deserialize_incoming::<ZugProtocolMessage<TestContext>>() {
+                        Ok(ZugProtocolMessage::Signed(
+                            signed_msg @ SignedMessage { content, .. },
+                        )) => match content {
                             Content::Echo(hash) => {
                                 let conflicting_message = SignedMessage::sign_new(
                                     signed_msg.round_id,
                                     signed_msg.instance_id,
-                                    Content::Echo(HashWrapper(hash.0.wrapping_add(1))),
+                                    Content::<TestContext>::Echo(HashWrapper(
+                                        hash.0.wrapping_add(1),
+                                    )),
                                     signed_msg.validator_idx,
                                     &TestSecret(signed_msg.validator_idx.0.into()),
                                 );
                                 vec![
-                                    ZugMessage::GossipMessage(EraMessage::Zug(Box::new(
-                                        ZugProtocolMessage::Signed(conflicting_message),
-                                    ))),
+                                    ZugMessage::GossipMessage(SerializedMessage::from_message(
+                                        &ZugProtocolMessage::Signed(conflicting_message),
+                                    )),
                                     msg,
                                 ]
                             }
@@ -317,21 +325,21 @@ impl ZugValidator {
                                 let conflicting_message = SignedMessage::sign_new(
                                     signed_msg.round_id,
                                     signed_msg.instance_id,
-                                    Content::Vote(!vote),
+                                    Content::<TestContext>::Vote(!vote),
                                     signed_msg.validator_idx,
                                     &TestSecret(signed_msg.validator_idx.0.into()),
                                 );
                                 vec![
-                                    ZugMessage::GossipMessage(EraMessage::Zug(Box::new(
-                                        ZugProtocolMessage::Signed(conflicting_message),
-                                    ))),
+                                    ZugMessage::GossipMessage(SerializedMessage::from_message(
+                                        &ZugProtocolMessage::Signed(conflicting_message),
+                                    )),
                                     msg,
                                 ]
                             }
-                        }
+                        },
+                        _ => vec![msg],
                     }
-                    _ => vec![msg],
-                },
+                }
                 _ => vec![msg],
             },
         }

--- a/node/src/components/consensus/protocols/zug/message.rs
+++ b/node/src/components/consensus/protocols/zug/message.rs
@@ -8,7 +8,7 @@ use either::Either;
 use crate::{
     components::consensus::{
         protocols::zug::{Proposal, RoundId},
-        traits::{Context, ValidatorSecret},
+        traits::{ConsensusNetworkMessage, Context, ValidatorSecret},
         utils::ValidatorIndex,
     },
     utils::ds,
@@ -25,7 +25,7 @@ mod relaxed {
 
     use crate::components::consensus::{
         protocols::zug::{proposal::Proposal, RoundId},
-        traits::Context,
+        traits::{ConsensusNetworkMessage, Context},
     };
 
     use super::{SignedMessage, SyncResponse};
@@ -86,6 +86,8 @@ mod relaxed {
         /// Two conflicting signatures by the same validator.
         Evidence(SignedMessage<C>, Content<C>, C::Signature),
     }
+
+    impl<C: Context> ConsensusNetworkMessage for Message<C> {}
 }
 pub(crate) use relaxed::{Content, ContentDiscriminants, Message, MessageDiscriminants};
 
@@ -214,6 +216,8 @@ where
     pub(crate) faulty: u128,
     pub(crate) instance_id: C::InstanceId,
 }
+
+impl<C: Context> ConsensusNetworkMessage for SyncRequest<C> {}
 
 impl<C: Context> SyncRequest<C> {
     /// Creates a `SyncRequest` for a round in which we haven't received any messages yet.

--- a/node/src/components/consensus/protocols/zug/tests.rs
+++ b/node/src/components/consensus/protocols/zug/tests.rs
@@ -132,7 +132,7 @@ fn remove_gossip(
                 .clone();
             assert!(signed_msg.verify_signature(&public_key));
         }
-        result.push(msg.clone());
+        result.push(msg);
         false
     });
     result
@@ -242,7 +242,7 @@ fn remove_targeted_messages(
                 .clone();
             assert!(signed_msg.verify_signature(&public_key));
         }
-        result.push(msg.clone());
+        result.push(msg);
         false
     });
     result

--- a/node/src/components/consensus/protocols/zug/tests.rs
+++ b/node/src/components/consensus/protocols/zug/tests.rs
@@ -18,7 +18,6 @@ use crate::{
             BOB_SECRET_KEY, CAROL_PUBLIC_KEY, CAROL_SECRET_KEY,
         },
         traits::Context,
-        EraMessage,
     },
     testing,
     types::BlockPayload,
@@ -87,9 +86,9 @@ fn create_message(
     round_id: RoundId,
     content: Content<ClContext>,
     keypair: &Keypair,
-) -> EraMessage<ClContext> {
+) -> SerializedMessage {
     let signed_msg = create_signed_message(validators, round_id, content, keypair);
-    Message::Signed(signed_msg).into()
+    SerializedMessage::from_message(&Message::Signed(signed_msg))
 }
 
 /// Creates a `Message::Proposal`
@@ -98,17 +97,16 @@ fn create_proposal_message(
     proposal: &Proposal<ClContext>,
     validators: &Validators<PublicKey>,
     keypair: &Keypair,
-) -> EraMessage<ClContext> {
+) -> SerializedMessage {
     let hashed_proposal = HashedProposal::new(proposal.clone());
     let echo_content = Content::Echo(*hashed_proposal.hash());
     let echo = create_signed_message(validators, round_id, echo_content, keypair);
-    Message::Proposal {
+    SerializedMessage::from_message(&Message::Proposal {
         round_id,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         proposal: proposal.clone(),
         echo,
-    }
-    .into()
+    })
 }
 
 /// Removes all `CreatedGossipMessage`s from `outcomes` and returns the messages, after

--- a/node/src/components/consensus/protocols/zug/tests.rs
+++ b/node/src/components/consensus/protocols/zug/tests.rs
@@ -119,11 +119,13 @@ fn remove_gossip(
     let expected_instance_id = ClContext::hash(INSTANCE_ID_DATA);
     outcomes.retain(|outcome| {
         let msg = match outcome {
-            ProtocolOutcome::CreatedGossipMessage(EraMessage::Zug(msg)) => &**msg,
+            ProtocolOutcome::CreatedGossipMessage(serialized_msg) => {
+                serialized_msg.deserialize_expect::<Message<ClContext>>()
+            }
             _ => return true,
         };
         assert_eq!(*msg.instance_id(), expected_instance_id);
-        if let Message::Signed(signed_msg) = msg {
+        if let Message::Signed(ref signed_msg) = msg {
             let public_key = validators
                 .id(signed_msg.validator_idx)
                 .expect("validator ID")
@@ -202,9 +204,7 @@ fn remove_requests_to_random(
     let expected_instance_id = ClContext::hash(INSTANCE_ID_DATA);
     outcomes.retain(|outcome| {
         let msg: SyncRequest<ClContext> = match outcome {
-            ProtocolOutcome::CreatedRequestToRandomPeer(msg) => {
-                msg.clone().try_into_zug().expect("Zug request")
-            }
+            ProtocolOutcome::CreatedRequestToRandomPeer(msg) => msg.deserialize_expect(),
             _ => return true,
         };
         assert_eq!(msg.instance_id, expected_instance_id);
@@ -225,14 +225,17 @@ fn remove_targeted_messages(
     let expected_instance_id = ClContext::hash(INSTANCE_ID_DATA);
     outcomes.retain(|outcome| {
         let (msg, peer) = match outcome {
-            ProtocolOutcome::CreatedTargetedMessage(EraMessage::Zug(msg), peer) => (&**msg, *peer),
+            ProtocolOutcome::CreatedTargetedMessage(serialized_message, peer) => (
+                serialized_message.deserialize_expect::<Message<ClContext>>(),
+                *peer,
+            ),
             _ => return true,
         };
         if peer != expected_peer {
             return true;
         }
         assert_eq!(*msg.instance_id(), expected_instance_id);
-        if let Message::Signed(signed_msg) = msg {
+        if let Message::Signed(ref signed_msg) = msg {
             let public_key = validators
                 .id(signed_msg.validator_idx)
                 .expect("validator ID")
@@ -288,7 +291,7 @@ fn expect_no_gossip_block_finalized(outcomes: ProtocolOutcomes<ClContext>) {
     for outcome in outcomes {
         match outcome {
             ProtocolOutcome::FinalizedBlock(fb) => panic!("unexpected finalized block: {:?}", fb),
-            ProtocolOutcome::CreatedGossipMessage(EraMessage::Zug(msg)) => {
+            ProtocolOutcome::CreatedGossipMessage(msg) => {
                 panic!("unexpected gossip message {:?}", msg);
             }
             ProtocolOutcome::CreateNewBlock(block_context) => {
@@ -786,12 +789,16 @@ fn zug_handles_sync_request() {
         faulty: zug.validator_bit_field(first_validator_idx, vec![carol_idx].into_iter()),
         instance_id: *zug.instance_id(),
     };
-    let (outcomes, response) = zug.handle_request_message(&mut rng, sender, msg.into(), timestamp);
+    let (outcomes, response) = zug.handle_request_message(
+        &mut rng,
+        sender,
+        SerializedMessage::from_message(&msg),
+        timestamp,
+    );
     assert_eq!(
         response
             .expect("response")
-            .try_into_zug()
-            .expect("Zug message"),
+            .deserialize_expect::<Message<_>>(),
         Message::SyncResponse(SyncResponse {
             round_id: 0,
             proposal_or_hash: Some(Either::Left(proposal0)),
@@ -819,16 +826,20 @@ fn zug_handles_sync_request() {
         faulty: zug.validator_bit_field(first_validator_idx, vec![].into_iter()),
         instance_id: *zug.instance_id(),
     };
-    let (mut outcomes, response) =
-        zug.handle_request_message(&mut rng, sender, msg.into(), timestamp);
+    let (mut outcomes, response) = zug.handle_request_message(
+        &mut rng,
+        sender,
+        SerializedMessage::from_message(&msg),
+        timestamp,
+    );
     assert_eq!(
         remove_targeted_messages(&validators, sender, &mut outcomes),
         vec![]
     );
     expect_no_gossip_block_finalized(outcomes);
 
-    let sync_response = match response.expect("response").try_into_zug() {
-        Ok(Message::SyncResponse(sync_response)) => sync_response,
+    let sync_response = match response.expect("response").deserialize_expect() {
+        Message::SyncResponse(sync_response) => sync_response,
         result => panic!("unexpected message: {:?}", result),
     };
 

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -81,3 +81,10 @@ pub trait Context: Clone + DataSize + Debug + Eq + Ord + Hash + Send {
         signature: &<Self::ValidatorSecret as ValidatorSecret>::Signature,
     ) -> bool;
 }
+
+/// A marker trait indicating that the given type is a valid consensus message to be sent across the
+/// network.
+///
+/// Only implement this for types that are native to the consensus module and never for `Vec<u8>`,
+/// as this would break accidental double-serialization protection.
+pub trait ConsensusNetworkMessage {}

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -229,9 +229,7 @@ fn is_ping(event: &MainEvent) -> bool {
     if let MainEvent::ConsensusMessageIncoming(ConsensusMessageIncoming { message, .. }) = event {
         if let ConsensusMessage::Protocol { ref payload, .. } = **message {
             return matches!(
-                consensus::deserialize_payload::<consensus::EraMessage<ClContext>>(&payload)
-                    .expect("TODO")
-                    .try_into_highway(),
+                payload.deserialize_incoming::<HighwayMessage::<ClContext>>(),
                 Ok(HighwayMessage::<ClContext>::NewVertex(HighwayVertex::Ping(
                     _
                 )))

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -17,7 +17,9 @@ use casper_types::{
 
 use crate::{
     components::{
-        consensus::{self, ClContext, ConsensusMessage, HighwayVertex, NewBlockPayload},
+        consensus::{
+            self, ClContext, ConsensusMessage, HighwayMessage, HighwayVertex, NewBlockPayload,
+        },
         gossiper, network, storage,
         upgrade_watcher::NextUpgrade,
     },

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -229,7 +229,9 @@ fn is_ping(event: &MainEvent) -> bool {
     if let MainEvent::ConsensusMessageIncoming(ConsensusMessageIncoming { message, .. }) = event {
         if let ConsensusMessage::Protocol { ref payload, .. } = **message {
             return matches!(
-                payload.clone().try_into_highway(),
+                consensus::deserialize_payload::<consensus::EraMessage<ClContext>>(&payload)
+                    .expect("TODO")
+                    .try_into_highway(),
                 Ok(HighwayMessage::<ClContext>::NewVertex(HighwayVertex::Ping(
                     _
                 )))

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -17,9 +17,7 @@ use casper_types::{
 
 use crate::{
     components::{
-        consensus::{
-            self, ClContext, ConsensusMessage, HighwayMessage, HighwayVertex, NewBlockPayload,
-        },
+        consensus::{self, ClContext, ConsensusMessage, HighwayVertex, NewBlockPayload},
         gossiper, network, storage,
         upgrade_watcher::NextUpgrade,
     },


### PR DESCRIPTION
Closes #3880.

This PR undoes the change from nested serialization to typed variants in the networking protocol message introduced in https://github.com/casper-network/casper-node/commit/d59a4015706328f679470dc51967afb672a497b5. As a result, the networking is agnostic of the underlying consensus protocol again, at the expense of some type safety.

The main goal is to restore binary compatibility for consensus message with 1.4 again, as third party implementations otherwise would have to reimplement their consensus code if the network encoding format changes.

To avoid some likely mistakes due to accidental double serialization, the `SerializedMessage` newtype has been added.

In the past 9 month additional features and especially tests have been added to consensus, so a simple reversal of the original patch was not possible.