### PR TITLE
Extend juliet unit test suite

### DIFF
--- a/juliet/proptest-regressions/io.txt
+++ b/juliet/proptest-regressions/io.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a5ecee32b10b8720f0f7b09871835a7a9fd674f8b5b9c1c9ac68e3fb977c0345 # shrinks to input = []
+cc b44cf1d77da7a1db17b3174b7bd9b55dbe835cc5e85acd5fd3ec137714ef50d3 # shrinks to input = [30, 0, 0, 0, 0, 247, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+cc 3cd7b8fb915fa8d98871218c077ab02a99b66eaf5d3306738331a55daddf9891 # shrinks to input = [117, 157, 0, 5, 0, 0, 0, 0, 0, 186, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 0, 93, 0, 0, 41, 0, 0, 223, 0, 0, 130, 169, 29, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/juliet/proptest-regressions/lib.txt
+++ b/juliet/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 298f935141dc04a8afb87a0f78f9491eb0fb39330b74592eb42fb3e78a859d61 # shrinks to raw = 0

--- a/juliet/src/lib.rs
+++ b/juliet/src/lib.rs
@@ -196,7 +196,7 @@ macro_rules! try_outcome {
 }
 
 /// Channel configuration values that needs to be agreed upon by all clients.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ChannelConfiguration {
     /// Maximum number of requests allowed on the channel.
     request_limit: u16,
@@ -263,7 +263,7 @@ mod tests {
     };
     use proptest_attr_macro::proptest;
 
-    use crate::{ChannelId, Id, Outcome};
+    use crate::{ChannelConfiguration, ChannelId, Id, Outcome};
 
     impl Arbitrary for ChannelId {
         type Parameters = <u8 as Arbitrary>::Parameters;
@@ -398,5 +398,23 @@ mod tests {
             Outcome::incomplete(123)
         );
         assert_eq!(try_outcome_func(Outcome::Fatal(-123)), Outcome::Fatal(-123));
+    }
+
+    #[test]
+    fn channel_configuration_can_be_built() {
+        let mut chan_cfg = ChannelConfiguration::new();
+        assert_eq!(chan_cfg, ChannelConfiguration::default());
+
+        chan_cfg = chan_cfg.with_request_limit(123);
+        assert_eq!(chan_cfg.request_limit, 123);
+
+        chan_cfg = chan_cfg.with_max_request_payload_size(99);
+        assert_eq!(chan_cfg.request_limit, 123);
+        assert_eq!(chan_cfg.max_request_payload_size, 99);
+
+        chan_cfg = chan_cfg.with_max_response_payload_size(77);
+        assert_eq!(chan_cfg.request_limit, 123);
+        assert_eq!(chan_cfg.max_request_payload_size, 99);
+        assert_eq!(chan_cfg.max_response_payload_size, 77);
     }
 }

--- a/juliet/src/util.rs
+++ b/juliet/src/util.rs
@@ -58,3 +58,39 @@ impl<'a> Display for PayloadFormat<'a> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::{Bytes, BytesMut};
+    use proptest_attr_macro::proptest;
+
+    use crate::util::PayloadFormat;
+
+    use super::Index;
+
+    #[proptest]
+    fn index_derefs_correctly(idx: usize) {
+        let buffer = BytesMut::new();
+        let index = Index::new(&buffer, idx);
+
+        assert_eq!(*index, idx);
+    }
+
+    #[test]
+    fn payload_formatting_works() {
+        let payload_small = Bytes::from_static(b"hello");
+        assert_eq!(
+            PayloadFormat(&payload_small).to_string(),
+            "68 65 6c 6c 6f (5 bytes)"
+        );
+
+        let payload_large = Bytes::from_static(b"goodbye, cruel world");
+        assert_eq!(
+            PayloadFormat(&payload_large).to_string(),
+            "67 6f 6f 64 62 79 65 2c 20 63 72 75 65 6c 20 77 ... (20 bytes)"
+        );
+
+        let payload_empty = Bytes::from_static(b"");
+        assert_eq!(PayloadFormat(&payload_empty).to_string(), "(0 bytes)");
+    }
+}


### PR DESCRIPTION
Closes #4242.

Extends the unit test coverage (though I'd prefer to add more still) covering low level functions, adding a mock-reader for IO data. Lead to at least one bug being fixed.
