### PR TITLE
consensus: don't error when deactivating era more than once

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -860,7 +860,8 @@ impl EraSupervisor {
             .ok_or_else(|| "attempt to deactivate an era with no eras instantiated!".to_string())?;
         let era = self.era_mut(which_era);
         if false == era.consensus.is_active() {
-            return Err(format!("attempt to deactivate inactive era {}", which_era));
+            debug!(era_id=%which_era, "attempt to deactivate inactive era");
+            return Ok(which_era);
         }
         era.consensus.deactivate_validator();
         Ok(which_era)


### PR DESCRIPTION
Don't return a fatal error when trying to deactivate an era that was already deactivated.
In the case where a node unbonds and drops from the validator list, it will switch to `KeepUp` in order to follow the chain. Switching to `KeepUp` will try to deactivate the current era which would have been already deactivated when the last block of the era was added. Print out a debug message to track when this happens.

Fixes: https://github.com/casper-network/casper-node/issues/4070
