### PR TITLE
ee: add support for emitting contract level messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "contract-messages-emitter"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution_engine/src/engine_state/genesis.rs
+++ b/execution_engine/src/engine_state/genesis.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_storage::global_state::state::StateProvider;
 use casper_types::{
-    addressable_entity::{ActionThresholds, NamedKeys},
+    addressable_entity::{ActionThresholds, MessageTopics, NamedKeys},
     execution::Effects,
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups},
     system::{
@@ -1166,6 +1166,7 @@ where
             main_purse,
             associated_keys,
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
 
         let access_key = self

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -2807,7 +2807,6 @@ fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool 
                 | ExecError::UnexpectedKeyVariant(_)
                 | ExecError::InvalidContractPackageKind(_)
                 | ExecError::Transform(_)
-                | ExecError::CannotEmitMessage(_)
                 | ExecError::InvalidMessageTopicOperation => false,
                 ExecError::DisabledUnrestrictedTransfers => false,
             },

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -45,7 +45,7 @@ use casper_storage::{
 };
 use casper_types::{
     account::{Account, AccountHash},
-    addressable_entity::{AssociatedKeys, NamedKeys},
+    addressable_entity::{AssociatedKeys, MessageTopics, NamedKeys},
     bytesrepr::ToBytes,
     execution::Effects,
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups},
@@ -875,6 +875,7 @@ where
             account.main_purse(),
             associated_keys,
             account.action_thresholds().clone().into(),
+            MessageTopics::default(),
         );
 
         let access_key = generator.new_uref(AccessRights::READ_ADD_WRITE);
@@ -2806,7 +2807,6 @@ fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool 
                 | ExecError::UnexpectedKeyVariant(_)
                 | ExecError::InvalidContractPackageKind(_)
                 | ExecError::Transform(_)
-                | ExecError::FailedTopicRegistration(_)
                 | ExecError::CannotEmitMessage(_)
                 | ExecError::InvalidMessageTopicOperation => false,
                 ExecError::DisabledUnrestrictedTransfers => false,

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -2714,11 +2714,13 @@ fn log_execution_result(preamble: &'static str, result: &ExecutionResult) {
             transfers,
             cost,
             effects,
+            messages,
         } => {
             debug!(
                 %cost,
                 transfer_count = %transfers.len(),
                 transforms_count = %effects.len(),
+                messages_count = %messages.len(),
                 "{}: execution success",
                 preamble
             );
@@ -2728,12 +2730,14 @@ fn log_execution_result(preamble: &'static str, result: &ExecutionResult) {
             transfers,
             cost,
             effects,
+            messages,
         } => {
             debug!(
                 %error,
                 %cost,
                 transfer_count = %transfers.len(),
                 transforms_count = %effects.len(),
+                messages_count = %messages.len(),
                 "{}: execution failure",
                 preamble
             );
@@ -2748,6 +2752,7 @@ fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool 
             transfers: _,
             cost: _,
             effects: _,
+            messages: _,
         } => match error {
             Error::Exec(err) => match err {
                 ExecError::WasmPreprocessing(_) | ExecError::UnsupportedWasmStart => true,
@@ -2800,7 +2805,10 @@ fn should_charge_for_errors_in_wasm(execution_result: &ExecutionResult) -> bool 
                 | ExecError::DisabledContract(_)
                 | ExecError::UnexpectedKeyVariant(_)
                 | ExecError::InvalidContractPackageKind(_)
-                | ExecError::Transform(_) => false,
+                | ExecError::Transform(_)
+                | ExecError::FailedTopicRegistration(_)
+                | ExecError::CannotEmitMessage(_)
+                | ExecError::InvalidMessageTopicOperation => false,
                 ExecError::DisabledUnrestrictedTransfers => false,
             },
             Error::WasmPreprocessing(_) => true,

--- a/execution_engine/src/engine_state/upgrade.rs
+++ b/execution_engine/src/engine_state/upgrade.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use casper_storage::global_state::state::StateProvider;
 use casper_types::{
-    addressable_entity::{ActionThresholds, AssociatedKeys, NamedKeys, Weight},
+    addressable_entity::{ActionThresholds, AssociatedKeys, MessageTopics, NamedKeys, Weight},
     bytesrepr::{self, ToBytes},
     execution::Effects,
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups},
@@ -183,6 +183,7 @@ where
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
         self.tracking_copy.borrow_mut().write(
             contract_hash.into(),
@@ -268,6 +269,7 @@ where
             main_purse,
             associated_keys,
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
 
         let access_key = address_generator.new_uref(AccessRights::READ_ADD_WRITE);

--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -191,9 +191,6 @@ pub enum Error {
     /// Failed to transfer tokens on a private chain.
     #[error("Failed to transfer with unrestricted transfers disabled")]
     DisabledUnrestrictedTransfers,
-    /// Failed to register a message topic due to config limits.
-    #[error("Failed to register a message topic: {0}")]
-    FailedTopicRegistration(MessagesLimitsError),
     /// Message was not emitted.
     #[error("Failed to emit a message on topic: {0}")]
     CannotEmitMessage(MessagesLimitsError),

--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -9,7 +9,7 @@ use casper_types::{
     execution::TransformError,
     package::ContractPackageKind,
     system, AccessRights, ApiError, CLType, CLValueError, ContractHash, ContractPackageHash,
-    ContractVersionKey, ContractWasmHash, Key, StoredValueTypeMismatch, URef,
+    ContractVersionKey, ContractWasmHash, Key, MessagesLimitsError, StoredValueTypeMismatch, URef,
 };
 
 use crate::{
@@ -191,6 +191,15 @@ pub enum Error {
     /// Failed to transfer tokens on a private chain.
     #[error("Failed to transfer with unrestricted transfers disabled")]
     DisabledUnrestrictedTransfers,
+    /// Failed to register a message topic due to config limits.
+    #[error("Failed to register a message topic: {0}")]
+    FailedTopicRegistration(MessagesLimitsError),
+    /// Message was not emitted.
+    #[error("Failed to emit a message on topic: {0}")]
+    CannotEmitMessage(MessagesLimitsError),
+    /// Invalid message topic operation.
+    #[error("The requested operation is invalid for a message topic")]
+    InvalidMessageTopicOperation,
 }
 
 impl From<PreprocessingError> for Error {

--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -9,7 +9,7 @@ use casper_types::{
     execution::TransformError,
     package::ContractPackageKind,
     system, AccessRights, ApiError, CLType, CLValueError, ContractHash, ContractPackageHash,
-    ContractVersionKey, ContractWasmHash, Key, MessagesLimitsError, StoredValueTypeMismatch, URef,
+    ContractVersionKey, ContractWasmHash, Key, StoredValueTypeMismatch, URef,
 };
 
 use crate::{
@@ -191,9 +191,6 @@ pub enum Error {
     /// Failed to transfer tokens on a private chain.
     #[error("Failed to transfer with unrestricted transfers disabled")]
     DisabledUnrestrictedTransfers,
-    /// Message was not emitted.
-    #[error("Failed to emit a message on topic: {0}")]
-    CannotEmitMessage(MessagesLimitsError),
     /// Invalid message topic operation.
     #[error("The requested operation is invalid for a message topic")]
     InvalidMessageTopicOperation,

--- a/execution_engine/src/execution/executor.rs
+++ b/execution_engine/src/execution/executor.rs
@@ -126,12 +126,14 @@ impl Executor {
                 effects: runtime.context().effects(),
                 transfers: runtime.context().transfers().to_owned(),
                 cost: runtime.context().gas_counter(),
+                messages: runtime.context().messages(),
             },
             Err(error) => ExecutionResult::Failure {
                 error: error.into(),
                 effects: runtime.context().effects(),
                 transfers: runtime.context().transfers().to_owned(),
                 cost: runtime.context().gas_counter(),
+                messages: runtime.context().messages(),
             },
         }
     }
@@ -193,6 +195,7 @@ impl Executor {
         );
 
         let effects = tracking_copy.borrow().effects();
+        let messages = tracking_copy.borrow().messages();
 
         // Standard payment is executed in the calling account's context; the stack already
         // captures that.
@@ -203,12 +206,14 @@ impl Executor {
                 effects: runtime.context().effects(),
                 transfers: runtime.context().transfers().to_owned(),
                 cost: runtime.context().gas_counter(),
+                messages: runtime.context().messages(),
             },
             Err(error) => ExecutionResult::Failure {
                 effects,
                 error: error.into(),
                 transfers: runtime.context().transfers().to_owned(),
                 cost: runtime.context().gas_counter(),
+                messages,
             },
         }
     }
@@ -254,6 +259,7 @@ impl Executor {
         // Snapshot of effects before execution, so in case of error only nonce update
         // can be returned.
         let effects = tracking_copy.borrow().effects();
+        let messages = tracking_copy.borrow().messages();
 
         let entry_point_name = direct_system_contract_call.entry_point_name();
 
@@ -327,6 +333,7 @@ impl Executor {
                     effects: runtime.context().effects(),
                     transfers: runtime.context().transfers().to_owned(),
                     cost: runtime.context().gas_counter(),
+                    messages: runtime.context().messages(),
                 }
                 .take_with_ret(ret),
                 Err(error) => ExecutionResult::Failure {
@@ -334,6 +341,7 @@ impl Executor {
                     error: Error::CLValue(error).into(),
                     transfers: runtime.context().transfers().to_owned(),
                     cost: runtime.context().gas_counter(),
+                    messages,
                 }
                 .take_without_ret(),
             },
@@ -342,6 +350,7 @@ impl Executor {
                 error: error.into(),
                 transfers: runtime.context().transfers().to_owned(),
                 cost: runtime.context().gas_counter(),
+                messages,
             }
             .take_without_ret(),
         }

--- a/execution_engine/src/resolvers/v1_function_index.rs
+++ b/execution_engine/src/resolvers/v1_function_index.rs
@@ -60,6 +60,8 @@ pub(crate) enum FunctionIndex {
     RandomBytes,
     DictionaryReadFuncIndex,
     EnableContractVersion,
+    ManageMessageTopic,
+    EmitMessage,
 }
 
 impl From<FunctionIndex> for usize {

--- a/execution_engine/src/resolvers/v1_resolver.rs
+++ b/execution_engine/src/resolvers/v1_resolver.rs
@@ -245,6 +245,14 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::EnableContractVersion.into(),
             ),
+            "casper_manage_message_topic" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
+                FunctionIndex::ManageMessageTopic.into(),
+            ),
+            "casper_emit_message" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
+                FunctionIndex::EmitMessage.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -22,7 +22,7 @@ use casper_types::{
         SetThresholdFailure, UpdateKeyFailure, Weight,
     },
     bytesrepr::ToBytes,
-    contract_messages::{Message, MessageAddr, MessageTopicHash, MessageTopicSummary},
+    contract_messages::{Message, MessageAddr, MessageTopicSummary, TopicNameHash},
     execution::Effects,
     package::ContractPackageKind,
     system::auction::{BidKind, EraInfo},
@@ -1390,7 +1390,7 @@ where
     pub(crate) fn add_message_topic(
         &mut self,
         topic_name: String,
-        topic_hash: MessageTopicHash,
+        topic_name_hash: TopicNameHash,
     ) -> Result<Result<(), MessageTopicError>, Error> {
         let entity_key: Key = self.get_entity_address();
         let entity_addr = entity_key.into_hash().ok_or(Error::InvalidContext)?;
@@ -1409,13 +1409,13 @@ where
                 return Ok(Err(MessageTopicError::MaxTopicsExceeded));
             }
 
-            if let Err(e) = entity.add_message_topic(topic_name, topic_hash) {
+            if let Err(e) = entity.add_message_topic(topic_name, topic_name_hash) {
                 return Ok(Err(e));
             }
             entity
         };
 
-        let topic_key = Key::Message(MessageAddr::new_topic_addr(entity_addr, topic_hash));
+        let topic_key = Key::Message(MessageAddr::new_topic_addr(entity_addr, topic_name_hash));
         let summary = StoredValue::MessageTopic(MessageTopicSummary::new(0, self.get_blocktime()));
 
         let entity_value = self.addressable_entity_to_validated_value(entity)?;

--- a/execution_engine/src/runtime_context/tests.rs
+++ b/execution_engine/src/runtime_context/tests.rs
@@ -13,8 +13,8 @@ use casper_storage::global_state::state::{self, lmdb::LmdbGlobalStateView, State
 use casper_types::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
     addressable_entity::{
-        ActionThresholds, ActionType, AddKeyFailure, AssociatedKeys, NamedKeys, RemoveKeyFailure,
-        SetThresholdFailure, Weight,
+        ActionThresholds, ActionType, AddKeyFailure, AssociatedKeys, MessageTopics, NamedKeys,
+        RemoveKeyFailure, SetThresholdFailure, Weight,
     },
     bytesrepr::ToBytes,
     execution::TransformKind,
@@ -83,6 +83,7 @@ fn new_addressable_entity_with_purse(
         URef::new(purse, AccessRights::READ_ADD_WRITE),
         associated_keys,
         Default::default(),
+        MessageTopics::default(),
     );
     let account_key = Key::Account(account_hash);
     let contract_key = contract_hash.into();
@@ -447,6 +448,7 @@ fn contract_key_addable_valid() {
         URef::default(),
         AssociatedKeys::default(),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
 
     let read_contract = runtime_context.read_gs(&contract_key).unwrap();

--- a/execution_engine/src/tracking_copy/byte_size.rs
+++ b/execution_engine/src/tracking_copy/byte_size.rs
@@ -40,6 +40,10 @@ impl ByteSize for StoredValue {
                 StoredValue::BidKind(bid_kind) => bid_kind.serialized_length(),
                 StoredValue::Withdraw(withdraw_purses) => withdraw_purses.serialized_length(),
                 StoredValue::Unbonding(unbonding_purses) => unbonding_purses.serialized_length(),
+                StoredValue::MessageTopic(message_topic_summary) => {
+                    message_topic_summary.serialized_length()
+                }
+                StoredValue::Message(message_summary) => message_summary.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/tracking_copy/ext.rs
+++ b/execution_engine/src/tracking_copy/ext.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeSet, convert::TryInto};
 use casper_storage::global_state::{state::StateReader, trie::merkle_proof::TrieMerkleProof};
 use casper_types::{
     account::AccountHash,
+    addressable_entity::MessageTopics,
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups},
     AccessRights, AddressableEntity, CLValue, ContractHash, ContractPackageHash, ContractWasm,
     ContractWasmHash, EntryPoints, Key, Motes, Package, Phase, ProtocolVersion, StoredValue,
@@ -146,6 +147,7 @@ where
                     account.main_purse(),
                     account.associated_keys().clone().into(),
                     account.action_thresholds().clone().into(),
+                    MessageTopics::default(),
                 );
 
                 let access_key = generator.new_uref(AccessRights::READ_ADD_WRITE);

--- a/execution_engine/src/tracking_copy/mod.rs
+++ b/execution_engine/src/tracking_copy/mod.rs
@@ -19,6 +19,7 @@ use casper_storage::global_state::{state::StateReader, trie::merkle_proof::TrieM
 use casper_types::{
     addressable_entity::NamedKeys,
     bytesrepr::{self},
+    contract_messages::Message,
     execution::{Effects, Transform, TransformError, TransformInstruction, TransformKind},
     CLType, CLValue, CLValueError, Digest, Key, KeyTag, StoredValue, StoredValueTypeMismatch,
     Tagged, U512,
@@ -223,6 +224,7 @@ pub struct TrackingCopy<R> {
     reader: R,
     cache: TrackingCopyCache<HeapSize>,
     effects: Effects,
+    messages: Vec<Message>,
 }
 
 /// Result of executing an "add" operation on a value in the state.
@@ -261,6 +263,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
             // TODO: Should `max_cache_size` be a fraction of wasm memory limit?
             cache: TrackingCopyCache::new(1024 * 16, HeapSize),
             effects: Effects::new(),
+            messages: Vec::new(),
         }
     }
 
@@ -340,6 +343,24 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         self.cache.insert_write(normalized_key, value.clone());
         let transform = Transform::new(normalized_key, TransformKind::Write(value));
         self.effects.push(transform);
+    }
+
+    /// Caches the emitted message and writes the message topic summary under the specified key.
+    ///
+    /// This function does not check the types for the key and the value so the caller should
+    /// correctly set the type. The `message_topic_key` should be of the `Key::MessageTopic`
+    /// variant and the `message_topic_summary` should be of the `StoredValue::Message` variant.
+    pub fn emit_message(
+        &mut self,
+        message_topic_key: Key,
+        message_topic_summary: StoredValue,
+        message_key: Key,
+        message_value: StoredValue,
+        message: Message,
+    ) {
+        self.write(message_key, message_value);
+        self.write(message_topic_key, message_topic_summary);
+        self.messages.push(message);
     }
 
     /// Prunes a `key`.
@@ -433,6 +454,11 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// Returns a copy of the execution effects cached by this instance.
     pub fn effects(&self) -> Effects {
         self.effects.clone()
+    }
+
+    /// Returns a copy of the messages cached by this instance.
+    pub fn messages(&self) -> Vec<Message> {
+        self.messages.clone()
     }
 
     /// Calling `query()` avoids calling into `self.cache`, so this will not return any values
@@ -562,6 +588,12 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 }
                 StoredValue::Unbonding(_) => {
                     return Ok(query.into_not_found_result("UnbondingPurses value found."));
+                }
+                StoredValue::MessageTopic(_) => {
+                    return Ok(query.into_not_found_result("MessageTopic value found."));
+                }
+                StoredValue::Message(_) => {
+                    return Ok(query.into_not_found_result("Message value found."));
                 }
             }
         }

--- a/execution_engine/src/tracking_copy/tests.rs
+++ b/execution_engine/src/tracking_copy/tests.rs
@@ -9,7 +9,9 @@ use casper_storage::global_state::{
 };
 use casper_types::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
-    addressable_entity::{ActionThresholds, AssociatedKeys, ContractHash, NamedKeys, Weight},
+    addressable_entity::{
+        ActionThresholds, AssociatedKeys, ContractHash, MessageTopics, NamedKeys, Weight,
+    },
     execution::{Effects, Transform, TransformKind},
     gens::*,
     package::ContractPackageHash,
@@ -196,6 +198,7 @@ fn tracking_copy_add_named_key() {
         URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
         associated_keys,
         Default::default(),
+        MessageTopics::default(),
     );
 
     let db = CountingDb::new_init(StoredValue::AddressableEntity(contract));
@@ -355,6 +358,7 @@ proptest! {
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         ));
         let contract_key = Key::Hash(hash);
 
@@ -398,7 +402,8 @@ proptest! {
             ProtocolVersion::V1_0_0,
             purse,
             associated_keys,
-            ActionThresholds::default()
+            ActionThresholds::default(),
+            MessageTopics::default(),
         );
 
 
@@ -448,6 +453,7 @@ proptest! {
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         ));
         let contract_key = Key::Hash(hash);
 
