### PR TITLE
Fix after private-chain merge

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -57,8 +57,8 @@ const DEFAULT_ADDRESS: [u8; 32] = [0; 32];
 pub const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 /// Default auction delay.
 pub const DEFAULT_AUCTION_DELAY: u64 = 1;
-/// Default lock-in period of 90 days
-pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * 24 * 60 * 60 * 1000;
+/// Default lock-in period is currently zero.
+pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 0;
 /// Default number of eras that need to pass to be able to withdraw unbonded funds.
 pub const DEFAULT_UNBONDING_DELAY: u64 = 7;
 /// Default round seigniorage rate represented as a fractional number.

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -49,16 +49,14 @@ pub use step_request_builder::StepRequestBuilder;
 pub use upgrade_request_builder::UpgradeRequestBuilder;
 pub use wasm_test_builder::{InMemoryWasmTestBuilder, LmdbWasmTestBuilder, WasmTestBuilder};
 
-const DAY_MILLIS: u64 = 24 * 60 * 60 * 1000;
-
 /// Default number of validator slots.
 pub const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 /// Default auction delay.
 pub const DEFAULT_AUCTION_DELAY: u64 = 1;
-/// Default lock-in period of 90 days
-pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
-/// Default length of total vesting schedule of 91 days.
-pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+/// Default lock-in period is currently zero.
+pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 0;
+/// Default length of total vesting schedule is currently zero.
+pub const DEFAULT_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 0;
 
 /// Default number of eras that need to pass to be able to withdraw unbonded funds.
 pub const DEFAULT_UNBONDING_DELAY: u64 = 7;

--- a/execution_engine_testing/tests/src/test/regression/gov_116.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_116.rs
@@ -5,10 +5,14 @@ use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_VALIDATOR_SLOTS, MINIMUM_ACCOUNT_CREATION_BALANCE,
+    DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_CHAINSPEC_REGISTRY, DEFAULT_GENESIS_CONFIG_HASH,
+    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION,
+    DEFAULT_VALIDATOR_SLOTS, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::core::engine_state::{genesis::GenesisValidator, GenesisAccount};
+use casper_execution_engine::core::engine_state::{
+    genesis::{ExecConfigBuilder, GenesisValidator},
+    EngineConfigBuilder, GenesisAccount, RunGenesisRequest,
+};
 use casper_types::{
     runtime_args,
     system::{
@@ -238,7 +242,48 @@ fn should_not_retain_genesis_validator_slot_protection_after_vesting_period_elap
 #[ignore]
 #[test]
 fn should_retain_genesis_validator_slot_protection() {
-    let mut builder = initialize_builder();
+    const CASPER_VESTING_SCHEDULE_PERIOD_MILLIS: u64 = 91 * DAY_MILLIS;
+    const CASPER_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * DAY_MILLIS;
+    const CASPER_VESTING_BASE: u64 =
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS + CASPER_LOCKED_FUNDS_PERIOD_MILLIS;
+
+    let mut builder = {
+        let engine_config = EngineConfigBuilder::default()
+            .with_vesting_schedule_period_millis(CASPER_VESTING_SCHEDULE_PERIOD_MILLIS)
+            .build();
+
+        let run_genesis_request = {
+            let accounts = GENESIS_ACCOUNTS.clone();
+            let exec_config = ExecConfigBuilder::default()
+                .with_accounts(accounts)
+                .with_locked_funds_period_millis(CASPER_LOCKED_FUNDS_PERIOD_MILLIS)
+                .build();
+
+            RunGenesisRequest::new(
+                *DEFAULT_GENESIS_CONFIG_HASH,
+                *DEFAULT_PROTOCOL_VERSION,
+                exec_config,
+                DEFAULT_CHAINSPEC_REGISTRY.clone(),
+            )
+        };
+
+        let mut builder = InMemoryWasmTestBuilder::new_with_config(engine_config);
+        builder.run_genesis(&run_genesis_request);
+
+        let fund_request = ExecuteRequestBuilder::transfer(
+            *DEFAULT_ACCOUNT_ADDR,
+            runtime_args! {
+                mint::ARG_TARGET => PublicKey::System.to_account_hash(),
+                mint::ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE),
+                mint::ARG_ID => <Option<u64>>::None,
+            },
+        )
+        .build();
+
+        builder.exec(fund_request).expect_success().commit();
+
+        builder
+    };
 
     let era_validators_1: EraValidators = builder.get_era_validators();
 
@@ -253,7 +298,7 @@ fn should_retain_genesis_validator_slot_protection() {
         "expected validator set should be unchanged"
     );
 
-    builder.run_auction(VESTING_BASE, Vec::new());
+    builder.run_auction(CASPER_VESTING_BASE, Vec::new());
 
     let era_validators_2: EraValidators = builder.get_era_validators();
 
@@ -276,7 +321,7 @@ fn should_retain_genesis_validator_slot_protection() {
 
     builder.exec(add_bid_request).expect_success().commit();
 
-    builder.run_auction(VESTING_BASE + WEEK_MILLIS, Vec::new());
+    builder.run_auction(CASPER_VESTING_BASE + WEEK_MILLIS, Vec::new());
 
     // All genesis validator slots are protected after ~1 week
     let era_validators_3: EraValidators = builder.get_era_validators();
@@ -286,7 +331,10 @@ fn should_retain_genesis_validator_slot_protection() {
     assert_eq!(next_validator_set_3, GENESIS_VALIDATOR_PUBLIC_KEYS.clone());
 
     // After 13 weeks ~ 91 days lowest stake validator is dropped and replaced with higher bid
-    builder.run_auction(VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS, Vec::new());
+    builder.run_auction(
+        CASPER_VESTING_BASE + VESTING_SCHEDULE_LENGTH_MILLIS,
+        Vec::new(),
+    );
 
     let era_validators_4: EraValidators = builder.get_era_validators();
     let (last_era_4, weights_4) = era_validators_4.iter().last().unwrap();

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -48,9 +48,9 @@ legacy_required_finality = 'Strict'
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1
 # The period after genesis during which a genesis validator's bid is locked.
-locked_funds_period = '90days'
+locked_funds_period = '0 days'
 # The period in which genesis validator's bid is released over time after it's unlocked.
-vesting_schedule_period = '13 weeks'
+vesting_schedule_period = '0 weeks'
 # Default number of eras that need to pass to be able to withdraw unbonded funds.
 unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -48,9 +48,9 @@ legacy_required_finality = 'Strict'
 # you will be a validator in era N + auction_delay + 1.
 auction_delay = 1
 # The period after genesis during which a genesis validator's bid is locked.
-locked_funds_period = '90days'
+locked_funds_period = '0 days'
 # The period in which genesis validator's bid is released over time after it's unlocked.
-vesting_schedule_period = '13 weeks'
+vesting_schedule_period = '0 weeks'
 # Default number of eras that need to pass to be able to withdraw unbonded funds.
 unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.


### PR DESCRIPTION
After doing the same merge three basically times (feat-1.6, #4109 and #4228) there's two issues fixed in this PR after #4109 :

- Due to conflicts, VFTA tests for locked amounts were incorrect (default should be 0 lockup, tests should exercise 90 days) - this was introduced in #3231, but conflicts in private chain changes made it revert to 90days.
- Payment errors penalty could've been paid to block proposer regardless of `fee_handling`/`refund_handling` option.

Once merged I'll apply this to both feat-1.6 (again) and feat-2.0