### PR TITLE
Change `check_network_sync` to `parallel_check_network_sync`

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_04.sh
@@ -347,7 +347,7 @@ function _step_12()
 {
     log_step_upgrades 12 "Asserting all nodes are in sync..."
     # args: first node, last node, timeout, log_step
-    check_network_sync '1' '10' '300' 'false'
+    parallel_check_network_sync '1' '10' '300' 'false'
 }
 
 # Step 13: Assert chain didn't stall.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_05.sh
@@ -347,7 +347,7 @@ function _step_12()
 {
     log_step_upgrades 12 "Asserting all nodes are in sync..."
     # args: first node, last node, timeout, log_step
-    check_network_sync '1' '10' '300' 'false'
+    parallel_check_network_sync '1' '10' '300' 'false'
 }
 
 # Step 13: Assert chain didn't stall.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_06.sh
@@ -329,7 +329,7 @@ function _step_12()
 {
     log_step_upgrades 12 "Asserting all nodes are in sync..."
     # args: first node, last node, timeout, log_step
-    check_network_sync '1' '10' '300' 'false'
+    parallel_check_network_sync '1' '10' '300' 'false'
 }
 
 # Step 13: Assert chain didn't stall.

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_07.sh
@@ -329,7 +329,7 @@ function _step_12()
 {
     log_step_upgrades 12 "Asserting all nodes are in sync..."
     # args: first node, last node, timeout, log_step
-    check_network_sync '1' '10' '300' 'false'
+    parallel_check_network_sync '1' '10' '300' 'false'
 }
 
 # Step 13: Assert chain didn't stall.

