### PR TITLE
Fix query_balance to handle addressable_entity

### DIFF
--- a/node/src/components/rpc_server/rpcs/error_code.rs
+++ b/node/src/components/rpc_server/rpcs/error_code.rs
@@ -35,6 +35,8 @@ pub enum ErrorCode {
     FailedToGetTrie = -32011,
     /// The requested state root hash was not found.
     NoSuchStateRoot = -32012,
+    /// The main purse for a given account hash does not exist.
+    NoSuchMainPurse = -32013,
 }
 
 impl From<ErrorCode> for (i64, &'static str) {
@@ -59,6 +61,7 @@ impl From<ErrorCode> for (i64, &'static str) {
             }
             ErrorCode::FailedToGetTrie => (error_code as i64, "Failed to get trie"),
             ErrorCode::NoSuchStateRoot => (error_code as i64, "No such state root"),
+            ErrorCode::NoSuchMainPurse => (error_code as i64, "Failed to get main purse"),
         }
     }
 }


### PR DESCRIPTION
CHANGELOG:

- Fixed the `query_balance` RPC method to handle the introduction of `AddressableEntity`

Manually verified by spinning up an NCTL network and running the casper-client against the 2.0 network


Closes #4284 
