### PR TITLE
Ensure node can transition out of validate mode

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -151,7 +151,7 @@ impl BlockAccumulator {
         if leap_instruction.should_leap() {
             return SyncInstruction::Leap { block_hash };
         }
-        match sync_identifier.block_hash_to_sync(self.next_synchable_block_hash(block_hash)) {
+        match sync_identifier.block_hash_to_sync(self.next_syncable_block_hash(block_hash)) {
             Some(block_hash_to_sync) => {
                 self.reset_last_progress();
                 SyncInstruction::BlockSync {
@@ -184,6 +184,7 @@ impl BlockAccumulator {
         if new_local_tip {
             self.purge();
             self.local_tip = Some(LocalTipIdentifier::new(height, era_id));
+            self.reset_last_progress();
             info!(local_tip=?self.local_tip, "new local tip detected");
         }
     }
@@ -590,7 +591,7 @@ impl BlockAccumulator {
         }
     }
 
-    fn next_synchable_block_hash(&self, parent_block_hash: BlockHash) -> Option<BlockHash> {
+    fn next_syncable_block_hash(&self, parent_block_hash: BlockHash) -> Option<BlockHash> {
         let child_hash = self.block_children.get(&parent_block_hash)?;
         let block_acceptor = self.block_acceptors.get(child_hash)?;
         if block_acceptor.has_sufficient_finality() {

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -22,9 +22,6 @@ use crate::{
     NodeRng,
 };
 
-/// Cranking delay when encountered a non-switch block when checking the validator status.
-const VALIDATION_STATUS_DELAY_FOR_NON_SWITCH_BLOCK: Duration = Duration::from_secs(2);
-
 impl MainReactor {
     pub(super) fn crank(
         &mut self,
@@ -185,9 +182,6 @@ impl MainReactor {
                     self.state = ReactorState::ShutdownForUpgrade;
                     (Duration::ZERO, Effects::new())
                 }
-                ValidateInstruction::NonSwitchBlock => {
-                    (VALIDATION_STATUS_DELAY_FOR_NON_SWITCH_BLOCK, Effects::new())
-                }
                 ValidateInstruction::CheckLater(msg, wait) => {
                     debug!("Validate: {}", msg);
                     (wait, Effects::new())
@@ -195,6 +189,11 @@ impl MainReactor {
                 ValidateInstruction::Do(wait, effects) => {
                     trace!("Validate: node is processing effects");
                     (wait, effects)
+                }
+                ValidateInstruction::CatchUp => {
+                    info!("Validate: switch to CatchUp");
+                    self.state = ReactorState::CatchUp;
+                    (Duration::ZERO, Effects::new())
                 }
                 ValidateInstruction::KeepUp => {
                     info!("Validate: switch to KeepUp");

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 use tracing::{debug, info, warn};
 
 use crate::{
-    components::consensus::ChainspecConsensusExt,
+    components::{
+        block_accumulator::{SyncIdentifier, SyncInstruction},
+        consensus::ChainspecConsensusExt,
+    },
     effect::{EffectBuilder, Effects},
     reactor::{
         self,
@@ -12,10 +15,13 @@ use crate::{
     NodeRng,
 };
 
+/// Cranking delay when encountered a non-switch block when checking the validator status.
+const VALIDATION_STATUS_DELAY_FOR_NON_SWITCH_BLOCK: Duration = Duration::from_secs(2);
+
 pub(super) enum ValidateInstruction {
     Do(Duration, Effects<MainEvent>),
     CheckLater(String, Duration),
-    NonSwitchBlock,
+    CatchUp,
     KeepUp,
     ShutdownForUpgrade,
     Fatal(String),
@@ -38,8 +44,23 @@ impl MainReactor {
 
         match self.storage.read_highest_complete_block() {
             Ok(Some(highest_complete_block)) => {
+                // If we're lagging behind the rest of the network, fall back out of Validate mode.
+                let sync_identifier = SyncIdentifier::LocalTip(
+                    *highest_complete_block.hash(),
+                    highest_complete_block.height(),
+                    highest_complete_block.header().era_id(),
+                );
+                match self.block_accumulator.sync_instruction(sync_identifier) {
+                    SyncInstruction::Leap { .. } => return ValidateInstruction::CatchUp,
+                    SyncInstruction::BlockSync { .. } => return ValidateInstruction::KeepUp,
+                    SyncInstruction::CaughtUp { .. } => (),
+                }
+
                 if !highest_complete_block.header().is_switch_block() {
-                    return ValidateInstruction::NonSwitchBlock;
+                    return ValidateInstruction::CheckLater(
+                        "tip is not a switch block, don't change from validate state".to_string(),
+                        VALIDATION_STATUS_DELAY_FOR_NON_SWITCH_BLOCK,
+                    );
                 }
             }
             Ok(None) => {


### PR DESCRIPTION
This PR fixes an issue whereby a node in `Validate` mode will not revert to `KeepUp` or `CatchUp` if it falls behind the objective tip of the chain.

After initially transitioning to `Validate` having spent a while doing the initial sync, the node could be well behind the objective tip.  In the likely case that its highest complete block is not a switch block, it would effectively be stuck waiting to produce a switch block before re-evaluating whether it should remain in `Validate` mode.  This switch block will never be created as it's fallen behind its peers and does nothing else to rectify that in `Validate` mode.

The fix is to query the `BlockAccumulator` as it does when in `KeepUp` mode.

The `ValidateInstruction::NonSwitchBlock` is also removed as it was just a special case of `ValidateInstruction::CheckLater`, but with no special handling of that variant.

Closes #4012.