### PR TITLE
Fix serialization for `ExecutableDeployItem`

### DIFF
--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -1850,12 +1850,8 @@
                     ],
                     "properties": {
                       "hash": {
-                        "description": "Contract hash.",
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ContractHash"
-                          }
-                        ]
+                        "description": "Hex-encoded contract hash.",
+                        "type": "string"
                       },
                       "entry_point": {
                         "description": "Name of an entry point.",
@@ -1928,12 +1924,8 @@
                     ],
                     "properties": {
                       "hash": {
-                        "description": "Contract package hash",
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ContractPackageHash"
-                          }
-                        ]
+                        "description": "Hex-encoded contract package hash.",
+                        "type": "string"
                       },
                       "version": {
                         "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -2247,14 +2239,6 @@
                 "additionalProperties": false
               }
             ]
-          },
-          "ContractHash": {
-            "description": "The hex-encoded hash address of the contract",
-            "type": "string"
-          },
-          "ContractPackageHash": {
-            "description": "The hex-encoded hash address of the contract package",
-            "type": "string"
           },
           "Approval": {
             "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
@@ -3650,6 +3634,10 @@
             },
             "additionalProperties": false
           },
+          "ContractPackageHash": {
+            "description": "The hex-encoded hash address of the contract package.",
+            "type": "string"
+          },
           "ContractWasmHash": {
             "description": "The hash address of the contract wasm",
             "type": "string"
@@ -3800,6 +3788,10 @@
                 "$ref": "#/components/schemas/ContractHash"
               }
             }
+          },
+          "ContractHash": {
+            "description": "The hex-encoded hash address of the contract.",
+            "type": "string"
           },
           "DisabledVersion": {
             "type": "object",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -657,12 +657,8 @@
               ],
               "properties": {
                 "hash": {
-                  "description": "Contract hash.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/ContractHash"
-                    }
-                  ]
+                  "description": "Hex-encoded contract hash.",
+                  "type": "string"
                 },
                 "entry_point": {
                   "description": "Name of an entry point.",
@@ -735,12 +731,8 @@
               ],
               "properties": {
                 "hash": {
-                  "description": "Contract package hash",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/ContractPackageHash"
-                    }
-                  ]
+                  "description": "Hex-encoded contract package hash.",
+                  "type": "string"
                 },
                 "version": {
                   "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -1054,14 +1046,6 @@
           "additionalProperties": false
         }
       ]
-    },
-    "ContractHash": {
-      "description": "The hex-encoded hash address of the contract",
-      "type": "string"
-    },
-    "ContractPackageHash": {
-      "description": "The hex-encoded hash address of the contract package",
-      "type": "string"
     },
     "Approval": {
       "description": "A struct containing a signature of a deploy hash and the public key of the signer.",

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -482,7 +482,7 @@ impl JsonSchema for ContractHash {
         let schema = gen.subschema_for::<String>();
         let mut schema_object = schema.into_object();
         schema_object.metadata().description =
-            Some("The hex-encoded hash address of the contract".to_string());
+            Some("The hex-encoded hash address of the contract.".to_string());
         schema_object.into()
     }
 }
@@ -636,7 +636,7 @@ impl JsonSchema for ContractPackageHash {
         let schema = gen.subschema_for::<String>();
         let mut schema_object = schema.into_object();
         schema_object.metadata().description =
-            Some("The hex-encoded hash address of the contract package".to_string());
+            Some("The hex-encoded hash address of the contract package.".to_string());
         schema_object.into()
     }
 }

--- a/types/src/deploy/executable_deploy_item.rs
+++ b/types/src/deploy/executable_deploy_item.rs
@@ -66,6 +66,11 @@ pub enum ExecutableDeployItem {
     /// [`RuntimeArgs`].
     StoredContractByHash {
         /// Contract hash.
+        #[serde(with = "contract_hash_as_digest")]
+        #[cfg_attr(
+            feature = "json-schema",
+            schemars(with = "String", description = "Hex-encoded contract hash.")
+        )]
         hash: ContractHash,
         /// Name of an entry point.
         entry_point: String,
@@ -86,6 +91,11 @@ pub enum ExecutableDeployItem {
     /// instance of [`RuntimeArgs`].
     StoredVersionedContractByHash {
         /// Contract package hash
+        #[serde(with = "contract_package_hash_as_digest")]
+        #[cfg_attr(
+            feature = "json-schema",
+            schemars(with = "String", description = "Hex-encoded contract package hash.")
+        )]
         hash: ContractPackageHash,
         /// An optional version of the contract to call. It will default to the highest enabled
         /// version if no value is specified.
@@ -767,6 +777,48 @@ impl Distribution<ExecutableDeployItem> for Standard {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+mod contract_hash_as_digest {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+    use crate::Digest;
+
+    pub(super) fn serialize<S: Serializer>(
+        contract_hash: &ContractHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_hash.value()).serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractHash::new(digest.value()))
+    }
+}
+
+mod contract_package_hash_as_digest {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+    use crate::Digest;
+
+    pub(super) fn serialize<S: Serializer>(
+        contract_package_hash: &ContractPackageHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_package_hash.value()).serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractPackageHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractPackageHash::new(digest.value()))
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue caused by the recent move of deploy types to `casper-types`.

As part of that PR, two custom serializers in the `ExecutableDeployItem` enum were removed which shouldn't have been, meaning that parsing such an item which was stored e.g. by a 1.4.x node would fail.