### PR TITLE
Disable unneeded casper-types feature in casper-hashing

### DIFF
--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,7 +12,7 @@ license-file = "../LICENSE"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "2.0.0", path = "../types", features = ["gens"] }
+casper-types = { version = "2.0.0", path = "../types" }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"


### PR DESCRIPTION
This avoids enabling `casper-types/gens` in `casper-hashing`.

A future PR will update casper-types to ensure the `gens` feature can be enabled standalone.
