### PR TITLE
Add event queue insight to log when there are many events in the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ To set the threshold at which a warn-level log message is generated for a long-r
 CL_EVENT_MAX_MICROSECS=1000
 ```
 
+To set the threshold above which the size of the current scheduler queues will be dumped to logs, use the `CL_EVENT_QUEUE_DUMP_THRESHOLD` variable. For example, to set the threshold to 10000 events:
+
+```
+CL_EVENT_QUEUE_DUMP_THRESHOLD=10000
+```
+
+This will dump a line to the log if the total number of events in queues exceeds 10000. After each dump, the threshold will be automatically increased by 10% to avoid log flooding.
+
+Example log entry:
+```
+Current event queue size (11000) is above the threshold (10000): details [("FinalitySignature", 3000), ("FromStorage", 1000), ("NetworkIncoming", 6500), ("Regular", 500)]
+```
 
 ## Logging
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 
+### Added
+* New environment variable `CL_EVENT_QUEUE_DUMP_THRESHOLD` to enable dumping of queue event counts to log when a certain threshold is exceeded.
+
 ### Fixed
 * Now possible to build outside a git repository context (e.g. from a source tarball). In such cases, the node's build version (as reported vie status endpoints) will not contain a trailing git short hash.
 

--- a/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
@@ -36,7 +36,7 @@ struct MockReactor {
 
 impl MockReactor {
     fn new() -> Self {
-        let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));
+        let scheduler = utils::leak(Scheduler::new(QueueKind::weights(), None));
         let event_queue_handle = EventQueueHandle::without_shutdown(scheduler);
         let effect_builder = EffectBuilder::new(event_queue_handle);
         MockReactor {

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -71,7 +71,7 @@ struct MockReactor {
 
 impl MockReactor {
     fn new() -> Self {
-        let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));
+        let scheduler = utils::leak(Scheduler::new(QueueKind::weights(), None));
         let event_queue_handle = EventQueueHandle::without_shutdown(scheduler);
         let effect_builder = EffectBuilder::new(event_queue_handle);
         MockReactor {

--- a/node/src/components/block_synchronizer/trie_accumulator/tests.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator/tests.rs
@@ -34,7 +34,7 @@ struct MockReactor {
 
 impl MockReactor {
     fn new() -> Self {
-        let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));
+        let scheduler = utils::leak(Scheduler::new(QueueKind::weights(), None));
         let event_queue_handle = EventQueueHandle::without_shutdown(scheduler);
         let effect_builder = EffectBuilder::new(event_queue_handle);
         MockReactor {

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -44,7 +44,7 @@ struct MockReactor {
 impl MockReactor {
     fn new() -> Self {
         MockReactor {
-            scheduler: utils::leak(Scheduler::new(QueueKind::weights())),
+            scheduler: utils::leak(Scheduler::new(QueueKind::weights(), None)),
         }
     }
 

--- a/node/src/components/deploy_buffer/tests.rs
+++ b/node/src/components/deploy_buffer/tests.rs
@@ -395,6 +395,7 @@ fn register_deploys_and_blocks() {
 }
 
 /// Event for the mock reactor.
+#[derive(Debug)]
 enum ReactorEvent {
     DeployBufferAnnouncement(DeployBufferAnnouncement),
     Event(Event),

--- a/node/src/components/deploy_buffer/tests.rs
+++ b/node/src/components/deploy_buffer/tests.rs
@@ -420,7 +420,7 @@ struct MockReactor {
 impl MockReactor {
     fn new() -> Self {
         MockReactor {
-            scheduler: utils::leak(Scheduler::new(QueueKind::weights())),
+            scheduler: utils::leak(Scheduler::new(QueueKind::weights(), None)),
         }
     }
 

--- a/node/src/components/diagnostics_port/tasks.rs
+++ b/node/src/components/diagnostics_port/tasks.rs
@@ -822,7 +822,7 @@ mod tests {
     #[tokio::test]
     async fn can_dump_actual_events_from_scheduler() {
         // Create a scheduler with a few synthetic events.
-        let scheduler = WeightedRoundRobin::new(QueueKind::weights());
+        let scheduler = WeightedRoundRobin::new(QueueKind::weights(), None);
         scheduler
             .push(
                 MainEvent::Network(network::Event::SweepOutgoing),

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -498,7 +498,7 @@ where
         }
 
         let event_queue_dump_threshold =
-            env::var("EVENT_QUEUE_DUMP_THRESHOLD").map_or(None, |s| s.parse::<usize>().ok());
+            env::var("CL_EVENT_QUEUE_DUMP_THRESHOLD").map_or(None, |s| s.parse::<usize>().ok());
 
         let scheduler = utils::leak(Scheduler::new(
             QueueKind::weights(),

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -497,7 +497,13 @@ where
             );
         }
 
-        let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));
+        let event_queue_dump_threshold =
+            env::var("EVENT_QUEUE_DUMP_THRESHOLD").map_or(None, |s| s.parse::<usize>().ok());
+
+        let scheduler = utils::leak(Scheduler::new(
+            QueueKind::weights(),
+            event_queue_dump_threshold,
+        ));
         let is_shutting_down = SharedFlag::new();
         let event_queue = EventQueueHandle::new(scheduler, is_shutting_down);
         let (reactor, initial_effects) = R::new(

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -138,7 +138,7 @@ pub(crate) struct ComponentHarnessBuilder<REv: 'static> {
     _phantom: PhantomData<REv>,
 }
 
-impl<REv: 'static> ComponentHarnessBuilder<REv> {
+impl<REv: 'static + Debug> ComponentHarnessBuilder<REv> {
     /// Builds a component harness instance.
     ///
     /// # Panics
@@ -314,7 +314,7 @@ impl<REv: 'static> ComponentHarness<REv> {
     }
 }
 
-impl<REv: 'static> Default for ComponentHarness<REv> {
+impl<REv: 'static + Debug> Default for ComponentHarness<REv> {
     fn default() -> Self {
         Self::builder().build()
     }

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -174,7 +174,7 @@ impl<REv: 'static + Debug> ComponentHarnessBuilder<REv> {
 
         let rng = self.rng.unwrap_or_else(TestRng::new);
 
-        let scheduler = Box::leak(Box::new(Scheduler::new(QueueKind::weights())));
+        let scheduler = Box::leak(Box::new(Scheduler::new(QueueKind::weights(), None)));
         let event_queue_handle = EventQueueHandle::without_shutdown(scheduler);
         let effect_builder = EffectBuilder::new(event_queue_handle);
         let runtime = runtime::Builder::new_multi_thread()

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -229,8 +229,8 @@ where
 
         // NOTE: Count may be off by one b/c of the way locking works when elements are popped.
         // It's fine for its purposes.
-        let total = self.queues.iter().map(|q| q.1.event_count()).sum::<usize>();
         if let Some(recent_event_count_peak) = &self.recent_event_count_peak {
+            let total = self.queues.iter().map(|q| q.1.event_count()).sum::<usize>();
             let recent_threshold = recent_event_count_peak.load(Ordering::SeqCst);
             if total > recent_threshold {
                 recent_event_count_peak.store(total, Ordering::SeqCst);

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -244,9 +244,7 @@ where
                     .map(|q| (q.0.to_string(), q.1.event_count()))
                     .filter(|(_, count)| count > &0)
                     .collect();
-                warn!(
-                "Current event queue size ({total}) is above the threshold ({recent_threshold}): details {info:?}"
-            );
+                warn!("Current event queue size ({total}) is above the threshold ({recent_threshold}): details {info:?}");
             }
         }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -44,7 +44,8 @@ pub struct WeightedRoundRobin<I, K> {
     /// Whether or not the queue is sealed (not accepting any more items).
     sealed: AtomicBool,
 
-    /// Only dump event counts when there are more of them than in the previous report.
+    /// Dump count of events only when there is a 10%+ increase of events compared to the previous
+    /// report. Setting to `None` disables the dump function.
     recent_event_count_peak: Option<AtomicUsize>,
 }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::Hash,
     num::NonZeroUsize,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -15,7 +15,7 @@ use std::{
 use enum_iterator::IntoEnumIterator;
 use serde::Serialize;
 use tokio::sync::{Mutex, MutexGuard, Semaphore};
-use tracing::debug;
+use tracing::{debug, error};
 
 /// Weighted round-robin scheduler.
 ///
@@ -169,7 +169,7 @@ where
 
 impl<I, K> WeightedRoundRobin<I, K>
 where
-    K: Copy + Clone + Eq + Hash,
+    K: Copy + Clone + Eq + Hash + Display,
 {
     /// Creates a new weighted round-robin scheduler.
     ///
@@ -213,6 +213,8 @@ where
             debug!("queue sealed, dropping item");
             return;
         }
+
+        error!("XXXXX - Putting ITEM into '{}'", queue);
 
         self.queues
             .get(&queue)


### PR DESCRIPTION
When the scheduler queue grows too much, the node will dump a basic breakdown of queue content into the log, like so:
```
Current event queue size (26) is above the threshold (25): details [("FinalitySignature", 3), ("FromStorage", 1), ("NetworkIncoming", 21), ("Regular", 1)]
```

The threshold is read from the environment variable: `CL_EVENT_QUEUE_DUMP_THRESHOLD`. If this variable is not set, this function is disabled.

Additionally, in order to prevent log flooding, the next dump will happen only if there are 10% more events in the queue than at the time of creating the previous dump.

This is a performance debug mechanism to support fixing issues with 16s blocks.