### PR TITLE
Bump openssl to `0.10.55`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,9 +3710,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -3751,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -52,7 +52,7 @@ num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
 num_cpus = "1"
 once_cell = "1"
-openssl = "0.10.32"
+openssl = "0.10.55"
 pin-project = "1.0.6"
 prometheus = "0.12.0"
 quanta = "0.7.2"


### PR DESCRIPTION
This PR bumps openssl to `0.10.55` to dodge the vulnerability: https://rustsec.org/advisories/RUSTSEC-2023-0044
