### PR TITLE
Amend upgrade logic

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -331,7 +331,7 @@ where
                 .map_err(|error| Error::Bytesrepr(error.to_string()))?;
 
         // We write the checksums of the chainspec settings to global state
-        // allowing verification of the reported chainspec data via the RPC.
+        // allowing verification of the chainspec data reported via the RPC.
         tracking_copy.borrow_mut().write(
             Key::ChainspecRegistry,
             StoredValue::CLValue(cl_value_chainspec_registry),

--- a/execution_engine_testing/tests/src/test/regression/gh_3710.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3710.rs
@@ -1,9 +1,8 @@
 use std::{collections::BTreeSet, convert::TryInto, fmt, iter::FromIterator};
 
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, UpgradeRequestBuilder,
-    WasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY,
-    PRODUCTION_RUN_GENESIS_REQUEST,
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, WasmTestBuilder,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY, PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -24,89 +23,6 @@ use crate::lmdb_fixture;
 const FIXTURE_N_ERAS: usize = 10;
 
 const GH_3710_FIXTURE: &str = "gh_3710";
-
-#[ignore]
-#[test]
-fn gh_3710_should_copy_latest_era_info_to_stable_key_at_upgrade_point() {
-    let (mut builder, lmdb_fixture_state, _temp_dir) =
-        lmdb_fixture::builder_from_global_state_fixture(GH_3710_FIXTURE);
-
-    let auction_delay: u64 = lmdb_fixture_state
-        .genesis_request
-        .get("ee_config")
-        .expect("should have ee_config")
-        .get("auction_delay")
-        .expect("should have auction delay")
-        .as_i64()
-        .expect("auction delay should be integer")
-        .try_into()
-        .expect("auction delay should be positive");
-
-    let last_expected_era_info = EraId::new(auction_delay + FIXTURE_N_ERAS as u64);
-    let first_era_after_protocol_upgrade = last_expected_era_info.successor();
-
-    let pre_upgrade_state_root_hash = builder.get_post_state_hash();
-
-    let previous_protocol_version = lmdb_fixture_state.genesis_protocol_version();
-
-    let current_protocol_version = lmdb_fixture_state.genesis_protocol_version();
-
-    let new_protocol_version = ProtocolVersion::from_parts(
-        current_protocol_version.value().major,
-        current_protocol_version.value().minor,
-        current_protocol_version.value().patch + 1,
-    );
-
-    let era_info_keys_before_upgrade = builder
-        .get_keys(KeyTag::EraInfo)
-        .expect("should return all the era info keys");
-
-    assert_eq!(
-        era_info_keys_before_upgrade.len(),
-        auction_delay as usize + 1 + FIXTURE_N_ERAS,
-    );
-
-    let mut upgrade_request = {
-        UpgradeRequestBuilder::new()
-            .with_current_protocol_version(previous_protocol_version)
-            .with_new_protocol_version(new_protocol_version)
-            .with_activation_point(first_era_after_protocol_upgrade)
-            .build()
-    };
-
-    builder
-        .upgrade_with_upgrade_request(*builder.get_engine_state().config(), &mut upgrade_request)
-        .expect_upgrade_success();
-
-    let upgrade_result = builder.get_upgrade_result(0).expect("result");
-
-    let upgrade_success = upgrade_result.as_ref().expect("success");
-    assert_eq!(
-        upgrade_success.post_state_hash,
-        builder.get_post_state_hash(),
-        "sanity check"
-    );
-
-    let era_info_keys_after_upgrade = builder
-        .get_keys(KeyTag::EraInfo)
-        .expect("should return all the era info keys");
-
-    assert_eq!(era_info_keys_after_upgrade, era_info_keys_before_upgrade);
-
-    let last_era_info_value = builder
-        .query(
-            Some(pre_upgrade_state_root_hash),
-            Key::EraInfo(last_expected_era_info),
-            &[],
-        )
-        .expect("should query pre-upgrade stored value");
-
-    let era_summary = builder
-        .query(None, Key::EraSummary, &[])
-        .expect("should query stable key after the upgrade");
-
-    assert_eq!(last_era_info_value, era_summary);
-}
 
 #[ignore]
 #[test]


### PR DESCRIPTION
CHANGELOG:

- Tweaked upgrade logic transforming withdraw purses to early exit if possible
- Tweaked upgrade logic to not perform the one-time transformation of the `Key::EraSummary`

Closes #4118 and #4117
