### PR TITLE
Lower chainspec control flow costs, lower block time and seigniorage rate

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -68,7 +68,7 @@ pub const DEFAULT_UNBONDING_DELAY: u64 = 7;
 /// Ticks per year: 31536000000
 ///
 /// (1+0.02)^((2^14)/31536000000)-1 is expressed as a fraction below.
-pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(6414, 623437335209);
+pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(7, 175070816);
 /// Default genesis timestamp in milliseconds.
 pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -51,21 +51,21 @@ pub const DEFAULT_CONTROL_FLOW_ELSE_OPCODE: u32 = 440;
 /// Default cost of the `end` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_END_OPCODE: u32 = 440;
 /// Default cost of the `br` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 440_000;
+pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 35_000;
 /// Default cost of the `br_if` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 440_000;
+pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 35_000;
 /// Default cost of the `return` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_RETURN_OPCODE: u32 = 440;
 /// Default cost of the `select` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_SELECT_OPCODE: u32 = 440;
 /// Default cost of the `call` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 140_000;
+pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 68_000;
 /// Default cost of the `call_indirect` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 140_000;
+pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 68_000;
 /// Default cost of the `drop` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_DROP_OPCODE: u32 = 440;
 /// Default fixed cost of the `br_table` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 440_000;
+pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 35_000;
 /// Default multiplier for the size of targets in `br_table` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER: u32 = 100;
 

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -64,11 +64,11 @@ pub const DEFAULT_UNBONDING_DELAY: u64 = 7;
 /// Round seigniorage rate represented as a fraction of the total supply.
 ///
 /// Annual issuance: 8%
-/// Minimum round length: 2^15 ms
+/// Minimum round length: 2^14 ms
 /// Ticks per year: 31536000000
 ///
-/// (1+0.08)^((2^15)/31536000000)-1 is expressed as a fractional number below.
-pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(7, 87535408);
+/// (1+0.08)^((2^14)/31536000000)-1 is expressed as a fractional number below.
+pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(7, 175070816);
 
 /// Default chain name.
 pub const DEFAULT_CHAIN_NAME: &str = "casper-execution-engine-testing";

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -908,10 +908,10 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 84_957_608_930;
-    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 579_007_510;
-    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 3_045_904_980;
-    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 3_247_050_250;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 82_537_580_930;
+    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 101_530_510;
+    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_630_671_980;
+    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_604_081_250;
 
     let installer_account = AccountHash::new([1u8; 32]);
     let user_account: AccountHash = AccountHash::new([2u8; 32]);

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -1165,6 +1165,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     const VALIDATOR_1_REWARD_FACTOR_1: u64 = 333333333334;
     const VALIDATOR_2_REWARD_FACTOR_1: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR_1: u64 = 333333333333;
+    const DUST: u64 = 1;
 
     const VALIDATOR_1_REWARD_FACTOR_2: u64 = 333333333333;
     const VALIDATOR_2_REWARD_FACTOR_2: u64 = 333333333333;
@@ -1340,7 +1341,8 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_2_actual_payout_1, validator_2_expected_payout_1);
 
     let validator_3_actual_payout_1 = {
@@ -1354,7 +1356,8 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_3_actual_payout_1, validator_3_expected_payout_1);
 
     let era_info_1 = {
@@ -2235,6 +2238,7 @@ fn should_distribute_by_factor() {
 
     const DELEGATION_RATE: DelegationRate = DELEGATION_RATE_DENOMINATOR;
 
+    const DUST: u64 = 1;
     const VALIDATOR_1_REWARD_FACTOR: u64 = 333333333334;
     const VALIDATOR_2_REWARD_FACTOR: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
@@ -2401,7 +2405,8 @@ fn should_distribute_by_factor() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
     let validator_3_actual_payout = {
@@ -2417,7 +2422,8 @@ fn should_distribute_by_factor() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let era_info = {
@@ -2462,6 +2468,8 @@ fn should_distribute_by_factor_regardless_of_stake() {
     const VALIDATOR_1_REWARD_FACTOR: u64 = 333333333334;
     const VALIDATOR_2_REWARD_FACTOR: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
+
+    const DUST: u64 = 1;
 
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -2626,7 +2634,8 @@ fn should_distribute_by_factor_regardless_of_stake() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
     let validator_3_actual_payout = {
@@ -2642,7 +2651,8 @@ fn should_distribute_by_factor_regardless_of_stake() {
             U512::from(BLOCK_REWARD),
         ))
         .map(|ratio| ratio.to_integer())
-        .unwrap();
+        .unwrap()
+        - U512::from(DUST);
     assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 
     let era_info = {
@@ -3228,6 +3238,8 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     const VALIDATOR_2_REWARD_FACTOR: u64 = 333333333333;
     const VALIDATOR_3_REWARD_FACTOR: u64 = 333333333333;
 
+    const DUST: u64 = 1;
+
     const DELEGATOR_1_STAKE: u64 = DEFAULT_MINIMUM_DELEGATION_AMOUNT;
 
     let system_fund_request = ExecuteRequestBuilder::standard(
@@ -3525,7 +3537,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
             ))
             .unwrap();
         let validator_portion = validator_share - Ratio::from(validator_2_delegator_1_share);
-        validator_portion.to_integer()
+        validator_portion.to_integer() - U512::from(DUST)
     };
     assert_eq!(validator_2_actual_payout, validator_2_expected_payout);
 
@@ -3573,7 +3585,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
             ))
             .unwrap();
         let validator_portion = validator_share - Ratio::from(validator_3_delegator_1_share);
-        validator_portion.to_integer()
+        validator_portion.to_integer() - U512::from(DUST)
     };
     assert_eq!(validator_3_actual_payout, validator_3_expected_payout);
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1021,6 +1021,18 @@ impl BlockHeader {
     fn serialize(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.to_bytes()
     }
+
+    /// Returns a modified block header without the era end.
+    ///
+    /// Test only function, block headers should not be mutated. This method is exclusively used in
+    /// generating the largest specimen.
+    pub(crate) fn without_era_end(self) -> Self {
+        Self {
+            era_end: None,
+            block_hash: OnceCell::new(),
+            ..self
+        }
+    }
 }
 
 impl PartialEq for BlockHeader {

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -2355,9 +2355,4 @@ mod tests {
             }
         }
     }
