### PR TITLE
Activate NCTL when running on DRONE

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -92,6 +92,14 @@ function run_soundness_test() {
     # Really-really make sure nothing is leftover
     nctl-assets-teardown
 
+    # If running on CI, activate NCTL via .bashrc to have it available inside Python subprocesses
+    if [ -v DRONE_BRANCH ]; then
+        echo "running on DRONE"
+        echo '. /drone/casper-node/utils/nctl/activate' >> /root/.bashrc
+    else
+        echo "NOT running on DRONE"
+    fi
+
     $NCTL/sh/scenarios/network_soundness.py
 
     # Clean up after the test


### PR DESCRIPTION
This PR ensures that NCTL is available for Python subprocesses via modifying `.bashrc`, but only if `DRONE_BRANCH` env variable is set.

Partially fixes #3862