### PR TITLE
Cleanup `Option<Arc<AtomicBool>>` in `network`.

### DIFF
--- a/node/src/components/network/tasks.rs
+++ b/node/src/components/network/tasks.rs
@@ -467,7 +467,7 @@ pub(super) async fn server<P, REv>(
 /// Juliet-based message receiver.
 pub(super) async fn message_receiver<REv, P>(
     context: Arc<NetworkContext<REv>>,
-    validator_status: Option<Arc<AtomicBool>>,
+    validator_status: Arc<AtomicBool>,
     mut rpc_server: RpcServer,
     shutdown: ObservableFuse,
     peer_id: NodeId,
@@ -532,11 +532,7 @@ where
             });
         }
 
-        let queue_kind = if validator_status
-            .as_ref()
-            .map(|arc| arc.load(Ordering::Relaxed))
-            .unwrap_or_default()
-        {
+        let queue_kind = if validator_status.load(Ordering::Relaxed) {
             QueueKind::MessageValidator
         } else if msg.is_low_priority() {
             QueueKind::MessageLowPriority

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1887,7 +1887,7 @@ impl BlockExecutionResultsOrChunk {
         num_results: usize,
     ) -> Self {
         let execution_results: Vec<casper_types::ExecutionResult> =
-            (0..num_results).into_iter().map(|_| rng.gen()).collect();
+            (0..num_results).map(|_| rng.gen()).collect();
 
         Self {
             block_hash,


### PR DESCRIPTION
A small fix that replaces an uncommon edge cases with a default (the key being absent), which in both cases evaluates to `false`, this version results in simpler code though.