### PR TITLE
casper-types: add a new `Key` variant for contract level messages

### DIFF
--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -330,6 +330,10 @@ where
                 error!("should not remove the checksum registry key");
                 Err(Error::RemoveKeyFailure(RemoveKeyFailure::PermissionDenied))
             }
+            Key::MessageTopic(_) => {
+                error!("should not remove the message keys");
+                Err(Error::RemoveKeyFailure(RemoveKeyFailure::PermissionDenied))
+            }
             bid_key @ Key::BidAddr(_) => {
                 let _bid_kind: BidKind = self.read_gs_typed(&bid_key)?;
                 self.named_keys.remove(name);
@@ -799,7 +803,8 @@ where
             | Key::Unbond(_)
             | Key::ChainspecRegistry
             | Key::ChecksumRegistry
-            | Key::BidAddr(_) => true,
+            | Key::BidAddr(_)
+            | Key::MessageTopic(_) => true,
         }
     }
 
@@ -821,7 +826,8 @@ where
             | Key::Unbond(_)
             | Key::ChainspecRegistry
             | Key::ChecksumRegistry
-            | Key::BidAddr(_) => false,
+            | Key::BidAddr(_)
+            | Key::MessageTopic(_) => false,
         }
     }
 
@@ -843,7 +849,8 @@ where
             | Key::Unbond(_)
             | Key::ChainspecRegistry
             | Key::ChecksumRegistry
-            | Key::BidAddr(_) => false,
+            | Key::BidAddr(_)
+            | Key::MessageTopic(_) => false,
         }
     }
 

--- a/types/src/contract_messages.rs
+++ b/types/src/contract_messages.rs
@@ -1,0 +1,93 @@
+//! Data types for interacting with contract level messages.
+
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    HashAddr,
+};
+use alloc::vec::Vec;
+use core::fmt::{Display, Formatter};
+
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// The length in bytes of a [`MessageTopicHash`].
+pub const MESSAGE_TOPIC_HASH_LENGTH: usize = 32;
+
+/// The hash of the name of the message topic.
+pub type MessageTopicHash = [u8; MESSAGE_TOPIC_HASH_LENGTH];
+
+/// MessageAddr
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+pub struct MessageTopicAddr {
+    /// The entity addr.
+    entity_addr: HashAddr,
+    /// The hash of the name of the message topic.
+    topic_hash: MessageTopicHash,
+}
+
+impl MessageTopicAddr {
+    /// Constructs a new [`MessageAddr`] based on the addressable entity addr and the hash of the
+    /// message topic name.
+    pub const fn new(entity_addr: HashAddr, topic_hash: MessageTopicHash) -> Self {
+        Self {
+            entity_addr,
+            topic_hash,
+        }
+    }
+}
+
+impl Display for MessageTopicAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            base16::encode_lower(&self.entity_addr),
+            base16::encode_lower(&self.topic_hash)
+        )
+    }
+}
+
+impl ToBytes for MessageTopicAddr {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.entity_addr.to_bytes()?);
+        buffer.append(&mut self.topic_hash.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.entity_addr.serialized_length() + self.topic_hash.serialized_length()
+    }
+}
+
+impl FromBytes for MessageTopicAddr {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (entity_addr, rem) = FromBytes::from_bytes(bytes)?;
+        let (topic_hash, rem) = FromBytes::from_bytes(rem)?;
+        Ok((
+            MessageTopicAddr {
+                entity_addr,
+                topic_hash,
+            },
+            rem,
+        ))
+    }
+}
+
+impl Distribution<MessageTopicAddr> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessageTopicAddr {
+        MessageTopicAddr {
+            entity_addr: rng.gen(),
+            topic_hash: rng.gen(),
+        }
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -34,6 +34,7 @@ mod chainspec;
 pub mod checksummed_hex;
 mod cl_type;
 mod cl_value;
+pub mod contract_messages;
 mod contract_wasm;
 pub mod contracts;
 pub mod crypto;


### PR DESCRIPTION
Add a new `Key::MessageTopic` variant under which message digests will be written to global state for messages emitted by contracts.

Fixes: https://github.com/casper-network/roadmap/issues/216
