### PR TITLE
GH-3734: Increase default max stack height

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+## [Unreleased]
+
+### Changed
+* Default value for `max_stack_height` is increased to 500.
+
+
+
 ## 5.0.0
 
 ### Added

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -12,7 +12,7 @@ use super::{
 /// Default maximum number of pages of the Wasm memory.
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 /// Default maximum stack height.
-pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 200;
+pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 500;
 
 /// Configuration of the Wasm execution environment.
 ///

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -17,19 +17,14 @@ use casper_execution_engine::{
     },
     shared::{
         wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
-        wasm_prep::DEFAULT_MAX_PARAMETER_COUNT,
+        wasm_prep::{self, WasmValidationError, DEFAULT_MAX_PARAMETER_COUNT},
     },
 };
 use casper_types::{EraId, ProtocolVersion, RuntimeArgs};
 
 use crate::wasm_utils;
 
-// Previously this value was derived from `wasmi::DEFAULT_CALL_STACK_LIMIT` as we haven't a check
-// for argument count declared in wasm functions. We have very restrictive stack height which also
-// means the maximum allowed function count still fails at runtime inside the stack limiter.
-//
-// Max parameter count - 1 will exercise the height limiter while passing the preprocessing stage.
-const ARITY_INTERPRETER_LIMIT: usize = DEFAULT_MAX_PARAMETER_COUNT as usize - 1;
+const ARITY_INTERPRETER_LIMIT: usize = DEFAULT_MAX_PARAMETER_COUNT as usize;
 const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 const I32_WAT_TYPE: &str = "i64";
 const NEW_WASM_STACK_HEIGHT: u32 = 16;
@@ -51,7 +46,7 @@ fn initialize_builder() -> InMemoryWasmTestBuilder {
 
 #[ignore]
 #[test]
-fn should_verify_interpreter_stack_limit() {
+fn should_pass_max_parameter_count() {
     let mut builder = initialize_builder();
 
     // This runs out of the interpreter stack limit
@@ -64,16 +59,32 @@ fn should_verify_interpreter_stack_limit() {
         RuntimeArgs::default(),
     )
     .build();
-    builder.exec(exec).expect_failure().commit();
 
+    builder.exec(exec).expect_success().commit();
+
+    let module_bytes = wasm_utils::make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT + 1, I32_WAT_TYPE)
+        .expect("should make wasm bytes");
+
+    let exec = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec).expect_failure().commit();
     let error = builder.get_error().expect("should have error");
 
-    // For default stack height of 64 * 1024 with a function that takes 16384 i32 arguments it will
-    // fail with following message: Function #0 reading/validation error: At instruction
-    // GetGlobal(0)(@16386): Stack: exceeded stack limit 16384 But due to the default being
-    // small it fails with Unreachable from within the stack height limiter.
     assert!(
-        matches!(&error, Error::Exec(ExecError::Interpreter(s)) if s.contains("Unreachable")),
+        matches!(
+            error,
+            Error::WasmPreprocessing(wasm_prep::PreprocessingError::WasmValidation(
+                WasmValidationError::TooManyParameters {
+                    max: 256,
+                    actual: 257
+                }
+            ))
+        ),
         "{:?}",
         error
     );

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -10,10 +10,7 @@ use casper_engine_test_support::{
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
-    core::{
-        engine_state::{self, Error},
-        execution,
-    },
+    core::{engine_state, execution},
     shared::wasm_prep::{
         PreprocessingError, WasmValidationError, DEFAULT_BR_TABLE_MAX_SIZE, DEFAULT_MAX_GLOBALS,
         DEFAULT_MAX_PARAMETER_COUNT, DEFAULT_MAX_TABLE_SIZE,
@@ -530,17 +527,7 @@ fn should_verify_max_param_count() {
     )
     .build();
 
-    builder.exec(exec_request).expect_failure().commit();
-
-    let error = builder.get_error().expect("should have error");
-
-    // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
-    // restrictive default stack height.
-    assert!(
-        matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),
-        "{:?}",
-        error
-    );
+    builder.exec(exec_request).expect_success().commit();
 
     let module_bytes_100_params =
         wasm_utils::make_n_arg_call_bytes(100, "i32").expect("should create wasm bytes");

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -111,7 +111,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 200
+max_stack_height = 500
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -118,7 +118,7 @@ native_transfer_minimum_motes = 2_500_000_000
 # Amount of free memory (in 64kB pages) each contract can use for stack.
 max_memory = 64
 # Max stack height (native WebAssembly stack limiter).
-max_stack_height = 200
+max_stack_height = 500
 
 [wasm.storage_costs]
 # Gas charged per byte stored in the global state.


### PR DESCRIPTION
Closes #3734

Increase default max stack height.

This should enable the usage of certain 3rd party crates that are quite expensive in terms of stack height cost.