### PR TITLE
Update weight of network_incoming event queue kind

### DIFF
--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -98,7 +98,7 @@ impl QueueKind {
             QueueKind::NetworkLowPriority => 1,
             QueueKind::NetworkInfo => 2,
             QueueKind::NetworkDemand => 2,
-            QueueKind::NetworkIncoming => 4,
+            QueueKind::NetworkIncoming => 8,
             QueueKind::Network => 4,
             QueueKind::Regular => 4,
             QueueKind::Fetch => 4,


### PR DESCRIPTION
This PR increases the weight of the `QueueKind::NetworkIncoming` in the expectation that it will help avoid joining nodes which are busy syncing (receiving fetch responses) missing gossiped messages due to timeouts.

Closes #3987.