### PR TITLE
Fix `PortBoundComponent` initialization

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -182,7 +182,7 @@ pub(crate) trait PortBoundComponent<REv>: InitializedComponent<REv> {
         }
 
         match self.listen(effect_builder) {
-            Ok(effects) => (effects, ComponentState::Initializing),
+            Ok(effects) => (effects, ComponentState::Initialized),
             Err(error) => (Effects::new(), ComponentState::Fatal(format!("{}", error))),
         }
     }


### PR DESCRIPTION
`PortBoundComponent` should end up in `Initialized` state, not `Initializing`.