@@ -551,6 +557,7 @@ fn query_for_circular_references_should_fail() {
         URef::default(),
         AssociatedKeys::default(),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
 
     let (global_state, root_hash, _tempdir) = state::lmdb::make_temporary_global_state([
@@ -604,6 +611,7 @@ fn validate_query_proof_should_work() {
         fake_purse,
         AssociatedKeys::new(account_hash, Weight::new(1)),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
 
     // create contract that refers to that account
@@ -623,6 +631,7 @@ fn validate_query_proof_should_work() {
         URef::default(),
         AssociatedKeys::default(),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
     let contract_key = Key::Hash([5; 32]);
 
@@ -649,6 +658,7 @@ fn validate_query_proof_should_work() {
         fake_purse,
         AssociatedKeys::new(account_hash, Weight::new(1)),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
 
     let main_account_value = StoredValue::CLValue(cl_value_2);
@@ -1072,6 +1082,7 @@ fn query_with_large_depth_with_fixed_path_should_fail() {
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         ));
         pairs.push((contract_key, contract));
         contract_keys.push(contract_key);
@@ -1134,6 +1145,7 @@ fn query_with_large_depth_with_urefs_should_fail() {
         URef::default(),
         AssociatedKeys::default(),
         ActionThresholds::default(),
+        MessageTopics::default(),
     ));
     let contract_key = Key::Hash([0; 32]);
     pairs.push((contract_key, contract));

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -1,11 +1,13 @@
+use std::cell::RefCell;
+
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_BLOCK_TIME,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_types::{
     bytesrepr::ToBytes,
-    contract_messages::{MessagePayload, MessageTopicHash, MessageTopicSummary},
-    crypto, runtime_args, ContractHash, Key, RuntimeArgs, StoredValue,
+    contract_messages::{MessagePayload, MessageSummary, MessageTopicHash, MessageTopicSummary},
+    crypto, runtime_args, ContractHash, Digest, Key, RuntimeArgs, StoredValue,
 };
 
 const MESSAGE_EMITTER_INSTALLER_WASM: &str = "contract_messages_emitter.wasm";
@@ -16,36 +18,9 @@ const ARG_MESSAGE_SUFFIX_NAME: &str = "message_suffix";
 
 const EMITTER_MESSAGE_PREFIX: &str = "generic message: ";
 
-fn query_message_topic(
-    builder: &mut LmdbWasmTestBuilder,
-    contract_hash: &ContractHash,
-    message_topic_hash: MessageTopicHash,
-) -> MessageTopicSummary {
-    let query_result = builder
-        .query(
-            None,
-            Key::message_topic(contract_hash.value(), message_topic_hash),
-            &[],
-        )
-        .expect("should query");
-
-    match query_result {
-        StoredValue::MessageTopic(summary) => summary,
-        _ => {
-            panic!(
-                "Stored value is not a message topic summary: {:?}",
-                query_result
-            );
-        }
-    }
-}
-
-#[ignore]
-#[test]
-fn should_emit_messages() {
-    let mut builder = LmdbWasmTestBuilder::default();
-    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
-
+fn install_messages_emitter_contract<'a>(
+    builder: &'a RefCell<LmdbWasmTestBuilder>,
+) -> (ContractHash, [u8; 32]) {
     // Request to install the contract that will be emitting messages.
     let install_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -56,10 +31,15 @@ fn should_emit_messages() {
 
     // Execute the request to install the message emitting contract.
     // This will also register a topic for the contract to emit messages on.
-    builder.exec(install_request).expect_success().commit();
+    builder
+        .borrow_mut()
+        .exec(install_request)
+        .expect_success()
+        .commit();
 
     // Get the contract package for the messages_emitter.
     let query_result = builder
+        .borrow_mut()
         .query(
             None,
             Key::from(*DEFAULT_ACCOUNT_ADDR),
@@ -80,58 +60,180 @@ fn should_emit_messages() {
         .last()
         .expect("Should have contract hash");
 
-    // Check that the topic exists for the installed contract.
-    let message_topic_hash = crypto::blake2b(MESSAGE_EMITTER_GENERIC_TOPIC);
-    assert_eq!(
-        query_message_topic(
-            &mut builder,
-            message_emitter_contract_hash,
-            message_topic_hash
-        )
-        .message_count(),
-        0
-    );
+    (
+        *message_emitter_contract_hash,
+        crypto::blake2b(MESSAGE_EMITTER_GENERIC_TOPIC),
+    )
+}
 
-    // Now call the entry point to emit some messages.
+fn emit_message_with_suffix<'a>(
+    builder: &'a RefCell<LmdbWasmTestBuilder>,
+    suffix: &str,
+    contract_hash: &ContractHash,
+    block_time: u64,
+) {
     let emit_message_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
-        *message_emitter_contract_hash,
+        *contract_hash,
         ENTRY_POINT_EMIT_MESSAGE,
         runtime_args! {
-            ARG_MESSAGE_SUFFIX_NAME => "test",
+            ARG_MESSAGE_SUFFIX_NAME => suffix,
         },
     )
+    .with_block_time(block_time)
     .build();
 
-    builder.exec(emit_message_request).expect_success().commit();
+    builder
+        .borrow_mut()
+        .exec(emit_message_request)
+        .expect_success()
+        .commit();
+}
 
-    let query_result = builder
-        .query(
-            None,
-            Key::message(message_emitter_contract_hash.value(), message_topic_hash, 0),
+struct MessageEmitterQueryView<'a> {
+    builder: &'a RefCell<LmdbWasmTestBuilder>,
+    contract_hash: ContractHash,
+    message_topic_hash: MessageTopicHash,
+}
+
+impl<'a> MessageEmitterQueryView<'a> {
+    fn new(
+        builder: &'a RefCell<LmdbWasmTestBuilder>,
+        contract_hash: ContractHash,
+        message_topic_hash: MessageTopicHash,
+    ) -> Self {
+        Self {
+            builder,
+            contract_hash,
+            message_topic_hash,
+        }
+    }
+
+    fn message_topic(&self) -> MessageTopicSummary {
+        let query_result = self
+            .builder
+            .borrow_mut()
+            .query(
+                None,
+                Key::message_topic(self.contract_hash.value(), self.message_topic_hash),
+                &[],
+            )
+            .expect("should query");
+
+        match query_result {
+            StoredValue::MessageTopic(summary) => summary,
+            _ => {
+                panic!(
+                    "Stored value is not a message topic summary: {:?}",
+                    query_result
+                );
+            }
+        }
+    }
+
+    fn message_summary(
+        &self,
+        message_index: u32,
+        state_hash: Option<Digest>,
+    ) -> Result<MessageSummary, String> {
+        let query_result = self.builder.borrow_mut().query(
+            state_hash,
+            Key::message(
+                self.contract_hash.value(),
+                self.message_topic_hash,
+                message_index,
+            ),
             &[],
-        )
-        .expect("should query");
+        )?;
 
-    let queried_message_summary = if let StoredValue::Message(summary) = query_result {
-        summary.value()
-    } else {
-        panic!("Stored value is not a message summary: {:?}", query_result);
-    };
+        match query_result {
+            StoredValue::Message(summary) => Ok(summary),
+            _ => panic!("Stored value is not a message summary: {:?}", query_result),
+        }
+    }
+}
 
+#[ignore]
+#[test]
+fn should_emit_messages() {
+    let builder = RefCell::new(LmdbWasmTestBuilder::default());
+    builder
+        .borrow_mut()
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let (contract_hash, message_topic_hash) = install_messages_emitter_contract(&builder);
+    let query_view = MessageEmitterQueryView::new(&builder, contract_hash, message_topic_hash);
+
+    // Check that the topic exists for the installed contract.
+    assert_eq!(query_view.message_topic().message_count(), 0);
+
+    // Now call the entry point to emit some messages.
+    emit_message_with_suffix(&builder, "test", &contract_hash, DEFAULT_BLOCK_TIME);
     let expected_message =
         MessagePayload::from_string(format!("{}{}", EMITTER_MESSAGE_PREFIX, "test"));
     let expected_message_hash = crypto::blake2b(expected_message.to_bytes().unwrap());
-
+    let queried_message_summary = query_view
+        .message_summary(0, None)
+        .expect("should have value")
+        .value();
     assert_eq!(expected_message_hash, queried_message_summary);
+    assert_eq!(query_view.message_topic().message_count(), 1);
 
-    assert_eq!(
-        query_message_topic(
-            &mut builder,
-            message_emitter_contract_hash,
-            message_topic_hash
-        )
-        .message_count(),
-        1
-    )
+    // call again to emit a new message and check that the index in the topic incremented.
+    emit_message_with_suffix(&builder, "test", &contract_hash, DEFAULT_BLOCK_TIME);
+    let queried_message_summary = query_view
+        .message_summary(1, None)
+        .expect("should have value")
+        .value();
+    assert_eq!(expected_message_hash, queried_message_summary);
+    assert_eq!(query_view.message_topic().message_count(), 2);
+
+    let first_block_state_hash = builder.borrow().get_post_state_hash();
+
+    // call to emit a new message but in another block.
+    emit_message_with_suffix(
+        &builder,
+        "new block time",
+        &contract_hash,
+        DEFAULT_BLOCK_TIME + 1,
+    );
+    let expected_message =
+        MessagePayload::from_string(format!("{}{}", EMITTER_MESSAGE_PREFIX, "new block time"));
+    let expected_message_hash = crypto::blake2b(expected_message.to_bytes().unwrap());
+    let queried_message_summary = query_view
+        .message_summary(0, None)
+        .expect("should have value")
+        .value();
+    assert_eq!(expected_message_hash, queried_message_summary);
+    assert_eq!(query_view.message_topic().message_count(), 1);
+
+    // old messages should be pruned from tip and inaccessible at the latest state hash.
+    assert!(query_view.message_summary(1, None).is_err());
+
+    // old messages should still be discoverable at a state hash before pruning.
+    assert!(query_view
+        .message_summary(1, Some(first_block_state_hash))
+        .is_ok());
+}
+
+#[ignore]
+#[test]
+fn should_emit_message_on_empty_topic_in_new_block() {
+    let builder = RefCell::new(LmdbWasmTestBuilder::default());
+    builder
+        .borrow_mut()
+        .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let (contract_hash, message_topic_hash) = install_messages_emitter_contract(&builder);
+
+    let query_view = MessageEmitterQueryView::new(&builder, contract_hash, message_topic_hash);
+    assert_eq!(query_view.message_topic().message_count(), 0);
+
+    emit_message_with_suffix(
+        &builder,
+        "new block time",
+        &contract_hash,
+        DEFAULT_BLOCK_TIME + 1,
+    );
+    assert_eq!(query_view.message_topic().message_count(), 1);
 }

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -1,0 +1,137 @@
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    PRODUCTION_RUN_GENESIS_REQUEST,
+};
+use casper_types::{
+    bytesrepr::ToBytes,
+    contract_messages::{MessagePayload, MessageTopicHash, MessageTopicSummary},
+    crypto, runtime_args, ContractHash, Key, RuntimeArgs, StoredValue,
+};
+
+const MESSAGE_EMITTER_INSTALLER_WASM: &str = "contract_messages_emitter.wasm";
+const MESSAGE_EMITTER_PACKAGE_NAME: &str = "messages_emitter_package_name";
+const MESSAGE_EMITTER_GENERIC_TOPIC: &str = "generic_messages";
+const ENTRY_POINT_EMIT_MESSAGE: &str = "emit_message";
+const ARG_MESSAGE_SUFFIX_NAME: &str = "message_suffix";
+
+const EMITTER_MESSAGE_PREFIX: &str = "generic message: ";
+
+fn query_message_topic(
+    builder: &mut LmdbWasmTestBuilder,
+    contract_hash: &ContractHash,
+    message_topic_hash: MessageTopicHash,
+) -> MessageTopicSummary {
+    let query_result = builder
+        .query(
+            None,
+            Key::message_topic(contract_hash.value(), message_topic_hash),
+            &[],
+        )
+        .expect("should query");
+
+    match query_result {
+        StoredValue::MessageTopic(summary) => summary,
+        _ => {
+            panic!(
+                "Stored value is not a message topic summary: {:?}",
+                query_result
+            );
+        }
+    }
+}
+
+#[ignore]
+#[test]
+fn should_emit_messages() {
+    let mut builder = LmdbWasmTestBuilder::default();
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    // Request to install the contract that will be emitting messages.
+    let install_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        MESSAGE_EMITTER_INSTALLER_WASM,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    // Execute the request to install the message emitting contract.
+    // This will also register a topic for the contract to emit messages on.
+    builder.exec(install_request).expect_success().commit();
+
+    // Get the contract package for the messages_emitter.
+    let query_result = builder
+        .query(
+            None,
+            Key::from(*DEFAULT_ACCOUNT_ADDR),
+            &[MESSAGE_EMITTER_PACKAGE_NAME.into()],
+        )
+        .expect("should query");
+
+    let message_emitter_package = if let StoredValue::ContractPackage(package) = query_result {
+        package
+    } else {
+        panic!("Stored value is not a contract package: {:?}", query_result);
+    };
+
+    // Get the contract hash of the messages_emitter contract.
+    let message_emitter_contract_hash = message_emitter_package
+        .versions()
+        .contract_hashes()
+        .last()
+        .expect("Should have contract hash");
+
+    // Check that the topic exists for the installed contract.
+    let message_topic_hash = crypto::blake2b(MESSAGE_EMITTER_GENERIC_TOPIC);
+    assert_eq!(
+        query_message_topic(
+            &mut builder,
+            message_emitter_contract_hash,
+            message_topic_hash
+        )
+        .message_count(),
+        0
+    );
+
+    // Now call the entry point to emit some messages.
+    let emit_message_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        *message_emitter_contract_hash,
+        ENTRY_POINT_EMIT_MESSAGE,
+        runtime_args! {
+            ARG_MESSAGE_SUFFIX_NAME => "test",
+        },
+    )
+    .build();
+
+    builder.exec(emit_message_request).expect_success().commit();
+
+    let query_result = builder
+        .query(
+            None,
+            Key::message(message_emitter_contract_hash.value(), message_topic_hash, 0),
+            &[],
+        )
+        .expect("should query");
+
+    let queried_message_summary = if let StoredValue::Message(summary) = query_result {
+        summary.value()
+    } else {
+        panic!("Stored value is not a message summary: {:?}", query_result);
+    };
+
+    let expected_message =
+        MessagePayload::from_string(format!("{}{}", EMITTER_MESSAGE_PREFIX, "test"));
+    let expected_message_hash = crypto::blake2b(expected_message.to_bytes().unwrap());
+
+    assert_eq!(expected_message_hash, queried_message_summary);
+
+    assert_eq!(
+        query_message_topic(
+            &mut builder,
+            message_emitter_contract_hash,
+            message_topic_hash
+        )
+        .message_count(),
+        1
+    )
+}

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -412,11 +412,13 @@ fn should_not_exceed_configured_limits() {
                 max_topic_name_size: 32,
                 max_message_size: 100,
                 max_topics_per_contract: 1,
-            }
+            },
         ))
         .build();
 
-    let builder = RefCell::new(LmdbWasmTestBuilder::new_temporary_with_config(custom_engine_config));
+    let builder = RefCell::new(LmdbWasmTestBuilder::new_temporary_with_config(
+        custom_engine_config,
+    ));
     builder
         .borrow_mut()
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);

--- a/execution_engine_testing/tests/src/test/mod.rs
+++ b/execution_engine_testing/tests/src/test/mod.rs
@@ -3,6 +3,7 @@ mod chainspec_registry;
 mod check_transfer_success;
 mod contract_api;
 mod contract_context;
+mod contract_messages;
 mod counter_factory;
 mod deploy;
 mod explorer;

--- a/execution_engine_testing/tests/src/test/private_chain.rs
+++ b/execution_engine_testing/tests/src/test/private_chain.rs
@@ -21,8 +21,8 @@ use once_cell::sync::Lazy;
 
 use casper_types::{
     account::AccountHash, system::auction::DELEGATION_RATE_DENOMINATOR, AdministratorAccount,
-    FeeHandling, GenesisAccount, GenesisValidator, HostFunction, HostFunctionCosts, Motes,
-    OpcodeCosts, PublicKey, RefundHandling, SecretKey, StorageCosts, WasmConfig,
+    FeeHandling, GenesisAccount, GenesisValidator, HostFunction, HostFunctionCosts, MessagesLimits,
+    Motes, OpcodeCosts, PublicKey, RefundHandling, SecretKey, StorageCosts, WasmConfig,
     DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
 };
 use tempfile::TempDir;
@@ -208,6 +208,7 @@ fn make_wasm_config() -> WasmConfig {
         OpcodeCosts::default(),
         StorageCosts::default(),
         host_functions,
+        MessagesLimits::default(),
     )
 }
 

--- a/execution_engine_testing/tests/src/test/private_chain.rs
+++ b/execution_engine_testing/tests/src/test/private_chain.rs
@@ -21,7 +21,7 @@ use once_cell::sync::Lazy;
 
 use casper_types::{
     account::AccountHash, system::auction::DELEGATION_RATE_DENOMINATOR, AdministratorAccount,
-    FeeHandling, GenesisAccount, GenesisValidator, HostFunction, HostFunctionCosts, MessagesLimits,
+    FeeHandling, GenesisAccount, GenesisValidator, HostFunction, HostFunctionCosts, MessageLimits,
     Motes, OpcodeCosts, PublicKey, RefundHandling, SecretKey, StorageCosts, WasmConfig,
     DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
 };
@@ -208,7 +208,7 @@ fn make_wasm_config() -> WasmConfig {
         OpcodeCosts::default(),
         StorageCosts::default(),
         host_functions,
-        MessagesLimits::default(),
+        MessageLimits::default(),
     )
 }
 

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -13,8 +13,8 @@ use casper_execution_engine::{
 };
 use casper_types::{
     addressable_entity::DEFAULT_ENTRY_POINT_NAME, runtime_args, ApiError, EraId, HostFunctionCosts,
-    OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, WasmConfig, DEFAULT_MAX_STACK_HEIGHT,
-    DEFAULT_WASM_MAX_MEMORY,
+    MessagesLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, WasmConfig,
+    DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY,
 };
 
 const CONTRACT_EE_966_REGRESSION: &str = "ee_966_regression.wasm";
@@ -28,6 +28,7 @@ static DOUBLED_WASM_MEMORY_LIMIT: Lazy<WasmConfig> = Lazy::new(|| {
         OpcodeCosts::default(),
         StorageCosts::default(),
         HostFunctionCosts::default(),
+        MessagesLimits::default(),
     )
 });
 static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -13,7 +13,7 @@ use casper_execution_engine::{
 };
 use casper_types::{
     addressable_entity::DEFAULT_ENTRY_POINT_NAME, runtime_args, ApiError, EraId, HostFunctionCosts,
-    MessagesLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, WasmConfig,
+    MessageLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, WasmConfig,
     DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY,
 };
 
@@ -28,7 +28,7 @@ static DOUBLED_WASM_MEMORY_LIMIT: Lazy<WasmConfig> = Lazy::new(|| {
         OpcodeCosts::default(),
         StorageCosts::default(),
         HostFunctionCosts::default(),
-        MessagesLimits::default(),
+        MessageLimits::default(),
     )
 });
 static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {

--- a/execution_engine_testing/tests/src/test/regression/gh_2280.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_2280.rs
@@ -758,6 +758,7 @@ fn make_wasm_config(
         old_wasm_config.opcode_costs(),
         old_wasm_config.storage_costs(),
         new_host_function_costs,
+        old_wasm_config.messages_limits(),
     )
 }
 

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -13,7 +13,7 @@ use casper_types::DEFAULT_ADD_BID_COST;
 use casper_types::{
     bytesrepr::{Bytes, ToBytes},
     BrTableCost, CLValue, ContractHash, ControlFlowCosts, EraId, HostFunction, HostFunctionCosts,
-    MessagesLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, StoredValue,
+    MessageLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, StoredValue,
     WasmConfig, DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
 };
 #[cfg(not(feature = "use-as-wasm"))]
@@ -143,7 +143,7 @@ static STORAGE_COSTS_ONLY: Lazy<WasmConfig> = Lazy::new(|| {
         NEW_OPCODE_COSTS,
         StorageCosts::default(),
         *NEW_HOST_FUNCTION_COSTS,
-        MessagesLimits::default(),
+        MessageLimits::default(),
     )
 });
 

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -13,8 +13,8 @@ use casper_types::DEFAULT_ADD_BID_COST;
 use casper_types::{
     bytesrepr::{Bytes, ToBytes},
     BrTableCost, CLValue, ContractHash, ControlFlowCosts, EraId, HostFunction, HostFunctionCosts,
-    OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, StoredValue, WasmConfig,
-    DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
+    MessagesLimits, OpcodeCosts, ProtocolVersion, RuntimeArgs, StorageCosts, StoredValue,
+    WasmConfig, DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
 };
 #[cfg(not(feature = "use-as-wasm"))]
 use casper_types::{
@@ -133,6 +133,8 @@ static NEW_HOST_FUNCTION_COSTS: Lazy<HostFunctionCosts> = Lazy::new(|| HostFunct
     blake2b: HostFunction::fixed(0),
     random_bytes: HostFunction::fixed(0),
     enable_contract_version: HostFunction::fixed(0),
+    manage_message_topic: HostFunction::fixed(0),
+    emit_message: HostFunction::fixed(0),
 });
 static STORAGE_COSTS_ONLY: Lazy<WasmConfig> = Lazy::new(|| {
     WasmConfig::new(
@@ -141,6 +143,7 @@ static STORAGE_COSTS_ONLY: Lazy<WasmConfig> = Lazy::new(|| {
         NEW_OPCODE_COSTS,
         StorageCosts::default(),
         *NEW_HOST_FUNCTION_COSTS,
+        MessagesLimits::default(),
     )
 });
 

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -17,9 +17,9 @@ use casper_types::{
         },
         mint::ROUND_SEIGNIORAGE_RATE_KEY,
     },
-    BrTableCost, CLValue, ControlFlowCosts, EraId, HostFunctionCosts, OpcodeCosts, ProtocolVersion,
-    StorageCosts, StoredValue, WasmConfig, DEFAULT_ADD_COST, DEFAULT_BIT_COST, DEFAULT_CONST_COST,
-    DEFAULT_CONTROL_FLOW_BLOCK_OPCODE, DEFAULT_CONTROL_FLOW_BR_IF_OPCODE,
+    BrTableCost, CLValue, ControlFlowCosts, EraId, HostFunctionCosts, MessagesLimits, OpcodeCosts,
+    ProtocolVersion, StorageCosts, StoredValue, WasmConfig, DEFAULT_ADD_COST, DEFAULT_BIT_COST,
+    DEFAULT_CONST_COST, DEFAULT_CONTROL_FLOW_BLOCK_OPCODE, DEFAULT_CONTROL_FLOW_BR_IF_OPCODE,
     DEFAULT_CONTROL_FLOW_BR_OPCODE, DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER,
     DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE, DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE,
     DEFAULT_CONTROL_FLOW_CALL_OPCODE, DEFAULT_CONTROL_FLOW_DROP_OPCODE,
@@ -74,12 +74,14 @@ fn get_upgraded_wasm_config() -> WasmConfig {
     };
     let storage_costs = StorageCosts::default();
     let host_function_costs = HostFunctionCosts::default();
+    let messages_limits = MessagesLimits::default();
     WasmConfig::new(
         DEFAULT_WASM_MAX_MEMORY,
         DEFAULT_MAX_STACK_HEIGHT * 2,
         opcode_cost,
         storage_costs,
         host_function_costs,
+        messages_limits,
     )
 }
 

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -17,7 +17,7 @@ use casper_types::{
         },
         mint::ROUND_SEIGNIORAGE_RATE_KEY,
     },
-    BrTableCost, CLValue, ControlFlowCosts, EraId, HostFunctionCosts, MessagesLimits, OpcodeCosts,
+    BrTableCost, CLValue, ControlFlowCosts, EraId, HostFunctionCosts, MessageLimits, OpcodeCosts,
     ProtocolVersion, StorageCosts, StoredValue, WasmConfig, DEFAULT_ADD_COST, DEFAULT_BIT_COST,
     DEFAULT_CONST_COST, DEFAULT_CONTROL_FLOW_BLOCK_OPCODE, DEFAULT_CONTROL_FLOW_BR_IF_OPCODE,
     DEFAULT_CONTROL_FLOW_BR_OPCODE, DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER,
@@ -74,7 +74,7 @@ fn get_upgraded_wasm_config() -> WasmConfig {
     };
     let storage_costs = StorageCosts::default();
     let host_function_costs = HostFunctionCosts::default();
