### PR TITLE
Make sure enough blocks are synced for rewarded signatures to be validatable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit
+	$(CARGO) audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0044
 
 .PHONY: audit-as
 audit-as:

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -2867,38 +2867,6 @@ impl Storage {
             .collect()
     }
 
-    /// Retrieves single switch block by era ID by looking it up in the index and returning it.
-    fn get_switch_block_by_era_id<Tx: Transaction>(
-        &self,
-        txn: &mut Tx,
-        era_id: EraId,
-    ) -> Result<Option<Block>, FatalStorageError> {
-        self.switch_block_era_id_index
-            .get(&era_id)
-            .and_then(|block_hash| self.get_single_block(txn, block_hash).transpose())
-            .transpose()
-    }
-
-    /// Get the switch block for a specified era number in a read-only LMDB database transaction.
-    ///
-    /// # Panics
-    ///
-    /// Panics on any IO or db corruption error.
-    pub(crate) fn transactional_get_switch_block_by_era_id(
-        &self,
-        switch_block_era_num: u64,
-    ) -> Result<Option<Block>, FatalStorageError> {
-        let mut txn = self
-            .env
-            .begin_ro_txn()
-            .expect("Could not start read only transaction for lmdb");
-        let switch_block = self
-            .get_switch_block_by_era_id(&mut txn, EraId::from(switch_block_era_num))
-            .expect("LMDB panicked trying to get switch block");
-        txn.commit().expect("Could not commit transaction");
-        Ok(switch_block)
-    }
-
     /// Directly returns a deploy from internal store.
     ///
     /// # Panics

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1756,6 +1756,16 @@ impl Storage {
         ret
     }
 
