### PR TITLE
Fix issue when a node that is supposed to be a validator gets stuck if it comes back after an upgrade slightly later than the other validators

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Fixed:      any bug fixes)
 [comment]: <> (Security:   in case of vulnerabilities)
 
+## [Unreleased]
+
+### Added
+* Added the `upgrade_timeout` config option under the `[node]` section.
 
 ## 1.5.0-rc.1
 

--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -1009,8 +1009,10 @@ impl BlockSynchronizer {
         };
         let demote_peer = maybe_sync_leap.is_none();
         if let Some(sync_leap) = maybe_sync_leap {
-            let era_validator_weights =
-                sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
+            let era_validator_weights = sync_leap.era_validator_weights(
+                self.validator_matrix.fault_tolerance_threshold(),
+                &self.chainspec.protocol_config,
+            );
             for evw in era_validator_weights {
                 self.validator_matrix.register_era_validator_weights(evw);
             }

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1403,6 +1403,12 @@ impl MainReactor {
                 ?state,
                 "should be a complete block after passing to accumulator"
             );
+        } else {
+            debug!(
+                "MetaBlock: block is marked complete: {} {}",
+                block.height(),
+                block.hash(),
+            );
         }
 
         debug!(

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -185,6 +185,7 @@ pub(crate) struct MainReactor {
     attempts: usize,
     idle_tolerance: TimeDiff,
     control_logic_default_delay: TimeDiff,
+    upgrade_timeout: TimeDiff,
     sync_to_genesis: bool,
     signature_gossip_tracker: SignatureGossipTracker,
 }
@@ -1167,6 +1168,7 @@ impl reactor::Reactor for MainReactor {
             max_attempts: config.node.max_attempts,
             idle_tolerance: config.node.idle_tolerance,
             control_logic_default_delay: config.node.control_logic_default_delay,
+            upgrade_timeout: config.node.upgrade_timeout,
             trusted_hash,
             validator_matrix,
             sync_to_genesis: config.node.sync_to_genesis,

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -146,7 +146,7 @@ impl MainReactor {
                     }
                     Err(storage_err) => {
                         return Either::Right(CatchUpInstruction::Fatal(format!(
-                            "Could not read storage to find highest switch block header: {}",
+                            "CatchUp: Could not read storage to find highest switch block header: {}",
                             storage_err
                         )));
                     }

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -382,9 +382,10 @@ impl MainReactor {
             "CatchUp: leap received"
         );
 
-        for validator_weights in
-            sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold())
-        {
+        for validator_weights in sync_leap.era_validator_weights(
+            self.validator_matrix.fault_tolerance_threshold(),
+            &self.chainspec.protocol_config,
+        ) {
             self.validator_matrix
                 .register_era_validator_weights(validator_weights);
         }

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -120,26 +120,37 @@ impl MainReactor {
                 // if too much time has passed, the node will shutdown and require a
                 // trusted block hash to be provided via the config file
                 info!("CatchUp: local tip detected, no trusted hash");
-                if block.header().is_switch_block() {
-                    self.switch_block_header = Some(block.header().clone());
-                }
                 Either::Left(SyncIdentifier::LocalTip(
                     *block.hash(),
                     block.height(),
                     block.header().era_id(),
                 ))
             }
-            Ok(None) if self.switch_block_header.is_none() => {
-                // no trusted hash, no local block, might be genesis
-                self.catch_up_check_genesis()
-            }
             Ok(None) => {
-                // no trusted hash, no local block, no error, must be waiting for genesis
-                info!("CatchUp: waiting to store genesis immediate switch block");
-                Either::Right(CatchUpInstruction::CheckLater(
-                    "waiting for genesis immediate switch block to be stored".to_string(),
-                    self.control_logic_default_delay.into(),
-                ))
+                match self
+                    .storage
+                    .read_highest_switch_block_headers(1)
+                    .map(|headers| headers.get(0).cloned())
+                {
+                    Ok(Some(_)) => {
+                        // no trusted hash, no local block, no error, must be waiting for genesis
+                        info!("CatchUp: waiting to store genesis immediate switch block");
+                        Either::Right(CatchUpInstruction::CheckLater(
+                            "waiting for genesis immediate switch block to be stored".to_string(),
+                            self.control_logic_default_delay.into(),
+                        ))
+                    }
+                    Ok(None) => {
+                        // no trusted hash, no local block, might be genesis
+                        self.catch_up_check_genesis()
+                    }
+                    Err(storage_err) => {
+                        return Either::Right(CatchUpInstruction::Fatal(format!(
+                            "Could not read storage to find highest switch block header: {}",
+                            storage_err
+                        )));
+                    }
+                }
             }
             Err(err) => Either::Right(CatchUpInstruction::Fatal(format!(
                 "CatchUp: fatal block store error when attempting to read \
@@ -370,10 +381,6 @@ impl MainReactor {
             %block_hash,
             "CatchUp: leap received"
         );
-
-        if let Err(msg) = self.update_highest_switch_block() {
-            return CatchUpInstruction::Fatal(msg);
-        }
 
         for validator_weights in
             sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold())

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use tracing::{debug, error, info, trace};
 
 use casper_hashing::Digest;
-use casper_types::{EraId, PublicKey};
+use casper_types::{EraId, PublicKey, Timestamp};
 
 use crate::{
     components::{
@@ -116,6 +116,8 @@ impl MainReactor {
                     Ok(effects) => {
                         info!("CatchUp: switch to Upgrading");
                         self.state = ReactorState::Upgrading;
+                        self.last_progress = Timestamp::now();
+                        self.attempts = 0;
                         (Duration::ZERO, effects)
                     }
                     Err(msg) => (
@@ -390,6 +392,7 @@ impl MainReactor {
         UpgradingInstruction::should_commit_upgrade(
             self.should_commit_upgrade(),
             self.control_logic_default_delay.into(),
+            self.last_progress,
         )
     }
 

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -393,6 +393,7 @@ impl MainReactor {
             self.should_commit_upgrade(),
             self.control_logic_default_delay.into(),
             self.last_progress,
+            self.upgrade_timeout,
         )
     }
 
@@ -486,14 +487,12 @@ impl MainReactor {
     pub(super) fn should_commit_upgrade(&self) -> bool {
         // header of latest complete block, and that block needs to be switch block
         let highest_switch_block_header = match self.storage.read_highest_complete_block() {
-            Ok(Some(highest_complete_block)) => {
-                if highest_complete_block.header().is_switch_block() {
-                    highest_complete_block.take_header()
-                } else {
-                    return false;
-                }
+            Ok(Some(highest_complete_block))
+                if highest_complete_block.header().is_switch_block() =>
+            {
+                highest_complete_block.take_header()
             }
-            Ok(None) => {
+            Ok(Some(_)) | Ok(None) => {
                 return false;
             }
             Err(error) => {

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -519,9 +519,6 @@ impl MainReactor {
         // era validator weights. if there are other processes which are holding on discovery
         // of relevant newly-seen era validator weights, they should naturally progress
         // themselves via notification on the event loop.
-        if let Err(msg) = self.update_highest_switch_block() {
-            return KeepUpInstruction::Fatal(msg);
-        }
         let block_hash = sync_leap.highest_block_hash();
         let block_height = sync_leap.highest_block_height();
         info!(%sync_leap, %block_height, %block_hash, "KeepUp: historical sync_back received");

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -523,8 +523,10 @@ impl MainReactor {
         let block_height = sync_leap.highest_block_height();
         info!(%sync_leap, %block_height, %block_hash, "KeepUp: historical sync_back received");
 
-        let era_validator_weights =
-            sync_leap.era_validator_weights(self.validator_matrix.fault_tolerance_threshold());
+        let era_validator_weights = sync_leap.era_validator_weights(
+            self.validator_matrix.fault_tolerance_threshold(),
+            &self.chainspec.protocol_config,
+        );
         for evw in era_validator_weights {
             let era_id = evw.era_id();
             debug!(%era_id, "KeepUp: attempt to register historical validators for era");

--- a/node/src/reactor/main_reactor/upgrading_instruction.rs
+++ b/node/src/reactor/main_reactor/upgrading_instruction.rs
@@ -1,5 +1,9 @@
 use std::time::Duration;
 
+use casper_types::{TimeDiff, Timestamp};
+
+const UPGRADE_TIMEOUT_SECONDS: u32 = 30;
+
 pub(super) enum UpgradingInstruction {
     CheckLater(String, Duration),
     CatchUp,
@@ -9,9 +13,14 @@ impl UpgradingInstruction {
     pub(super) fn should_commit_upgrade(
         should_commit_upgrade: bool,
         wait: Duration,
+        last_progress: Timestamp,
     ) -> UpgradingInstruction {
         if should_commit_upgrade {
-            UpgradingInstruction::CheckLater("awaiting upgrade".to_string(), wait)
+            if last_progress.elapsed() > TimeDiff::from_seconds(UPGRADE_TIMEOUT_SECONDS) {
+                UpgradingInstruction::CatchUp
+            } else {
+                UpgradingInstruction::CheckLater("awaiting upgrade".to_string(), wait)
+            }
         } else {
             UpgradingInstruction::CatchUp
         }

--- a/node/src/reactor/main_reactor/upgrading_instruction.rs
+++ b/node/src/reactor/main_reactor/upgrading_instruction.rs
@@ -2,8 +2,6 @@ use std::time::Duration;
 
 use casper_types::{TimeDiff, Timestamp};
 
-const UPGRADE_TIMEOUT_SECONDS: u32 = 30;
-
 pub(super) enum UpgradingInstruction {
     CheckLater(String, Duration),
     CatchUp,
@@ -14,9 +12,10 @@ impl UpgradingInstruction {
         should_commit_upgrade: bool,
         wait: Duration,
         last_progress: Timestamp,
+        upgrade_timeout: TimeDiff,
     ) -> UpgradingInstruction {
         if should_commit_upgrade {
-            if last_progress.elapsed() > TimeDiff::from_seconds(UPGRADE_TIMEOUT_SECONDS) {
+            if last_progress.elapsed() > upgrade_timeout {
                 UpgradingInstruction::CatchUp
             } else {
                 UpgradingInstruction::CheckLater("awaiting upgrade".to_string(), wait)

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -8,6 +8,7 @@ use casper_types::TimeDiff;
 const DEFAULT_IDLE_TOLERANCE: &str = "20min";
 const DEFAULT_MAX_ATTEMPTS: usize = 3;
 const DEFAULT_CONTROL_LOGIC_DEFAULT_DELAY: &str = "1sec";
+const DEFAULT_UPGRADE_TIMEOUT: &str = "30sec";
 
 /// Node fast-sync configuration.
 #[derive(DataSize, Debug, Deserialize, Serialize, Clone)]
@@ -33,6 +34,9 @@ pub struct NodeConfig {
 
     /// Flag which forces the node to resync all of the blocks.
     pub force_resync: bool,
+
+    /// Maximum time a node will wait for an upgrade to commit
+    pub upgrade_timeout: TimeDiff,
 }
 
 impl Default for NodeConfig {
@@ -44,6 +48,7 @@ impl Default for NodeConfig {
             max_attempts: DEFAULT_MAX_ATTEMPTS,
             control_logic_default_delay: DEFAULT_CONTROL_LOGIC_DEFAULT_DELAY.parse().unwrap(),
             force_resync: false,
+            upgrade_timeout: DEFAULT_UPGRADE_TIMEOUT.parse().unwrap(),
         }
     }
 }

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -35,7 +35,7 @@ pub struct NodeConfig {
     /// Flag which forces the node to resync all of the blocks.
     pub force_resync: bool,
 
-    /// Maximum time a node will wait for an upgrade to commit
+    /// Maximum time a node will wait for an upgrade to commit.
     pub upgrade_timeout: TimeDiff,
 }
 

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -23,7 +23,7 @@ use crate::{
     utils::{self, BlockSignatureError},
 };
 
-use super::sync_leap_validation_metadata::SyncLeapValidationMetaData;
+use super::{chainspec::ProtocolConfig, sync_leap_validation_metadata::SyncLeapValidationMetaData};
 
 #[derive(Error, Debug)]
 pub(crate) enum SyncLeapValidationError {
@@ -128,7 +128,18 @@ impl SyncLeap {
     pub(crate) fn era_validator_weights(
         &self,
         fault_tolerance_fraction: Ratio<u64>,
+        protocol_config: &ProtocolConfig,
     ) -> impl Iterator<Item = EraValidatorWeights> + '_ {
+        // determine if the validator set has been updated in the
+        // current protocol version through an emergency upgrade
+        let validators_changed_in_current_protocol = protocol_config
+            .global_state_update
+            .as_ref()
+            .map_or(false, |global_state_update| {
+                global_state_update.validators.is_some()
+            });
+        let current_protocol_version = protocol_config.version;
+
         let block_protocol_versions: HashMap<_, _> = self
             .headers()
             .map(|hdr| (hdr.height(), hdr.protocol_version()))
@@ -148,11 +159,22 @@ impl SyncLeap {
                     // filter out switch blocks preceding upgrades - we don't want to read the era
                     // validators directly from them, as they might have been altered by the
                     // upgrade, we'll get them from the blocks' global states instead
+                    //
+                    // we can reliably determine if the validator set was changed by an upgrade to
+                    // the current protocol version by looking at the chainspec. If validators have
+                    // not been altered in any way, then we can use the set reported in the sync
+                    // leap by the previous switch block and not read the global states
                     .filter(move |block_header| {
                         block_protocol_versions
                             .get(&(block_header.height() + 1))
                             .map_or(true, |other_protocol_version| {
-                                block_header.protocol_version() == *other_protocol_version
+                                if block_header.protocol_version() == *other_protocol_version {
+                                    true
+                                } else if *other_protocol_version == current_protocol_version {
+                                    !validators_changed_in_current_protocol
+                                } else {
+                                    false
+                                }
                             })
                     })
                     .flat_map(move |block_header| {
@@ -426,10 +448,12 @@ mod tests {
     use crate::{
         components::fetcher::FetchItem,
         types::{
-            chainspec::GlobalStateUpdate, sync_leap::SyncLeapValidationError,
-            sync_leap_validation_metadata::SyncLeapValidationMetaData, ActivationPoint, Block,
-            BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockSignatures, EraValidatorWeights,
-            FinalitySignature, FinalizedBlock, SyncLeapIdentifier,
+            chainspec::{GlobalStateUpdate, ProtocolConfig},
+            sync_leap::SyncLeapValidationError,
+            sync_leap_validation_metadata::SyncLeapValidationMetaData,
+            ActivationPoint, Block, BlockHash, BlockHeader, BlockHeaderWithMetadata,
+            BlockSignatures, EraValidatorWeights, FinalitySignature, FinalizedBlock,
+            SyncLeapIdentifier,
         },
         utils::BlockSignatureError,
     };
@@ -1589,6 +1613,7 @@ mod tests {
 
         let mut block_iter = sync_leap.signed_block_headers.iter();
         let first_switch_block = block_iter.next().unwrap().clone();
+        let protocol_version = first_switch_block.block_header.protocol_version();
         let validator_1 = validators
             .get(FIRST_SIGNED_BLOCK_HEADER_VALIDATOR_OFFSET)
             .unwrap();
@@ -1654,8 +1679,15 @@ mod tests {
             fault_tolerance_fraction,
         );
 
+        let protocol_config = ProtocolConfig {
+            version: protocol_version,
+            global_state_update: None,
+            activation_point: ActivationPoint::EraId(rng.gen()),
+            hard_reset: rng.gen(),
+        };
+
         let result: Vec<_> = sync_leap
-            .era_validator_weights(fault_tolerance_fraction)
+            .era_validator_weights(fault_tolerance_fraction, &protocol_config)
             .collect();
         assert_eq!(
             result,
@@ -1816,7 +1848,7 @@ mod tests {
             signed_block_header_with_metadata_2,
             signed_block_header_with_metadata_3,
         ) = make_three_switch_blocks_at_era_and_height_and_version(
-            rng,
+            &mut rng,
             (1, 10, version),
             (2, 20, version),
             (3, 30, version),
@@ -1839,8 +1871,15 @@ mod tests {
         // `should_return_era_validator_weights_for_correct_sync_leap` test already covers the
         // actual weight validation.
 
+        let protocol_config = ProtocolConfig {
+            version,
+            global_state_update: None,
+            hard_reset: false,
+            activation_point: ActivationPoint::EraId(rng.gen()),
+        };
+
         let actual_eras: BTreeSet<u64> = sync_leap
-            .era_validator_weights(fault_tolerance_fraction)
+            .era_validator_weights(fault_tolerance_fraction, &protocol_config)
             .map(|era_validator_weights| era_validator_weights.era_id().into())
             .collect();
         let mut expected_eras: BTreeSet<u64> = BTreeSet::new();
@@ -1863,7 +1902,7 @@ mod tests {
             signed_block_header_with_metadata_2,
             signed_block_header_with_metadata_3,
         ) = make_three_switch_blocks_at_era_and_height_and_version(
-            rng,
+            &mut rng,
             (1, 10, version_1),
             (2, 20, version_1),
             (3, 21, version_2),
@@ -1886,8 +1925,18 @@ mod tests {
         // `should_return_era_validator_weights_for_correct_sync_leap` test already covers the
         // actual weight validation.
 
+        let protocol_config = ProtocolConfig {
+            version: version_2,
+            global_state_update: Some(GlobalStateUpdate {
+                validators: Some(BTreeMap::new()),
+                entries: BTreeMap::new(),
+            }),
+            hard_reset: false,
+            activation_point: ActivationPoint::EraId(rng.gen()),
+        };
+
         let actual_eras: BTreeSet<u64> = sync_leap
-            .era_validator_weights(fault_tolerance_fraction)
+            .era_validator_weights(fault_tolerance_fraction, &protocol_config)
             .map(|era_validator_weights| era_validator_weights.era_id().into())
             .collect();
         let mut expected_eras: BTreeSet<u64> = BTreeSet::new();
@@ -1897,6 +1946,26 @@ mod tests {
         // Block #3 (era=3, height=21) - immediate switch block.
         // Expect the successor of block #2 to be not present.
         expected_eras.extend([2, 4]);
+        assert_eq!(expected_eras, actual_eras);
+
+        let protocol_config = ProtocolConfig {
+            version: version_2,
+            global_state_update: None,
+            hard_reset: rng.gen(),
+            activation_point: ActivationPoint::EraId(rng.gen()),
+        };
+
+        let actual_eras: BTreeSet<u64> = sync_leap
+            .era_validator_weights(fault_tolerance_fraction, &protocol_config)
+            .map(|era_validator_weights| era_validator_weights.era_id().into())
+            .collect();
+        let mut expected_eras: BTreeSet<u64> = BTreeSet::new();
+
+        // Block #1 (era=1, height=10)
+        // Block #2 (era=2, height=20) - block preceding immediate switch block
+        // Block #3 (era=3, height=21) - immediate switch block.
+        // Expect era 3 to be present since the upgrade did not change the validators in any way.
+        expected_eras.extend([2, 3, 4]);
         assert_eq!(expected_eras, actual_eras);
     }
 
@@ -1913,7 +1982,7 @@ mod tests {
             signed_block_header_with_metadata_2,
             signed_block_header_with_metadata_3,
         ) = make_three_switch_blocks_at_era_and_height_and_version(
-            rng,
+            &mut rng,
             (0, 0, version),
             (1, 10, version),
             (2, 20, version),
@@ -1935,9 +2004,15 @@ mod tests {
         // Assert only if correct eras are selected, since the the
         // `should_return_era_validator_weights_for_correct_sync_leap` test already covers the
         // actual weight validation.
+        let protocol_config = ProtocolConfig {
+            version,
+            global_state_update: None,
+            hard_reset: false,
+            activation_point: ActivationPoint::EraId(rng.gen()),
+        };
 
         let actual_eras: BTreeSet<u64> = sync_leap
-            .era_validator_weights(fault_tolerance_fraction)
+            .era_validator_weights(fault_tolerance_fraction, &protocol_config)
             .map(|era_validator_weights| era_validator_weights.era_id().into())
             .collect();
         let mut expected_eras: BTreeSet<u64> = BTreeSet::new();
@@ -1948,7 +2023,7 @@ mod tests {
     }
 
     fn make_three_switch_blocks_at_era_and_height_and_version(
-        mut rng: TestRng,
+        rng: &mut TestRng,
         (era_1, height_1, version_1): (u64, u64, ProtocolVersion),
         (era_2, height_2, version_2): (u64, u64, ProtocolVersion),
         (era_3, height_3, version_3): (u64, u64, ProtocolVersion),
@@ -1958,19 +2033,19 @@ mod tests {
         BlockHeaderWithMetadata,
     ) {
         let signed_block_1 = random_switch_block_at_height_and_era_and_version(
-            &mut rng,
+            rng,
             height_1,
             era_1.into(),
             version_1,
         );
         let signed_block_2 = random_switch_block_at_height_and_era_and_version(
-            &mut rng,
+            rng,
             height_2,
             era_2.into(),
             version_2,
         );
         let signed_block_3 = random_switch_block_at_height_and_era_and_version(
-            &mut rng,
+            rng,
             height_3,
             era_3.into(),
             version_3,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -21,7 +21,7 @@ control_logic_default_delay = '1sec'
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
 
-# Maximum time a node will wait for an upgrade to commit
+# Maximum time a node will wait for an upgrade to commit.
 upgrade_timeout = '30sec'
 
 # =================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -21,6 +21,8 @@ control_logic_default_delay = '1sec'
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
 
+# Maximum time a node will wait for an upgrade to commit
+upgrade_timeout = '30sec'
 
 # =================================
 # Configuration options for logging

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -21,7 +21,7 @@ control_logic_default_delay = '1sec'
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
 
-# Maximum time a node will wait for an upgrade to commit
+# Maximum time a node will wait for an upgrade to commit.
 upgrade_timeout = '30sec'
 
 # =================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -21,6 +21,8 @@ control_logic_default_delay = '1sec'
 # Flag which forces the node to resync all of the blocks.
 force_resync = false
 
+# Maximum time a node will wait for an upgrade to commit
+upgrade_timeout = '30sec'
 
 # =================================
 # Configuration options for logging


### PR DESCRIPTION
This PR fixes an issue where a node that is supposed to be a validator gets stuck if it comes back after an upgrade slightly later than the other validators. There are 3 commits that fix this issue:
* Remove the usage of `switch_block_header` for determining if a node should commit upgrade and use the highest **complete** block header instead to do that determination:
  * The control logic was using the cached `switch_block_header` to determine if the node is ready to commit an upgrade. This field was not only updated with the header of the latest complete block and was set also by the `CatchUp` logic to the highest block header that the node has stored. In the case where a `SyncLeap` is received, the headers in that message are stored. This in turn can lead `switch_block_header` to hold a header of a block that may not have been marked as completed.
  * Because of this the control logic was tricked into thinking that it should not commit an upgrade (because there was a header that was of the newer protocol version received through SyncLeap) and switch to `KeepUp` and then to `Validate` (if it was supposed to be a validator) even if the node did not have the immediate switch block marked as complete.
  * This can happen if the node that is supposed to be validating comes up after an upgrade a little later than the other nodes in the network; in this case it comes late enough such that its peers already completed and are responding to a SyncLeap with the newly created immediate switch block.
* Preventing the reactor from looping indefinitely in the `Upgrading` state and moving it to `CatchUp` where it can try to recover:
  * In some cases, the node can become stuck trying to commit the upgrade due to different reasons. One scenario is that of a node that comes up a little later than the others after an emergency upgrade and tries to commit the upgrade. Because the other validators may have already finished gossiping the new immediate switch block, this node may not have heard the gossip since it was down. In this situation the node will not be able to store the immediate switch block it created since it can't hear about sufficient signatures from the other peers.
  * Instead of looping in the `Upgrading` state indefinitely without no chance of being able to store the block, if enough time has passed we switch the node back to `CatchUp`. In this state it can determine if it is at tip or not and either try to upgrade again or sync back the immediate switch block from the network.
* Relaxing the filtering out of switch blocks preceding an upgrade in a `SyncLeap` response when trying to determine the era validators from that message:
  * We can determine if an upgrade did change the validator set or not by looking at the chainspec. If the upgrade to the current protocol version did not alter the validator set, then we can use the validators in the switch block preceding the upgrade.

Fixes: https://github.com/casper-network/casper-node/issues/3961
Fixes: https://github.com/casper-network/casper-node/issues/3852
