### PR TITLE
GH-3849: Get keys deserialize fix

### DIFF
--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -596,6 +596,8 @@ where
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        // NOTE: When changing this make sure all partial deserializers that are referencing
+        // `LazyTrieLeaf` are also updated.
         writer.push(u8::from(self.tag()));
         match self {
             Trie::Leaf { key, value } => {

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -527,10 +527,10 @@ where
     let trie_tag = lazy_trie_tag(&bytes);
 
     if trie_tag == Some(TrieTag::Leaf) {
-        Ok(Either::Left(bytes))
+        Ok(LazyTrieLeaf::Left(bytes))
     } else {
         let deserialized: Trie<K, V> = bytesrepr::deserialize(bytes.into())?;
-        Ok(Either::Right(deserialized))
+        Ok(LazyTrieLeaf::Right(deserialized))
     }
 }
 
@@ -538,11 +538,11 @@ pub(crate) fn lazy_trie_iter_children<K, V>(
     trie_bytes: &LazyTrieLeaf<K, V>,
 ) -> DescendantsIterator {
     match trie_bytes {
-        Either::Left(_) => {
+        LazyTrieLeaf::Left(_) => {
             // Leaf bytes does not have any children
             DescendantsIterator::ZeroOrOne(None)
         }
-        Either::Right(trie) => {
+        LazyTrieLeaf::Right(trie) => {
             // Trie::Node or Trie::Extension has children
             trie.iter_children()
         }

--- a/execution_engine/src/storage/trie_store/operations/debug_store.rs
+++ b/execution_engine/src/storage/trie_store/operations/debug_store.rs
@@ -1,0 +1,54 @@
+use std::marker::PhantomData;
+
+use casper_hashing::Digest;
+use casper_types::bytesrepr::{self, FromBytes};
+
+use crate::storage::{store::Store, trie::Trie, trie_store::TrieStore};
+
+/// A [`TrieStore`] wrapper that panics in debug mode whenever an attempt to deserialize [`V`] is
+/// made, otherwise it behaves as a [`TrieStore`].
+///
+/// The debug panic is used to ensure that this wrapper has  To ensure this wrapper has zero
+/// overhead, a debug assertion is used.
+pub(crate) struct EnsureNeverDeserializes<'a, K, V, S>(&'a S, PhantomData<*const (K, V)>)
+where
+    S: TrieStore<K, V>;
+
+impl<'a, K, V, S> EnsureNeverDeserializes<'a, K, V, S>
+where
+    S: TrieStore<K, V>,
+{
+    pub(crate) fn new(store: &'a S) -> Self {
+        Self(store, PhantomData)
+    }
+}
+
+impl<'a, K, V, S> Store<Digest, Trie<K, V>> for EnsureNeverDeserializes<'a, K, V, S>
+where
+    S: TrieStore<K, V>,
+{
+    type Error = S::Error;
+
+    type Handle = S::Handle;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        self.0.handle()
+    }
+
+    #[inline]
+    fn deserialize_value(&self, bytes: &[u8]) -> Result<Trie<K, V>, bytesrepr::Error>
+    where
+        Trie<K, V>: FromBytes,
+    {
+        #[cfg(debug_assertions)]
+        {
+            let _ = bytes;
+            panic!("Tried to deserialize a value but expected no deserialization to happen.")
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            bytesrepr::deserialize_from_slice(bytes)
+        }
+    }
+}

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod debug_store;
+pub(crate) mod store_wrappers;
 #[cfg(test)]
 mod tests;
 
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-use self::debug_store::EnsureNeverDeserializes;
+use self::store_wrappers::NonDeserializingStore;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq)]
@@ -1038,7 +1038,7 @@ struct VisitedTrieNode<K, V> {
 pub struct KeysIterator<'a, 'b, K, V, T, S: TrieStore<K, V>> {
     initial_descend: VecDeque<u8>,
     visited: Vec<VisitedTrieNode<K, V>>,
-    store: EnsureNeverDeserializes<'a, K, V, S>, //&'a S,
+    store: NonDeserializingStore<'a, K, V, S>,
     txn: &'b T,
     state: KeysIteratorState<K, V, S>,
 }
@@ -1222,7 +1222,7 @@ where
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,
 {
-    let store = debug_store::EnsureNeverDeserializes::new(store);
+    let store = store_wrappers::NonDeserializingStore::new(store);
     let (visited, init_state): (Vec<VisitedTrieNode<K, V>>, _) = match store.get_raw(txn, root) {
         Ok(None) => (vec![], KeysIteratorState::Ok),
         Err(e) => (vec![], KeysIteratorState::ReturnError(e)),

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -1078,7 +1078,10 @@ where
                             return Some(Err(e.into()));
                         }
                     };
-                    debug_assert!(key_bytes.starts_with(&path));
+                    debug_assert!(
+                        key_bytes.starts_with(&path),
+                        "Expected key bytes to start with the current path"
+                    );
                     // only return the leaf if it matches the initial descend path
                     path.extend(&self.initial_descend);
                     if key_bytes.starts_with(&path) {
@@ -1104,7 +1107,10 @@ where
                                     return Some(Err(e));
                                 }
                             };
-                            debug_assert!(maybe_next_trie.is_some());
+                            debug_assert!(
+                                maybe_next_trie.is_some(),
+                                "Trie at the pointer is expected to exist"
+                            );
                             if self.initial_descend.pop_front().is_none() {
                                 self.visited.push(VisitedTrieNode {
                                     trie,
@@ -1142,7 +1148,11 @@ where
                                 return Some(Err(e));
                             }
                         };
-                        debug_assert!({ matches!(&maybe_next_trie, Some(Trie::Node { .. })) });
+                        debug_assert!(
+                            { matches!(&maybe_next_trie, Some(Trie::Node { .. })) },
+                            "Expected a Trie::Node but received {:?}",
+                            maybe_next_trie
+                        );
                         path.extend(affix);
                     }
                 }

