### PR TITLE
Use test_block_builder only for tests

### DIFF
--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -16,7 +16,7 @@ use tokio::time;
 
 use casper_types::{
     generate_ed25519_keypair, testing::TestRng, ActivationPoint, Block, Chainspec,
-    ChainspecRawBytes, ProtocolVersion, PublicKey, SecretKey, SemVer, Signature, U512,
+    ChainspecRawBytes, ProtocolVersion, PublicKey, SecretKey, Signature, U512,
 };
 use reactor::ReactorEvent;
 
@@ -35,7 +35,7 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, EventQueueHandle, QueueKind, Reactor, Runner, TryCrankOutcome},
-    types::EraValidatorWeights,
+    types::{EraValidatorWeights, TestBlockBuilder},
     utils::{Loadable, WithDir},
     NodeRng,
 };
@@ -377,7 +377,7 @@ fn upsert_acceptor() {
 #[test]
 fn acceptor_get_peers() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
     assert!(acceptor.peers().is_empty());
     let first_peer = NodeId::random(&mut rng);
@@ -392,7 +392,7 @@ fn acceptor_get_peers() {
 fn acceptor_register_finality_signature() {
     let mut rng = TestRng::new();
     // Create a block and an acceptor for it.
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     let mut meta_block = MetaBlock::new(block.clone(), vec![], MetaBlockState::new());
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
 
@@ -535,12 +535,13 @@ fn acceptor_register_finality_signature() {
 fn acceptor_register_block() {
     let mut rng = TestRng::new();
     // Create a block and an acceptor for it.
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     let mut meta_block = meta_block_with_default_state(block.clone());
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
 
     // Create a finality signature with the wrong block hash.
-    let wrong_block = meta_block_with_default_state(Arc::new(Block::random(&mut rng)));
+    let wrong_block =
+        meta_block_with_default_state(Arc::new(TestBlockBuilder::new().build(&mut rng)));
     assert!(matches!(
         acceptor.register_block(wrong_block, None).unwrap_err(),
         Error::BlockHashMismatch {
@@ -551,7 +552,7 @@ fn acceptor_register_block() {
 
     {
         // Invalid block case.
-        let invalid_block = Arc::new(Block::random_invalid(&mut rng));
+        let invalid_block = Arc::new(TestBlockBuilder::new().build_invalid(&mut rng));
         let mut invalid_block_acceptor = BlockAcceptor::new(*invalid_block.hash(), vec![]);
         let invalid_meta_block = meta_block_with_default_state(invalid_block);
         let malicious_peer = NodeId::random(&mut rng);
@@ -612,7 +613,7 @@ fn acceptor_register_block() {
 fn acceptor_should_store_block() {
     let mut rng = TestRng::new();
     // Create a block and an acceptor for it.
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     let mut meta_block = meta_block_with_default_state(block.clone());
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
 
@@ -746,7 +747,7 @@ fn acceptor_should_correctly_bound_the_signatures() {
     let validator_slots = 2;
 
     // Create a block and an acceptor for it.
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
     let first_peer = NodeId::random(&mut rng);
 
@@ -773,7 +774,7 @@ fn acceptor_signatures_bound_should_not_be_triggered_if_peers_are_different() {
     let validator_slots = 3;
 
     // Create a block and an acceptor for it.
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
     let first_peer = NodeId::random(&mut rng);
     let second_peer = NodeId::random(&mut rng);
@@ -848,8 +849,11 @@ fn accumulator_should_leap() {
 
     // Create an acceptor to change the highest usable block height.
     {
-        let block =
-            Block::random_with_specifics(&mut rng, era_id, 1, ProtocolVersion::V1_0_0, false, None);
+        let block = TestBlockBuilder::new()
+            .era(era_id)
+            .height(1)
+            .switch_block(false)
+            .build(&mut rng);
 
         block_accumulator
             .block_acceptors
@@ -864,14 +868,11 @@ fn accumulator_should_leap() {
     let block_height = attempt_execution_threshold;
     // Insert an acceptor within execution range
     {
-        let block = Block::random_with_specifics(
-            &mut rng,
-            era_id,
-            block_height,
-            ProtocolVersion::V1_0_0,
-            false,
-            None,
-        );
+        let block = TestBlockBuilder::new()
+            .era(era_id)
+            .height(block_height)
+            .switch_block(false)
+            .build(&mut rng);
 
         block_accumulator
             .block_acceptors
@@ -888,14 +889,11 @@ fn accumulator_should_leap() {
     let centurion = 100;
     // Insert an upgrade boundary
     {
-        let block = Block::random_with_specifics(
-            &mut rng,
-            era_id,
-            centurion,
-            ProtocolVersion::new(SemVer::new(1, 1, 0)),
-            true,
-            None,
-        );
+        let block = TestBlockBuilder::new()
+            .era(era_id)
+            .height(centurion)
+            .switch_block(true)
+            .build(&mut rng);
 
         block_accumulator
             .block_acceptors
@@ -1170,14 +1168,15 @@ fn accumulator_purge() {
         .contains_key(&peer_2));
 
     // Create a block just in range of block 3 to not qualify for a purge.
-    let in_range_block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        block_3.era_id(),
-        block_3.height() - block_accumulator.attempt_execution_threshold,
-        block_3.protocol_version(),
-        false,
-        None,
-    ));
+    let in_range_block = Arc::new(
+        TestBlockBuilder::new()
+            .era(block_3.era_id())
+            .height(block_3.height() - block_accumulator.attempt_execution_threshold)
+            .protocol_version(block_3.protocol_version())
+            .switch_block(false)
+            .build(&mut rng),
+    );
+
     let in_range_block_sig = FinalitySignature::create(
         *in_range_block.hash(),
         in_range_block.era_id(),
@@ -1205,14 +1204,14 @@ fn accumulator_purge() {
     }
 
     // Create a block just out of range of block 3 to qualify for a purge.
-    let out_of_range_block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        block_3.era_id(),
-        block_3.height() - block_accumulator.attempt_execution_threshold - 1,
-        block_3.protocol_version(),
-        false,
-        None,
-    ));
+    let out_of_range_block = Arc::new(
+        TestBlockBuilder::new()
+            .era(block_3.era_id())
+            .height(block_3.height() - block_accumulator.attempt_execution_threshold - 1)
+            .protocol_version(block_3.protocol_version())
+            .switch_block(false)
+            .build(&mut rng),
+    );
     let out_of_range_block_sig = FinalitySignature::create(
         *out_of_range_block.hash(),
         out_of_range_block.era_id(),
@@ -1286,14 +1285,14 @@ fn accumulator_purge() {
     }
 
     // Create a future block after block 3.
-    let future_block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        block_3.era_id(),
-        block_3.height() + block_accumulator.attempt_execution_threshold,
-        block_3.protocol_version(),
-        false,
-        None,
-    ));
+    let future_block = Arc::new(
+        TestBlockBuilder::new()
+            .era(block_3.era_id())
+            .height(block_3.height() + block_accumulator.attempt_execution_threshold)
+            .protocol_version(block_3.protocol_version())
+            .switch_block(false)
+            .build(&mut rng),
+    );
     let future_block_sig = FinalitySignature::create(
         *future_block.hash(),
         future_block.era_id(),
@@ -1322,14 +1321,14 @@ fn accumulator_purge() {
 
     // Create a future block after block 3, but which will not have strict
     // finality.
-    let future_unsigned_block = Arc::new(Block::random_with_specifics(
-        &mut rng,
-        block_3.era_id(),
-        block_3.height() + block_accumulator.attempt_execution_threshold * 2,
-        block_3.protocol_version(),
-        false,
-        None,
-    ));
+    let future_unsigned_block = Arc::new(
+        TestBlockBuilder::new()
+            .era(block_3.era_id())
+            .height(block_3.height() + block_accumulator.attempt_execution_threshold * 2)
+            .protocol_version(block_3.protocol_version())
+            .switch_block(false)
+            .build(&mut rng),
+    );
     let future_unsigned_block_sig = FinalitySignature::create(
         *future_unsigned_block.hash(),
         future_unsigned_block.era_id(),
@@ -1417,15 +1416,13 @@ fn generate_next_block(rng: &mut TestRng, block: &Block) -> Block {
     } else {
         block.era_id()
     };
-    Block::random_with_specifics(
-        rng,
-        era_id,
-        // Safe because generated heights can't get to `u64::MAX`.
-        block.height() + 1,
-        block.protocol_version(),
-        false,
-        None,
-    )
+
+    TestBlockBuilder::new()
+        .era(era_id)
+        .height(block.height() + 1)
+        .protocol_version(block.protocol_version())
+        .switch_block(false)
+        .build(rng)
 }
 
 fn generate_non_genesis_block(rng: &mut TestRng) -> Block {
@@ -1433,25 +1430,20 @@ fn generate_non_genesis_block(rng: &mut TestRng) -> Block {
     let height = era * 10 + rng.gen_range(0..10);
     let is_switch = rng.gen_bool(0.1);
 
-    Block::random_with_specifics(
-        rng,
-        EraId::from(era),
-        height,
-        ProtocolVersion::V1_0_0,
-        is_switch,
-        None,
-    )
+    TestBlockBuilder::new()
+        .era(era)
+        .height(height)
+        .switch_block(is_switch)
+        .build(rng)
 }
 
 fn generate_older_block(rng: &mut TestRng, block: &Block, height_difference: u64) -> Block {
-    Block::random_with_specifics(
-        rng,
-        block.era_id().predecessor().unwrap_or_default(),
-        block.height() - height_difference,
-        block.protocol_version(),
-        false,
-        None,
-    )
+    TestBlockBuilder::new()
+        .era(block.era_id().predecessor().unwrap_or_default())
+        .height(block.height() - height_difference)
+        .protocol_version(block.protocol_version())
+        .switch_block(false)
+        .build(rng)
 }
 
 #[tokio::test]
@@ -1785,14 +1777,12 @@ async fn block_accumulator_reactor_flow() {
             .contains_key(older_block.hash()));
     }
 
-    let old_era_block = Block::random_with_specifics(
-        &mut rng,
-        block_1.era_id() - RECENT_ERA_INTERVAL - 1,
-        1,
-        ProtocolVersion::V1_0_0,
-        false,
-        None,
-    );
+    let old_era_block = TestBlockBuilder::new()
+        .era(block_1.era_id() - RECENT_ERA_INTERVAL - 1)
+        .height(1)
+        .switch_block(false)
+        .build(&mut rng);
+
     let old_era_signature = FinalitySignature::create(
         *old_era_block.hash(),
         old_era_block.era_id(),

--- a/node/src/components/block_synchronizer/block_builder/tests.rs
+++ b/node/src/components/block_synchronizer/block_builder/tests.rs
@@ -3,14 +3,17 @@ use std::{collections::BTreeMap, thread, time::Duration};
 use casper_types::testing::TestRng;
 use num_rational::Ratio;
 
-use crate::components::consensus::tests::utils::{ALICE_PUBLIC_KEY, ALICE_SECRET_KEY};
+use crate::{
+    components::consensus::tests::utils::{ALICE_PUBLIC_KEY, ALICE_SECRET_KEY},
+    types::TestBlockBuilder,
+};
 
 use super::*;
 
 #[test]
 fn handle_acceptance() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     let mut builder = BlockBuilder::new(
         *block.hash(),
         false,
@@ -93,7 +96,7 @@ fn handle_acceptance() {
 #[test]
 fn register_era_validator_weights() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     let mut builder = BlockBuilder::new(
         *block.hash(),
         false,
@@ -141,7 +144,7 @@ fn register_era_validator_weights() {
 fn register_finalized_block() {
     let mut rng = TestRng::new();
     // Create a random block.
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     // Create a builder for the block.
     let mut builder = BlockBuilder::new(
         *block.hash(),
@@ -209,7 +212,7 @@ fn register_finalized_block() {
 fn register_block_execution() {
     let mut rng = TestRng::new();
     // Create a random block.
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     // Create a builder for the block.
     let mut builder = BlockBuilder::new(
         *block.hash(),
@@ -286,7 +289,7 @@ fn register_block_execution() {
 fn register_block_executed() {
     let mut rng = TestRng::new();
     // Create a random block.
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     // Create a builder for the block.
     let mut builder = BlockBuilder::new(
         *block.hash(),
@@ -349,7 +352,7 @@ fn register_block_executed() {
 fn register_block_marked_complete() {
     let mut rng = TestRng::new();
     // Create a random block.
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     // Create a builder for the block.
     let mut builder = BlockBuilder::new(
         *block.hash(),

--- a/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
@@ -4,10 +4,9 @@ use assert_matches::assert_matches;
 use rand::Rng;
 
 use casper_storage::global_state::trie::merkle_proof::TrieMerkleProof;
-use casper_types::{
-    testing::TestRng, AccessRights, Block, CLValue, Deploy, EraId, ProtocolVersion, StoredValue,
-    URef,
-};
+use casper_types::{testing::TestRng, AccessRights, CLValue, Deploy, StoredValue, URef};
+
+use crate::types::TestBlockBuilder;
 
 use super::*;
 
@@ -27,16 +26,12 @@ fn gen_approvals_hashes<'a, I: Iterator<Item = &'a Deploy> + Clone>(
     deploys_iter: I,
 ) -> ApprovalsHashes {
     let era = rng.gen_range(0..6);
-    let height = era * 10 + rng.gen_range(0..10);
-    let is_switch = rng.gen_bool(0.1);
-    let block = Block::random_with_specifics(
-        rng,
-        EraId::from(era),
-        height,
-        ProtocolVersion::V1_0_0,
-        is_switch,
-        deploys_iter.clone().map(|deploy| *deploy.hash()),
-    );
+    let block = TestBlockBuilder::new()
+        .era(era)
+        .height(era * 10 + rng.gen_range(0..10))
+        .deploys(deploys_iter.clone())
+        .build(rng);
+
     ApprovalsHashes::new(
         block.hash(),
         deploys_iter

--- a/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
@@ -1,17 +1,20 @@
 use assert_matches::assert_matches;
 use rand::Rng;
 
-use casper_types::{bytesrepr::ToBytes, testing::TestRng, Block};
+use casper_types::{bytesrepr::ToBytes, testing::TestRng};
 
 use super::*;
-use crate::components::block_synchronizer::tests::test_utils::chunks_with_proof_from_data;
+use crate::{
+    components::block_synchronizer::tests::test_utils::chunks_with_proof_from_data,
+    types::TestBlockBuilder,
+};
 
 const NUM_TEST_EXECUTION_RESULTS: u64 = 100000;
 
 #[test]
 fn execution_results_chunks_apply_correctly() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     // Create chunkable execution results
     let exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
@@ -70,7 +73,7 @@ fn single_chunk_execution_results_dont_apply_other_chunks() {
     let first_chunk = test_chunks.first_key_value().unwrap();
 
     let apply_result = apply_chunk(
-        *Block::random(&mut rng).hash(),
+        *TestBlockBuilder::new().build(&mut rng).hash(),
         ExecutionResultsChecksum::Uncheckable,
         test_chunks.clone().into_iter().collect(),
         first_chunk.1.clone(),
@@ -83,7 +86,7 @@ fn single_chunk_execution_results_dont_apply_other_chunks() {
 #[test]
 fn execution_results_chunks_from_block_with_different_hash_are_not_applied() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     let test_chunks = chunks_with_proof_from_data(&[0; ChunkWithProof::CHUNK_SIZE_BYTES * 3]);
 
     // Start acquiring chunks
@@ -104,10 +107,11 @@ fn execution_results_chunks_from_block_with_different_hash_are_not_applied() {
     assert_matches!(acquisition, ExecutionResultsAcquisition::Acquiring { .. });
 
     // Applying execution results from other block should return an error
-    let exec_result = BlockExecutionResultsOrChunkId::new(*Block::random(&mut rng).hash())
-        .response(ValueOrChunk::ChunkWithProof(
-            test_chunks.first_key_value().unwrap().1.clone(),
-        ));
+    let exec_result =
+        BlockExecutionResultsOrChunkId::new(*TestBlockBuilder::new().build(&mut rng).hash())
+            .response(ValueOrChunk::ChunkWithProof(
+                test_chunks.first_key_value().unwrap().1.clone(),
+            ));
     assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, vec![]),
         Err(Error::BlockHashMismatch {expected, .. }) => assert_eq!(expected, *block.hash())
@@ -128,7 +132,7 @@ fn execution_results_chunks_from_trie_with_different_chunk_count_are_not_applied
     let bad_chunk = test_chunks_2.first_key_value().unwrap();
 
     let apply_result = apply_chunk(
-        *Block::random(&mut rng).hash(),
+        *TestBlockBuilder::new().build(&mut rng).hash(),
         ExecutionResultsChecksum::Uncheckable,
         test_chunks_1.into_iter().take(2).collect(),
         bad_chunk.1.clone(),
@@ -141,7 +145,7 @@ fn execution_results_chunks_from_trie_with_different_chunk_count_are_not_applied
 #[test]
 fn invalid_execution_results_from_applied_chunks_dont_deserialize() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     // Create some chunk data that cannot pe serialized into execution results
     let test_chunks = chunks_with_proof_from_data(&[0; ChunkWithProof::CHUNK_SIZE_BYTES * 2]);
@@ -162,7 +166,7 @@ fn invalid_execution_results_from_applied_chunks_dont_deserialize() {
 #[test]
 fn cant_apply_chunk_from_different_exec_results_or_invalid_checksum() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     // Create valid execution results
     let valid_exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
@@ -284,7 +288,7 @@ impl ExecutionResultsAcquisition {
 #[test]
 fn acquisition_needed_state_has_correct_transitions() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     let acquisition = ExecutionResultsAcquisition::new_needed(*block.hash());
 
@@ -314,7 +318,7 @@ fn acquisition_needed_state_has_correct_transitions() {
 #[test]
 fn acquisition_pending_state_has_correct_transitions() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     let acquisition = ExecutionResultsAcquisition::new_pending(
         *block.hash(),
@@ -376,7 +380,7 @@ fn acquisition_pending_state_has_correct_transitions() {
 #[test]
 fn acquisition_acquiring_state_has_correct_transitions() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     // Generate valid execution results that are chunkable
     let exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
@@ -429,7 +433,7 @@ fn acquisition_acquiring_state_has_correct_transitions() {
 #[test]
 fn acquisition_acquiring_state_gets_overridden_by_value() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
     let test_chunks = chunks_with_proof_from_data(&[0; ChunkWithProof::CHUNK_SIZE_BYTES * 3]);
 
     // Start acquiring chunks
@@ -478,7 +482,7 @@ fn acquisition_acquiring_state_gets_overridden_by_value() {
 #[test]
 fn acquisition_complete_state_has_correct_transitions() {
     let mut rng = TestRng::new();
-    let block = Block::random(&mut rng);
+    let block = TestBlockBuilder::new().build(&mut rng);
 
     let acquisition = ExecutionResultsAcquisition::new_complete(
         *block.hash(),

--- a/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
@@ -3,11 +3,12 @@ use std::time::Duration;
 use futures::channel::oneshot;
 use rand::Rng;
 
-use casper_types::{bytesrepr::Bytes, testing::TestRng, Block};
+use casper_types::{bytesrepr::Bytes, testing::TestRng};
 
 use super::*;
 use crate::{
     reactor::{EventQueueHandle, QueueKind, Scheduler},
+    types::TestBlockBuilder,
     utils,
 };
 
@@ -87,7 +88,7 @@ fn random_sync_global_state_request(
     rng: &mut TestRng,
     responder: Responder<Result<Response, Error>>,
 ) -> (SyncGlobalStateRequest, TrieRaw) {
-    let block = Block::random(rng);
+    let block = TestBlockBuilder::new().build(rng);
     let trie = random_test_trie(rng);
 
     // Create a request

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -714,7 +714,7 @@ fn duplicate_register_block_not_allowed_if_builder_is_not_failed() {
     assert!(!block_synchronizer.register_block_by_hash(*block.hash(), false));
 
     // Trying to register a different block should replace the old one
-    let new_block = Block::random(&mut rng);
+    let new_block = TestBlockBuilder::new().build(&mut rng);
     assert!(block_synchronizer.register_block_by_hash(*new_block.hash(), false));
     assert_eq!(
         block_synchronizer.forward.unwrap().block_hash(),
@@ -2141,7 +2141,8 @@ fn builders_are_purged_when_requested() {
     assert!(block_synchronizer.register_block_by_hash(*block.hash(), false));
 
     // Registering block for historical sync
-    assert!(block_synchronizer.register_block_by_hash(*Block::random(&mut rng).hash(), true));
+    assert!(block_synchronizer
+        .register_block_by_hash(*TestBlockBuilder::new().build(&mut rng).hash(), true));
 
     assert!(block_synchronizer.forward.is_some());
     assert!(block_synchronizer.historical.is_some());
@@ -2150,7 +2151,8 @@ fn builders_are_purged_when_requested() {
     assert!(block_synchronizer.forward.is_some());
     assert!(block_synchronizer.historical.is_none());
 
-    assert!(block_synchronizer.register_block_by_hash(*Block::random(&mut rng).hash(), true));
+    assert!(block_synchronizer
+        .register_block_by_hash(*TestBlockBuilder::new().build(&mut rng).hash(), true));
     assert!(block_synchronizer.forward.is_some());
     assert!(block_synchronizer.historical.is_some());
 

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -45,7 +45,7 @@ use crate::{
     protocol::Message,
     reactor::{self, EventQueueHandle, QueueKind, Runner, TryCrankOutcome},
     testing::ConditionCheckReactor,
-    types::NodeId,
+    types::{NodeId, TestBlockBuilder},
     utils::{Loadable, WithDir},
     NodeRng,
 };
@@ -692,7 +692,7 @@ fn inject_balance_check_for_peer(
     rng: &mut TestRng,
     responder: Responder<Result<(), super::Error>>,
 ) -> impl FnOnce(EffectBuilder<Event>) -> Effects<Event> {
-    let block_header = Box::new(Block::random(rng).header().clone());
+    let block_header = Box::new(TestBlockBuilder::new().build(rng).header().clone());
     |effect_builder: EffectBuilder<Event>| {
         let event_metadata = Box::new(EventMetadata::new(deploy, source, Some(responder)));
         effect_builder
@@ -729,7 +729,7 @@ async fn run_deploy_acceptor_without_timeout(
     .await
     .unwrap();
 
-    let block = Arc::new(Block::random(&mut rng));
+    let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
     // Create a channel to assert that the block was successfully injected into storage.
     let (result_sender, result_receiver) = oneshot::channel();
 

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -33,14 +33,14 @@ use warp::{
 };
 
 #[cfg(test)]
-use casper_types::{testing::TestRng, Block};
+use casper_types::testing::TestRng;
 use casper_types::{
     BlockHash, Deploy, DeployHash, EraId, ExecutionEffect, ExecutionResult, FinalitySignature,
     JsonBlock, ProtocolVersion, PublicKey, TimeDiff, Timestamp,
 };
 
 #[cfg(test)]
-use crate::testing;
+use crate::{testing, types::TestBlockBuilder};
 
 /// The URL root path.
 pub const SSE_API_ROOT_PATH: &str = "events";
@@ -147,7 +147,7 @@ impl SseData {
 
     /// Returns a random `SseData::BlockAdded`.
     pub(super) fn random_block_added(rng: &mut TestRng) -> Self {
-        let block = Block::random(rng);
+        let block = TestBlockBuilder::new().build(rng);
         SseData::BlockAdded {
             block_hash: *block.hash(),
             block: Box::new(JsonBlock::new(block, None)),

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -36,7 +36,7 @@ use crate::{
     types::{
         sync_leap_validation_metadata::SyncLeapValidationMetaData, AvailableBlockRange,
         DeployMetadata, DeployMetadataExt, DeployWithFinalizedApprovals, LegacyDeploy,
-        SyncLeapIdentifier,
+        SyncLeapIdentifier, TestBlockBuilder,
     },
     utils::{Loadable, WithDir},
 };
@@ -118,18 +118,14 @@ fn create_sync_leap_test_chain(
             *blocks.get((height - 1) as usize).unwrap().hash()
         };
 
-        let block = Block::random_with_specifics_and_parent_and_validator_weights(
-            &mut harness.rng,
-            era_id,
-            height,
-            chainspec.protocol_version(),
-            parent_hash,
-            if is_switch {
-                Some(trusted_validator_weights.clone())
-            } else {
-                None
-            },
-        );
+        let block = TestBlockBuilder::new()
+            .era(era_id)
+            .height(height)
+            .protocol_version(chainspec.protocol_version())
+            .parent_hash(parent_hash)
+            .validator_weights(trusted_validator_weights.clone())
+            .switch_block(is_switch)
+            .build(&mut harness.rng);
 
         blocks.push(block);
     });
@@ -487,14 +483,14 @@ fn read_block_by_height_with_available_block_range() {
     let mut harness = ComponentHarness::default();
 
     // Create a random block, load and store it.
-    let block_33 = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        33,
-        ProtocolVersion::from_parts(1, 5, 0),
-        true,
-        None,
-    ));
+    let block_33 = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(33)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(true)
+            .build(&mut harness.rng),
+    );
 
     let mut storage = storage_fixture(&harness);
     assert!(get_block_header_at_height(&mut storage, 0, false).is_none());
@@ -513,14 +509,14 @@ fn read_block_by_height_with_available_block_range() {
     );
 
     // Create a random block as a different height, load and store it.
-    let block_14 = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        14,
-        ProtocolVersion::from_parts(1, 5, 0),
-        false,
-        None,
-    ));
+    let block_14 = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(14)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(false)
+            .build(&mut harness.rng),
+    );
 
     let was_new = put_complete_block(&mut harness, &mut storage, block_14.clone());
     assert!(was_new);
@@ -537,30 +533,31 @@ fn can_retrieve_block_by_height() {
     let mut harness = ComponentHarness::default();
 
     // Create some random blocks, load and store them.
-    let block_33 = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        33,
-        ProtocolVersion::from_parts(1, 5, 0),
-        true,
-        None,
-    ));
-    let block_14 = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        14,
-        ProtocolVersion::from_parts(1, 5, 0),
-        false,
-        None,
-    ));
-    let block_99 = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(2),
-        99,
-        ProtocolVersion::from_parts(1, 5, 0),
-        true,
-        None,
-    ));
+    let block_33 = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(33)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(true)
+            .build(&mut harness.rng),
+    );
+    let block_14 = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(14)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(false)
+            .build(&mut harness.rng),
+    );
+
+    let block_99 = Arc::new(
+        TestBlockBuilder::new()
+            .era(2)
+            .height(99)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(true)
+            .build(&mut harness.rng),
+    );
 
     let mut storage = storage_fixture(&harness);
 
@@ -689,22 +686,20 @@ fn different_block_at_height_is_fatal() {
     let mut storage = storage_fixture(&harness);
 
     // Create two different blocks at the same height.
-    let block_44_a = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        44,
-        ProtocolVersion::V1_0_0,
-        false,
-        None,
-    ));
-    let block_44_b = Arc::new(Block::random_with_specifics(
-        &mut harness.rng,
-        EraId::new(1),
-        44,
-        ProtocolVersion::V1_0_0,
-        false,
-        None,
-    ));
+    let block_44_a = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(44)
+            .switch_block(false)
+            .build(&mut harness.rng),
+    );
+    let block_44_b = Arc::new(
+        TestBlockBuilder::new()
+            .era(1)
+            .height(44)
+            .switch_block(false)
+            .build(&mut harness.rng),
+    );
 
     let was_new = put_complete_block(&mut harness, &mut storage, block_44_a.clone());
     assert!(was_new);
@@ -1088,7 +1083,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);
 
-    let block = Block::random(&mut harness.rng);
+    let block = TestBlockBuilder::new().build(&mut harness.rng);
     let block_height = block.height();
 
     // Create some sample data.
@@ -1151,19 +1146,14 @@ fn should_hard_reset() {
     let blocks: Vec<Block> = (0..blocks_count)
         .map(|height| {
             let is_switch = height % blocks_per_era == blocks_per_era - 1;
-            Block::random_with_specifics(
-                &mut harness.rng,
-                EraId::from(height as u64 / 3),
-                height as u64,
-                ProtocolVersion::V1_0_0,
-                is_switch,
-                iter::once(
-                    *random_deploys
-                        .get(height)
-                        .expect("should_have_deploy")
-                        .hash(),
-                ),
-            )
+            TestBlockBuilder::new()
+                .era(height as u64 / 3)
+                .height(height as u64)
+                .switch_block(is_switch)
+                .deploys(iter::once(
+                    random_deploys.get(height).expect("should_have_deploy"),
+                ))
+                .build(&mut harness.rng)
         })
         .collect();
 
@@ -1386,8 +1376,7 @@ fn can_put_and_get_block() {
     let only_from_available_block_range = false;
 
     // Create a random block, store and load it.
-    let block = Block::random(&mut harness.rng);
-    let block = Arc::new(block);
+    let block = Arc::new(TestBlockBuilder::new().build(&mut harness.rng));
 
     let mut storage = storage_fixture(&harness);
 
@@ -1624,17 +1613,16 @@ fn should_restrict_returned_blocks() {
     let mut storage = storage_fixture(&harness);
 
     // Create the following disjoint sequences: 1-2 4-5
-    [1, 2, 4, 5].iter().for_each(|height| {
-        let block = Block::random_with_specifics(
-            &mut harness.rng,
-            EraId::from(1),
-            *height,
-            ProtocolVersion::from_parts(1, 5, 0),
-            false,
-            None,
-        );
+    IntoIterator::into_iter([1, 2, 4, 5]).for_each(|height| {
+        let block = TestBlockBuilder::new()
+            .era(1)
+            .height(height)
+            .protocol_version(ProtocolVersion::from_parts(1, 5, 0))
+            .switch_block(false)
+            .build(&mut harness.rng);
+
         storage.write_block(&block).unwrap();
-        storage.completed_blocks.insert(*height);
+        storage.completed_blocks.insert(height);
     });
 
     // Without restriction, the node should attempt to return any requested block
@@ -1691,7 +1679,7 @@ fn should_get_block_header_by_height() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);
 
-    let block = Block::random(&mut harness.rng);
+    let block = TestBlockBuilder::new().build(&mut harness.rng);
     let expected_header = block.header().clone();
     let height = block.height();
 
@@ -1716,12 +1704,12 @@ fn check_force_resync_with_marker_file() {
     assert!(!force_resync_file_path.exists());
 
     // Add a couple of blocks into storage.
-    let first_block = Block::random(&mut harness.rng);
+    let first_block = TestBlockBuilder::new().build(&mut harness.rng);
     put_complete_block(&mut harness, &mut storage, Arc::new(first_block.clone()));
     let second_block = loop {
         // We need to make sure that the second random block has different height than the first
         // one.
-        let block = Block::random(&mut harness.rng);
+        let block = TestBlockBuilder::new().build(&mut harness.rng);
         if block.height() != first_block.height() {
             break block;
         }

--- a/node/src/components/sync_leaper/leap_activity.rs
+++ b/node/src/components/sync_leaper/leap_activity.rs
@@ -155,25 +155,22 @@ mod tests {
 
     use rand::seq::SliceRandom;
 
-    use casper_types::{testing::TestRng, Block, BlockHash, BlockHeader, ProtocolVersion};
+    use casper_types::{testing::TestRng, Block, BlockHash, BlockHeader};
 
     use crate::{
         components::sync_leaper::{
             leap_activity::LeapActivity, tests::make_test_sync_leap, LeapActivityError, LeapState,
             PeerState,
         },
-        types::{NodeId, SyncLeap, SyncLeapIdentifier},
+        types::{NodeId, SyncLeap, SyncLeapIdentifier, TestBlockBuilder},
     };
 
     fn make_random_block_with_height(rng: &mut TestRng, height: u64) -> Block {
-        Block::random_with_specifics(
-            rng,
-            0.into(),
-            height,
-            ProtocolVersion::default(),
-            false,
-            None,
-        )
+        TestBlockBuilder::new()
+            .era(0)
+            .height(height)
+            .switch_block(false)
+            .build(rng)
     }
 
     fn make_sync_leap_with_trusted_block_header(trusted_block_header: BlockHeader) -> SyncLeap {

--- a/node/src/components/sync_leaper/tests.rs
+++ b/node/src/components/sync_leaper/tests.rs
@@ -2,20 +2,20 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use prometheus::Registry;
 
-use casper_types::{testing::TestRng, Block, BlockHash, Chainspec};
+use casper_types::{testing::TestRng, BlockHash, Chainspec};
 
 use crate::{
     components::{
         fetcher::{self, FetchResult, FetchedData},
         sync_leaper::{LeapState, PeerState, RegisterLeapAttemptOutcome},
     },
-    types::{NodeId, SyncLeap, SyncLeapIdentifier},
+    types::{NodeId, SyncLeap, SyncLeapIdentifier, TestBlockBuilder},
 };
 
 use super::{Error, SyncLeaper};
 
 pub(crate) fn make_test_sync_leap(rng: &mut TestRng) -> SyncLeap {
-    let block = Block::random(rng);
+    let block = TestBlockBuilder::new().build(rng);
     SyncLeap {
         trusted_ancestor_only: false,
         trusted_block_header: block.header().clone(),

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -709,9 +709,12 @@ fn is_timestamp_at_ttl(
 mod tests {
     use std::str::FromStr;
 
-    use casper_types::{testing::TestRng, Block, ProtocolVersion, TimeDiff, Timestamp};
+    use casper_types::{testing::TestRng, TimeDiff, Timestamp};
 
-    use crate::reactor::main_reactor::keep_up::{is_timestamp_at_ttl, synced_to_ttl};
+    use crate::{
+        reactor::main_reactor::keep_up::{is_timestamp_at_ttl, synced_to_ttl},
+        types::TestBlockBuilder,
+    };
 
     const TWO_DAYS_SECS: u32 = 60 * 60 * 24 * 2;
     const MAX_TTL: TimeDiff = TimeDiff::from_seconds(86400);
@@ -772,25 +775,19 @@ mod tests {
 
     #[test]
     fn should_detect_ttl_at_genesis() {
-        let mut rng = TestRng::new();
+        let rng = &mut TestRng::new();
 
-        let latest_switch_block = Block::random_with_specifics(
-            &mut rng,
-            100.into(),
-            1000,
-            ProtocolVersion::default(),
-            true,
-            None,
-        );
+        let latest_switch_block = TestBlockBuilder::new()
+            .era(100)
+            .height(1000)
+            .switch_block(true)
+            .build(rng);
 
-        let latest_orphaned_block = Block::random_with_specifics(
-            &mut rng,
-            0.into(),
-            0,
-            ProtocolVersion::default(),
-            true,
-            None,
-        );
+        let latest_orphaned_block = TestBlockBuilder::new()
+            .era(0)
+            .height(0)
+            .switch_block(true)
+            .build(rng);
 
         assert_eq!(latest_orphaned_block.height(), 0);
         assert_eq!(

--- a/node/src/types/block/meta_block.rs
+++ b/node/src/types/block/meta_block.rs
@@ -76,11 +76,11 @@ impl MetaBlock {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
-
     use rand::Rng;
 
     use casper_types::{testing::TestRng, Deploy};
+
+    use crate::types::TestBlockBuilder;
 
     use super::*;
 
@@ -88,7 +88,7 @@ mod tests {
     fn should_merge_when_same_non_empty_execution_results() {
         let mut rng = TestRng::new();
 
-        let block = Arc::new(Block::random(&mut rng));
+        let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
         let deploy = Deploy::random(&mut rng);
         let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
         let state = State::new_already_stored();
@@ -108,7 +108,7 @@ mod tests {
     fn should_merge_when_both_empty_execution_results() {
         let mut rng = TestRng::new();
 
-        let block = Arc::new(Block::random(&mut rng));
+        let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
         let state = State::new();
 
         let meta_block1 = MetaBlock::new(Arc::clone(&block), vec![], state);
@@ -126,7 +126,7 @@ mod tests {
     fn should_merge_when_one_empty_execution_results() {
         let mut rng = TestRng::new();
 
-        let block = Arc::new(Block::random(&mut rng));
+        let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
         let deploy = Deploy::random(&mut rng);
         let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
         let state = State::new_not_to_be_gossiped();
@@ -144,18 +144,17 @@ mod tests {
 
     #[test]
     fn should_fail_to_merge_different_blocks() {
-        let mut rng = TestRng::new();
+        let rng = &mut TestRng::new();
 
-        let block1 = Arc::new(Block::random(&mut rng));
-        let block2 = Arc::new(Block::random_with_specifics(
-            &mut rng,
-            block1.era_id().successor(),
-            block1.height() + 1,
-            block1.protocol_version(),
-            true,
-            iter::empty(),
-        ));
-        let deploy = Deploy::random(&mut rng);
+        let block1 = Arc::new(TestBlockBuilder::new().build(rng));
+        let block2 = Arc::new(
+            TestBlockBuilder::new()
+                .era(block1.era_id().successor())
+                .height(block1.height() + 1)
+                .switch_block(true)
+                .build(rng),
+        );
+        let deploy = Deploy::random(rng);
         let execution_results = vec![(*deploy.hash(), deploy.take_header(), rng.gen())];
         let state = State::new();
 
@@ -176,7 +175,7 @@ mod tests {
     fn should_fail_to_merge_different_execution_results() {
         let mut rng = TestRng::new();
 
-        let block = Arc::new(Block::random(&mut rng));
+        let block = Arc::new(TestBlockBuilder::new().build(&mut rng));
         let deploy1 = Deploy::random(&mut rng);
         let execution_results1 = vec![(*deploy1.hash(), deploy1.take_header(), rng.gen())];
         let deploy2 = Deploy::random(&mut rng);

--- a/types/src/block/era_end.rs
+++ b/types/src/block/era_end.rs
@@ -139,7 +139,17 @@ mod tests {
     #[test]
     fn bytesrepr_roundtrip() {
         let rng = &mut TestRng::new();
-        let block = Block::random_switch_block(rng);
+        let block = {
+            let mut block = Block::random(rng);
+
+            let next_era_weights = (0..6)
+                .map(|index| (PublicKey::random(rng), U512::from(index)))
+                .collect();
+            block.header.era_end = Some(EraEnd::new(EraReport::random(rng), next_era_weights));
+
+            block
+        };
+
         bytesrepr::test_serialization_roundtrip(block.era_end().unwrap());
     }
 }


### PR DESCRIPTION
Replace all the calls to `Block::random_XXX` with a use of `TestBlockBuilder`.