### PR TITLE
node/rpc-server/query_global_state: make state_identifier optional

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.  The format
 ### Fixed
 * Now possible to build outside a git repository context (e.g. from a source tarball). In such cases, the node's build version (as reported vie status endpoints) will not contain a trailing git short hash.
 
+### Changed
+* The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest block known to the node will be used to fulfil the request.
 
 
 ## 1.5.1

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 * Now possible to build outside a git repository context (e.g. from a source tarball). In such cases, the node's build version (as reported vie status endpoints) will not contain a trailing git short hash.
 
 ### Changed
-* The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest block known to the node will be used to fulfil the request.
+* The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest complete block known to the node will be used to fulfill the request.
 
 
 ## 1.5.1

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -99,7 +99,9 @@ static GET_DICTIONARY_ITEM_RESULT: Lazy<GetDictionaryItemResult> =
     });
 static QUERY_GLOBAL_STATE_PARAMS: Lazy<QueryGlobalStateParams> =
     Lazy::new(|| QueryGlobalStateParams {
-        state_identifier: GlobalStateIdentifier::BlockHash(*Block::doc_example().hash()),
+        state_identifier: Some(GlobalStateIdentifier::BlockHash(
+            *Block::doc_example().hash(),
+        )),
         key: "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1".to_string(),
         path: vec![],
     });
@@ -773,8 +775,9 @@ pub enum GlobalStateIdentifier {
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateParams {
-    /// The identifier used for the query.
-    pub state_identifier: GlobalStateIdentifier,
+    /// The identifier used for the query. If none is passed
+    /// the tip of the chain will be used.
+    pub state_identifier: Option<GlobalStateIdentifier>,
     /// `casper_types::Key` as formatted string.
     pub key: String,
     /// The path components starting from the key as base.
@@ -823,9 +826,29 @@ impl RpcWithParams for QueryGlobalState {
         api_version: ProtocolVersion,
         params: Self::RequestParams,
     ) -> Result<Self::ResponseResult, Error> {
-        let (state_root_hash, maybe_block_header) =
-            get_state_root_hash_and_optional_header(effect_builder, params.state_identifier)
-                .await?;
+        let (state_root_hash, maybe_block_header) = match params.state_identifier {
+            None => match effect_builder
+                .get_highest_complete_block_header_from_storage()
+                .await
+            {
+                None => {
+                    return Err(Error::new(
+                        ErrorCode::NoSuchBlock,
+                        "query-global-state failed to retrieve highest block header",
+                    ))
+                }
+                Some(block_header) => (
+                    *block_header.state_root_hash(),
+                    Some(JsonBlockHeader::from(block_header.clone())),
+                ),
+            },
+            Some(state_identifier) => {
+                let (state_root_hash, maybe_block_header) =
+                    get_state_root_hash_and_optional_header(effect_builder, state_identifier)
+                        .await?;
+                (state_root_hash, maybe_block_header)
+            }
+        };
 
         let base_key = match Key::from_formatted_str(&params.key)
             .map_err(|error| format!("failed to parse key: {}", error))

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -488,20 +488,27 @@
           "summary": "a query to global state using either a Block hash or state root hash",
           "params": [
             {
-              "name": "state_identifier",
-              "schema": {
-                "description": "The identifier used for the query.",
-                "$ref": "#/components/schemas/GlobalStateIdentifier"
-              },
-              "required": true
-            },
-            {
               "name": "key",
               "schema": {
                 "description": "`casper_types::Key` as formatted string.",
                 "type": "string"
               },
               "required": true
+            },
+            {
+              "name": "state_identifier",
+              "schema": {
+                "description": "The identifier used for the query. If none is passed the tip of the chain will be used.",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/GlobalStateIdentifier"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "required": false
             },
             {
               "name": "path",


### PR DESCRIPTION
Make the `state_identifier` parameter of the `query_global_state` JSON-RPC method optional. If no `state_identifier` is specified, the highest complete block is used as an identifier.

Fixes: https://github.com/casper-network/casper-node/issues/4054
