### PR TITLE
Update BlockValidator to validate cited finality signatures

### DIFF
--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -30,7 +30,7 @@ use crate::{
         storage::{self, Storage},
     },
     effect::{
-        announcements::ControlAnnouncement,
+        announcements::{ControlAnnouncement, StoredExecutedBlockAnnouncement},
         requests::{ContractRuntimeRequest, MarkBlockCompletedRequest, NetworkRequest},
     },
     protocol::Message,
@@ -65,6 +65,8 @@ fn signatures_for_block(block: &Block, signatures: &Vec<FinalitySignature>) -> B
 enum Event {
     #[from]
     Storage(#[serde(skip_serializing)] storage::Event),
+    #[from]
+    StoredExecutedBlockAnnouncement(StoredExecutedBlockAnnouncement),
     #[from]
     BlockAccumulator(#[serde(skip_serializing)] super::Event),
     #[from]
@@ -109,6 +111,9 @@ impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::Storage(event) => write!(formatter, "storage: {}", event),
+            Event::StoredExecutedBlockAnnouncement(event) => {
+                write!(formatter, "stored executed block: {}", event)
+            }
             Event::BlockAccumulator(event) => write!(formatter, "block accumulator: {}", event),
             Event::ControlAnnouncement(ctrl_ann) => write!(formatter, "control: {}", ctrl_ann),
             Event::FatalAnnouncement(fatal_ann) => write!(formatter, "fatal: {}", fatal_ann),
@@ -212,6 +217,9 @@ impl Reactor for MockReactor {
                 Event::Storage,
                 self.storage.handle_event(effect_builder, rng, event),
             ),
+            Event::StoredExecutedBlockAnnouncement(ann) => {
+                panic!("unhandled StoredExecutedBlockAnnouncement: {}", ann)
+            }
             Event::StorageRequest(req) => reactor::wrap_effects(
                 Event::Storage,
                 self.storage.handle_event(effect_builder, rng, req.into()),

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -609,6 +609,11 @@ where
                     .iter()
                     .any(|sigs| sigs.has_some())
                 {
+                    debug!(
+                        ?block, %minimum_block_height, %proposed_block_height,
+                        "block cites signatures, validation required - requesting past blocks \
+                        from storage"
+                    );
                     let proposed_block = block.clone();
                     effects.extend(
                         effect_builder
@@ -626,6 +631,7 @@ where
                     );
                 } else {
                     // If no signatures are cited, the citation is automatically valid.
+                    debug!("no signatures included in block, no validation of signatures required");
                     state
                         .signatures_validation_state
                         .require_signatures(HashSet::new(), KeyedCounter::default());

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -424,7 +424,7 @@ impl BlockValidator {
                         .body()
                         .rewarded_signatures()
                         .clone()
-                        .left_padded(rel_height);
+                        .left_padded(rel_height.saturating_add(1));
                     if rewarded_signatures
                         .intersection(&padded_signatures)
                         .has_some()

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -569,10 +569,6 @@ where
                 }
 
                 let deploy_count = block.deploy_hashes().count() + block.transfer_hashes().count();
-                if deploy_count == 0 {
-                    // If there are no deploys, return early.
-                    return responder.respond(true).ignore();
-                }
 
                 // Collect the deploys in a map. If they are fewer now, then there was a duplicate!
                 let block_deploys: HashMap<_, _> = block.deploys_and_transfers_iter().collect();

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -90,7 +90,7 @@ pub(crate) enum Event {
 
     /// Past blocks with metadata relevant to the finality signatures included in the proposed
     /// block have been read from storage.
-    #[display(fmt = "{:?} read from storage", past_blocks_with_metadata)]
+    #[display(fmt = "past blocks read from storage")]
     GotPastBlocksWithMetadata {
         past_blocks_with_metadata: Vec<Option<BlockWithMetadata>>,
         proposed_block: ProposedBlock<ClContext>,

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -32,6 +32,8 @@ enum ReactorEvent {
     FinalitySignatureFetcher(FetcherRequest<FinalitySignature>),
     #[from]
     Storage(StorageRequest),
+    #[from]
+    FatalAnnouncement(FatalAnnouncement),
 }
 
 impl From<BlockValidationRequest> for ReactorEvent {

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -50,7 +50,10 @@ impl ValidatorSecret for Keypair {
 
 impl ConsensusValueT for Arc<BlockPayload> {
     fn needs_validation(&self) -> bool {
-        !self.transfers().is_empty() || !self.deploys().is_empty() || !self.accusations().is_empty()
+        !self.transfers().is_empty()
+            || !self.deploys().is_empty()
+            || !self.accusations().is_empty()
+            || self.rewarded_signatures().has_some()
     }
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -964,9 +964,7 @@ impl EraSupervisor {
             ProtocolOutcome::CreateNewBlock(block_context) => {
                 let signature_rewards_max_delay =
                     self.chainspec.core_config.signature_rewards_max_delay;
-                let initial_era_height = self.era(era_id).start_height;
-                let current_block_height =
-                    initial_era_height + block_context.ancestor_values().len() as u64;
+                let current_block_height = self.proposed_block_height(&block_context, era_id);
                 let minimum_block_height =
                     current_block_height.saturating_sub(signature_rewards_max_delay);
 
@@ -1122,11 +1120,14 @@ impl EraSupervisor {
                     let msg = ConsensusMessage::EvidenceRequest { era_id, pub_key };
                     effects.extend(effect_builder.send_message(sender, msg.into()).ignore());
                 }
+                let proposed_block_height =
+                    self.proposed_block_height(proposed_block.context(), era_id);
                 effects.extend(
                     async move {
                         check_deploys_for_replay_in_previous_eras_and_validate_block(
                             effect_builder,
                             era_id,
+                            proposed_block_height,
                             sender,
                             proposed_block,
                         )
@@ -1201,6 +1202,11 @@ impl EraSupervisor {
     /// This node's public signing key.
     pub(crate) fn public_key(&self) -> &PublicKey {
         self.validator_matrix.public_signing_key()
+    }
+
+    fn proposed_block_height(&self, block_context: &BlockContext<ClContext>, era_id: EraId) -> u64 {
+        let initial_era_height = self.era(era_id).start_height;
+        initial_era_height.saturating_add(block_context.ancestor_values().len() as u64)
     }
 }
 
@@ -1333,6 +1339,7 @@ fn instance_id(chainspec_hash: Digest, era_id: EraId, key_block_hash: BlockHash)
 async fn check_deploys_for_replay_in_previous_eras_and_validate_block<REv>(
     effect_builder: EffectBuilder<REv>,
     proposed_block_era_id: EraId,
+    proposed_block_height: u64,
     sender: NodeId,
     proposed_block: ProposedBlock<ClContext>,
 ) -> Event
@@ -1366,7 +1373,12 @@ where
 
     let sender_for_validate_block: NodeId = sender;
     let valid = effect_builder
-        .validate_block(sender_for_validate_block, proposed_block.clone())
+        .validate_block(
+            sender_for_validate_block,
+            proposed_block_era_id,
+            proposed_block_height,
+            proposed_block.clone(),
+        )
         .await;
 
     Event::ResolveValidity(ResolveValidity {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -34,7 +34,9 @@ use crate::{
         storage::{self, Storage},
     },
     effect::{
-        announcements::{ControlAnnouncement, DeployAcceptorAnnouncement},
+        announcements::{
+            ControlAnnouncement, DeployAcceptorAnnouncement, StoredExecutedBlockAnnouncement,
+        },
         requests::{
             ContractRuntimeRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest,
             NetworkRequest,
@@ -87,6 +89,12 @@ impl From<MakeBlockExecutableRequest> for Event {
 impl From<MarkBlockCompletedRequest> for Event {
     fn from(request: MarkBlockCompletedRequest) -> Self {
         Event::Storage(storage::Event::MarkBlockCompletedRequest(request))
+    }
+}
+
+impl From<StoredExecutedBlockAnnouncement> for Event {
+    fn from(_: StoredExecutedBlockAnnouncement) -> Self {
+        unimplemented!("the announcement isn't used in deploy acceptor tests")
     }
 }
 

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -25,7 +25,7 @@ use crate::{
     effect::{
         announcements::{
             ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement,
-            RpcServerAnnouncement,
+            RpcServerAnnouncement, StoredExecutedBlockAnnouncement,
         },
         incoming::{
             ConsensusMessageIncoming, DemandIncoming, FinalitySignatureIncoming, GossiperIncoming,
@@ -93,6 +93,8 @@ enum Event {
     Network(in_memory_network::Event<Message>),
     #[from]
     Storage(storage::Event),
+    #[from]
+    StoredExecutedBlockAnnouncement(StoredExecutedBlockAnnouncement),
     #[from]
     FakeDeployAcceptor(deploy_acceptor::Event),
     #[from]
@@ -258,7 +260,8 @@ impl ReactorTrait for Reactor {
             | Event::FetchedNewBlockAnnouncement(_)
             | Event::FetchedNewFinalitySignatureAnnouncement(_)
             | Event::ControlAnnouncement(_)
-            | Event::FatalAnnouncement(_) => panic!("unexpected: {}", event),
+            | Event::FatalAnnouncement(_)
+            | Event::StoredExecutedBlockAnnouncement(_) => panic!("unexpected: {}", event),
         }
     }
 

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -30,7 +30,7 @@ use crate::{
     effect::{
         announcements::{
             ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement,
-            GossiperAnnouncement, RpcServerAnnouncement,
+            GossiperAnnouncement, RpcServerAnnouncement, StoredExecutedBlockAnnouncement,
         },
         incoming::{
             ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming,
@@ -118,6 +118,7 @@ impl Unhandled for TrieRequestIncoming {}
 impl Unhandled for TrieDemand {}
 impl Unhandled for TrieResponseIncoming {}
 impl Unhandled for FinalitySignatureIncoming {}
+impl Unhandled for StoredExecutedBlockAnnouncement {}
 
 /// Error type returned by the test reactor.
 #[derive(Debug, Error)]

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -161,7 +161,7 @@ use announcements::{
     ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement, FatalAnnouncement,
     FetchedNewBlockAnnouncement, FetchedNewFinalitySignatureAnnouncement, GossiperAnnouncement,
     MetaBlockAnnouncement, PeerBehaviorAnnouncement, QueueDumpFormat, RpcServerAnnouncement,
-    UnexecutedBlockAnnouncement, UpgradeWatcherAnnouncement,
+    StoredExecutedBlockAnnouncement, UnexecutedBlockAnnouncement, UpgradeWatcherAnnouncement,
 };
 use diagnostics_port::DumpConsensusStateRequest;
 use requests::{
@@ -1770,6 +1770,8 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn validate_block(
         self,
         sender: NodeId,
+        proposed_block_era_id: EraId,
+        proposed_block_height: u64,
         block: ProposedBlock<ClContext>,
     ) -> bool
     where
@@ -1777,6 +1779,8 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| BlockValidationRequest {
+                proposed_block_era_id,
+                proposed_block_height,
                 block,
                 sender,
                 responder,
@@ -1831,6 +1835,19 @@ impl<REv> EffectBuilder<REv> {
         self.event_queue
             .schedule(
                 UnexecutedBlockAnnouncement(block_height),
+                QueueKind::Regular,
+            )
+            .await
+    }
+
+    /// Announces that an executed block has been stored.
+    pub(crate) async fn announce_executed_block_stored(self, block_height: u64)
+    where
+        REv: From<StoredExecutedBlockAnnouncement>,
+    {
+        self.event_queue
+            .schedule(
+                StoredExecutedBlockAnnouncement(block_height),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -145,6 +145,19 @@ impl Display for UnexecutedBlockAnnouncement {
     }
 }
 
+#[derive(DataSize, Serialize, Debug)]
+pub(crate) struct StoredExecutedBlockAnnouncement(pub(crate) u64);
+
+impl Display for StoredExecutedBlockAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "announcement for stored executed block at height {}",
+            self.0,
+        )
+    }
+}
+
 /// Queue dump format with handler.
 #[derive(Serialize)]
 pub(crate) enum QueueDumpFormat {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1080,6 +1080,10 @@ impl Display for SyncGlobalStateRequest {
 #[derive(Debug)]
 #[must_use]
 pub(crate) struct BlockValidationRequest {
+    ///TODO
+    pub(crate) proposed_block_era_id: EraId,
+    ///TODO
+    pub(crate) proposed_block_height: u64,
     /// The block to be validated.
     pub(crate) block: ProposedBlock<ClContext>,
     /// The sender of the block, which will be asked to provide all missing deploys.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1080,9 +1080,9 @@ impl Display for SyncGlobalStateRequest {
 #[derive(Debug)]
 #[must_use]
 pub(crate) struct BlockValidationRequest {
-    ///TODO
+    /// The era in which the proposed block was created.
     pub(crate) proposed_block_era_id: EraId,
-    ///TODO
+    /// The height of the proposed block in the chain.
     pub(crate) proposed_block_height: u64,
     /// The block to be validated.
     pub(crate) block: ProposedBlock<ClContext>,

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -24,8 +24,8 @@ use crate::{
             ControlAnnouncement, DeployAcceptorAnnouncement, DeployBufferAnnouncement,
             FatalAnnouncement, FetchedNewBlockAnnouncement,
             FetchedNewFinalitySignatureAnnouncement, GossiperAnnouncement, MetaBlockAnnouncement,
-            PeerBehaviorAnnouncement, RpcServerAnnouncement, UnexecutedBlockAnnouncement,
-            UpgradeWatcherAnnouncement,
+            PeerBehaviorAnnouncement, RpcServerAnnouncement, StoredExecutedBlockAnnouncement,
+            UnexecutedBlockAnnouncement, UpgradeWatcherAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
@@ -245,6 +245,8 @@ pub(crate) enum MainEvent {
     MetaBlockAnnouncement(MetaBlockAnnouncement),
     #[from]
     UnexecutedBlockAnnouncement(UnexecutedBlockAnnouncement),
+    #[from]
+    StoredExecutedBlockAnnouncement(StoredExecutedBlockAnnouncement),
 
     // Event related to figuring out validators for blocks after upgrades.
     GotBlockAfterUpgradeEraValidators(EraId, EraValidators, EraValidators),
@@ -360,6 +362,7 @@ impl ReactorEvent for MainEvent {
             MainEvent::MakeBlockExecutableRequest(_) => "MakeBlockExecutableRequest",
             MainEvent::MetaBlockAnnouncement(_) => "MetaBlockAnnouncement",
             MainEvent::UnexecutedBlockAnnouncement(_) => "UnexecutedBlockAnnouncement",
+            MainEvent::StoredExecutedBlockAnnouncement(_) => "StoredExecutedBlockAnnouncement",
             MainEvent::GotBlockAfterUpgradeEraValidators(_, _, _) => {
                 "GotImmediateSwitchBlockEraValidators"
             }
@@ -542,6 +545,7 @@ impl Display for MainEvent {
             MainEvent::MakeBlockExecutableRequest(inner) => Display::fmt(inner, f),
             MainEvent::MetaBlockAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::UnexecutedBlockAnnouncement(inner) => Display::fmt(inner, f),
+            MainEvent::StoredExecutedBlockAnnouncement(inner) => Display::fmt(inner, f),
             MainEvent::GotBlockAfterUpgradeEraValidators(era_id, _, _) => {
                 write!(
                     f,

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -37,7 +37,7 @@ use casper_types::{testing::TestRng, TimeDiff, Timestamp};
 use crate::{
     components::Component,
     effect::{
-        announcements::{ControlAnnouncement, FatalAnnouncement},
+        announcements::{ControlAnnouncement, FatalAnnouncement, StoredExecutedBlockAnnouncement},
         requests::NetworkRequest,
         EffectBuilder, Effects, Responder,
     },
@@ -334,13 +334,17 @@ pub(crate) enum UnitTestEvent {
     /// A network request made by the component under test.
     #[from]
     NetworkRequest(NetworkRequest<Message>),
+    /// An announcement that an executed block was stored, made by the storage component.
+    #[from]
+    StoredExecutedBlockAnnouncement(StoredExecutedBlockAnnouncement),
 }
 
 impl ReactorEvent for UnitTestEvent {
     fn is_control(&self) -> bool {
         match self {
             UnitTestEvent::ControlAnnouncement(_) | UnitTestEvent::FatalAnnouncement(_) => true,
-            UnitTestEvent::NetworkRequest(_) => false,
+            UnitTestEvent::NetworkRequest(_)
+            | UnitTestEvent::StoredExecutedBlockAnnouncement(_) => false,
         }
     }
 
@@ -350,7 +354,8 @@ impl ReactorEvent for UnitTestEvent {
             UnitTestEvent::FatalAnnouncement(FatalAnnouncement { file, line, msg }) => {
                 Some(ControlAnnouncement::FatalError { file, line, msg })
             }
-            UnitTestEvent::NetworkRequest(_) => None,
+            UnitTestEvent::NetworkRequest(_)
+            | UnitTestEvent::StoredExecutedBlockAnnouncement(_) => None,
         }
     }
 }

--- a/node/src/types/block/rewarded_signatures.rs
+++ b/node/src/types/block/rewarded_signatures.rs
@@ -126,9 +126,12 @@ impl SingleBlockRewardedSignatures {
 
     /// Calculates the set intersection of two instances of `SingleBlockRewardedSignatures`.
     pub(crate) fn intersection(mut self, other: &SingleBlockRewardedSignatures) -> Self {
-        for (self_byte, other_byte) in self.0.iter_mut().zip(other.0.iter()) {
-            *self_byte &= other_byte;
-        }
+        self.0 = self
+            .0
+            .iter()
+            .zip(other.0.iter())
+            .map(|(a, b)| *a & *b)
+            .collect();
         self
     }
 

--- a/node/src/types/block/rewarded_signatures.rs
+++ b/node/src/types/block/rewarded_signatures.rs
@@ -254,6 +254,23 @@ impl RewardedSignatures {
         self.0.iter()
     }
 
+    /// Iterates over the `SingleBlockRewardedSignatures`, yielding the signatures together with
+    /// the block height for each entry. `block_height` is the height of the block that contains
+    /// this instance of `RewardedSignatures`.
+    pub fn iter_with_height(
+        &self,
+        block_height: u64,
+    ) -> impl Iterator<Item = (u64, &SingleBlockRewardedSignatures)> {
+        self.0.iter().enumerate().map(move |(rel_height, sbrs)| {
+            (
+                block_height
+                    .saturating_sub(rel_height as u64)
+                    .saturating_sub(1),
+                sbrs,
+            )
+        })
+    }
+
     /// Returns `true` if there is at least one cited signature.
     pub fn has_some(&self) -> bool {
         self.0.iter().any(|signatures| signatures.has_some())

--- a/node/src/types/block/rewarded_signatures.rs
+++ b/node/src/types/block/rewarded_signatures.rs
@@ -123,6 +123,19 @@ impl SingleBlockRewardedSignatures {
         }
         self
     }
+
+    /// Calculates the set intersection of two instances of `SingleBlockRewardedSignatures`.
+    pub(crate) fn intersection(mut self, other: &SingleBlockRewardedSignatures) -> Self {
+        for (self_byte, other_byte) in self.0.iter_mut().zip(other.0.iter()) {
+            *self_byte &= other_byte;
+        }
+        self
+    }
+
+    /// Returns `true` if the set contains at least one signature.
+    pub(crate) fn has_some(&self) -> bool {
+        self.0.iter().any(|byte| *byte != 0)
+    }
 }
 
 impl ToBytes for SingleBlockRewardedSignatures {
@@ -216,6 +229,31 @@ impl RewardedSignatures {
                 })
                 .collect(),
         )
+    }
+
+    /// Calculates the set intersection between two instances of `RewardedSignatures`.
+    pub fn intersection(&self, other: &RewardedSignatures) -> Self {
+        Self(
+            self.0
+                .iter()
+                .zip(other.0.iter())
+                .map(|(single_block_signatures, other_block_signatures)| {
+                    single_block_signatures
+                        .clone()
+                        .intersection(other_block_signatures)
+                })
+                .collect(),
+        )
+    }
+
+    /// Iterates over the `SingleBlockRewardedSignatures` for each rewarded block.
+    pub fn iter(&self) -> impl Iterator<Item = &SingleBlockRewardedSignatures> {
+        self.0.iter()
+    }
+
+    /// Returns `true` if there is at least one cited signature.
+    pub fn has_some(&self) -> bool {
+        self.0.iter().any(|signatures| signatures.has_some())
     }
 }
 

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -331,6 +331,10 @@ impl EraValidatorWeights {
         self.validator_weights.keys()
     }
 
+    pub(crate) fn into_validator_public_keys(self) -> impl Iterator<Item = PublicKey> {
+        self.validator_weights.into_keys()
+    }
+
     pub(crate) fn missing_validators<'a>(
         &self,
         validator_keys: impl Iterator<Item = &'a PublicKey>,


### PR DESCRIPTION
This PR extends the BlockValidator with functionality necessary for validating finality signatures cited in blocks for reward purposes.

A block is now only considered valid if all the cited finality signatures can be determined to exist on the network, in addition to all the existing criteria.

The nodes check for the signatures' existence by first consulting their local storage, and attempting to fetch any signatures that are missing locally - similar to how deploys are handled.

Closes #3913 
