### PR TITLE
Revert types change and bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-hashing",
  "casper-types",
+ "casper-wasm",
  "clap 2.34.0",
  "criterion",
  "dictionary",
@@ -444,7 +445,6 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "parity-wasm",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -465,7 +465,9 @@ dependencies = [
  "bincode",
  "casper-hashing",
  "casper-types",
+ "casper-wasm",
  "casper-wasm-utils",
+ "casper-wasmi",
  "criterion",
  "datasize",
  "either",
@@ -484,7 +486,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
- "parity-wasm",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -499,7 +500,6 @@ dependencies = [
  "uint",
  "uuid",
  "walrus",
- "wasmi",
 ]
 
 [[package]]
@@ -709,14 +709,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "casper-wasm-utils"
-version = "2.0.0"
+name = "casper-wasm"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49e4ef1382d48c312809fe8f09d0c7beb434a74f5026c5f12efe384df51ca42"
+checksum = "48f53c4e789fbff66ead0ea44030b1af2fc3c465201973483528e479a9155f98"
+
+[[package]]
+name = "casper-wasm-utils"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d9f1a2269d52961812862f67d209ef29742d06b47634e2982a96e80d0fe2b4"
 dependencies = [
  "byteorder",
+ "casper-wasm",
  "log",
- "parity-wasm",
+]
+
+[[package]]
+name = "casper-wasmi"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8357f19a7fd98073d8fe8df60f1bef1e677b7c623c1e6e2e07d2f8e59ceb87fc"
+dependencies = [
+ "casper-wasm",
+ "casper-wasmi-core",
+ "casper-wasmi-validation",
+]
+
+[[package]]
+name = "casper-wasmi-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60089625560924f184cf91d59b0731373d5114b81224f1201c6a39ccc1d8388c"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "casper-wasmi-validation"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f669d385132ce321a57fdf453588d69c01654e75991bee3d22392a3aaaad80bb"
+dependencies = [
+ "casper-wasm",
 ]
 
 [[package]]
@@ -3167,10 +3206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-wasm"
-version = "0.45.0"
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "async-compression",
  "bytes",
@@ -5419,39 +5454,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmi"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
-dependencies = [
- "parity-wasm",
- "wasmi-validation",
- "wasmi_core",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
-dependencies = [
- "parity-wasm",
-]
-
-[[package]]
-name = "wasmi_core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
-dependencies = [
- "downcast-rs",
- "libm",
- "memory_units",
- "num-rational",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "casper-execution-engine",
  "casper-hashing",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1756,23 +1756,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2323,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2527,7 +2516,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2553,7 +2542,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.3",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
@@ -2594,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4100,11 +4089,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4146,9 +4135,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4159,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5370,9 +5359,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5380,24 +5369,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5407,9 +5396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote 1.0.26",
  "wasm-bindgen-macro-support",
@@ -5417,22 +5406,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
@@ -5485,9 +5474,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5529,9 +5518,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -5541,21 +5530,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
 
 [[package]]
 name = "windows-sys"
@@ -5572,7 +5546,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5592,17 +5566,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5613,9 +5587,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5625,9 +5599,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5637,9 +5611,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5649,9 +5623,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5661,9 +5635,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5673,9 +5647,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5685,9 +5659,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "4.0.0"
+version = "3.0.0"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -1711,12 +1711,23 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
+ "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -3152,7 +3163,6 @@ dependencies = [
 [[package]]
 name = "parity-wasm"
 version = "0.45.0"
-source = "git+https://github.com/casper-network/casper-wasm.git?branch=casper-0.45.0#49752a84f34d2f8748133cdd95e3064d1158b0af"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "datasize"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -5010,13 +5016,13 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,3 @@ lto = true
 [profile.bench]
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-parity-wasm = { git = "https://github.com/casper-network/casper-wasm.git", branch = "casper-0.45.0" }

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -10,10 +10,19 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
-## [Unreleased]
+
+## 6.0.0
 
 ### Changed
 * Default value for `max_stack_height` is increased to 500.
+* Replaced usage of `parity-wasm` and `wasmi` with Casper forks `casper-wasm` and `casper-wasmi` respectively.
+
+### Fixed
+* Fix incorrect handling of unbonding purses for validators that were also evicted in that era.
+* Fix issue with one-time code used for migrating data to support redelegations.
+
+### Security
+* Fix unbounded memory allocation issue while parsing Wasm.
 
 
 

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "5.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "6.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,11 +16,13 @@ base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "2.0.0", path = "../hashing" }
 casper-types = { version = "3.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
-casper-wasm-utils = "2.0.0"
+casper-wasm = { version = "0.46.0", default-features = false }
+casper-wasm-utils = "3.0.0"
+casper-wasmi = "0.13.2"
 datasize = "0.2.4"
 either = "1.8.1"
-hex_fmt = "0.3.0"
 hex-buffer-serde = "0.2.1"
+hex_fmt = "0.3.0"
 hostname = "0.3.0"
 humantime = "2"
 itertools = "0.10.0"
@@ -34,7 +36,6 @@ num-rational = { version = "0.4.0", features = ["serde"] }
 num-traits = "0.2.10"
 num_cpus = "1"
 once_cell = "1.5.2"
-parity-wasm = { version = "0.45.0", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8.3"
 rand_chacha = "0.3.0"
@@ -47,7 +48,6 @@ thiserror = "1.0.18"
 tracing = "0.1.18"
 uint = "0.9.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-wasmi = "0.13.2"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 casper-hashing = { version = "2.0.0", path = "../hashing" }
-casper-types = { version = "4.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
+casper-types = { version = "3.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 casper-wasm-utils = "2.0.0"
 datasize = "0.2.4"
 either = "1.8.1"

--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
     WasmPreprocessing(#[from] wasm_prep::PreprocessingError),
     /// WASM serialization error.
     #[error("Wasm serialization error: {0:?}")]
-    WasmSerialization(#[from] parity_wasm::SerializationError),
+    WasmSerialization(#[from] casper_wasm::SerializationError),
     /// Contract execution error.
     #[error(transparent)]
     Exec(execution::Error),

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -1,5 +1,5 @@
 //! Execution error and supporting code.
-use parity_wasm::elements;
+use casper_wasm::elements;
 use thiserror::Error;
 
 use casper_types::{
@@ -197,10 +197,10 @@ impl Error {
     }
 }
 
-impl wasmi::HostError for Error {}
+impl casper_wasmi::HostError for Error {}
 
-impl From<wasmi::Error> for Error {
-    fn from(error: wasmi::Error) -> Self {
+impl From<casper_wasmi::Error> for Error {
+    fn from(error: casper_wasmi::Error) -> Self {
         match error
             .as_host_error()
             .and_then(|host_error| host_error.downcast_ref::<Error>())

--- a/execution_engine/src/core/resolvers/memory_resolver.rs
+++ b/execution_engine/src/core/resolvers/memory_resolver.rs
@@ -1,5 +1,5 @@
 //! This module contains resolver of a memory section of the WASM code.
-use wasmi::MemoryRef;
+use casper_wasmi::MemoryRef;
 
 use super::error::ResolverError;
 

--- a/execution_engine/src/core/resolvers/mod.rs
+++ b/execution_engine/src/core/resolvers/mod.rs
@@ -4,7 +4,7 @@ pub mod memory_resolver;
 pub(crate) mod v1_function_index;
 mod v1_resolver;
 
-use wasmi::ModuleImportResolver;
+use casper_wasmi::ModuleImportResolver;
 
 use casper_types::ProtocolVersion;
 

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use wasmi::{
+use casper_wasmi::{
     memory_units::Pages, Error as InterpreterError, FuncInstance, FuncRef, MemoryDescriptor,
     MemoryInstance, MemoryRef, ModuleImportResolver, Signature, ValueType,
 };

--- a/execution_engine/src/core/runtime/args.rs
+++ b/execution_engine/src/core/runtime/args.rs
@@ -1,4 +1,4 @@
-use wasmi::{FromValue, RuntimeArgs, Trap};
+use casper_wasmi::{FromValue, RuntimeArgs, Trap};
 
 pub(crate) trait Args
 where

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, convert::TryFrom};
 
-use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
+use casper_wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
 use casper_types::{
     account::AccountHash,

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -16,9 +16,9 @@ use std::{
     iter::FromIterator,
 };
 
-use parity_wasm::elements::Module;
+use casper_wasm::elements::Module;
+use casper_wasmi::{MemoryRef, Trap, TrapCode};
 use tracing::error;
-use wasmi::{MemoryRef, Trap, TrapCode};
 
 use casper_types::{
     account::{Account, AccountHash, ActionType, Weight},
@@ -205,14 +205,14 @@ where
         self.try_get_memory()?
             .with_direct_access(|buffer| {
                 let end = offset.checked_add(size).ok_or_else(|| {
-                    wasmi::Error::Memory(format!(
+                    casper_wasmi::Error::Memory(format!(
                         "trying to access memory block of size {} from offset {}",
                         size, offset
                     ))
                 })?;
 
                 if end > buffer.len() {
-                    return Err(wasmi::Error::Memory(format!(
+                    return Err(casper_wasmi::Error::Memory(format!(
                         "trying to access region [{}..{}] in memory [0..{}]",
                         offset,
                         end,
@@ -1367,7 +1367,7 @@ where
                 None => return Err(Error::KeyNotFound(context_key)),
             };
 
-            parity_wasm::deserialize_buffer(contract_wasm.bytes())?
+            casper_wasm::deserialize_buffer(contract_wasm.bytes())?
         };
 
         let context = self.context.new_from_self(

--- a/execution_engine/src/core/runtime/utils.rs
+++ b/execution_engine/src/core/runtime/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use parity_wasm::elements::Module;
-use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef};
+use casper_wasm::elements::Module;
+use casper_wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef};
 
 use casper_types::{
     contracts::NamedKeys, AccessRights, CLType, CLValue, Key, ProtocolVersion, PublicKey,
@@ -30,7 +30,7 @@ pub(super) fn instance_and_memory(
     protocol_version: ProtocolVersion,
     wasm_config: &WasmConfig,
 ) -> Result<(ModuleRef, MemoryRef), Error> {
-    let module = wasmi::Module::from_parity_wasm_module(parity_module)?;
+    let module = casper_wasmi::Module::from_casper_wasm_module(parity_module)?;
     let resolver = resolvers::create_module_resolver(protocol_version, wasm_config)?;
     let mut imports = ImportsBuilder::new();
     imports.push_resolver("env", &resolver);

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/5.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/6.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -1,9 +1,9 @@
 //! Support for Wasm opcode costs.
 use std::{convert::TryInto, num::NonZeroU32};
 
+use casper_wasm::elements::Instruction;
 use casper_wasm_utils::rules::{MemoryGrowCost, Rules};
 use datasize::DataSize;
-use parity_wasm::elements::Instruction;
 use rand::{distributions::Standard, prelude::*, Rng};
 use serde::{Deserialize, Serialize};
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,8 +1,8 @@
 //! Preprocessing of Wasm modules.
-use casper_wasm_utils::{self, stack_height};
-use parity_wasm::elements::{
+use casper_wasm::elements::{
     self, External, Instruction, Internal, MemorySection, Module, Section, TableType, Type,
 };
+use casper_wasm_utils::{self, stack_height};
 use thiserror::Error;
 
 use super::wasm_config::WasmConfig;
@@ -405,7 +405,7 @@ pub fn preprocess(
 
 /// Returns a parity Module from the given bytes without making modifications or checking limits.
 pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
-    parity_wasm::deserialize_buffer::<Module>(module_bytes).map_err(Into::into)
+    casper_wasm::deserialize_buffer::<Module>(module_bytes).map_err(Into::into)
 }
 
 /// Creates new wasm module from entry points.
@@ -431,7 +431,7 @@ pub fn get_module_from_entry_points(
         Some(missing_name) => Err(execution::Error::FunctionNotFound(missing_name)),
         None => {
             casper_wasm_utils::optimize(&mut module, entry_point_names)?;
-            parity_wasm::serialize(module).map_err(execution::Error::ParityWasm)
+            casper_wasm::serialize(module).map_err(execution::Error::ParityWasm)
         }
     }
 }
@@ -439,7 +439,7 @@ pub fn get_module_from_entry_points(
 #[cfg(test)]
 mod tests {
     use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
-    use parity_wasm::{
+    use casper_wasm::{
         builder,
         elements::{CodeSection, Instructions},
     };
@@ -484,7 +484,7 @@ mod tests {
             .memory()
             .build()
             .build();
-        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let module_bytes = casper_wasm::serialize(module).expect("should serialize");
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
@@ -523,7 +523,7 @@ mod tests {
             .memory()
             .build()
             .build();
-        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let module_bytes = casper_wasm::serialize(module).expect("should serialize");
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
@@ -559,7 +559,7 @@ mod tests {
             .memory()
             .build()
             .build();
-        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let module_bytes = casper_wasm::serialize(module).expect("should serialize");
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
@@ -580,7 +580,7 @@ mod tests {
             .memory()
             .build()
             .build();
-        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let module_bytes = casper_wasm::serialize(module).expect("should serialize");
 
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
@@ -603,7 +603,7 @@ mod tests {
             .memory()
             .build()
             .build();
-        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let module_bytes = casper_wasm::serialize(module).expect("should serialize");
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(

--- a/execution_engine/src/storage/error/lmdb.rs
+++ b/execution_engine/src/storage/error/lmdb.rs
@@ -28,7 +28,7 @@ pub enum Error {
     CommitError(#[from] CommitError),
 }
 
-impl wasmi::HostError for Error {}
+impl casper_wasmi::HostError for Error {}
 
 impl From<bytesrepr::Error> for Error {
     fn from(error: bytesrepr::Error) -> Self {

--- a/execution_engine_testing/test_support/CHANGELOG.md
+++ b/execution_engine_testing/test_support/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 6.0.0
+
+### Changed
+* Update `casper-execution-engine` dependency.
+* Handle evict items in the `WasmTestBuilder` when advancing eras or calling `step`.
+
+
+
 ## 5.0.0
 
 ### Added

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 casper-execution-engine = { version = "5.0.0", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "2.0.0", path = "../../hashing" }
-casper-types = { version = "4.0.0", path = "../../types" }
+casper-types = { version = "3.0.0", path = "../../types" }
 humantime = "2"
 filesize = "0.2.0"
 lmdb-rkv = "0.14"
@@ -27,7 +27,7 @@ toml = "0.5.6"
 tempfile = "3.4.0"
 
 [dev-dependencies]
-casper-types = { version = "4.0.0", path = "../../types", features = ["std"] }
+casper-types = { version = "3.0.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [features]

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "5.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "6.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license = "Apache-2.0"
 
 [dependencies]
-casper-execution-engine = { version = "5.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "6.0.0", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "2.0.0", path = "../../hashing" }
 casper-types = { version = "3.0.0", path = "../../types" }
 humantime = "2"

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library to support testing of Wasm smart contracts for use on the Casper Platform.
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/5.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/6.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -10,10 +10,10 @@ casper-engine-test-support = { path = "../test_support", features = ["test-suppo
 casper-execution-engine = { path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { path = "../../hashing" }
 casper-types = { path = "../../types", features = ["datasize", "json-schema"] }
+casper-wasm = "0.46.0"
 clap = "2"
 fs_extra = "1.2.0"
 log = "0.4.8"
-parity-wasm = "0.45.0"
 rand = "0.8.3"
 serde = "1"
 serde_json = "1"

--- a/execution_engine_testing/tests/src/test/gas_counter.rs
+++ b/execution_engine_testing/tests/src/test/gas_counter.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{BlockType, Instruction, Instructions},
 };
@@ -33,7 +33,7 @@ fn make_session_code_with(instructions: Vec<Instruction>) -> Vec<u8> {
         .memory()
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -1,6 +1,6 @@
+use casper_wasm::builder;
 use num_traits::Zero;
 use once_cell::sync::Lazy;
-use parity_wasm::builder;
 
 use casper_engine_test_support::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
@@ -438,7 +438,7 @@ fn do_nothing_without_memory() -> Vec<u8> {
         .field(DEFAULT_ENTRY_POINT_NAME)
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/regression/ee_890.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_890.rs
@@ -1,4 +1,4 @@
-use parity_wasm::{self, builder};
+use casper_wasm::{self, builder};
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
@@ -32,7 +32,7 @@ fn make_do_nothing_with_start() -> Vec<u8> {
         .build()
         .build();
 
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/regression/ee_966.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_966.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
+use casper_wasm::builder;
 use once_cell::sync::Lazy;
-use parity_wasm::builder;
 
 use casper_engine_test_support::{
     DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
@@ -73,7 +73,7 @@ fn make_session_code_with_memory_pages(initial_pages: u32, max_pages: Option<u32
         .with_max(max_pages)
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 fn make_request_with_session_bytes(session_code: Vec<u8>) -> ExecuteRequest {

--- a/execution_engine_testing/tests/src/test/regression/regression_20210924.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210924.rs
@@ -9,7 +9,7 @@ use casper_execution_engine::{
     shared::opcode_costs::DEFAULT_NOP_COST,
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, runtime_args, Gas, RuntimeArgs, U512};
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{Instruction, Instructions},
 };
@@ -37,7 +37,7 @@ pub fn do_minimum_bytes() -> Vec<u8> {
         .memory()
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{Instruction, Instructions},
 };
@@ -275,7 +275,7 @@ fn should_not_allow_more_than_one_table() {
         .memory()
         .build()
         .build();
-    let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+    let module_bytes = casper_wasm::serialize(module).expect("should serialize");
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/test_utils.rs
+++ b/execution_engine_testing/tests/src/test/regression/test_utils.rs
@@ -1,5 +1,5 @@
 use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{Instruction, Instructions},
 };
@@ -38,7 +38,7 @@ pub(crate) fn make_gas_counter_overflow() -> Vec<u8> {
         .memory()
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 /// Prepare malicious payload in a form of a wasm module without memory section.
@@ -67,7 +67,7 @@ pub(crate) fn make_module_without_memory_section() -> Vec<u8> {
         .field(DEFAULT_ENTRY_POINT_NAME)
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 /// Prepare malicious payload in a form of a wasm module with forbidden start section.

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -5,13 +5,13 @@ use num_traits::{One, Zero};
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder,
-    UpgradeRequestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
-    DEFAULT_CHAINSPEC_REGISTRY, DEFAULT_EXEC_CONFIG, DEFAULT_GENESIS_CONFIG_HASH,
-    DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION,
-    DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
-    DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG, MINIMUM_ACCOUNT_CREATION_BALANCE,
-    PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
+    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, StepRequestBuilder, DEFAULT_ACCOUNTS,
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_CHAINSPEC_REGISTRY,
+    DEFAULT_EXEC_CONFIG, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
+    DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PROTOCOL_VERSION, DEFAULT_ROUND_SEIGNIORAGE_RATE,
+    DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY, DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
+    TIMESTAMP_MILLIS_INCREMENT,
 };
 use casper_execution_engine::{
     core::{
@@ -41,14 +41,14 @@ use casper_types::{
         self,
         auction::{
             self, Bids, DelegationRate, EraValidators, Error as AuctionError, UnbondingPurses,
-            ValidatorWeights, WithdrawPurses, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR,
-            ARG_NEW_VALIDATOR, ARG_PUBLIC_KEY, ARG_VALIDATOR, ERA_ID_KEY, INITIAL_ERA_ID,
+            ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_NEW_VALIDATOR,
+            ARG_PUBLIC_KEY, ARG_VALIDATOR, ERA_ID_KEY, INITIAL_ERA_ID,
         },
     },
     EraId, Motes, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U256, U512,
 };
 
-use crate::{lmdb_fixture, test::system_contracts::auction::bids::engine_state::ExecConfig};
+use crate::test::system_contracts::auction::bids::engine_state::ExecConfig;
 
 const ARG_TARGET: &str = "target";
 
@@ -106,16 +106,6 @@ static ACCOUNT_2_PK: Lazy<PublicKey> = Lazy::new(|| {
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_2_PK));
 const ACCOUNT_2_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_2_BOND: u64 = 200_000;
-
-static GENESIS_VALIDATOR_ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
-    let secret_key = SecretKey::ed25519_from_bytes([200; SecretKey::ED25519_LENGTH]).unwrap();
-    PublicKey::from(&secret_key)
-});
-
-static GENESIS_VALIDATOR_ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
-    let secret_key = SecretKey::ed25519_from_bytes([202; SecretKey::ED25519_LENGTH]).unwrap();
-    PublicKey::from(&secret_key)
-});
 
 static BID_ACCOUNT_1_PK: Lazy<PublicKey> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([204; SecretKey::ED25519_LENGTH]).unwrap();

--- a/execution_engine_testing/tests/src/wasm_utils.rs
+++ b/execution_engine_testing/tests/src/wasm_utils.rs
@@ -1,7 +1,7 @@
 //! Wasm helpers.
 use std::fmt::Write;
 
-use parity_wasm::builder;
+use casper_wasm::builder;
 
 use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
 
@@ -23,7 +23,7 @@ pub fn do_nothing_bytes() -> Vec<u8> {
         .memory()
         .build()
         .build();
-    parity_wasm::serialize(module).expect("should serialize")
+    casper_wasm::serialize(module).expect("should serialize")
 }
 
 /// Creates minimal session code that contains a function with arbitrary number of parameters.

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 blake2 = "0.9.0"
 base16 = "0.2.1"
-casper-types = { version = "4.0.0", path = "../types", features = ["datasize", "std"] }
+casper-types = { version = "3.0.0", path = "../types", features = ["datasize", "std"] }
 datasize = "0.2.9"
 hex = { version = "0.4.2", default-features = false, features = ["serde"] }
 hex-buffer-serde = "0.3.0"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## Unreleased
+## 1.5.3
 
 ### Added
 * Add `deploy_acceptor` section to config with a single option `timestamp_leeway` to allow a small leeway when deciding if a deploy is future-dated.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,7 +21,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "5.0.0", path = "../execution_engine" }
+casper-execution-engine = { version = "6.0.0", path = "../execution_engine" }
 casper-hashing = { version = "2.0.0", path = "../hashing" }
 casper-json-rpc = { version = "1.1.0", path = "../json_rpc" }
 casper-types = { version = "3.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1.0.1"
 casper-execution-engine = { version = "5.0.0", path = "../execution_engine" }
 casper-hashing = { version = "2.0.0", path = "../hashing" }
 casper-json-rpc = { version = "1.1.0", path = "../json_rpc" }
-casper-types = { version = "4.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-types = { version = "3.0.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 datasize = { version = "0.2.11", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"
 ed25519-dalek = { version = "1", default-features = false, features = ["rand", "serde", "u64_backend"] }

--- a/node/src/types/deploy/metadata.rs
+++ b/node/src/types/deploy/metadata.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
-use casper_types::{ExecutionResult, Transfer};
+use casper_types::ExecutionResult;
 
 use crate::types::{BlockHash, BlockHashAndHeight};
 
@@ -16,22 +15,6 @@ pub(crate) struct Metadata {
     /// The block hashes of blocks containing the related deploy, along with the results of
     /// executing the related deploy in the context of one or more blocks.
     pub(crate) execution_results: HashMap<BlockHash, ExecutionResult>,
-}
-
-impl Metadata {
-    pub(crate) fn successful_transfers(&self, block_hash: &BlockHash) -> Vec<Transfer> {
-        match self.execution_results.get(block_hash) {
-            Some(exec_result) => exec_result.successful_transfers(),
-            None => {
-                error!(
-                    execution_results = ?self.execution_results,
-                    %block_hash,
-                    "should have exec result"
-                );
-                vec![]
-            }
-        }
-    }
 }
 
 /// Additional information describing a deploy.

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license = "Apache-2.0"
 
 [dependencies]
-casper-types = { version = "4.0.0", path = "../../types" }
+casper-types = { version = "3.0.0", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "4.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "3.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -179,27 +179,6 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
-    /// Returns all `Transform::WriteTransfer`s from the execution effects if this is an
-    /// `ExecutionResult::Success`, or an empty `Vec` if `ExecutionResult::Failure`.
-    pub fn successful_transfers(&self) -> Vec<Transfer> {
-        let effects = match self {
-            ExecutionResult::Success { effect, .. } => effect,
-            ExecutionResult::Failure { .. } => return vec![],
-        };
-
-        effects
-            .transforms
-            .iter()
-            .filter_map(|transform_entry| {
-                if let Transform::WriteTransfer(transfer) = transform_entry.transform {
-                    Some(transfer)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     // This method is not intended to be used by third party crates.
     #[doc(hidden)]
     #[cfg(feature = "json-schema")]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/4.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/3.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR includes the following changes:
* reverts the version bump of `casper-types` to 4.0.0 and contains a minor refactor to avoid the need for a breaking change to the casper-types API
* fixes clippy and audit warnings
* replaces usage of several Parity crates with our own forks containing bugfixes
* bumps version of EE and test support crates
