### PR TITLE
test scenarios for sync to genesis after restart when historical sync is working on blocks from era 0 created pre-1.5

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -218,6 +218,26 @@ function start_upgrade_scenario_13() {
     nctl-exec-upgrade-scenario-13
 }
 
+function start_upgrade_scenario_14() {
+    log "... Setting up custom starting version"
+    local PATH_TO_STAGE
+
+    PATH_TO_STAGE="$(get_path_to_stage 1)"
+
+    log "... downloading remote for 1.4.13"
+    nctl-stage-set-remotes "1.4.13"
+
+    log "... tearing down old stages"
+    nctl-stage-teardown
+
+    log "... creating new stage"
+    dev_branch_settings "$PATH_TO_STAGE" "1.4.13"
+    build_from_settings_file
+
+    log "... Starting Upgrade Scenario 14"
+    nctl-exec-upgrade-scenario-14
+}
+
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -85,6 +85,7 @@ function run_nightly_upgrade_test() {
     bash -c "./ci/nctl_upgrade.sh test_id=11"
     bash -c "./ci/nctl_upgrade.sh test_id=12"
     bash -c "./ci/nctl_upgrade.sh test_id=13"
+    bash -c "./ci/nctl_upgrade.sh test_id=14"
 }
 
 function run_soundness_test() {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2420,7 +2420,7 @@ impl Storage {
         }
     }
 
