### PR TITLE
Fix synchronizer busy looping when no peers are available

### DIFF
--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -663,6 +663,12 @@ impl BlockBuilder {
     }
 
     pub(super) fn register_peers(&mut self, peers: Vec<NodeId>) {
+        if peers.is_empty() {
+            // We asked for peers but none were provided. Exit early without
+            // clearing the latch so that we don't ask again needlessly.
+            trace!("BlockSynchronizer: no peers available");
+            return;
+        }
         if !(self.is_finished() || self.is_failed()) {
             peers
                 .into_iter()

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -446,6 +446,92 @@ async fn global_state_sync_wont_stall_with_bad_peers() {
 }
 
 #[tokio::test]
+async fn synchronizer_doesnt_busy_loop_without_peers() {
+    let mut rng = TestRng::new();
+    let mock_reactor = MockReactor::new();
+    let test_env = TestEnv::random(&mut rng).with_block(
+        TestBlockBuilder::new()
+            .era(1)
+            .random_deploys(1, &mut rng)
+            .build(&mut rng),
+    );
+    let block = test_env.block();
+    let validator_matrix = test_env.gen_validator_matrix();
+    let cfg = Config {
+        latch_reset_interval: TimeDiff::from_millis(TEST_LATCH_RESET_INTERVAL_MILLIS),
+        ..Default::default()
+    };
+    let mut block_synchronizer =
+        BlockSynchronizer::new_initialized(&mut rng, validator_matrix, cfg);
+
+    block_synchronizer.register_block_by_hash(*block.hash(), true);
+    {
+        // We registered no peers, so the synchronizer should ask for peers.
+        let effects = block_synchronizer.handle_event(
+            mock_reactor.effect_builder(),
+            &mut rng,
+            Event::Request(BlockSynchronizerRequest::NeedNext),
+        );
+        assert_eq!(effects.len(), 2);
+        let events = mock_reactor.process_effects(effects).await;
+        // Given this is a historical builder, ask for peers from the network.
+        assert_matches!(
+            events[0],
+            MockReactorEvent::NetworkInfoRequest(NetworkInfoRequest::FullyConnectedPeers {
+                count,
+                ..
+            }) if count == MAX_SIMULTANEOUS_PEERS
+        );
+        // Ask for peers from the accumulator.
+        assert_matches!(
+            events[1],
+            MockReactorEvent::BlockAccumulatorRequest(BlockAccumulatorRequest::GetPeersForBlock {
+                block_hash,
+                ..
+            }) if block_hash == *block.hash()
+        );
+    }
+
+    {
+        // Inject an empty response from the network, simulating no available
+        // peers.
+        let effects = block_synchronizer.handle_event(
+            mock_reactor.effect_builder(),
+            &mut rng,
+            Event::NetworkPeers(*block.hash(), vec![]),
+        );
+        // The builder should have its latch set and should not ask for peers
+        // until the latch clears itself.
+        assert!(effects.is_empty());
+        assert!(block_synchronizer
+            .historical
+            .as_mut()
+            .unwrap()
+            .in_flight_latch()
+            .is_some());
+    }
+
+    {
+        // Inject an empty response from the accumulator, simulating no
+        // available peers.
+        let effects = block_synchronizer.handle_event(
+            mock_reactor.effect_builder(),
+            &mut rng,
+            Event::AccumulatedPeers(*block.hash(), Some(vec![])),
+        );
+        // The builder should have its latch set and should not ask for peers
+        // until the latch clears itself.
+        assert!(effects.is_empty());
+        assert!(block_synchronizer
+            .historical
+            .as_mut()
+            .unwrap()
+            .in_flight_latch()
+            .is_some());
+    }
+}
+
+#[tokio::test]
 async fn should_not_stall_after_registering_new_era_validator_weights() {
     let mut rng = TestRng::new();
     let mock_reactor = MockReactor::new();


### PR DESCRIPTION
Fixes #3986 

This PR fixes the busy looping in the block synchronizer when it's asking for peers but none are available. Out of all possible solutions, I found that just not clearing the in flight latch and waiting for the whole `latch_reset_interval` time to pass before asking for peers again was the most straightforward solution. I implemented an attempt based solution, but I found that the extra logic does not bring significant benefit. The reasoning is that if the network component did not have the peers 100ms ago, it is very unlikely it will have them now, but we can afford to ask every 5s without significant overhead in the logs or reactor cranks.
