### PR TITLE
GH-3967: Remove obsolete alias

### DIFF
--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -203,12 +203,10 @@ pub struct HostFunctionCosts {
     /// Cost of calling the `read_value` host function.
     pub read_value: HostFunction<[Cost; 3]>,
     /// Cost of calling the `dictionary_get` host function.
-    #[serde(alias = "read_value_local")]
     pub dictionary_get: HostFunction<[Cost; 3]>,
     /// Cost of calling the `write` host function.
     pub write: HostFunction<[Cost; 4]>,
     /// Cost of calling the `dictionary_put` host function.
-    #[serde(alias = "write_local")]
     pub dictionary_put: HostFunction<[Cost; 4]>,
     /// Cost of calling the `add` host function.
     pub add: HostFunction<[Cost; 4]>,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -201,7 +201,7 @@ provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
 put_key = { cost = 38_000, arguments = [0, 1_100, 0, 0] }
 read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
 read_value = { cost = 6_000, arguments = [0, 0, 0] }
-read_value_local = { cost = 5_500, arguments = [0, 590, 0] }
+dictionary_get = { cost = 5_500, arguments = [0, 590, 0] }
 remove_associated_key = { cost = 4_200, arguments = [0, 0] }
 remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }
 remove_contract_user_group_urefs = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
@@ -214,7 +214,7 @@ transfer_from_purse_to_purse = { cost = 82_000, arguments = [0, 0, 0, 0, 0, 0, 0
 transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] }
 update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
-write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+dictionary_put = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -208,7 +208,7 @@ provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
 put_key = { cost = 38_000, arguments = [0, 1_100, 0, 0] }
 read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
 read_value = { cost = 6_000, arguments = [0, 0, 0] }
-read_value_local = { cost = 5_500, arguments = [0, 590, 0] }
+dictionary_get = { cost = 5_500, arguments = [0, 590, 0] }
 remove_associated_key = { cost = 4_200, arguments = [0, 0] }
 remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }
 remove_contract_user_group_urefs = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
@@ -221,7 +221,7 @@ transfer_from_purse_to_purse = { cost = 82_000, arguments = [0, 0, 0, 0, 0, 0, 0
 transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] }
 update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
-write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+dictionary_put = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -119,7 +119,7 @@ provision_contract_user_group_uref = { cost = 124, arguments = [0,1,2,3,4] }
 put_key = { cost = 125, arguments = [0, 1, 2, 3] }
 read_host_buffer = { cost = 126, arguments = [0, 1, 2] }
 read_value = { cost = 127, arguments = [0, 1, 0] }
-read_value_local = { cost = 128,  arguments = [0, 1, 0] }
+dictionary_get = { cost = 128,  arguments = [0, 1, 0] }
 remove_associated_key = { cost = 129, arguments = [0, 1] }
 remove_contract_user_group = { cost = 130, arguments = [0, 1, 2, 3] }
 remove_contract_user_group_urefs = { cost = 131, arguments = [0,1,2,3,4,5] }
@@ -132,7 +132,7 @@ transfer_from_purse_to_purse = { cost = 137, arguments = [0, 1, 2, 3, 4, 5, 6, 7
 transfer_to_account = { cost = 138, arguments = [0, 1, 2, 3, 4, 5, 6] }
 update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
-write_local = { cost = 141, arguments = [0, 1, 2, 3] }
+dictionary_put = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -117,7 +117,7 @@ provision_contract_user_group_uref = { cost = 124, arguments = [0,1,2,3,4] }
 put_key = { cost = 125, arguments = [0, 1, 2, 3] }
 read_host_buffer = { cost = 126, arguments = [0, 1, 2] }
 read_value = { cost = 127, arguments = [0, 1, 0] }
-read_value_local = { cost = 128,  arguments = [0, 1, 0] }
+dictionary_get = { cost = 128,  arguments = [0, 1, 0] }
 remove_associated_key = { cost = 129, arguments = [0, 1] }
 remove_contract_user_group = { cost = 130, arguments = [0, 1, 2, 3] }
 remove_contract_user_group_urefs = { cost = 131, arguments = [0,1,2,3,4,5] }
@@ -130,7 +130,7 @@ transfer_from_purse_to_purse = { cost = 137, arguments = [0, 1, 2, 3, 4, 5, 6, 7
 transfer_to_account = { cost = 138, arguments = [0, 1, 2, 3, 4, 5, 6] }
 update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
-write_local = { cost = 141, arguments = [0, 1, 2, 3] }
+dictionary_put = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -120,7 +120,7 @@ put_key = { cost = 125, arguments = [0, 1, 2, 3] }
 random_bytes = { cost = 123, arguments = [0, 1] }
 read_host_buffer = { cost = 126, arguments = [0, 1, 2] }
 read_value = { cost = 127, arguments = [0, 1, 0] }
-read_value_local = { cost = 128,  arguments = [0, 1, 0] }
+dictionary_get = { cost = 128,  arguments = [0, 1, 0] }
 remove_associated_key = { cost = 129, arguments = [0, 1] }
 remove_contract_user_group = { cost = 130, arguments = [0, 1, 2, 3] }
 remove_contract_user_group_urefs = { cost = 131, arguments = [0,1,2,3,4,5] }
@@ -133,7 +133,7 @@ transfer_from_purse_to_purse = { cost = 137, arguments = [0, 1, 2, 3, 4, 5, 6, 7
 transfer_to_account = { cost = 138, arguments = [0, 1, 2, 3, 4, 5, 6] }
 update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
-write_local = { cost = 141, arguments = [0, 1, 2, 3] }
+dictionary_put = { cost = 141, arguments = [0, 1, 2, 3] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000


### PR DESCRIPTION
Closes #3967

This PR removes obsolete and confusing `#[serde(alias="...")]` that references non-existing host function names. 