-    let messages_limits = MessagesLimits::default();
+    let messages_limits = MessageLimits::default();
     WasmConfig::new(
         DEFAULT_WASM_MAX_MEMORY,
         DEFAULT_MAX_STACK_HEIGHT * 2,

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -16,7 +16,7 @@ use casper_types::{
         handle_payment, mint, AUCTION,
     },
     AuctionCosts, BrTableCost, ControlFlowCosts, EraId, Gas, GenesisAccount, GenesisValidator,
-    HandlePaymentCosts, HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits,
+    HandlePaymentCosts, HostFunction, HostFunctionCost, HostFunctionCosts, MessageLimits,
     MintCosts, Motes, OpcodeCosts, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey,
     StandardPaymentCosts, StorageCosts, SystemConfig, WasmConfig, DEFAULT_ADD_BID_COST,
     DEFAULT_MAX_STACK_HEIGHT, DEFAULT_TRANSFER_COST, DEFAULT_WASMLESS_TRANSFER_COST,
@@ -979,7 +979,7 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
         new_opcode_costs,
         new_storage_costs,
         new_host_function_costs,
-        MessagesLimits::default(),
+        MessageLimits::default(),
     );
 
     let new_wasmless_transfer_cost = 0;

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -16,10 +16,11 @@ use casper_types::{
         handle_payment, mint, AUCTION,
     },
     AuctionCosts, BrTableCost, ControlFlowCosts, EraId, Gas, GenesisAccount, GenesisValidator,
-    HandlePaymentCosts, HostFunction, HostFunctionCost, HostFunctionCosts, MintCosts, Motes,
-    OpcodeCosts, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StandardPaymentCosts,
-    StorageCosts, SystemConfig, WasmConfig, DEFAULT_ADD_BID_COST, DEFAULT_MAX_STACK_HEIGHT,
-    DEFAULT_TRANSFER_COST, DEFAULT_WASMLESS_TRANSFER_COST, DEFAULT_WASM_MAX_MEMORY, U512,
+    HandlePaymentCosts, HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits,
+    MintCosts, Motes, OpcodeCosts, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey,
+    StandardPaymentCosts, StorageCosts, SystemConfig, WasmConfig, DEFAULT_ADD_BID_COST,
+    DEFAULT_MAX_STACK_HEIGHT, DEFAULT_TRANSFER_COST, DEFAULT_WASMLESS_TRANSFER_COST,
+    DEFAULT_WASM_MAX_MEMORY, U512,
 };
 
 use crate::wasm_utils;
@@ -968,6 +969,8 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
         blake2b: HostFunction::fixed(0),
         random_bytes: HostFunction::fixed(0),
         enable_contract_version: HostFunction::fixed(0),
+        manage_message_topic: HostFunction::fixed(0),
+        emit_message: HostFunction::fixed(0),
     };
 
     let new_wasm_config = WasmConfig::new(
@@ -976,6 +979,7 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
         new_opcode_costs,
         new_storage_costs,
         new_host_function_costs,
+        MessagesLimits::default(),
     );
 
     let new_wasmless_transfer_cost = 0;

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -129,7 +129,7 @@ mod tests {
     use casper_types::{
         bytesrepr::FromBytes, ActivationPoint, BrTableCost, ChainspecRawBytes, ControlFlowCosts,
         CoreConfig, EraId, GlobalStateUpdate, HighwayConfig, HostFunction, HostFunctionCosts,
-        MessagesLimits, Motes, OpcodeCosts, ProtocolConfig, ProtocolVersion, StorageCosts,
+        MessageLimits, Motes, OpcodeCosts, ProtocolConfig, ProtocolVersion, StorageCosts,
         StoredValue, TestBlockBuilder, TimeDiff, Timestamp, TransactionConfig, WasmConfig, U512,
     };
 
@@ -231,7 +231,7 @@ mod tests {
             EXPECTED_GENESIS_COSTS,
             EXPECTED_GENESIS_STORAGE_COSTS,
             *EXPECTED_GENESIS_HOST_FUNCTION_COSTS,
-            MessagesLimits::default(),
+            MessageLimits::default(),
         )
     });
 

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -129,8 +129,8 @@ mod tests {
     use casper_types::{
         bytesrepr::FromBytes, ActivationPoint, BrTableCost, ChainspecRawBytes, ControlFlowCosts,
         CoreConfig, EraId, GlobalStateUpdate, HighwayConfig, HostFunction, HostFunctionCosts,
-        Motes, OpcodeCosts, ProtocolConfig, ProtocolVersion, StorageCosts, StoredValue,
-        TestBlockBuilder, TimeDiff, Timestamp, TransactionConfig, WasmConfig, U512,
+        MessagesLimits, Motes, OpcodeCosts, ProtocolConfig, ProtocolVersion, StorageCosts,
+        StoredValue, TestBlockBuilder, TimeDiff, Timestamp, TransactionConfig, WasmConfig, U512,
     };
 
     use super::*;
@@ -221,6 +221,8 @@ mod tests {
             blake2b: HostFunction::new(133, [0, 1, 2, 3]),
             random_bytes: HostFunction::new(123, [0, 1]),
             enable_contract_version: HostFunction::new(142, [0, 1, 2, 3]),
+            manage_message_topic: HostFunction::new(100, [0, 1, 2, 4]),
+            emit_message: HostFunction::new(100, [0, 1, 2, 3]),
         });
     static EXPECTED_GENESIS_WASM_COSTS: Lazy<WasmConfig> = Lazy::new(|| {
         WasmConfig::new(
@@ -229,6 +231,7 @@ mod tests {
             EXPECTED_GENESIS_COSTS,
             EXPECTED_GENESIS_STORAGE_COSTS,
             *EXPECTED_GENESIS_HOST_FUNCTION_COSTS,
+            MessagesLimits::default(),
         )
     });
 

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -258,6 +258,7 @@ emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256
+max_topics_per_contract = 128
 max_message_size = 1_024
 
 [system_costs]

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -253,6 +253,12 @@ transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] 
 update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
+emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
+
+[wasm.messages_limits]
+max_topic_name_size = 256
+max_message_size = 1_024
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -269,6 +269,7 @@ emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256
+max_topics_per_contract = 128
 max_message_size = 1_024
 
 [system_costs]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -264,6 +264,12 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
+manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
+emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
+
+[wasm.messages_limits]
+max_topic_name_size = 256
+max_message_size = 1_024
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3692,7 +3692,7 @@
                 "type": "string"
               },
               "message": {
-                "description": "Message payload",
+                "description": "The payload of the message.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/MessagePayload"
@@ -3700,11 +3700,11 @@
                 ]
               },
               "topic": {
-                "description": "Topic name",
+                "description": "The name of the topic on which the message was emitted on.",
                 "type": "string"
               },
               "index": {
-                "description": "Message index in the topic",
+                "description": "Message index in the topic.",
                 "type": "integer",
                 "format": "uint32",
                 "minimum": 0.0
@@ -3714,13 +3714,6 @@
           "MessagePayload": {
             "description": "The payload of the message emitted by an addressable entity during execution.",
             "oneOf": [
-              {
-                "description": "Empty message.",
-                "type": "string",
-                "enum": [
-                  "Empty"
-                ]
-              },
               {
                 "description": "Human readable string message.",
                 "type": "object",
@@ -4213,7 +4206,7 @@
                 ],
                 "properties": {
                   "Message": {
-                    "$ref": "#/components/schemas/MessageSummary"
+                    "$ref": "#/components/schemas/MessageChecksum"
                   }
                 },
                 "additionalProperties": false
@@ -4709,24 +4702,25 @@
           "MessageTopic": {
             "type": "object",
             "required": [
-              "topic_hash",
-              "topic_name"
+              "topic_name",
+              "topic_name_hash"
             ],
             "properties": {
               "topic_name": {
                 "type": "string"
               },
-              "topic_hash": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                },
-                "maxItems": 32,
-                "minItems": 32
+              "topic_name_hash": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TopicNameHash"
+                  }
+                ]
               }
             }
+          },
+          "TopicNameHash": {
+            "description": "The hash of the name of the message topic.",
+            "type": "string"
           },
           "MessageTopicSummary": {
             "description": "Summary of a message topic that will be stored in global state.",
@@ -4758,8 +4752,8 @@
             "format": "uint64",
             "minimum": 0.0
           },
-          "MessageSummary": {
-            "description": "Message summary as a formatted string.",
+          "MessageChecksum": {
+            "description": "Message checksum as a formatted string.",
             "type": "string"
           },
           "GlobalStateIdentifier": {

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -4666,6 +4666,7 @@
               "contract_wasm_hash",
               "entry_points",
               "main_purse",
+              "message_topics",
               "named_keys",
               "protocol_version"
             ],
@@ -4693,6 +4694,37 @@
               },
               "action_thresholds": {
                 "$ref": "#/components/schemas/ActionThresholds"
+              },
+              "message_topics": {
+                "$ref": "#/components/schemas/Array_of_MessageTopic"
+              }
+            }
+          },
+          "Array_of_MessageTopic": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageTopic"
+            }
+          },
+          "MessageTopic": {
+            "type": "object",
+            "required": [
+              "topic_hash",
+              "topic_name"
+            ],
+            "properties": {
+              "topic_name": {
+                "type": "string"
+              },
+              "topic_hash": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                },
+                "maxItems": 32,
+                "minItems": 32
               }
             }
           },

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3689,14 +3689,7 @@
             "properties": {
               "entity_addr": {
                 "description": "The identity of the entity that produced the message.",
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                },
-                "maxItems": 32,
-                "minItems": 32
+                "type": "string"
               },
               "message": {
                 "description": "Message payload",
@@ -4707,6 +4700,7 @@
             "description": "Summary of a message topic that will be stored in global state.",
             "type": "object",
             "required": [
+              "blocktime",
               "message_count"
             ],
             "properties": {
@@ -4715,8 +4709,22 @@
                 "type": "integer",
                 "format": "uint32",
                 "minimum": 0.0
+              },
+              "blocktime": {
+                "description": "Block timestamp in which these messages were emitted.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockTime"
+                  }
+                ]
               }
             }
+          },
+          "BlockTime": {
+            "description": "A newtype wrapping a [`u64`] which represents the block time.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "MessageSummary": {
             "description": "Message summary as a formatted string.",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -277,7 +277,8 @@
                           "transfer-5959595959595959595959595959595959595959595959595959595959595959",
                           "transfer-8282828282828282828282828282828282828282828282828282828282828282"
                         ],
-                        "cost": "123456"
+                        "cost": "123456",
+                        "messages": []
                       }
                     }
                   }
@@ -3571,6 +3572,7 @@
                       "cost",
                       "effects",
                       "error_message",
+                      "messages",
                       "transfers"
                     ],
                     "properties": {
@@ -3600,6 +3602,13 @@
                       "error_message": {
                         "description": "The error message associated with executing the deploy.",
                         "type": "string"
+                      },
+                      "messages": {
+                        "description": "Messages that were emitted during execution.",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/Message"
+                        }
                       }
                     },
                     "additionalProperties": false
@@ -3619,6 +3628,7 @@
                     "required": [
                       "cost",
                       "effects",
+                      "messages",
                       "transfers"
                     ],
                     "properties": {
@@ -3644,6 +3654,13 @@
                             "$ref": "#/components/schemas/U512"
                           }
                         ]
+                      },
+                      "messages": {
+                        "description": "Messages that were emitted during execution.",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/Message"
+                        }
                       }
                     },
                     "additionalProperties": false
@@ -3659,6 +3676,72 @@
             "items": {
               "$ref": "#/components/schemas/Transform"
             }
+          },
+          "Message": {
+            "description": "Message that was emitted by an addressable entity during execution.",
+            "type": "object",
+            "required": [
+              "entity_addr",
+              "index",
+              "message",
+              "topic"
+            ],
+            "properties": {
+              "entity_addr": {
+                "description": "The identity of the entity that produced the message.",
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                },
+                "maxItems": 32,
+                "minItems": 32
+              },
+              "message": {
+                "description": "Message payload",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MessagePayload"
+                  }
+                ]
+              },
+              "topic": {
+                "description": "Topic name",
+                "type": "string"
+              },
+              "index": {
+                "description": "Message index in the topic",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          },
+          "MessagePayload": {
+            "description": "The payload of the message emitted by an addressable entity during execution.",
+            "oneOf": [
+              {
+                "description": "Empty message.",
+                "type": "string",
+                "enum": [
+                  "Empty"
+                ]
+              },
+              {
+                "description": "Human readable string message.",
+                "type": "object",
+                "required": [
+                  "String"
+                ],
+                "properties": {
+                  "String": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           },
           "AccountIdentifier": {
             "description": "Identifier of an account.",
@@ -4112,6 +4195,32 @@
                 "properties": {
                   "BidKind": {
                     "$ref": "#/components/schemas/BidKind"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Variant that stores a message topic.",
+                "type": "object",
+                "required": [
+                  "MessageTopic"
+                ],
+                "properties": {
+                  "MessageTopic": {
+                    "$ref": "#/components/schemas/MessageTopicSummary"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "description": "Variant that stores a message digest.",
+                "type": "object",
+                "required": [
+                  "Message"
+                ],
+                "properties": {
+                  "Message": {
+                    "$ref": "#/components/schemas/MessageSummary"
                   }
                 },
                 "additionalProperties": false
@@ -4593,6 +4702,25 @@
                 "$ref": "#/components/schemas/ActionThresholds"
               }
             }
+          },
+          "MessageTopicSummary": {
+            "description": "Summary of a message topic that will be stored in global state.",
+            "type": "object",
+            "required": [
+              "message_count"
+            ],
+            "properties": {
+              "message_count": {
+                "description": "Number of messages in this topic.",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          },
+          "MessageSummary": {
+            "description": "Message summary as a formatted string.",
+            "type": "string"
           },
           "GlobalStateIdentifier": {
             "description": "Identifier for possible ways to query Global State",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3684,7 +3684,8 @@
               "entity_addr",
               "index",
               "message",
-              "topic"
+              "topic_name",
+              "topic_name_hash"
             ],
             "properties": {
               "entity_addr": {
@@ -3699,9 +3700,17 @@
                   }
                 ]
               },
-              "topic": {
+              "topic_name": {
                 "description": "The name of the topic on which the message was emitted on.",
                 "type": "string"
+              },
+              "topic_name_hash": {
+                "description": "The hash of the name of the topic.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TopicNameHash"
+                  }
+                ]
               },
               "index": {
                 "description": "Message index in the topic.",
@@ -3728,6 +3737,10 @@
                 "additionalProperties": false
               }
             ]
+          },
+          "TopicNameHash": {
+            "description": "The hash of the name of the message topic.",
+            "type": "string"
           },
           "AccountIdentifier": {
             "description": "Identifier of an account.",
@@ -4717,10 +4730,6 @@
                 ]
               }
             }
-          },
-          "TopicNameHash": {
-            "description": "The hash of the name of the message topic.",
-            "type": "string"
           },
           "MessageTopicSummary": {
             "description": "Summary of a message topic that will be stored in global state.",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -2562,7 +2562,8 @@
         "entity_addr",
         "index",
         "message",
-        "topic"
+        "topic_name",
+        "topic_name_hash"
       ],
       "properties": {
         "entity_addr": {
@@ -2577,9 +2578,17 @@
             }
           ]
         },
-        "topic": {
+        "topic_name": {
           "description": "The name of the topic on which the message was emitted on.",
           "type": "string"
+        },
+        "topic_name_hash": {
+          "description": "The hash of the name of the topic.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TopicNameHash"
+            }
+          ]
         },
         "index": {
           "description": "Message index in the topic.",
@@ -2606,6 +2615,10 @@
           "additionalProperties": false
         }
       ]
+    },
+    "TopicNameHash": {
+      "description": "The hash of the name of the message topic.",
+      "type": "string"
     },
     "FinalitySignature": {
       "description": "A validator's signature of a block, confirming it is finalized.",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -2570,7 +2570,7 @@
           "type": "string"
         },
         "message": {
-          "description": "Message payload",
+          "description": "The payload of the message.",
           "allOf": [
             {
               "$ref": "#/definitions/MessagePayload"
@@ -2578,11 +2578,11 @@
           ]
         },
         "topic": {
-          "description": "Topic name",
+          "description": "The name of the topic on which the message was emitted on.",
           "type": "string"
         },
         "index": {
-          "description": "Message index in the topic",
+          "description": "Message index in the topic.",
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0
@@ -2592,13 +2592,6 @@
     "MessagePayload": {
       "description": "The payload of the message emitted by an addressable entity during execution.",
       "oneOf": [
-        {
-          "description": "Empty message.",
-          "type": "string",
-          "enum": [
-            "Empty"
-          ]
-        },
         {
           "description": "Human readable string message.",
           "type": "object",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -2450,6 +2450,7 @@
                 "cost",
                 "effects",
                 "error_message",
+                "messages",
                 "transfers"
               ],
               "properties": {
@@ -2479,6 +2480,13 @@
                 "error_message": {
                   "description": "The error message associated with executing the deploy.",
                   "type": "string"
+                },
+                "messages": {
+                  "description": "Messages that were emitted during execution.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Message"
+                  }
                 }
               },
               "additionalProperties": false
@@ -2498,6 +2506,7 @@
               "required": [
                 "cost",
                 "effects",
+                "messages",
                 "transfers"
               ],
               "properties": {
@@ -2523,6 +2532,13 @@
                       "$ref": "#/definitions/U512"
                     }
                   ]
+                },
+                "messages": {
+                  "description": "Messages that were emitted during execution.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Message"
+                  }
                 }
               },
               "additionalProperties": false
@@ -2538,6 +2554,65 @@
       "items": {
         "$ref": "#/definitions/Transform"
       }
