### PR TITLE
Update timeout in network_soundness test

### DIFF
--- a/utils/nctl/sh/scenarios/network_soundness.py
+++ b/utils/nctl/sh/scenarios/network_soundness.py
@@ -24,7 +24,7 @@ HUGE_DEPLOY_SPAM_COUNT = 2
 DISTURBANCE_INTERVAL_SECS = 5
 
 # Time allowed for the network to progress
-PROGRESS_WAIT_TIMEOUT_SECS = 2 * 60
+PROGRESS_WAIT_TIMEOUT_SECS = 5 * 60
 
 invoke_lock = threading.Lock()
 current_node_count = 5


### PR DESCRIPTION
This PR increases a timeout in the network_soundness test, in the expectation that a joining node will have time to sync leap after the initial syncing has completed if required.

Closes #3987.