### PR TITLE
Add timeouts to `juliet` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "proptest-derive",
- "quanta",
+ "quanta 0.7.2",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -3256,6 +3256,7 @@ dependencies = [
  "proptest",
  "proptest-attr-macro",
  "proptest-derive",
+ "quanta 0.11.1",
  "rand",
  "static_assertions",
  "strum 0.25.0",
@@ -3395,6 +3396,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -4320,7 +4330,23 @@ dependencies = [
  "libc",
  "mach",
  "once_cell",
- "raw-cpuid",
+ "raw-cpuid 9.1.1",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils 0.8.15",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid 10.7.0",
+ "wasi",
+ "web-sys",
  "winapi",
 ]
 
@@ -4423,6 +4449,15 @@ name = "raw-cpuid"
 version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "proptest-derive",
- "quanta 0.7.2",
+ "quanta",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -3256,7 +3256,6 @@ dependencies = [
  "proptest",
  "proptest-attr-macro",
  "proptest-derive",
- "quanta 0.11.1",
  "rand",
  "static_assertions",
  "strum 0.25.0",
@@ -3396,15 +3395,6 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -4330,23 +4320,7 @@ dependencies = [
  "libc",
  "mach",
  "once_cell",
- "raw-cpuid 9.1.1",
- "winapi",
-]
-
-[[package]]
-name = "quanta"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
-dependencies = [
- "crossbeam-utils 0.8.15",
- "libc",
- "mach2",
- "once_cell",
- "raw-cpuid 10.7.0",
- "wasi",
- "web-sys",
+ "raw-cpuid",
  "winapi",
 ]
 
@@ -4449,15 +4423,6 @@ name = "raw-cpuid"
 version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]

--- a/juliet/Cargo.toml
+++ b/juliet/Cargo.toml
@@ -13,7 +13,6 @@ bytes = "1.4.0"
 futures = "0.3.28"
 hex_fmt = "0.3.0"
 once_cell = "1.18.0"
-quanta = "0.11.1"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
 tokio = { version = "1.29.1", features = [ "macros", "io-util", "sync", "time" ] }

--- a/juliet/Cargo.toml
+++ b/juliet/Cargo.toml
@@ -13,9 +13,10 @@ bytes = "1.4.0"
 futures = "0.3.28"
 hex_fmt = "0.3.0"
 once_cell = "1.18.0"
+quanta = "0.11.1"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
-tokio = { version = "1.29.1", features = [ "macros", "io-util", "sync" ] }
+tokio = { version = "1.29.1", features = [ "macros", "io-util", "sync", "time" ] }
 tracing = { version = "0.1.37", optional = true }
 
 [dev-dependencies]

--- a/juliet/README.md
+++ b/juliet/README.md
@@ -21,3 +21,16 @@ This crate's implementation includes benefits such as
 ## Examples
 
 For a quick usage example, see `examples/fizzbuzz.rs`.
+
+## `tracing` support
+
+The crate has an optional dependency on the [`tracing`](https://docs.rs/tracing) crate, which, if enabled, allows detailed insights through logs. If the feature is not enabled, no log statements are compiled in.
+
+Log levels in general are used as follows:
+
+* `ERROR` and `WARN`: Actual issues that are not protocol level errors -- peer errors are expected and do not warrant a `WARN` level.
+* `INFO`: Insights into received high level events (e.g. connection, disconnection, etc), except information concerning individual requests/messages.
+* `DEBUG`: Detailed insights down to the level of individual requests, but not frames. A multi-megabyte single message transmission will NOT clog the logs.
+* `TRACE`: Like `DEBUG`, but also including frame and wire-level information, as well as local functions being called.
+
+At `INFO`, it is thus conceivable for a peer to maliciously spam local logs, although with some effort if connection attempts are rate limited. At `DEBUG` or lower, this becomes trivial.

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -116,7 +116,7 @@ impl Display for QueuedItem {
                 if let Some(payload) = payload {
                     write!(f, ", payload: {}", PayloadFormat(payload))?;
                 }
-                f.write_str(" }}")
+                f.write_str(" }")
             }
             QueuedItem::RequestCancellation { io_id } => {
                 write!(f, "RequestCancellation {{ io_id: {} }}", io_id)
@@ -130,7 +130,7 @@ impl Display for QueuedItem {
                 if let Some(payload) = payload {
                     write!(f, ", payload: {}", PayloadFormat(payload))?;
                 }
-                f.write_str(" }}")
+                f.write_str(" }")
             }
             QueuedItem::ResponseCancellation { channel, id } => {
                 write!(
@@ -343,7 +343,7 @@ impl Display for IoEvent {
                 if let Some(ref payload) = payload {
                     write!(f, ", payload: {}", PayloadFormat(payload))?;
                 }
-                f.write_str(" }}")
+                f.write_str(" }")
             }
 
             IoEvent::RequestCancelled { channel, id } => {
@@ -354,7 +354,7 @@ impl Display for IoEvent {
                 if let Some(ref payload) = payload {
                     write!(f, ", payload: {}", PayloadFormat(payload))?;
                 }
-                f.write_str(" }}")
+                f.write_str(" }")
             }
             IoEvent::ReceivedCancellationResponse { io_id } => {
                 write!(f, "RequestCancalled {{ io_id: {} }}", io_id)
@@ -598,6 +598,8 @@ where
         &mut self,
         completed_read: CompletedRead,
     ) -> Result<IoEvent, CoreError> {
+        #[cfg(feature = "tracing")]
+        tracing::debug!(%completed_read, "completed read");
         match completed_read {
             CompletedRead::ErrorReceived { header, data } => {
                 // We've received an error from the peer, they will be closing the connection.

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -158,7 +158,7 @@ pub enum CoreError {
 /// Request layer IO IDs are unique across the program per request that originated from the local
 /// endpoint. They are used to allow for buffering large numbers of items without exhausting the
 /// pool of protocol level request IDs, which are limited to `u16`s.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IoId(u64);
 
 /// IO layer for the juliet protocol.

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -693,8 +693,8 @@ where
                 drop(permit);
             }
             QueuedItem::RequestCancellation { io_id } => {
-                if let Some((_, (channel, id))) = self.request_map.remove_by_left(&io_id) {
-                    if let Some(msg) = self.juliet.cancel_request(channel, id)? {
+                if let Some((channel, id)) = self.request_map.get_by_left(&io_id) {
+                    if let Some(msg) = self.juliet.cancel_request(*channel, *id)? {
                         self.ready_queue.push_back(msg.frames());
                     }
                 } else {

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -168,6 +168,7 @@ pub struct IoId(u64);
 /// items to be sent.
 ///
 /// Once instantiated, a continuous polling of [`IoCore::next_event`] is expected.
+#[derive(Debug)]
 pub struct IoCore<const N: usize, R, W> {
     /// The actual protocol state.
     juliet: JulietProtocol<N>,

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -357,7 +357,7 @@ impl Display for IoEvent {
                 f.write_str(" }")
             }
             IoEvent::ReceivedCancellationResponse { io_id } => {
-                write!(f, "RequestCancalled {{ io_id: {} }}", io_id)
+                write!(f, "ReceivedCancellationResponse {{ io_id: {} }}", io_id)
             }
         }
     }

--- a/juliet/src/io.rs
+++ b/juliet/src/io.rs
@@ -456,8 +456,7 @@ where
 
                     #[cfg(feature = "tracing")]
                     {
-                        use tracing::trace;
-                        trace!(frame=%frame_sent, "sent");
+                        tracing::trace!(frame=%frame_sent, "sent");
                     }
 
                     if frame_sent.header().is_error() {

--- a/juliet/src/protocol.rs
+++ b/juliet/src/protocol.rs
@@ -447,17 +447,11 @@ pub enum LocalProtocolViolation {
 macro_rules! log_frame {
     ($header:expr) => {
         #[cfg(feature = "tracing")]
-        {
-            use tracing::trace;
-            trace!(header=%$header, "received");
-        }
+        tracing::trace!(header=%$header, "received");
     };
     ($header:expr, $payload:expr) => {
         #[cfg(feature = "tracing")]
-        {
-            use tracing::trace;
-            trace!(header=%$header, payload=%crate::util::PayloadFormat(&$payload), "received");
-        }
+        tracing::trace!(header=%$header, payload=%crate::util::PayloadFormat(&$payload), "received");
     };
 }
 
@@ -705,7 +699,7 @@ impl<const N: usize> JulietProtocol<N> {
                 None => {
                     // The header was invalid, return an error.
                     #[cfg(feature = "tracing")]
-                    tracing::trace!(?header_raw, "received invalid header");
+                    tracing::debug!(?header_raw, "received invalid header");
                     return Fatal(OutgoingMessage::new(
                         Header::new_error(ErrorKind::InvalidHeader, UNKNOWN_CHANNEL, UNKNOWN_ID),
                         None,
@@ -892,8 +886,7 @@ impl<const N: usize> JulietProtocol<N> {
 
                     #[cfg(feature = "tracing")]
                     {
-                        use tracing::trace;
-                        trace!(%header, "received request cancellation");
+                        tracing::debug!(%header, "received request cancellation");
                     }
 
                     // Multi-frame transfers that have not yet been completed are a special case,

--- a/juliet/src/protocol.rs
+++ b/juliet/src/protocol.rs
@@ -418,7 +418,7 @@ pub enum CompletedRead {
 ///
 /// Higher level layers like [`rpc`](crate::rpc) should make it impossible to encounter
 /// [`LocalProtocolViolation`]s.
-#[derive(Copy, Clone, Debug, Error)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum LocalProtocolViolation {
     /// A request was not sent because doing so would exceed the request limit on channel.
     ///

--- a/juliet/src/protocol/outgoing_message.rs
+++ b/juliet/src/protocol/outgoing_message.rs
@@ -672,11 +672,11 @@ mod tests {
         assert_eq!(byte_iter.chunk(), &[11]);
         byte_iter.advance(1);
         assert_eq!(byte_iter.remaining(), 0);
-        assert_eq!(byte_iter.chunk(), &[]);
-        assert_eq!(byte_iter.chunk(), &[]);
-        assert_eq!(byte_iter.chunk(), &[]);
-        assert_eq!(byte_iter.chunk(), &[]);
-        assert_eq!(byte_iter.chunk(), &[]);
+        assert_eq!(byte_iter.chunk(), &[0u8; 0]);
+        assert_eq!(byte_iter.chunk(), &[0u8; 0]);
+        assert_eq!(byte_iter.chunk(), &[0u8; 0]);
+        assert_eq!(byte_iter.chunk(), &[0u8; 0]);
+        assert_eq!(byte_iter.chunk(), &[0u8; 0]);
         assert_eq!(byte_iter.remaining(), 0);
         assert_eq!(byte_iter.remaining(), 0);
         assert_eq!(byte_iter.remaining(), 0);

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -231,7 +231,7 @@ where
     /// `next_request` as soon as possible.
     pub async fn next_request(&mut self) -> Result<Option<IncomingRequest>, RpcServerError> {
         loop {
-            let now = self.clock.recent();
+            let now = self.clock.now();
 
             // Process all the timeouts.
             let until_timeout_check = self.process_timeouts(now);
@@ -378,8 +378,6 @@ impl<'a, const N: usize> JulietRpcRequestBuilder<'a, N> {
     /// Sets the timeout for the request.
     ///
     /// By default, there is an infinite timeout.
-    ///
-    /// **TODO**: Currently the timeout feature is not implemented.
     pub const fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
@@ -434,7 +432,7 @@ impl<'a, const N: usize> JulietRpcRequestBuilder<'a, N> {
 
         // If a timeout is set, calculate expiration time.
         let expires = if let Some(timeout) = self.timeout {
-            match clock.recent().checked_add(timeout) {
+            match clock.now().checked_add(timeout) {
                 Some(expires) => Some(expires),
                 None => {
                     // The timeout is so high that the resulting `Instant` would overflow.

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -1092,7 +1092,7 @@ mod tests {
 
         assert_eq!(
             drain_heap_while(&mut heap, |&v| v > 10).collect::<Vec<_>>(),
-            vec![]
+            Vec::<i32>::new()
         );
 
         assert_eq!(

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -266,7 +266,7 @@ where
                     #[cfg(feature = "tracing")]
                     {
                         if let Some(ref new_request) = opt_new_request {
-                            tracing::debug!(%new_request, "request to send");
+                            tracing::debug!(%new_request, "trying to enqueue");
                         }
                     }
                     if let Some(NewOutgoingRequest { ticket, guard, payload, expires }) = opt_new_request {

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -373,6 +373,12 @@ where
                 #[cfg(feature = "tracing")]
                 tracing::debug!(%io_id, "timeout due to response not received in time");
                 guard_ref.set_and_notify(Err(RequestError::TimedOut));
+
+                // We also need to send a cancellation.
+                if self.handle.enqueue_request_cancellation(io_id).is_err() {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(%io_id, "dropping timeout cancellation, remote already closed");
+                }
             }
         }
 

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -538,7 +538,7 @@ pub enum RequestError {
 /// The existence of a [`RequestGuard`] indicates that a request has been made or is ongoing. It
 /// can also be used to attempt to [`cancel`](RequestGuard::cancel) the request, or retrieve its
 /// values using [`wait_for_response`](RequestGuard::wait_for_response) or
-/// [`try_wait_for_response`](RequestGuard::try_wait_for_response).
+/// [`try_get_response`](RequestGuard::try_get_response).
 #[derive(Debug)]
 #[must_use = "dropping the request guard will immediately cancel the request"]
 pub struct RequestGuard {

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -759,9 +759,7 @@ struct DrainConditional<'a, T, F> {
     predicate: F,
 }
 
-/// Removes ites from the top of a heap while a given predicate is true.
-///
-/// Will take items from `heap` as long as `predicate` evaluates to `true`.
+/// Removes items from the top of a heap while a given predicate is true.
 fn drain_heap_while<T, F: FnMut(&T) -> bool>(
     heap: &mut BinaryHeap<T>,
     predicate: F,

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -101,6 +101,7 @@ pub struct JulietRpcClient<const N: usize> {
 /// [`queue_for_sending`](JulietRpcRequestBuilder::queue_for_sending) or
 /// [`try_queue_for_sending`](JulietRpcRequestBuilder::try_queue_for_sending), returning a
 /// [`RequestGuard`], which can be used to await the results of the request.
+#[derive(Debug)]
 pub struct JulietRpcRequestBuilder<'a, const N: usize> {
     client: &'a JulietRpcClient<N>,
     channel: ChannelId,
@@ -117,6 +118,7 @@ pub struct JulietRpcRequestBuilder<'a, const N: usize> {
 /// ## Shutdown
 ///
 /// The server will automatically be shutdown if the last [`JulietRpcClient`] is dropped.
+#[derive(Debug)]
 pub struct JulietRpcServer<const N: usize, R, W> {
     core: IoCore<N, R, W>,
     handle: Handle,
@@ -125,6 +127,7 @@ pub struct JulietRpcServer<const N: usize, R, W> {
 }
 
 /// Internal structure representing a new outgoing request.
+#[derive(Debug)]
 struct NewOutgoingRequest {
     /// The already reserved ticket.
     ticket: RequestTicket,

--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -993,7 +993,8 @@ mod tests {
         assert_eq!(result_short, Err(RequestError::TimedOut));
         assert_eq!(result_long, Ok(Some(payload_long)));
 
-        // TODO: Ensure cancellation was sent.
+        // TODO: Ensure cancellation was sent. Right now, we can verify this in the logs, but it
+        //       would be nice to have a test tailored to ensure this.
     }
 
     #[test]

--- a/juliet/test.sh
+++ b/juliet/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+#: Shorthand script to run test with logging setup correctly.
+
+RUST_LOG=${RUST_LOG:-juliet=trace}
+export RUST_LOG
+
+# Run one thread at a time to not get interleaved output.
+exec cargo test --features tracing -- --test-threads=1 --nocapture $@

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -1489,7 +1489,7 @@ where
 /// `RequestGuard`. Potential errors that are available early are dropped, later errors discarded.
 #[inline]
 fn process_request_guard(channel: Channel, guard: RequestGuard) {
-    match guard.try_wait_for_response() {
+    match guard.try_get_response() {
         Ok(Ok(_outcome)) => {
             // We got an incredibly quick round-trip, lucky us! Nothing to do.
         }


### PR DESCRIPTION
Closes #4139.

Adds support for timeouts to the `juliet` crate. Note that this function is not yet used in the node (`with_timeout` is never called), so there is no direct impact yet.

It also renames one function (hence the node change), adds a lot more traceability and some additional tests, fixing some bugs in the process.