--- a/execution_engine/src/storage/trie_store/operations/store_wrappers.rs
+++ b/execution_engine/src/storage/trie_store/operations/store_wrappers.rs
@@ -8,13 +8,12 @@ use crate::storage::{store::Store, trie::Trie, trie_store::TrieStore};
 /// A [`TrieStore`] wrapper that panics in debug mode whenever an attempt to deserialize [`V`] is
 /// made, otherwise it behaves as a [`TrieStore`].
 ///
-/// The debug panic is used to ensure that this wrapper has  To ensure this wrapper has zero
-/// overhead, a debug assertion is used.
-pub(crate) struct EnsureNeverDeserializes<'a, K, V, S>(&'a S, PhantomData<*const (K, V)>)
+/// To ensure this wrapper has zero overhead, a debug assertion is used.
+pub(crate) struct NonDeserializingStore<'a, K, V, S>(&'a S, PhantomData<*const (K, V)>)
 where
     S: TrieStore<K, V>;
 
-impl<'a, K, V, S> EnsureNeverDeserializes<'a, K, V, S>
+impl<'a, K, V, S> NonDeserializingStore<'a, K, V, S>
 where
     S: TrieStore<K, V>,
 {
@@ -23,7 +22,7 @@ where
     }
 }
 
-impl<'a, K, V, S> Store<Digest, Trie<K, V>> for EnsureNeverDeserializes<'a, K, V, S>
+impl<'a, K, V, S> Store<Digest, Trie<K, V>> for NonDeserializingStore<'a, K, V, S>
 where
     S: TrieStore<K, V>,
 {

--- a/execution_engine/src/storage/trie_store/operations/tests/bytesrepr_utils.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/bytesrepr_utils.rs
@@ -1,0 +1,37 @@
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub(crate) struct PanickingFromBytes<T>(T);
+
+impl<T> FromBytes for PanickingFromBytes<T>
+where
+    T: FromBytes,
+{
+    fn from_bytes(_: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        unreachable!("This type is expected to never deserialize.");
+    }
+}
+
+impl<T> ToBytes for PanickingFromBytes<T>
+where
+    T: ToBytes,
+{
+    fn into_bytes(self) -> Result<Vec<u8>, bytesrepr::Error>
+    where
+        Self: Sized,
+    {
+        self.0.into_bytes()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.0.write_bytes(writer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bytesrepr_utils;
 mod delete;
 mod ee_699;
 mod keys;


### PR DESCRIPTION
Closes #3849

This PR ensures that the `keys_with_prefix` iterator never deserializes `StoredValue`. This is accomplished by adding two zero-overhead types:
- `EnsureNeverDeserializes` wrapper for a `TrieStore` that will panic under debug mode when a value is deserialized, and
- `PanickingFromBytes` that wraps V, but the implementation will always panic when it's deserialized.