### PR TITLE
Purge `SyncLeaper` when switching to `CatchUp` mode

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,7 +136,7 @@ steps:
 - name: nctl-compile
   <<: *buildenv
   commands:
-  - bash -i ./ci/nctl_compile.sh
+  - bash -c ./ci/nctl_compile.sh
 
 - name: nctl-upgrade-test
   <<: *buildenv
@@ -146,12 +146,12 @@ steps:
     AWS_SECRET_ACCESS_KEY:
       from_secret: put-drone-aws-sk
   commands:
-  - bash -i ./ci/nctl_upgrade.sh
+  - bash -c ./ci/nctl_upgrade.sh
 
 - name: check CPU features
   <<: *buildenv
   commands:
-  - bash -i ./ci/check_cpu_features.sh  
+  - bash -i ./ci/check_cpu_features.sh
 
 volumes:
 - name: rustup
@@ -480,7 +480,7 @@ steps:
 - name: nctl-compile
   <<: *buildenv
   commands:
-  - bash -i ./ci/nctl_compile.sh
+  - bash -c ./ci/nctl_compile.sh
 
 - name: nctl-nightly-tests
   <<: *buildenv
@@ -490,7 +490,7 @@ steps:
     AWS_SECRET_ACCESS_KEY:
       from_secret: put-drone-aws-sk
   commands:
-  - bash -i ./ci/nightly-test.sh
+  - bash -c ./ci/nightly-test.sh
 
 - name: notify
   image: plugins/slack

--- a/ci/nctl_compile.sh
+++ b/ci/nctl_compile.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+shopt -s expand_aliases
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 JSON_CONFIG_FILE="$ROOT_DIR/utils/nctl/ci/ci.json"

--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+shopt -s expand_aliases
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 
@@ -8,7 +9,7 @@ pushd "$ROOT_DIR"
 source $(pwd)/utils/nctl/activate
 
 # Call compile wrapper for client, launcher, and nctl-compile
-bash -i "$ROOT_DIR/ci/nctl_compile.sh"
+bash -c "$ROOT_DIR/ci/nctl_compile.sh"
 
 function main() {
     local TEST_ID=${1}

--- a/ci/nctl_upgrade_stage.sh
+++ b/ci/nctl_upgrade_stage.sh
@@ -3,6 +3,7 @@
 # Script used to group everything needed for nctl upgrade remotes.
 
 set -e
+shopt -s expand_aliases
 
 trap clean_up EXIT
 

--- a/node/src/components/block_synchronizer/block_synchronizer_progress.rs
+++ b/node/src/components/block_synchronizer/block_synchronizer_progress.rs
@@ -26,35 +26,36 @@ impl BlockSynchronizerProgress {
 
 impl Display for BlockSynchronizerProgress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let display_height = |f: &mut Formatter<'_>, maybe_height: &Option<u64>| match maybe_height
+        {
+            Some(height) => write!(f, "block {height}"),
+            None => write!(f, "unknown block height"),
+        };
         match self {
-            BlockSynchronizerProgress::Idle => write!(f, "Idle",),
+            BlockSynchronizerProgress::Idle => write!(f, "block synchronizer idle"),
             BlockSynchronizerProgress::Syncing(block_hash, block_height, timestamp) => {
-                write!(
-                    f,
-                    "block_height: {:?} timestamp: {} block_hash: {}",
-                    block_height, timestamp, block_hash
-                )
+                write!(f, "block synchronizer syncing ")?;
+                display_height(f, block_height)?;
+                write!(f, "{}, {}", timestamp, block_hash)
             }
             BlockSynchronizerProgress::Executing(block_hash, block_height, era_id) => {
                 write!(
                     f,
-                    "block_height: {} block_hash: {} era_id: {}",
+                    "block synchronizer executing block {}, {}, {}",
                     block_height, block_hash, era_id
                 )
             }
             BlockSynchronizerProgress::Synced(block_hash, block_height, era_id) => {
                 write!(
                     f,
-                    "block_height: {} block_hash: {} era_id: {}",
+                    "block synchronizer synced block {}, {}, {}",
                     block_height, block_hash, era_id
                 )
             }
             BlockSynchronizerProgress::Stalled(block_hash, block_height, timestamp) => {
-                write!(
-                    f,
-                    "block_height: {:?} timestamp: {} block_hash: {}",
-                    block_height, timestamp, block_hash
-                )
+                write!(f, "block synchronizer stalled on ")?;
+                display_height(f, block_height)?;
+                write!(f, "{}, {}", timestamp, block_hash)
             }
         }
     }

--- a/node/src/components/sync_leaper.rs
+++ b/node/src/components/sync_leaper.rs
@@ -90,7 +90,10 @@ impl SyncLeaper {
         })
     }
 