--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -18,7 +18,7 @@ function main() {
     # 1. Allow the chain to progress
     do_await_era_change 1
     # 2. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3. Submit bid for node 6
     do_submit_auction_bids "6"
     do_read_lfb_hash "5"

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -196,7 +196,7 @@ function parallel_check_network_sync() {
         fi
 
         if [ "$UNIQUE_HASH_COUNT" -eq 1 ]; then
-            log "nodes 1 to $LAST_NODE in sync, proceeding..."
+            log "nodes $FIRST_NODE to $LAST_NODE in sync, proceeding..."
             nctl-view-chain-height
             rm -f $PIPE
             break

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -129,83 +129,91 @@ function get_reactor_state() {
     echo "$REACTOR_STATE"
 }
 
-function parallel_check_nodes_1_to_5_sync() {
-    local ALL_HASHES
-    local UNIQUE_HASH_COUNT
-    local TIMEOUT_SEC=${1-300}
-    local ATTEMPTS=0
-    
-    while [ "$ATTEMPTS" -le "$TIMEOUT_SEC" ]; do
-        ALL_HASHES=$(get_chain_latest_block_hash 1 & \
-                     get_chain_latest_block_hash 2 & \
-                     get_chain_latest_block_hash 3 & \
-                     get_chain_latest_block_hash 4 & \
-                     get_chain_latest_block_hash 5 & \
-                     wait)
-        log "All hashes:\n$ALL_HASHES"
-        UNIQUE_HASH_COUNT=$(echo $ALL_HASHES | sort | uniq | wc -l)
-        log "Unique hashes count: $UNIQUE_HASH_COUNT"
-        if [ "$UNIQUE_HASH_COUNT" -eq 1 ]; then
-            log "nodes 1 to 5 in sync, proceeding..."
-            nctl-view-chain-height
-            break
-        fi
-        ATTEMPTS=$((ATTEMPTS + 1))
-        if [ "$ATTEMPTS" -lt "$TIMEOUT_SEC" ]; then
-            sleep 1
-            log "attempt $ATTEMPTS out of $TIMEOUT_SEC..."
-        fi
-    done
+function write_lfb_of_node_to_pipe() {
+    local LOG=${3:-'true'}
+
+    HASH=$(get_chain_latest_block_hash $1)
+    if [ "$LOG" = 'true' ]; then
+        log "writing $HASH for node $1 to pipe"
+    fi
+    echo "$HASH" >$2
 }
 
-function check_network_sync() {
-    local WAIT_TIME_SEC=0
+function parallel_check_network_sync() {
     local FIRST_NODE=${1:-1}
     local LAST_NODE=${2:-10}
     local SYNC_TIMEOUT_SEC=${3:-"$SYNC_TIMEOUT_SEC"}
     local LOG=${4:-'true'}
 
+    local PIPE=/tmp/casper_lfb_test_pipe
+    local ALL_HASHES=""
+    local EXPECTED
+    local ATTEMPTS=0
+
+    rm -f $PIPE
+    if [[ ! -p $PIPE ]]; then
+        mkfifo $PIPE
+    fi
+
     if [ "$LOG" = 'true' ]; then
         log_step "checking nodes' $FIRST_NODE to $LAST_NODE LFBs are in sync"
     fi
 
-    while [ "$WAIT_TIME_SEC" != "$SYNC_TIMEOUT_SEC" ]; do
-        declare -a ALL_LFBS
-
-        index=0
-        for i in $(eval echo "{$FIRST_NODE..$LAST_NODE}")
+    while [ "$ATTEMPTS" -le "$SYNC_TIMEOUT_SEC" ]; do
+        ALL_HASHES=""
+        EXPECTED=$((LAST_NODE-FIRST_NODE+1))
+        for IDX in $(seq "$FIRST_NODE" "$LAST_NODE")
         do
-            ALL_LFBS[$index]=$(do_read_lfb_hash $i)
-            log "got LFB of node $i"
-            index=$((index + 1))
+            write_lfb_of_node_to_pipe $IDX $PIPE $LOG &
         done
 
-        LFB_COUNT=${#ALL_LFBS[@]}
-        BASE_LFB=${ALL_LFBS[0]}
-        ALL_EQUAL=1
-        for i in $(eval echo "{0..$((LFB_COUNT - 1))}")
+        while true
         do
-            if [[ "$BASE_LFB" != "${ALL_LFBS[$i]}" ]]; then
-                log "not all LFBs equal, will try again"
-                ALL_EQUAL=0
-                break
+            if read LINE;
+            then
+                if [ "$LOG" = 'true' ]; then
+                    log "read $LINE from pipe"
+                fi
+                ALL_HASHES="$ALL_HASHES $LINE"
+                EXPECTED=$((EXPECTED - 1))
+                if [ "$LOG" = 'true' ]; then
+                    log "expected $EXPECTED"
+                fi
+                if [ "$EXPECTED" -eq "0" ]; then
+                    break
+                fi
             fi
-        done
+        done < $PIPE
+        wait
 
-        if [ "$ALL_EQUAL" -eq 1 ]; then
-            log "nodes $FIRST_NODE to $LAST_NODE in sync, proceeding..."
-            nctl-view-chain-height
-            break
+        if [ "$LOG" = 'true' ]; then
+            log "I have all hashes: $ALL_HASHES"
         fi
 
-        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
-        if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
+        UNIQUE_HASH_COUNT=$(echo $ALL_HASHES | tr " " "\n" | sort | uniq | wc -l)
+        if [ "$LOG" = 'true' ]; then
+            log "unique hash count: $UNIQUE_HASH_COUNT"
+        fi
+
+        if [ "$UNIQUE_HASH_COUNT" -eq 1 ]; then
+            log "nodes 1 to $LAST_NODE in sync, proceeding..."
+            nctl-view-chain-height
+            rm -f $PIPE
+            break
+        fi
+        ATTEMPTS=$((ATTEMPTS + 1))
+        if [ "$ATTEMPTS" -lt "$SYNC_TIMEOUT_SEC" ]; then
+            sleep 1
+            if [ "$LOG" = 'true' ]; then
+                log "attempt $ATTEMPTS out of $SYNC_TIMEOUT_SEC..."
+            fi
+        else
             log "ERROR: Failed to confirm network sync"
             nctl-status
             nctl-view-chain-height
+            rm -f $PIPE
             exit 1
         fi
-        sleep 1
     done
 }
 

--- a/utils/nctl/sh/scenarios/gov96.sh
+++ b/utils/nctl/sh/scenarios/gov96.sh
@@ -27,7 +27,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3-6. Stop four nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -46,11 +46,11 @@ function main() {
     do_start_node "3" "$STALLED_LFB"
     do_start_node "2" "$STALLED_LFB"
     # 13. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 14. Ensure era proceeds after restart
     do_await_era_change "2"
     # 15. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 16-17. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst01.sh
+++ b/utils/nctl/sh/scenarios/itst01.sh
@@ -40,9 +40,9 @@ function main() {
     # wait 1 era, and then check they are still in sync.
     # This way we can verify that the node is up-to-date with the protocol state
     # after transitioning to an active validator.
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5 
     do_await_era_change
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 9. Run Closing Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -24,7 +24,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3-5. Stop three nodes
     do_stop_node "5"
     do_stop_node "4"
@@ -36,11 +36,11 @@ function main() {
     do_start_node "4" "$STALLED_LFB"
     do_start_node "3" "$STALLED_LFB"
     # 10. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 11. Ensure era proceeds after restart
     do_await_era_change "2"
     # 12. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 13-15. Compare stalled lfb hash to current
     assert_chain_progressed "5" "$STALLED_LFB"
     assert_chain_progressed "4" "$STALLED_LFB"

--- a/utils/nctl/sh/scenarios/itst06.sh
+++ b/utils/nctl/sh/scenarios/itst06.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasmless_transfers '5'
     # 4. Stop node being sent transfers
@@ -34,7 +34,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst07.sh
+++ b/utils/nctl/sh/scenarios/itst07.sh
@@ -21,7 +21,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks '5'
     # 2. Verify network is in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3. Background transfers so we can stop the node mid-stream
     do_background_wasm_transfers '5'
     # 4. Stop node being sent transfers
@@ -33,7 +33,7 @@ function main() {
     do_read_lfb_hash '1'
     do_start_node '5' "$LFB_HASH"
     # 7. Verify network is in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 8. Give the transfers a chance to be included
     do_await_n_blocks '30'
     # 9. Walkback and verify transfers were included in blocks

--- a/utils/nctl/sh/scenarios/itst11.sh
+++ b/utils/nctl/sh/scenarios/itst11.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Allow chain to progress
     do_await_era_change
     # 2. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3. Create the doppelganger
     create_doppelganger '5' '6'
     # 4. Get LFB Hash

--- a/utils/nctl/sh/scenarios/itst13.sh
+++ b/utils/nctl/sh/scenarios/itst13.sh
@@ -22,7 +22,7 @@ function main() {
     # Wait for network start up
     do_await_genesis_era_to_complete
     # Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # Stop the node
     do_stop_node '5'
     # Wait until N+1

--- a/utils/nctl/sh/scenarios/itst14.sh
+++ b/utils/nctl/sh/scenarios/itst14.sh
@@ -22,7 +22,7 @@ function main() {
     # 1. Verify network is creating blocks
     do_await_n_blocks "5"
     # 2. Verify network is in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 3a. Get era
     STOPPED_ERA=$(check_current_era)
     # 3b. Stop node
@@ -34,11 +34,11 @@ function main() {
     do_read_lfb_hash 1
     do_start_node "5" "$LFB_HASH"
     # 6. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 7. Verify network is creating blocks post-restart
     do_await_n_blocks "5"
     # 8. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 9. Verify node proposed a block
     assert_node_proposed '5' '180'
     # 10. Verify we are in the same era
@@ -46,7 +46,7 @@ function main() {
     # 11. Wait an era
     do_await_era_change
     # 12. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
     # 13. Run Health Checks
     # ... restarts=1: due to node being stopped and started
     source "$NCTL"/sh/scenarios/common/health_checks.sh \

--- a/utils/nctl/sh/scenarios/swap_validator_set.sh
+++ b/utils/nctl/sh/scenarios/swap_validator_set.sh
@@ -22,7 +22,7 @@ function main() {
     PRE_SWAP_HASH=$(do_read_lfb_hash 1)
 
     # 2. Verify all nodes are in sync
-    parallel_check_nodes_1_to_5_sync
+    parallel_check_network_sync 1 5
 
     # 3. Send some wasm to all running nodes
     log_step "sending wasm trandfers to validators"
@@ -81,7 +81,7 @@ function main() {
     nctl-await-n-eras offset='3' sleep_interval='10.0' timeout='300' node='6'
 
     # 22. Check network is in sync
-    check_network_sync 1 10
+    parallel_check_network_sync 1 10
 
     source "$NCTL"/sh/scenarios/common/health_checks.sh \
             errors='0' \


### PR DESCRIPTION
This PR implements the `parallel_check_network_sync` NCTL function, which allows asking all nodes at once for an LFB, instead of doing it in serial.

It removes:
* the "hacky" `parallel_check_nodes_1_to_5_sync()` function which was hardcoded to talk to nodes from 1 to 5 only.
* the original `check_network_sync` function
