### PR TITLE
fast sync: Fix stale sync leaper activity that affects recovery code

### DIFF
--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -115,6 +115,15 @@ impl SyncLeaper {
         }
     }
 
+    // drop the leap activity for historical sync
+    pub(crate) fn purge_sync_back_activity(&mut self) {
+        if let Some(activity) = &self.leap_activity {
+            if activity.sync_leap_identifier().trusted_ancestor_only() {
+                self.leap_activity = None;
+            }
+        }
+    }
+
     #[cfg_attr(doc, aquamarine::aquamarine)]
     /// ```mermaid
     /// flowchart TD

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -291,9 +291,12 @@ impl MainReactor {
         match self.sync_back_instruction(&sync_back_progress) {
             Ok(Some(sync_back_instruction)) => match sync_back_instruction {
                 SyncBackInstruction::TtlSynced | SyncBackInstruction::GenesisSynced => {
-                    // we don't need to sync any historical blocks currently
+                    // we don't need to sync any historical blocks currently, so we clear both the
+                    // historical synchronizer and the sync back leap activity since they will not
+                    // be required anymore
                     debug!("KeepUp: synced to TTL or Genesis");
                     self.block_synchronizer.purge_historical();
+                    self.sync_leaper.purge_sync_back_activity();
                     None
                 }
                 SyncBackInstruction::Syncing => {


### PR DESCRIPTION
Sometimes the sync leaper leap activity is not correctly reset and causes the node to fail to recover later when it gets out of sync. This happens due to a race condition that appears when we update the validator matrix with the validators for a block after an upgrade.

This happens because the validator matrix update is delayed because the validators need to be read from global state but by doing so the update can interleave within the normal determination of the keep up sync instruction. If the update comes after a leap request is sent, the leap activity will not be reset since the keep up look may not need to check the leap status again if it starts to sync a block and then finishes historical sync.

This patch purges any potential stale sync back leap activities after the node is done syncing back since any new received leap activity is not needed anymore (and it will actually never be checked again until the node switches to CatchUp).