### PR TITLE
Short-circuit initialization of block and deploy metadata DB

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -3000,6 +3000,11 @@ fn initialize_block_metadata_db(
             let (raw_key, _) = row?;
             if deleted_block_hashes.contains(raw_key) {
                 cursor.del(WriteFlags::empty())?;
+                let digest = Digest::try_from(raw_key);
+                debug!(
+                    "purged metadata for block {}",
+                    digest.map_or("<unknown>".to_string(), |digest| digest.to_string())
+                );
                 continue;
             }
         }


### PR DESCRIPTION
Make both `initialize_block_metadata_db()` and `initialize_deploy_metadata_db()` a no-op if there is no data to be purged on storage initialization.

Additionally, in case purging happens, hash of the purged blocks will be logged, like so:
```
2023-10-04T10:12:48.855232Z DEBUG init{; node_id=tls:7ebd..32a6}: [casper_node::components::storage storage.rs:3005] purged metadata for block 032b..0011
2023-10-04T10:12:48.855243Z DEBUG init{; node_id=tls:7ebd..32a6}: [casper_node::components::storage storage.rs:3005] purged metadata for block 2d5c..5602
```