### PR TITLE
Fix serialization issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,9 +3094,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -2712,7 +2712,7 @@
             ],
             "properties": {
               "deploy_hash": {
-                "description": "The relevant Deploy.",
+                "description": "Hex-encoded Deploy hash.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/DeployHash"
@@ -2880,7 +2880,7 @@
             ],
             "properties": {
               "deploy_hash": {
-                "description": "Deploy that created the transfer",
+                "description": "Hex-encoded Deploy hash of Deploy that created the transfer.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/DeployHash"

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -1850,12 +1850,8 @@
                     ],
                     "properties": {
                       "hash": {
-                        "description": "Contract hash.",
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ContractHash"
-                          }
-                        ]
+                        "description": "Hex-encoded contract hash.",
+                        "type": "string"
                       },
                       "entry_point": {
                         "description": "Name of an entry point.",
@@ -1928,12 +1924,8 @@
                     ],
                     "properties": {
                       "hash": {
-                        "description": "Contract package hash",
-                        "allOf": [
-                          {
-                            "$ref": "#/components/schemas/ContractPackageHash"
-                          }
-                        ]
+                        "description": "Hex-encoded contract package hash.",
+                        "type": "string"
                       },
                       "version": {
                         "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -2247,14 +2239,6 @@
                 "additionalProperties": false
               }
             ]
-          },
-          "ContractHash": {
-            "description": "The hex-encoded hash address of the contract",
-            "type": "string"
-          },
-          "ContractPackageHash": {
-            "description": "The hex-encoded hash address of the contract package",
-            "type": "string"
           },
           "Approval": {
             "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
@@ -3650,6 +3634,10 @@
             },
             "additionalProperties": false
           },
+          "ContractPackageHash": {
+            "description": "The hex-encoded hash address of the contract package.",
+            "type": "string"
+          },
           "ContractWasmHash": {
             "description": "The hash address of the contract wasm",
             "type": "string"
@@ -3800,6 +3788,10 @@
                 "$ref": "#/components/schemas/ContractHash"
               }
             }
+          },
+          "ContractHash": {
+            "description": "The hex-encoded hash address of the contract.",
+            "type": "string"
           },
           "DisabledVersion": {
             "type": "object",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -657,12 +657,8 @@
               ],
               "properties": {
                 "hash": {
-                  "description": "Contract hash.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/ContractHash"
-                    }
-                  ]
+                  "description": "Hex-encoded contract hash.",
+                  "type": "string"
                 },
                 "entry_point": {
                   "description": "Name of an entry point.",
@@ -735,12 +731,8 @@
               ],
               "properties": {
                 "hash": {
-                  "description": "Contract package hash",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/ContractPackageHash"
-                    }
-                  ]
+                  "description": "Hex-encoded contract package hash.",
+                  "type": "string"
                 },
                 "version": {
                   "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -1054,14 +1046,6 @@
           "additionalProperties": false
         }
       ]