-
-    #[test]
-    fn sync_leap_largest_specimen() {
-        // SyncLeap::largest_specimen();
-    }
 }

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -389,27 +389,39 @@ impl FetchItem for SyncLeap {
 }
 
 mod specimen_support {
-    use crate::utils::specimen::{
-        estimator_max_rounds_per_era, vec_of_largest_specimen, vec_prop_specimen, Cache,
-        LargestSpecimen, SizeEstimator,
+    use crate::{
+        types::BlockHeader,
+        utils::specimen::{
+            estimator_max_rounds_per_era, vec_of_largest_specimen, vec_prop_specimen, Cache,
+            LargestSpecimen, SizeEstimator,
+        },
     };
 
     use super::{SyncLeap, SyncLeapIdentifier};
 
     impl LargestSpecimen for SyncLeap {
         fn largest_specimen<E: SizeEstimator>(estimator: &E, cache: &mut Cache) -> Self {
+            // Will at most contain as many blocks as a single era. And how many blocks can
+            // there be in an era is determined by the chainspec: it's the
+            // maximum of minimum_era_height and era_duration / minimum_block_time
+            let mut trusted_ancestor_headers: Vec<BlockHeader> =
+                vec_of_largest_specimen(estimator, estimator_max_rounds_per_era(estimator), cache);
+
+            let pseudo_switch_block = trusted_ancestor_headers
+                .pop()
+                .expect("should generate at least one block header");
+            let mut trusted_ancestor_headers: Vec<_> = trusted_ancestor_headers
+                .into_iter()
+                .map(BlockHeader::without_era_end)
+                .collect();
+            trusted_ancestor_headers.push(pseudo_switch_block);
+
+            let signed_block_headers = vec_prop_specimen(estimator, "recent_era_count", cache);
             SyncLeap {
                 trusted_ancestor_only: LargestSpecimen::largest_specimen(estimator, cache),
                 trusted_block_header: LargestSpecimen::largest_specimen(estimator, cache),
-                // Will at most contain as many blocks as a single era. And how many blocks can
-                // there be in an era is determined by the chainspec: it's the
-                // maximum of minimum_era_height and era_duration / minimum_block_time
-                trusted_ancestor_headers: vec_of_largest_specimen(
-                    estimator,
-                    estimator_max_rounds_per_era(estimator),
-                    cache,
-                ),
-                signed_block_headers: vec_prop_specimen(estimator, "recent_era_count", cache),
+                trusted_ancestor_headers,
+                signed_block_headers,
             }
         }
     }
@@ -2341,5 +2353,10 @@ mod tests {
                 assert!(!block.header().is_switch_block())
             }
         }
+    }
+
+    #[test]
+    fn sync_leap_largest_specimen() {
+        // SyncLeap::largest_specimen();
     }
 }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -183,17 +183,17 @@ loop = 440
 if = 440
 else = 440
 end = 440
-br = 440_000
-br_if = 440_000
+br = 35_000
+br_if = 35_000
 return = 440
 select = 440
-call = 140_000
-call_indirect = 140_000
+call = 68_000
+call_indirect = 68_000
 drop = 440
 
 [wasm.opcode_costs.control_flow.br_table]
 # Fixed cost per `br_table` opcode