+    },
+    "Message": {
+      "description": "Message that was emitted by an addressable entity during execution.",
+      "type": "object",
+      "required": [
+        "entity_addr",
+        "index",
+        "message",
+        "topic"
+      ],
+      "properties": {
+        "entity_addr": {
+          "description": "The identity of the entity that produced the message.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message payload",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MessagePayload"
+            }
+          ]
+        },
+        "topic": {
+          "description": "Topic name",
+          "type": "string"
+        },
+        "index": {
+          "description": "Message index in the topic",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "MessagePayload": {
+      "description": "The payload of the message emitted by an addressable entity during execution.",
+      "oneOf": [
+        {
+          "description": "Empty message.",
+          "type": "string",
+          "enum": [
+            "Empty"
+          ]
+        },
+        {
+          "description": "Human readable string message.",
+          "type": "object",
+          "required": [
+            "String"
+          ],
+          "properties": {
+            "String": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "FinalitySignature": {
       "description": "A validator's signature of a block, confirming it is finalized.",

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -805,4 +805,33 @@ extern "C" {
         contract_hash_ptr: *const u8,
         contract_hash_size: usize,
     ) -> i32;
+    /// Manages a message topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic_name_ptr` - pointer to a `str` containing the name of the message topic.
+    /// * `topic_name_size` - size of the topic string.
+    /// * `operation_ptr` - pointer to the management operation to be performed for the specified
+    ///   topic.
+    /// * `operation_ptr_size` - size of the operation.
+    pub fn casper_manage_message_topic(
+        topic_name_ptr: *const u8,
+        topic_name_size: usize,
+        operation_ptr: *const u8,
+        operation_size: usize,
+    ) -> i32;
+    /// Emits a new message on the specified topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic_name_ptr` - pointer to a `str` containing the name of the topic to be registered.
+    /// * `topic_name_size` - size of the topic string.
+    /// * `message_ptr` - pointer pointer to serialized message payload.
+    /// * `message_size` - size of the serialized message payload.
+    pub fn casper_emit_message(
+        topic_name_ptr: *const u8,
+        topic_name_size: usize,
+        message_ptr: *const u8,
+        message_size: usize,
+    ) -> i32;
 }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -809,8 +809,8 @@ extern "C" {
     ///
     /// # Arguments
     ///
-    /// * `topic_name_ptr` - pointer to a `str` containing the name of the message topic.
-    /// * `topic_name_size` - size of the topic string.
+    /// * `topic_name_ptr` - pointer to the serialized topic name string.
+    /// * `topic_name_size` - size of the serialized name string.
     /// * `operation_ptr` - pointer to the management operation to be performed for the specified
     ///   topic.
     /// * `operation_ptr_size` - size of the operation.
@@ -824,9 +824,10 @@ extern "C" {
     ///
     /// # Arguments
     ///
-    /// * `topic_name_ptr` - pointer to a `str` containing the name of the topic to be registered.
-    /// * `topic_name_size` - size of the topic string.
-    /// * `message_ptr` - pointer pointer to serialized message payload.
+    /// * `topic_name_ptr` - pointer to the serialized topic name string where the message will be
+    ///   emitted.
+    /// * `topic_name_size` - size of the serialized name string.
+    /// * `message_ptr` - pointer to the serialized message payload to be emitted.
     /// * `message_size` - size of the serialized message payload.
     pub fn casper_emit_message(
         topic_name_ptr: *const u8,

--- a/smart_contracts/contracts/test/contract-messages-emitter/Cargo.toml
+++ b/smart_contracts/contracts/test/contract-messages-emitter/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "contract-messages-emitter"
+version = "0.1.0"
+authors = ["Alexandru Sardan <alexandru@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "contract_messages_emitter"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/contract-messages-emitter/src/main.rs
+++ b/smart_contracts/contracts/test/contract-messages-emitter/src/main.rs
@@ -1,0 +1,83 @@
+#![no_std]
+#![no_main]
+
+#[macro_use]
+extern crate alloc;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use casper_contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+
+use casper_types::{
+    addressable_entity::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys},
+    api_error::ApiError,
+    contract_messages::{MessagePayload, MessageTopicOperation},
+    CLType, CLTyped, Parameter, RuntimeArgs,
+};
+
+pub const ENTRY_POINT_INIT: &str = "init";
+pub const ENTRY_POINT_EMIT_MESSAGE: &str = "emit_message";
+pub const MESSAGE_EMITTER_INITIALIZED: &str = "message_emitter_initialized";
+pub const ARG_MESSAGE_SUFFIX_NAME: &str = "message_suffix";
+
+pub const MESSAGE_EMITTER_GENERIC_TOPIC: &str = "generic_messages";
+pub const MESSAGE_PREFIX: &str = "generic message: ";
+
+#[no_mangle]
+pub extern "C" fn emit_message() {
+    let suffix: String = runtime::get_named_arg(ARG_MESSAGE_SUFFIX_NAME);
+
+    runtime::emit_message(
+        MESSAGE_EMITTER_GENERIC_TOPIC,
+        &MessagePayload::from_string(format!("{}{}", MESSAGE_PREFIX, suffix)),
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn init() {
+    if runtime::has_key(MESSAGE_EMITTER_INITIALIZED) {
+        runtime::revert(ApiError::User(0));
+    }
+
+    runtime::manage_message_topic(MESSAGE_EMITTER_GENERIC_TOPIC, MessageTopicOperation::Add);
+
+    runtime::put_key(MESSAGE_EMITTER_INITIALIZED, storage::new_uref(()).into());
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mut emitter_entry_points = EntryPoints::new();
+    emitter_entry_points.add_entry_point(EntryPoint::new(
+        ENTRY_POINT_INIT,
+        Vec::new(),
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    ));
+    emitter_entry_points.add_entry_point(EntryPoint::new(
+        ENTRY_POINT_EMIT_MESSAGE,
+        vec![Parameter::new(ARG_MESSAGE_SUFFIX_NAME, String::cl_type())],
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    ));
+
+    let (stored_contract_hash, _contract_version) = storage::new_contract(
+        emitter_entry_points,
+        Some(NamedKeys::new()),
+        Some("messages_emitter_package_name".to_string()),
+        Some("messages_emitter_access_uref".to_string()),
+    );
+
+    // Call contract to initialize it
+    runtime::call_contract::<()>(
+        stored_contract_hash,
+        ENTRY_POINT_INIT,
+        RuntimeArgs::default(),
+    );
+}

--- a/types/benches/bytesrepr_bench.rs
+++ b/types/benches/bytesrepr_bench.rs
@@ -7,7 +7,9 @@ use std::{
 
 use casper_types::{
     account::AccountHash,
-    addressable_entity::{ActionThresholds, AddressableEntity, AssociatedKeys, NamedKeys},
+    addressable_entity::{
+        ActionThresholds, AddressableEntity, AssociatedKeys, MessageTopics, NamedKeys,
+    },
     bytesrepr::{self, Bytes, FromBytes, ToBytes},
     package::{ContractPackageKind, ContractPackageStatus},
     system::auction::{Bid, Delegator, EraInfo, SeigniorageAllocation},
@@ -502,6 +504,7 @@ fn sample_contract(named_keys_len: u8, entry_points_len: u8) -> AddressableEntit
         URef::default(),
         AssociatedKeys::default(),
         ActionThresholds::default(),
+        MessageTopics::default(),
     )
 }
 

--- a/types/src/addressable_entity.rs
+++ b/types/src/addressable_entity.rs
@@ -647,7 +647,7 @@ impl MessageTopics {
         topic_name: String,
         topic_name_hash: TopicNameHash,
     ) -> Result<(), MessageTopicError> {
-        if self.0.len() > u32::MAX as usize {
+        if self.0.len() >= u32::MAX as usize {
             return Err(MessageTopicError::MaxTopicsExceeded);
         }
 
@@ -680,7 +680,7 @@ impl MessageTopics {
         self.0.is_empty()
     }
 
-    /// Returns an iterator over the account hash and the weights.
+    /// Returns an iterator over the topic name and its hash.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &TopicNameHash)> {
         self.0.iter()
     }

--- a/types/src/addressable_entity.rs
+++ b/types/src/addressable_entity.rs
@@ -10,7 +10,7 @@ mod named_keys;
 mod weight;
 
 use alloc::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
     format,
     string::{String, ToString},
     vec::Vec,
@@ -49,6 +49,7 @@ use crate::{
     account::{Account, AccountHash},
     bytesrepr::{self, FromBytes, ToBytes},
     checksummed_hex,
+    contract_messages::MessageTopicHash,
     contract_wasm::ContractWasmHash,
     contracts::Contract,
     uref::{self, URef},
@@ -608,6 +609,114 @@ impl KeyValueJsonSchema for EntryPointLabels {
     const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("NamedEntryPoint");
 }
 
+/// Collection of named message topics.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Default)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+#[serde(transparent, deny_unknown_fields)]
+pub struct MessageTopics(
+    #[serde(with = "BTreeMapToArray::<String, MessageTopicHash, MessageTopicLabels>")]
+    BTreeMap<String, MessageTopicHash>,
+);
+
+impl ToBytes for MessageTopics {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.0.write_bytes(writer)
+    }
+}
+
+impl FromBytes for MessageTopics {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (message_topics_map, remainder) =
+            BTreeMap::<String, MessageTopicHash>::from_bytes(bytes)?;
+        Ok((MessageTopics(message_topics_map), remainder))
+    }
+}
+
+impl MessageTopics {
+    /// Adds new message topic by topic name.
+    pub fn add_topic(
+        &mut self,
+        topic_name: String,
+        topic_hash: MessageTopicHash,
+    ) -> Result<(), MessageTopicError> {
+        if self.0.len() > u32::MAX as usize {
+            return Err(MessageTopicError::MaxTopicsExceeded);
+        }
+
+        match self.0.entry(topic_name) {
+            Entry::Vacant(entry) => {
+                entry.insert(topic_hash);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(MessageTopicError::DuplicateTopic),
+        }
+    }
+
+    /// Checks if given topic name exists.
+    pub fn has_topic(&self, topic_name: &str) -> bool {
+        self.0.contains_key(topic_name)
+    }
+
+    /// Gets the topic hash from the collection by its topic name.
+    pub fn get(&self, topic_name: &str) -> Option<&MessageTopicHash> {
+        self.0.get(topic_name)
+    }
+
+    /// Returns the length of the message topics.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if no message topics are registered.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the account hash and the weights.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &MessageTopicHash)> {
+        self.0.iter()
+    }
+}
+
+struct MessageTopicLabels;
+
+impl KeyValueLabels for MessageTopicLabels {
+    const KEY: &'static str = "topic_name";
+    const VALUE: &'static str = "topic_hash";
+}
+
+#[cfg(feature = "json-schema")]
+impl KeyValueJsonSchema for MessageTopicLabels {
+    const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("MessageTopic");
+}
+
+impl From<BTreeMap<String, MessageTopicHash>> for MessageTopics {
+    fn from(topics: BTreeMap<String, MessageTopicHash>) -> MessageTopics {
+        MessageTopics(topics)
+    }
+}
+
+/// Errors that can occur while adding a new topic.
+#[derive(PartialEq, Eq, Debug, Clone)]
+#[non_exhaustive]
+pub enum MessageTopicError {
+    /// Topic already exists.
+    DuplicateTopic,
+    /// Maximum number of topics exceeded.
+    MaxTopicsExceeded,
+    /// Topic name size exceeded.
+    TopicNameSizeExceeded,
+}
+
 /// Methods and type signatures supported by a contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
@@ -621,6 +730,7 @@ pub struct AddressableEntity {
     main_purse: URef,
     associated_keys: AssociatedKeys,
     action_thresholds: ActionThresholds,
+    message_topics: MessageTopics,
 }
 
 impl From<AddressableEntity>
@@ -661,6 +771,7 @@ impl AddressableEntity {
         main_purse: URef,
         associated_keys: AssociatedKeys,
         action_thresholds: ActionThresholds,
+        message_topics: MessageTopics,
     ) -> Self {
         AddressableEntity {
             contract_package_hash,
@@ -671,6 +782,7 @@ impl AddressableEntity {
             main_purse,
             action_thresholds,
             associated_keys,
+            message_topics,
         }
     }
 
@@ -876,6 +988,20 @@ impl AddressableEntity {
         &self.entry_points
     }
 
+    /// Returns a reference to the message topics
+    pub fn message_topics(&self) -> &MessageTopics {
+        &self.message_topics
+    }
+
+    /// Adds a new message topic to the entity
+    pub fn add_message_topic(
+        &mut self,
+        topic_name: String,
+        topic_hash: MessageTopicHash,
+    ) -> Result<(), MessageTopicError> {
+        self.message_topics.add_topic(topic_name, topic_hash)
+    }
+
     /// Takes `named_keys`
     pub fn take_named_keys(self) -> NamedKeys {
         self.named_keys
@@ -928,6 +1054,7 @@ impl ToBytes for AddressableEntity {
         self.main_purse().write_bytes(&mut result)?;
         self.associated_keys().write_bytes(&mut result)?;
         self.action_thresholds().write_bytes(&mut result)?;
+        self.message_topics().write_bytes(&mut result)?;
         Ok(result)
     }
 
@@ -940,6 +1067,7 @@ impl ToBytes for AddressableEntity {
             + ToBytes::serialized_length(&self.main_purse)
             + ToBytes::serialized_length(&self.associated_keys)
             + ToBytes::serialized_length(&self.action_thresholds)
+            + ToBytes::serialized_length(&self.message_topics)
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
@@ -951,6 +1079,7 @@ impl ToBytes for AddressableEntity {
         self.main_purse().write_bytes(writer)?;
         self.associated_keys().write_bytes(writer)?;
         self.action_thresholds().write_bytes(writer)?;
+        self.message_topics().write_bytes(writer)?;
         Ok(())
     }
 }
@@ -965,6 +1094,7 @@ impl FromBytes for AddressableEntity {
         let (main_purse, bytes) = URef::from_bytes(bytes)?;
         let (associated_keys, bytes) = AssociatedKeys::from_bytes(bytes)?;
         let (action_thresholds, bytes) = ActionThresholds::from_bytes(bytes)?;
+        let (message_topics, bytes) = MessageTopics::from_bytes(bytes)?;
         Ok((
             AddressableEntity {
                 contract_package_hash,
@@ -975,6 +1105,7 @@ impl FromBytes for AddressableEntity {
                 main_purse,
                 associated_keys,
                 action_thresholds,
+                message_topics,
             },
             bytes,
         ))
@@ -992,6 +1123,7 @@ impl Default for AddressableEntity {
             main_purse: URef::default(),
             action_thresholds: ActionThresholds::default(),
             associated_keys: AssociatedKeys::default(),
+            message_topics: MessageTopics::default(),
         }
     }
 }
@@ -1007,6 +1139,7 @@ impl From<Contract> for AddressableEntity {
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         )
     }
 }
@@ -1022,6 +1155,7 @@ impl From<Account> for AddressableEntity {
             value.main_purse(),
             value.associated_keys().clone().into(),
             value.action_thresholds().clone().into(),
+            MessageTopics::default(),
         )
     }
 }
@@ -1462,6 +1596,7 @@ mod tests {
             associated_keys,
             ActionThresholds::new(Weight::new(1), Weight::new(1))
                 .expect("should create thresholds"),
+            MessageTopics::default(),
         );
         let access_rights = contract.extract_access_rights(contract_hash);
         let expected_uref = URef::new([42; UREF_ADDR_LENGTH], AccessRights::READ_ADD_WRITE);

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -396,6 +396,24 @@ pub enum ApiError {
     /// }
     /// ```
     User(u16),
+    /// The message topic is already registered.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(41), ApiError::MessageTopicAlreadyRegistered);
+    /// ```
+    MessageTopicAlreadyRegistered,
+    /// The message topic is not registered.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(42), ApiError::MessageTopicNotRegistered);
+    /// ```
+    MessageTopicNotRegistered,
+    /// The message topic is full and cannot accept new messages.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(43), ApiError::MessageTopicFull);
+    /// ```
+    MessageTopicFull,
 }
 
 impl From<bytesrepr::Error> for ApiError {
@@ -542,6 +560,9 @@ impl From<ApiError> for u32 {
             ApiError::MissingSystemContractHash => 38,
             ApiError::ExceededRecursionDepth => 39,
             ApiError::NonRepresentableSerialization => 40,
+            ApiError::MessageTopicAlreadyRegistered => 41,
+            ApiError::MessageTopicNotRegistered => 42,
+            ApiError::MessageTopicFull => 43,
             ApiError::AuctionError(value) => AUCTION_ERROR_OFFSET + u32::from(value),
             ApiError::ContractHeader(value) => HEADER_ERROR_OFFSET + u32::from(value),
             ApiError::Mint(value) => MINT_ERROR_OFFSET + u32::from(value),
@@ -594,6 +615,9 @@ impl From<u32> for ApiError {
             38 => ApiError::MissingSystemContractHash,
             39 => ApiError::ExceededRecursionDepth,
             40 => ApiError::NonRepresentableSerialization,
+            41 => ApiError::MessageTopicAlreadyRegistered,
+            42 => ApiError::MessageTopicNotRegistered,
+            43 => ApiError::MessageTopicFull,
             USER_ERROR_MIN..=USER_ERROR_MAX => ApiError::User(value as u16),
             HP_ERROR_MIN..=HP_ERROR_MAX => ApiError::HandlePayment(value as u8),
             MINT_ERROR_MIN..=MINT_ERROR_MAX => ApiError::Mint(value as u8),
@@ -652,6 +676,13 @@ impl Debug for ApiError {
             ApiError::NonRepresentableSerialization => {
                 write!(f, "ApiError::NonRepresentableSerialization")?
             }
+            ApiError::MessageTopicAlreadyRegistered => {
+                write!(f, "ApiError::MessageTopicAlreadyRegistered")?
+            }
+            ApiError::MessageTopicNotRegistered => {
+                write!(f, "ApiError::MessageTopicNotRegistered")?
+            }
+            ApiError::MessageTopicFull => write!(f, "ApiError::MessageTopicFull")?,
             ApiError::ExceededRecursionDepth => write!(f, "ApiError::ExceededRecursionDepth")?,
             ApiError::AuctionError(value) => write!(
                 f,
@@ -871,5 +902,8 @@ mod tests {
         round_trip(Err(ApiError::User(u16::MAX)));
         round_trip(Err(ApiError::AuctionError(0)));
         round_trip(Err(ApiError::AuctionError(u8::MAX)));
+        round_trip(Err(ApiError::MessageTopicAlreadyRegistered));
+        round_trip(Err(ApiError::MessageTopicNotRegistered));
+        round_trip(Err(ApiError::MessageTopicFull));
     }
 }

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -426,6 +426,12 @@ pub enum ApiError {
     /// assert_eq!(ApiError::from(45), ApiError::MessageTopicFull);
     /// ```
     MessageTopicFull,
+    /// The message topic is full and cannot accept new messages.
+    /// ```
+    /// # use casper_types::ApiError;
+    /// assert_eq!(ApiError::from(46), ApiError::MessageTooLarge);
+    /// ```
+    MessageTooLarge,
 }
 
 impl From<bytesrepr::Error> for ApiError {
@@ -587,6 +593,7 @@ impl From<ApiError> for u32 {
             ApiError::MaxTopicNameSizeExceeded => 43,
             ApiError::MessageTopicNotRegistered => 44,
             ApiError::MessageTopicFull => 45,
+            ApiError::MessageTooLarge => 46,
             ApiError::AuctionError(value) => AUCTION_ERROR_OFFSET + u32::from(value),
             ApiError::ContractHeader(value) => HEADER_ERROR_OFFSET + u32::from(value),
             ApiError::Mint(value) => MINT_ERROR_OFFSET + u32::from(value),
@@ -644,6 +651,7 @@ impl From<u32> for ApiError {
             43 => ApiError::MaxTopicNameSizeExceeded,
             44 => ApiError::MessageTopicNotRegistered,
             45 => ApiError::MessageTopicFull,
+            46 => ApiError::MessageTooLarge,
             USER_ERROR_MIN..=USER_ERROR_MAX => ApiError::User(value as u16),
             HP_ERROR_MIN..=HP_ERROR_MAX => ApiError::HandlePayment(value as u8),
             MINT_ERROR_MIN..=MINT_ERROR_MAX => ApiError::Mint(value as u8),
@@ -711,6 +719,7 @@ impl Debug for ApiError {
                 write!(f, "ApiError::MessageTopicNotRegistered")?
             }
             ApiError::MessageTopicFull => write!(f, "ApiError::MessageTopicFull")?,
+            ApiError::MessageTooLarge => write!(f, "ApiError::MessageTooLarge")?,
             ApiError::ExceededRecursionDepth => write!(f, "ApiError::ExceededRecursionDepth")?,
             ApiError::AuctionError(value) => write!(
                 f,
@@ -935,5 +944,6 @@ mod tests {
         round_trip(Err(ApiError::MaxTopicNameSizeExceeded));
         round_trip(Err(ApiError::MessageTopicNotRegistered));
         round_trip(Err(ApiError::MessageTopicFull));
+        round_trip(Err(ApiError::MessageTooLarge));
     }
 }

--- a/types/src/block_time.rs
+++ b/types/src/block_time.rs
@@ -2,11 +2,19 @@ use alloc::vec::Vec;
 
 use crate::bytesrepr::{Error, FromBytes, ToBytes, U64_SERIALIZED_LENGTH};
 
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 /// The number of bytes in a serialized [`BlockTime`].
 pub const BLOCKTIME_SERIALIZED_LENGTH: usize = U64_SERIALIZED_LENGTH;
 
 /// A newtype wrapping a [`u64`] which represents the block time.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
 pub struct BlockTime(u64);
 
 impl BlockTime {

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -47,9 +47,9 @@ pub use transaction_config::{DeployConfig, TransactionConfig, TransactionV1Confi
 pub use transaction_config::{DEFAULT_MAX_PAYMENT_MOTES, DEFAULT_MIN_TRANSFER_MOTES};
 pub use vm_config::{
     AuctionCosts, BrTableCost, ChainspecRegistry, ControlFlowCosts, HandlePaymentCosts,
-    HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits, MessagesLimitsError,
-    MintCosts, OpcodeCosts, StandardPaymentCosts, StorageCosts, SystemConfig, UpgradeConfig,
-    WasmConfig, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
+    HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits, MintCosts, OpcodeCosts,
+    StandardPaymentCosts, StorageCosts, SystemConfig, UpgradeConfig, WasmConfig,
+    DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
 };
 #[cfg(any(feature = "testing", test))]
 pub use vm_config::{

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -47,9 +47,9 @@ pub use transaction_config::{DeployConfig, TransactionConfig, TransactionV1Confi
 pub use transaction_config::{DEFAULT_MAX_PAYMENT_MOTES, DEFAULT_MIN_TRANSFER_MOTES};
 pub use vm_config::{
     AuctionCosts, BrTableCost, ChainspecRegistry, ControlFlowCosts, HandlePaymentCosts,
-    HostFunction, HostFunctionCost, HostFunctionCosts, MintCosts, OpcodeCosts,
-    StandardPaymentCosts, StorageCosts, SystemConfig, UpgradeConfig, WasmConfig,
-    DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
+    HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits, MessagesLimitsError,
+    MintCosts, OpcodeCosts, StandardPaymentCosts, StorageCosts, SystemConfig, UpgradeConfig,
+    WasmConfig, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
 };
 #[cfg(any(feature = "testing", test))]
 pub use vm_config::{

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -47,7 +47,7 @@ pub use transaction_config::{DeployConfig, TransactionConfig, TransactionV1Confi
 pub use transaction_config::{DEFAULT_MAX_PAYMENT_MOTES, DEFAULT_MIN_TRANSFER_MOTES};
 pub use vm_config::{
     AuctionCosts, BrTableCost, ChainspecRegistry, ControlFlowCosts, HandlePaymentCosts,
-    HostFunction, HostFunctionCost, HostFunctionCosts, MessagesLimits, MintCosts, OpcodeCosts,
+    HostFunction, HostFunctionCost, HostFunctionCosts, MessageLimits, MintCosts, OpcodeCosts,
     StandardPaymentCosts, StorageCosts, SystemConfig, UpgradeConfig, WasmConfig,
     DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
 };

--- a/types/src/chainspec/vm_config.rs
+++ b/types/src/chainspec/vm_config.rs
@@ -2,6 +2,7 @@ mod auction_costs;
 mod chainspec_registry;
 mod handle_payment_costs;
 mod host_function_costs;
+mod messages_limits;
 mod mint_costs;
 mod opcode_costs;
 mod standard_payment_costs;
@@ -17,6 +18,7 @@ pub use host_function_costs::{
     Cost as HostFunctionCost, HostFunction, HostFunctionCosts,
     DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_NEW_DICTIONARY_COST,
 };
+pub use messages_limits::{Error as MessagesLimitsError, MessagesLimits};
 pub use mint_costs::{MintCosts, DEFAULT_TRANSFER_COST};
 pub use opcode_costs::{BrTableCost, ControlFlowCosts, OpcodeCosts};
 #[cfg(any(feature = "testing", test))]

--- a/types/src/chainspec/vm_config.rs
+++ b/types/src/chainspec/vm_config.rs
@@ -2,7 +2,7 @@ mod auction_costs;
 mod chainspec_registry;
 mod handle_payment_costs;
 mod host_function_costs;
-mod messages_limits;
+mod message_limits;
 mod mint_costs;
 mod opcode_costs;
 mod standard_payment_costs;
@@ -18,7 +18,7 @@ pub use host_function_costs::{
     Cost as HostFunctionCost, HostFunction, HostFunctionCosts,
     DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_NEW_DICTIONARY_COST,
 };
-pub use messages_limits::MessagesLimits;
+pub use message_limits::MessageLimits;
 pub use mint_costs::{MintCosts, DEFAULT_TRANSFER_COST};
 pub use opcode_costs::{BrTableCost, ControlFlowCosts, OpcodeCosts};
 #[cfg(any(feature = "testing", test))]

--- a/types/src/chainspec/vm_config.rs
+++ b/types/src/chainspec/vm_config.rs
@@ -18,7 +18,7 @@ pub use host_function_costs::{
     Cost as HostFunctionCost, HostFunction, HostFunctionCosts,
     DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_NEW_DICTIONARY_COST,
 };
-pub use messages_limits::{Error as MessagesLimitsError, MessagesLimits};
+pub use messages_limits::MessagesLimits;
 pub use mint_costs::{MintCosts, DEFAULT_TRANSFER_COST};
 pub use opcode_costs::{BrTableCost, ControlFlowCosts, OpcodeCosts};
 #[cfg(any(feature = "testing", test))]

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -295,6 +295,10 @@ pub struct HostFunctionCosts {
     pub random_bytes: HostFunction<[Cost; 2]>,
     /// Cost of calling the `enable_contract_version` host function.
     pub enable_contract_version: HostFunction<[Cost; 4]>,
+    /// Cost of calling the `casper_manage_message_topic` host function.
+    pub manage_message_topic: HostFunction<[Cost; 4]>,
+    /// Cost of calling the `casper_emit_message` host function.
+    pub emit_message: HostFunction<[Cost; 4]>,
 }
 
 impl Default for HostFunctionCosts {
@@ -427,6 +431,8 @@ impl Default for HostFunctionCosts {
             blake2b: HostFunction::default(),
             random_bytes: HostFunction::default(),
             enable_contract_version: HostFunction::default(),
+            manage_message_topic: HostFunction::default(),
+            emit_message: HostFunction::default(),
         }
     }
 }
@@ -478,6 +484,8 @@ impl ToBytes for HostFunctionCosts {
         ret.append(&mut self.blake2b.to_bytes()?);
         ret.append(&mut self.random_bytes.to_bytes()?);
         ret.append(&mut self.enable_contract_version.to_bytes()?);
+        ret.append(&mut self.manage_message_topic.to_bytes()?);
+        ret.append(&mut self.emit_message.to_bytes()?);
         Ok(ret)
     }
 
@@ -526,6 +534,8 @@ impl ToBytes for HostFunctionCosts {
             + self.blake2b.serialized_length()
             + self.random_bytes.serialized_length()
             + self.enable_contract_version.serialized_length()
+            + self.manage_message_topic.serialized_length()
+            + self.emit_message.serialized_length()
     }
 }
 
@@ -575,6 +585,8 @@ impl FromBytes for HostFunctionCosts {
         let (blake2b, rem) = FromBytes::from_bytes(rem)?;
         let (random_bytes, rem) = FromBytes::from_bytes(rem)?;
         let (enable_contract_version, rem) = FromBytes::from_bytes(rem)?;
+        let (manage_message_topic, rem) = FromBytes::from_bytes(rem)?;
+        let (emit_message, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             HostFunctionCosts {
                 read_value,
@@ -621,6 +633,8 @@ impl FromBytes for HostFunctionCosts {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
+                manage_message_topic,
+                emit_message,
             },
             rem,
         ))
@@ -674,6 +688,8 @@ impl Distribution<HostFunctionCosts> for Standard {
             blake2b: rng.gen(),
             random_bytes: rng.gen(),
             enable_contract_version: rng.gen(),
+            manage_message_topic: rng.gen(),
+            emit_message: rng.gen(),
         }
     }
 }
@@ -737,6 +753,8 @@ pub mod gens {
             blake2b in host_function_cost_arb(),
             random_bytes in host_function_cost_arb(),
             enable_contract_version in host_function_cost_arb(),
+            manage_message_topic in host_function_cost_arb(),
+            emit_message in host_function_cost_arb(),
         ) -> HostFunctionCosts {
             HostFunctionCosts {
                 read_value,
@@ -783,6 +801,8 @@ pub mod gens {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
+                manage_message_topic,
+                emit_message,
             }
         }
     }

--- a/types/src/chainspec/vm_config/messages_limits.rs
+++ b/types/src/chainspec/vm_config/messages_limits.rs
@@ -2,7 +2,6 @@
 use datasize::DataSize;
 use rand::{distributions::Standard, prelude::*, Rng};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
 
@@ -20,15 +19,6 @@ pub struct MessagesLimits {
 }
 
 impl MessagesLimits {
-    /// Check if a specified message size exceeds the configured max value.
-    pub fn message_size_within_limits(&self, message_size: u32) -> Result<(), Error> {
-        if message_size > self.max_message_size {
-            Err(Error::MessageTooLarge(self.max_message_size, message_size))
-        } else {
-            Ok(())
-        }
-    }
-
     /// Returns the max number of topics a contract can register.
     pub fn max_topics_per_contract(&self) -> u32 {
         self.max_topics_per_contract
@@ -37,6 +27,11 @@ impl MessagesLimits {
     /// Returns the maximum allowed size for the topic name string.
     pub fn max_topic_name_size(&self) -> u32 {
         self.max_topic_name_size
+    }
+
+    /// Returns the maximum allowed size (in bytes) of the serialized message payload.
+    pub fn max_message_size(&self) -> u32 {
+        self.max_message_size
     }
 }
 
@@ -93,22 +88,6 @@ impl Distribution<MessagesLimits> for Standard {
             max_topics_per_contract: rng.gen(),
         }
     }
-}
-
-/// Possible execution errors.
-#[derive(Error, Debug, Clone)]
-#[non_exhaustive]
-pub enum Error {
-    /// Topic name size exceeded.
-    #[error(
-        "Topic name size is too large: expected less then {} bytes, got {} bytes",
-        _0,
-        _1
-    )]
-    TopicNameSizeExceeded(u32, u32),
-    /// Message size exceeded.
-    #[error("Message size cannot exceed {} bytes; actual size {}", _0, _1)]
-    MessageTooLarge(u32, u32),
 }
 
 #[doc(hidden)]

--- a/types/src/chainspec/vm_config/messages_limits.rs
+++ b/types/src/chainspec/vm_config/messages_limits.rs
@@ -1,0 +1,125 @@
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+use rand::{distributions::Standard, prelude::*, Rng};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::bytesrepr::{self, FromBytes, ToBytes};
+
+/// Configuration for messages limits.
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[serde(deny_unknown_fields)]
+pub struct MessagesLimits {
+    /// Maximum size (in bytes) of a topic name.
+    max_topic_name_size: u32,
+    /// Maximum message size in bytes.
+    max_message_size: u32,
+}
+
+impl MessagesLimits {
+    /// Check if a specified topic `name_size` exceeds the configured value.
+    pub fn topic_name_size_within_limits(&self, name_size: u32) -> Result<(), Error> {
+        if name_size > self.max_topic_name_size {
+            Err(Error::TopicNameSizeExceeded(
+                self.max_topic_name_size,
+                name_size,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Check if a specified message size exceeds the configured max value.
+    pub fn message_size_within_limits(&self, message_size: u32) -> Result<(), Error> {
+        if message_size > self.max_message_size {
+            Err(Error::MessageTooLarge(self.max_message_size, message_size))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for MessagesLimits {
+    fn default() -> Self {
+        Self {
+            max_topic_name_size: 256,
+            max_message_size: 1024,
+        }
+    }
+}
+
+impl ToBytes for MessagesLimits {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut ret = bytesrepr::unchecked_allocate_buffer(self);
+
+        ret.append(&mut self.max_topic_name_size.to_bytes()?);
+        ret.append(&mut self.max_message_size.to_bytes()?);
+
+        Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.max_topic_name_size.serialized_length() + self.max_message_size.serialized_length()
+    }
+}
+
+impl FromBytes for MessagesLimits {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (max_topic_name_size, rem) = FromBytes::from_bytes(bytes)?;
+        let (max_message_size, rem) = FromBytes::from_bytes(rem)?;
+
+        Ok((
+            MessagesLimits {
+                max_topic_name_size,
+                max_message_size,
+            },
+            rem,
+        ))
+    }
+}
+
+impl Distribution<MessagesLimits> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessagesLimits {
+        MessagesLimits {
+            max_topic_name_size: rng.gen(),
+            max_message_size: rng.gen(),
+        }
+    }
+}
+
+/// Possible execution errors.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    /// Topic name size exceeded.
+    #[error(
+        "Topic name size is too large: expected less then {} bytes, got {} bytes",
+        _0,
+        _1
+    )]
+    TopicNameSizeExceeded(u32, u32),
+    /// Message size exceeded.
+    #[error("Message size cannot exceed {} bytes; actual size {}", _0, _1)]
+    MessageTooLarge(u32, u32),
+}
+
+#[doc(hidden)]
+#[cfg(any(feature = "gens", test))]
+pub mod gens {
+    use proptest::{num, prop_compose};
+
+    use super::MessagesLimits;
+
+    prop_compose! {
+        pub fn message_limits_arb()(
+            max_topic_name_size in num::u32::ANY,
+            max_message_size in num::u32::ANY,
+        ) -> MessagesLimits {
+            MessagesLimits {
+                max_topic_name_size,
+                max_message_size,
+            }
+        }
+    }
+}

--- a/types/src/chainspec/vm_config/wasm_config.rs
+++ b/types/src/chainspec/vm_config/wasm_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
-    chainspec::vm_config::{HostFunctionCosts, MessagesLimits, OpcodeCosts, StorageCosts},
+    chainspec::vm_config::{HostFunctionCosts, MessageLimits, OpcodeCosts, StorageCosts},
 };
 
 /// Default maximum number of pages of the Wasm memory.
@@ -33,7 +33,7 @@ pub struct WasmConfig {
     /// Host function costs table.
     host_function_costs: HostFunctionCosts,
     /// Messages limits.
-    messages_limits: MessagesLimits,
+    messages_limits: MessageLimits,
 }
 
 impl WasmConfig {
@@ -44,7 +44,7 @@ impl WasmConfig {
         opcode_costs: OpcodeCosts,
         storage_costs: StorageCosts,
         host_function_costs: HostFunctionCosts,
-        messages_limits: MessagesLimits,
+        messages_limits: MessageLimits,
     ) -> Self {
         Self {
             max_memory,
@@ -72,7 +72,7 @@ impl WasmConfig {
     }
 
     /// Returns the limits config for messages.
-    pub fn messages_limits(&self) -> MessagesLimits {
+    pub fn messages_limits(&self) -> MessageLimits {
         self.messages_limits
     }
 }
@@ -85,7 +85,7 @@ impl Default for WasmConfig {
             opcode_costs: OpcodeCosts::default(),
             storage_costs: StorageCosts::default(),
             host_function_costs: HostFunctionCosts::default(),
-            messages_limits: MessagesLimits::default(),
+            messages_limits: MessageLimits::default(),
         }
     }
 }
@@ -156,7 +156,7 @@ pub mod gens {
     use crate::{
         chainspec::vm_config::{
             host_function_costs::gens::host_function_costs_arb,
-            messages_limits::gens::message_limits_arb, opcode_costs::gens::opcode_costs_arb,
+            message_limits::gens::message_limits_arb, opcode_costs::gens::opcode_costs_arb,
             storage_costs::gens::storage_costs_arb,
         },
         WasmConfig,

--- a/types/src/chainspec/vm_config/wasm_config.rs
+++ b/types/src/chainspec/vm_config/wasm_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
-    chainspec::vm_config::{HostFunctionCosts, OpcodeCosts, StorageCosts},
+    chainspec::vm_config::{HostFunctionCosts, MessagesLimits, OpcodeCosts, StorageCosts},
 };
 
 /// Default maximum number of pages of the Wasm memory.
@@ -32,6 +32,8 @@ pub struct WasmConfig {
     storage_costs: StorageCosts,
     /// Host function costs table.
     host_function_costs: HostFunctionCosts,
+    /// Messages limits.
+    messages_limits: MessagesLimits,
 }
 
 impl WasmConfig {
@@ -42,6 +44,7 @@ impl WasmConfig {
         opcode_costs: OpcodeCosts,
         storage_costs: StorageCosts,
         host_function_costs: HostFunctionCosts,
+        messages_limits: MessagesLimits,
     ) -> Self {
         Self {
             max_memory,
@@ -49,6 +52,7 @@ impl WasmConfig {
             opcode_costs,
             storage_costs,
             host_function_costs,
+            messages_limits,
         }
     }
 
@@ -66,6 +70,11 @@ impl WasmConfig {
     pub fn take_host_function_costs(self) -> HostFunctionCosts {
         self.host_function_costs
     }
+
+    /// Returns the limits config for messages.
+    pub fn messages_limits(&self) -> MessagesLimits {
+        self.messages_limits
+    }
 }
 
 impl Default for WasmConfig {
@@ -76,6 +85,7 @@ impl Default for WasmConfig {
             opcode_costs: OpcodeCosts::default(),
             storage_costs: StorageCosts::default(),
             host_function_costs: HostFunctionCosts::default(),
+            messages_limits: MessagesLimits::default(),
         }
     }
 }
@@ -109,6 +119,7 @@ impl FromBytes for WasmConfig {
         let (opcode_costs, rem) = FromBytes::from_bytes(rem)?;
         let (storage_costs, rem) = FromBytes::from_bytes(rem)?;
         let (host_function_costs, rem) = FromBytes::from_bytes(rem)?;
+        let (messages_limits, rem) = FromBytes::from_bytes(rem)?;
 
         Ok((
             WasmConfig {
@@ -117,6 +128,7 @@ impl FromBytes for WasmConfig {
                 opcode_costs,
                 storage_costs,
                 host_function_costs,
+                messages_limits,
             },
             rem,
         ))
@@ -131,6 +143,7 @@ impl Distribution<WasmConfig> for Standard {
             opcode_costs: rng.gen(),
             storage_costs: rng.gen(),
             host_function_costs: rng.gen(),
+            messages_limits: rng.gen(),
         }
     }
 }
@@ -143,7 +156,8 @@ pub mod gens {
     use crate::{
         chainspec::vm_config::{
             host_function_costs::gens::host_function_costs_arb,
-            opcode_costs::gens::opcode_costs_arb, storage_costs::gens::storage_costs_arb,
+            messages_limits::gens::message_limits_arb, opcode_costs::gens::opcode_costs_arb,
+            storage_costs::gens::storage_costs_arb,
         },
         WasmConfig,
     };
@@ -155,6 +169,7 @@ pub mod gens {
             opcode_costs in opcode_costs_arb(),
             storage_costs in storage_costs_arb(),
             host_function_costs in host_function_costs_arb(),
+            messages_limits in message_limits_arb(),
         ) -> WasmConfig {
             WasmConfig {
                 max_memory,
@@ -162,6 +177,7 @@ pub mod gens {
                 opcode_costs,
                 storage_costs,
                 host_function_costs,
+                messages_limits,
             }
         }
     }

--- a/types/src/contract_messages.rs
+++ b/types/src/contract_messages.rs
@@ -1,17 +1,23 @@
 //! Data types for interacting with contract level messages.
+
+mod error;
+mod messages;
+mod topics;
+
+pub use error::FromStrError;
+pub use messages::{Message, MessageChecksum, MessagePayload};
+pub use topics::{MessageTopicOperation, MessageTopicSummary, TopicNameHash};
+
 use crate::{
     alloc::string::ToString,
-    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    checksummed_hex, BlockTime, HashAddr, KEY_HASH_LENGTH,
+    bytesrepr::{self, FromBytes, ToBytes},
+    checksummed_hex, HashAddr, KEY_HASH_LENGTH,
 };
 
 use core::convert::TryFrom;
 
 use alloc::{string::String, vec::Vec};
-use core::{
-    fmt::{self, Display, Formatter},
-    num::ParseIntError,
-};
+use core::fmt::{Debug, Display, Formatter};
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
@@ -23,104 +29,8 @@ use rand::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// The length in bytes of a [`MessageTopicHash`].
-pub const MESSAGE_TOPIC_HASH_LENGTH: usize = 32;
-
-/// The length of a message digest
-pub const MESSAGE_DIGEST_LENGTH: usize = 32;
-
-/// The hash of the name of the message topic.
-pub type MessageTopicHash = [u8; MESSAGE_TOPIC_HASH_LENGTH];
-
 const TOPIC_FORMATTED_STRING_PREFIX: &str = "topic-";
-
-/// A newtype wrapping an array which contains the raw bytes of
-/// the hash of the message emitted
-#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(
-    feature = "json-schema",
-    derive(JsonSchema),
-    schemars(description = "Message summary as a formatted string.")
-)]
-pub struct MessageSummary(
-    #[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))]
-    pub  [u8; MESSAGE_DIGEST_LENGTH],
-);
-
-impl MessageSummary {
-    /// Returns inner value of the message summary
-    pub fn value(&self) -> [u8; MESSAGE_DIGEST_LENGTH] {
-        self.0
-    }
-}
-
-impl ToBytes for MessageSummary {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.append(&mut self.0.to_bytes()?);
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.0.serialized_length()
-    }
-}
-
-impl FromBytes for MessageSummary {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (summary, rem) = FromBytes::from_bytes(bytes)?;
-        Ok((MessageSummary(summary), rem))
-    }
-}
-
-/// Error while parsing a `[MessageTopicAddr]` from string.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum FromStrError {
-    /// No message index at the end of the string.
-    MissingMessageIndex,
-    /// Cannot parse entity hash.
-    EntityHashParseError(String),
-    /// Cannot parse message topic hash.
-    MessageTopicParseError(String),
-    /// Failed to decode address portion of URef.
-    Hex(base16::DecodeError),
-    /// Failed to parse an int.
-    Int(ParseIntError),
-}
-
-impl From<base16::DecodeError> for FromStrError {
-    fn from(error: base16::DecodeError) -> Self {
-        FromStrError::Hex(error)
-    }
-}
-
-impl From<ParseIntError> for FromStrError {
-    fn from(error: ParseIntError) -> Self {
-        FromStrError::Int(error)
-    }
-}
-
-impl Display for FromStrError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            FromStrError::MissingMessageIndex => {
-                write!(f, "no message index found at the end of the string")
-            }
-            FromStrError::EntityHashParseError(err) => {
-                write!(f, "could not parse entity hash: {}", err)
-            }
-            FromStrError::MessageTopicParseError(err) => {
-                write!(f, "could not parse topic hash: {}", err)
-            }
-            FromStrError::Hex(error) => {
-                write!(f, "failed to decode address portion from hex: {}", error)
-            }
-            FromStrError::Int(error) => write!(f, "failed to parse an int: {}", error),
-        }
-    }
-}
+const MESSAGE_ADDR_PREFIX: &str = "message-";
 
 /// MessageTopicAddr
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, Debug)]
@@ -130,7 +40,7 @@ pub struct MessageAddr {
     /// The entity addr.
     entity_addr: HashAddr,
     /// The hash of the name of the message topic.
-    topic_hash: MessageTopicHash,
+    topic_name_hash: TopicNameHash,
     /// The message index.
     message_index: Option<u32>,
 }
@@ -138,10 +48,10 @@ pub struct MessageAddr {
 impl MessageAddr {
     /// Constructs a new topic address based on the addressable entity addr and the hash of the
     /// message topic name.
-    pub const fn new_topic_addr(entity_addr: HashAddr, topic_hash: MessageTopicHash) -> Self {
+    pub const fn new_topic_addr(entity_addr: HashAddr, topic_name_hash: TopicNameHash) -> Self {
         Self {
             entity_addr,
-            topic_hash,
+            topic_name_hash,
             message_index: None,
         }
     }
@@ -150,41 +60,71 @@ impl MessageAddr {
     /// message topic name and the message index in the topic.
     pub const fn new_message_addr(
         entity_addr: HashAddr,
-        topic_hash: MessageTopicHash,
+        topic_name_hash: TopicNameHash,
         message_index: u32,
     ) -> Self {
         Self {
             entity_addr,
-            topic_hash,
+            topic_name_hash,
             message_index: Some(message_index),
+        }
+    }
+
+    /// Formats the [`MessageAddr`] as a prefixed, hex-encoded string.
+    pub fn to_formatted_string(self) -> String {
+        match self.message_index {
+            Some(index) => {
+                format!(
+                    "{}{}-{}-{:x}",
+                    MESSAGE_ADDR_PREFIX,
+                    base16::encode_lower(&self.entity_addr),
+                    self.topic_name_hash.to_formatted_string(),
+                    index,
+                )
+            }
+            None => {
+                format!(
+                    "{}{}{}-{}",
+                    MESSAGE_ADDR_PREFIX,
+                    TOPIC_FORMATTED_STRING_PREFIX,
+                    base16::encode_lower(&self.entity_addr),
+                    self.topic_name_hash.to_formatted_string(),
+                )
+            }
         }
     }
 
     /// Parses a formatted string into a [`MessageAddr`].
     pub fn from_formatted_str(input: &str) -> Result<Self, FromStrError> {
-        let (remainder, message_index) = match input.strip_prefix(TOPIC_FORMATTED_STRING_PREFIX) {
+        let remainder = input
+            .strip_prefix(MESSAGE_ADDR_PREFIX)
+            .ok_or(FromStrError::InvalidPrefix)?;
+
+        let (remainder, message_index) = match remainder.strip_prefix(TOPIC_FORMATTED_STRING_PREFIX)
+        {
             Some(topic_string) => (topic_string, None),
             None => {
-                let parts = input.splitn(2, '-').collect::<Vec<_>>();
+                let parts = input.rsplitn(2, '-').collect::<Vec<_>>();
                 if parts.len() != 2 {
                     return Err(FromStrError::MissingMessageIndex);
                 }
-                (parts[0], Some(u32::from_str_radix(parts[1], 16)?))
+                (parts[1], Some(u32::from_str_radix(parts[0], 16)?))
             }
         };
 
-        let bytes = checksummed_hex::decode(remainder)?;
+        let parts = remainder.splitn(2, '-').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            return Err(FromStrError::MissingMessageIndex);
+        }
 
+        let bytes = checksummed_hex::decode(parts[0])?;
         let entity_addr = <[u8; KEY_HASH_LENGTH]>::try_from(bytes[0..KEY_HASH_LENGTH].as_ref())
             .map_err(|err| FromStrError::EntityHashParseError(err.to_string()))?;
 
-        let topic_hash =
-            <[u8; MESSAGE_TOPIC_HASH_LENGTH]>::try_from(bytes[KEY_HASH_LENGTH..].as_ref())
-                .map_err(|err| FromStrError::MessageTopicParseError(err.to_string()))?;
-
+        let topic_name_hash = TopicNameHash::from_formatted_str(parts[1])?;
         Ok(MessageAddr {
             entity_addr,
-            topic_hash,
+            topic_name_hash,
             message_index,
         })
     }
@@ -201,19 +141,18 @@ impl Display for MessageAddr {
             Some(index) => {
                 write!(
                     f,
-                    "{}{}-{:x}",
+                    "{}-{}-{:x}",
                     base16::encode_lower(&self.entity_addr),
-                    base16::encode_lower(&self.topic_hash),
+                    self.topic_name_hash,
                     index,
                 )
             }
             None => {
                 write!(
                     f,
-                    "{}{}{}",
-                    TOPIC_FORMATTED_STRING_PREFIX,
+                    "{}-{}",
                     base16::encode_lower(&self.entity_addr),
-                    base16::encode_lower(&self.topic_hash),
+                    self.topic_name_hash,
                 )
             }
         }
@@ -224,14 +163,14 @@ impl ToBytes for MessageAddr {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.append(&mut self.entity_addr.to_bytes()?);
-        buffer.append(&mut self.topic_hash.to_bytes()?);
+        buffer.append(&mut self.topic_name_hash.to_bytes()?);
         buffer.append(&mut self.message_index.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
         self.entity_addr.serialized_length()
-            + self.topic_hash.serialized_length()
+            + self.topic_name_hash.serialized_length()
             + self.message_index.serialized_length()
     }
 }
@@ -244,7 +183,7 @@ impl FromBytes for MessageAddr {
         Ok((
             MessageAddr {
                 entity_addr,
-                topic_hash,
+                topic_name_hash: topic_hash,
                 message_index,
             },
             rem,
@@ -256,235 +195,8 @@ impl Distribution<MessageAddr> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessageAddr {
         MessageAddr {
             entity_addr: rng.gen(),
-            topic_hash: rng.gen(),
+            topic_name_hash: rng.gen(),
             message_index: rng.gen(),
-        }
-    }
-}
-
-/// Summary of a message topic that will be stored in global state.
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
-pub struct MessageTopicSummary {
-    /// Number of messages in this topic.
-    pub(crate) message_count: u32,
-    /// Block timestamp in which these messages were emitted.
-    pub(crate) blocktime: BlockTime,
-}
-
-impl MessageTopicSummary {
-    /// Creates a new topic summary.
-    pub fn new(message_count: u32, blocktime: BlockTime) -> Self {
-        Self {
-            message_count,
-            blocktime,
-        }
-    }
-
-    /// Returns the number of messages that were sent on this topic.
-    pub fn message_count(&self) -> u32 {
-        self.message_count
-    }
-
-    /// Returns the block time.
-    pub fn blocktime(&self) -> BlockTime {
-        self.blocktime
-    }
-}
-
-impl ToBytes for MessageTopicSummary {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.append(&mut self.message_count.to_bytes()?);
-        buffer.append(&mut self.blocktime.to_bytes()?);
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.message_count.serialized_length() + self.blocktime.serialized_length()
-    }
-}
-
-impl FromBytes for MessageTopicSummary {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (message_count, rem) = FromBytes::from_bytes(bytes)?;
-        let (blocktime, rem) = FromBytes::from_bytes(rem)?;
-        Ok((
-            MessageTopicSummary {
-                message_count,
-                blocktime,
-            },
-            rem,
-        ))
-    }
-}
-
-const MESSAGE_PAYLOAD_TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
-
-/// Tag for an empty message payload.
-pub const MESSAGE_PAYLOAD_EMPTY_TAG: u8 = 0;
-/// Tag for a message payload that contains a human readable string.
-pub const MESSAGE_PAYLOAD_STRING_TAG: u8 = 1;
-
-/// The payload of the message emitted by an addressable entity during execution.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
-pub enum MessagePayload {
-    /// Empty message.
-    Empty,
-    /// Human readable string message.
-    String(String),
-}
-
-impl MessagePayload {
-    /// Creates a new [`MessagePayload`] from a [`String`].
-    pub fn from_string(message: String) -> Self {
-        Self::String(message)
-    }
-}
-
-impl ToBytes for MessagePayload {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        match self {
-            MessagePayload::Empty => {
-                buffer.insert(0, MESSAGE_PAYLOAD_EMPTY_TAG);
-            }
-            MessagePayload::String(message_string) => {
-                buffer.insert(0, MESSAGE_PAYLOAD_STRING_TAG);
-                buffer.extend(message_string.to_bytes()?);
-            }
-        }
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        MESSAGE_PAYLOAD_TAG_LENGTH
-            + match self {
-                MessagePayload::Empty => 0,
-                MessagePayload::String(message_string) => message_string.serialized_length(),
-            }
-    }
-}
-
-impl FromBytes for MessagePayload {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (tag, remainder) = u8::from_bytes(bytes)?;
-        match tag {
-            MESSAGE_PAYLOAD_EMPTY_TAG => Ok((Self::Empty, remainder)),
-            MESSAGE_PAYLOAD_STRING_TAG => {
-                let (message, remainder): (String, _) = FromBytes::from_bytes(remainder)?;
-                Ok((Self::String(message), remainder))
-            }
-            _ => Err(bytesrepr::Error::Formatting),
-        }
-    }
-}
-
-/// Message that was emitted by an addressable entity during execution.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
-pub struct Message {
-    /// The identity of the entity that produced the message.
-    #[cfg_attr(feature = "json-schema", schemars(with = "String"))]
-    entity_addr: HashAddr,
-    /// Message payload
-    message: MessagePayload,
-    /// Topic name
-    topic: String,
-    /// Message index in the topic
-    index: u32,
-}
-
-impl Message {
-    /// Creates new instance of [`Message`] with the specified source and message payload.
-    pub fn new(source: HashAddr, message: MessagePayload, topic: String, index: u32) -> Self {
-        Self {
-            entity_addr: source,
-            message,
-            topic,
-            index,
-        }
-    }
-}
-
-impl ToBytes for Message {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.append(&mut self.entity_addr.to_bytes()?);
-        buffer.append(&mut self.message.to_bytes()?);
-        buffer.append(&mut self.topic.to_bytes()?);
-        buffer.append(&mut self.index.to_bytes()?);
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.entity_addr.serialized_length()
-            + self.message.serialized_length()
-            + self.topic.serialized_length()
-            + self.index.serialized_length()
-    }
-}
-
-impl FromBytes for Message {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (entity_addr, rem) = FromBytes::from_bytes(bytes)?;
-        let (message, rem) = FromBytes::from_bytes(rem)?;
-        let (topic, rem) = FromBytes::from_bytes(rem)?;
-        let (index, rem) = FromBytes::from_bytes(rem)?;
-        Ok((
-            Message {
-                entity_addr,
-                message,
-                topic,
-                index,
-            },
-            rem,
-        ))
-    }
-}
-
-const TOPIC_OPERATION_ADD_TAG: u8 = 0;
-const OPERATION_MAX_SERIALIZED_LEN: usize = 1;
-
-/// Operations that can be performed on message topics.
-pub enum MessageTopicOperation {
-    /// Add a new message topic.
-    Add,
-}
-
-impl MessageTopicOperation {
-    /// Maximum serialized length of a message topic operation.
-    pub const fn max_serialized_len() -> usize {
-        OPERATION_MAX_SERIALIZED_LEN
-    }
-}
-
-impl ToBytes for MessageTopicOperation {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        match self {
-            MessageTopicOperation::Add => buffer.push(TOPIC_OPERATION_ADD_TAG),
-        }
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        match self {
-            MessageTopicOperation::Add => 1,
-        }
-    }
-}
-
-impl FromBytes for MessageTopicOperation {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (tag, remainder): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
-        match tag {
-            TOPIC_OPERATION_ADD_TAG => Ok((MessageTopicOperation::Add, remainder)),
-            _ => Err(bytesrepr::Error::Formatting),
         }
     }
 }
@@ -493,30 +205,19 @@ impl FromBytes for MessageTopicOperation {
 mod tests {
     use crate::{bytesrepr, KEY_HASH_LENGTH};
 
-    use super::*;
+    use super::{topics::TOPIC_NAME_HASH_LENGTH, *};
 
     #[test]
     fn serialization_roundtrip() {
-        let message_addr =
-            MessageAddr::new_topic_addr([1; KEY_HASH_LENGTH], [2; MESSAGE_TOPIC_HASH_LENGTH]);
-        bytesrepr::test_serialization_roundtrip(&message_addr);
+        let topic_addr =
+            MessageAddr::new_topic_addr([1; KEY_HASH_LENGTH], [2; TOPIC_NAME_HASH_LENGTH].into());
+        bytesrepr::test_serialization_roundtrip(&topic_addr);
 
-        let topic_summary = MessageTopicSummary::new(100, BlockTime::new(1000));
-        bytesrepr::test_serialization_roundtrip(&topic_summary);
-
-        let string_message_payload =
-            MessagePayload::from_string("new contract message".to_string());
-        bytesrepr::test_serialization_roundtrip(&string_message_payload);
-
-        let empty_message_payload = MessagePayload::Empty;
-        bytesrepr::test_serialization_roundtrip(&empty_message_payload);
-
-        let message = Message::new(
+        let message_addr = MessageAddr::new_message_addr(
             [1; KEY_HASH_LENGTH],
-            string_message_payload,
-            "new contract message".to_string(),
-            32,
+            [2; TOPIC_NAME_HASH_LENGTH].into(),
+            3,
         );
-        bytesrepr::test_serialization_roundtrip(&message);
+        bytesrepr::test_serialization_roundtrip(&message_addr);
     }
 }

--- a/types/src/contract_messages.rs
+++ b/types/src/contract_messages.rs
@@ -1,11 +1,17 @@
 //! Data types for interacting with contract level messages.
-
 use crate::{
-    bytesrepr::{self, FromBytes, ToBytes},
-    HashAddr,
+    alloc::string::ToString,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    checksummed_hex, HashAddr, KEY_HASH_LENGTH,
 };
-use alloc::vec::Vec;
-use core::fmt::{Display, Formatter};
+
+use core::convert::TryFrom;
+
+use alloc::{string::String, vec::Vec};
+use core::{
+    fmt::{self, Display, Formatter},
+    num::ParseIntError,
+};
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
@@ -20,74 +26,478 @@ use serde::{Deserialize, Serialize};
 /// The length in bytes of a [`MessageTopicHash`].
 pub const MESSAGE_TOPIC_HASH_LENGTH: usize = 32;
 
+/// The length of a message digest
+pub const MESSAGE_DIGEST_LENGTH: usize = 32;
+
 /// The hash of the name of the message topic.
 pub type MessageTopicHash = [u8; MESSAGE_TOPIC_HASH_LENGTH];
 
-/// MessageAddr
-#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+const TOPIC_FORMATTED_STRING_PREFIX: &str = "topic-";
+
+/// A newtype wrapping an array which contains the raw bytes of
+/// the hash of the message emitted
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-pub struct MessageTopicAddr {
-    /// The entity addr.
-    entity_addr: HashAddr,
-    /// The hash of the name of the message topic.
-    topic_hash: MessageTopicHash,
-}
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Message summary as a formatted string.")
+)]
+pub struct MessageSummary(
+    #[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))]
+    pub  [u8; MESSAGE_DIGEST_LENGTH],
+);
 
-impl MessageTopicAddr {
-    /// Constructs a new [`MessageAddr`] based on the addressable entity addr and the hash of the
-    /// message topic name.
-    pub const fn new(entity_addr: HashAddr, topic_hash: MessageTopicHash) -> Self {
-        Self {
-            entity_addr,
-            topic_hash,
-        }
+impl MessageSummary {
+    /// Returns inner value of the message summary
+    pub fn value(&self) -> [u8; MESSAGE_DIGEST_LENGTH] {
+        self.0
     }
 }
 
-impl Display for MessageTopicAddr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "{}{}",
-            base16::encode_lower(&self.entity_addr),
-            base16::encode_lower(&self.topic_hash)
-        )
-    }
-}
-
-impl ToBytes for MessageTopicAddr {
+impl ToBytes for MessageSummary {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.append(&mut self.entity_addr.to_bytes()?);
-        buffer.append(&mut self.topic_hash.to_bytes()?);
+        buffer.append(&mut self.0.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.entity_addr.serialized_length() + self.topic_hash.serialized_length()
+        self.0.serialized_length()
     }
 }
 
-impl FromBytes for MessageTopicAddr {
+impl FromBytes for MessageSummary {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (summary, rem) = FromBytes::from_bytes(bytes)?;
+        Ok((MessageSummary(summary), rem))
+    }
+}
+
+/// Error while parsing a `[MessageTopicAddr]` from string.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FromStrError {
+    /// No message index at the end of the string.
+    MissingMessageIndex,
+    /// Cannot parse entity hash.
+    EntityHashParseError(String),
+    /// Cannot parse message topic hash.
+    MessageTopicParseError(String),
+    /// Failed to decode address portion of URef.
+    Hex(base16::DecodeError),
+    /// Failed to parse an int.
+    Int(ParseIntError),
+}
+
+impl From<base16::DecodeError> for FromStrError {
+    fn from(error: base16::DecodeError) -> Self {
+        FromStrError::Hex(error)
+    }
+}
+
+impl From<ParseIntError> for FromStrError {
+    fn from(error: ParseIntError) -> Self {
+        FromStrError::Int(error)
+    }
+}
+
+impl Display for FromStrError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            FromStrError::MissingMessageIndex => {
+                write!(f, "no message index found at the end of the string")
+            }
+            FromStrError::EntityHashParseError(err) => {
+                write!(f, "could not parse entity hash: {}", err)
+            }
+            FromStrError::MessageTopicParseError(err) => {
+                write!(f, "could not parse topic hash: {}", err)
+            }
+            FromStrError::Hex(error) => {
+                write!(f, "failed to decode address portion from hex: {}", error)
+            }
+            FromStrError::Int(error) => write!(f, "failed to parse an int: {}", error),
+        }
+    }
+}
+
+/// MessageTopicAddr
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+pub struct MessageAddr {
+    /// The entity addr.
+    entity_addr: HashAddr,
+    /// The hash of the name of the message topic.
+    topic_hash: MessageTopicHash,
+    /// The message index.
+    message_index: Option<u32>,
+}
+
+impl MessageAddr {
+    /// Constructs a new topic address based on the addressable entity addr and the hash of the
+    /// message topic name.
+    pub const fn new_topic_addr(entity_addr: HashAddr, topic_hash: MessageTopicHash) -> Self {
+        Self {
+            entity_addr,
+            topic_hash,
+            message_index: None,
+        }
+    }
+
+    /// Constructs a new message address based on the addressable entity addr, the hash of the
+    /// message topic name and the message index in the topic.
+    pub const fn new_message_addr(
+        entity_addr: HashAddr,
+        topic_hash: MessageTopicHash,
+        message_index: u32,
+    ) -> Self {
+        Self {
+            entity_addr,
+            topic_hash,
+            message_index: Some(message_index),
+        }
+    }
+
+    /// Parses a formatted string into a [`MessageAddr`].
+    pub fn from_formatted_str(input: &str) -> Result<Self, FromStrError> {
+        let (remainder, message_index) = match input.strip_prefix(TOPIC_FORMATTED_STRING_PREFIX) {
+            Some(topic_string) => (topic_string, None),
+            None => {
+                let parts = input.splitn(2, '-').collect::<Vec<_>>();
+                if parts.len() != 2 {
+                    return Err(FromStrError::MissingMessageIndex);
+                }
+                (parts[0], Some(u32::from_str_radix(parts[1], 16)?))
+            }
+        };
+
+        let bytes = checksummed_hex::decode(remainder)?;
+
+        let entity_addr = <[u8; KEY_HASH_LENGTH]>::try_from(bytes[0..KEY_HASH_LENGTH].as_ref())
+            .map_err(|err| FromStrError::EntityHashParseError(err.to_string()))?;
+
+        let topic_hash =
+            <[u8; MESSAGE_TOPIC_HASH_LENGTH]>::try_from(bytes[KEY_HASH_LENGTH..].as_ref())
+                .map_err(|err| FromStrError::MessageTopicParseError(err.to_string()))?;
+
+        Ok(MessageAddr {
+            entity_addr,
+            topic_hash,
+            message_index,
+        })
+    }
+
+    /// Returns the entity addr of this message topic.
+    pub fn entity_addr(&self) -> HashAddr {
+        self.entity_addr
+    }
+}
+
+impl Display for MessageAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self.message_index {
+            Some(index) => {
+                write!(
+                    f,
+                    "{}{}-{:x}",
+                    base16::encode_lower(&self.entity_addr),
+                    base16::encode_lower(&self.topic_hash),
+                    index,
+                )
+            }
+            None => {
+                write!(
+                    f,
+                    "{}{}{}",
+                    TOPIC_FORMATTED_STRING_PREFIX,
+                    base16::encode_lower(&self.entity_addr),
+                    base16::encode_lower(&self.topic_hash),
+                )
+            }
+        }
+    }
+}
+
+impl ToBytes for MessageAddr {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.entity_addr.to_bytes()?);
+        buffer.append(&mut self.topic_hash.to_bytes()?);
+        buffer.append(&mut self.message_index.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.entity_addr.serialized_length()
+            + self.topic_hash.serialized_length()
+            + self.message_index.serialized_length()
+    }
+}
+
+impl FromBytes for MessageAddr {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (entity_addr, rem) = FromBytes::from_bytes(bytes)?;
         let (topic_hash, rem) = FromBytes::from_bytes(rem)?;
+        let (message_index, rem) = FromBytes::from_bytes(rem)?;
         Ok((
-            MessageTopicAddr {
+            MessageAddr {
                 entity_addr,
                 topic_hash,
+                message_index,
             },
             rem,
         ))
     }
 }
 
-impl Distribution<MessageTopicAddr> for Standard {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessageTopicAddr {
-        MessageTopicAddr {
+impl Distribution<MessageAddr> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessageAddr {
+        MessageAddr {
             entity_addr: rng.gen(),
             topic_hash: rng.gen(),
+            message_index: rng.gen(),
         }
+    }
+}
+
+/// Summary of a message topic that will be stored in global state.
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct MessageTopicSummary {
+    /// Number of messages in this topic.
+    pub(crate) message_count: u32,
+}
+
+impl MessageTopicSummary {
+    /// Creates a new topic summary.
+    pub fn new(message_count: u32) -> Self {
+        Self { message_count }
+    }
+
+    /// Returns the number of messages that were sent on this topic.
+    pub fn message_count(&self) -> u32 {
+        self.message_count
+    }
+}
+
+impl ToBytes for MessageTopicSummary {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.message_count.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.message_count.serialized_length()
+    }
+}
+
+impl FromBytes for MessageTopicSummary {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (message_count, rem) = FromBytes::from_bytes(bytes)?;
+        Ok((MessageTopicSummary { message_count }, rem))
+    }
+}
+
+const MESSAGE_PAYLOAD_TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
+
+/// Tag for an empty message payload.
+pub const MESSAGE_PAYLOAD_EMPTY_TAG: u8 = 0;
+/// Tag for a message payload that contains a human readable string.
+pub const MESSAGE_PAYLOAD_STRING_TAG: u8 = 1;
+
+/// The payload of the message emitted by an addressable entity during execution.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub enum MessagePayload {
+    /// Empty message.
+    Empty,
+    /// Human readable string message.
+    String(String),
+}
+
+impl MessagePayload {
+    /// Creates a new [`MessagePayload`] from a [`String`].
+    pub fn from_string(message: String) -> Self {
+        Self::String(message)
+    }
+}
+
+impl ToBytes for MessagePayload {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            MessagePayload::Empty => {
+                buffer.insert(0, MESSAGE_PAYLOAD_EMPTY_TAG);
+            }
+            MessagePayload::String(message_string) => {
+                buffer.insert(0, MESSAGE_PAYLOAD_STRING_TAG);
+                buffer.extend(message_string.to_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        MESSAGE_PAYLOAD_TAG_LENGTH
+            + match self {
+                MessagePayload::Empty => 0,
+                MessagePayload::String(message_string) => message_string.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for MessagePayload {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            MESSAGE_PAYLOAD_EMPTY_TAG => Ok((Self::Empty, remainder)),
+            MESSAGE_PAYLOAD_STRING_TAG => {
+                let (message, remainder): (String, _) = FromBytes::from_bytes(remainder)?;
+                Ok((Self::String(message), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+/// Message that was emitted by an addressable entity during execution.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct Message {
+    /// The identity of the entity that produced the message.
+    entity_addr: HashAddr,
+    /// Message payload
+    message: MessagePayload,
+    /// Topic name
+    topic: String,
+    /// Message index in the topic
+    index: u32,
+}
+
+impl Message {
+    /// Creates new instance of [`Message`] with the specified source and message payload.
+    pub fn new(source: HashAddr, message: MessagePayload, topic: String, index: u32) -> Self {
+        Self {
+            entity_addr: source,
+            message,
+            topic,
+            index,
+        }
+    }
+}
+
+impl ToBytes for Message {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.entity_addr.to_bytes()?);
+        buffer.append(&mut self.message.to_bytes()?);
+        buffer.append(&mut self.topic.to_bytes()?);
+        buffer.append(&mut self.index.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.entity_addr.serialized_length()
+            + self.message.serialized_length()
+            + self.topic.serialized_length()
+            + self.index.serialized_length()
+    }
+}
+
+impl FromBytes for Message {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (entity_addr, rem) = FromBytes::from_bytes(bytes)?;
+        let (message, rem) = FromBytes::from_bytes(rem)?;
+        let (topic, rem) = FromBytes::from_bytes(rem)?;
+        let (index, rem) = FromBytes::from_bytes(rem)?;
+        Ok((
+            Message {
+                entity_addr,
+                message,
+                topic,
+                index,
+            },
+            rem,
+        ))
+    }
+}
+
+const TOPIC_OPERATION_ADD_TAG: u8 = 0;
+const OPERATION_MAX_SERIALIZED_LEN: usize = 1;
+
+/// Operations that can be performed on message topics.
+pub enum MessageTopicOperation {
+    /// Add a new message topic.
+    Add,
+}
+
+impl MessageTopicOperation {
+    /// Maximum serialized length of a message topic operation.
+    pub const fn max_serialized_len() -> usize {
+        OPERATION_MAX_SERIALIZED_LEN
+    }
+}
+
+impl ToBytes for MessageTopicOperation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            MessageTopicOperation::Add => buffer.push(TOPIC_OPERATION_ADD_TAG),
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        match self {
+            MessageTopicOperation::Add => 1,
+        }
+    }
+}
+
+impl FromBytes for MessageTopicOperation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            TOPIC_OPERATION_ADD_TAG => Ok((MessageTopicOperation::Add, remainder)),
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{bytesrepr, KEY_HASH_LENGTH};
+
+    use super::*;
+
+    #[test]
+    fn serialization_roundtrip() {
+        let message_addr =
+            MessageAddr::new_topic_addr([1; KEY_HASH_LENGTH], [2; MESSAGE_TOPIC_HASH_LENGTH]);
+        bytesrepr::test_serialization_roundtrip(&message_addr);
+
+        let topic_summary = MessageTopicSummary::new(100);
+        bytesrepr::test_serialization_roundtrip(&topic_summary);
+
+        let string_message_payload =
+            MessagePayload::from_string("new contract message".to_string());
+        bytesrepr::test_serialization_roundtrip(&string_message_payload);
+
+        let empty_message_payload = MessagePayload::Empty;
+        bytesrepr::test_serialization_roundtrip(&empty_message_payload);
+
+        let message = Message::new(
+            [1; KEY_HASH_LENGTH],
+            string_message_payload,
+            "new contract message".to_string(),
+            32,
+        );
+        bytesrepr::test_serialization_roundtrip(&message);
     }
 }

--- a/types/src/contract_messages/error.rs
+++ b/types/src/contract_messages/error.rs
@@ -1,0 +1,74 @@
+use core::array::TryFromSliceError;
+
+use alloc::string::String;
+use core::{
+    fmt::{self, Debug, Display, Formatter},
+    num::ParseIntError,
+};
+
+/// Error while parsing message hashes from string.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FromStrError {
+    /// The prefix is invalid.
+    InvalidPrefix,
+    /// No message index at the end of the string.
+    MissingMessageIndex,
+    /// String not formatted correctly.
+    Formatting,
+    /// Cannot parse entity hash.
+    EntityHashParseError(String),
+    /// Cannot parse message topic hash.
+    MessageTopicParseError(String),
+    /// Failed to decode address portion of URef.
+    Hex(base16::DecodeError),
+    /// Failed to parse an int.
+    Int(ParseIntError),
+    /// The slice is the wrong length.
+    Length(TryFromSliceError),
+}
+
+impl From<base16::DecodeError> for FromStrError {
+    fn from(error: base16::DecodeError) -> Self {
+        FromStrError::Hex(error)
+    }
+}
+
+impl From<ParseIntError> for FromStrError {
+    fn from(error: ParseIntError) -> Self {
+        FromStrError::Int(error)
+    }
+}
+
+impl From<TryFromSliceError> for FromStrError {
+    fn from(error: TryFromSliceError) -> Self {
+        FromStrError::Length(error)
+    }
+}
+
+impl Display for FromStrError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            FromStrError::InvalidPrefix => {
+                write!(f, "prefix is invalid")
+            }
+            FromStrError::MissingMessageIndex => {
+                write!(f, "no message index found at the end of the string")
+            }
+            FromStrError::Formatting => {
+                write!(f, "string not properly formatted")
+            }
+            FromStrError::EntityHashParseError(err) => {
+                write!(f, "could not parse entity hash: {}", err)
+            }
+            FromStrError::MessageTopicParseError(err) => {
+                write!(f, "could not parse topic hash: {}", err)
+            }
+            FromStrError::Hex(error) => {
+                write!(f, "failed to decode address portion from hex: {}", error)
+            }
+            FromStrError::Int(error) => write!(f, "failed to parse an int: {}", error),
+            FromStrError::Length(error) => write!(f, "address portion is wrong length: {}", error),
+        }
+    }
+}

