### PR TITLE
Fix network stall recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,9 +3100,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3141,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -51,7 +51,7 @@ num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
 num_cpus = "1"
 once_cell = "1"
-openssl = "0.10.32"
+openssl = "0.10.55"
 pin-project = "1.0.6"
 prometheus = "0.12.0"
 quanta = "0.7.2"

--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -161,7 +161,7 @@ impl BlockAccumulator {
             None => {
                 if self.is_stale() {
                     debug!(%block_hash, "BlockAccumulator: leap because stale gossip");
-                    SyncInstruction::Leap { block_hash }
+                    SyncInstruction::LeapIntervalElapsed { block_hash }
                 } else {
                     SyncInstruction::CaughtUp { block_hash }
                 }

--- a/node/src/components/block_accumulator/sync_instruction.rs
+++ b/node/src/components/block_accumulator/sync_instruction.rs
@@ -5,6 +5,7 @@ pub(crate) enum SyncInstruction {
     Leap { block_hash: BlockHash },
     BlockSync { block_hash: BlockHash },
     CaughtUp { block_hash: BlockHash },
+    LeapIntervalElapsed { block_hash: BlockHash },
 }
 
 impl SyncInstruction {
@@ -12,7 +13,8 @@ impl SyncInstruction {
         match self {
             SyncInstruction::Leap { block_hash }
             | SyncInstruction::BlockSync { block_hash }
-            | SyncInstruction::CaughtUp { block_hash } => *block_hash,
+            | SyncInstruction::CaughtUp { block_hash }
+            | SyncInstruction::LeapIntervalElapsed { block_hash } => *block_hash,
         }
     }
 }

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -273,7 +273,8 @@ impl MainReactor {
         sync_instruction: SyncInstruction,
     ) -> Option<CatchUpInstruction> {
         match sync_instruction {
-            SyncInstruction::Leap { block_hash } => {
+            SyncInstruction::Leap { block_hash }
+            | SyncInstruction::LeapIntervalElapsed { block_hash } => {
                 Some(self.catch_up_leap(effect_builder, rng, block_hash))
             }
             SyncInstruction::BlockSync { block_hash } => {

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -242,7 +242,7 @@ impl MainReactor {
         sync_instruction: SyncInstruction,
     ) -> Option<KeepUpInstruction> {
         match sync_instruction {
-            SyncInstruction::Leap { .. } => {
+            SyncInstruction::Leap { .. } | SyncInstruction::LeapIntervalElapsed { .. } => {
                 // the block accumulator is unsure what our block position is relative to the
                 // network and wants to check peers for their notion of current tip.
                 // to do this, we switch back to CatchUp which will engage the necessary


### PR DESCRIPTION
Fixes an issue where it would be harder to recover if enough validators have left the network and the network is unable to progress. Once enough validators come back up, the network should resume producing blocks.
Because the validating nodes that remained up switched to CatchUp after a while, it was required that the new set of validators that come up to have enough stake to produce blocks.

With this fix, validators can come back up one by one, and the network will start producing blocks after sufficient weight is up.

Fixes: https://github.com/casper-network/casper-node/issues/4091