### PR TITLE
Fix issues in storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit
+	$(CARGO) audit --ignore RUSTSEC-2022-0093
 
 .PHONY: audit-as
 audit-as:

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.5.2-alt
+
+### Fixed
+* Fix issue in `chain_get_block_transfers` JSON-RPC where blocks with no deploys could be reported as having `null` transfers rather than `[]`.
+* Fix issue in `chain_get_block_transfers` JSON-RPC where blocks containing successful transfers could erroneously be reported as having none.
+
+
+
 ## 1.5.2
 
 ### Added

--- a/node/src/types/deploy/metadata.rs
+++ b/node/src/types/deploy/metadata.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
-use casper_types::ExecutionResult;
+use casper_types::{ExecutionResult, Transfer};
 
 use crate::types::{BlockHash, BlockHashAndHeight};
 
@@ -15,6 +16,22 @@ pub(crate) struct Metadata {
     /// The block hashes of blocks containing the related deploy, along with the results of
     /// executing the related deploy in the context of one or more blocks.
     pub(crate) execution_results: HashMap<BlockHash, ExecutionResult>,
+}
+
+impl Metadata {
+    pub(crate) fn successful_transfers(&self, block_hash: &BlockHash) -> Vec<Transfer> {
+        match self.execution_results.get(block_hash) {
+            Some(exec_result) => exec_result.successful_transfers(),
+            None => {
+                error!(
+                    execution_results = ?self.execution_results,
+                    %block_hash,
+                    "should have exec result"
+                );
+                vec![]
+            }
+        }
+    }
 }
 
 /// Additional information describing a deploy.

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -179,6 +179,27 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
+    /// Returns all `Transform::WriteTransfer`s from the execution effects if this is an
+    /// `ExecutionResult::Success`, or an empty `Vec` if `ExecutionResult::Failure`.
+    pub fn successful_transfers(&self) -> Vec<Transfer> {
+        let effects = match self {
+            ExecutionResult::Success { effect, .. } => effect,
+            ExecutionResult::Failure { .. } => return vec![],
+        };
+
+        effects
+            .transforms
+            .iter()
+            .filter_map(|transform_entry| {
+                if let Transform::WriteTransfer(transfer) = transform_entry.transform {
+                    Some(transfer)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     // This method is not intended to be used by third party crates.
     #[doc(hidden)]
     #[cfg(feature = "json-schema")]


### PR DESCRIPTION
This PR fixes two separate issues:
* a historical synced block with no deploys would have no entry written for it in the `transfers_db`, causing the JSON-RPC `chain_get_block_transfers` to report the block's transfers as `null` rather than `[]`
* for a block with a non-zero number of successful transfers, if its execution results were put to storage more than once, the initial valid entry in the `transfers_db` would be overwritten with an invalid empty collection, causing the JSON-RPC `chain_get_block_transfers` to report the block's transfers as `[]` rather then the correct value

Th fix is to have `Storage` reconstitute the correct value when reading from `transfers_db` if it encounters a missing value or an empty collection, and store the corrected value before returning it.  The `Storage::write_execution_results` method has also been corrected to not overwrite good values with empty collections.

Closes #4255.
Closes #4268.