### PR TITLE
Move an old changelg entry back to 1.5.3

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for a new FFI function `enable_contract_version` for enabling a specific version of a contract.
 
 ### Changed
-* Default value for `max_stack_height` is increased to 500.
 * `current stack height` is written to `stderr` in case `Trap(Unreachable)` error is encountered during Wasm execution.
 * Tweak upgrade logic transforming withdraw purses to early exit if possible.
 * Lower the default gas costs of opcodes.
@@ -36,6 +35,7 @@ All notable changes to this project will be documented in this file.  The format
 ## 6.0.0
 
 ### Changed
+* Default value for `max_stack_height` is increased to 500.
 * Replaced usage of `parity-wasm` and `wasmi` with Casper forks `casper-wasm` and `casper-wasmi` respectively.
 
 ### Fixed


### PR DESCRIPTION
@cspramit has noticed that an old changelog entry has been moved to the Unreleased section at some point.
It can be seen in the 1.5.3 changelog here: https://github.com/casper-network/casper-node/blob/v1.5.3/execution_engine/CHANGELOG.md#changed.
I've had a look at the other entries in the changelogs to catch similar issues, but this seems to be the only one.