-    fn get_available_block_range(&self) -> AvailableBlockRange {
+    pub(crate) fn get_available_block_range(&self) -> AvailableBlockRange {
         match self.completed_blocks.highest_sequence() {
             Some(&seq) => seq.into(),
             None => AvailableBlockRange::RANGE_0_0,

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -38,8 +38,8 @@ use crate::{
     },
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        ActivationPoint, BlockHeader, BlockPayload, Chainspec, ChainspecRawBytes, Deploy, ExitCode,
-        NodeRng,
+        ActivationPoint, BlockHash, BlockHeader, BlockPayload, Chainspec, ChainspecRawBytes,
+        Deploy, ExitCode, NodeId, NodeRng,
     },
     utils::{External, Loadable, Source, RESOURCES_PATH},
     WithDir,
@@ -51,6 +51,7 @@ struct TestChain {
     storages: Vec<TempDir>,
     chainspec: Arc<Chainspec>,
     chainspec_raw_bytes: Arc<ChainspecRawBytes>,
+    first_node_port: u16,
 }
 
 type Nodes = testing::network::Nodes<FilterReactor<MainReactor>>;
@@ -133,16 +134,31 @@ impl TestChain {
         chainspec.core_config.auction_delay = 1;
         chainspec.core_config.unbonding_delay = 3;
 
+        let first_node_port = testing::unused_port_on_localhost();
+
         TestChain {
             keys,
             storages: Vec::new(),
             chainspec: Arc::new(chainspec),
             chainspec_raw_bytes: Arc::new(chainspec_raw_bytes),
+            first_node_port,
         }
     }
 
     fn chainspec_mut(&mut self) -> &mut Chainspec {
         Arc::get_mut(&mut self.chainspec).unwrap()
+    }
+
+    fn chainspec(&self) -> Arc<Chainspec> {
+        self.chainspec.clone()
+    }
+
+    fn chainspec_raw_bytes(&self) -> Arc<ChainspecRawBytes> {
+        self.chainspec_raw_bytes.clone()
+    }
+
+    fn first_node_port(&self) -> u16 {
+        self.first_node_port
     }
 
     /// Creates an initializer/validator configuration for the `idx`th validator.
@@ -180,11 +196,10 @@ impl TestChain {
         let root = RESOURCES_PATH.join("local");
 
         let mut network: TestingNetwork<FilterReactor<MainReactor>> = TestingNetwork::new();
-        let first_node_port = testing::unused_port_on_localhost();
 
         for idx in 0..self.keys.len() {
             info!("creating node {}", idx);
-            let cfg = self.create_node_config(idx, first_node_port);
+            let cfg = self.create_node_config(idx, self.first_node_port);
             network
                 .add_node_with_config_and_chainspec(
                     WithDir::new(root.clone(), cfg),
@@ -221,6 +236,21 @@ fn has_completed_era(era_id: EraId) -> impl Fn(&Nodes) -> bool {
                 .unwrap()
                 .last()
                 .map_or(false, |header| header.era_id() == era_id)
+        })
+    }
+}
+
+fn lowest_available_block_height_on_node(height: u64, node_id: NodeId) -> impl Fn(&Nodes) -> bool {
+    move |nodes: &Nodes| {
+        nodes.get(&node_id).map_or(true, |runner| {
+            let storage = runner.main_reactor().storage();
+
+            let available_block_range = storage.get_available_block_range();
+            if available_block_range.low() == 0 && available_block_range.high() == 0 {
+                false
+            } else {
+                available_block_range.low() <= height
+            }
         })
     }
 }
@@ -337,6 +367,113 @@ async fn run_network() {
         &mut rng,
         is_in_era(EraId::from(2)),
         Duration::from_secs(1001),
+    )
+    .await;
+}
+
+fn highest_finalized_block_hash(
+    runner: &Runner<ConditionCheckReactor<FilterReactor<MainReactor>>>,
+) -> Option<BlockHash> {
+    let storage = runner.main_reactor().storage();
+
+    if let Some(highest_block) = storage.read_highest_complete_block().unwrap_or(None) {
+        return Some(*highest_block.hash());
+    } else {
+        None
+    }
+}
+
+#[tokio::test]
+async fn historical_sync_with_era_height_1() {
+    testing::init_logging();
+
+    let mut rng = crate::new_rng();
+
+    // Instantiate a new chain with a fixed size.
+    const NETWORK_SIZE: usize = 5;
+    let mut chain = TestChain::new(&mut rng, NETWORK_SIZE, None);
+    chain.chainspec_mut().core_config.minimum_era_height = 1;
+
+    let mut net = chain
+        .create_initialized_network(&mut rng)
+        .await
+        .expect("network initialization failed");
+
+    // Wait for all nodes to reach era 3.
+    net.settle_on(
+        &mut rng,
+        is_in_era(EraId::from(3)),
+        Duration::from_secs(1000),
+    )
+    .await;
+
+    let (_, first_node) = net
+        .nodes()
+        .iter()
+        .next()
+        .expect("Expected non-empty network");
+
+    // Get a trusted hash
+    let lfb = highest_finalized_block_hash(first_node)
+        .expect("Could not determine the latest finalized block for this network");
+
+    // Create a joiner node
+    let mut config = Config {
+        network: network::Config::default_local_net(chain.first_node_port()),
+        gossip: gossiper::Config::new_with_small_timeouts(),
+        ..Default::default()
+    };
+    let joiner_key = Arc::new(SecretKey::random(&mut rng));
+    let (storage_cfg, temp_dir) = storage::Config::default_for_tests();
+    {
+        let secret_key_path = temp_dir.path().join("secret_key");
+        joiner_key
+            .to_file(secret_key_path.clone())
+            .expect("could not write secret key");
+        config.consensus.secret_key_path = External::Path(secret_key_path);
+    }
+    config.storage = storage_cfg;
+    config.node.trusted_hash = Some(lfb);
+    config.node.sync_to_genesis = true;
+    let root = RESOURCES_PATH.join("local");
+    let cfg = WithDir::new(root.clone(), config);
+
+    let (joiner_id, _) = net
+        .add_node_with_config_and_chainspec(
+            cfg,
+            chain.chainspec(),
+            chain.chainspec_raw_bytes(),
+            &mut rng,
+        )
+        .await
+        .expect("could not add node to reactor");
+
+    // Wait for joiner node to sync back to the block from era 1
+    net.settle_on(
+        &mut rng,
+        lowest_available_block_height_on_node(1, joiner_id),
+        Duration::from_secs(1000),
+    )
+    .await;
+
+    // Remove the weights for era 0 and era 1 from the validator matrix
+    let runner = net
+        .nodes_mut()
+        .get_mut(&joiner_id)
+        .expect("Could not find runner for node {joiner_id}");
+    let reactor = runner.reactor_mut().inner_mut().inner_mut();
+    reactor
+        .validator_matrix
+        .purge_era_validators(&EraId::from(0));
+    reactor
+        .validator_matrix
+        .purge_era_validators(&EraId::from(1));
+
+    // Continue syncing and check if the joiner node reaches era 0
+    net.settle_on(
+        &mut rng,
+        lowest_available_block_height_on_node(0, joiner_id),
+        Duration::from_secs(1000),
     )
     .await;
 }

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -376,7 +376,7 @@ async fn run_network() {
     .await;
 }
 
-fn highest_finalized_block_hash(
+fn highest_complete_block_hash(
     runner: &Runner<ConditionCheckReactor<FilterReactor<MainReactor>>>,
 ) -> Option<BlockHash> {
     let storage = runner.main_reactor().storage();
@@ -419,8 +419,8 @@ async fn historical_sync_with_era_height_1() {
         .expect("Expected non-empty network");
 
     // Get a trusted hash
-    let lfb = highest_finalized_block_hash(first_node)
-        .expect("Could not determine the latest finalized block for this network");
+    let lfb = highest_complete_block_hash(first_node)
+        .expect("Could not determine the latest complete block for this network");
 
     // Create a joiner node
     let mut config = Config {

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -240,7 +240,12 @@ fn has_completed_era(era_id: EraId) -> impl Fn(&Nodes) -> bool {
     }
 }
 
-fn lowest_available_block_height_on_node(height: u64, node_id: NodeId) -> impl Fn(&Nodes) -> bool {
+/// Given a block height and a node id, returns a predicate to check if the lowest available block
+/// for the specified node is at or below the specified height.
+fn node_has_lowest_available_block_at_or_below_height(
+    height: u64,
+    node_id: NodeId,
+) -> impl Fn(&Nodes) -> bool {
     move |nodes: &Nodes| {
         nodes.get(&node_id).map_or(true, |runner| {
             let storage = runner.main_reactor().storage();
@@ -451,7 +456,7 @@ async fn historical_sync_with_era_height_1() {
     // Wait for joiner node to sync back to the block from era 1
     net.settle_on(
         &mut rng,
-        lowest_available_block_height_on_node(1, joiner_id),
+        node_has_lowest_available_block_at_or_below_height(1, joiner_id),
         Duration::from_secs(1000),
     )
     .await;
@@ -472,7 +477,7 @@ async fn historical_sync_with_era_height_1() {
     // Continue syncing and check if the joiner node reaches era 0
     net.settle_on(
         &mut rng,
-        lowest_available_block_height_on_node(0, joiner_id),
+        node_has_lowest_available_block_at_or_below_height(0, joiner_id),
         Duration::from_secs(1000),
     )
     .await;

--- a/node/src/testing/filter_reactor.rs
+++ b/node/src/testing/filter_reactor.rs
@@ -40,6 +40,10 @@ impl<R: Reactor> FilterReactor<R> {
     pub(crate) fn inner(&self) -> &R {
         &self.reactor
     }
+
+    pub(crate) fn inner_mut(&mut self) -> &mut R {
+        &mut self.reactor
+    }
 }
 
 impl<R: Reactor> Reactor for FilterReactor<R> {

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -287,6 +287,11 @@ impl ValidatorMatrix {
     pub(crate) fn eras(&self) -> Vec<EraId> {
         self.read_inner().keys().copied().collect_vec()
     }
+
+    #[cfg(test)]
+    pub(crate) fn purge_era_validators(&mut self, era_id: &EraId) {
+        self.inner.write().unwrap().remove(era_id);
+    }
 }
 
 impl Debug for ValidatorMatrix {

--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -166,3 +166,4 @@ alias nctl-exec-upgrade-scenario-10='source $NCTL/sh/scenarios-upgrades/upgrade_
 alias nctl-exec-upgrade-scenario-11='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_11.sh'
 alias nctl-exec-upgrade-scenario-12='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_12.sh'
 alias nctl-exec-upgrade-scenario-13='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_13.sh'
+alias nctl-exec-upgrade-scenario-14='source $NCTL/sh/scenarios-upgrades/upgrade_scenario_14.sh'

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_14.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_14.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------
+# Synopsis.
+# -----------------------------------------------------------------
+
+# Before 1.5.0 there wasn't an immediate switch block committed at
+# genesis. Because historical sync relies on sync leaps to get the
+# validators for a particular era, we encounter a special case
+# when syncing the blocks of era 0 if they were created before 1.5.0
+# because sync leap will not be able to include a switch block that
+# has the validators for era 0.
+# Since the auction delay is at least 1, we can generally rely on
+# the fact that the validator set for era 1 and era 0 are the same.
+#
+# Test if a node that has synced back to some block in era 0 can
+# continue syncing to genesis after it was restarted (and lost its
+# validator matrix).
+
+# Step 01: Start network from pre-built stage.
+# Step 02: Await era-id >= 2.
+# Step 03: Stage nodes 1-5 and upgrade.
+# Step 04: Assert upgraded nodes 1-5.
+# Step 05: Assert nodes 1-5 didn't stall.
+# Step 06: Await 1 era.
+# Step 07: Start node 6.
+# Step 08: Wait for node 6 to sync back to a block in era 0.
+# Step 09: Stop and restart node 6.
+# Step 10: Wait for node 6 to sync to genesis.
+# Step 11: Start node 7.
+# Step 12: Wait for node 7 to sync back to the first block in era 1.
+# Step 13: Stop and restart node 7.
+# Step 14: Wait for node 7 to sync to genesis.
+# Step 15: Terminate.
+
+# ----------------------------------------------------------------
+# Imports.
+# ----------------------------------------------------------------
+
+source "$NCTL/sh/utils/main.sh"
+source "$NCTL/sh/views/utils.sh"
+source "$NCTL/sh/node/svc_$NCTL_DAEMON_TYPE".sh
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Main entry point.
+function _main()
+{
+    local STAGE_ID=${1}
+    local INITIAL_PROTOCOL_VERSION
+    local ACTIVATION_POINT
+    local UPGRADE_HASH
+
+    if [ ! -d "$(get_path_to_stage "$STAGE_ID")" ]; then
+        log "ERROR :: stage $STAGE_ID has not been built - cannot run scenario"
+        exit 1
+    fi
+
+    _step_01 "$STAGE_ID"
+    _step_02
+
+    # Set initial protocol version for use later.
+    INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
+    # Establish consistent activation point for use later.
+    ACTIVATION_POINT="$(get_chain_era)"
+    # Get minimum era height
+    MIN_ERA_HEIGHT=$(($(grep "minimum_era_height" "$(get_path_to_net)"/chainspec/chainspec.toml | cut -d'=' -f2)))
+
+    _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
+    _step_04 "$INITIAL_PROTOCOL_VERSION"
+    _step_05
+    _step_06
+    _step_07
+    _step_08
+    _step_09
+    _step_10
+    _step_11
+    _step_12
+    _step_13
+    _step_14
+    _step_15
+}
+
+# Step 01: Start network from pre-built stage.
+function _step_01()
+{
+    local STAGE_ID=${1}
+
+    log_step_upgrades 0 "Begin upgrade_scenario_14"
+    log_step_upgrades 1 "starting network from stage ($STAGE_ID)"
+
+    source "$NCTL/sh/assets/setup_from_stage.sh" \
+            stage="$STAGE_ID" \
+    log "... Starting 5 validators"
+    source "$NCTL/sh/node/start.sh" node=all
+}
+
+# Step 02: Await era-id >= 2.
+function _step_02()
+{
+    log_step_upgrades 2 "awaiting until era 2"
+    await_until_era_n 2
+}
+
+# Step 03: Stage nodes 1-6 and upgrade.
+function _step_03()
+{
+    local STAGE_ID=${1}
+    local ACTIVATION_POINT=${2}
+
+    log_step_upgrades 3 "upgrading 1 thru 5 from stage ($STAGE_ID)"
+
+    log "... setting upgrade assets"
+
+    for i in $(seq 1 7); do
+        log "... staging upgrade on validator node-$i"
+        source "$NCTL/sh/assets/upgrade_from_stage_single_node.sh" stage="$STAGE_ID" verbose=false node="$i" era="$ACTIVATION_POINT"
+        echo ""
+    done
+
+    log "... awaiting 2 eras + 1 block"
+    await_n_eras '2' 'true' '5.0' '2'
+    await_n_blocks '1' 'true' '2'
+}
+
+# Step 04: Assert upgraded nodes 1-5.
+function _step_04()
+{
+    local PROTOCOL_VERSION_INITIAL=${1}
+    local NX_PROTOCOL_VERSION
+    local NODE_ID
+
+    log_step_upgrades 4 "Asserting nodes 1 thru 5 upgraded"
+
+    # Assert nodes are running same protocol version.
+    for NODE_ID in $(seq 1 5)
+    do
+        NX_PROTOCOL_VERSION=$(get_node_protocol_version "$NODE_ID")
+        if [ "$NX_PROTOCOL_VERSION" = "$PROTOCOL_VERSION_INITIAL" ]; then
+            log "ERROR :: upgrade failure :: nodes are not all running same protocol version"
+            log "... Node $NODE_ID: $NX_PROTOCOL_VERSION = $PROTOCOL_VERSION_INITIAL"
+            exit 1
+        else
+            log "Node $NODE_ID upgraded successfully: $PROTOCOL_VERSION_INITIAL -> $NX_PROTOCOL_VERSION"
+        fi
+    done
+}
+
+# Step 05: Assert nodes 1-5 didn't stall.
+function _step_05()
+{
+    local HEIGHT_1
+    local HEIGHT_2
+    local NODE_ID
+
+    log_step_upgrades 5 "Asserting nodes 1 thru 5 didn't stall"
+
+    HEIGHT_1=$(get_chain_height 2)
+    await_n_blocks '5' 'true' '2'
+    for NODE_ID in $(seq 1 5)
+    do
+        HEIGHT_2=$(get_chain_height "$NODE_ID")
+        if [ "$HEIGHT_2" != "N/A" ] && [ "$HEIGHT_2" -le "$HEIGHT_1" ]; then
+            log "ERROR :: upgrade failure :: node-$NODE_ID has stalled"
+            log " ... node-$NODE_ID : $HEIGHT_2 <= $HEIGHT_1"
+            exit 1
+        else
+            log " ... no stall detected on node-$NODE_ID: $HEIGHT_2 > $HEIGHT_1 [expected]"
+        fi
+    done
+}
+
+# Step 06: Await 1 era.
+function _step_06()
+{
+    log_step_upgrades 6 "awaiting 1 era"
+    await_n_eras '1' 'true' '5.0' '2'
+}
+
+function start_node_with_latest_trusted_hash()
+{
+    local NODE_ID=${1}
+
+    local LFB_HASH=$(render_last_finalized_block_hash "1" | cut -f2 -d= | cut -f2 -d ' ')
+    do_start_node "$NODE_ID" "$LFB_HASH"
+}
+
+function wait_historical_sync_to_height()
+{
+    local NODE_ID=${1}
+    local HEIGHT=${2}
+
+    local LOW=$(get_node_lowest_available_block "$NODE_ID")
+    local HIGH=$(get_node_highest_available_block "$NODE_ID")
+
+    # First wait for node to start syncing
+    while [ -z $HIGH ] || [ -z $LOW ] || [[ $HIGH -eq $LOW ]] || [[ $HIGH -eq 0 ]] || [[ $LOW -eq 0 ]]; do
+        sleep 0.2
+        LOW=$(get_node_lowest_available_block "$NODE_ID")
+        HIGH=$(get_node_highest_available_block "$NODE_ID")
+    done
+
+    while [ -z $LOW ] || [[ $LOW -gt $HEIGHT ]]; do
+        sleep 0.2
+        LOW=$(get_node_lowest_available_block "$NODE_ID")
+    done
+}
+
+# Step 07: Start node 6.
+function _step_07()
+{
+    log_step_upgrades 7 "starting node 6"
+    start_node_with_latest_trusted_hash "6"
+}
+
+# Step 08: Wait for node 6 to sync back to a block in era 0.
+function _step_08()
+{
+    log_step_upgrades 8 "Wait for node 6 to sync back to a block in era 0"
+
+    wait_historical_sync_to_height "6" "$(($MIN_ERA_HEIGHT-1))"
+}
+
+# Step 09: Stop and restart node 6.
+function _step_09()
+{
+    log_step_upgrades 9 "Stopping and re-starting node 6"
+
+    do_stop_node "6"
+    sleep 2
+    start_node_with_latest_trusted_hash "6"
+}
+
+# Step 10: Wait for node 6 to sync to genesis.
+function _step_10()
+{
+    log_step_upgrades 10 "Waiting for node 6 to sync to genesis"
+    await_node_historical_sync_to_genesis '6' '60'
+}
+
+# Step 11: Start node 7.
+function _step_11()
+{
+    log_step_upgrades 11 "starting node 7"
+    start_node_with_latest_trusted_hash "7"
+}
+
+# Step 12: Wait for node 7 to sync back to the first block in era 1.
+function _step_12()
+{
+    log_step_upgrades 12 "Wait for node 7 to sync back to the first block in era 1"
+
+    wait_historical_sync_to_height "7" "$(($MIN_ERA_HEIGHT+1))"
+}
+
+# Step 13: Stop and restart node 7.
+function _step_13()
+{
+    log_step_upgrades 13 "Stopping and re-starting node 7"
+
+    do_stop_node "7"
+    sleep 2
+    start_node_with_latest_trusted_hash "7"
+}
+
+# Step 14: Wait for node 7 to sync to genesis.
+function _step_14()
+{
+    log_step_upgrades 14 "Waiting for node 7 to sync to genesis"
+    await_node_historical_sync_to_genesis '7' '60'
+}
+
+# Step 15: Terminate.
+function _step_15()
+{
+    log_step_upgrades 15 "upgrade_scenario_14 successful - tidying up"
+
+    source "$NCTL/sh/assets/teardown.sh"
+
+    log_break
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset _STAGE_ID
+unset INITIAL_PROTOCOL_VERSION
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        stage) _STAGE_ID=${VALUE} ;;
+        *)
+    esac
+done
+
+_main "${_STAGE_ID:-1}"

--- a/utils/nctl/sh/utils/blocking.sh
+++ b/utils/nctl/sh/utils/blocking.sh
@@ -175,13 +175,13 @@ function await_node_historical_sync_to_genesis() {
     local WAIT_TIME_SEC=0
     local LOWEST=$(get_node_lowest_available_block "$NODE_ID")
     local HIGHEST=$(get_node_highest_available_block "$NODE_ID")
-    while [ -z $HIGHEST ] || [ -z $LOWEST ] || [ $LOWEST -ne 0 ] || [ $HIGHEST -eq 0 ]; do
+    while [ -z $HIGHEST ] || [ -z $LOWEST ] || [[ $LOWEST -ne 0 ]] || [[ $HIGHEST -eq 0 ]]; do
         log "node $NODE_ID lowest available block: $LOWEST, highest available block: $HIGHEST"
         if [ $WAIT_TIME_SEC -gt $SYNC_TIMEOUT_SEC ]; then
             log "ERROR: node 1 failed to do historical sync in ${SYNC_TIMEOUT_SEC} seconds"
             exit 1
         fi
-        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
+        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 5))
         sleep 5.0
         LOWEST=$(get_node_lowest_available_block "$NODE_ID")
         HIGHEST="$(get_node_highest_available_block "$NODE_ID")"


### PR DESCRIPTION
Before 1.5.0 there wasn't an immediate switch block committed at genesis.
Because historical sync relies on sync leaps to get the validators for a particular era, we encounter a special case when syncing the blocks of era 0 if they were created before 1.5.0 because sync leap will not be able to include a switch block that has the validators for era 0.
Since the auction delay is at least 1, we can generally rely on the fact that the validator set for era 1 and era 0 are the same.

Test if a node that has synced back to some block in era 0 can continue syncing to genesis after it was restarted (and lost its validator matrix).

Addresses: https://github.com/casper-network/casper-node/issues/4077