### PR TITLE
nctl: fix upgrade_after_emergency_upgrade_test_pre_1.5

### DIFF
--- a/utils/nctl/sh/scenarios/configs/upgrade_after_emergency_upgrade_test_pre_1_5.config.toml.override
+++ b/utils/nctl/sh/scenarios/configs/upgrade_after_emergency_upgrade_test_pre_1_5.config.toml.override
@@ -1,0 +1,2 @@
+[block_synchronizer]
+peer_refresh_interval = "10 seconds"

--- a/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
+++ b/utils/nctl/sh/scenarios/upgrade_after_emergency_upgrade_test_pre_1.5.sh
@@ -286,7 +286,9 @@ function do_await_deploy_inclusion() {
 function do_upgrade_second_time() {
     ACTIVATE_ERA_2=$(($(get_chain_era)+2))
     log_step "scheduling the network upgrade to version ${TEST_PROTOCOL_VERSION_2} at era ${ACTIVATE_ERA_2}"
-    nctl-assets-upgrade-from-stage stage="1" era="$ACTIVATE_ERA_2"
+
+    CONFIG_PATH="$NCTL/overrides/upgrade_after_emergency_upgrade_test_pre_1_5.config.toml"
+    nctl-assets-upgrade-from-stage stage="1" era="$ACTIVATE_ERA_2" config_path="$CONFIG_PATH"
 }
 
 function do_await_second_upgrade() {


### PR DESCRIPTION
In some runs this upgrade test was failing because it was hitting the 300 second timeout for syncing to genesis.
Sometimes when synchronizing historical blocks, the block synchronizer for node 1 was selecting 5 other nodes that did not have the finality signatures for that block (usually nodes 6-10).
Because the peer refresh interval was set to 90 seconds, the node did not have time to finish fetching the historical blocks if the situation described above happened for multiple blocks since the total timeout was 300 seconds.

Reduce the `block_synchonizer.peer_refresh_interval` config parameter for this test to 10s to allow it to become more lively and finish within the 300s timeout.

Fixes: https://github.com/casper-network/casper-node/issues/4365