### PR TITLE
GH-4108: Better error message for multi value proposal

### DIFF
--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -429,7 +429,17 @@ pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
             ) => PreprocessingError::Deserialize(
                 "Sign extension operations are not supported".to_string(),
             ),
+            parity_wasm::SerializationError::Other(msg) if msg == "Enable the multi_value feature to deserialize more than one function result" => {
+                // Due to the way parity-wasm crate works, it's always deserializes opcodes
+                // from multi_value proposal but if the feature is not enabled, then it will
+                // error with very specific message (as compared to other extensions).
+                //
+                // That's OK since we'd prefer to not inspect deserialized bytecode. We
+                // can simply replace the error message with a more user friendly one.
+                PreprocessingError::Deserialize("Multi value extension is not supported".to_string())
+            }
             _ => deserialize_error.into(),
+
         }
     })
 }
@@ -674,7 +684,7 @@ mod tests {
             .expect_err("should fail with an error");
         assert!(
             matches!(&error, PreprocessingError::Deserialize(msg)
-            if msg == "Enable the multi_value feature to deserialize more than one function result"),
+            if msg == "Multi value extension is not supported"),
             "{:?}",
             error,
         );


### PR DESCRIPTION
This PR changes error message for a Wasm file that was compiled with multi_value extension as we're currently supporting MVP opcodes (minus floating points). This is a follow up for PR #4082.

Error before change:

```
Enable the multi_value feature to deserialize more than one function result"
```

After the change:

```
Multi value extension is not supported
```