### PR TITLE
Attempt to fix block synchronizer request storm by tweaking the latching.

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -807,7 +807,11 @@ impl BlockSynchronizer {
         };
 
         let validator_matrix = &self.validator_matrix.clone();
-        if let Some(builder) = self.get_builder(block_hash, true) {
+        if let Some(builder) = self.get_builder(block_hash, false) {
+            if builder.waiting_for_block_header() {
+                builder.latch_decrement();
+            }
+
             match maybe_block_header {
                 None => {
                     if let Some(peer_id) = maybe_peer_id {
@@ -851,7 +855,11 @@ impl BlockSynchronizer {
             }
         };
 
-        if let Some(builder) = self.get_builder(block_hash, true) {
+        if let Some(builder) = self.get_builder(block_hash, false) {
+            if builder.waiting_for_block() {
+                builder.latch_decrement();
+            }
+
             match maybe_block {
                 None => {
                     if let Some(peer_id) = maybe_peer_id {
@@ -895,7 +903,11 @@ impl BlockSynchronizer {
             }
         };
 
-        if let Some(builder) = self.get_builder(block_hash, true) {
+        if let Some(builder) = self.get_builder(block_hash, false) {
+            if builder.waiting_for_approvals_hashes() {
+                builder.latch_decrement();
+            }
+
             match maybe_approvals_hashes {
                 None => {
                     if let Some(peer_id) = maybe_peer_id {
@@ -936,7 +948,11 @@ impl BlockSynchronizer {
             }
         };
 
-        if let Some(builder) = self.get_builder(id.block_hash, true) {
+        if let Some(builder) = self.get_builder(id.block_hash, false) {
+            if builder.waiting_for_signatures() {
+                builder.latch_decrement();
+            }
+
             match maybe_finality_signature {
                 None => {
                     if let Some(peer_id) = maybe_peer_id {
@@ -1198,7 +1214,11 @@ impl BlockSynchronizer {
             FetchedData::FromStorage { item } => (item, None),
         };
 
-        if let Some(builder) = self.get_builder(block_hash, true) {
+        if let Some(builder) = self.get_builder(block_hash, false) {
+            if builder.waiting_for_deploys() {
+                builder.latch_decrement();
+            }
+
             if let Err(error) = builder.register_deploy(deploy.fetch_id(), maybe_peer) {
                 error!(%block_hash, %error, "BlockSynchronizer: failed to apply deploy");
             }

--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -668,6 +668,53 @@ impl BlockAcquisitionState {
         };
     }
 
+    pub(super) fn actively_acquiring_signatures(&self, is_historical: bool) -> bool {
+        match self {
+            BlockAcquisitionState::HaveBlockHeader(..) => true,
+            BlockAcquisitionState::Initialized(..)
+            | BlockAcquisitionState::HaveWeakFinalitySignatures(..)
+            | BlockAcquisitionState::HaveStrictFinalitySignatures(..)
+            | BlockAcquisitionState::HaveFinalizedBlock(..)
+            | BlockAcquisitionState::Failed(..)
+            | BlockAcquisitionState::Complete(..) => false,
+            BlockAcquisitionState::HaveBlock(_, acquired_signatures, acquired_deploys) => {
+                !is_historical
+                    && acquired_deploys.needs_deploy().is_none()
+                    && acquired_signatures.signature_weight() != SignatureWeight::Strict
+            }
+            BlockAcquisitionState::HaveGlobalState(
+                _,
+                acquired_signatures,
+                acquired_deploys,
+                ..,
+            ) => {
+                acquired_deploys.needs_deploy().is_none()
+                    && acquired_signatures.signature_weight() != SignatureWeight::Strict
+            }
+            BlockAcquisitionState::HaveApprovalsHashes(
+                _,
+                acquired_signatures,
+                acquired_deploys,
+            ) => {
+                acquired_deploys.needs_deploy().is_none()
+                    && acquired_signatures.signature_weight() != SignatureWeight::Strict
+            }
+            BlockAcquisitionState::HaveAllExecutionResults(
+                _,
+                acquired_signatures,
+                acquired_deploys,
+                ..,
+            ) => {
+                acquired_signatures.is_legacy()
+                    && acquired_deploys.needs_deploy().is_none()
+                    && acquired_signatures.signature_weight() != SignatureWeight::Strict
+            }
+            BlockAcquisitionState::HaveAllDeploys(_, acquired_signatures) => {
+                acquired_signatures.signature_weight() != SignatureWeight::Strict
+            }
+        }
+    }
+
     /// Register a finality signature for this block.
     pub(super) fn register_finality_signature(
         &mut self,
@@ -682,7 +729,7 @@ impl BlockAcquisitionState {
         let signer = signature.public_key.clone();
         let acceptance: Acceptance;
         let maybe_block_hash: Option<BlockHash>;
-        let currently_acquiring_sigs: bool;
+        let currently_acquiring_sigs = self.actively_acquiring_signatures(is_historical);
         let maybe_new_state: Option<BlockAcquisitionState> = match self {
             BlockAcquisitionState::HaveBlockHeader(header, acquired_signatures) => {
                 // we are attempting to acquire at least ~1/3 signature weight before
@@ -692,7 +739,6 @@ impl BlockAcquisitionState {
                 // signature.
                 maybe_block_hash = Some(header.block_hash());
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
-                currently_acquiring_sigs = true;
                 if acquired_signatures.has_sufficient_finality(is_historical, false) {
                     Some(BlockAcquisitionState::HaveWeakFinalitySignatures(
                         header.clone(),
@@ -704,9 +750,6 @@ impl BlockAcquisitionState {
             }
             BlockAcquisitionState::HaveBlock(block, acquired_signatures, acquired_deploys) => {
                 maybe_block_hash = Some(*block.hash());
-                currently_acquiring_sigs = !is_historical
-                    && acquired_deploys.needs_deploy().is_none()
-                    && acquired_signatures.signature_weight() != SignatureWeight::Strict;
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 if !is_historical
                     && acquired_deploys.needs_deploy().is_none()
@@ -730,8 +773,6 @@ impl BlockAcquisitionState {
                 ..,
             ) => {
                 maybe_block_hash = Some(*block.hash());
-                currently_acquiring_sigs = acquired_deploys.needs_deploy().is_none()
-                    && acquired_signatures.signature_weight() != SignatureWeight::Strict;
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 if acquired_deploys.needs_deploy().is_none()
                     && acquired_signatures.has_sufficient_finality(is_historical, true)
@@ -744,14 +785,8 @@ impl BlockAcquisitionState {
                     None
                 }
             }
-            BlockAcquisitionState::HaveApprovalsHashes(
-                block,
-                acquired_signatures,
-                acquired_deploys,
-            ) => {
+            BlockAcquisitionState::HaveApprovalsHashes(block, acquired_signatures, ..) => {
                 maybe_block_hash = Some(*block.hash());
-                currently_acquiring_sigs = acquired_deploys.needs_deploy().is_none()
-                    && acquired_signatures.signature_weight() != SignatureWeight::Strict;
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 None
             }
@@ -762,9 +797,6 @@ impl BlockAcquisitionState {
                 ..,
             ) => {
                 maybe_block_hash = Some(*block.hash());
-                currently_acquiring_sigs = acquired_signatures.is_legacy()
-                    && acquired_deploys.needs_deploy().is_none()
-                    && acquired_signatures.signature_weight() != SignatureWeight::Strict;
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 if acquired_signatures.is_legacy()
                     && acquired_deploys.needs_deploy().is_none()
@@ -780,8 +812,6 @@ impl BlockAcquisitionState {
             }
             BlockAcquisitionState::HaveAllDeploys(block, acquired_signatures) => {
                 maybe_block_hash = Some(*block.hash());
-                currently_acquiring_sigs =
-                    acquired_signatures.signature_weight() != SignatureWeight::Strict;
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
                 if acquired_signatures.has_sufficient_finality(is_historical, true) {
                     Some(BlockAcquisitionState::HaveStrictFinalitySignatures(
@@ -795,7 +825,6 @@ impl BlockAcquisitionState {
             BlockAcquisitionState::HaveStrictFinalitySignatures(block, acquired_signatures) => {
                 maybe_block_hash = Some(*block.hash());
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
-                currently_acquiring_sigs = false;
                 None
             }
             BlockAcquisitionState::HaveWeakFinalitySignatures(header, acquired_signatures) => {
@@ -805,7 +834,6 @@ impl BlockAcquisitionState {
                 // will accept late comers while resting in this state
                 maybe_block_hash = Some(header.block_hash());
                 acceptance = acquired_signatures.apply_signature(signature, validator_weights);
-                currently_acquiring_sigs = false;
                 None
             }
             BlockAcquisitionState::Initialized(..)

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -483,13 +483,15 @@ impl BlockBuilder {
         block_header: BlockHeader,
         maybe_peer: Option<NodeId>,
     ) -> Result<(), Error> {
+        let was_waiting_for_block_header = self.waiting_for_block_header();
+
         let era_id = block_header.era_id();
         let acceptance = self.acquisition_state.register_block_header(
             block_header,
             self.strict_finality_protocol_version,
             self.should_fetch_execution_state,
         );
-        self.handle_acceptance(maybe_peer, acceptance)?;
+        self.handle_acceptance(maybe_peer, acceptance, was_waiting_for_block_header)?;
         self.era_id = Some(era_id);
         Ok(())
     }
@@ -516,10 +518,11 @@ impl BlockBuilder {
         block: &Block,
         maybe_peer: Option<NodeId>,
     ) -> Result<(), Error> {
+        let was_waiting_for_block = self.waiting_for_block();
         let acceptance = self
             .acquisition_state
             .register_block(block, self.should_fetch_execution_state);
-        self.handle_acceptance(maybe_peer, acceptance)
+        self.handle_acceptance(maybe_peer, acceptance, was_waiting_for_block)
     }
 
     pub(super) fn waiting_for_approvals_hashes(&self) -> bool {
@@ -550,10 +553,11 @@ impl BlockBuilder {
         approvals_hashes: &ApprovalsHashes,
         maybe_peer: Option<NodeId>,
     ) -> Result<(), Error> {
+        let was_waiting_for_approvals_hashes = self.waiting_for_approvals_hashes();
         let acceptance = self
             .acquisition_state
             .register_approvals_hashes(approvals_hashes, self.should_fetch_execution_state);
-        self.handle_acceptance(maybe_peer, acceptance)
+        self.handle_acceptance(maybe_peer, acceptance, was_waiting_for_approvals_hashes)
     }
 
     pub(super) fn register_finality_signature_pending(&mut self, validator: PublicKey) {
@@ -590,6 +594,7 @@ impl BlockBuilder {
         finality_signature: FinalitySignature,
         maybe_peer: Option<NodeId>,
     ) -> Result<(), Error> {
+        let was_waiting_for_sigs = self.waiting_for_signatures();
         let validator_weights = self
             .validator_weights
             .as_ref()
@@ -599,7 +604,7 @@ impl BlockBuilder {
             validator_weights,
             self.should_fetch_execution_state,
         );
-        self.handle_acceptance(maybe_peer, acceptance)
+        self.handle_acceptance(maybe_peer, acceptance, was_waiting_for_sigs)
     }
 
     pub(super) fn register_global_state(&mut self, global_state: Digest) -> Result<(), Error> {
@@ -629,12 +634,31 @@ impl BlockBuilder {
         Ok(())
     }
 
+    pub(super) fn waiting_for_execution_results(&self) -> bool {
+        match &self.acquisition_state {
+            BlockAcquisitionState::HaveGlobalState(..) if self.should_fetch_execution_state => true,
+            BlockAcquisitionState::HaveAllDeploys(..)
+            | BlockAcquisitionState::HaveGlobalState(..)
+            | BlockAcquisitionState::HaveBlock(..)
+            | BlockAcquisitionState::Initialized(..)
+            | BlockAcquisitionState::HaveBlockHeader(..)
+            | BlockAcquisitionState::HaveWeakFinalitySignatures(..)
+            | BlockAcquisitionState::HaveAllExecutionResults(..)
+            | BlockAcquisitionState::HaveStrictFinalitySignatures(..)
+            | BlockAcquisitionState::HaveApprovalsHashes(..)
+            | BlockAcquisitionState::HaveFinalizedBlock(..)
+            | BlockAcquisitionState::Failed(..)
+            | BlockAcquisitionState::Complete(..) => false,
+        }
+    }
+
     pub(super) fn register_fetched_execution_results(
         &mut self,
         maybe_peer: Option<NodeId>,
         block_execution_results_or_chunk: BlockExecutionResultsOrChunk,
     ) -> Result<Option<HashMap<DeployHash, casper_types::ExecutionResult>>, Error> {
         debug!(block_hash=%self.block_hash, "register_fetched_execution_results");
+        let was_waiting_for_execution_results = self.waiting_for_execution_results();
         match self.acquisition_state.register_execution_results_or_chunk(
             block_execution_results_or_chunk,
             self.should_fetch_execution_state,
@@ -647,7 +671,11 @@ impl BlockBuilder {
                     ?acceptance,
                     "register_fetched_execution_results: Ok(RegisterExecResultsOutcome)"
                 );
-                self.handle_acceptance(maybe_peer, Ok(acceptance))?;
+                self.handle_acceptance(
+                    maybe_peer,
+                    Ok(acceptance),
+                    was_waiting_for_execution_results,
+                )?;
                 Ok(exec_results)
             }
             Err(BlockAcquisitionError::ExecutionResults(error)) => {
@@ -663,6 +691,9 @@ impl BlockBuilder {
                     | execution_results_acquisition::Error::AttemptToApplyDataWhenMissingChecksum { .. }
                     | execution_results_acquisition::Error::InvalidOutcomeFromApplyingChunk { .. }
                     => {
+                        if was_waiting_for_execution_results {
+                            self.latch_decrement();
+                        }
                         debug!(
                             "register_fetched_execution_results: BlockHashMismatch | \
                             InvalidAttemptToApplyChecksum | AttemptToApplyDataWhenMissingChecksum \
@@ -686,6 +717,9 @@ impl BlockBuilder {
                                 self.disqualify_peer(peer);
                             }
                         }
+                        if was_waiting_for_execution_results {
+                            self.latch_decrement();
+                        }
                     }
                     // malicious peer
                     execution_results_acquisition::Error::InvalidChunkCount { .. }
@@ -696,10 +730,16 @@ impl BlockBuilder {
                         if let Some(peer) = maybe_peer {
                             self.disqualify_peer(peer);
                         }
+                        if was_waiting_for_execution_results {
+                            self.latch_decrement();
+                        }
                     }
                     // checksum unavailable, so unknown if this peer is malicious
                     execution_results_acquisition::Error::ChunksWithDifferentChecksum { .. } => {
                         debug!("register_fetched_execution_results: ChunksWithDifferentChecksum");
+                        if was_waiting_for_execution_results {
+                            self.latch_decrement();
+                        }
                     }
                 }
                 Err(Error::BlockAcquisition(
@@ -760,10 +800,11 @@ impl BlockBuilder {
         deploy_id: DeployId,
         maybe_peer: Option<NodeId>,
     ) -> Result<(), Error> {
+        let was_waiting_for_deploys = self.waiting_for_deploys();
         let acceptance = self
             .acquisition_state
             .register_deploy(deploy_id, self.should_fetch_execution_state);
-        self.handle_acceptance(maybe_peer, acceptance)
+        self.handle_acceptance(maybe_peer, acceptance, was_waiting_for_deploys)
     }
 
     pub(super) fn register_peers(&mut self, peers: Vec<NodeId>) {
@@ -785,19 +826,36 @@ impl BlockBuilder {
         &mut self,
         maybe_peer: Option<NodeId>,
         acceptance: Result<Option<Acceptance>, BlockAcquisitionError>,
+        should_unlatch: bool,
     ) -> Result<(), Error> {
         match acceptance {
             Ok(Some(Acceptance::NeededIt)) => {
+                // Got a useful response. Unlatch in all cases since we want to get the next item.
                 self.touch();
                 if let Some(peer) = maybe_peer {
                     self.promote_peer(peer);
                 }
             }
-            Ok(Some(Acceptance::HadIt)) | Ok(None) => (),
+            Ok(Some(Acceptance::HadIt)) => {
+                // Already had this item, which means that this was a late response for a previous
+                // fetch. We don't unlatch in this case and wait for a valid response.
+            }
+            Ok(None) => {
+                if should_unlatch {
+                    self.latch_decrement();
+                }
+            }
             Err(error) => {
                 if let Some(peer) = maybe_peer {
                     self.disqualify_peer(peer);
                 }
+
+                // If we were waiting for a response and the item was not good,
+                // decrement latch. Fetch will be retried when unlatched.
+                if should_unlatch {
+                    self.latch_decrement();
+                }
+
                 return Err(Error::BlockAcquisition(error));
             }
         }

--- a/node/src/components/block_synchronizer/block_builder/tests.rs
+++ b/node/src/components/block_synchronizer/block_builder/tests.rs
@@ -25,38 +25,38 @@ fn handle_acceptance() {
 
     // Builder acceptance for needed signature from ourselves.
     assert!(builder
-        .handle_acceptance(None, Ok(Some(Acceptance::NeededIt)))
+        .handle_acceptance(None, Ok(Some(Acceptance::NeededIt)), true)
         .is_ok());
     assert!(builder.peer_list().qualified_peers(&mut rng).is_empty());
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for existent signature from ourselves.
     assert!(builder
-        .handle_acceptance(None, Ok(Some(Acceptance::HadIt)))
+        .handle_acceptance(None, Ok(Some(Acceptance::HadIt)), true)
         .is_ok());
     assert!(builder.peer_list().qualified_peers(&mut rng).is_empty());
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for no signature from ourselves.
-    assert!(builder.handle_acceptance(None, Ok(None)).is_ok());
+    assert!(builder.handle_acceptance(None, Ok(None), true).is_ok());
     assert!(builder.peer_list().qualified_peers(&mut rng).is_empty());
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for no signature from a peer.
     // Peer shouldn't be registered.
     assert!(builder
-        .handle_acceptance(Some(honest_peer), Ok(None))
+        .handle_acceptance(Some(honest_peer), Ok(None), true)
         .is_ok());
     assert!(builder.peer_list().qualified_peers(&mut rng).is_empty());
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for existent signature from a peer.
     // Peer shouldn't be registered.
     assert!(builder
-        .handle_acceptance(Some(honest_peer), Ok(Some(Acceptance::HadIt)))
+        .handle_acceptance(Some(honest_peer), Ok(Some(Acceptance::HadIt)), true)
         .is_ok());
     assert!(builder.peer_list().qualified_peers(&mut rng).is_empty());
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for needed signature from a peer.
     // Peer should be registered as honest.
     assert!(builder
-        .handle_acceptance(Some(honest_peer), Ok(Some(Acceptance::NeededIt)))
+        .handle_acceptance(Some(honest_peer), Ok(Some(Acceptance::NeededIt)), true)
         .is_ok());
     assert!(builder
         .peer_list()
@@ -65,7 +65,11 @@ fn handle_acceptance() {
     assert!(builder.peer_list().dishonest_peers().is_empty());
     // Builder acceptance for error on signature handling from ourselves.
     assert!(builder
-        .handle_acceptance(None, Err(BlockAcquisitionError::InvalidStateTransition))
+        .handle_acceptance(
+            None,
+            Err(BlockAcquisitionError::InvalidStateTransition),
+            true
+        )
         .is_err());
     assert!(builder
         .peer_list()
@@ -77,7 +81,8 @@ fn handle_acceptance() {
     assert!(builder
         .handle_acceptance(
             Some(dishonest_peer),
-            Err(BlockAcquisitionError::InvalidStateTransition)
+            Err(BlockAcquisitionError::InvalidStateTransition),
+            true
         )
         .is_err());
     assert!(builder

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1876,16 +1876,29 @@ impl BlockExecutionResultsOrChunk {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_mock_value(block_hash: BlockHash) -> Self {
+    pub(crate) fn new_mock_value(rng: &mut TestRng, block_hash: BlockHash) -> Self {
+        Self::new_mock_value_with_multiple_random_results(rng, block_hash, 1)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_mock_value_with_multiple_random_results(
+        rng: &mut TestRng,
+        block_hash: BlockHash,
+        num_results: usize,
+    ) -> Self {
+        let execution_results: Vec<casper_types::ExecutionResult> =
+            (0..num_results).into_iter().map(|_| rng.gen()).collect();
+
         Self {
             block_hash,
-            value: ValueOrChunk::Value(vec![casper_types::ExecutionResult::Success {
-                effect: Default::default(),
-                transfers: vec![],
-                cost: U512::from(123),
-            }]),
+            value: ValueOrChunk::new(execution_results, 0).unwrap(),
             is_valid: OnceCell::with_value(Ok(true)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn value(&self) -> &ValueOrChunk<Vec<casper_types::ExecutionResult>> {
+        &self.value
     }
 }
 


### PR DESCRIPTION
Attempt to fix block synchronizer request storm by tweaking the latching.

Don't decrement the latch when responses for old requests that are no longer needed (are received in a state that expects other data).
For example if the synchonizer is the `HaveWeakFinality` state, it will try to fetch the block body from some peers. The latch will be incremented by `num_peers`. If a late finality signature response comes in this state it will decrement the latch. If multiple late responses come, the latch can become 0, and the synchronizer would try to fetch the block body again even if no response for the initial requests were received yet.

Added a test for this also. It's a bit ugly and copy-pasty but I think it showcases the issue.

Attempted fix for: https://github.com/casper-network/casper-node/issues/4202
