### PR TITLE
Update state_get_account_info RPC handler

### DIFF
--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -70,7 +70,7 @@ static GET_ACCOUNT_INFO_PARAMS: Lazy<GetAccountInfoParams> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([0; 32]).unwrap();
     let public_key = PublicKey::from(&secret_key);
     GetAccountInfoParams {
-        public_key,
+        public_key: AccountIdentifier::PublicKey(public_key),
         block_identifier: Some(BlockIdentifier::Hash(*Block::doc_example().hash())),
     }
 });
@@ -468,12 +468,22 @@ impl RpcWithOptionalParams for GetAuctionInfo {
     }
 }
 
+/// Identifier of an account.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum AccountIdentifier {
+    /// The public key of an account
+    PublicKey(PublicKey),
+    /// The account hash of an account
+    AccountHash(AccountHash),
+}
+
 /// Params for "state_get_account_info" RPC request
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountInfoParams {
     /// The public key of the Account.
-    pub public_key: PublicKey,
+    pub public_key: AccountIdentifier,
     /// The block identifier.
     pub block_identifier: Option<BlockIdentifier>,
 }
@@ -530,7 +540,14 @@ impl RpcWithParams for GetAccountInfo {
 
         let state_root_hash = *block.header().state_root_hash();
         let base_key = {
-            let account_hash = params.public_key.to_account_hash();
+            let account_hash = match params.public_key{
+                AccountIdentifier::PublicKey(public_key) => {
+                    public_key.to_account_hash()
+                }
+                AccountIdentifier::AccountHash(account_hash) => {
+                    account_hash
+                }
+            };
             Key::Account(account_hash)
         };
         let (stored_value, merkle_proof) =

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -550,7 +550,6 @@ impl RpcWithParams for GetAccountInfo {
         let (stored_value, merkle_proof) =
             common::run_query_and_encode(effect_builder, state_root_hash, base_key, vec![]).await?;
 
-
         let account = if let StoredValue::Account(account) = stored_value {
             account
         } else {

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -540,13 +540,9 @@ impl RpcWithParams for GetAccountInfo {
 
         let state_root_hash = *block.header().state_root_hash();
         let base_key = {
-            let account_hash = match params.public_key{
-                AccountIdentifier::PublicKey(public_key) => {
-                    public_key.to_account_hash()
-                }
-                AccountIdentifier::AccountHash(account_hash) => {
-                    account_hash
-                }
+            let account_hash = match params.public_key {
+                AccountIdentifier::PublicKey(public_key) => public_key.to_account_hash(),
+                AccountIdentifier::AccountHash(account_hash) => account_hash,
             };
             Key::Account(account_hash)
         };

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -483,7 +483,8 @@ pub enum AccountIdentifier {
 #[serde(deny_unknown_fields)]
 pub struct GetAccountInfoParams {
     /// The public key of the Account.
-    pub public_key: AccountIdentifier,
+    #[serde(alias = "public_key")]
+    pub account_identifier: AccountIdentifier,
     /// The block identifier.
     pub block_identifier: Option<BlockIdentifier>,
 }

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -70,7 +70,7 @@ static GET_ACCOUNT_INFO_PARAMS: Lazy<GetAccountInfoParams> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([0; 32]).unwrap();
     let public_key = PublicKey::from(&secret_key);
     GetAccountInfoParams {
-        public_key: AccountIdentifier::PublicKey(public_key),
+        account_identifier: AccountIdentifier::PublicKey(public_key),
         block_identifier: Some(BlockIdentifier::Hash(*Block::doc_example().hash())),
     }
 });
@@ -541,7 +541,7 @@ impl RpcWithParams for GetAccountInfo {
 
         let state_root_hash = *block.header().state_root_hash();
         let base_key = {
-            let account_hash = match params.public_key {
+            let account_hash = match params.account_identifier {
                 AccountIdentifier::PublicKey(public_key) => public_key.to_account_hash(),
                 AccountIdentifier::AccountHash(account_hash) => account_hash,
             };
@@ -549,6 +549,7 @@ impl RpcWithParams for GetAccountInfo {
         };
         let (stored_value, merkle_proof) =
             common::run_query_and_encode(effect_builder, state_root_hash, base_key, vec![]).await?;
+
 
         let account = if let StoredValue::Account(account) = stored_value {
             account

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -470,7 +470,7 @@ impl RpcWithOptionalParams for GetAuctionInfo {
 
 /// Identifier of an account.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, untagged)]
 pub enum AccountIdentifier {
     /// The public key of an account
     PublicKey(PublicKey),

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -307,7 +307,7 @@
               "name": "public_key",
               "schema": {
                 "description": "The public key of the Account.",
-                "$ref": "#/components/schemas/PublicKey"
+                "$ref": "#/components/schemas/AccountIdentifier"
               },
               "required": true
             },
@@ -360,7 +360,9 @@
               "params": [
                 {
                   "name": "public_key",
-                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
+                  "value": {
+                    "public_key": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
+                  }
                 },
                 {
                   "name": "block_identifier",
@@ -3245,6 +3247,37 @@
               }
             },
             "additionalProperties": false
+          },
+          "AccountIdentifier": {
+            "description": "Identifier of an account.",
+            "anyOf": [
+              {
+                "description": "The public key of an account",
+                "type": "object",
+                "required": [
+                  "public_key"
+                ],
+                "properties": {
+                  "public_key": {
+                    "$ref": "#/components/schemas/PublicKey"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "The account hash of an account",
+                "type": "object",
+                "required": [
+                  "account_hash"
+                ],
+                "properties": {
+                  "account_hash": {
+                    "$ref": "#/components/schemas/AccountHash"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "BlockIdentifier": {
             "description": "Identifier for possible ways to retrieve a block.",

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -304,7 +304,7 @@
           "summary": "returns an Account from the network",
           "params": [
             {
-              "name": "public_key",
+              "name": "account_identifier",
               "schema": {
                 "description": "The public key of the Account.",
                 "$ref": "#/components/schemas/AccountIdentifier"
@@ -359,7 +359,7 @@
               "name": "state_get_account_info_example",
               "params": [
                 {
-                  "name": "public_key",
+                  "name": "account_identifier",
                   "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                 },
                 {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -360,9 +360,7 @@
               "params": [
                 {
                   "name": "public_key",
-                  "value": {
-                    "public_key": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
-                  }
+                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                 },
                 {
                   "name": "block_identifier",
@@ -3253,29 +3251,19 @@
             "anyOf": [
               {
                 "description": "The public key of an account",
-                "type": "object",
-                "required": [
-                  "public_key"
-                ],
-                "properties": {
-                  "public_key": {
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/PublicKey"
                   }
-                },
-                "additionalProperties": false
+                ]
               },
               {
                 "description": "The account hash of an account",
-                "type": "object",
-                "required": [
-                  "account_hash"
-                ],
-                "properties": {
-                  "account_hash": {
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/AccountHash"
                   }
-                },
-                "additionalProperties": false
+                ]
               }
             ]
           },


### PR DESCRIPTION
# Summary of work done:
- Update `state_get_account_info` RPC handler to handle an `AccountIdentifier` as a parameter
- Add `AccountIdentifier` enum that can be a public key or account hash
- Ensure serde properly formats the `AccountIdentifier` enum to prevent this change from breaking the RPC API

### Sample requests:

Request for an account using a public key from an NCTL network
```
{
  "jsonrpc": "2.0",
  "method": "state_get_account_info",
  "params": {
    "public_key": "01fbabf372fe762ad840834f7dab5d88e522ffa39c9f53d1e991056cef110faeb2",
    "block_identifier": null
  },
  "id": -2271248039839344330
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "account": {
      "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
      "named_keys": [],
      "main_purse": "uref-cf8a03704e4865323fd1b02166e52302ce8fc4c931d76d04e6faea33ee52d93e-007",
      "associated_keys": [
        {
          "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
          "weight": 1
        }
      ],
      "action_thresholds": {
        "deployment": 1,
        "key_management": 1
      }
    },
    "merkle_proof": "[2228 hex chars]"
  },
  "id": -2271248039839344330
}
```

Request for the same account using an account hash instead:

```
{
  "jsonrpc": "2.0",
  "method": "state_get_account_info",
  "params": {
    "public_key": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
    "block_identifier": null
  },
  "id": -3436401869523751496
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "account": {
      "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
      "named_keys": [],
      "main_purse": "uref-cf8a03704e4865323fd1b02166e52302ce8fc4c931d76d04e6faea33ee52d93e-007",
      "associated_keys": [
        {
          "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
          "weight": 1
        }
      ],
      "action_thresholds": {
        "deployment": 1,
        "key_management": 1
      }
    },
    "merkle_proof": "[2228 hex chars]"
  },
  "id": -3436401869523751496
}
```

# Associated ticket(s):
- #4203 
- [Update the RPC handler for state_get_account_info](https://app.zenhub.com/workspaces/rust-sdk-64b185bf2cb87924e7759d9d/issues/gh/casper-network/casper-node/4203) 
