### PR TITLE
Version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "casper-contract"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "casper-hashing"
-version = "1.4.4"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "base16",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "casper-json-rpc"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "env_logger",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.15-alt"
+version = "1.5.0-rc.1"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,10 +687,10 @@ dependencies = [
 name = "casper-updater"
 version = "0.3.0"
 dependencies = [
- "casper-types 2.0.0",
- "clap 2.34.0",
+ "clap 4.2.7",
  "once_cell",
  "regex",
+ "semver",
 ]
 
 [[package]]
@@ -720,13 +769,38 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.2.0",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "once_cell",
+ "strsim 0.10.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -743,6 +817,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +851,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "contract-context"
@@ -2402,6 +2500,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4446,6 +4556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "test-payment-stored"
 version = "0.1.0"
 dependencies = [
@@ -5046,6 +5166,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,40 +6,40 @@ version = 3
 name = "activate-bid"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "add-associated-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "add-bid"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "add-gas-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -174,16 +174,16 @@ dependencies = [
 name = "auction-bidding"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "auction-bids"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -281,8 +281,8 @@ dependencies = [
 name = "blake2b"
 version = "0.8.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -344,20 +344,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "casper-contract"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790b76807d64788758208757b0a17970bf756cb7c392f55b1a22021a34f95991"
-dependencies = [
- "casper-types 1.6.0",
- "hex_fmt",
- "wee_alloc",
-]
-
-[[package]]
-name = "casper-contract"
 version = "2.0.0"
 dependencies = [
- "casper-types 2.0.0",
+ "casper-types",
  "hex_fmt",
  "version-sync",
  "wee_alloc",
@@ -369,7 +358,7 @@ version = "4.0.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
- "casper-types 2.0.0",
+ "casper-types",
  "filesize",
  "humantime",
  "lmdb-rkv",
@@ -393,7 +382,7 @@ dependencies = [
  "casper-engine-test-support",
  "casper-execution-engine",
  "casper-hashing",
- "casper-types 2.0.0",
+ "casper-types",
  "clap 2.34.0",
  "criterion",
  "dictionary",
@@ -426,7 +415,7 @@ dependencies = [
  "base16",
  "bincode",
  "casper-hashing",
- "casper-types 2.0.0",
+ "casper-types",
  "casper-wasm-utils",
  "criterion",
  "datasize",
@@ -472,7 +461,7 @@ dependencies = [
  "base16",
  "bincode",
  "blake2",
- "casper-types 2.0.0",
+ "casper-types",
  "criterion",
  "datasize",
  "hex",
@@ -525,7 +514,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-hashing",
  "casper-json-rpc",
- "casper-types 2.0.0",
+ "casper-types",
  "datasize",
  "derive_more",
  "ed25519-dalek",
@@ -603,32 +592,6 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3288bc90c55767bc72460a7b4d050f6a38915142339b8c86a43fd10d2c77becf"
-dependencies = [
- "base16",
- "base64 0.13.1",
- "bitflags",
- "blake2",
- "ed25519-dalek",
- "hex",
- "hex_fmt",
- "k256",
- "num",
- "num-derive",
- "num-integer",
- "num-rational 0.4.1",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_json",
- "uint",
-]
-
-[[package]]
-name = "casper-types"
 version = "2.0.0"
 dependencies = [
  "base16",
@@ -687,7 +650,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base16",
- "casper-types 2.0.0",
+ "casper-types",
  "clap 3.2.25",
  "derive_more",
  "hex",
@@ -801,8 +764,8 @@ dependencies = [
 name = "contract-context"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -831,8 +794,8 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 name = "counter-installer"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -857,24 +820,24 @@ dependencies = [
 name = "create-accounts"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "create-purse-01"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "create-purses"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -903,8 +866,8 @@ name = "create-test-node-shared"
 version = "0.1.0"
 dependencies = [
  "base16",
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1166,8 +1129,8 @@ dependencies = [
 name = "delegate"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1196,24 +1159,24 @@ dependencies = [
 name = "deserialize-error"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "dictionary"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "dictionary-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "dictionary",
 ]
 
@@ -1221,16 +1184,16 @@ dependencies = [
 name = "dictionary-item-key-length"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "dictionary-read"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1262,31 +1225,31 @@ dependencies = [
 name = "do-nothing"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
+ "casper-contract",
 ]
 
 [[package]]
 name = "do-nothing-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "do-nothing-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "do-nothing-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "create-purse-01",
 ]
 
@@ -1354,175 +1317,175 @@ dependencies = [
 name = "ee-1071-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-1129-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-1217-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-1225-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-401-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-441-rng-state"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-460-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-532-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
+ "casper-contract",
 ]
 
 [[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-539-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-549-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-550-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-572-regression-create"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-572-regression-escalate"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-584-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-597-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-598-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-599-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-601-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "ee-771-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1568,8 +1531,8 @@ dependencies = [
 name = "endless-loop"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1673,8 +1636,8 @@ dependencies = [
 name = "expensive-calculation"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1696,16 +1659,16 @@ dependencies = [
 name = "faucet"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "faucet-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "faucet",
 ]
 
@@ -1733,8 +1696,8 @@ dependencies = [
 name = "finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1902,24 +1865,24 @@ dependencies = [
 name = "get-arg"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-call-stack-call-recursive-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "get-call-stack-recursive-subcall",
 ]
 
@@ -1927,48 +1890,48 @@ dependencies = [
 name = "get-call-stack-recursive-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-caller"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-caller-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-payment-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-phase"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "get-phase-payment"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -1998,16 +1961,16 @@ dependencies = [
 name = "gh-1470-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "gh-1470-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "gh-1470-regression",
 ]
 
@@ -2015,40 +1978,40 @@ dependencies = [
 name = "gh-1688-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "gh-2280-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "gh-2280-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "gh-3097-regression"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "gh-3097-regression-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2091,7 +2054,7 @@ dependencies = [
  "casper-engine-test-support",
  "casper-execution-engine",
  "casper-hashing",
- "casper-types 2.0.0",
+ "casper-types",
  "clap 2.34.0",
  "lmdb-rkv",
  "rand 0.8.5",
@@ -2114,8 +2077,8 @@ dependencies = [
 name = "groups"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2193,8 +2156,8 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 name = "hello-world"
 version = "0.1.0"
 dependencies = [
- "casper-contract 1.4.4",
- "casper-types 1.6.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2270,16 +2233,16 @@ dependencies = [
 name = "host-function-costs"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "host-function-metrics"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "rand 0.8.5",
 ]
 
@@ -2391,8 +2354,8 @@ dependencies = [
 name = "increment-counter"
 version = "1.0.0"
 dependencies = [
- "casper-contract 1.4.4",
- "casper-types 1.6.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2499,8 +2462,8 @@ dependencies = [
 name = "key-management-thresholds"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2567,16 +2530,16 @@ checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 name = "list-authorization-keys"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "list-named-keys"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2636,16 +2599,16 @@ dependencies = [
 name = "main-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "manage-groups"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2673,8 +2636,8 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 name = "measure-gas-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2751,8 +2714,8 @@ dependencies = [
 name = "mint-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2789,48 +2752,48 @@ dependencies = [
 name = "multisig-authorization"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "named-dictionary-test"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "named-keys"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "named-keys-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "named-keys-stored-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "named-purse-payment"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -2855,15 +2818,15 @@ dependencies = [
 name = "nctl-dictionary"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "new-named-uref"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
+ "casper-contract",
 ]
 
 [[package]]
@@ -3083,8 +3046,8 @@ dependencies = [
 name = "ordered-transforms"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3112,8 +3075,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 name = "overwrite-uref-content"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3469,24 +3432,24 @@ dependencies = [
 name = "purse-holder-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "purse-holder-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "purse-holder-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3628,16 +3591,16 @@ dependencies = [
 name = "random-bytes"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "random-bytes-payment"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3675,16 +3638,16 @@ dependencies = [
 name = "read-from-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "redelegate"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3709,8 +3672,8 @@ dependencies = [
 name = "refund-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3749,136 +3712,136 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 name = "regression-20210707"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20210831"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220204"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220204-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220204-nontrivial"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220207"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220208"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220211"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220211-call"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-20220222"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-add-bid"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-delegate"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-payment"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression-transfer"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression_20211110"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "regression_20220119"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -3924,8 +3887,8 @@ dependencies = [
 name = "revert"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4203,8 +4166,8 @@ dependencies = [
 name = "set-action-thresholds"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4279,8 +4242,8 @@ dependencies = [
 name = "simple-transfer"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4321,8 +4284,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 name = "state-initializer"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4341,8 +4304,8 @@ checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 name = "storage-costs"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4456,8 +4419,8 @@ dependencies = [
 name = "system-contract-hashes"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4486,8 +4449,8 @@ dependencies = [
 name = "test-payment-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -4830,32 +4793,32 @@ dependencies = [
 name = "transfer-main-purse-to-new-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-main-purse-to-two-purses"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-account"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-account-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "transfer-purse-to-account",
 ]
 
@@ -4863,24 +4826,24 @@ dependencies = [
 name = "transfer-purse-to-account-with-id"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-accounts"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-accounts-stored"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
  "transfer-purse-to-accounts",
 ]
 
@@ -4888,72 +4851,72 @@ dependencies = [
 name = "transfer-purse-to-accounts-subcall"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-public-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-account"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-account-u512"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-existing-account"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-named-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-public-key"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
 name = "transfer-to-purse"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -5009,8 +4972,8 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 name = "undelegate"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]
@@ -5633,8 +5596,8 @@ dependencies = [
 name = "withdraw-bid"
 version = "0.1.0"
 dependencies = [
- "casper-contract 2.0.0",
- "casper-types 2.0.0",
+ "casper-contract",
+ "casper-types",
 ]
 
 [[package]]

--- a/ci/casper_updater/Cargo.toml
+++ b/ci/casper_updater/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.3.0"
 
 [dependencies]
-casper-types = { path = "../../types" }
-clap = "2"
-once_cell = "1"
-regex = "1"
+clap = { version = "4.2.7", features = ["cargo", "deprecated", "wrap_help"] }
+once_cell = "1.17.1"
+regex = "1.8.1"
+semver = "1.0.17"

--- a/ci/casper_updater/src/chainspec.rs
+++ b/ci/casper_updater/src/chainspec.rs
@@ -1,11 +1,7 @@
-use std::{
-    convert::TryFrom,
-    io::{self, Write},
-};
+use std::io::{self, Write};
 
 use regex::Regex;
-
-use casper_types::SemVer;
+use semver::Version;
 
 use crate::{package, regex_data};
 
@@ -15,7 +11,7 @@ const CAPTURE_INDEX: usize = 2;
 /// updated.
 pub struct Chainspec {
     /// The current production protocol version.
-    current_protocol_version: SemVer,
+    current_protocol_version: Version,
     /// The current production activation point.
     current_activation_point: String,
 }
@@ -50,8 +46,8 @@ impl Chainspec {
 
         let protocol_version = find_value(&regex_data::chainspec_protocol_version::REGEX);
         let current_activation_point = find_value(&regex_data::chainspec_activation_point::REGEX);
-        let current_protocol_version = SemVer::try_from(protocol_version.as_str())
-            .expect("should parse current protocol version");
+        let current_protocol_version =
+            Version::parse(&protocol_version).expect("should parse current protocol version");
 
         Chainspec {
             current_protocol_version,
@@ -66,7 +62,7 @@ impl Chainspec {
                 self.current_protocol_version
             );
             if let Some(bump_version) = crate::bump_version() {
-                let updated_protocol_version = bump_version.update(self.current_protocol_version);
+                let updated_protocol_version = bump_version.update(&self.current_protocol_version);
                 println!("Will be updated to {}", updated_protocol_version);
             }
             println!("Files affected by the protocol version:");
@@ -97,12 +93,12 @@ impl Chainspec {
         let updated_protocol_version = match crate::bump_version() {
             None => match package::get_updated_version_from_user(
                 "chainspec protocol",
-                self.current_protocol_version,
+                &self.current_protocol_version,
             ) {
                 Some(version) => version,
                 None => return,
             },
-            Some(bump_version) => bump_version.update(self.current_protocol_version),
+            Some(bump_version) => bump_version.update(&self.current_protocol_version),
         };
 
         for dependent_file in &*regex_data::chainspec_protocol_version::DEPENDENT_FILES {

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -28,6 +28,11 @@ pub mod types {
     pub static DEPENDENT_FILES: Lazy<Vec<DependentFile>> = Lazy::new(|| {
         vec![
             DependentFile::new(
+                "hashing/Cargo.toml",
+                Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                replacement,
+            ),
+            DependentFile::new(
                 "execution_engine/Cargo.toml",
                 Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
                 replacement,

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
-## Unreleased
+## 5.0.0
 
 ### Added
 * Add a new entry point `redelegate` to the Auction system contract which allows users to redelegate to another validator without having to unbond. The function signature for the entrypoint is: `redelegate(delegator: PublicKey, validator: PublicKey, amount: U512, new_validator: PublicKey)`
@@ -21,9 +21,8 @@ All notable changes to this project will be documented in this file.  The format
 * Fix some integer casts.
 * Change both genesis and upgrade functions to write `ChainspecRegistry` under the fixed `Key::ChainspecRegistry`.
 * Lift the temporary limit of the size of individual values stored in global state.
-* Lift the temporary limit of the global maximum delegator capacity.
 * Providing incorrect Wasm for execution will cause the default 2.5CSPR to be charged.
-* Update the default `control_flow` opcode cost from `440` to `440000`.
+* Update the default `control_flow` opcode cost from `440` to `440_000`.
 
 
 

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "4.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "5.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -14,8 +14,8 @@ license = "Apache-2.0"
 anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
-casper-hashing = { version = "1.4.4", path = "../hashing" }
-casper-types = { version = "2.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-hashing = { version = "2.0.0", path = "../hashing" }
+casper-types = { version = "3.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 casper-wasm-utils = "1.0.0"
 datasize = "0.2.4"
 either = "1.8.1"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/4.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/5.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 5.0.0
 
 ### Added
 * Add `WasmTestBuilder::get_execution_journals` method for returning execution journals for all test runs.
@@ -22,9 +22,6 @@ All notable changes to this project will be documented in this file.  The format
 ### Changed
 * `WasmTestBuilder::get_transforms` is deprecated in favor of `WasmTestBuilder::get_execution_journals`.
 * `deploy_hash` field is now defaulted to a random value rather than zeros in `DeployItemBuilder`.
-
-### Deprecated
-* Deprecate the `DEFAULT_GENESIS_REQUEST` in favor of `PRODUCTION_GENESIS_REQUEST`.
 
 
 
@@ -69,7 +66,9 @@ All notable changes to this project will be documented in this file.  The format
 * Add some auction and transfer test support functions for reuse among benchmarks and unit tests.
 
 ### Deprecated
-* Deprecated the `DEFAULT_GENESIS_REQUEST` in favor of `PRODUCTION_GENESIS_REQUEST`.
+* Deprecated the `DEFAULT_RUN_GENESIS_REQUEST` in favor of `PRODUCTION_RUN_GENESIS_REQUEST`.
+
+
 
 ## 2.1.0
 

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "4.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "5.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license = "Apache-2.0"
 
 [dependencies]
-casper-execution-engine = { version = "4.0.0", path = "../../execution_engine", features = ["test-support"] }
-casper-hashing = { version = "1.4.4", path = "../../hashing" }
-casper-types = { version = "2.0.0", path = "../../types" }
+casper-execution-engine = { version = "5.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-hashing = { version = "2.0.0", path = "../../hashing" }
+casper-types = { version = "3.0.0", path = "../../types" }
 humantime = "2"
 filesize = "0.2.0"
 lmdb-rkv = "0.14"
@@ -27,7 +27,7 @@ toml = "0.5.6"
 tempfile = "3.4.0"
 
 [dev-dependencies]
-casper-types = { version = "2.0.0", path = "../../types", features = ["std"] }
+casper-types = { version = "3.0.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [features]

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/4.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/5.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/hashing/CHANGELOG.md
+++ b/hashing/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 2.0.0
+
+### Added
+* Add `ChunkWithProof` to support chunking of large values, and associated Merkle-proofs of these.
+
+
+
 ## 1.4.4
 
 ### Changed

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-hashing"
-version = "1.4.4"
+version = "2.0.0"
 edition = "2018"
 description = "A library providing hashing functionality including Merkle Proof utilities."
 readme = "README.md"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "2.0.0", path = "../types", features = ["datasize", "std"] }
+casper-types = { version = "3.0.0", path = "../types", features = ["datasize", "std"] }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"

--- a/hashing/src/error.rs
+++ b/hashing/src/error.rs
@@ -5,6 +5,7 @@ use crate::{ChunkWithProof, Digest};
 
 /// Possible hashing errors.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Incorrect digest length {0}, expected length {}.", Digest::LENGTH)]
     /// The digest length was an incorrect size.

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -1,5 +1,5 @@
 //! A library providing hashing functionality including Merkle Proof utilities.
-#![doc(html_root_url = "https://docs.rs/casper-hashing/1.4.4")]
+#![doc(html_root_url = "https://docs.rs/casper-hashing/2.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/json_rpc/CHANGELOG.md
+++ b/json_rpc/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
-## [Unreleased]
+## 1.0.0
 
 ### Added
 * Add initial content.

--- a/json_rpc/Cargo.toml
+++ b/json_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-json-rpc"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A library suitable for use as the framework for a JSON-RPC server."

--- a/json_rpc/src/lib.rs
+++ b/json_rpc/src/lib.rs
@@ -65,7 +65,7 @@
 //! Generally a set of custom error codes should be provided.  These should all implement
 //! [`ErrorCodeT`].
 
-#![doc(html_root_url = "https://docs.rs/casper-json-rpc/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/casper-json-rpc/1.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
-## [Unreleased]
+## 1.5.0-rc.1
 
 ### Added
 * Introduce fast-syncing to join the network, avoiding the need to execute every block to catch up.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.15-alt" # when updating, also update 'html_root_url' in lib.rs
+version = "1.5.0-rc.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -21,10 +21,10 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "4.0.0", path = "../execution_engine" }
-casper-hashing = { version = "1.4.4", path = "../hashing" }
-casper-json-rpc = { version = "0.1.0", path = "../json_rpc" }
-casper-types = { version = "2.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-execution-engine = { version = "5.0.0", path = "../execution_engine" }
+casper-hashing = { version = "2.0.0", path = "../hashing" }
+casper-json-rpc = { version = "1.0.0", path = "../json_rpc" }
+casper-types = { version = "3.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 datasize = { version = "0.2.11", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"
 ed25519-dalek = { version = "1", default-features = false, features = ["rand", "serde", "u64_backend"] }

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -30,7 +30,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 15);
+    ProtocolVersion::from_parts(1, 5, 0);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.15-alt")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.5.0-rc.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.15'
+version = '1.5.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -5,7 +5,7 @@
     {
       "openrpc": "1.0.0-rc1",
       "info": {
-        "version": "1.4.15",
+        "version": "1.5.0",
         "title": "Client API of Casper Node",
         "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
         "contact": {
@@ -120,7 +120,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -205,7 +205,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "deploy": {
                     "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                     "header": {
@@ -372,7 +372,7 @@
               "result": {
                 "name": "state_get_account_info_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "account": {
                     "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                     "named_keys": [],
@@ -468,7 +468,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "stored_value": {
                     "CLValue": {
@@ -576,7 +576,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "block_header": {
                     "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
                     "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
@@ -710,7 +710,7 @@
               "result": {
                 "name": "query_balance_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "balance": "123456"
                 }
               }
@@ -750,7 +750,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "peers": [
                     {
                       "node_id": "tls:0101..0101",
@@ -885,7 +885,7 @@
                       "address": "127.0.0.1:54321"
                     }
                   ],
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -963,7 +963,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -1012,7 +1012,7 @@
               "result": {
                 "name": "info_get_chainspec_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "chainspec_bytes": {
                     "chainspec_bytes": "2a2a",
                     "maybe_genesis_accounts_bytes": null,
@@ -1078,7 +1078,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "block": {
                     "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "header": {
@@ -1206,7 +1206,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -1280,7 +1280,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -1369,7 +1369,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "stored_value": {
                     "CLValue": {
                       "cl_type": "U64",
@@ -1447,7 +1447,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -1510,7 +1510,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -1590,7 +1590,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "auction_state": {
                     "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                     "block_height": 10,
@@ -1672,7 +1672,7 @@
               "result": {
                 "name": "chain_get_era_summary_example_result",
                 "value": {
-                  "api_version": "1.4.15",
+                  "api_version": "1.5.0",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -11,10 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## 2.0.0
-
-### Changed
-* Update `casper-types` to v2.0.0 due to additional `Key` variant, requiring a major version bump here.
+## 3.0.0
 
 ### Added
 * Support fetching the calling account's authorization keys via the new function `runtime::list_authorization_keys` which calls the new `ext_ffi::casper_load_authorization_keys`.
@@ -25,9 +22,15 @@ All notable changes to this project will be documented in this file.  The format
 * Add `storage::named_dictionary_get` for reading a named value from a named dictionary.
 
 ### Changed
-* Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 * Update pinned version of Rust to `nightly-2022-08-03`.
+* Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 
+
+
+## 2.0.0
+
+### Changed
+* Update `casper-types` to v2.0.0 due to additional `Key` variant, requiring a major version bump here.
 
 
 

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "A library for developing Casper network smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license = "Apache-2.0"
 
 [dependencies]
-casper-types = { version = "2.0.0", path = "../../types" }
+casper-types = { version = "3.0.0", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -50,7 +50,7 @@
     all(not(test), feature = "no-std-helpers"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/3.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/CHANGELOG.md
+++ b/smart_contracts/contract_as/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 1.5.0-rc.1
 
 ### Added
 * Add `casper_random_bytes` function.

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.15-alt",
+  "version": "1.5.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.15-alt",
+  "version": "1.5.0-rc.1",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contracts/tutorial/hello-world/.cargo/config
+++ b/smart_contracts/contracts/tutorial/hello-world/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-unknown-unknown"

--- a/smart_contracts/contracts/tutorial/hello-world/Cargo.toml
+++ b/smart_contracts/contracts/tutorial/hello-world/Cargo.toml
@@ -2,11 +2,7 @@
 name = "hello-world"
 version = "0.1.0"
 authors = ["darthsiroftardis <karan@casperlabs.io>", "Michał Papierski <michal@casperlabs.io>"]
-edition = "2021"
-
-[dependencies]
-casper-contract = "1.4.4"
-casper-types = "1.5.0"
+edition = "2018"
 
 [[bin]]
 name = "hello_world"
@@ -14,3 +10,7 @@ path = "src/main.rs"
 bench = false
 doctest = false
 test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/tutorial/increment-counter/Cargo.toml
+++ b/smart_contracts/contracts/tutorial/increment-counter/Cargo.toml
@@ -2,11 +2,7 @@
 name = "increment-counter"
 version = "1.0.0"
 authors = ["Maciej Zielinski <maciej@casperlabs.io>", "Michał Papierski <michal@casperlabs.io>"]
-edition = "2021"
-
-[dependencies]
-casper-contract = "1.4.4"
-casper-types = "1.5.0"
+edition = "2018"
 
 [[bin]]
 name = "increment_counter"
@@ -14,3 +10,7 @@ path = "src/main.rs"
 bench = false
 doctest = false
 test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## 3.0.0
 
 ### Added
 * Add new `bytesrepr::Error::NotRepresentable` error variant that represents values that are not representable by the serialization format.
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.  The format
 * Extend `UnbondingPurse` to take a new field `new_validator` which represents the validator to whom tokens will be re-delegated.
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 * Change prefix of formatted string representation of `ContractPackageHash` from "contract-package-wasm" to "contract-package-". Parsing from the old format is still supported.
-* Applied `#[non_exhaustive]` to error enums.
+* Apply `#[non_exhaustive]` to error enums.
 * Change Debug output of `DeployHash` to hex-encoded string rather than a list of integers.
 
 ### Fixed
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.  The format
 ## 2.0.0
 
 ### Fixed
-* Republished v1.6.0 as v2.0.0 due to missed breaking change in API (addition of new variant to `Key`).
+* Republish v1.6.0 as v2.0.0 due to missed breaking change in API (addition of new variant to `Key`).
 
 
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/3.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR bumps the versions of all of the published crates in preparation for the node 1.5.0 release.

In running the `casper-updater` tool, I discovered that a couple of Rust smart contracts had used crates.io as the source of casper dependencies, so this has been rectified in the first commit.

The tool itself also needed to be updated to handle semvers containing a pre-release version, and to include `casper-hashing`'s manifest in the set of files to be updated when `casper-types` is version-bumped.