### PR TITLE
Add test for network recovery after at least 1/3 validators go down

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -114,6 +114,7 @@ start_run_teardown "sync_test.sh timeout=500"
 start_run_teardown "gov96.sh"
 start_run_teardown "swap_validator_set.sh"
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
+start_run_teardown "validators_disconnect.sh"
 # Without start_run_teardown - these ones perform their own assets setup, network start and teardown
 source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
 source "$SCENARIOS_DIR/regression_3976.sh"

--- a/utils/nctl/sh/scenarios/accounts_toml/validators_disconnect.accounts.toml.override
+++ b/utils/nctl/sh/scenarios/accounts_toml/validators_disconnect.accounts.toml.override
@@ -1,0 +1,154 @@
+# FAUCET.
+[[accounts]]
+public_key = "PBK_FAUCET"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 1.
+[[accounts]]
+public_key = "PBK_V1"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 2.
+[[accounts]]
+public_key = "PBK_V2"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 3.
+[[accounts]]
+public_key = "PBK_V3"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 4.
+[[accounts]]
+public_key = "PBK_V4"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 5.
+[[accounts]]
+public_key = "PBK_V5"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 6.
+[[accounts]]
+public_key = "PBK_V6"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 7.
+[[accounts]]
+public_key = "PBK_V7"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 8.
+[[accounts]]
+public_key = "PBK_V8"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 9.
+[[accounts]]
+public_key = "PBK_V9"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# VALIDATOR 10.
+[[accounts]]
+public_key = "PBK_V10"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "1000"
+delegation_rate = 1
+
+# USER 1.
+[[delegators]]
+validator_public_key = "PBK_V1"
+delegator_public_key = "PBK_U1"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 2.
+[[delegators]]
+validator_public_key = "PBK_V2"
+delegator_public_key = "PBK_U2"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 3.
+[[delegators]]
+validator_public_key = "PBK_V3"
+delegator_public_key = "PBK_U3"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 4.
+[[delegators]]
+validator_public_key = "PBK_V4"
+delegator_public_key = "PBK_U4"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 5.
+[[delegators]]
+validator_public_key = "PBK_V5"
+delegator_public_key = "PBK_U5"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 6.
+[[accounts]]
+public_key = "PBK_U6"
+balance = "1000000000000000000000000000000000"
+
+# USER 7.
+[[accounts]]
+public_key = "PBK_U7"
+balance = "1000000000000000000000000000000000"
+
+# USER 8.
+[[accounts]]
+public_key = "PBK_U8"
+balance = "1000000000000000000000000000000000"
+
+# USER 9.
+[[accounts]]
+public_key = "PBK_U9"
+balance = "1000000000000000000000000000000000"
+
+# USER 10.
+[[accounts]]
+public_key = "PBK_U10"
+balance = "1000000000000000000000000000000000"

--- a/utils/nctl/sh/scenarios/chainspecs/validators_disconnect.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/validators_disconnect.chainspec.toml.override
@@ -1,0 +1,2 @@
+[core]
+validator_slots = 10

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -588,3 +588,28 @@ function delegate_to() {
         delegator="$ACCOUNT_ID" \
         validator="$NODE_ID"
 }
+
+function assert_chain_stalled() {
+    # Fucntion checks that the two remaining node's LFB checked
+    # n-seconds apart doesnt progress
+    log_step "ensuring chain stalled"
+    local SLEEP_TIME=${1}
+    # Sleep 5 seconds to allow for final message propagation.
+    sleep 5
+    local LFB_1_PRE=$(do_read_lfb_hash 1)
+    local LFB_2_PRE=$(do_read_lfb_hash 2)
+    log "Sleeping ${SLEEP_TIME}s..."
+    sleep $SLEEP_TIME
+    local LFB_1_POST=$(do_read_lfb_hash 1)
+    local LFB_2_POST=$(do_read_lfb_hash 2)
+
+    if [ "$LFB_1_PRE" != "$LFB_1_POST" ] && [ "$LFB_2_PRE" != "$LFB_2_POST" ]; then
+       log "Error: Chain progressed."
+       exit 1
+    else
+        STALLED_LFB=$LFB_1_POST
+        log "node-1 LFB: $LFB_1_PRE = $LFB_1_POST"
+        log "node-2 LFB: $LFB_2_PRE = $LFB_2_POST"
+        log "Stall successfully detected, continuing..."
+    fi
+}

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -225,6 +225,14 @@ function do_await_era_change() {
     nctl-await-n-eras offset="$ERA_COUNT" sleep_interval='5.0'
 }
 