+    /// Retrieves single switch block header by era ID by looking it up in the index and returning
+    /// it.
+    pub(crate) fn read_switch_block_header_by_era_id(
+        &self,
+        era_id: EraId,
+    ) -> Result<Option<BlockHeader>, FatalStorageError> {
+        let mut txn = self.env.begin_ro_txn()?;
+        self.get_switch_block_header_by_era_id(&mut txn, era_id)
+    }
+
     /// Retrieves a single block header by deploy hash by looking it up in the index and returning
     /// it.
     fn get_block_header_by_deploy_hash<Tx: Transaction>(

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -640,10 +640,11 @@ impl MainReactor {
                         .map_err(|err| err.to_string())?
                         .last()
                     {
-                        if synced_to_ttl(
+                        if synced_to_ttl_and_signature_delay(
                             highest_switch_block_header,
                             &highest_orphaned_block_header,
                             self.chainspec.deploy_config.max_ttl,
+                            self.chainspec.core_config.signature_rewards_max_delay,
                         )? {
                             return Ok(Some(SyncBackInstruction::TtlSynced));
                         }
@@ -704,17 +705,22 @@ impl MainReactor {
     }
 }
 
-pub(crate) fn synced_to_ttl(
+pub(crate) fn synced_to_ttl_and_signature_delay(
     latest_switch_block_header: &BlockHeader,
     highest_orphaned_block_header: &BlockHeader,
     max_ttl: TimeDiff,
+    signature_delay: u64,
 ) -> Result<bool, String> {
     Ok(highest_orphaned_block_header.height() == 0
-        || is_timestamp_at_ttl(
+        || (is_timestamp_at_ttl(
             latest_switch_block_header.timestamp(),
             highest_orphaned_block_header.timestamp(),
             max_ttl,
-        ))
+        ) && has_blocks_within_signature_delay(
+            latest_switch_block_header.height(),
+            highest_orphaned_block_header.height(),
+            signature_delay,
+        )))
 }
 
 fn is_timestamp_at_ttl(
@@ -725,6 +731,14 @@ fn is_timestamp_at_ttl(
     lowest_block_timestamp < latest_switch_block_timestamp.saturating_sub(max_ttl)
 }
 
+fn has_blocks_within_signature_delay(
+    latest_switch_block_height: u64,
+    lowest_block_height: u64,
+    signature_delay: u64,
+) -> bool {
+    lowest_block_height < latest_switch_block_height.saturating_sub(signature_delay)
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -732,12 +746,16 @@ mod tests {
     use casper_types::{testing::TestRng, ProtocolVersion, TimeDiff, Timestamp};
 
     use crate::{
-        reactor::main_reactor::keep_up::{is_timestamp_at_ttl, synced_to_ttl},
+        reactor::main_reactor::keep_up::{
+            has_blocks_within_signature_delay, is_timestamp_at_ttl,
+            synced_to_ttl_and_signature_delay,
+        },
         types::Block,
     };
 
     const TWO_DAYS_SECS: u32 = 60 * 60 * 24 * 2;
     const MAX_TTL: TimeDiff = TimeDiff::from_seconds(86400);
+    const SIG_DELAY: u64 = 5;
 
     #[test]
     fn should_be_at_ttl() {
@@ -752,6 +770,17 @@ mod tests {
     }
 
     #[test]
+    fn should_have_blocks_within_sig_delay() {
+        let latest_switch_block_height = 100;
+        let lowest_block_height = latest_switch_block_height - SIG_DELAY - 5;
+        assert!(has_blocks_within_signature_delay(
+            latest_switch_block_height,
+            lowest_block_height,
+            SIG_DELAY
+        ));
+    }
+
+    #[test]
     fn should_not_be_at_ttl() {
         let latest_switch_block_timestamp = Timestamp::from_str("2010-06-15 00:00:00.000").unwrap();
         let lowest_block_timestamp = Timestamp::from_str("2010-06-14 00:00:00.000").unwrap();
@@ -760,6 +789,17 @@ mod tests {
             latest_switch_block_timestamp,
             lowest_block_timestamp,
             max_ttl
+        ));
+    }
+
+    #[test]
+    fn should_not_have_blocks_within_sig_delay() {
+        let latest_switch_block_height = 100;
+        let lowest_block_height = latest_switch_block_height - SIG_DELAY + 2;
+        assert!(!has_blocks_within_signature_delay(
+            latest_switch_block_height,
+            lowest_block_height,
+            SIG_DELAY
         ));
     }
 
@@ -794,6 +834,31 @@ mod tests {
     }
 
     #[test]
+    fn should_detect_sig_delay_at_boundary() {
+        let latest_switch_block_height = 100;
+        let lowest_block_height = latest_switch_block_height - SIG_DELAY - 1;
+        assert!(has_blocks_within_signature_delay(
+            latest_switch_block_height,
+            lowest_block_height,
+            SIG_DELAY
+        ));
+
+        let lowest_block_height = latest_switch_block_height - SIG_DELAY;
+        assert!(!has_blocks_within_signature_delay(
+            latest_switch_block_height,
+            lowest_block_height,
+            SIG_DELAY
+        ));
+
+        let lowest_block_height = latest_switch_block_height - SIG_DELAY + 1;
+        assert!(!has_blocks_within_signature_delay(
+            latest_switch_block_height,
+            lowest_block_height,
+            SIG_DELAY
+        ));
+    }
+
+    #[test]
     fn should_detect_ttl_at_genesis() {
         let mut rng = TestRng::new();
 
@@ -817,10 +882,11 @@ mod tests {
 
         assert_eq!(latest_orphaned_block.height(), 0);
         assert_eq!(
-            synced_to_ttl(
+            synced_to_ttl_and_signature_delay(
                 latest_switch_block.header(),
                 latest_orphaned_block.header(),
-                MAX_TTL
+                MAX_TTL,
+                SIG_DELAY,
             ),
             Ok(true)
         );

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -253,9 +253,9 @@ impl SwitchBlocks {
             let mut header_iter = nodes.values().map(|runner| {
                 let storage = runner.main_reactor().storage();
                 let maybe_block = storage
-                    .transactional_get_switch_block_by_era_id(era_number)
-                    .expect("failed to get switch block by era id");
-                maybe_block.expect("missing switch block").take_header()
+                    .read_switch_block_header_by_era_id(era_number.into())
+                    .expect("failed to get switch block header by era id");
+                maybe_block.expect("missing switch block header")
             });
             let header = header_iter.next().unwrap();
             assert_eq!(era_number, header.era_id().value());

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -120,12 +120,25 @@ impl MainReactor {
         if let HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) =
             self.storage.get_highest_orphaned_block_header()
         {
-            if synced_to_ttl_and_signature_delay(
-                highest_switch_block_header,
-                &highest_orphaned_block_header,
-                self.chainspec.deploy_config.max_ttl,
-                self.chainspec.core_config.signature_rewards_max_delay,
-            )? {
+            let highest_orphaned_block_era = highest_orphaned_block_header.era_id();
+            let maybe_highest_orphaned_era_switch_block = self
+                .storage
+                .read_switch_block_header_by_era_id(highest_orphaned_block_era)
+                .map_err(|err| err.to_string())?;
+            let synced_to_ttl = if let Some(highest_orphaned_era_switch_block) =
+                maybe_highest_orphaned_era_switch_block
+            {
+                synced_to_ttl_and_signature_delay(
+                    highest_switch_block_header,
+                    &highest_orphaned_era_switch_block,
+                    &highest_orphaned_block_header,
+                    self.chainspec.deploy_config.max_ttl,
+                    self.chainspec.core_config.signature_rewards_max_delay,
+                )?
+            } else {
+                false
+            };
+            if synced_to_ttl {
                 debug!(%self.state,"{}: sufficient deploy TTL awareness to safely participate in consensus", self.state);
             } else {
                 info!(

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -6,7 +6,7 @@ use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{
         self,
-        main_reactor::{keep_up::synced_to_ttl, MainEvent, MainReactor},
+        main_reactor::{keep_up::synced_to_ttl_and_signature_delay, MainEvent, MainReactor},
     },
     storage::HighestOrphanedBlockResult,
     NodeRng,
@@ -120,10 +120,11 @@ impl MainReactor {
         if let HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) =
             self.storage.get_highest_orphaned_block_header()
         {
-            if synced_to_ttl(
+            if synced_to_ttl_and_signature_delay(
                 highest_switch_block_header,
                 &highest_orphaned_block_header,
                 self.chainspec.deploy_config.max_ttl,
+                self.chainspec.core_config.signature_rewards_max_delay,
             )? {
                 debug!(%self.state,"{}: sufficient deploy TTL awareness to safely participate in consensus", self.state);
             } else {


### PR DESCRIPTION
This extends the `synced_to_ttl` function to also check if we have enough blocks for the rewarded finality signatures to be validatable.

Closes #4123 