### PR TITLE
no ticket - Fix node changelog

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,17 +11,21 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## 1.5.2
-
-### Added
-* Added the `cors_origin` config option under the `[rest_server]`, `[rpc_server]`, `[event_stream_server]` and `[speculative_exec_server]` sections to allow configuration of the CORS Origin.
-
+## Unreleased
 
 ### Fixed
 * Now possible to build outside a git repository context (e.g. from a source tarball). In such cases, the node's build version (as reported vie status endpoints) will not contain a trailing git short hash.
 
 ### Changed
 * The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest complete block known to the node will be used to fulfill the request.
+
+
+
+## 1.5.2
+
+### Added
+* Added the `cors_origin` config option under the `[rest_server]`, `[rpc_server]`, `[event_stream_server]` and `[speculative_exec_server]` sections to allow configuration of the CORS Origin.
+
 
 
 ## 1.5.1


### PR DESCRIPTION
This PR fixes the `casper-node` changelog, which was broken when merging `release-1.5.2` back to `dev`.