-cost = 440_000
+cost = 35_000
 # Size of target labels in the `br_table` opcode will be multiplied by `size_multiplier`
 size_multiplier = 100
 

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -194,17 +194,17 @@ loop = 440
 if = 440
 else = 440
 end = 440
-br = 440_000
-br_if = 440_000
+br = 35_000
+br_if = 35_000
 return = 440
 select = 440
-call = 140_000
-call_indirect = 140_000
+call = 68_000
+call_indirect = 68_000
 drop = 440
 
 [wasm.opcode_costs.control_flow.br_table]
 # Fixed cost per `br_table` opcode
-cost = 440_000
+cost = 35_000
 # Size of target labels in the `br_table` opcode will be multiplied by `size_multiplier`
 size_multiplier = 100
 

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -56,14 +56,14 @@ unbonding_delay = 7
 # Round seigniorage rate represented as a fraction of the total supply.
 #
 # Annual issuance: 8%
-# Minimum block time: 2^15 milliseconds
+# Minimum block time: 2^14 milliseconds
 # Ticks per year: 31536000000
 #
-# (1+0.08)^((2^15)/31536000000)-1 is expressed as a fractional number below
+# (1+0.08)^((2^14)/31536000000)-1 is expressed as a fractional number below
 # Python:
 # from fractions import Fraction
-# Fraction((1 + 0.08)**((2**15)/31536000000) - 1).limit_denominator(1000000000)
-round_seigniorage_rate = [7, 87535408]
+# Fraction((1 + 0.08)**((2**14)/31536000000) - 1).limit_denominator(1000000000)
+round_seigniorage_rate = [7, 175070816]
 # Maximum number of associated keys for a single account.
 max_associated_keys = 100
 # Maximum height of contract runtime call stack.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -29,7 +29,7 @@ era_duration = '120 minutes'
 # minimum height.
 minimum_era_height = 20
 # Minimum difference between a block's and its child's timestamp.
-minimum_block_time = '32768 ms'
+minimum_block_time = '16384 ms'
 # Number of slots available in validator auction.
 validator_slots = 100
 # A number between 0 and 1 representing the fault tolerance threshold as a fraction, used by the internal finalizer.
@@ -135,7 +135,7 @@ block_max_transfer_count = 1250
 # The maximum number of approvals permitted in a single block.
 block_max_approval_count = 2600
 # The upper limit of total gas of all deploys in a block.
-block_gas_limit = 10_000_000_000_000
+block_gas_limit = 4_000_000_000_000
 # The limit of length of serialized payment code arguments.
 payment_args_max_length = 1024
 # The limit of length of serialized session code arguments.

--- a/smart_contracts/contracts/explorer/faucet/README.md
+++ b/smart_contracts/contracts/explorer/faucet/README.md
@@ -35,7 +35,7 @@ If you try to invoke the contract before these variables are set, then you'll ge
 
 | feature | cost             |
 |---------|------------------|
-| faucet install | `84_957_608_930` |
-| faucet set variables | `579_007_510` |
-| faucet call by installer | `3_045_904_980` |
-| faucet call by user | `3_247_050_250` |
+| faucet install | `82_537_580_930` |
+| faucet set variables | `101_530_510` |
+| faucet call by installer | `2_630_671_980` |
+| faucet call by user | `2_604_081_250` |


### PR DESCRIPTION
This PR updates chain spec to lower opcode costs and as a consequence also adjusts other network properties to be consistent with the changes.

# Opcode costs

This lowers the gas costs for `br`, `br_if`, `br_table`, `call`, and `call_indirect` costs. The researched value is lower than current costs, and also secure for the upcoming 16-second blocks. The impact on NFT contract:

measurement | cost before | costs modified | impact
-- | -- | -- | --
install_cost | 268614304810 | 254901355810 | 94.89%
second_mint_gas_costs | 12184348140 | 2536357140 | 20.82%
third_mint_gas_costs | 12184348140 | 2536357140 | 20.82%
reverse_lookup_gas_cost | 269147109850 | 255096390850 | 94.78%
no_lookup_gas_cost | 268364628780 | 254799495780 | 94.95%
reverse_lookup_gas_cost | 269147110490 | 255096391490 | 94.78%
no_lookup_gas_cost | 268364628780 | 254799495780 | 94.95%
second_transfer_gas_cost | 19648823480 | 3936857480 | 20.04%
third_transfer_gas_cost | 19648823480 | 3936857480 | 20.04%

The operating expenses are cheaper (mint, transfer) at around 80%, while the upfront costs for installation are about ~5% cheaper.

# Block time

To be consistent with decreased opcode costs, this change also lowers block time from 32s to 16s.

# Round seigniorage

To be also consistent with decreased block time, this PR also lowers round seigniorage rate.