### PR TITLE
Wait for era `1` to assume genesis, not era `2`

### DIFF
--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -377,7 +377,7 @@ function do_await_genesis_era_to_complete() {
     while :
     do
         CURRENT_ERA=$(get_chain_era)
-        if [ "$CURRENT_ERA" -ge "2" ]
+        if [ "$CURRENT_ERA" -ge "1" ]
         then
             log "genesis reached, era=$CURRENT_ERA"
             return


### PR DESCRIPTION
This PR modifies the NCTL framework to wait for era 1 to assume the network reached genesis.

Previously we used 2 to be on the safe side while debugging tests that been failing due to 1.5 changes.

This should speedup the total execution time of NCTL tests.