### PR TITLE
Avoid exponential increase in requests for execution results in `BlockSynchronizer`

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -1006,7 +1006,7 @@ impl BlockAcquisitionState {
                         block_execution_results_or_chunk,
                         deploy_hashes,
                     ) {
-                    Ok((new_acquistion, acceptance)) => match new_acquistion {
+                    Ok((new_acquisition, acceptance)) => match new_acquisition {
                         ExecutionResultsAcquisition::Needed { .. }
                         | ExecutionResultsAcquisition::Pending { .. } => {
                             debug!("apply_block_execution_results_or_chunk: Needed | Pending");
@@ -1021,7 +1021,7 @@ impl BlockAcquisitionState {
                                 block.clone(),
                                 signatures.clone(),
                                 deploys.clone(),
-                                new_acquistion.clone(),
+                                new_acquisition.clone(),
                             );
                             let maybe_exec_results = Some(results.clone());
                             (new_state, maybe_exec_results, acceptance)
@@ -1032,7 +1032,7 @@ impl BlockAcquisitionState {
                                 block.clone(),
                                 signatures.clone(),
                                 deploys.clone(),
-                                new_acquistion,
+                                new_acquisition,
                             );
                             let maybe_exec_results = None;
                             (new_state, maybe_exec_results, acceptance)

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -575,7 +575,10 @@ impl BlockBuilder {
                 exec_results,
                 acceptance,
             }) => {
-                debug!("register_fetched_execution_results: Ok(maybe)");
+                debug!(
+                    ?acceptance,
+                    "register_fetched_execution_results: Ok(RegisterExecResultsOutcome)"
+                );
                 self.handle_acceptance(maybe_peer, Ok(acceptance))?;
                 Ok(exec_results)
             }

--- a/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
@@ -100,7 +100,7 @@ fn execution_results_chunks_from_block_with_different_hash_are_not_applied() {
     );
     acquisition = assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, vec![]),
-        Ok(acq) => acq
+        Ok((acq, Acceptance::NeededIt)) => acq
     );
     assert_matches!(acquisition, ExecutionResultsAcquisition::Acquiring { .. });
 
@@ -344,7 +344,10 @@ fn acquisition_pending_state_has_correct_transitions() {
             exec_result,
             vec![DeployHash::new(Digest::hash([0; 32]))]
         ),
-        Ok(ExecutionResultsAcquisition::Complete { .. })
+        Ok((
+            ExecutionResultsAcquisition::Complete { .. },
+            Acceptance::NeededIt
+        ))
     );
 
     // Acquisition can transition from `Pending` to `Acquiring` if a single chunk is applied
@@ -364,7 +367,10 @@ fn acquisition_pending_state_has_correct_transitions() {
         .collect();
     assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, deploy_hashes),
-        Ok(ExecutionResultsAcquisition::Acquiring { .. })
+        Ok((
+            ExecutionResultsAcquisition::Acquiring { .. },
+            Acceptance::NeededIt
+        ))
     );
 }
 
@@ -401,7 +407,7 @@ fn acquisition_acquiring_state_has_correct_transitions() {
             .response(ValueOrChunk::ChunkWithProof(chunk.clone()));
         acquisition = assert_matches!(
             acquisition.apply_block_execution_results_or_chunk(exec_result, vec![]),
-            Ok(acq) => acq
+            Ok((acq, Acceptance::NeededIt)) => acq
         );
         assert_matches!(acquisition, ExecutionResultsAcquisition::Acquiring { .. });
     }
@@ -416,7 +422,7 @@ fn acquisition_acquiring_state_has_correct_transitions() {
         .collect();
     acquisition = assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, deploy_hashes),
-        Ok(acq) => acq
+        Ok((acq, Acceptance::NeededIt)) => acq
     );
     assert_matches!(acquisition, ExecutionResultsAcquisition::Complete { .. });
 }
@@ -440,7 +446,7 @@ fn acquisition_acquiring_state_gets_overridden_by_value() {
     );
     acquisition = assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, vec![]),
-        Ok(acq) => acq
+        Ok((acq, Acceptance::NeededIt)) => acq
     );
     assert_matches!(acquisition, ExecutionResultsAcquisition::Acquiring { .. });
 
@@ -463,7 +469,10 @@ fn acquisition_acquiring_state_gets_overridden_by_value() {
             exec_result,
             vec![DeployHash::new(Digest::hash([0; 32]))]
         ),
-        Ok(ExecutionResultsAcquisition::Complete { .. })
+        Ok((
+            ExecutionResultsAcquisition::Complete { .. },
+            Acceptance::NeededIt
+        ))
     );
 }
 


### PR DESCRIPTION
This PR updates the flow for fetching execution results in the `BlockSynchronizer` to make use of the `Acceptance` enum in order to regulate the number of subsequent requests a successful fetch response can generate.  This brings it more in line with e.g. fetching deploys.

Closes #4030.