--- a/types/src/contract_messages/messages.rs
+++ b/types/src/contract_messages/messages.rs
@@ -187,3 +187,28 @@ impl FromBytes for Message {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{bytesrepr, contract_messages::topics::TOPIC_NAME_HASH_LENGTH, KEY_HASH_LENGTH};
+
+    use super::*;
+
+    #[test]
+    fn serialization_roundtrip() {
+        let message_checksum = MessageChecksum([1; MESSAGE_CHECKSUM_LENGTH]);
+        bytesrepr::test_serialization_roundtrip(&message_checksum);
+
+        let message_payload = MessagePayload::from_string("message payload".to_string());
+        bytesrepr::test_serialization_roundtrip(&message_payload);
+
+        let message = Message::new(
+            [1; KEY_HASH_LENGTH],
+            message_payload,
+            "test_topic".to_string(),
+            TopicNameHash::new([0x4du8; TOPIC_NAME_HASH_LENGTH]),
+            10,
+        );
+        bytesrepr::test_serialization_roundtrip(&message);
+    }
+}

--- a/types/src/contract_messages/messages.rs
+++ b/types/src/contract_messages/messages.rs
@@ -1,0 +1,174 @@
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    HashAddr,
+};
+
+use alloc::{string::String, vec::Vec};
+use core::fmt::Debug;
+
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// The length of a message digest
+pub const MESSAGE_CHECKSUM_LENGTH: usize = 32;
+
+/// A newtype wrapping an array which contains the raw bytes of
+/// the hash of the message emitted.
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Message checksum as a formatted string.")
+)]
+pub struct MessageChecksum(
+    #[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))]
+    pub  [u8; MESSAGE_CHECKSUM_LENGTH],
+);
+
+impl MessageChecksum {
+    /// Returns inner value of the message checksum.
+    pub fn value(&self) -> [u8; MESSAGE_CHECKSUM_LENGTH] {
+        self.0
+    }
+}
+
+impl ToBytes for MessageChecksum {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.0.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}
+
+impl FromBytes for MessageChecksum {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (checksum, rem) = FromBytes::from_bytes(bytes)?;
+        Ok((MessageChecksum(checksum), rem))
+    }
+}
+
+const MESSAGE_PAYLOAD_TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
+
+/// Tag for a message payload that contains a human readable string.
+pub const MESSAGE_PAYLOAD_STRING_TAG: u8 = 0;
+
+/// The payload of the message emitted by an addressable entity during execution.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub enum MessagePayload {
+    /// Human readable string message.
+    String(String),
+}
+
+impl MessagePayload {
+    /// Creates a new [`MessagePayload`] from a [`String`].
+    pub fn from_string(message: String) -> Self {
+        Self::String(message)
+    }
+}
+
+impl ToBytes for MessagePayload {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            MessagePayload::String(message_string) => {
+                buffer.insert(0, MESSAGE_PAYLOAD_STRING_TAG);
+                buffer.extend(message_string.to_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        MESSAGE_PAYLOAD_TAG_LENGTH
+            + match self {
+                MessagePayload::String(message_string) => message_string.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for MessagePayload {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            MESSAGE_PAYLOAD_STRING_TAG => {
+                let (message, remainder): (String, _) = FromBytes::from_bytes(remainder)?;
+                Ok((Self::String(message), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+/// Message that was emitted by an addressable entity during execution.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct Message {
+    /// The identity of the entity that produced the message.
+    #[cfg_attr(feature = "json-schema", schemars(with = "String"))]
+    entity_addr: HashAddr,
+    /// The payload of the message.
+    message: MessagePayload,
+    /// The name of the topic on which the message was emitted on.
+    topic: String,
+    /// Message index in the topic.
+    index: u32,
+}
+
+impl Message {
+    /// Creates new instance of [`Message`] with the specified source and message payload.
+    pub fn new(source: HashAddr, message: MessagePayload, topic: String, index: u32) -> Self {
+        Self {
+            entity_addr: source,
+            message,
+            topic,
+            index,
+        }
+    }
+}
+
+impl ToBytes for Message {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.entity_addr.to_bytes()?);
+        buffer.append(&mut self.message.to_bytes()?);
+        buffer.append(&mut self.topic.to_bytes()?);
+        buffer.append(&mut self.index.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.entity_addr.serialized_length()
+            + self.message.serialized_length()
+            + self.topic.serialized_length()
+            + self.index.serialized_length()
+    }
+}
+
+impl FromBytes for Message {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (entity_addr, rem) = FromBytes::from_bytes(bytes)?;
+        let (message, rem) = FromBytes::from_bytes(rem)?;
+        let (topic, rem) = FromBytes::from_bytes(rem)?;
+        let (index, rem) = FromBytes::from_bytes(rem)?;
+        Ok((
+            Message {
+                entity_addr,
+                message,
+                topic,
+                index,
+            },
+            rem,
+        ))
+    }
+}

--- a/types/src/contract_messages/topics.rs
+++ b/types/src/contract_messages/topics.rs
@@ -195,6 +195,7 @@ const TOPIC_OPERATION_ADD_TAG: u8 = 0;
 const OPERATION_MAX_SERIALIZED_LEN: usize = 1;
 
 /// Operations that can be performed on message topics.
+#[derive(Debug, PartialEq)]
 pub enum MessageTopicOperation {
     /// Add a new message topic.
     Add,
@@ -230,5 +231,24 @@ impl FromBytes for MessageTopicOperation {
             TOPIC_OPERATION_ADD_TAG => Ok((MessageTopicOperation::Add, remainder)),
             _ => Err(bytesrepr::Error::Formatting),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bytesrepr;
+
+    use super::*;
+
+    #[test]
+    fn serialization_roundtrip() {
+        let topic_name_hash = TopicNameHash::new([0x4du8; TOPIC_NAME_HASH_LENGTH]);
+        bytesrepr::test_serialization_roundtrip(&topic_name_hash);
+
+        let topic_summary = MessageTopicSummary::new(10, BlockTime::new(100));
+        bytesrepr::test_serialization_roundtrip(&topic_summary);
+
+        let topic_operation = MessageTopicOperation::Add;
+        bytesrepr::test_serialization_roundtrip(&topic_operation);
     }
 }

--- a/types/src/contract_messages/topics.rs
+++ b/types/src/contract_messages/topics.rs
@@ -1,0 +1,234 @@
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    checksummed_hex, BlockTime,
+};
+
+use core::convert::TryFrom;
+
+use alloc::{string::String, vec::Vec};
+use core::fmt::{Debug, Display, Formatter};
+
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::FromStrError;
+
+/// The length in bytes of a topic name hash.
+pub const TOPIC_NAME_HASH_LENGTH: usize = 32;
+const MESSAGE_TOPIC_NAME_HASH: &str = "topic-name-";
+
+/// The hash of the name of the message topic.
+#[derive(Default, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "The hash of the name of the message topic.")
+)]
+pub struct TopicNameHash(
+    #[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))]
+    pub  [u8; TOPIC_NAME_HASH_LENGTH],
+);
+
+impl TopicNameHash {
+    /// Returns a new [`TopicNameHash`] based on the specified value.
+    pub const fn new(topic_name_hash: [u8; TOPIC_NAME_HASH_LENGTH]) -> TopicNameHash {
+        TopicNameHash(topic_name_hash)
+    }
+
+    /// Returns inner value of the topic hash.
+    pub fn value(&self) -> [u8; TOPIC_NAME_HASH_LENGTH] {
+        self.0
+    }
+
+    /// Formats the [`TopicNameHash`] as a prefixed, hex-encoded string.
+    pub fn to_formatted_string(self) -> String {
+        format!(
+            "{}{}",
+            MESSAGE_TOPIC_NAME_HASH,
+            base16::encode_lower(&self.0),
+        )
+    }
+
+    /// Parses a string formatted as per `Self::to_formatted_string()` into a [`TopicNameHash`].
+    pub fn from_formatted_str(input: &str) -> Result<Self, FromStrError> {
+        let remainder = input
+            .strip_prefix(MESSAGE_TOPIC_NAME_HASH)
+            .ok_or(FromStrError::InvalidPrefix)?;
+        let bytes =
+            <[u8; TOPIC_NAME_HASH_LENGTH]>::try_from(checksummed_hex::decode(remainder)?.as_ref())?;
+        Ok(TopicNameHash(bytes))
+    }
+}
+
+impl ToBytes for TopicNameHash {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.0.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}
+
+impl FromBytes for TopicNameHash {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (hash, rem) = FromBytes::from_bytes(bytes)?;
+        Ok((TopicNameHash(hash), rem))
+    }
+}
+
+impl Serialize for TopicNameHash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            self.to_formatted_string().serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TopicNameHash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let formatted_string = String::deserialize(deserializer)?;
+            TopicNameHash::from_formatted_str(&formatted_string).map_err(SerdeError::custom)
+        } else {
+            let bytes = <[u8; TOPIC_NAME_HASH_LENGTH]>::deserialize(deserializer)?;
+            Ok(TopicNameHash(bytes))
+        }
+    }
+}
+
+impl Display for TopicNameHash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", base16::encode_lower(&self.0))
+    }
+}
+
+impl Debug for TopicNameHash {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        write!(f, "MessageTopicHash({})", base16::encode_lower(&self.0))
+    }
+}
+
+impl Distribution<TopicNameHash> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TopicNameHash {
+        TopicNameHash(rng.gen())
+    }
+}
+
+impl From<[u8; TOPIC_NAME_HASH_LENGTH]> for TopicNameHash {
+    fn from(value: [u8; TOPIC_NAME_HASH_LENGTH]) -> Self {
+        TopicNameHash(value)
+    }
+}
+
+/// Summary of a message topic that will be stored in global state.
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct MessageTopicSummary {
+    /// Number of messages in this topic.
+    pub(crate) message_count: u32,
+    /// Block timestamp in which these messages were emitted.
+    pub(crate) blocktime: BlockTime,
+}
+
+impl MessageTopicSummary {
+    /// Creates a new topic summary.
+    pub fn new(message_count: u32, blocktime: BlockTime) -> Self {
+        Self {
+            message_count,
+            blocktime,
+        }
+    }
+
+    /// Returns the number of messages that were sent on this topic.
+    pub fn message_count(&self) -> u32 {
+        self.message_count
+    }
+
+    /// Returns the block time.
+    pub fn blocktime(&self) -> BlockTime {
+        self.blocktime
+    }
+}
+
+impl ToBytes for MessageTopicSummary {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.message_count.to_bytes()?);
+        buffer.append(&mut self.blocktime.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.message_count.serialized_length() + self.blocktime.serialized_length()
+    }
+}
+
+impl FromBytes for MessageTopicSummary {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (message_count, rem) = FromBytes::from_bytes(bytes)?;
+        let (blocktime, rem) = FromBytes::from_bytes(rem)?;
+        Ok((
+            MessageTopicSummary {
+                message_count,
+                blocktime,
+            },
+            rem,
+        ))
+    }
+}
+
+const TOPIC_OPERATION_ADD_TAG: u8 = 0;
+const OPERATION_MAX_SERIALIZED_LEN: usize = 1;
+
+/// Operations that can be performed on message topics.
+pub enum MessageTopicOperation {
+    /// Add a new message topic.
+    Add,
+}
+
+impl MessageTopicOperation {
+    /// Maximum serialized length of a message topic operation.
+    pub const fn max_serialized_len() -> usize {
+        OPERATION_MAX_SERIALIZED_LEN
+    }
+}
+
+impl ToBytes for MessageTopicOperation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            MessageTopicOperation::Add => buffer.push(TOPIC_OPERATION_ADD_TAG),
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        match self {
+            MessageTopicOperation::Add => 1,
+        }
+    }
+}
+
+impl FromBytes for MessageTopicOperation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            TOPIC_OPERATION_ADD_TAG => Ok((MessageTopicOperation::Add, remainder)),
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}

