### PR TITLE
Merge SSE event streams

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -121,6 +121,7 @@ start_run_teardown "gov96.sh"
 start_run_teardown "swap_validator_set.sh"
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
 start_run_teardown "validators_disconnect.sh"
+start_run_teardown "event_stream.sh"
 # Without start_run_teardown - these ones perform their own assets setup, network start and teardown
 source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
 source "$SCENARIOS_DIR/regression_3976.sh"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest complete block known to the node will be used to fulfill the request.
+* All SSE events are emitted via the main endpoint: `<IP:Port>/events/main`. Both `/events/deploys` and `/events/sigs` are no longer available.
 
 
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * The `state_identifier` parameter of the `query_global_state` JSON-RPC method is now optional. If no `state_identifier` is specified, the highest complete block known to the node will be used to fulfill the request.
-* All SSE events are emitted via the main endpoint: `<IP:Port>/events/main`. Both `/events/deploys` and `/events/sigs` are no longer available.
+* All SSE events are emitted via the `<IP:Port>/events` endpoint. None of the previous ones (`/events/main`, `/events/deploys`, and `/events/sigs`) is available any longer.
 
 
 

--- a/utils/nctl/sh/scenarios/event_stream.sh
+++ b/utils/nctl/sh/scenarios/event_stream.sh
@@ -19,11 +19,12 @@ TMP_EVENTS_FILE=tmp_events_main.txt
 # - `DeployAccepted`    via /events/deploys
 # - `FinalitySignature` via /events/sigs
 #
-# Currently, all events should be emitted via `/events/main`. We check only for the above three
+# Currently, all events should be emitted via `/events`. We check only for the above three
 # explicitly mentioned events as more detailed tests are located in the `tests` module
 # of the `event_stream_server`.
 #
-# Additionally, this test verifies that `/events/deploys` and `/events/sigs` are no longer accessible.
+# Additionally, this test verifies that `/events/main`, `/events/deploys` and `/events/sigs`
+# are no longer accessible.
 #######################################
 function main() {
     log "------------------------------------------------------------"
@@ -33,6 +34,7 @@ function main() {
     do_await_genesis_era_to_complete
     do_check_endpoint_does_not_exist 'deploys'
     do_check_endpoint_does_not_exist 'sigs'
+    do_check_endpoint_does_not_exist 'main'
     do_attach_to_event_stream
     do_send_wasm_deploys
     await_n_blocks 1 false
@@ -63,7 +65,7 @@ function do_check_event_emitted() {
 
 function do_attach_to_event_stream() {
     log_step "attaching to event stream"
-    curl -o $TMP_EVENTS_FILE -N -s localhost:18101/events/main &
+    curl -o $TMP_EVENTS_FILE -N -s localhost:18101/events &
 }
 
 function do_check_endpoint_does_not_exist() {
@@ -73,7 +75,7 @@ function do_check_endpoint_does_not_exist() {
     log_step "checking endpoint '$EVENT_PATH' does not exist"
 
     RESPONSE=$(curl -s localhost:18101/events/{$EVENT_PATH})
-    if [ "$RESPONSE" != "invalid path: expected '/events/main'" ]; then
+    if [ "$RESPONSE" != "invalid path: expected '/events'" ]; then
         exit 1
     fi
 }

--- a/utils/nctl/sh/scenarios/event_stream.sh
+++ b/utils/nctl/sh/scenarios/event_stream.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/utils/main.sh
+source "$NCTL"/sh/views/utils.sh
+source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+#######################################
+# Runs an integration tests that verifies if events are routed via correct SSE endpoints.
+# - `BlockAdded`        via /events/main
+# - `DeployAccepted`    via /events/deploys
+# - `FinalitySignature` via /events/sigs
+#######################################
+function main() {
+    log "------------------------------------------------------------"
+    log "Event stream test begins"
+    log "------------------------------------------------------------"
+
+    do_await_genesis_era_to_complete
+
+    ################################################
+    curl -o events_main.txt -N -s localhost:18101/events/main &
+    log "Attached to event stream output (main)"
+
+    curl -o events_deploys.txt -N -s localhost:18101/events/deploys &
+    log "Attached to event stream output (deploys)"
+
+    curl -o events_sigs.txt -N -s localhost:18101/events/sigs &
+    log "Attached to event stream output (sigs)"
+
+    log "Awaiting one block"
+    await_n_blocks 1 false
+
+    cat events_main.txt
+    if grep -q BlockAdded events_main.txt
+    then
+        log "Found"
+    else
+        log "ERROR: BlockAdded Not found"
+        exit 1
+    fi
+
+    ################################################
+
+
+    do_send_wasm_deploys
+
+    cat events_deploys.txt
+    if grep -q DeployAccepted events_deploys.txt
+    then
+        log "Found"
+    else
+        log "ERROR: DeployAccepted Not found"
+        exit 1
+    fi
+
+
+    ################################################
+
+
+    cat events_sigs.txt
+    if grep -q FinalitySignature events_sigs.txt
+    then
+        log "Found"
+    else
+        log "ERROR: FinalitySignature Not found"
+        exit 1
+    fi
+
+    log "------------------------------------------------------------"
+    log "Event stream test complete"
+    log "------------------------------------------------------------"
+}
+
+function do_send_wasm_deploys() {
+    # NOTE: Maybe make these arguments to the test?
+    local BATCH_COUNT=1
+    local BATCH_SIZE=1
+    local TRANSFER_AMOUNT=2500000000
+    log_step "sending Wasm deploys"
+    # prepare wasm batch
+    prepare_wasm_batch "$TRANSFER_AMOUNT" "$BATCH_COUNT" "$BATCH_SIZE"
+    # dispatch wasm batches
+    for BATCH_ID in $(seq 1 $BATCH_COUNT); do
+        dispatch_wasm_batch "$BATCH_ID"
+    done
+}
+
+function prepare_wasm_batch() {
+    local AMOUNT=${1}
+    local BATCH_COUNT=${2}
+    local BATCH_SIZE=${3}
+
+    source "$NCTL"/sh/contracts-transfers/do_prepare_wasm_batch.sh amount="$AMOUNT" \
+        count="$BATCH_COUNT" \
+        size="$BATCH_SIZE"
+}
+
+function dispatch_wasm_batch() {
+    local BATCH_ID=${1:-1}
+    local INTERVAL=${2:-0.01}
+    local NODE_ID=${3:-"random"}
+
+    source "$NCTL"/sh/contracts-transfers/do_dispatch_wasm_batch.sh batch="$BATCH_ID" \
+        interval="$INTERVAL" \
+        node="$NODE_ID"
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+main

--- a/utils/nctl/sh/scenarios/event_stream.sh
+++ b/utils/nctl/sh/scenarios/event_stream.sh
@@ -13,7 +13,7 @@ TMP_EVENTS_FILE=tmp_events_main.txt
 #######################################
 # Runs an integration tests that verifies if events are routed via correct SSE endpoints.
 # Prior to https://github.com/casper-network/casper-node/issues/4314 there were 3 different
-# endpoints, serving different evvents. The 3 events that this test verifies used to be
+# endpoints, serving different events. The 3 events that this test verifies used to be
 # routed as follows:
 # - `BlockAdded`        via /events/main
 # - `DeployAccepted`    via /events/deploys


### PR DESCRIPTION
This PR changes the SSE server in a way that all events are emitted through a single endpoint `<IP:Port>/events`.

Closes #4314 
