### PR TITLE
Use juliet's default timeout and timeout bubbling to make missed ACKs fatal.

### DIFF
--- a/juliet/src/rpc.rs
+++ b/juliet/src/rpc.rs
@@ -72,7 +72,7 @@ impl<const N: usize> RpcBuilder<N> {
         }
     }
 
-    /// Enable timeout bubbling.
+    /// Enables timeout bubbling.
     ///
     /// If enabled, any timeout from an RPC call will also cause an error in
     /// [`JulietRpcServer::next_request`], specifically an [`RpcServerError::FatalTimeout`], which
@@ -81,7 +81,7 @@ impl<const N: usize> RpcBuilder<N> {
     /// This feature can be used to implement a liveness check, causing any timed out request to be
     /// considered fatal. Note that under high load a remote server may take time to answer, thus it
     /// is best not to set too aggressive timeout values on requests if this setting is enabled.
-    pub fn bubble_timeouts(mut self, bubble_timeouts: bool) -> Self {
+    pub fn with_bubble_timeouts(mut self, bubble_timeouts: bool) -> Self {
         self.bubble_timeouts = bubble_timeouts;
         self
     }

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -49,6 +49,7 @@ impl Default for Config {
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
+            ack_timeout: TimeDiff::from_seconds(30),
             blocklist_retain_duration: TimeDiff::from_seconds(600),
             identity: None,
         }
@@ -107,6 +108,8 @@ pub struct Config {
     pub tarpit_chance: f32,
     /// Maximum number of demands for objects that can be in-flight.
     pub max_in_flight_demands: u16,
+    /// Timeout for completing handling of a message before closing a connection to a peer.
+    pub ack_timeout: TimeDiff,
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
     /// Network identity configuration option.

--- a/node/src/components/network/transport.rs
+++ b/node/src/components/network/transport.rs
@@ -3,6 +3,7 @@
 //! The low-level transport is built on top of an existing TLS stream, handling all multiplexing. It
 //! is based on a configuration of the Juliet protocol implemented in the `juliet` crate.
 
+use casper_types::TimeDiff;
 use juliet::{rpc::IncomingRequest, ChannelConfiguration};
 use strum::EnumCount;
 
@@ -14,6 +15,7 @@ use super::Channel;
 pub(super) fn create_rpc_builder(
     maximum_message_size: u32,
     max_in_flight_demands: u16,
+    ack_timeout: TimeDiff,
 ) -> juliet::rpc::RpcBuilder<{ Channel::COUNT }> {
     // Note: `maximum_message_size` is a bit misleading, since it is actually the maximum payload
     //       size. In the future, the chainspec setting should be overhauled and the
@@ -36,6 +38,8 @@ pub(super) fn create_rpc_builder(
     );
 
     juliet::rpc::RpcBuilder::new(io_core)
+        .with_bubble_timeouts(true)
+        .with_default_timeout(ack_timeout.into())
 }
 
 /// Adapter for incoming Juliet requests.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -221,6 +221,10 @@ max_incoming_message_rate_non_validators = 0
 # `0` means unlimited.
 max_in_flight_demands = 50
 
+# Timeout before giving up on a peer. If a peer exceeds this time limit for acknowledging or
+# responding to a received message, it is considered unresponsive and the connection severed.
+ack_timeout = '30sec'
+
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -221,6 +221,10 @@ max_incoming_message_rate_non_validators = 3000
 # `0` means unlimited.
 max_in_flight_demands = 50
 
+# Timeout before giving up on a peer. If a peer exceeds this time limit for acknowledging or
+# responding to a received message, it is considered unresponsive and the connection severed.
+ack_timeout = '30sec'
+
 # Version threshold to enable tarpit for.
 #
 # When set to a version (the value may be `null` to disable the feature), any peer that reports a


### PR DESCRIPTION
Addition to #4269.

* Makes the timeout configurable (from hardcoded 30 seconds).
* Every request has its timeout set through `juliet` means (default timeout), instead of requiring special node logic.
* In the same vein, timeouts bubble up to be a server error as well as a per-request one if configured to do so.
