### PR TITLE
Update comment describing leap attempt because of stale gossip

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -160,7 +160,7 @@ impl BlockAccumulator {
             }
             None => {
                 if self.is_stale() {
-                    debug!(%block_hash, "BlockAccumulator: leap because stale gossip");
+                    debug!(%block_hash, "BlockAccumulator: when not in Validate leap because stale gossip");
                     SyncInstruction::LeapIntervalElapsed { block_hash }
                 } else {
                     SyncInstruction::CaughtUp { block_hash }


### PR DESCRIPTION
This PR updates a comment to reflect the recent changes to `SyncInstruction` introduced [here](https://github.com/casper-network/casper-node/pull/4110).