### PR TITLE
GH-3766: Update wasmi to 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "casper-wasm-utils"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cd18418b19bc2cbd2bc724cc9050055848e734182e861af43e130a0d442291"
+checksum = "b49e4ef1382d48c312809fe8f09d0c7beb434a74f5026c5f12efe384df51ca42"
 dependencies = [
  "byteorder",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,6 @@ dependencies = [
  "uuid",
  "walrus",
  "wasmi",
- "wasmi-validation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
  "humantime",
  "lmdb-rkv",
  "log",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "once_cell",
  "rand 0.8.5",
@@ -409,7 +409,7 @@ dependencies = [
  "gh-1470-regression",
  "gh-1470-regression-call",
  "log",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "once_cell",
  "parity-wasm 0.41.0",
@@ -448,11 +448,11 @@ dependencies = [
  "log",
  "num",
  "num-derive",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "num_cpus",
  "once_cell",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -468,6 +468,7 @@ dependencies = [
  "uuid",
  "walrus",
  "wasmi",
+ "wasmi-validation",
 ]
 
 [[package]]
@@ -556,7 +557,7 @@ dependencies = [
  "muxink",
  "num",
  "num-derive",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "num_cpus",
  "once_cell",
@@ -624,7 +625,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-integer",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "rand 0.8.5",
  "serde",
@@ -654,7 +655,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-integer",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "once_cell",
  "openssl",
@@ -704,13 +705,13 @@ dependencies = [
 
 [[package]]
 name = "casper-wasm-utils"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9c4208106e8a95a83ab3cb5f4e800114bfc101df9e7cb8c2160c7e298c6397"
+checksum = "13cd18418b19bc2cbd2bc724cc9050055848e734182e861af43e130a0d442291"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
 ]
 
 [[package]]
@@ -2683,12 +2684,6 @@ dependencies = [
 
 [[package]]
 name = "memory_units"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
-
-[[package]]
-name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
@@ -2863,22 +2858,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
+ "num-rational",
  "num-traits",
 ]
 
@@ -2936,24 +2920,12 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "serde",
@@ -3105,9 +3077,9 @@ checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking_lot"
@@ -5321,26 +5293,35 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.9.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
+checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
 dependencies = [
- "downcast-rs",
- "libc",
- "memory_units 0.3.0",
- "num-rational 0.2.4",
- "num-traits",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "wasmi-validation",
+ "wasmi_core",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
+checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
 dependencies = [
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -5388,7 +5369,7 @@ checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "memory_units 0.4.0",
+ "memory_units",
  "winapi",
 ]
 

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,7 +16,7 @@ base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.4.4", path = "../hashing" }
 casper-types = { version = "2.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
-casper-wasm-utils = "1.1.0"
+casper-wasm-utils = "2.0.0"
 datasize = "0.2.4"
 either = "1.8.1"
 hex_fmt = "0.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,7 +16,7 @@ base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "1.4.4", path = "../hashing" }
 casper-types = { version = "2.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
-casper-wasm-utils = "1.0.0"
+casper-wasm-utils = "1.1.0"
 datasize = "0.2.4"
 either = "1.8.1"
 hex_fmt = "0.3.0"
@@ -34,7 +34,7 @@ num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
 num_cpus = "1"
 once_cell = "1.5.2"
-parity-wasm = { version = "0.42", default-features = false }
+parity-wasm = { version = "0.45.0", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8.3"
 rand_chacha = "0.3.0"
@@ -47,7 +47,8 @@ thiserror = "1.0.18"
 tracing = "0.1.18"
 uint = "0.9.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-wasmi = "0.9.1"
+wasmi = "0.13.2"
+wasmi-validation = "0.5.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -48,7 +48,6 @@ tracing = "0.1.18"
 uint = "0.9.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wasmi = "0.13.2"
-wasmi-validation = "0.5.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine/src/core/runtime/args.rs
+++ b/execution_engine/src/core/runtime/args.rs
@@ -1,4 +1,4 @@
-use wasmi::{FromRuntimeValue, RuntimeArgs, Trap};
+use wasmi::{FromValue, RuntimeArgs, Trap};
 
 pub(crate) trait Args
 where
@@ -9,7 +9,7 @@ where
 
 impl<T1> Args for (T1,)
 where
-    T1: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -19,8 +19,8 @@ where
 
 impl<T1, T2> Args for (T1, T2)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -31,9 +31,9 @@ where
 
 impl<T1, T2, T3> Args for (T1, T2, T3)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -45,10 +45,10 @@ where
 
 impl<T1, T2, T3, T4> Args for (T1, T2, T3, T4)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -61,11 +61,11 @@ where
 
 impl<T1, T2, T3, T4, T5> Args for (T1, T2, T3, T4, T5)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -79,12 +79,12 @@ where
 
 impl<T1, T2, T3, T4, T5, T6> Args for (T1, T2, T3, T4, T5, T6)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -99,13 +99,13 @@ where
 
 impl<T1, T2, T3, T4, T5, T6, T7> Args for (T1, T2, T3, T4, T5, T6, T7)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
-    T7: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
+    T7: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -121,14 +121,14 @@ where
 
 impl<T1, T2, T3, T4, T5, T6, T7, T8> Args for (T1, T2, T3, T4, T5, T6, T7, T8)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
-    T7: FromRuntimeValue + Sized,
-    T8: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
+    T7: FromValue + Sized,
+    T8: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -145,15 +145,15 @@ where
 
 impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> Args for (T1, T2, T3, T4, T5, T6, T7, T8, T9)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
-    T7: FromRuntimeValue + Sized,
-    T8: FromRuntimeValue + Sized,
-    T9: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
+    T7: FromValue + Sized,
+    T8: FromValue + Sized,
+    T9: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -171,16 +171,16 @@ where
 
 impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Args for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
-    T7: FromRuntimeValue + Sized,
-    T8: FromRuntimeValue + Sized,
-    T9: FromRuntimeValue + Sized,
-    T10: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
+    T7: FromValue + Sized,
+    T8: FromValue + Sized,
+    T9: FromValue + Sized,
+    T10: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;
@@ -200,17 +200,17 @@ where
 impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Args
     for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
 where
-    T1: FromRuntimeValue + Sized,
-    T2: FromRuntimeValue + Sized,
-    T3: FromRuntimeValue + Sized,
-    T4: FromRuntimeValue + Sized,
-    T5: FromRuntimeValue + Sized,
-    T6: FromRuntimeValue + Sized,
-    T7: FromRuntimeValue + Sized,
-    T8: FromRuntimeValue + Sized,
-    T9: FromRuntimeValue + Sized,
-    T10: FromRuntimeValue + Sized,
-    T11: FromRuntimeValue + Sized,
+    T1: FromValue + Sized,
+    T2: FromValue + Sized,
+    T3: FromValue + Sized,
+    T4: FromValue + Sized,
+    T5: FromValue + Sized,
+    T6: FromValue + Sized,
+    T7: FromValue + Sized,
+    T8: FromValue + Sized,
+    T9: FromValue + Sized,
+    T10: FromValue + Sized,
+    T11: FromValue + Sized,
 {
     fn parse(args: RuntimeArgs) -> Result<Self, Trap> {
         let a0: T1 = args.nth_checked(0)?;

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -320,15 +320,15 @@ where
                 )?;
                 let account_hash: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let amount: U512 = {
                     let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let id: Option<u64> = {
                     let bytes = self.bytes_from_mem(id_ptr, id_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
 
                 let ret = match self.transfer_to_account(account_hash, amount, id)? {
@@ -382,19 +382,19 @@ where
                 )?;
                 let source_purse = {
                     let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let account_hash: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let amount: U512 = {
                     let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let id: Option<u64> = {
                     let bytes = self.bytes_from_mem(id_ptr, id_size as usize)?;
-                    bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+                    bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
                 };
                 let ret = match self.transfer_from_purse_to_account(
                     source_purse,
@@ -695,13 +695,13 @@ where
                     self.t_from_mem(entry_point_name_ptr, entry_point_name_size)?;
                 let args_bytes: Vec<u8> = {
                     let args_size: u32 = args_size;
-                    self.bytes_from_mem(args_ptr, args_size as usize)?
+                    self.bytes_from_mem(args_ptr, args_size as usize)?.to_vec()
                 };
 
                 let ret = self.call_contract_host_buffer(
                     contract_hash,
                     &entry_point_name,
-                    args_bytes,
+                    &args_bytes,
                     result_size_ptr,
                 )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
@@ -751,14 +751,14 @@ where
                     self.t_from_mem(entry_point_name_ptr, entry_point_name_size)?;
                 let args_bytes: Vec<u8> = {
                     let args_size: u32 = args_size;
-                    self.bytes_from_mem(args_ptr, args_size as usize)?
+                    self.bytes_from_mem(args_ptr, args_size as usize)?.to_vec()
                 };
 
                 let ret = self.call_versioned_contract_host_buffer(
                     contract_package_hash,
                     contract_version,
                     entry_point_name,
-                    args_bytes,
+                    &args_bytes,
                     result_size_ptr,
                 )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
@@ -882,8 +882,10 @@ where
                     &host_function_costs.blake2b,
                     [in_ptr, in_size, out_ptr, out_size],
                 )?;
-                let input: Vec<u8> = self.bytes_from_mem(in_ptr, in_size as usize)?;
-                let digest = crypto::blake2b(input);
+                let digest =
+                    self.checked_memory_slice(in_ptr as usize, in_size as usize, |input| {
+                        crypto::blake2b(input)
+                    })?;
 
                 let result = if digest.len() != out_size as usize {
                     Err(ApiError::BufferTooSmall)

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -18,7 +18,7 @@ use std::{
 
 use parity_wasm::elements::Module;
 use tracing::error;
-use wasmi::{MemoryRef, Trap, TrapKind};
+use wasmi::{MemoryRef, Trap, TrapCode};
 
 use casper_types::{
     account::{Account, AccountHash, ActionType, Weight},
@@ -190,37 +190,76 @@ where
         self.context.charge_system_contract_call(amount)
     }
 
+    fn checked_memory_slice<Ret>(
+        &self,
+        offset: usize,
+        size: usize,
+        func: impl FnOnce(&[u8]) -> Ret,
+    ) -> Result<Ret, Error> {
+        // This is mostly copied from a private function `MemoryInstance::checked_memory_region`
+        // that calls a user defined function with a validated slice of memory. This allows
+        // usage patterns that does not involve copying data onto heap first i.e. deserialize
+        // values without copying data first, etc.
+        // NOTE: Depending on the VM backend used in future, this may change, as not all VMs may
+        // support direct memory access.
+        self.try_get_memory()?
+            .with_direct_access(|buffer| {
+                let end = offset.checked_add(size).ok_or_else(|| {
+                    wasmi::Error::Memory(format!(
+                        "trying to access memory block of size {} from offset {}",
+                        size, offset
+                    ))
+                })?;
+
+                if end > buffer.len() {
+                    return Err(wasmi::Error::Memory(format!(
+                        "trying to access region [{}..{}] in memory [0..{}]",
+                        offset,
+                        end,
+                        buffer.len(),
+                    )));
+                }
+
+                Ok(func(&buffer[offset..end]))
+            })
+            .map_err(Into::into)
+    }
+
     /// Returns bytes from the WASM memory instance.
+    #[inline]
     fn bytes_from_mem(&self, ptr: u32, size: usize) -> Result<Vec<u8>, Error> {
-        self.try_get_memory()?.get(ptr, size).map_err(Into::into)
+        self.checked_memory_slice(ptr as usize, size, |data| data.to_vec())
     }
 
     /// Returns a deserialized type from the WASM memory instance.
+    #[inline]
     fn t_from_mem<T: FromBytes>(&self, ptr: u32, size: u32) -> Result<T, Error> {
-        let bytes = self.bytes_from_mem(ptr, size as usize)?;
-        bytesrepr::deserialize(bytes).map_err(Into::into)
+        let result = self.checked_memory_slice(ptr as usize, size as usize, |data| {
+            bytesrepr::deserialize_from_slice(data)
+        })?;
+        Ok(result?)
     }
 
     /// Reads key (defined as `key_ptr` and `key_size` tuple) from Wasm memory.
+    #[inline]
     fn key_from_mem(&mut self, key_ptr: u32, key_size: u32) -> Result<Key, Error> {
-        let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
-        bytesrepr::deserialize(bytes).map_err(Into::into)
+        self.t_from_mem(key_ptr, key_size)
     }
 
     /// Reads `CLValue` (defined as `cl_value_ptr` and `cl_value_size` tuple) from Wasm memory.
+    #[inline]
     fn cl_value_from_mem(
         &mut self,
         cl_value_ptr: u32,
         cl_value_size: u32,
     ) -> Result<CLValue, Error> {
-        let bytes = self.bytes_from_mem(cl_value_ptr, cl_value_size as usize)?;
-        bytesrepr::deserialize(bytes).map_err(Into::into)
+        self.t_from_mem(cl_value_ptr, cl_value_size)
     }
 
     /// Returns a deserialized string from the WASM memory instance.
+    #[inline]
     fn string_from_mem(&self, ptr: u32, size: u32) -> Result<String, Trap> {
-        let bytes = self.bytes_from_mem(ptr, size as usize)?;
-        bytesrepr::deserialize(bytes).map_err(|e| Error::BytesRepr(e).into())
+        self.t_from_mem(ptr, size).map_err(Trap::from)
     }
 
     fn get_module_from_entry_points(
@@ -235,8 +274,7 @@ where
 
     #[allow(clippy::wrong_self_convention)]
     fn is_valid_uref(&self, uref_ptr: u32, uref_size: u32) -> Result<bool, Trap> {
-        let bytes = self.bytes_from_mem(uref_ptr, uref_size as usize)?;
-        let uref: URef = bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?;
+        let uref: URef = self.t_from_mem(uref_ptr, uref_size)?;
         Ok(self.context.validate_uref(&uref).is_ok())
     }
 
@@ -444,18 +482,15 @@ where
     /// type is `Trap`, indicating that this function will always kill the current Wasm instance.
     fn ret(&mut self, value_ptr: u32, value_size: usize) -> Trap {
         self.host_buffer = None;
-        let memory = match self.try_get_memory() {
-            Ok(memory) => memory,
-            Err(error) => return Trap::from(error),
-        };
-        let mem_get = memory
-            .get(value_ptr, value_size)
-            .map_err(|e| Error::Interpreter(e.into()));
+
+        let mem_get =
+            self.checked_memory_slice(value_ptr as usize, value_size, |data| data.to_vec());
+
         match mem_get {
             Ok(buf) => {
                 // Set the result field in the runtime and return the proper element of the `Error`
                 // enum indicating that the reason for exiting the module was a call to ret.
-                self.host_buffer = bytesrepr::deserialize(buf).ok();
+                self.host_buffer = bytesrepr::deserialize_from_slice(buf).ok();
 
                 let urefs = match &self.host_buffer {
                     Some(buf) => utils::extract_urefs(buf),
@@ -1416,14 +1451,14 @@ where
         &mut self,
         contract_hash: ContractHash,
         entry_point_name: &str,
-        args_bytes: Vec<u8>,
+        args_bytes: &[u8],
         result_size_ptr: u32,
     ) -> Result<Result<(), ApiError>, Error> {
         // Exit early if the host buffer is already occupied
         if let Err(err) = self.check_host_buffer() {
             return Ok(Err(err));
         }
-        let args: RuntimeArgs = bytesrepr::deserialize(args_bytes)?;
+        let args: RuntimeArgs = bytesrepr::deserialize_from_slice(args_bytes)?;
         let result = self.call_contract(contract_hash, entry_point_name, args)?;
         self.manage_call_contract_host_buffer(result_size_ptr, result)
     }
@@ -1433,14 +1468,14 @@ where
         contract_package_hash: ContractPackageHash,
         contract_version: Option<ContractVersion>,
         entry_point_name: String,
-        args_bytes: Vec<u8>,
+        args_bytes: &[u8],
         result_size_ptr: u32,
     ) -> Result<Result<(), ApiError>, Error> {
         // Exit early if the host buffer is already occupied
         if let Err(err) = self.check_host_buffer() {
             return Ok(Err(err));
         }
-        let args: RuntimeArgs = bytesrepr::deserialize(args_bytes)?;
+        let args: RuntimeArgs = bytesrepr::deserialize_from_slice(args_bytes)?;
         let result = self.call_versioned_contract(
             contract_package_hash,
             contract_version,
@@ -1912,7 +1947,7 @@ where
             let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
             // Account hash deserialized
             let source: AccountHash =
-                bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
+                bytesrepr::deserialize_from_slice(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
         let weight = Weight::new(weight_value);
@@ -1939,7 +1974,7 @@ where
             let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
             // Account hash deserialized
             let source: AccountHash =
-                bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
+                bytesrepr::deserialize_from_slice(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
         match self.context.remove_associated_key(account_hash) {
@@ -1960,7 +1995,7 @@ where
             let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
             // Account hash deserialized
             let source: AccountHash =
-                bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
+                bytesrepr::deserialize_from_slice(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
         let weight = Weight::new(weight_value);
@@ -1991,7 +2026,7 @@ where
                     Err(e) => Err(e.into()),
                 }
             }
-            Err(_) => Err(Trap::new(TrapKind::Unreachable)),
+            Err(_) => Err(Trap::Code(TrapCode::Unreachable)),
         }
     }
 
@@ -2280,22 +2315,22 @@ where
     ) -> Result<Result<(), mint::Error>, Error> {
         let source: URef = {
             let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
-            bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+            bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
         };
 
         let target: URef = {
             let bytes = self.bytes_from_mem(target_ptr, target_size as usize)?;
-            bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+            bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
         };
 
         let amount: U512 = {
             let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
-            bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+            bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
         };
 
         let id: Option<u64> = {
             let bytes = self.bytes_from_mem(id_ptr, id_size as usize)?;
-            bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
+            bytesrepr::deserialize_from_slice(bytes).map_err(Error::BytesRepr)?
         };
 
         self.context.validate_uref(&source)?;
@@ -2333,7 +2368,7 @@ where
 
         let purse: URef = {
             let bytes = self.bytes_from_mem(purse_ptr, purse_size)?;
-            match bytesrepr::deserialize(bytes) {
+            match bytesrepr::deserialize_from_slice(bytes) {
                 Ok(purse) => purse,
                 Err(error) => return Ok(Err(error.into())),
             }
@@ -2744,13 +2779,13 @@ where
         }
 
         let uref: URef = self.t_from_mem(uref_ptr, uref_size)?;
-        let dictionary_item_key_bytes = self.bytes_from_mem(
-            dictionary_item_key_bytes_ptr,
+        let dictionary_item_key = self.checked_memory_slice(
+            dictionary_item_key_bytes_ptr as usize,
             dictionary_item_key_bytes_size as usize,
+            |utf8_bytes| std::str::from_utf8(utf8_bytes).map(ToOwned::to_owned),
         )?;
 
-        let dictionary_item_key = if let Ok(item_key) = String::from_utf8(dictionary_item_key_bytes)
-        {
+        let dictionary_item_key = if let Ok(item_key) = dictionary_item_key {
             item_key
         } else {
             return Ok(Err(ApiError::InvalidDictionaryItemKey));
@@ -2824,12 +2859,16 @@ where
         value_size: u32,
     ) -> Result<Result<(), ApiError>, Trap> {
         let uref: URef = self.t_from_mem(uref_ptr, uref_size)?;
-        let dictionary_item_key_bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
-        if dictionary_item_key_bytes.len() > DICTIONARY_ITEM_KEY_MAX_LENGTH {
-            return Ok(Err(ApiError::DictionaryItemKeyExceedsLength));
-        }
-        let dictionary_item_key = if let Ok(item_key) = String::from_utf8(dictionary_item_key_bytes)
-        {
+        let dictionary_item_key_bytes = {
+            if (key_size as usize) > DICTIONARY_ITEM_KEY_MAX_LENGTH {
+                return Ok(Err(ApiError::DictionaryItemKeyExceedsLength));
+            }
+            self.checked_memory_slice(key_ptr as usize, key_size as usize, |data| {
+                std::str::from_utf8(data).map(ToOwned::to_owned)
+            })?
+        };
+
+        let dictionary_item_key = if let Ok(item_key) = dictionary_item_key_bytes {
             item_key
         } else {
             return Ok(Err(ApiError::InvalidDictionaryItemKey));


### PR DESCRIPTION
Closes #3766 

Update wasmi to 0.13.2.

This wasmi version deprecates allocating `MemoryInstance::get` that always allocates and copies data back and forth between VM linear memory and the heap on the host.

With this commit host does not allocate data, but is deserializing data straight from a linear memory without allocating. Copies are made only when absolutely necessary.