+function do_await_era_change_with_timeout() {
+    # allow chain height to grow
+    local ERA_COUNT=${1:-"1"}
+    local TIME_OUT=${2:-''}
+    log_step "awaiting $ERA_COUNT eras…"
+    nctl-await-n-eras offset="$ERA_COUNT" sleep_interval='5.0' timeout="$TIME_OUT"
+}
+
 function check_current_era {
     local NODE_ID=${1:-$(get_node_for_dispatch)}
     local ERA="null"

--- a/utils/nctl/sh/scenarios/itst02.sh
+++ b/utils/nctl/sh/scenarios/itst02.sh
@@ -73,31 +73,6 @@ function assert_chain_progressed() {
     fi
 }
 
-function assert_chain_stalled() {
-    # Fucntion checks that the two remaining node's LFB checked
-    # n-seconds apart doesnt progress
-    log_step "ensuring chain stalled"
-    local SLEEP_TIME=${1}
-    # Sleep 5 seconds to allow for final message propagation.
-    sleep 5
-    local LFB_1_PRE=$(do_read_lfb_hash 1)
-    local LFB_2_PRE=$(do_read_lfb_hash 2)
-    log "Sleeping ${SLEEP_TIME}s..."
-    sleep $SLEEP_TIME
-    local LFB_1_POST=$(do_read_lfb_hash 1)
-    local LFB_2_POST=$(do_read_lfb_hash 2)
-
-    if [ "$LFB_1_PRE" != "$LFB_1_POST" ] && [ "$LFB_2_PRE" != "$LFB_2_POST" ]; then
-       log "Error: Chain progressed."
-       exit 1
-    else
-        STALLED_LFB=$LFB_1_POST
-        log "node-1 LFB: $LFB_1_PRE = $LFB_1_POST"
-        log "node-2 LFB: $LFB_2_PRE = $LFB_2_POST"
-        log "Stall successfully detected, continuing..."
-    fi
-}
-
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/utils/nctl/sh/scenarios/validators_disconnect.sh
+++ b/utils/nctl/sh/scenarios/validators_disconnect.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/utils/main.sh
+source "$NCTL"/sh/views/utils.sh
+source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+function main() {
+    log "------------------------------------------------------------"
+    log "Starting Scenario: Half of validators disconnecting"
+    log "------------------------------------------------------------"
+
+    # 0. Start the rest of the validator nodes
+    log_step "Starting nodes 6-10"
+    nctl-start node=6
+    nctl-start node=7
+    nctl-start node=8
+    nctl-start node=9
+    nctl-start node=10
+    # 1. Wait for the genesis era to complete
+    do_await_genesis_era_to_complete
+    # 2. Allow the chain to progress
+    do_await_era_change 1
+    # 3. Verify all nodes are in sync
+    parallel_check_network_sync 1 10
+    # 4. Stop half of the validators
+    log_step "Stopping nodes 6-10"
+    nctl-stop node=6
+    nctl-stop node=7
+    nctl-stop node=8
+    nctl-stop node=9
+    nctl-stop node=10
+    # 5. Wait for a period longer than the dead air interval
+    sleep_and_display_reactor_state '260.0'
+    # 6. Start 2 previously stopped validator node.
+    #    Now the network should have 7/10 active and start progressing.
+    log_step "Starting nodes 6, 7"
+    nctl-start node=6
+    nctl-start node=7
+    # 7. Check if the network is progressing
+    do_await_era_change_with_timeout 1 "500"
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=2 \
+            ejections=0
+
+    log "------------------------------------------------------------"
+    log "Scenario half of validators disconnecting complete"
+    log "------------------------------------------------------------"
+}
+
+function sleep_and_display_reactor_state() {
+    local TIME_OUT=${1:-'360.0'}
+    local NODE_ID=${2:-"1"}
+    local SLEEP_INTERVAL='10.0'
+
+    log_step "Waiting $TIME_OUT seconds to pass…"
+    while true
+    do
+        local REACTOR_STATUS=$(nctl-view-node-status node=1 | tail -n +2)
+        local REACTOR_STATE=$(echo $REACTOR_STATUS | jq '.reactor_state')
+        local HIGHEST_BLOCK=$(echo $REACTOR_STATUS | jq '.available_block_range.high' )
+        LOG_OUTPUT="reactor state for node $NODE_ID = $REACTOR_STATE; highest block = $HIGHEST_BLOCK :: sleeping $SLEEP_INTERVAL seconds"
+
+        if [ "$EMIT_LOG" = true ] && [ ! -z "$TIME_OUT" ]; then
+            log "$LOG_OUTPUT :: sleep time = $TIME_OUT seconds"
+        elif [ "$EMIT_LOG" = true ]; then
+            log "$LOG_OUTPUT"
+        fi
+
+        sleep "$SLEEP_INTERVAL"
+
+        if [ ! -z "$TIME_OUT" ]; then
+            # Using jq since its required by NCTL anyway to do this floating point arith
+            # ... done to maintain backwards compatibility
+            TIME_OUT=$(jq -n "$TIME_OUT-$SLEEP_INTERVAL")
+
+            if [ "$TIME_OUT" -le "0" ]; then
+                log "Finished waiting"
+                break
+            fi
+        else
+            log "Finished waiting"
+            break
+        fi
+    done
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+STEP=0
+
+main

--- a/utils/nctl/sh/scenarios/validators_disconnect.sh
+++ b/utils/nctl/sh/scenarios/validators_disconnect.sh
@@ -22,20 +22,20 @@ function main() {
     nctl-start node=10
     # 1. Wait for the genesis era to complete
     do_await_genesis_era_to_complete
-    # 2. Allow the chain to progress
-    do_await_era_change 1
-    # 3. Verify all nodes are in sync
+    # 2. Verify all nodes are in sync
     parallel_check_network_sync 1 10
-    # 4. Stop half of the validators
+    # 3. Stop half of the validators
     log_step "Stopping nodes 6-10"
     nctl-stop node=6
     nctl-stop node=7
     nctl-stop node=8
     nctl-stop node=9
     nctl-stop node=10
+    # 4. Assert that the chain actually stalled
+    assert_chain_stalled "30"
     # 5. Wait for a period longer than the dead air interval
     sleep_and_display_reactor_state '260.0'
-    # 6. Start 2 previously stopped validator node.
+    # 6. Start 2 previously stopped validator nodes.
     #    Now the network should have 7/10 active and start progressing.
     log_step "Starting nodes 6, 7"
     nctl-start node=6


### PR DESCRIPTION
If more than 1/3 of the validator weight leaves the network, the network will stop producing blocks. When validators join back again such that more than 2/3 of weight is reached, the network should start producing blocks again.
Add a test that checks this scenario.