-    // called from Reactor control logic to scrape results
+    /// Returns whether a sync leap is ongoing or completed and its state if so.
+    ///
+    /// If a sync leap has been completed, successfully or not, the results are returned and the
+    /// attempt is removed, effectively making the component idle.
     pub(crate) fn leap_status(&mut self) -> LeapState {
         match &self.leap_activity {
             None => LeapState::Idle,
@@ -115,12 +118,11 @@ impl SyncLeaper {
         }
     }
 
-    // drop the leap activity for historical sync
-    pub(crate) fn purge_sync_back_activity(&mut self) {
-        if let Some(activity) = &self.leap_activity {
-            if activity.sync_leap_identifier().trusted_ancestor_only() {
-                self.leap_activity = None;
-            }
+    /// Causes any ongoing sync leap attempt to be abandoned, i.e. results gathered so far are
+    /// dropped and responses received later for this attempt are ignored.
+    pub(crate) fn purge(&mut self) {
+        if let Some(activity) = self.leap_activity.take() {
+            debug!(identifier = %activity.sync_leap_identifier(), "purging sync leap");
         }
     }
 

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -235,12 +235,6 @@ impl MainReactor {
         maybe_block_height: Option<u64>,
         last_progress: Timestamp,
     ) -> Either<SyncIdentifier, CatchUpInstruction> {
-        // if any progress has been made, reset attempts
-        if last_progress > self.last_progress {
-            debug!(%last_progress, "CatchUp: syncing");
-            self.last_progress = last_progress;
-            self.attempts = 0;
-        }
         // if we have not made progress on our attempt to catch up with the network, increment
         // attempts counter and try again; the crank logic will shut the node down on the next
         // crank if we've exceeded our reattempts

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -161,6 +161,7 @@ impl MainReactor {
                 }
                 KeepUpInstruction::CatchUp => {
                     self.block_synchronizer.purge();
+                    self.sync_leaper.purge();
                     info!("KeepUp: switch to CatchUp");
                     self.state = ReactorState::CatchUp;
                     (Duration::ZERO, Effects::new())

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -296,7 +296,7 @@ impl MainReactor {
                     // be required anymore
                     debug!("KeepUp: synced to TTL or Genesis");
                     self.block_synchronizer.purge_historical();
-                    self.sync_leaper.purge_sync_back_activity();
+                    self.sync_leaper.purge();
                     None
                 }
                 SyncBackInstruction::Syncing => {

--- a/utils/nctl/sh/scenarios/network_soundness.py
+++ b/utils/nctl/sh/scenarios/network_soundness.py
@@ -66,8 +66,9 @@ def invoke(command, quiet=False):
         log("invoking command: {}".format(command))
     invoke_lock.acquire()
     try:
-        result = subprocess.check_output(['/bin/bash', '-i', '-c',
-                                          command]).decode("utf-8").rstrip()
+        result = subprocess.check_output(['/bin/bash', '-c',
+                                          'shopt -s expand_aliases\nsource $NCTL/activate\n{}'
+                                         .format(command)]).decode("utf-8").rstrip()
         return result
     except subprocess.CalledProcessError as e:
         log("command returned non-zero exit code - this can be a transitory error if the node is temporarily down"


### PR DESCRIPTION
This PR fixes an issue where a historical sync leap is incorrectly interpreted as current just after transitioning from `KeepUp` to `CatchUp` mode.  Ultimately, this causes the node to shut down as further leap attempts are made using the historical block's hash as the trusted hash, and the peers respond with `FetchResponse::NotProvided`.

The fix is to purge the `SyncLeaper` as the node transitions from `KeepUp` to `CatchUp`.

The PR also removes a small, unneeded block from `catch_up_syncing` where the attempt counter is reset.  This has always already just been performed via `self.update_last_progress` in `catch_up_process`.

Finally, the bash and python scripts used by drone in CI have been updated to invoke bash calls in non-interactive mode (`bash -c ...` rather than `bash -i ...`) as the output in CI is polluted with many instances of 
```
bash: cannot set terminal process group (1): Inappropriate ioctl for device
bash: no job control in this shell
```
(see [this test run](https://drone-auto-casper-network.casperlabs.io/casper-network/casper-node/8286/1/4) for example).

Closes #3965.