### PR TITLE
Exclude proptest-regressions from packaged files

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node/tree/master/node"
 license = "Apache-2.0"
 default-run = "casper-node"
+exclude = ["proptest-regressions"]
 
 [dependencies]
 ansi_term = "0.12.1"


### PR DESCRIPTION
This PR causes the `proptest-regressions` folder to be excluded from packaged files.

Closes #4061.
