### PR TITLE
Add casper-storage to casper-updater

### DIFF
--- a/ci/casper_updater/src/main.rs
+++ b/ci/casper_updater/src/main.rs
@@ -230,6 +230,7 @@ fn get_args() -> Args {
 fn main() {
     let rust_packages = [
         Package::cargo("types", &regex_data::types::DEPENDENT_FILES),
+        Package::cargo("storage", &regex_data::storage::DEPENDENT_FILES),
         Package::cargo(
             "execution_engine",
             &regex_data::execution_engine::DEPENDENT_FILES,

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -64,6 +64,43 @@ pub mod types {
     });
 }
 
+pub mod storage {
+    use super::*;
+
+    pub static DEPENDENT_FILES: Lazy<Vec<DependentFile>> = Lazy::new(|| {
+        vec![
+            DependentFile::new(
+                "execution_engine/Cargo.toml",
+                Regex::new(r#"(?m)(^casper-storage = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                replacement,
+            ),
+            DependentFile::new(
+                "execution_engine_testing/test_support/Cargo.toml",
+                Regex::new(r#"(?m)(^casper-storage = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                replacement,
+            ),
+            DependentFile::new(
+                "node/Cargo.toml",
+                Regex::new(r#"(?m)(^casper-storage = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                replacement,
+            ),
+            DependentFile::new(
+                "storage/Cargo.toml",
+                MANIFEST_VERSION_REGEX.clone(),
+                replacement,
+            ),
+            DependentFile::new(
+                "storage/src/lib.rs",
+                Regex::new(
+                    r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-storage)/(?:[^"]+)"#,
+                )
+                .unwrap(),
+                replacement_with_slash,
+            ),
+        ]
+    });
+}
+
 pub mod execution_engine {
     use super::*;
 

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 base16 = "0.2.1"
-casper-storage = { version = "1.4.3", path = "../../storage" }
+casper-storage = { path = "../../storage" }
 casper-engine-test-support = { path = "../test_support" }
 casper-execution-engine = { path = "../../execution_engine", features = ["test-support"] }
 casper-types = { path = "../../types", default_features = false, features = ["datasize", "json-schema"] }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "casper-storage"
 version = "1.4.3"
 edition = "2018"
-description = "A library providing global state functionality."
+description = "Storage for a node on the Casper network."
 readme = "README.md"
 documentation = "https://docs.rs/casper-storage"
 homepage = "https://casperlabs.io"
@@ -30,3 +30,7 @@ anyhow = "1.0.33"
 proptest = "1.0.0"
 rand = "0.8.3"
 serde_json = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -6,8 +6,6 @@
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
     test(attr(forbid(warnings)))
 )]
-// TODO - enable and fix warnings.
-// #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod data_access_layer;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,2 +1,14 @@
+//! Storage for a node on the Casper network.
+
+#![doc(html_root_url = "https://docs.rs/casper-storage/1.4.3")]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
+    html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
+    test(attr(forbid(warnings)))
+)]
+// TODO - enable and fix warnings.
+// #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 pub mod data_access_layer;
 pub mod global_state;


### PR DESCRIPTION
This PR updates the `casper-updater` tool to include `casper-storage`.

Closes #4035.
