### PR TITLE
New parameters are added in relation to the finality rewards:

### DIFF
--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -94,7 +94,7 @@ pub struct CoreConfig {
     pub finality_signature_proportion: Ratio<u64>,
 
     /// Lookback interval indicating which past block we are looking at to reward.
-    pub rewards_lag: u32,
+    pub rewards_lag: u64,
 }
 
 impl CoreConfig {
@@ -284,7 +284,7 @@ impl FromBytes for CoreConfig {
         let (consensus_protocol, remainder) = ConsensusProtocolName::from_bytes(remainder)?;
         let (finders_fee, remainder) = Ratio::from_bytes(remainder)?;
         let (finality_signature_proportion, remainder) = Ratio::from_bytes(remainder)?;
-        let (rewards_lag, remainder) = u32::from_bytes(remainder)?;
+        let (rewards_lag, remainder) = u64::from_bytes(remainder)?;
         let config = CoreConfig {
             era_duration,
             minimum_era_height,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -69,6 +69,12 @@ strict_argument_checking = false
 simultaneous_peer_requests = 5
 # The consensus protocol to use. Options are "Zug" and "Highway".
 consensus_protocol = 'Highway'
+# The split in finality signature rewards between block producer and participating signers.
+finders_fee = [1, 5]
+# The proportion of baseline rewards going to reward finality signatures specifically.
+finality_signature_proportion = [1, 2]
+# Lookback interval indicating which past block we are looking at to reward.
+rewards_lag = 3
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -76,6 +76,12 @@ strict_argument_checking = false
 simultaneous_peer_requests = 5
 # The consensus protocol to use. Options are "Zug" and "Highway".
 consensus_protocol = 'Highway'
+# The split in finality signature rewards between block producer and participating signers.
+finders_fee = [1, 5]
+# The proportion of baseline rewards going to reward finality signatures specifically.
+finality_signature_proportion = [1, 2]
+# Lookback interval indicating which past block we are looking at to reward.
+rewards_lag = 3
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.


### PR DESCRIPTION
Fixes #3915
New parameters are added in relation to the finality rewards:
- `finders_fee`
- `finality_signature_proportion`
- `rewards_lag`