### PR TITLE
Log the `leap_instruction`

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -145,6 +145,7 @@ impl BlockAccumulator {
     pub(crate) fn sync_instruction(&mut self, sync_identifier: SyncIdentifier) -> SyncInstruction {
         let block_hash = sync_identifier.block_hash();
         let leap_instruction = self.leap_instruction(&sync_identifier);
+        debug!(?leap_instruction, "BlockAccumulator");
         if let Some((block_height, era_id)) = sync_identifier.block_height_and_era() {
             self.register_local_tip(block_height, era_id);
         }


### PR DESCRIPTION
Log the actual `leap_instruction` in order to help debugging our dance with various "instruction" functions.

In this particular case, the following call to `leap_instruction.should_leap()` flattens that actual leap instruction to `bool`.