### PR TITLE
Route deploy from speculative-exec server to `DeployAcceptor`

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+
+## Unreleased
+
+### Changed
+* `speculative_exec` server now routes deploys to `DeployAcceptor` for more comprehensive validation, including cryptographic verification of signatures.
+
+
+
 ## 1.5.0-rc.1
 
 ### Added

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -27,8 +27,8 @@ use tracing::{debug, error, info, trace};
 
 use casper_execution_engine::{
     core::engine_state::{
-        self, genesis::GenesisError, ChainspecRegistry, EngineConfig, EngineState, GenesisSuccess,
-        SystemContractRegistry, UpgradeConfig, UpgradeSuccess,
+        self, genesis::GenesisError, ChainspecRegistry, DeployItem, EngineConfig, EngineState,
+        GenesisSuccess, SystemContractRegistry, UpgradeConfig, UpgradeSuccess,
     },
     shared::{newtypes::CorrelationId, system_config::SystemConfig, wasm_config::WasmConfig},
     storage::{
@@ -569,7 +569,11 @@ impl ContractRuntime {
                 let engine_state = Arc::clone(&self.engine_state);
                 async move {
                     let result = run_intensive_task(move || {
-                        execute_only(engine_state.as_ref(), execution_prestate, (*deploy).into())
+                        execute_only(
+                            engine_state.as_ref(),
+                            execution_prestate,
+                            DeployItem::from((*deploy).clone()),
+                        )
                     })
                     .await;
                     responder.respond(result).await

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -242,6 +242,7 @@ impl DeployAcceptor {
             &self.chain_name,
             &self.deploy_config,
             self.max_associated_keys,
+            verification_start_timestamp,
         );
         // checks chainspec values
         if let Err(error) = acceptable_result {

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use serde::Serialize;
 
@@ -10,21 +13,21 @@ use casper_types::{
 use super::Source;
 use crate::{
     components::deploy_acceptor::Error,
-    effect::{announcements::RpcServerAnnouncement, Responder},
+    effect::Responder,
     types::{BlockHeader, Deploy},
 };
 
 /// A utility struct to hold duplicated information across events.
 #[derive(Debug, Serialize)]
 pub(crate) struct EventMetadata {
-    pub(crate) deploy: Box<Deploy>,
+    pub(crate) deploy: Arc<Deploy>,
     pub(crate) source: Source,
     pub(crate) maybe_responder: Option<Responder<Result<(), Error>>>,
 }
 
 impl EventMetadata {
     pub(crate) fn new(
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Self {
@@ -41,7 +44,7 @@ impl EventMetadata {
 pub(crate) enum Event {
     /// The initiating event to accept a new `Deploy`.
     Accept {
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     },
@@ -98,18 +101,6 @@ pub(crate) enum Event {
         maybe_contract_package: Option<Box<ContractPackage>>,
         verification_start_timestamp: Timestamp,
     },
-}
-
-impl From<RpcServerAnnouncement> for Event {
-    fn from(announcement: RpcServerAnnouncement) -> Self {
-        match announcement {
-            RpcServerAnnouncement::DeployReceived { deploy, responder } => Event::Accept {
-                deploy,
-                source: Source::Client,
-                maybe_responder: responder,
-            },
-        }
-    }
 }
 
 impl Display for Event {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -653,7 +653,7 @@ fn put_block_to_storage_and_mark_complete(
 }
 
 fn put_deploy_to_storage(
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
     result_sender: Sender<bool>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
@@ -669,7 +669,7 @@ fn put_deploy_to_storage(
 }
 
 fn schedule_accept_deploy(
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
     source: Source,
     responder: Responder<Result<(), super::Error>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
@@ -689,7 +689,7 @@ fn schedule_accept_deploy(
 }
 
 fn inject_balance_check_for_peer(
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
     source: Source,
     rng: &mut TestRng,
     responder: Responder<Result<(), super::Error>>,
@@ -753,14 +753,14 @@ async fn run_deploy_acceptor_without_timeout(
     let deploy_responder = Responder::without_shutdown(deploy_sender);
 
     // Create a deploy specific to the test scenario
-    let deploy = test_scenario.deploy(&mut rng);
+    let deploy = Arc::new(test_scenario.deploy(&mut rng));
     // Mark the source as either a peer or a client depending on the scenario.
     let source = test_scenario.source(&mut rng);
 
     {
         // Inject the deploy artificially into storage to simulate a previously seen deploy.
         if test_scenario.is_repeated_deploy_case() {
-            let injected_deploy = Box::new(deploy.clone());
+            let injected_deploy = Arc::clone(&deploy);
             let (result_sender, result_receiver) = oneshot::channel();
             runner
                 .process_injected_effects(put_deploy_to_storage(injected_deploy, result_sender))
@@ -773,7 +773,7 @@ async fn run_deploy_acceptor_without_timeout(
         }
 
         if test_scenario == TestScenario::BalanceCheckForDeploySentByPeer {
-            let fatal_deploy = Box::new(deploy.clone());
+            let fatal_deploy = Arc::clone(&deploy);
             let (deploy_sender, _) = oneshot::channel();
             let deploy_responder = Responder::without_shutdown(deploy_sender);
             runner
@@ -792,7 +792,7 @@ async fn run_deploy_acceptor_without_timeout(
 
     runner
         .process_injected_effects(schedule_accept_deploy(
-            Box::new(deploy.clone()),
+            Arc::clone(&deploy),
             source,
             deploy_responder,
         ))

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -25,7 +25,7 @@ mod sse_server;
 #[cfg(test)]
 mod tests;
 
-use std::{fmt::Debug, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, net::SocketAddr, path::PathBuf};
 
 use datasize::DataSize;
 use tokio::sync::{
@@ -240,9 +240,7 @@ where
                     block_hash: *block.hash(),
                     block: Box::new(JsonBlock::new(&block, None)),
                 }),
-                Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted {
-                    deploy: Arc::new(*deploy),
-                }),
+                Event::DeployAccepted(deploy) => self.broadcast(SseData::DeployAccepted { deploy }),
                 Event::DeployProcessed {
                     deploy_hash,
                     deploy_header,

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -12,7 +12,7 @@ use crate::types::{Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalityS
 pub enum Event {
     Initialize,
     BlockAdded(Arc<Block>),
-    DeployAccepted(Box<Deploy>),
+    DeployAccepted(Arc<Deploy>),
     DeployProcessed {
         deploy_hash: DeployHash,
         deploy_header: Box<DeployHeader>,

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -85,7 +85,6 @@ pub enum SseData {
     /// The given deploy has been newly-accepted by this node.
     DeployAccepted {
         #[schemars(with = "Deploy", description = "a deploy")]
-        // It's an Arc to not create multiple copies of the same deploy for multiple subscribers.
         deploy: Arc<Deploy>,
     },
     /// The given deploy has been executed, committed and forms part of the given block.

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -134,7 +134,7 @@ where
                 Source::PeerGossiped(peer) | Source::Peer(peer) => {
                     self.got_from_peer(effect_builder, peer, item)
                 }
-                Source::Client | Source::Ourself => Effects::new(),
+                Source::Client | Source::SpeculativeExec(_) | Source::Ourself => Effects::new(),
             },
             Event::GotInvalidRemotely { .. } => Effects::new(),
             Event::AbsentRemotely { id, peer } => {

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -73,7 +73,7 @@ impl From<DeployAcceptorAnnouncement> for Event<Deploy> {
         match announcement {
             DeployAcceptorAnnouncement::AcceptedNewDeploy { deploy, source } => {
                 Event::GotRemotely {
-                    item: deploy,
+                    item: Box::new((*deploy).clone()),
                     source,
                 }
             }

--- a/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/deploy_fetcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -39,7 +39,7 @@ impl ItemFetcher<Deploy> for Fetcher<Deploy> {
         StoringState::Enqueued(
             async move {
                 let is_new = effect_builder
-                    .put_deploy_to_storage(Box::new(item.clone()))
+                    .put_deploy_to_storage(Arc::new(item.clone()))
                     .await;
                 // If `is_new` is `false`, the deploy was previously stored, and the incoming
                 // deploy could have a different set of approvals to the one already stored.

--- a/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
+++ b/node/src/components/fetcher/fetcher_impls/legacy_deploy_fetcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -40,7 +40,7 @@ impl ItemFetcher<LegacyDeploy> for Fetcher<LegacyDeploy> {
     ) -> StoringState<'a, LegacyDeploy> {
         StoringState::Enqueued(
             effect_builder
-                .put_deploy_to_storage(Box::new(Deploy::from(item)))
+                .put_deploy_to_storage(Arc::new(Deploy::from(item)))
                 .map(|_| ())
                 .boxed(),
         )

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -23,17 +23,13 @@ use crate::{
         storage::{self, Storage},
     },
     effect::{
-        announcements::{
-            ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement,
-            RpcServerAnnouncement,
-        },
+        announcements::{ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement},
         incoming::{
             ConsensusMessageIncoming, DemandIncoming, FinalitySignatureIncoming, GossiperIncoming,
             NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
             TrieResponseIncoming,
         },
-        requests::MarkBlockCompletedRequest,
-        Responder,
+        requests::{AcceptDeployRequest, MarkBlockCompletedRequest},
     },
     fatal,
     protocol::Message,
@@ -106,9 +102,9 @@ enum Event {
     #[from]
     BlockAccumulatorRequest(BlockAccumulatorRequest),
     #[from]
-    DeployAcceptorAnnouncement(DeployAcceptorAnnouncement),
+    AcceptDeployRequest(AcceptDeployRequest),
     #[from]
-    RpcServerAnnouncement(RpcServerAnnouncement),
+    DeployAcceptorAnnouncement(DeployAcceptorAnnouncement),
     #[from]
     FetchedNewFinalitySignatureAnnouncement(FetchedNewFinalitySignatureAnnouncement),
     #[from]
@@ -221,11 +217,23 @@ impl ReactorTrait for Reactor {
                 self.deploy_fetcher
                     .handle_event(effect_builder, rng, announcement.into()),
             ),
-            Event::RpcServerAnnouncement(announcement) => reactor::wrap_effects(
-                Event::FakeDeployAcceptor,
-                self.fake_deploy_acceptor
-                    .handle_event(effect_builder, rng, announcement.into()),
-            ),
+            Event::AcceptDeployRequest(AcceptDeployRequest {
+                deploy,
+                speculative_exec_at_block,
+                responder,
+            }) => {
+                assert!(speculative_exec_at_block.is_none());
+                let event = deploy_acceptor::Event::Accept {
+                    deploy,
+                    source: Source::Client,
+                    maybe_responder: Some(responder),
+                };
+                reactor::wrap_effects(
+                    Event::FakeDeployAcceptor,
+                    self.fake_deploy_acceptor
+                        .handle_event(effect_builder, rng, event),
+                )
+            }
             Event::NetRequestIncoming(announcement) => reactor::wrap_effects(
                 Event::Storage,
                 self.storage
@@ -311,7 +319,7 @@ impl Reactor {
                 let deploy = match bincode::deserialize::<FetchResponse<Deploy, DeployHash>>(
                     serialized_item,
                 ) {
-                    Ok(FetchResponse::Fetched(deploy)) => Box::new(deploy),
+                    Ok(FetchResponse::Fetched(deploy)) => Arc::new(deploy),
                     Ok(FetchResponse::NotFound(deploy_hash)) => {
                         return fatal!(
                             effect_builder,
@@ -366,13 +374,10 @@ impl NetworkedReactor for Reactor {
     }
 }
 
-fn announce_deploy_received(
-    deploy: Deploy,
-    responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
-) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
+fn announce_deploy_received(deploy: Deploy) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
     |effect_builder: EffectBuilder<Event>| {
         effect_builder
-            .announce_deploy_received(Box::new(deploy), responder)
+            .try_accept_deploy(Arc::new(deploy), None)
             .ignore()
     }
 }
@@ -401,11 +406,10 @@ async fn store_deploy(
     deploy: &Deploy,
     node_id: &NodeId,
     network: &mut TestingNetwork<Reactor>,
-    responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
     rng: &mut TestRng,
 ) {
     network
-        .process_injected_effect_on(node_id, announce_deploy_received(deploy.clone(), responder))
+        .process_injected_effect_on(node_id, announce_deploy_received(deploy.clone()))
         .await;
 
     // cycle to deploy acceptor announcement
@@ -512,7 +516,7 @@ async fn should_fetch_from_local() {
 
     // Store deploy on a node.
     let node_to_store_on = &node_ids[0];
-    store_deploy(&deploy, node_to_store_on, &mut network, None, &mut rng).await;
+    store_deploy(&deploy, node_to_store_on, &mut network, &mut rng).await;
 
     // Try to fetch the deploy from a node that holds it.
     let node_id = node_ids[0];
@@ -559,7 +563,7 @@ async fn should_fetch_from_peer() {
 
     // Store deploy on a node.
     let node_with_deploy = node_ids[0];
-    store_deploy(&deploy, &node_with_deploy, &mut network, None, &mut rng).await;
+    store_deploy(&deploy, &node_with_deploy, &mut network, &mut rng).await;
 
     let node_without_deploy = node_ids[1];
     let deploy_id = deploy.fetch_id();
@@ -611,7 +615,7 @@ async fn should_timeout_fetch_from_peer() {
     let requesting_node = node_ids[1];
 
     // Store deploy on holding node.
-    store_deploy(&deploy, &holding_node, &mut network, None, &mut rng).await;
+    store_deploy(&deploy, &holding_node, &mut network, &mut rng).await;
 
     // Initiate requesting node asking for deploy from holding node.
     let fetched = Arc::new(Mutex::new((false, None)));

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -30,14 +30,14 @@ use crate::{
     effect::{
         announcements::{
             ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement,
-            GossiperAnnouncement, RpcServerAnnouncement,
+            GossiperAnnouncement,
         },
         incoming::{
             ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming,
             NetRequestIncoming, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
             TrieResponseIncoming,
         },
-        Responder,
+        requests::AcceptDeployRequest,
     },
     protocol::Message as NodeMessage,
     reactor::{self, EventQueueHandle, QueueKind, Runner, TryCrankOutcome},
@@ -72,7 +72,7 @@ enum Event {
     #[from]
     StorageRequest(StorageRequest),
     #[from]
-    RpcServerAnnouncement(#[serde(skip_serializing)] RpcServerAnnouncement),
+    AcceptDeployRequest(AcceptDeployRequest),
     #[from]
     DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     #[from]
@@ -261,14 +261,16 @@ impl reactor::Reactor for Reactor {
                 self.storage
                     .handle_event(effect_builder, rng, request.into()),
             ),
-            Event::RpcServerAnnouncement(RpcServerAnnouncement::DeployReceived {
+            Event::AcceptDeployRequest(AcceptDeployRequest {
                 deploy,
+                speculative_exec_at_block,
                 responder,
             }) => {
+                assert!(speculative_exec_at_block.is_none());
                 let event = deploy_acceptor::Event::Accept {
                     deploy,
                     source: Source::Client,
-                    maybe_responder: responder,
+                    maybe_responder: Some(responder),
                 };
                 self.dispatch_event(effect_builder, rng, Event::DeployAcceptor(event))
             }
@@ -296,7 +298,7 @@ impl reactor::Reactor for Reactor {
                     effect_builder,
                     rng,
                     deploy_acceptor::Event::Accept {
-                        deploy: item,
+                        deploy: Arc::new(*item),
                         source: Source::Peer(sender),
                         maybe_responder: None,
                     },
@@ -323,14 +325,9 @@ impl NetworkedReactor for Reactor {
 }
 
 fn announce_deploy_received(
-    deploy: Box<Deploy>,
-    responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
+    deploy: Arc<Deploy>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
-    |effect_builder: EffectBuilder<Event>| {
-        effect_builder
-            .announce_deploy_received(deploy, responder)
-            .ignore()
-    }
+    |effect_builder: EffectBuilder<Event>| effect_builder.try_accept_deploy(deploy, None).ignore()
 }
 
 async fn run_gossip(rng: &mut TestRng, network_size: usize, deploy_count: usize) {
@@ -345,7 +342,7 @@ async fn run_gossip(rng: &mut TestRng, network_size: usize, deploy_count: usize)
 
     // Create `deploy_count` random deploys.
     let (all_deploy_hashes, mut deploys): (BTreeSet<_>, Vec<_>) = iter::repeat_with(|| {
-        let deploy = Box::new(Deploy::random_valid_native_transfer(rng));
+        let deploy = Arc::new(Deploy::random_valid_native_transfer(rng));
         (*deploy.hash(), deploy)
     })
     .take(deploy_count)
@@ -355,7 +352,7 @@ async fn run_gossip(rng: &mut TestRng, network_size: usize, deploy_count: usize)
     for deploy in deploys.drain(..) {
         let index: usize = rng.gen_range(0..network_size);
         network
-            .process_injected_effect_on(&node_ids[index], announce_deploy_received(deploy, None))
+            .process_injected_effect_on(&node_ids[index], announce_deploy_received(deploy))
             .await;
     }
 
@@ -402,13 +399,13 @@ async fn should_get_from_alternate_source() {
     let node_ids = network.add_nodes(&mut rng, NETWORK_SIZE).await;
 
     // Create random deploy.
-    let deploy = Box::new(Deploy::random_valid_native_transfer(&mut rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(&mut rng));
     let deploy_id = *deploy.hash();
 
     // Give the deploy to nodes 0 and 1 to be gossiped.
     for node_id in node_ids.iter().take(2) {
         network
-            .process_injected_effect_on(node_id, announce_deploy_received(deploy.clone(), None))
+            .process_injected_effect_on(node_id, announce_deploy_received(Arc::clone(&deploy)))
             .await;
     }
 
@@ -481,12 +478,12 @@ async fn should_timeout_gossip_response() {
         .await;
 
     // Create random deploy.
-    let deploy = Box::new(Deploy::random_valid_native_transfer(&mut rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(&mut rng));
     let deploy_id = *deploy.hash();
 
     // Give the deploy to node 0 to be gossiped.
     network
-        .process_injected_effect_on(&node_ids[0], announce_deploy_received(deploy.clone(), None))
+        .process_injected_effect_on(&node_ids[0], announce_deploy_received(Arc::clone(&deploy)))
         .await;
 
     // Run node 0 until it has sent the gossip requests.
@@ -559,11 +556,11 @@ async fn should_timeout_new_item_from_peer() {
     // component triggers the `ItemReceived` event.
     reactor_0.fake_deploy_acceptor.set_active(false);
 
-    let deploy = Box::new(Deploy::random_valid_native_transfer(rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(rng));
 
     // Give the deploy to node 1 to gossip to node 0.
     network
-        .process_injected_effect_on(&node_1, announce_deploy_received(deploy.clone(), None))
+        .process_injected_effect_on(&node_1, announce_deploy_received(Arc::clone(&deploy)))
         .await;
 
     // Run the network until node 1 has sent the gossip request and node 0 has handled it to the
@@ -616,12 +613,12 @@ async fn should_not_gossip_old_stored_item_again() {
     let node_ids = network.add_nodes(rng, NETWORK_SIZE).await;
     let node_0 = node_ids[0];
 
-    let deploy = Box::new(Deploy::random_valid_native_transfer(rng));
+    let deploy = Arc::new(Deploy::random_valid_native_transfer(rng));
 
     // Store the deploy on node 0.
     let store_deploy = |effect_builder: EffectBuilder<Event>| {
         effect_builder
-            .put_deploy_to_storage(deploy.clone())
+            .put_deploy_to_storage(Arc::clone(&deploy))
             .ignore()
     };
     network

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -12,8 +12,7 @@ use casper_types::{system::auction::EraValidators, Transfer};
 
 use crate::{
     effect::{requests::RpcRequest, Responder},
-    rpcs::chain::BlockIdentifier,
-    types::{BlockHash, BlockWithMetadata, Deploy, DeployHash, DeployMetadataExt, NodeId},
+    types::{BlockHash, Deploy, DeployHash, DeployMetadataExt, NodeId},
 };
 
 #[derive(Debug, From)]
@@ -21,11 +20,6 @@ pub(crate) enum Event {
     Initialize,
     #[from]
     RpcRequest(RpcRequest),
-    GetBlockResult {
-        maybe_id: Option<BlockIdentifier>,
-        result: Option<Box<BlockWithMetadata>>,
-        main_responder: Responder<Option<Box<BlockWithMetadata>>>,
-    },
     GetBlockTransfersResult {
         block_hash: BlockHash,
         result: Option<Vec<Transfer>>,
@@ -63,21 +57,6 @@ impl Display for Event {
         match self {
             Event::Initialize => write!(formatter, "initialize"),
             Event::RpcRequest(request) => write!(formatter, "{}", request),
-            Event::GetBlockResult {
-                maybe_id: Some(BlockIdentifier::Hash(hash)),
-                result,
-                ..
-            } => write!(formatter, "get block result for {}: {:?}", hash, result),
-            Event::GetBlockResult {
-                maybe_id: Some(BlockIdentifier::Height(height)),
-                result,
-                ..
-            } => write!(formatter, "get block result for {}: {:?}", height, result),
-            Event::GetBlockResult {
-                maybe_id: None,
-                result,
-                ..
-            } => write!(formatter, "get latest block result: {:?}", result),
             Event::GetBlockTransfersResult {
                 block_hash, result, ..
             } => write!(

--- a/node/src/components/rpc_server/rpcs/account.rs
+++ b/node/src/components/rpc_server/rpcs/account.rs
@@ -3,24 +3,23 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-use std::str;
+use std::{str, sync::Arc};
 
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::debug;
 
 use casper_types::ProtocolVersion;
 
 use super::{
     docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
-    Error, ReactorEventT, RpcRequest, RpcWithParams,
+    Error, ReactorEventT, RpcWithParams,
 };
 use crate::{
     components::rpc_server::rpcs::ErrorCode,
     effect::EffectBuilder,
-    reactor::QueueKind,
     types::{Deploy, DeployHash},
 };
 
@@ -79,18 +78,11 @@ impl RpcWithParams for PutDeploy {
     ) -> Result<Self::ResponseResult, Error> {
         let deploy_hash = *params.deploy.hash();
 
-        // Submit the new deploy to be announced.
-        let put_deploy_result = effect_builder
-            .make_request(
-                |responder| RpcRequest::SubmitDeploy {
-                    deploy: Box::new(params.deploy),
-                    responder,
-                },
-                QueueKind::Api,
-            )
+        let accept_deploy_result = effect_builder
+            .try_accept_deploy(Arc::new(params.deploy), None)
             .await;
 
-        match put_deploy_result {
+        match accept_deploy_result {
             Ok(_) => {
                 debug!(%deploy_hash, "deploy was stored");
                 let result = Self::ResponseResult {
@@ -100,7 +92,7 @@ impl RpcWithParams for PutDeploy {
                 Ok(result)
             }
             Err(error) => {
-                info!(
+                debug!(
                     %deploy_hash,
                     %error,
                     "the deploy submitted by the client was invalid",

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -451,7 +451,7 @@ fn put_block_signatures(
 fn put_deploy(
     harness: &mut ComponentHarness<UnitTestEvent>,
     storage: &mut Storage,
-    deploy: Box<Deploy>,
+    deploy: Arc<Deploy>,
 ) -> bool {
     let response = harness.send_request(storage, move |responder| {
         StorageRequest::PutDeploy { deploy, responder }.into()
@@ -755,28 +755,28 @@ fn can_retrieve_store_and_load_deploys() {
     let mut storage = storage_fixture(&harness);
 
     // Create a random deploy, store and load it.
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
 
-    let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
+    let was_new = put_deploy(&mut harness, &mut storage, Arc::clone(&deploy));
     let block_hash_and_height = BlockHashAndHeight::random(&mut harness.rng);
     // Insert to the deploy hash index as well so that we can perform the GET later.
     // Also check that we don't have an entry there for this deploy.
     assert!(insert_to_deploy_index(
         &mut storage,
-        *deploy.clone(),
+        (*deploy).clone(),
         block_hash_and_height
     ));
     assert!(was_new, "putting deploy should have returned `true`");
 
     // Storing the same deploy again should work, but yield a result of `false`.
-    let was_new_second_time = put_deploy(&mut harness, &mut storage, deploy.clone());
+    let was_new_second_time = put_deploy(&mut harness, &mut storage, Arc::clone(&deploy));
     assert!(
         !was_new_second_time,
         "storing deploy the second time should have returned `false`"
     );
     assert!(!insert_to_deploy_index(
         &mut storage,
-        *deploy.clone(),
+        (*deploy).clone(),
         block_hash_and_height
     ));
 
@@ -811,9 +811,9 @@ fn can_retrieve_store_and_load_deploys() {
     }
 
     // Create a random deploy, store and load it.
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
 
-    assert!(put_deploy(&mut harness, &mut storage, deploy.clone()));
+    assert!(put_deploy(&mut harness, &mut storage, Arc::clone(&deploy)));
     // Don't insert to the deploy hash index. Since we have no execution results
     // either, we should receive an empty metadata response.
     let (deploy_response, metadata_response) = harness
@@ -851,7 +851,7 @@ fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
     let mut deploy_hashes = Vec::new();
 
     for _ in 0..total {
-        let deploy = Box::new(Deploy::random(&mut harness.rng));
+        let deploy = Arc::new(Deploy::random(&mut harness.rng));
         deploy_hashes.push(*deploy.hash());
         put_deploy(&mut harness, &mut storage, deploy);
     }
@@ -877,7 +877,7 @@ fn store_execution_results_for_two_blocks() {
     let block_hash_b = BlockHash::random(&mut harness.rng);
 
     // Store the deploy.
-    put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+    put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
 
     // Ensure deploy exists.
     assert_eq!(
@@ -944,7 +944,7 @@ fn store_random_execution_results() {
 
     // Store shared deploys.
     for deploy in &shared_deploys {
-        put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+        put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
     }
 
     // We collect the expected result per deploy in parallel to adding them.
@@ -967,7 +967,7 @@ fn store_random_execution_results() {
             let deploy = Deploy::random(&mut harness.rng);
 
             // Store unique deploy.
-            put_deploy(harness, storage, Box::new(deploy.clone()));
+            put_deploy(harness, storage, Arc::new(deploy.clone()));
 
             let execution_result: ExecutionResult = harness.rng.gen();
 
@@ -1085,15 +1085,15 @@ fn test_legacy_interface() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);
 
-    let deploy = Box::new(Deploy::random(&mut harness.rng));
-    let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
+    let deploy = Arc::new(Deploy::random(&mut harness.rng));
+    let was_new = put_deploy(&mut harness, &mut storage, Arc::clone(&deploy));
     assert!(was_new);
 
     // Ensure we get the deploy we expect.
     let result = storage
         .get_legacy_deploy(*deploy.hash())
         .expect("should get deploy");
-    assert_eq!(result, Some(LegacyDeploy::from(*deploy)));
+    assert_eq!(result, Some(LegacyDeploy::from((*deploy).clone())));
 
     // A non-existent deploy should simply return `None`.
     assert!(storage
@@ -1113,7 +1113,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
     // Create some sample data.
     let deploy = Deploy::random(&mut harness.rng);
     let execution_result: ExecutionResult = harness.rng.gen();
-    put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+    put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
     put_complete_block(&mut harness, &mut storage, Arc::new(block.clone()));
     let mut execution_results = HashMap::new();
     execution_results.insert(*deploy.hash(), execution_result.clone());
@@ -1206,7 +1206,7 @@ fn should_hard_reset() {
     for (index, block_hash) in blocks.iter().map(|block| block.hash()).enumerate() {
         let deploy = random_deploys.get(index).expect("should have deploys");
         let execution_result: ExecutionResult = harness.rng.gen();
-        put_deploy(&mut harness, &mut storage, Box::new(deploy.clone()));
+        put_deploy(&mut harness, &mut storage, Arc::new(deploy.clone()));
         let mut exec_results = HashMap::new();
         exec_results.insert(*deploy.hash(), execution_result);
         put_execution_results(

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1647,12 +1647,16 @@ impl<REv> EffectBuilder<REv> {
     /// Gets the highest block with its associated metadata.
     pub(crate) async fn get_highest_block_with_metadata_from_storage(
         self,
+        only_from_available_block_range: bool,
     ) -> Option<BlockWithMetadata>
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
-            |responder| StorageRequest::GetHighestBlockWithMetadata { responder },
+            |responder| StorageRequest::GetHighestBlockWithMetadata {
+                only_from_available_block_range,
+                responder,
+            },
             QueueKind::FromStorage,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -160,16 +160,16 @@ use announcements::{
     BlockAccumulatorAnnouncement, ConsensusAnnouncement, ContractRuntimeAnnouncement,
     ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement, FatalAnnouncement,
     FetchedNewBlockAnnouncement, FetchedNewFinalitySignatureAnnouncement, GossiperAnnouncement,
-    MetaBlockAnnouncement, PeerBehaviorAnnouncement, QueueDumpFormat, RpcServerAnnouncement,
-    UnexecutedBlockAnnouncement, UpgradeWatcherAnnouncement,
+    MetaBlockAnnouncement, PeerBehaviorAnnouncement, QueueDumpFormat, UnexecutedBlockAnnouncement,
+    UpgradeWatcherAnnouncement,
 };
 use diagnostics_port::DumpConsensusStateRequest;
 use requests::{
-    BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest, BlockValidationRequest,
-    ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest, DeployBufferRequest,
-    FetcherRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest, MetricsRequest,
-    NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, SetNodeStopRequest, StorageRequest,
-    SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
+    AcceptDeployRequest, BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest,
+    BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest,
+    DeployBufferRequest, FetcherRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest,
+    MetricsRequest, NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, SetNodeStopRequest,
+    StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
@@ -914,26 +914,30 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Announces that the HTTP API server has received a deploy.
-    pub(crate) async fn announce_deploy_received(
+    /// Try to accept a deploy received from the JSON-RPC server.
+    pub(crate) async fn try_accept_deploy(
         self,
-        deploy: Box<Deploy>,
-        responder: Option<Responder<Result<(), deploy_acceptor::Error>>>,
-    ) where
-        REv: From<RpcServerAnnouncement>,
+        deploy: Arc<Deploy>,
+        speculative_exec_at_block: Option<Box<BlockHeader>>,
+    ) -> Result<(), deploy_acceptor::Error>
+    where
+        REv: From<AcceptDeployRequest>,
     {
-        self.event_queue
-            .schedule(
-                RpcServerAnnouncement::DeployReceived { deploy, responder },
-                QueueKind::Api,
-            )
-            .await;
+        self.make_request(
+            |responder| AcceptDeployRequest {
+                deploy,
+                speculative_exec_at_block,
+                responder,
+            },
+            QueueKind::Api,
+        )
+        .await
     }
 
     /// Announces that a deploy not previously stored has now been accepted and stored.
     pub(crate) fn announce_new_deploy_accepted(
         self,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
     ) -> impl Future<Output = ()>
     where
@@ -977,7 +981,7 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that an invalid deploy has been received.
     pub(crate) fn announce_invalid_deploy(
         self,
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         source: Source,
     ) -> impl Future<Output = ()>
     where
@@ -1451,7 +1455,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts the given deploy into the deploy store.
-    pub(crate) async fn put_deploy_to_storage(self, deploy: Box<Deploy>) -> bool
+    pub(crate) async fn put_deploy_to_storage(self, deploy: Arc<Deploy>) -> bool
     where
         REv: From<StorageRequest>,
     {
@@ -2178,7 +2182,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn speculative_execute_deploy(
         self,
         execution_prestate: SpeculativeExecutionState,
-        deploy: Deploy,
+        deploy: Arc<Deploy>,
     ) -> Result<Option<ExecutionResult>, engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
@@ -2186,7 +2190,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| ContractRuntimeRequest::SpeculativeDeployExecution {
                 execution_prestate,
-                deploy: Box::new(deploy),
+                deploy,
                 responder,
             },
             QueueKind::ContractRuntime,

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -19,7 +19,6 @@ use casper_types::{EraId, ExecutionEffect, PublicKey, Timestamp, U512};
 use crate::{
     components::{
         consensus::{ClContext, ProposedBlock},
-        deploy_acceptor::Error,
         diagnostics_port::FileSerializer,
         fetcher::FetchItem,
         gossiper::GossipItem,
@@ -166,36 +165,13 @@ impl QueueDumpFormat {
     }
 }
 
-/// An RPC API server announcement.
-#[derive(Debug, Serialize)]
-#[must_use]
-pub(crate) enum RpcServerAnnouncement {
-    /// A new deploy received.
-    DeployReceived {
-        /// The received deploy.
-        deploy: Box<Deploy>,
-        /// A client responder in the case where a client submits a deploy.
-        responder: Option<Responder<Result<(), Error>>>,
-    },
-}
-
-impl Display for RpcServerAnnouncement {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            RpcServerAnnouncement::DeployReceived { deploy, .. } => {
-                write!(formatter, "api server received {}", deploy.hash())
-            }
-        }
-    }
-}
-
 /// A `DeployAcceptor` announcement.
 #[derive(Debug, Serialize)]
 pub(crate) enum DeployAcceptorAnnouncement {
     /// A deploy which wasn't previously stored on this node has been accepted and stored.
     AcceptedNewDeploy {
         /// The new deploy.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// The source (peer or client) of the deploy.
         source: Source,
     },
@@ -203,7 +179,7 @@ pub(crate) enum DeployAcceptorAnnouncement {
     /// An invalid deploy was received.
     InvalidDeploy {
         /// The invalid deploy.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// The source (peer or client) of the deploy.
         source: Source,
     },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -39,7 +39,7 @@ use crate::{
         },
         consensus::{ClContext, ProposedBlock, ValidatorChange},
         contract_runtime::EraValidatorsRequest,
-        deploy_acceptor::Error,
+        deploy_acceptor,
         diagnostics_port::StopAtSpec,
         fetcher::{FetchItem, FetchResult},
         gossiper::GossipItem,
@@ -357,7 +357,7 @@ pub(crate) enum StorageRequest {
     /// Store given deploy.
     PutDeploy {
         /// Deploy to store.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// Responder to call with the result.  Returns `true` if the deploy was stored on this
         /// attempt or false if it was previously stored.
         responder: Responder<bool>,
@@ -686,13 +686,6 @@ impl Display for DeployBufferRequest {
 #[derive(Debug)]
 #[must_use]
 pub(crate) enum RpcRequest {
-    /// Submit a deploy to be announced.
-    SubmitDeploy {
-        /// The deploy to be announced.
-        deploy: Box<Deploy>,
-        /// Responder to call.
-        responder: Responder<Result<(), Error>>,
-    },
     /// If `maybe_identifier` is `Some`, return the specified block if it exists, else `None`.  If
     /// `maybe_identifier` is `None`, return the latest block.
     GetBlock {
@@ -772,22 +765,11 @@ pub(crate) enum RpcRequest {
         /// Responder to call with the result.
         responder: Responder<AvailableBlockRange>,
     },
-    /// Executs a deploy against a specified block, returning the effects.
-    /// Does not commit the effects. This is a "read-only" action.
-    SpeculativeDeployExecute {
-        /// Block header representing the state on top of which we will run the deploy.
-        block_header: Box<BlockHeader>,
-        /// Deploy to execute.
-        deploy: Box<Deploy>,
-        /// Responder.
-        responder: Responder<Result<Option<ExecutionResult>, engine_state::Error>>,
-    },
 }
 
 impl Display for RpcRequest {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            RpcRequest::SubmitDeploy { deploy, .. } => write!(formatter, "submit {}", *deploy),
             RpcRequest::GetBlock {
                 maybe_id: Some(BlockIdentifier::Hash(hash)),
                 ..
@@ -842,7 +824,6 @@ impl Display for RpcRequest {
             RpcRequest::GetAvailableBlockRange { .. } => {
                 write!(formatter, "get available block range")
             }
-            RpcRequest::SpeculativeDeployExecute { .. } => write!(formatter, "execute deploy"),
         }
     }
 }
@@ -959,7 +940,7 @@ pub(crate) enum ContractRuntimeRequest {
         /// Hash of a block on top of which to execute the deploy.
         execution_prestate: SpeculativeExecutionState,
         /// Deploy to execute.
-        deploy: Box<Deploy>,
+        deploy: Arc<Deploy>,
         /// Results
         responder: Responder<Result<Option<ExecutionResult>, engine_state::Error>>,
     },
@@ -1212,6 +1193,28 @@ impl Display for SetNodeStopRequest {
         match self.stop_at {
             None => f.write_str("clear node stop"),
             Some(stop_at) => write!(f, "set node stop to: {}", stop_at),
+        }
+    }
+}
+
+/// A request to accept a new deploy.
+#[derive(DataSize, Debug, Serialize)]
+pub(crate) struct AcceptDeployRequest {
+    pub(crate) deploy: Arc<Deploy>,
+    pub(crate) speculative_exec_at_block: Option<Box<BlockHeader>>,
+    pub(crate) responder: Responder<Result<(), deploy_acceptor::Error>>,
+}
+
+impl Display for AcceptDeployRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.speculative_exec_at_block.is_some() {
+            write!(
+                f,
+                "accept deploy {} for speculative exec",
+                self.deploy.hash()
+            )
+        } else {
+            write!(f, "accept deploy {}", self.deploy.hash())
         }
     }
 }

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -24,8 +24,7 @@ use crate::{
             ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
             FatalAnnouncement, FetchedNewBlockAnnouncement,
             FetchedNewFinalitySignatureAnnouncement, GossiperAnnouncement, MetaBlockAnnouncement,
-            PeerBehaviorAnnouncement, RpcServerAnnouncement, UnexecutedBlockAnnouncement,
-            UpgradeWatcherAnnouncement,
+            PeerBehaviorAnnouncement, UnexecutedBlockAnnouncement, UpgradeWatcherAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
@@ -34,9 +33,9 @@ use crate::{
             TrieResponseIncoming,
         },
         requests::{
-            BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest,
-            BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest,
-            ContractRuntimeRequest, DeployBufferRequest, FetcherRequest,
+            AcceptDeployRequest, BeginGossipRequest, BlockAccumulatorRequest,
+            BlockSynchronizerRequest, BlockValidationRequest, ChainspecRawBytesRequest,
+            ConsensusRequest, ContractRuntimeRequest, DeployBufferRequest, FetcherRequest,
             MakeBlockExecutableRequest, MarkBlockCompletedRequest, MetricsRequest,
             NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, RestRequest, RpcRequest,
             SetNodeStopRequest, StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
@@ -77,8 +76,6 @@ pub(crate) enum MainEvent {
     UpgradeWatcherAnnouncement(#[serde(skip_serializing)] UpgradeWatcherAnnouncement),
     #[from]
     RpcServer(#[serde(skip_serializing)] rpc_server::Event),
-    #[from]
-    RpcServerAnnouncement(#[serde(skip_serializing)] RpcServerAnnouncement),
     #[from]
     RestServer(#[serde(skip_serializing)] rest_server::Event),
     #[from]
@@ -188,6 +185,8 @@ pub(crate) enum MainEvent {
     #[from]
     DeployAcceptor(#[serde(skip_serializing)] deploy_acceptor::Event),
     #[from]
+    AcceptDeployRequest(AcceptDeployRequest),
+    #[from]
     DeployAcceptorAnnouncement(#[serde(skip_serializing)] DeployAcceptorAnnouncement),
     #[from]
     DeployGossiper(#[serde(skip_serializing)] gossiper::Event<Deploy>),
@@ -277,6 +276,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::UpgradeWatcher(_) => "UpgradeWatcher",
             MainEvent::Consensus(_) => "Consensus",
             MainEvent::DeployAcceptor(_) => "DeployAcceptor",
+            MainEvent::AcceptDeployRequest(_) => "AcceptDeployRequest",
             MainEvent::LegacyDeployFetcher(_) => "LegacyDeployFetcher",
             MainEvent::DeployFetcher(_) => "DeployFetcher",
             MainEvent::DeployGossiper(_) => "DeployGossiper",
@@ -316,7 +316,6 @@ impl ReactorEvent for MainEvent {
             MainEvent::DumpConsensusStateRequest(_) => "DumpConsensusStateRequest",
             MainEvent::ControlAnnouncement(_) => "ControlAnnouncement",
             MainEvent::FatalAnnouncement(_) => "FatalAnnouncement",
-            MainEvent::RpcServerAnnouncement(_) => "RpcServerAnnouncement",
             MainEvent::DeployAcceptorAnnouncement(_) => "DeployAcceptorAnnouncement",
             MainEvent::ConsensusAnnouncement(_) => "ConsensusAnnouncement",
             MainEvent::ContractRuntimeAnnouncement(_) => "ContractRuntimeAnnouncement",
@@ -383,6 +382,7 @@ impl Display for MainEvent {
             MainEvent::UpgradeWatcher(event) => write!(f, "upgrade watcher: {}", event),
             MainEvent::Consensus(event) => write!(f, "consensus: {}", event),
             MainEvent::DeployAcceptor(event) => write!(f, "deploy acceptor: {}", event),
+            MainEvent::AcceptDeployRequest(req) => write!(f, "{}", req),
             MainEvent::LegacyDeployFetcher(event) => write!(f, "legacy deploy fetcher: {}", event),
             MainEvent::DeployFetcher(event) => write!(f, "deploy fetcher: {}", event),
             MainEvent::DeployGossiper(event) => write!(f, "deploy gossiper: {}", event),
@@ -485,9 +485,6 @@ impl Display for MainEvent {
             MainEvent::FatalAnnouncement(fatal_ann) => write!(f, "fatal: {}", fatal_ann),
             MainEvent::DumpConsensusStateRequest(req) => {
                 write!(f, "dump consensus state: {}", req)
-            }
-            MainEvent::RpcServerAnnouncement(ann) => {
-                write!(f, "api server announcement: {}", ann)
             }
             MainEvent::DeployAcceptorAnnouncement(ann) => {
                 write!(f, "deploy acceptor announcement: {}", ann)

--- a/node/src/reactor/main_reactor/fetchers.rs
+++ b/node/src/reactor/main_reactor/fetchers.rs
@@ -166,7 +166,7 @@ impl Fetchers {
                     effect_builder,
                     rng,
                     fetcher::Event::GotRemotely {
-                        item: deploy,
+                        item: Box::new((*deploy).clone()),
                         source,
                     },
                 ),

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -737,7 +737,7 @@ async fn should_store_finalized_approvals() {
             runner
                 .process_injected_effects(|effect_builder| {
                     effect_builder
-                        .put_deploy_to_storage(Box::new(deploy_alice_bob.clone()))
+                        .put_deploy_to_storage(Arc::new(deploy_alice_bob.clone()))
                         .ignore()
                 })
                 .await;
@@ -745,7 +745,7 @@ async fn should_store_finalized_approvals() {
                 .process_injected_effects(|effect_builder| {
                     effect_builder
                         .announce_new_deploy_accepted(
-                            Box::new(deploy_alice_bob.clone()),
+                            Arc::new(deploy_alice_bob.clone()),
                             Source::Client,
                         )
                         .ignore()
@@ -756,7 +756,7 @@ async fn should_store_finalized_approvals() {
             runner
                 .process_injected_effects(|effect_builder| {
                     effect_builder
-                        .put_deploy_to_storage(Box::new(deploy_alice_bob_charlie.clone()))
+                        .put_deploy_to_storage(Arc::new(deploy_alice_bob_charlie.clone()))
                         .ignore()
                 })
                 .await;
@@ -764,7 +764,7 @@ async fn should_store_finalized_approvals() {
                 .process_injected_effects(|effect_builder| {
                     effect_builder
                         .announce_new_deploy_accepted(
-                            Box::new(deploy_alice_bob_charlie.clone()),
+                            Arc::new(deploy_alice_bob_charlie.clone()),
                             Source::Client,
                         )
                         .ignore()

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -89,9 +89,11 @@ impl AppendableBlock {
         {
             return Err(AddError::Duplicate);
         }
-        if !footprint
-            .header
-            .is_valid(&self.deploy_config, self.timestamp)
+        if footprint.header.expired(self.timestamp)
+            || footprint
+                .header
+                .is_valid(&self.deploy_config, self.timestamp, transfer.deploy_hash())
+                .is_err()
         {
             return Err(AddError::InvalidDeploy);
         }
@@ -120,9 +122,11 @@ impl AppendableBlock {
         if self.deploy_and_transfer_set.contains(deploy.deploy_hash()) {
             return Err(AddError::Duplicate);
         }
-        if !footprint
-            .header
-            .is_valid(&self.deploy_config, self.timestamp)
+        if footprint.header.expired(self.timestamp)
+            || footprint
+                .header
+                .is_valid(&self.deploy_config, self.timestamp, deploy.deploy_hash())
+                .is_err()
         {
             return Err(AddError::InvalidDeploy);
         }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -1241,7 +1241,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let deploy = create_deploy(
             &mut rng,
@@ -1249,6 +1248,7 @@ mod tests {
             deploy_config.max_dependencies.into(),
             chain_name,
         );
+        let current_timestamp = deploy.header().timestamp();
         deploy
             .is_config_compliant(
                 chain_name,
@@ -1265,7 +1265,6 @@ mod tests {
         let expected_chain_name = "net-1";
         let wrong_chain_name = "net-2".to_string();
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let deploy = create_deploy(
             &mut rng,
@@ -1279,6 +1278,7 @@ mod tests {
             got: wrong_chain_name,
         };
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 expected_chain_name,
@@ -1299,7 +1299,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let dependency_count = usize::from(deploy_config.max_dependencies + 1);
 
@@ -1315,6 +1314,7 @@ mod tests {
             got: dependency_count,
         };
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 chain_name,
@@ -1335,7 +1335,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let ttl = deploy_config.max_ttl + TimeDiff::from(Duration::from_secs(1));
 
@@ -1351,6 +1350,7 @@ mod tests {
             got: ttl,
         };
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 chain_name,
@@ -1405,7 +1405,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let payment = ExecutableDeployItem::ModuleBytes {
             module_bytes: Bytes::new(),
@@ -1430,6 +1429,7 @@ mod tests {
         deploy.payment = payment;
         deploy.session = session;
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 chain_name,
@@ -1450,7 +1450,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
 
         let payment = ExecutableDeployItem::ModuleBytes {
             module_bytes: Bytes::new(),
@@ -1477,6 +1476,7 @@ mod tests {
         deploy.payment = payment;
         deploy.session = session;
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 chain_name,
@@ -1497,7 +1497,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let amount = U512::from(deploy_config.block_gas_limit + 1);
 
         let payment = ExecutableDeployItem::ModuleBytes {
@@ -1530,6 +1529,7 @@ mod tests {
             got: Box::new(amount),
         };
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             deploy.is_config_compliant(
                 chain_name,
@@ -1551,7 +1551,6 @@ mod tests {
         let secret_key = SecretKey::random(&mut rng);
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let amount = U512::from(deploy_config.block_gas_limit + 1);
 
         let payment = ExecutableDeployItem::ModuleBytes {
@@ -1583,6 +1582,7 @@ mod tests {
             None,
         );
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             Ok(()),
             deploy.is_config_compliant(
@@ -1599,7 +1599,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let deploy = create_deploy(
             &mut rng,
             deploy_config.max_ttl,
@@ -1609,6 +1608,7 @@ mod tests {
         // This test is to ensure a given limit is being checked.
         // Therefore, set the limit to one less than the approvals in the deploy.
         let max_associated_keys = (deploy.approvals.len() - 1) as u32;
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             Err(DeployConfigurationFailure::ExcessiveApprovals {
                 got: deploy.approvals.len() as u32,
@@ -1628,7 +1628,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let mut deploy = create_deploy(
             &mut rng,
             deploy_config.max_ttl,
@@ -1642,6 +1641,7 @@ mod tests {
         };
         deploy.session = session;
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             Err(DeployConfigurationFailure::MissingTransferAmount),
             deploy.is_config_compliant(
@@ -1658,7 +1658,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let mut deploy = create_deploy(
             &mut rng,
             deploy_config.max_ttl,
@@ -1676,6 +1675,7 @@ mod tests {
         };
         deploy.session = session;
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             Err(DeployConfigurationFailure::FailedToParseTransferAmount),
             deploy.is_config_compliant(
@@ -1692,7 +1692,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
-        let current_timestamp = Timestamp::now();
         let mut deploy = create_deploy(
             &mut rng,
             deploy_config.max_ttl,
@@ -1713,6 +1712,7 @@ mod tests {
         };
         deploy.session = session;
 
+        let current_timestamp = deploy.header().timestamp();
         assert_eq!(
             Err(DeployConfigurationFailure::InsufficientTransferAmount {
                 minimum: Box::new(U512::from(deploy_config.native_transfer_minimum_motes)),

--- a/node/src/types/deploy/deploy_header.rs
+++ b/node/src/types/deploy/deploy_header.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use datasize::DataSize;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use casper_hashing::Digest;
 use casper_types::{
@@ -12,7 +13,7 @@ use casper_types::{
 
 #[cfg(doc)]
 use super::Deploy;
-use super::DeployHash;
+use super::{DeployConfigurationFailure, DeployHash};
 use crate::{types::chainspec::DeployConfig, utils::DisplayIter};
 
 /// The header portion of a [`Deploy`].
@@ -91,13 +92,49 @@ impl DeployHeader {
         &self.chain_name
     }
 
-    /// Determine if this deploy header has valid values based on a `DeployConfig` and timestamp.
-    pub fn is_valid(&self, deploy_config: &DeployConfig, current_timestamp: Timestamp) -> bool {
-        let ttl_valid = self.ttl() <= deploy_config.max_ttl;
-        let timestamp_valid = self.timestamp() <= current_timestamp;
-        let not_expired = !self.expired(current_timestamp);
-        let num_deps_valid = self.dependencies().len() <= deploy_config.max_dependencies as usize;
-        ttl_valid && timestamp_valid && not_expired && num_deps_valid
+    /// Returns Ok if and only if the dependencies count and TTL are within limits, and the
+    /// timestamp is not later than `at`.  Does NOT check for expiry.
+    pub fn is_valid(
+        &self,
+        config: &DeployConfig,
+        at: Timestamp,
+        deploy_hash: &DeployHash,
+    ) -> Result<(), DeployConfigurationFailure> {
+        if self.dependencies.len() > config.max_dependencies as usize {
+            debug!(
+                %deploy_hash,
+                deploy_header = %self,
+                max_dependencies = %config.max_dependencies,
+                "deploy dependency ceiling exceeded"
+            );
+            return Err(DeployConfigurationFailure::ExcessiveDependencies {
+                max_dependencies: config.max_dependencies,
+                got: self.dependencies().len(),
+            });
+        }
+
+        if self.ttl() > config.max_ttl {
+            debug!(
+                %deploy_hash,
+                deploy_header = %self,
+                max_ttl = %config.max_ttl,
+                "deploy ttl excessive"
+            );
+            return Err(DeployConfigurationFailure::ExcessiveTimeToLive {
+                max_ttl: config.max_ttl,
+                got: self.ttl(),
+            });
+        }
+
+        if self.timestamp() > at {
+            debug!(%deploy_hash, deploy_header = %self, %at, "deploy timestamp in the future");
+            return Err(DeployConfigurationFailure::TimestampInFuture {
+                validation_timestamp: at,
+                got: self.timestamp(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Returns the timestamp of when the deploy expires, i.e. `self.timestamp + self.ttl`.

--- a/node/src/types/deploy/error.rs
+++ b/node/src/types/deploy/error.rs
@@ -4,7 +4,7 @@ use datasize::DataSize;
 use serde::Serialize;
 use thiserror::Error;
 
-use casper_types::{TimeDiff, U512};
+use casper_types::{TimeDiff, Timestamp, U512};
 
 /// A representation of the way in which a deploy failed validation checks.
 #[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Error, Serialize)]
@@ -38,6 +38,17 @@ pub enum DeployConfigurationFailure {
         max_ttl: TimeDiff,
         /// The received time-to-live.
         got: TimeDiff,
+    },
+
+    /// Deploy's timestamp is in the future.
+    #[error(
+        "timestamp of {got} is later than node's validation timestamp of {validation_timestamp}"
+    )]
+    TimestampInFuture {
+        /// The node's timestamp when validating the deploy.
+        validation_timestamp: Timestamp,
+        /// The deploy's timestamp.
+        got: Timestamp,
     },
 
     /// The provided body hash does not match the actual hash of the body.
@@ -93,7 +104,7 @@ pub enum DeployConfigurationFailure {
         /// Configured block gas limit.
         block_gas_limit: u64,
         /// The payment amount received.
-        got: U512,
+        got: Box<U512>,
     },
 
     /// Missing payment "amount" runtime argument
@@ -108,9 +119,9 @@ pub enum DeployConfigurationFailure {
     #[error("insufficient transfer amount; minimum: {minimum} attempted: {attempted}")]
     InsufficientTransferAmount {
         /// The minimum transfer amount.
-        minimum: U512,
+        minimum: Box<U512>,
         /// The attempted transfer amount.
-        attempted: U512,
+        attempted: Box<U512>,
     },
 
     /// The amount of approvals on the deploy exceeds the max_associated_keys limit.

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::{error, warn};
 
-use crate::types::NodeId;
+use crate::types::{BlockHeader, NodeId};
 pub(crate) use block_signatures::{check_sufficient_block_signatures, BlockSignatureError};
 pub(crate) use display_error::display_error;
 #[cfg(test)]
@@ -289,6 +289,8 @@ pub(crate) enum Source {
     Peer(NodeId),
     /// A client.
     Client,
+    /// A client via the speculative_exec server.
+    SpeculativeExec(Box<BlockHeader>),
     /// This node.
     Ourself,
 }
@@ -296,14 +298,17 @@ pub(crate) enum Source {
 impl Source {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn is_client(&self) -> bool {
-        matches!(self, Source::Client)
+        match self {
+            Source::Client | Source::SpeculativeExec(_) => true,
+            Source::PeerGossiped(_) | Source::Peer(_) | Source::Ourself => false,
+        }
     }
 
     /// If `self` represents a peer, returns its ID, otherwise returns `None`.
     pub(crate) fn node_id(&self) -> Option<NodeId> {
         match self {
             Source::Peer(node_id) | Source::PeerGossiped(node_id) => Some(*node_id),
-            Source::Client | Source::Ourself => None,
+            Source::Client | Source::SpeculativeExec(_) | Source::Ourself => None,
         }
     }
 }
@@ -314,6 +319,7 @@ impl Display for Source {
             Source::PeerGossiped(node_id) => Display::fmt(node_id, formatter),
             Source::Peer(node_id) => Display::fmt(node_id, formatter),
             Source::Client => write!(formatter, "client"),
+            Source::SpeculativeExec(_) => write!(formatter, "client (speculative exec)"),
             Source::Ourself => write!(formatter, "ourself"),
         }
     }

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -73,8 +73,6 @@ function _set_nodes()
         cp "$PATH_TO_CONFIG_TOML" "$PATH_TO_CFG"
         cp "$(get_path_to_net)"/chainspec/* "$PATH_TO_CFG"
 
-        SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_FILE || true)
-
         local SCRIPT=(
             "import toml;"
             "cfg=toml.load('$PATH_TO_FILE');"
@@ -86,16 +84,8 @@ function _set_nodes()
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
-            "toml.dump(cfg, open('$PATH_TO_FILE', 'w'));"
-        )
-
-        if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
-            SCRIPT+=(
-                "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
-            )
-        fi
-
-        SCRIPT+=(
+            "cfg['speculative_exec_server']['address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
+            "cfg['speculative_exec_server']['enable_server']=True;"
             "toml.dump(cfg, open('$PATH_TO_FILE', 'w'));"
         )
 

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -408,8 +408,6 @@ function setup_asset_node_configs()
         cp "$PATH_TO_NET/chainspec/chainspec.toml" "$PATH_TO_CONFIG"
         cp "$PATH_TO_TEMPLATE" "$PATH_TO_CONFIG_FILE"
 
-        SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_CONFIG_FILE || true)
-
         # Set node configuration settings.
         SCRIPT=(
             "import toml;"
@@ -422,17 +420,11 @@ function setup_asset_node_configs()
             "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$IDX")';"
             "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$IDX")';"
             "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$IDX")';"
-        )
-
-        if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
-            SCRIPT+=(
-                "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
-            )
-        fi
-
-        SCRIPT+=(
+            "cfg['speculative_exec_server']['address']='0.0.0.0:$(get_node_port_speculative_exec "$IDX")';"
+            "cfg['speculative_exec_server']['enable_server']=True;"
             "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
         )
+
         python3 -c "${SCRIPT[*]}"
     done
 }

--- a/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage_single_node.sh
@@ -181,8 +181,6 @@ function _setup_asset_node_configs()
     cp "$PATH_TO_NET/chainspec/chainspec.toml" "$PATH_TO_CONFIG"
     cp "$PATH_TO_TEMPLATE" "$PATH_TO_CONFIG_FILE"
 
-    SPECULATIVE_EXEC_ADDR=$(grep 'speculative_execution_address' $PATH_TO_CONFIG_FILE || true)
-
     # Set node configuration settings.
     SCRIPT=(
         "import toml;"
@@ -195,15 +193,8 @@ function _setup_asset_node_configs()
         "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$NODE_ID")';"
         "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$NODE_ID")';"
         "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$NODE_ID")';"
-    )
-
-    if [ ! -z "$SPECULATIVE_EXEC_ADDR" ]; then
-        SCRIPT+=(
-            "cfg['rpc_server']['speculative_execution_address']='0.0.0.0:$(get_node_port_speculative_exec "$NODE_ID")';"
-        )
-    fi
-
-    SCRIPT+=(
+        "cfg['speculative_exec_server']['address']='0.0.0.0:$(get_node_port_speculative_exec "$NODE_ID")';"
+        "cfg['speculative_exec_server']['enable_server']=True;"
         "toml.dump(cfg, open('$PATH_TO_CONFIG_FILE', 'w'));"
     )
 

--- a/utils/nctl/sh/views/view_node_ports.sh
+++ b/utils/nctl/sh/views/view_node_ports.sh
@@ -14,10 +14,10 @@ function main()
     if [ "$NODE_ID" = "all" ]; then
         for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
         do
-            echo "------------------------------------------------------------------------------------------------------------------------------------"
+            echo "----------------------------------------------------------------------------------------------------------------------------------------------------------------"
             do_render "$NODE_ID"
         done
-        echo "------------------------------------------------------------------------------------------------------------------------------------"
+        echo "----------------------------------------------------------------------------------------------------------------------------------------------------------------"
     else
         do_render "$NODE_ID"
     fi
@@ -37,13 +37,15 @@ function do_render()
     local PORT_REST
     local PORT_RPC
     local PORT_SSE
+    local PORT_SPECULATIVE_EXEC
 
     PORT_VNET=$(get_node_port "$NCTL_BASE_PORT_NETWORK" "$NODE_ID")
     PORT_REST=$(get_node_port_rest "$NODE_ID")
     PORT_RPC=$(get_node_port_rpc "$NODE_ID")
     PORT_SSE=$(get_node_port_sse "$NODE_ID")
+    PORT_SPECULATIVE_EXEC=$(get_node_port_speculative_exec "$NODE_ID")
 
-    log "node-$NODE_ID :: VNET @ $PORT_VNET :: RPC @ $PORT_RPC :: REST @ $PORT_REST :: SSE @ $PORT_SSE"
+    log "node-$NODE_ID :: VNET @ $PORT_VNET :: RPC @ $PORT_RPC :: REST @ $PORT_REST :: SSE @ $PORT_SSE :: SPECULATIVE_EXEC @ $PORT_SPECULATIVE_EXEC"
 }
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
This PR primarily updates the speculative-exec server to pass incoming deploys to the `DeployAcceptor` before attempting speculative execution.  This more closely matches the normal flow for incoming deploys, and means such deploys will undergo more rigorous validation, including cryptographic verification of the approvals.

This required a little reworking of `DeployAcceptor` to ensure the speculative-exec deploys are not stored on the node or announced to other components.  It also meant that the `DeployAcceptor` had to be able to use a specific block for validation, rather than just the highest complete block, as the speculative-exec endpoint allows clients to specify a block at which to attempt execution.

There is also a fix for nctl, so that all nodes by default enable their speculative-exec servers, on ports 25101, 25102, etc.

Closes #3969.