--- a/types/src/execution/execution_result_v2.rs
+++ b/types/src/execution/execution_result_v2.rs
@@ -165,7 +165,7 @@ impl ExecutionResultV2 {
             .filter_map(|transform| {
                 if let Key::Message(addr) = transform.key() {
                     let topic_name = Alphanumeric.sample_string(rng, 32);
-                    let topic_name_hash = crypto::blake2b(AsRef::<[u8]>::as_ref(&topic_name));
+                    let topic_name_hash = crypto::blake2b(&topic_name);
                     Some(Message::new(
                         addr.entity_addr(),
                         MessagePayload::from_string(format!("random_msg: {}", rng.gen::<u64>())),

--- a/types/src/execution/execution_result_v2.rs
+++ b/types/src/execution/execution_result_v2.rs
@@ -30,7 +30,7 @@ use super::{Transform, TransformKind};
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, RESULT_ERR_TAG, RESULT_OK_TAG, U8_SERIALIZED_LENGTH},
     contract_messages::Message,
-    TransferAddr, U512,
+    crypto, TransferAddr, U512,
 };
 #[cfg(any(feature = "testing", test))]
 use crate::{contract_messages::MessagePayload, testing::TestRng};
@@ -111,10 +111,13 @@ impl Distribution<ExecutionResultV2> for Standard {
             .iter()
             .filter_map(|transform| {
                 if let Key::Message(addr) = transform.key() {
+                    let topic_name = Alphanumeric.sample_string(rng, 32);
+                    let topic_name_hash = crypto::blake2b(AsRef::<[u8]>::as_ref(&topic_name));
                     Some(Message::new(
                         addr.entity_addr(),
                         MessagePayload::from_string(format!("random_msg: {}", rng.gen::<u64>())),
-                        Alphanumeric.sample_string(rng, 32),
+                        topic_name,
+                        topic_name_hash.into(),
                         rng.gen::<u32>(),
                     ))
                 } else {
@@ -159,10 +162,13 @@ impl ExecutionResultV2 {
             .iter()
             .filter_map(|transform| {
                 if let Key::Message(addr) = transform.key() {
+                    let topic_name = Alphanumeric.sample_string(rng, 32);
+                    let topic_name_hash = crypto::blake2b(AsRef::<[u8]>::as_ref(&topic_name));
                     Some(Message::new(
                         addr.entity_addr(),
                         MessagePayload::from_string(format!("random_msg: {}", rng.gen::<u64>())),
-                        Alphanumeric.sample_string(rng, 32),
+                        topic_name,
+                        topic_name_hash.into(),
                         rng.gen::<u32>(),
                     ))
                 } else {

--- a/types/src/execution/execution_result_v2.rs
+++ b/types/src/execution/execution_result_v2.rs
@@ -27,10 +27,12 @@ use serde::{Deserialize, Serialize};
 use super::Effects;
 #[cfg(feature = "json-schema")]
 use super::{Transform, TransformKind};
+#[cfg(any(feature = "testing", test))]
+use crate::crypto;
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, RESULT_ERR_TAG, RESULT_OK_TAG, U8_SERIALIZED_LENGTH},
     contract_messages::Message,
-    crypto, TransferAddr, U512,
+    TransferAddr, U512,
 };
 #[cfg(any(feature = "testing", test))]
 use crate::{contract_messages::MessagePayload, testing::TestRng};

--- a/types/src/execution/execution_result_v2.rs
+++ b/types/src/execution/execution_result_v2.rs
@@ -10,10 +10,16 @@ use alloc::{string::String, vec::Vec};
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
+use itertools::Itertools;
 #[cfg(feature = "json-schema")]
 use once_cell::sync::Lazy;
 #[cfg(any(feature = "testing", test))]
-use rand::{distributions::Standard, prelude::Distribution, Rng};
+use rand::{
+    distributions::{Alphanumeric, DistString, Standard},
+    prelude::Distribution,
+    Rng,
+};
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -21,12 +27,13 @@ use serde::{Deserialize, Serialize};
 use super::Effects;
 #[cfg(feature = "json-schema")]
 use super::{Transform, TransformKind};
-#[cfg(any(feature = "testing", test))]
-use crate::testing::TestRng;
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, RESULT_ERR_TAG, RESULT_OK_TAG, U8_SERIALIZED_LENGTH},
+    contract_messages::Message,
     TransferAddr, U512,
 };
+#[cfg(any(feature = "testing", test))]
+use crate::{contract_messages::MessagePayload, testing::TestRng};
 #[cfg(feature = "json-schema")]
 use crate::{Key, KEY_HASH_LENGTH};
 
@@ -53,6 +60,7 @@ static EXECUTION_RESULT: Lazy<ExecutionResultV2> = Lazy::new(|| {
         effects,
         transfers,
         cost: U512::from(123_456),
+        messages: Vec::default(),
     }
 });
 
@@ -72,6 +80,8 @@ pub enum ExecutionResultV2 {
         cost: U512,
         /// The error message associated with executing the deploy.
         error_message: String,
+        /// Messages that were emitted during execution.
+        messages: Vec<Message>,
     },
     /// The result of a successful execution.
     Success {
@@ -81,6 +91,8 @@ pub enum ExecutionResultV2 {
         transfers: Vec<TransferAddr>,
         /// The cost in Motes of executing the deploy.
         cost: U512,
+        /// Messages that were emitted during execution.
+        messages: Vec<Message>,
     },
 }
 
@@ -93,18 +105,38 @@ impl Distribution<ExecutionResultV2> for Standard {
             transfers.push(TransferAddr::new(rng.gen()))
         }
 
+        let effects = Effects::random(rng);
+        let messages = effects
+            .transforms()
+            .iter()
+            .filter_map(|transform| {
+                if let Key::Message(addr) = transform.key() {
+                    Some(Message::new(
+                        addr.entity_addr(),
+                        MessagePayload::from_string(format!("random_msg: {}", rng.gen::<u64>())),
+                        Alphanumeric.sample_string(rng, 32),
+                        rng.gen::<u32>(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+
         if rng.gen() {
             ExecutionResultV2::Failure {
-                effects: Effects::random(rng),
+                effects,
                 transfers,
                 cost: rng.gen::<u64>().into(),
                 error_message: format!("Error message {}", rng.gen::<u64>()),
+                messages,
             }
         } else {
             ExecutionResultV2::Success {
-                effects: Effects::random(rng),
+                effects,
                 transfers,
                 cost: rng.gen::<u64>().into(),
+                messages,
             }
         }
     }
@@ -122,6 +154,22 @@ impl ExecutionResultV2 {
     #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         let effects = Effects::random(rng);
+        let messages = effects
+            .transforms()
+            .iter()
+            .filter_map(|transform| {
+                if let Key::Message(addr) = transform.key() {
+                    Some(Message::new(
+                        addr.entity_addr(),
+                        MessagePayload::from_string(format!("random_msg: {}", rng.gen::<u64>())),
+                        Alphanumeric.sample_string(rng, 32),
+                        rng.gen::<u32>(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
 
         let transfer_count = rng.gen_range(0..6);
         let mut transfers = vec![];
@@ -137,12 +185,14 @@ impl ExecutionResultV2 {
                 transfers,
                 cost,
                 error_message: format!("Error message {}", rng.gen::<u64>()),
+                messages,
             }
         } else {
             ExecutionResultV2::Success {
                 effects,
                 transfers,
                 cost,
+                messages,
             }
         }
     }
@@ -156,22 +206,26 @@ impl ToBytes for ExecutionResultV2 {
                 transfers,
                 cost,
                 error_message,
+                messages,
             } => {
                 RESULT_ERR_TAG.write_bytes(writer)?;
                 effects.write_bytes(writer)?;
                 transfers.write_bytes(writer)?;
                 cost.write_bytes(writer)?;
-                error_message.write_bytes(writer)
+                error_message.write_bytes(writer)?;
+                messages.write_bytes(writer)
             }
             ExecutionResultV2::Success {
                 effects,
                 transfers,
                 cost,
+                messages,
             } => {
                 RESULT_OK_TAG.write_bytes(writer)?;
                 effects.write_bytes(writer)?;
                 transfers.write_bytes(writer)?;
-                cost.write_bytes(writer)
+                cost.write_bytes(writer)?;
+                messages.write_bytes(writer)
             }
         }
     }
@@ -190,20 +244,24 @@ impl ToBytes for ExecutionResultV2 {
                     transfers,
                     cost,
                     error_message,
+                    messages,
                 } => {
                     effects.serialized_length()
                         + transfers.serialized_length()
                         + cost.serialized_length()
                         + error_message.serialized_length()
+                        + messages.serialized_length()
                 }
                 ExecutionResultV2::Success {
                     effects,
                     transfers,
                     cost,
+                    messages,
                 } => {
                     effects.serialized_length()
                         + transfers.serialized_length()
                         + cost.serialized_length()
+                        + messages.serialized_length()
                 }
             }
     }
@@ -218,11 +276,13 @@ impl FromBytes for ExecutionResultV2 {
                 let (transfers, remainder) = Vec::<TransferAddr>::from_bytes(remainder)?;
                 let (cost, remainder) = U512::from_bytes(remainder)?;
                 let (error_message, remainder) = String::from_bytes(remainder)?;
+                let (messages, remainder) = Vec::<Message>::from_bytes(remainder)?;
                 let execution_result = ExecutionResultV2::Failure {
                     effects,
                     transfers,
                     cost,
                     error_message,
+                    messages,
                 };
                 Ok((execution_result, remainder))
             }
@@ -230,10 +290,12 @@ impl FromBytes for ExecutionResultV2 {
                 let (effects, remainder) = Effects::from_bytes(remainder)?;
                 let (transfers, remainder) = Vec::<TransferAddr>::from_bytes(remainder)?;
                 let (cost, remainder) = U512::from_bytes(remainder)?;
+                let (messages, remainder) = Vec::<Message>::from_bytes(remainder)?;
                 let execution_result = ExecutionResultV2::Success {
                     effects,
                     transfers,
                     cost,
+                    messages,
                 };
                 Ok((execution_result, remainder))
             }

--- a/types/src/execution/transform_kind.rs
+++ b/types/src/execution/transform_kind.rs
@@ -162,6 +162,16 @@ impl TransformKind {
                     let found = "Unbonding".to_string();
                     Err(StoredValueTypeMismatch::new(expected, found).into())
                 }
+                StoredValue::MessageTopic(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "MessageTopic".to_string();
+                    Err(StoredValueTypeMismatch::new(expected, found).into())
+                }
+                StoredValue::Message(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "Message".to_string();
+                    Err(StoredValueTypeMismatch::new(expected, found).into())
+                }
             },
             TransformKind::Failure(error) => Err(error),
         }

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -20,7 +20,7 @@ use proptest::{
 use crate::{
     account::{self, action_thresholds::gens::account_action_thresholds_arb, AccountHash},
     addressable_entity::{MessageTopics, NamedKeys, Parameters, Weight},
-    contract_messages::{MessageSummary, MessageTopicHash, MessageTopicSummary},
+    contract_messages::{MessageChecksum, MessageTopicSummary, TopicNameHash},
     crypto::{self, gens::public_key_arb_no_system},
     package::{ContractPackageStatus, ContractVersionKey, ContractVersions, Groups},
     system::auction::{
@@ -350,8 +350,11 @@ pub fn message_topics_arb() -> impl Strategy<Value = MessageTopics> {
         MessageTopics::from(
             topic_names
                 .into_iter()
-                .map(|name| (name.clone(), crypto::blake2b(name)))
-                .collect::<BTreeMap<String, MessageTopicHash>>(),
+                .map(|name| {
+                    let name_hash = crypto::blake2b(AsRef::<[u8]>::as_ref(&name)).into();
+                    (name, name_hash)
+                })
+                .collect::<BTreeMap<String, TopicNameHash>>(),
         )
     })
 }
@@ -647,8 +650,8 @@ fn message_topic_summary_arb() -> impl Strategy<Value = MessageTopicSummary> {
     })
 }
 
-fn message_summary_arb() -> impl Strategy<Value = MessageSummary> {
-    u8_slice_32().prop_map(MessageSummary)
+fn message_summary_arb() -> impl Strategy<Value = MessageChecksum> {
+    u8_slice_32().prop_map(MessageChecksum)
 }
 
 pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -15,6 +15,7 @@ use proptest::{
 use crate::{
     account::{self, action_thresholds::gens::account_action_thresholds_arb, AccountHash},
     addressable_entity::{NamedKeys, Parameters, Weight},
+    contract_messages::{MessageSummary, MessageTopicSummary},
     crypto::gens::public_key_arb_no_system,
     package::{ContractPackageStatus, ContractVersionKey, ContractVersions, Groups},
     system::auction::{
@@ -620,6 +621,14 @@ fn unbondings_arb(size: impl Into<SizeRange>) -> impl Strategy<Value = Vec<Unbon
     collection::vec(unbonding_arb(), size)
 }
 
+fn message_topic_summary_arb() -> impl Strategy<Value = MessageTopicSummary> {
+    any::<u32>().prop_map(|message_count| MessageTopicSummary { message_count })
+}
+
+fn message_summary_arb() -> impl Strategy<Value = MessageSummary> {
+    u8_slice_32().prop_map(MessageSummary)
+}
+
 pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {
     prop_oneof![
         cl_value_arb().prop_map(StoredValue::CLValue),
@@ -635,7 +644,9 @@ pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {
         validator_bid_arb().prop_map(StoredValue::BidKind),
         delegator_bid_arb().prop_map(StoredValue::BidKind),
         withdraws_arb(1..50).prop_map(StoredValue::Withdraw),
-        unbondings_arb(1..50).prop_map(StoredValue::Unbonding)
+        unbondings_arb(1..50).prop_map(StoredValue::Unbonding),
+        message_topic_summary_arb().prop_map(StoredValue::MessageTopic),
+        message_summary_arb().prop_map(StoredValue::Message),
     ]
     .prop_map(|stored_value|
         // The following match statement is here only to make sure
@@ -654,5 +665,7 @@ pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {
             StoredValue::Unbonding(_) => stored_value,
             StoredValue::AddressableEntity(_) => stored_value,
             StoredValue::BidKind(_) => stored_value,
+            StoredValue::MessageTopic(_) => stored_value,
+            StoredValue::Message(_) => stored_value,
         })
 }

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -351,7 +351,7 @@ pub fn message_topics_arb() -> impl Strategy<Value = MessageTopics> {
             topic_names
                 .into_iter()
                 .map(|name| {
-                    let name_hash = crypto::blake2b(AsRef::<[u8]>::as_ref(&name)).into();
+                    let name_hash = crypto::blake2b(&name).into();
                     (name, name_hash)
                 })
                 .collect::<BTreeMap<String, TopicNameHash>>(),

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -23,9 +23,9 @@ use crate::{
         DELEGATION_RATE_DENOMINATOR,
     },
     transfer::TransferAddr,
-    AccessRights, AddressableEntity, CLType, CLValue, ContractHash, ContractWasm, EntryPoint,
-    EntryPointAccess, EntryPointType, EntryPoints, EraId, Group, Key, NamedArg, Package, Parameter,
-    Phase, ProtocolVersion, SemVer, StoredValue, URef, U128, U256, U512,
+    AccessRights, AddressableEntity, BlockTime, CLType, CLValue, ContractHash, ContractWasm,
+    EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, EraId, Group, Key, NamedArg,
+    Package, Parameter, Phase, ProtocolVersion, SemVer, StoredValue, URef, U128, U256, U512,
 };
 
 use crate::{
@@ -622,7 +622,10 @@ fn unbondings_arb(size: impl Into<SizeRange>) -> impl Strategy<Value = Vec<Unbon
 }
 
 fn message_topic_summary_arb() -> impl Strategy<Value = MessageTopicSummary> {
-    any::<u32>().prop_map(|message_count| MessageTopicSummary { message_count })
+    (any::<u32>(), any::<u64>()).prop_map(|(message_count, blocktime)| MessageTopicSummary {
+        message_count,
+        blocktime: BlockTime::new(blocktime),
+    })
 }
 
 fn message_summary_arb() -> impl Strategy<Value = MessageSummary> {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -703,7 +703,7 @@ impl Key {
     }
 
     /// Creates a new [`Key::Message`] variant that identifies an indexed message based on an
-    /// `entity_addr` `topic_hash` and message `index`.
+    /// `entity_addr`, `topic_name_hash` and message `index`.
     pub fn message(entity_addr: HashAddr, topic_name_hash: TopicNameHash, index: u32) -> Key {
         Key::Message(MessageAddr::new_message_addr(
             entity_addr,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -105,9 +105,9 @@ pub use chainspec::{
     ControlFlowCosts, CoreConfig, DelegatorConfig, DeployConfig, FeeHandling, GenesisAccount,
     GenesisValidator, GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError,
     HandlePaymentCosts, HighwayConfig, HostFunction, HostFunctionCost, HostFunctionCosts,
-    LegacyRequiredFinality, MintCosts, NetworkConfig, OpcodeCosts, ProtocolConfig, RefundHandling,
-    StandardPaymentCosts, StorageCosts, SystemConfig, TransactionConfig, TransactionV1Config,
-    UpgradeConfig, ValidatorConfig, WasmConfig,
+    LegacyRequiredFinality, MessagesLimits, MessagesLimitsError, MintCosts, NetworkConfig,
+    OpcodeCosts, ProtocolConfig, RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig,
+    TransactionConfig, TransactionV1Config, UpgradeConfig, ValidatorConfig, WasmConfig,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use chainspec::{

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -105,9 +105,9 @@ pub use chainspec::{
     ControlFlowCosts, CoreConfig, DelegatorConfig, DeployConfig, FeeHandling, GenesisAccount,
     GenesisValidator, GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError,
     HandlePaymentCosts, HighwayConfig, HostFunction, HostFunctionCost, HostFunctionCosts,
-    LegacyRequiredFinality, MessagesLimits, MessagesLimitsError, MintCosts, NetworkConfig,
-    OpcodeCosts, ProtocolConfig, RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig,
-    TransactionConfig, TransactionV1Config, UpgradeConfig, ValidatorConfig, WasmConfig,
+    LegacyRequiredFinality, MessagesLimits, MintCosts, NetworkConfig, OpcodeCosts, ProtocolConfig,
+    RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig, TransactionConfig,
+    TransactionV1Config, UpgradeConfig, ValidatorConfig, WasmConfig,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use chainspec::{

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -105,7 +105,7 @@ pub use chainspec::{
     ControlFlowCosts, CoreConfig, DelegatorConfig, DeployConfig, FeeHandling, GenesisAccount,
     GenesisValidator, GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError,
     HandlePaymentCosts, HighwayConfig, HostFunction, HostFunctionCost, HostFunctionCosts,
-    LegacyRequiredFinality, MessagesLimits, MintCosts, NetworkConfig, OpcodeCosts, ProtocolConfig,
+    LegacyRequiredFinality, MessageLimits, MintCosts, NetworkConfig, OpcodeCosts, ProtocolConfig,
     RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig, TransactionConfig,
     TransactionV1Config, UpgradeConfig, ValidatorConfig, WasmConfig,
 };

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -673,8 +673,9 @@ mod serde_helpers {
         AddressableEntity(&'a AddressableEntity),
         /// Variant that stores [`BidKind`].
         BidKind(&'a BidKind),
-        /// Variant that stores [`MessageSummary`].
+        /// Variant that stores [`MessageTopicSummary`].
         MessageTopic(&'a MessageTopicSummary),
+        /// Variant that stores a [`MessageChecksum`].
         Message(&'a MessageChecksum),
     }
 
@@ -706,9 +707,9 @@ mod serde_helpers {
         AddressableEntity(AddressableEntity),
         /// Variant that stores [`BidKind`].
         BidKind(BidKind),
-        /// Variant that stores [`MessageSummary`].
+        /// Variant that stores [`MessageTopicSummary`].
         MessageTopic(MessageTopicSummary),
-        /// Variant that stores [`MessageDigest`].
+        /// Variant that stores [`MessageChecksum`].
         Message(MessageChecksum),
     }
 

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -17,6 +17,7 @@ use serde_bytes::ByteBuf;
 use crate::{
     account::Account,
     bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    contract_messages::{MessageSummary, MessageTopicSummary},
     contracts::Contract,
     package::Package,
     system::auction::{Bid, BidKind, EraInfo, UnbondingPurse, WithdrawPurse},
@@ -40,6 +41,8 @@ enum Tag {
     Unbonding = 10,
     AddressableEntity = 11,
     BidKind = 12,
+    MessageTopic = 13,
+    Message = 14,
 }
 
 /// A value stored in Global State.
@@ -78,6 +81,10 @@ pub enum StoredValue {
     AddressableEntity(AddressableEntity),
     /// Variant that stores [`BidKind`].
     BidKind(BidKind),
+    /// Variant that stores a message topic.
+    MessageTopic(MessageTopicSummary),
+    /// Variant that stores a message digest.
+    Message(MessageSummary),
 }
 
 impl StoredValue {
@@ -309,6 +316,8 @@ impl StoredValue {
             StoredValue::Unbonding(_) => "Unbonding".to_string(),
             StoredValue::AddressableEntity(_) => "AddressableEntity".to_string(),
             StoredValue::BidKind(_) => "BidKind".to_string(),
+            StoredValue::MessageTopic(_) => "MessageTopic".to_string(),
+            StoredValue::Message(_) => "Message".to_string(),
         }
     }
 
@@ -327,6 +336,8 @@ impl StoredValue {
             StoredValue::Unbonding(_) => Tag::Unbonding,
             StoredValue::AddressableEntity(_) => Tag::AddressableEntity,
             StoredValue::BidKind(_) => Tag::BidKind,
+            StoredValue::MessageTopic(_) => Tag::MessageTopic,
+            StoredValue::Message(_) => Tag::Message,
         }
     }
 }
@@ -544,6 +555,10 @@ impl ToBytes for StoredValue {
                 StoredValue::Unbonding(unbonding_purses) => unbonding_purses.serialized_length(),
                 StoredValue::AddressableEntity(entity) => entity.serialized_length(),
                 StoredValue::BidKind(bid_kind) => bid_kind.serialized_length(),
+                StoredValue::MessageTopic(message_topic_summary) => {
+                    message_topic_summary.serialized_length()
+                }
+                StoredValue::Message(message_digest) => message_digest.serialized_length(),
             }
     }
 
@@ -565,6 +580,10 @@ impl ToBytes for StoredValue {
             StoredValue::Unbonding(unbonding_purses) => unbonding_purses.write_bytes(writer)?,
             StoredValue::AddressableEntity(entity) => entity.write_bytes(writer)?,
             StoredValue::BidKind(bid_kind) => bid_kind.write_bytes(writer)?,
+            StoredValue::MessageTopic(message_topic_summary) => {
+                message_topic_summary.write_bytes(writer)?
+            }
+            StoredValue::Message(message_digest) => message_digest.write_bytes(writer)?,
         };
         Ok(())
     }
@@ -612,6 +631,15 @@ impl FromBytes for StoredValue {
             }
             tag if tag == Tag::AddressableEntity as u8 => AddressableEntity::from_bytes(remainder)
                 .map(|(entity, remainder)| (StoredValue::AddressableEntity(entity), remainder)),
+            tag if tag == Tag::MessageTopic as u8 => MessageTopicSummary::from_bytes(remainder)
+                .map(|(message_summary, remainder)| {
+                    (StoredValue::MessageTopic(message_summary), remainder)
+                }),
+            tag if tag == Tag::Message as u8 => {
+                MessageSummary::from_bytes(remainder).map(|(message_digest, remainder)| {
+                    (StoredValue::Message(message_digest), remainder)
+                })
+            }
             _ => Err(Error::Formatting),
         }
     }
@@ -648,6 +676,9 @@ mod serde_helpers {
         AddressableEntity(&'a AddressableEntity),
         /// Variant that stores [`BidKind`].
         BidKind(&'a BidKind),
+        /// Variant that stores [`MessageSummary`].
+        MessageTopic(&'a MessageTopicSummary),
+        Message(&'a MessageSummary),
     }
 
     #[derive(Deserialize)]
@@ -678,6 +709,10 @@ mod serde_helpers {
         AddressableEntity(AddressableEntity),
         /// Variant that stores [`BidKind`].
         BidKind(BidKind),
+        /// Variant that stores [`MessageSummary`].
+        MessageTopic(MessageTopicSummary),
+        /// Variant that stores [`MessageDigest`].
+        Message(MessageSummary),
     }
 
     impl<'a> From<&'a StoredValue> for BinarySerHelper<'a> {
@@ -698,6 +733,10 @@ mod serde_helpers {
                     BinarySerHelper::AddressableEntity(payload)
                 }
                 StoredValue::BidKind(payload) => BinarySerHelper::BidKind(payload),
+                StoredValue::MessageTopic(message_topic_summary) => {
+                    BinarySerHelper::MessageTopic(message_topic_summary)
+                }
+                StoredValue::Message(message_digest) => BinarySerHelper::Message(message_digest),
             }
         }
     }
@@ -722,6 +761,10 @@ mod serde_helpers {
                     StoredValue::AddressableEntity(payload)
                 }
                 BinaryDeserHelper::BidKind(payload) => StoredValue::BidKind(payload),
+                BinaryDeserHelper::MessageTopic(message_topic_summary) => {
+                    StoredValue::MessageTopic(message_topic_summary)
+                }
+                BinaryDeserHelper::Message(message_digest) => StoredValue::Message(message_digest),
             }
         }
     }

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 
 use casper_types::{
     account::AccountHash,
-    addressable_entity::{ActionThresholds, AssociatedKeys, NamedKeys, Weight},
+    addressable_entity::{ActionThresholds, AssociatedKeys, MessageTopics, NamedKeys, Weight},
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups},
     system::auction::{BidAddr, BidKind, BidsExt, SeigniorageRecipientsSnapshot, UnbondingPurse},
     AccessRights, AddressableEntity, CLValue, ContractHash, ContractPackageHash, ContractWasmHash,
@@ -176,6 +176,7 @@ impl<T: StateReader> StateTracker<T> {
             main_purse,
             associated_keys,
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
 
         let mut contract_package = Package::new(

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use casper_types::{
     account::AccountHash,
-    addressable_entity::{ActionThresholds, AssociatedKeys, NamedKeys, Weight},
+    addressable_entity::{ActionThresholds, AssociatedKeys, MessageTopics, NamedKeys, Weight},
     system::auction::{
         BidKind, BidsExt, Delegator, SeigniorageRecipient, SeigniorageRecipients,
         SeigniorageRecipientsSnapshot, UnbondingPurse, UnbondingPurses, ValidatorBid,
@@ -68,6 +68,7 @@ impl MockStateReader {
             main_purse,
             AssociatedKeys::new(account_hash, Weight::new(1)),
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
 
         self.purses.insert(main_purse.addr(), balance);

--- a/utils/validation/src/generators.rs
+++ b/utils/validation/src/generators.rs
@@ -8,7 +8,9 @@ use casper_types::{
         Account, AccountHash, ActionThresholds as AccountActionThresholds,
         AssociatedKeys as AccountAssociatedKeys, Weight as AccountWeight,
     },
-    addressable_entity::{ActionThresholds, AddressableEntity, AssociatedKeys, NamedKeys},
+    addressable_entity::{
+        ActionThresholds, AddressableEntity, AssociatedKeys, MessageTopics, NamedKeys,
+    },
     package::{ContractPackageKind, ContractPackageStatus, ContractVersions, Groups, Package},
     system::auction::{
         Bid, BidAddr, BidKind, Delegator, EraInfo, SeigniorageAllocation, UnbondingPurse,
@@ -376,6 +378,7 @@ pub fn make_abi_test_fixtures() -> Result<TestFixtures, Error> {
             URef::default(),
             AssociatedKeys::default(),
             ActionThresholds::default(),
+            MessageTopics::default(),
         );
         stored_value.insert(
             "AddressableEntity".to_string(),


### PR DESCRIPTION
Draft work for adding Contract level messages.
Added:
* 2 new FFIs that enable contracts to manage message topics and emit human readable string messages.
* topic names and hashes are added to the addressable entity for easy discovery
* for each topic there is a control record in global state under `Key::message_topic(entity_addr, topic_hash)` that stores the count of messages that were emitted  on a topic and the block time of the block where the deploys that emitted the messages have executed.
* each message checksum is stored in global state under `Key::message(entity_addr, topic_hash, message_index)` and can be discretely queried and verified.
* messages get sent out the SSE as part of `ExecutionResultV2` for each deploy.

Some tests are currently broken because the gas costs were not adjusted in the tests.
Will address these tests in a separate PR that will also implement linear gas cost increase for messages.