### PR TITLE
GH-3231: Default vesting schedule

### DIFF
--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -47,16 +47,14 @@ pub use step_request_builder::StepRequestBuilder;
 pub use upgrade_request_builder::UpgradeRequestBuilder;
 pub use wasm_test_builder::{InMemoryWasmTestBuilder, LmdbWasmTestBuilder, WasmTestBuilder};
 
-const DAY_MILLIS: u64 = 24 * 60 * 60 * 1000;
-
 /// Default number of validator slots.
 pub const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 /// Default auction delay.
 pub const DEFAULT_AUCTION_DELAY: u64 = 1;
-/// Default lock-in period of 90 days
-pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
-/// Default length of total vesting schedule of 91 days.
-pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+/// Default lock-in period is currently zero.
+pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 0;
+/// Default length of total vesting schedule is currently zero.
+pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 0;
 
 /// Default number of eras that need to pass to be able to withdraw unbonded funds.
 pub const DEFAULT_UNBONDING_DELAY: u64 = 7;

--- a/execution_engine_testing/tests/src/test/regression/gov_116.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_116.rs
@@ -5,10 +5,18 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_VALIDATOR_SLOTS, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_AUCTION_DELAY, DEFAULT_CHAINSPEC_REGISTRY,
+    DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_MAX_ASSOCIATED_KEYS, DEFAULT_PROTOCOL_VERSION,
+    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
+    DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::core::engine_state::{genesis::GenesisValidator, GenesisAccount};
+use casper_execution_engine::core::engine_state::{
+    engine_config::{DEFAULT_MINIMUM_DELEGATION_AMOUNT, DEFAULT_STRICT_ARGUMENT_CHECKING},
+    genesis::GenesisValidator,
+    EngineConfig, ExecConfig, GenesisAccount, RunGenesisRequest, DEFAULT_MAX_QUERY_DEPTH,
+    DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+};
 use casper_types::{
     runtime_args,
     system::{
@@ -238,7 +246,73 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
 #[ignore]
 #[test]
 fn should_retain_genesis_validator_slot_protection() {
-    let mut builder = initialize_builder();
+    const CASPER_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+    const CASPER_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
+    const CASPER_VESTING_BASE: u64 =
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
+
+    let mut builder = {
+        let engine_config = EngineConfig::new(
+            DEFAULT_MAX_QUERY_DEPTH,
+            DEFAULT_MAX_ASSOCIATED_KEYS,
+            DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+            DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+            DEFAULT_STRICT_ARGUMENT_CHECKING,
+            CASPER_VESTING_SCHEDULE_PERIOD_MILLIS,
+            None,
+            *DEFAULT_WASM_CONFIG,
+            *DEFAULT_SYSTEM_CONFIG,
+        );
+
+        let run_genesis_request = {
+            let accounts = GENESIS_ACCOUNTS.clone();
+            let exec_config = {
+                let wasm_config = *DEFAULT_WASM_CONFIG;
+                let system_config = *DEFAULT_SYSTEM_CONFIG;
+                let validator_slots = DEFAULT_VALIDATOR_SLOTS;
+                let auction_delay = DEFAULT_AUCTION_DELAY;
+                let locked_funds_period_millis = CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
+                let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
+                let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+                let genesis_timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
+                ExecConfig::new(
+                    accounts,
+                    wasm_config,
+                    system_config,
+                    validator_slots,
+                    auction_delay,
+                    locked_funds_period_millis,
+                    round_seigniorage_rate,
+                    unbonding_delay,
+                    genesis_timestamp_millis,
+                )
+            };
+
+            RunGenesisRequest::new(
+                *DEFAULT_GENESIS_CONFIG_HASH,
+                *DEFAULT_PROTOCOL_VERSION,
+                exec_config,
+                DEFAULT_CHAINSPEC_REGISTRY.clone(),
+            )
+        };
+
+        let mut builder = InMemoryWasmTestBuilder::new_with_config(engine_config);
+        builder.run_genesis(&run_genesis_request);
+
+        let fund_request = ExecuteRequestBuilder::transfer(
+            *DEFAULT_ACCOUNT_ADDR,
+            runtime_args! {
+                mint::ARG_TARGET => PublicKey::System.to_account_hash(),
+                mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
+                mint::ARG_ID => <Option<u64>>::None,
+            },
+        )
+        .build();
+
+        builder.exec(fund_request).expect_success().commit();
+
+        builder
+    };
 
     let era_validators_1: EraValidators = builder.get_era_validators();
 
@@ -253,7 +327,7 @@ fn should_retain_genesis_validator_slot_protection() {
         "expected validator set should be unchanged"
     );
 
-    builder.run_auction(VESTING_BASE, Vec::new());
+    builder.run_auction(CASPER_VESTING_BASE, Vec::new());
 
     let era_validators_2: EraValidators = builder.get_era_validators();
 
@@ -276,7 +350,7 @@ fn should_retain_genesis_validator_slot_protection() {
 
     builder.exec(add_bid_request).expect_success().commit();
 
-    builder.run_auction(VESTING_BASE + WEEK_MILLIS, Vec::new());
+    builder.run_auction(CASPER_VESTING_BASE + WEEK_MILLIS, Vec::new());
 
     // All genesis validator slots are protected after ~1 week
     let era_validators_3: EraValidators = builder.get_era_validators();
@@ -286,7 +360,10 @@ fn should_retain_genesis_validator_slot_protection() {
     assert_eq!(next_validator_set_3, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
 
     // After 13 weeks ~ 91 days lowest stake validator is dropped and replaced with higher bid
-    builder.run_auction(VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS, Vec::new());
+    builder.run_auction(
+        CASPER_VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS,
+        Vec::new(),
+    );
 
     let era_validators_4: EraValidators = builder.get_era_validators();
     let (last_era_4, weights_4) = era_validators_4.iter().last().unwrap();
@@ -299,7 +376,11 @@ fn should_retain_genesis_validator_slot_protection() {
         pks
     };
     assert_eq!(
-        next_validator_set_4, expected_validators,
-        "actual next validator set does not match expected validator set"
+        next_validator_set_4,
+        expected_validators,
+        "actual next validator set does not match expected validator set (diff {:?})",
+        expected_validators
+            .difference(&next_validator_set_4)
+            .collect::<BTreeSet<_>>(),
     );
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -5,13 +5,13 @@ use num_traits::{One, Zero};
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder,
-    UpgradeRequestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, UpgradeRequestBuilder,
+    DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_AUCTION_DELAY,
     DEFAULT_CHAINSPEC_REGISTRY, DEFAULT_EXEC_CONFIG, DEFAULT_GENESIS_CONFIG_HASH,
-    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
-    DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG, MINIMUM_ACCOUNT_CREATION_BALANCE,
-    PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
+    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_PROTOCOL_VERSION, DEFAULT_ROUND_SEIGNIORAGE_RATE,
+    DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY, DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
+    TIMESTAMP_MILLIS_INCREMENT,
 };
 use casper_execution_engine::{
     core::{
@@ -29,10 +29,8 @@ use casper_execution_engine::{
         execution,
     },
     shared::{system_config::SystemConfig, transform::Transform, wasm_config::WasmConfig},
-    storage::global_state::in_memory::InMemoryGlobalState,
 };
 use casper_types::{
-    self,
     account::AccountHash,
     api_error::ApiError,
     runtime_args,
@@ -154,7 +152,7 @@ const DELEGATOR_2_BALANCE: u64 = DEFAULT_ACCOUNT_INITIAL_BALANCE;
 const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
 
 const EXPECTED_INITIAL_RELEASE_TIMESTAMP_MILLIS: u64 =
-    DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
 
 const WEEK_TIMESTAMPS: [u64; 14] = [
     EXPECTED_INITIAL_RELEASE_TIMESTAMP_MILLIS,
@@ -173,6 +171,61 @@ const WEEK_TIMESTAMPS: [u64; 14] = [
     EXPECTED_INITIAL_RELEASE_TIMESTAMP_MILLIS + (WEEK_MILLIS * 13),
 ];
 
+const DAY_MILLIS: u64 = 24 * 60 * 60 * 1000;
+const CASPER_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+const CASPER_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
+
+fn setup(accounts: Vec<GenesisAccount>) -> InMemoryWasmTestBuilder {
+    let engine_config = EngineConfig::new(
+        DEFAULT_MAX_QUERY_DEPTH,
+        DEFAULT_MAX_ASSOCIATED_KEYS,
+        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+        DEFAULT_STRICT_ARGUMENT_CHECKING,
+        CASPER_VESTING_SCHEDULE_PERIOD_MILLIS,
+        None,
+        *DEFAULT_WASM_CONFIG,
+        *DEFAULT_SYSTEM_CONFIG,
+    );
+
+    let run_genesis_request = {
+        let exec_config = {
+            let wasm_config = *DEFAULT_WASM_CONFIG;
+            let system_config = *DEFAULT_SYSTEM_CONFIG;
+            let validator_slots = DEFAULT_VALIDATOR_SLOTS;
+            let auction_delay = DEFAULT_AUCTION_DELAY;
+            let locked_funds_period_millis = CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
+            let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
+            let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+            let genesis_timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
+            ExecConfig::new(
+                accounts,
+                wasm_config,
+                system_config,
+                validator_slots,
+                auction_delay,
+                locked_funds_period_millis,
+                round_seigniorage_rate,
+                unbonding_delay,
+                genesis_timestamp_millis,
+            )
+        };
+
+        RunGenesisRequest::new(
+            *DEFAULT_GENESIS_CONFIG_HASH,
+            *DEFAULT_PROTOCOL_VERSION,
+            exec_config,
+            DEFAULT_CHAINSPEC_REGISTRY.clone(),
+        )
+    };
+
+    let mut builder = InMemoryWasmTestBuilder::new_with_config(engine_config);
+
+    builder.run_genesis(&run_genesis_request);
+
+    builder
+}
+
 #[ignore]
 #[test]
 fn should_add_new_bid() {
@@ -187,11 +240,7 @@ fn should_add_new_bid() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *BID_ACCOUNT_1_ADDR,
@@ -231,11 +280,7 @@ fn should_increase_existing_bid() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *BID_ACCOUNT_1_ADDR,
@@ -290,11 +335,7 @@ fn should_decrease_existing_bid() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let bid_request = ExecuteRequestBuilder::standard(
         *BID_ACCOUNT_1_ADDR,
@@ -358,11 +399,7 @@ fn should_run_delegate_and_undelegate() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -538,11 +575,7 @@ fn should_calculate_era_validators() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -600,7 +633,7 @@ fn should_calculate_era_validators() {
     assert_eq!(pre_era_id, EraId::from(0));
 
     builder.run_auction(
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS,
         Vec::new(),
     );
 
@@ -696,29 +729,7 @@ fn should_get_first_seigniorage_recipients() {
         tmp
     };
 
-    // We can't use `utils::create_run_genesis_request` as the snapshot used an auction delay of 3.
-    let auction_delay = 3;
-    let exec_config = ExecConfig::new(
-        accounts,
-        *DEFAULT_WASM_CONFIG,
-        *DEFAULT_SYSTEM_CONFIG,
-        DEFAULT_VALIDATOR_SLOTS,
-        auction_delay,
-        DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
-        DEFAULT_ROUND_SEIGNIORAGE_RATE,
-        DEFAULT_UNBONDING_DELAY,
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    );
-    let run_genesis_request = RunGenesisRequest::new(
-        *DEFAULT_GENESIS_CONFIG_HASH,
-        *DEFAULT_PROTOCOL_VERSION,
-        exec_config,
-        DEFAULT_CHAINSPEC_REGISTRY.clone(),
-    );
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -738,7 +749,7 @@ fn should_get_first_seigniorage_recipients() {
         founding_validator_1
             .vesting_schedule()
             .map(|vesting_schedule| vesting_schedule.initial_release_timestamp_millis()),
-        Some(DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS)
+        Some(DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS)
     );
 
     let founding_validator_2 = bids.get(&ACCOUNT_2_PK).expect("should have account 2 pk");
@@ -746,14 +757,14 @@ fn should_get_first_seigniorage_recipients() {
         founding_validator_2
             .vesting_schedule()
             .map(|vesting_schedule| vesting_schedule.initial_release_timestamp_millis()),
-        Some(DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS)
+        Some(DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS)
     );
 
     builder.exec(transfer_request_1).commit().expect_success();
 
     // run_auction should be executed first
     builder.run_auction(
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS,
         Vec::new(),
     );
 
@@ -865,11 +876,7 @@ fn should_release_founder_stake() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let fund_system_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -995,11 +1002,7 @@ fn should_fail_to_get_era_validators() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     assert_eq!(
         builder.get_validator_weights(EraId::MAX),
@@ -1026,11 +1029,7 @@ fn should_use_era_validators_endpoint_for_first_era() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let validator_weights = builder
         .get_validator_weights(INITIAL_ERA_ID)
@@ -1084,11 +1083,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let genesis_validator_weights = builder
         .get_validator_weights(INITIAL_ERA_ID)
@@ -1155,7 +1150,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
 
     // run auction and compute validators for new era
     builder.run_auction(
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS,
         Vec::new(),
     );
     // Verify first era validators
@@ -1252,12 +1247,9 @@ fn undelegated_funds_should_be_released() {
         delegator_1_validator_1_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    let mut timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1378,12 +1370,9 @@ fn fully_undelegated_funds_should_be_released() {
         delegator_1_validator_1_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    let mut timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1539,12 +1528,9 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         validator_1_partial_withdraw_bid,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    let mut timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1776,12 +1762,9 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         delegator_2_delegate_request,
     ];
 
-    let mut timestamp_millis =
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
+    let mut timestamp_millis = DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1962,11 +1945,7 @@ fn should_handle_evictions() {
 
     let mut timestamp = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     builder.exec(system_fund_request).commit().expect_success();
 
@@ -2105,11 +2084,7 @@ fn should_validate_orphaned_genesis_delegators() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 #[should_panic(expected = "DuplicatedDelegatorEntry")]
@@ -2160,11 +2135,7 @@ fn should_validate_duplicated_genesis_delegators() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 #[should_panic(expected = "InvalidDelegationRate")]
@@ -2185,11 +2156,7 @@ fn should_validate_delegation_rate_of_genesis_validator() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 #[should_panic(expected = "InvalidBondAmount")]
@@ -2207,11 +2174,7 @@ fn should_validate_bond_amount_of_genesis_validator() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 #[ignore]
@@ -2244,11 +2207,7 @@ fn should_setup_genesis_delegators() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let _account_1 = builder
         .get_account(*ACCOUNT_1_ADDR)
@@ -2309,11 +2268,7 @@ fn should_not_partially_undelegate_uninitialized_vesting_schedule() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let fund_delegator_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -2383,11 +2338,7 @@ fn should_not_fully_undelegate_uninitialized_vesting_schedule() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let fund_delegator_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -2457,11 +2408,7 @@ fn should_not_undelegate_vfta_holder_stake() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let post_genesis_requests = {
         let fund_delegator_account = ExecuteRequestBuilder::standard(
@@ -2558,7 +2505,6 @@ fn should_release_vfta_holder_stake() {
         (DELEGATOR_1_STAKE - DEFAULT_MINIMUM_DELEGATION_AMOUNT) / 14;
     const DELEGATOR_VFTA_STAKE: u64 = DELEGATOR_1_STAKE - DEFAULT_MINIMUM_DELEGATION_AMOUNT;
     const EXPECTED_REMAINDER: u64 = 12;
-    const NEW_MINIMUM_DELEGATION_AMOUNT: u64 = 0;
     const EXPECTED_LOCKED_AMOUNTS: [u64; 14] = [
         1392858, 1285716, 1178574, 1071432, 964290, 857148, 750006, 642864, 535722, 428580, 321438,
         214296, 107154, 0,
@@ -2642,25 +2588,7 @@ fn should_release_vfta_holder_stake() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let custom_engine_config = EngineConfig::new(
-        DEFAULT_MAX_QUERY_DEPTH,
-        DEFAULT_MAX_ASSOCIATED_KEYS,
-        DEFAULT_MAX_RUNTIME_CALL_STACK_HEIGHT,
-        NEW_MINIMUM_DELEGATION_AMOUNT,
-        DEFAULT_STRICT_ARGUMENT_CHECKING,
-        DEFAULT_VESTING_SCHEDULE_LENGTH_MILLIS,
-        None,
-        WasmConfig::default(),
-        SystemConfig::default(),
-    );
-
-    let global_state = InMemoryGlobalState::empty().expect("should create global state");
-
-    let mut builder = InMemoryWasmTestBuilder::new(global_state, custom_engine_config, None);
-
-    builder.run_genesis(&run_genesis_request);
+    let mut builder = setup(accounts);
 
     let fund_delegator_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -2929,9 +2857,7 @@ fn should_reset_delegators_stake_after_slashing() {
         delegator_2_validator_2_delegate_request,
     ];
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).expect_success().commit();
@@ -3080,11 +3006,7 @@ fn should_validate_genesis_delegators_bond_amount() {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 fn check_validator_slots_for_accounts(accounts: usize) {
@@ -3114,11 +3036,7 @@ fn check_validator_slots_for_accounts(accounts: usize) {
         tmp
     };
 
-    let run_genesis_request = utils::create_run_genesis_request(accounts);
-
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&run_genesis_request);
+    let _builder = setup(accounts);
 }
 
 #[should_panic(expected = "InvalidValidatorSlots")]
@@ -3220,9 +3138,7 @@ fn should_delegate_and_redelegate() {
         delegator_1_validator_1_delegate_request,
     ];
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -3445,9 +3361,7 @@ fn should_handle_redelegation_to_inactive_validator() {
         delegator_2_validator_1_delegate_request,
     ];
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -4014,9 +3928,7 @@ fn should_transfer_to_main_purse_when_validator_is_no_longer_active() {
 #[ignore]
 #[test]
 fn should_enforce_minimum_delegation_amount() {
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -4095,9 +4007,7 @@ fn should_enforce_minimum_delegation_amount() {
 #[ignore]
 #[test]
 fn should_allow_delegations_with_minimal_floor_amount() {
-    let mut builder = InMemoryWasmTestBuilder::default();
-
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+    let mut builder = setup(DEFAULT_ACCOUNTS.clone());
 
     let transfer_to_validator_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -48,9 +48,9 @@ legacy_required_finality = 'Strict'
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1
 # The period after genesis during which a genesis validator's bid is locked.
-locked_funds_period = '90days'
+locked_funds_period = '0 days'
 # The period in which genesis validator's bid is released over time after it's unlocked.
-vesting_schedule_period = '13 weeks'
+vesting_schedule_period = '0 weeks'
 # Default number of eras that need to pass to be able to withdraw unbonded funds.
 unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -48,9 +48,9 @@ legacy_required_finality = 'Strict'
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1
 # The period after genesis during which a genesis validator's bid is locked.
-locked_funds_period = '90days'
+locked_funds_period = '0 days'
 # The period in which genesis validator's bid is released over time after it's unlocked.
-vesting_schedule_period = '13 weeks'
+vesting_schedule_period = '0 weeks'
 # Default number of eras that need to pass to be able to withdraw unbonded funds.
 unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.


### PR DESCRIPTION
Closes [#3231](https://github.com/casper-network/casper-node/issues/3231)

This PR defaults the locked funds period to 0 days and the vesting schedule to 0 days. Only the tests relevant to Casper network's main net tests are set to 91 days locked period and 90 days of the vesting schedule. All other tests start with unlocked genesis balances.