### PR TITLE
node/KeepUp: don't check TTL synced if node is not synced back past start of active era

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2409,6 +2409,11 @@ impl Storage {
         Ok(FetchResponse::NotFound(sync_leap_identifier))
     }
 
+    /// Checks if a block at the specified `block_height` is marked complete in storage.
+    pub(crate) fn block_at_height_is_complete(&self, block_height: u64) -> bool {
+        self.get_available_block_range().contains(block_height)
+    }
+
     /// Creates a serialized representation of a `FetchResponse` and the resulting message.
     ///
     /// If the given item is `Some`, returns a serialization of `FetchResponse::Fetched`. If

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -651,14 +651,6 @@ impl MainReactor {
             .map_err(|err| err.to_string())?
             .last()
         {
-            // It is possible that if a node just caught up, its highest orphaned block
-            // is within the current active era. We need to let the node sync back past the
-            // start of the active era and only after that we can determine if it is synced
-            // to TTL.
-            if highest_switch_block_header.era_id() < highest_orphaned_block_header.era_id() {
-                return Ok(None);
-            }
-
             let max_ttl: MaxTtl = self.chainspec.deploy_config.max_ttl.into();
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -651,6 +651,14 @@ impl MainReactor {
             .map_err(|err| err.to_string())?
             .last()
         {
+            // It is possible that if a node just caught up, its highest orphaned block
+            // is within the current active era. We need to let the node sync back past the
+            // start of the active era and only after that we can determine if it is synced
+            // to TTL.
+            if highest_switch_block_header.era_id() < highest_orphaned_block_header.era_id() {
+                return Ok(None);
+            }
+
             let max_ttl: MaxTtl = self.chainspec.deploy_config.max_ttl.into();
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -151,6 +151,17 @@ impl MainReactor {
             self.storage.get_highest_orphaned_block_header()
         {
             let max_ttl: MaxTtl = self.chainspec.deploy_config.max_ttl.into();
+            if !self
+                .storage
+                .block_at_height_is_complete(highest_switch_block_header.height())
+            {
+                info!(
+                    "{}: cannot determine TTL awareness to safely participate in consensus; highest switch block is not complete",
+                    self.state
+                );
+                return Ok(None);
+            }
+
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),
                 &highest_orphaned_block_header,

--- a/node/src/types/max_ttl.rs
+++ b/node/src/types/max_ttl.rs
@@ -29,22 +29,14 @@ impl MaxTtl {
     /// Determine if orphaned block header is older than ttl requires.
     pub fn synced_to_ttl(
         &self,
-        latest_switch_block_timestamp: Timestamp,
+        latest_complete_switch_block_timestamp: Timestamp,
         highest_orphaned_block_header: &BlockHeader,
     ) -> Result<bool, String> {
         if highest_orphaned_block_header.is_genesis() {
             Ok(true)
         } else {
-            // It is possible that if a node just caught up, its highest orphaned block
-            // is within the current active era. We need to let the node sync back past the
-            // start of the active era and only after that we can determine if it is synced
-            // to TTL.
-            if latest_switch_block_timestamp < highest_orphaned_block_header.timestamp() {
-                return Ok(false);
-            }
-
             self.ttl_elapsed(
-                latest_switch_block_timestamp,
+                latest_complete_switch_block_timestamp,
                 highest_orphaned_block_header.timestamp(),
             )
         }

--- a/node/src/types/max_ttl.rs
+++ b/node/src/types/max_ttl.rs
@@ -35,6 +35,14 @@ impl MaxTtl {
         if highest_orphaned_block_header.is_genesis() {
             Ok(true)
         } else {
+            // It is possible that if a node just caught up, its highest orphaned block
+            // is within the current active era. We need to let the node sync back past the
+            // start of the active era and only after that we can determine if it is synced
+            // to TTL.
+            if latest_switch_block_timestamp < highest_orphaned_block_header.timestamp() {
+                return Ok(false);
+            }
+
             self.ttl_elapsed(
                 latest_switch_block_timestamp,
                 highest_orphaned_block_header.timestamp(),


### PR DESCRIPTION
It is possible that if a node just caught up, its highest orphaned block is within the current active era. We need to let the node sync back past the start of the active era and only after that we can determine if it is synced to TTL.

Fixes: https://github.com/casper-network/casper-node/issues/4160
