### PR TITLE
node/max_ttl: remove error for timestamp chronology

### DIFF
--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -655,7 +655,7 @@ impl MainReactor {
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),
                 highest_orphaned_block_header,
-            )? {
+            ) {
                 return Ok(Some(SyncBackInstruction::TtlSynced));
             }
         }

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -154,7 +154,7 @@ impl MainReactor {
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),
                 &highest_orphaned_block_header,
-            )? {
+            ) {
                 debug!(%self.state,"{}: sufficient deploy TTL awareness to safely participate in consensus", self.state);
             } else {
                 info!(

--- a/node/src/types/max_ttl.rs
+++ b/node/src/types/max_ttl.rs
@@ -147,11 +147,10 @@ mod tests {
             }
             (timestamp, block.header().clone())
         };
-        let synced = max_ttl
-            .synced_to_ttl(
-                latest_switch_block_timestamp,
-                &highest_orphaned_block_header,
-            );
+        let synced = max_ttl.synced_to_ttl(
+            latest_switch_block_timestamp,
+            &highest_orphaned_block_header,
+        );
         assert_eq!(synced, ttl_synced_expected, "{}", msg);
     }
 

--- a/node/src/types/max_ttl.rs
+++ b/node/src/types/max_ttl.rs
@@ -18,12 +18,8 @@ impl MaxTtl {
     }
 
     /// Determine if two timestamps are more than max_ttl apart.
-    pub fn ttl_elapsed(&self, higher: Timestamp, lower: Timestamp) -> Result<bool, String> {
-        if lower > higher {
-            Err("invalid timestamp chronology".to_string())
-        } else {
-            Ok(lower < higher.saturating_sub(self.0))
-        }
+    pub fn ttl_elapsed(&self, higher: Timestamp, lower: Timestamp) -> bool {
+        lower < higher.saturating_sub(self.0)
     }
 
     /// Determine if orphaned block header is older than ttl requires.
@@ -31,9 +27,9 @@ impl MaxTtl {
         &self,
         latest_switch_block_timestamp: Timestamp,
         highest_orphaned_block_header: &BlockHeader,
-    ) -> Result<bool, String> {
+    ) -> bool {
         if highest_orphaned_block_header.is_genesis() {
-            Ok(true)
+            true
         } else {
             self.ttl_elapsed(
                 latest_switch_block_timestamp,
@@ -67,9 +63,7 @@ mod tests {
         msg: &str,
     ) {
         let max_ttl: MaxTtl = max_ttl.into();
-        let elapsed = max_ttl
-            .ttl_elapsed(higher, lower)
-            .expect("should not error");
+        let elapsed = max_ttl.ttl_elapsed(higher, lower);
         assert_eq!(elapsed, elapsed_expected, "{}", msg);
     }
 
@@ -120,17 +114,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn should_err() {
-        let higher = Timestamp::now();
-        let lower = higher.saturating_sub(SUB_MAX_TTL);
-        let max_ttl: MaxTtl = MAX_TTL.into();
-        assert!(
-            max_ttl.ttl_elapsed(lower, higher).is_err(),
-            "should have errored because timestamps are chronologically reversed (programmer error)"
-        );
-    }
-
     fn assert_sync_to_ttl(is_genesis: bool, ttl_synced_expected: bool, msg: &str) {
         let max_ttl: MaxTtl = MAX_TTL.into();
         let mut rng = TestRng::new();
@@ -168,8 +151,7 @@ mod tests {
             .synced_to_ttl(
                 latest_switch_block_timestamp,
                 &highest_orphaned_block_header,
-            )
-            .expect("should not error");
+            );
         assert_eq!(synced, ttl_synced_expected, "{}", msg);
     }
 

--- a/node/src/types/max_ttl.rs
+++ b/node/src/types/max_ttl.rs
@@ -17,9 +17,9 @@ impl MaxTtl {
         self.0
     }
 
-    /// Determine if two timestamps are more than max_ttl apart.
-    pub fn ttl_elapsed(&self, higher: Timestamp, lower: Timestamp) -> bool {
-        lower < higher.saturating_sub(self.0)
+    /// If rearview is earlier than (vantage - ttl duration), ttl has elapsed.
+    pub fn ttl_elapsed(&self, vantage: Timestamp, rearview: Timestamp) -> bool {
+        rearview < vantage.saturating_sub(self.0)
     }
 
     /// Determine if orphaned block header is older than ttl requires.


### PR DESCRIPTION
It is possible that if a node just caught up, its highest orphaned block is within the current active era.
Right now the node errors because the `latest_switch_block_timestamp` is lower than the `highest_orphaned_block_timestamp` but this is not necessary.

Fixes: https://github.com/casper-network/casper-node/issues/4160