-    },
-    "ContractHash": {
-      "description": "The hex-encoded hash address of the contract",
-      "type": "string"
-    },
-    "ContractPackageHash": {
-      "description": "The hex-encoded hash address of the contract package",
-      "type": "string"
     },
     "Approval": {
       "description": "A struct containing a signature of a deploy hash and the public key of the signer.",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1480,7 +1480,7 @@
       ],
       "properties": {
         "deploy_hash": {
-          "description": "The relevant Deploy.",
+          "description": "Hex-encoded Deploy hash.",
           "allOf": [
             {
               "$ref": "#/definitions/DeployHash"
@@ -1644,7 +1644,7 @@
       ],
       "properties": {
         "deploy_hash": {
-          "description": "Deploy that created the transfer",
+          "description": "Hex-encoded Deploy hash of Deploy that created the transfer.",
           "allOf": [
             {
               "$ref": "#/definitions/DeployHash"

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -482,7 +482,7 @@ impl JsonSchema for ContractHash {
         let schema = gen.subschema_for::<String>();
         let mut schema_object = schema.into_object();
         schema_object.metadata().description =
-            Some("The hex-encoded hash address of the contract".to_string());
+            Some("The hex-encoded hash address of the contract.".to_string());
         schema_object.into()
     }
 }
@@ -636,7 +636,7 @@ impl JsonSchema for ContractPackageHash {
         let schema = gen.subschema_for::<String>();
         let mut schema_object = schema.into_object();
         schema_object.metadata().description =
-            Some("The hex-encoded hash address of the contract package".to_string());
+            Some("The hex-encoded hash address of the contract package.".to_string());
         schema_object.into()
     }
 }

--- a/types/src/deploy/executable_deploy_item.rs
+++ b/types/src/deploy/executable_deploy_item.rs
@@ -21,7 +21,7 @@ use crate::{
     account::AccountHash,
     bytesrepr::{self, Bytes, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     contracts::DEFAULT_ENTRY_POINT_NAME,
-    runtime_args,
+    runtime_args, serde_helpers,
     system::mint::ARG_AMOUNT,
     ContractHash, ContractPackageHash, ContractVersion, Gas, Motes, Phase, PublicKey, RuntimeArgs,
     URef, U512,
@@ -66,7 +66,7 @@ pub enum ExecutableDeployItem {
     /// [`RuntimeArgs`].
     StoredContractByHash {
         /// Contract hash.
-        #[serde(with = "contract_hash_as_digest")]
+        #[serde(with = "serde_helpers::contract_hash_as_digest")]
         #[cfg_attr(
             feature = "json-schema",
             schemars(with = "String", description = "Hex-encoded contract hash.")
@@ -91,7 +91,7 @@ pub enum ExecutableDeployItem {
     /// instance of [`RuntimeArgs`].
     StoredVersionedContractByHash {
         /// Contract package hash
-        #[serde(with = "contract_package_hash_as_digest")]
+        #[serde(with = "serde_helpers::contract_package_hash_as_digest")]
         #[cfg_attr(
             feature = "json-schema",
             schemars(with = "String", description = "Hex-encoded contract package hash.")
@@ -777,48 +777,6 @@ impl Distribution<ExecutableDeployItem> for Standard {
             }
             _ => unreachable!(),
         }
-    }
-}
-
-mod contract_hash_as_digest {
-    use serde::{Deserializer, Serializer};
-
-    use super::*;
-    use crate::Digest;
-
-    pub(super) fn serialize<S: Serializer>(
-        contract_hash: &ContractHash,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        Digest::from(contract_hash.value()).serialize(serializer)
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<ContractHash, D::Error> {
-        let digest = Digest::deserialize(deserializer)?;
-        Ok(ContractHash::new(digest.value()))
-    }
-}
-
-mod contract_package_hash_as_digest {
-    use serde::{Deserializer, Serializer};
-
-    use super::*;
-    use crate::Digest;
-
-    pub(super) fn serialize<S: Serializer>(
-        contract_package_hash: &ContractPackageHash,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        Digest::from(contract_package_hash.value()).serialize(serializer)
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<ContractPackageHash, D::Error> {
-        let digest = Digest::deserialize(deserializer)?;
-        Ok(ContractPackageHash::new(digest.value()))
     }
 }
 

--- a/types/src/deploy/executable_deploy_item.rs
+++ b/types/src/deploy/executable_deploy_item.rs
@@ -66,6 +66,11 @@ pub enum ExecutableDeployItem {
     /// [`RuntimeArgs`].
     StoredContractByHash {
         /// Contract hash.
+        #[serde(with = "contract_hash_as_digest")]
+        #[cfg_attr(
+            feature = "json-schema",
+            schemars(with = "String", description = "Hex-encoded contract hash.")
+        )]
         hash: ContractHash,
         /// Name of an entry point.
         entry_point: String,
@@ -86,6 +91,11 @@ pub enum ExecutableDeployItem {
     /// instance of [`RuntimeArgs`].
     StoredVersionedContractByHash {
         /// Contract package hash
+        #[serde(with = "contract_package_hash_as_digest")]
+        #[cfg_attr(
+            feature = "json-schema",
+            schemars(with = "String", description = "Hex-encoded contract package hash.")
+        )]
         hash: ContractPackageHash,
         /// An optional version of the contract to call. It will default to the highest enabled
         /// version if no value is specified.
@@ -767,6 +777,48 @@ impl Distribution<ExecutableDeployItem> for Standard {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+mod contract_hash_as_digest {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+    use crate::Digest;
+
+    pub(super) fn serialize<S: Serializer>(
+        contract_hash: &ContractHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_hash.value()).serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractHash::new(digest.value()))
+    }
+}
+
+mod contract_package_hash_as_digest {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+    use crate::Digest;
+
+    pub(super) fn serialize<S: Serializer>(
+        contract_package_hash: &ContractPackageHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_package_hash.value()).serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractPackageHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractPackageHash::new(digest.value()))
     }
 }
 

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
-    DeployHash, TransferAddr, URef, U512,
+    serde_helpers, DeployHash, TransferAddr, URef, U512,
 };
 
 /// Information relating to the given Deploy.
@@ -22,6 +22,11 @@ use crate::{
 #[serde(deny_unknown_fields)]
 pub struct DeployInfo {
     /// The relevant Deploy.
+    #[serde(with = "serde_helpers::deploy_hash_as_array")]
+    #[cfg_attr(
+        feature = "json-schema",
+        schemars(with = "DeployHash", description = "Hex-encoded Deploy hash.")
+    )]
     pub deploy_hash: DeployHash,
     /// Transfers performed by the Deploy.
     pub transfers: Vec<TransferAddr>,

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -943,6 +943,7 @@ mod serde_helpers {
         Hash(&'a HashAddr),
         URef(&'a URef),
         Transfer(&'a TransferAddr),
+        #[serde(with = "crate::serde_helpers::deploy_hash_as_array")]
         DeployInfo(&'a DeployHash),
         EraInfo(&'a EraId),
         Balance(&'a URefAddr),
@@ -984,6 +985,7 @@ mod serde_helpers {
         Hash(HashAddr),
         URef(URef),
         Transfer(TransferAddr),
+        #[serde(with = "crate::serde_helpers::deploy_hash_as_array")]
         DeployInfo(DeployHash),
         EraInfo(EraId),
         Balance(URefAddr),

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -53,6 +53,7 @@ mod named_key;
 mod phase;
 mod protocol_version;
 mod semver;
+pub(crate) mod serde_helpers;
 mod stored_value;
 pub mod system;
 mod tagged;

--- a/types/src/serde_helpers.rs
+++ b/types/src/serde_helpers.rs
@@ -1,0 +1,82 @@
+use alloc::string::String;
+use core::convert::TryFrom;
+
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Digest;
+
+pub(crate) mod contract_hash_as_digest {
+    use super::*;
+    use crate::ContractHash;
+
+    pub(crate) fn serialize<S: Serializer>(
+        contract_hash: &ContractHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_hash.value()).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractHash::new(digest.value()))
+    }
+}
+
+pub(crate) mod contract_package_hash_as_digest {
+    use super::*;
+    use crate::ContractPackageHash;
+
+    pub(crate) fn serialize<S: Serializer>(
+        contract_package_hash: &ContractPackageHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Digest::from(contract_package_hash.value()).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ContractPackageHash, D::Error> {
+        let digest = Digest::deserialize(deserializer)?;
+        Ok(ContractPackageHash::new(digest.value()))
+    }
+}
+
+/// This module allows `DeployHash`es to be serialized and deserialized using the underlying
+/// `[u8; 32]` rather than delegating to the wrapped `Digest`, which in turn delegates to a
+/// `Vec<u8>` for legacy reasons.
+///
+/// This is required as the `DeployHash` defined in `casper-types` up until v4.0.0 used the array
+/// form, while the `DeployHash` defined in `casper-node` during this period delegated to `Digest`.
+///
+/// We use this module in places where the old `casper_types::DeployHash` was held as a member of a
+/// type which implements `Serialize` and/or `Deserialize`.
+pub(crate) mod deploy_hash_as_array {
+    use super::*;
+    use crate::DeployHash;
+
+    pub(crate) fn serialize<S: Serializer>(
+        deploy_hash: &DeployHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            base16::encode_lower(&deploy_hash.inner().value()).serialize(serializer)
+        } else {
+            deploy_hash.inner().value().serialize(serializer)
+        }
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<DeployHash, D::Error> {
+        let bytes = if deserializer.is_human_readable() {
+            let hex_string = String::deserialize(deserializer)?;
+            let vec_bytes = base16::decode(hex_string.as_bytes()).map_err(SerdeError::custom)?;
+            <[u8; DeployHash::LENGTH]>::try_from(vec_bytes.as_ref()).map_err(SerdeError::custom)?
+        } else {
+            <[u8; DeployHash::LENGTH]>::deserialize(deserializer)?
+        };
+        Ok(DeployHash::new(Digest::from(bytes)))
+    }
+}

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -21,7 +21,7 @@ use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Seria
 use crate::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
-    checksummed_hex, CLType, CLTyped, DeployHash, URef, U512,
+    checksummed_hex, serde_helpers, CLType, CLTyped, DeployHash, URef, U512,
 };
 
 /// The length of a transfer address.
@@ -35,6 +35,14 @@ pub(super) const TRANSFER_ADDR_FORMATTED_STRING_PREFIX: &str = "transfer-";
 #[serde(deny_unknown_fields)]
 pub struct Transfer {
     /// Deploy that created the transfer
+    #[serde(with = "serde_helpers::deploy_hash_as_array")]
+    #[cfg_attr(
+        feature = "json-schema",
+        schemars(
+            with = "DeployHash",
+            description = "Hex-encoded Deploy hash of Deploy that created the transfer."
+        )
+    )]
     pub deploy_hash: DeployHash,
     /// Account from which transfer was executed
     pub from: AccountHash,


### PR DESCRIPTION
This PR fixes two issues caused by the recent move of deploy types to casper-types.

As part of that PR, two custom serializers in the `ExecutableDeployItem` enum were removed which shouldn't have been, meaning that parsing such an item which was stored e.g. by a 1.4.x node would fail.

A further issue was that binary serialization of `casper-node::types::DeployHash` delegated to `Digest`, which delegated to `Vec<u8>` for legacy reasons.  When bincode-encoding such a `DeployHash` it has a length prepended to the serialized data.  This is still how the moved `DeployHash` is handled.  However, prior to the move, there was a `casper_types::DeployHash` which delegated to `[u8; 32]` for binary serialization.  Bincode does not prepend a length for a fixed-length array like this.  As such, to retain the ability to parse historical stored data which held an old `casper_types::DeployHash`, we need to provide helpers to use array-style encoding rather than Vec.

Closes #4074.