### PR TITLE
Revert change to max_ttl setting of local test chainspec

### DIFF
--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -85,7 +85,7 @@ reduced_reward_multiplier = [1, 5]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.
 max_payment_cost = '0'
 # The duration after the deploy timestamp that it can be included in a block.
-max_ttl = '5minutes'
+max_ttl = '1day'
 # The maximum number of other deploys a deploy can depend on (require to have been executed before it can execute).
 max_dependencies = 10
 # Maximum block size in bytes including deploys contained by the block.  0 means unlimited.


### PR DESCRIPTION
This PR reverts a recent change to the `max_ttl` setting of the chainspec used for local testing and nctl networks.

After running the full test suite including nightly nctl tests, it appears that no tests depend upon this being set to `'5minutes'`.

Closes #3960.