### PR TITLE
Minor logging changes

### DIFF
--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -202,7 +202,7 @@ impl Debug for Message {
             Message::GetRequest { tag, serialized_id } => f
                 .debug_struct("GetRequest")
                 .field("tag", tag)
-                .field("serialized_item", &HexFmt(serialized_id))
+                .field("serialized_id", &HexFmt(serialized_id))
                 .finish(),
             Message::GetResponse {
                 tag,
@@ -210,7 +210,10 @@ impl Debug for Message {
             } => f
                 .debug_struct("GetResponse")
                 .field("tag", tag)
-                .field("serialized_item", &HexFmt(serialized_item))
+                .field(
+                    "serialized_item",
+                    &format!("{} bytes", serialized_item.len()),
+                )
                 .finish(),
             Message::FinalitySignature(fs) => {
                 f.debug_tuple("FinalitySignature").field(&fs).finish()

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -39,6 +39,7 @@ function clean_up() {
             tar -cvzf "${DRONE_BUILD_NUMBER}"_nctl_dump.tar.gz * > /dev/null 2>&1
             aws s3 cp ./"${DRONE_BUILD_NUMBER}"_nctl_dump.tar.gz s3://nctl.casperlabs.io/nightly-logs/ > /dev/null 2>&1
             log "Download the dump file: curl -O https://s3.us-east-2.amazonaws.com/nctl.casperlabs.io/nightly-logs/${DRONE_BUILD_NUMBER}_nctl_dump.tar.gz"
+            log "\nextra log lines to push\ndownload instructions above\nserver license expired banner\n"
             popd
         fi
     fi


### PR DESCRIPTION
This PR changes the debug output of `Message::GetResponse` to not print the full hex-encoded `serialized_item` field as it can be fairly large.

It also adds a few extra lines of output to failed CI runs so the command to download the dumped files is visible above the overlaid banner.