### PR TITLE
Read validators for genesis era from storage in case they are needed

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1736,20 +1736,13 @@ impl Storage {
     }
 
     /// Get the switch block for a specified era number in a read-only LMDB database transaction.
-    ///
-    /// # Panics
-    ///
-    /// Panics on any IO or db corruption error.
     pub(crate) fn transactional_get_switch_block_header_by_era_id(
         &self,
         era_id: EraId,
     ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let mut txn = self
-            .env
-            .begin_ro_txn()
-            .expect("Could not start read only transaction for lmdb");
+        let mut txn = self.env.begin_ro_txn()?;
         let ret = self.get_switch_block_header_by_era_id(&mut txn, era_id);
-        txn.commit().expect("Could not commit transaction");
+        txn.commit()?;
         ret
     }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1735,6 +1735,24 @@ impl Storage {
             .transpose()
     }
 
+    /// Get the switch block for a specified era number in a read-only LMDB database transaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any IO or db corruption error.
+    pub(crate) fn transactional_get_switch_block_header_by_era_id(
+        &self,
+        era_id: EraId,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let mut txn = self
+            .env
+            .begin_ro_txn()
+            .expect("Could not start read only transaction for lmdb");
+        let ret = self.get_switch_block_header_by_era_id(&mut txn, era_id);
+        txn.commit().expect("Could not commit transaction");
+        ret
+    }
+
     /// Retrieves single switch block header by era ID by looking it up in the index and returning
     /// it.
     fn get_switch_block_header_by_era_id<Tx: Transaction>(

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1735,17 +1735,6 @@ impl Storage {
             .transpose()
     }
 
-    /// Get the switch block for a specified era number in a read-only LMDB database transaction.
-    pub(crate) fn transactional_get_switch_block_header_by_era_id(
-        &self,
-        era_id: EraId,
-    ) -> Result<Option<BlockHeader>, FatalStorageError> {
-        let mut txn = self.env.begin_ro_txn()?;
-        let ret = self.get_switch_block_header_by_era_id(&mut txn, era_id);
-        txn.commit()?;
-        ret
-    }
-
     /// Retrieves single switch block header by era ID by looking it up in the index and returning
     /// it.
     fn get_switch_block_header_by_era_id<Tx: Transaction>(


### PR DESCRIPTION
Node will get stuck on historical sync when it is syncing to genesis through era 0 of the pre 1.5 chain and at the same time it is restarted for upgrade.

We attempt to fix this by trying to read the validators from the local storage and saturate the validator matrix, so that the SyncLeap is not needed.

This is an alternative solution to the one prepared [here](https://github.com/casper-network/casper-node/pull/4081).

Closes #4077
