### PR TITLE
Add NCTL tests checking for round exponent changes

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -119,6 +119,8 @@ start_run_teardown "sync_test.sh timeout=500"
 start_run_teardown "swap_validator_set.sh"
 start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
 start_run_teardown "validators_disconnect.sh"
+start_run_teardown "slow-node-01.sh"
+start_run_teardown "slow-node-02.sh"
 # Without start_run_teardown - these ones perform their own assets setup, network start and teardown
 source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
 source "$SCENARIOS_DIR/regression_3976.sh"

--- a/utils/nctl/sh/assets/compile_node.sh
+++ b/utils/nctl/sh/assets/compile_node.sh
@@ -26,9 +26,9 @@ while getopts 'd' opt; do
 done
 
 if [ "$NCTL_COMPILE_TARGET" = "debug" ] || [ "$COMPILE_MODE" = "debug" ]; then
-    cargo build --package casper-node
+    cargo build --package casper-node --features failpoints
 else
-    cargo build --release --package casper-node
+    cargo build --release --package casper-node --features failpoints
 fi
 
 unset OPTIND

--- a/utils/nctl/sh/scenarios/accounts_toml/slow-node-02.accounts.toml.override
+++ b/utils/nctl/sh/scenarios/accounts_toml/slow-node-02.accounts.toml.override
@@ -1,0 +1,134 @@
+# FAUCET.
+[[accounts]]
+public_key = "PBK_FAUCET"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 1.
+[[accounts]]
+public_key = "PBK_V1"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "10000"
+delegation_rate = 1
+
+# VALIDATOR 2.
+[[accounts]]
+public_key = "PBK_V2"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "20000"
+delegation_rate = 2
+
+# VALIDATOR 3.
+[[accounts]]
+public_key = "PBK_V3"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "40000"
+delegation_rate = 3
+
+# VALIDATOR 4.
+[[accounts]]
+public_key = "PBK_V4"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "80000"
+delegation_rate = 4
+
+# VALIDATOR 5.
+[[accounts]]
+public_key = "PBK_V5"
+balance = "1000000000000000000000000000000000"
+
+[accounts.validator]
+bonded_amount = "160000"
+delegation_rate = 5
+
+# VALIDATOR 6.
+[[accounts]]
+public_key = "PBK_V6"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 7.
+[[accounts]]
+public_key = "PBK_V7"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 8.
+[[accounts]]
+public_key = "PBK_V8"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 9.
+[[accounts]]
+public_key = "PBK_V9"
+balance = "1000000000000000000000000000000000"
+
+# VALIDATOR 10.
+[[accounts]]
+public_key = "PBK_V10"
+balance = "1000000000000000000000000000000000"
+
+# USER 1.
+[[delegators]]
+validator_public_key = "PBK_V1"
+delegator_public_key = "PBK_U1"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 2.
+[[delegators]]
+validator_public_key = "PBK_V2"
+delegator_public_key = "PBK_U2"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 3.
+[[delegators]]
+validator_public_key = "PBK_V3"
+delegator_public_key = "PBK_U3"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 4.
+[[delegators]]
+validator_public_key = "PBK_V4"
+delegator_public_key = "PBK_U4"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 5.
+[[delegators]]
+validator_public_key = "PBK_V5"
+delegator_public_key = "PBK_U5"
+balance = "1000000000000000000000000000000000"
+delegated_amount = "1"
+
+# USER 6.
+[[accounts]]
+public_key = "PBK_U6"
+balance = "1000000000000000000000000000000000"
+
+# USER 7.
+[[accounts]]
+public_key = "PBK_U7"
+balance = "1000000000000000000000000000000000"
+
+# USER 8.
+[[accounts]]
+public_key = "PBK_U8"
+balance = "1000000000000000000000000000000000"
+
+# USER 9.
+[[accounts]]
+public_key = "PBK_U9"
+balance = "1000000000000000000000000000000000"
+
+# USER 10.
+[[accounts]]
+public_key = "PBK_U10"
+balance = "1000000000000000000000000000000000"

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -613,3 +613,22 @@ function assert_chain_stalled() {
         log "Stall successfully detected, continuing..."
     fi
 }
+
+function slow_down_node_network() {
+    local NODE=${1}
+    local DELAY=${2:-3000}
+    local PV=$(get_node_protocol_version $NODE | sed -e 's/\./_/g')
+
+    echo "set-failpoint consensus.message_delay=$DELAY" \
+        | socat - unix-client:"$(get_path_to_node $NODE)"/config/$PV/debug.socket
+}
+
+function dump_consensus() {
+    local NODE=${1}
+    local ERA=${2}
+    local PV=$(get_node_protocol_version $NODE | sed -e 's/\./_/g')
+
+    echo -e "set -o bincode -q true\ndump-consensus $ERA" \
+        | socat - unix-client:"$(get_path_to_node $NODE)"/config/$PV/debug.socket \
+        > /tmp/consensus-dump-n$NODE-e$ERA.bincode
+}

--- a/utils/nctl/sh/scenarios/slow-node-01.sh
+++ b/utils/nctl/sh/scenarios/slow-node-01.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+#######################################
+# Runs an integration tests that tries to simulate
+# a slow validator in the network and check if it did
+# slow down.
+# Arguments:
+#   `timeout=XXX` timeout (in seconds) when syncing.
+#######################################
+function main() {
+    log "------------------------------------------------------------"
+    log "Starting Scenario: slow-node-01"
+    log "------------------------------------------------------------"
+
+    # 0. Wait for network start up
+    do_await_genesis_era_to_complete
+    # 1. Verify network is creating blocks
+    do_await_n_blocks "5"
+    # 2. Verify network is in sync
+    parallel_check_network_sync 1 5
+    INIT_ROUND_LEN=$(get_node_round_len 1)
+    # 3. Slow down node
+    slow_down_node_network 1
+    # 4. Wait 2 eras
+    do_await_era_change 2
+    # Dump consensus data from node 2 for era 2 for debugging
+    dump_consensus 2 2
+    # 5. Verify all nodes are in sync
+    parallel_check_network_sync 1 5
+    # 6. Check that round length of node 1 is different
+    NEW_ROUND_LEN=$(get_node_round_len 1)
+    assert_round_len_changed "$INIT_ROUND_LEN" "$NEW_ROUND_LEN"
+    # 7. Run Health Checks
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
+
+    log "------------------------------------------------------------"
+    log "Scenario slow-node-01 complete"
+    log "------------------------------------------------------------"
+}
+
+function assert_round_len_changed() {
+    local LEN1=${1}
+    local LEN2=${2}
+    if [ "$LEN1" = "$LEN2" ]; then
+        log "Round length didn't change!"
+        exit 1
+    else
+        log "Round length changed from $LEN1 to $LEN2 - OK"
+    fi
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset SYNC_TIMEOUT_SEC
+unset LFB_HASH
+unset PUBLIC_KEY_HEX
+STEP=0
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+SYNC_TIMEOUT_SEC=${SYNC_TIMEOUT_SEC:-"300"}
+
+main

--- a/utils/nctl/sh/scenarios/slow-node-02.sh
+++ b/utils/nctl/sh/scenarios/slow-node-02.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/scenarios/common/itst.sh
+
+# Exit if any of the commands fail.
+set -e
+
+#######################################
+# Runs an integration tests that tries to simulate
+# a slow validator in a network with uneven stakes
+# and check if it did slow down.
+# Note: needs the accounts.toml.override file to
+# simulate the uneven stakes.
+# Arguments:
+#   `timeout=XXX` timeout (in seconds) when syncing.
+#######################################
+function main() {
+    log "------------------------------------------------------------"
+    log "Starting Scenario: slow-node-02"
+    log "------------------------------------------------------------"
+
+    # 0. Wait for network start up
+    do_await_genesis_era_to_complete
+    # 1. Verify network is creating blocks
+    do_await_n_blocks "5"
+    # 2. Verify network is in sync
+    parallel_check_network_sync 1 5
+    INIT_ROUND_LEN=$(get_node_round_len 1)
+    # 3. Slow down node
+    slow_down_node_network 1
+    # 4. Wait 2 eras
+    do_await_era_change 2
+    # Dump consensus data from node 2 for era 2 for debugging
+    dump_consensus 2 2
+    # 5. Verify all nodes are in sync
+    parallel_check_network_sync 1 5
+    # 6. Check that round length of node 1 is different
+    NEW_ROUND_LEN=$(get_node_round_len 1)
+    assert_round_len_changed "$INIT_ROUND_LEN" "$NEW_ROUND_LEN"
+    # 7. Run Health Checks
+    source "$NCTL"/sh/scenarios/common/health_checks.sh \
+            errors=0 \
+            equivocators=0 \
+            doppels=0 \
+            crashes=0 \
+            restarts=0 \
+            ejections=0
+
+    log "------------------------------------------------------------"
+    log "Scenario slow-node-02 complete"
+    log "------------------------------------------------------------"
+}
+
+function assert_round_len_changed() {
+    local LEN1=${1}
+    local LEN2=${2}
+    if [ "$LEN1" = "$LEN2" ]; then
+        log "Round length didn't change!"
+        exit 1
+    else
+        log "Round length changed from $LEN1 to $LEN2 - OK"
+    fi
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset SYNC_TIMEOUT_SEC
+unset LFB_HASH
+unset PUBLIC_KEY_HEX
+STEP=0
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+SYNC_TIMEOUT_SEC=${SYNC_TIMEOUT_SEC:-"300"}
+
+main

--- a/utils/nctl/sh/utils/queries.sh
+++ b/utils/nctl/sh/utils/queries.sh
@@ -100,6 +100,21 @@ function get_node_protocol_version()
 }
 
 #######################################
+# Returns the current round length on the node
+# Arguments:
+#   Node ordinal identifier.
+#   Duration for which to retry once per second in the case the node is not responding.
+#######################################
+function get_node_round_len()
+{
+    local NODE_ID=${1}
+    local TIMEOUT_SEC=${2:-20}
+
+    echo $(_get_from_status_with_retry "$NODE_ID" "$TIMEOUT_SEC" ".round_length") \
+        | sed -e 's/^"//' -e 's/"$//'
+}
+
+#######################################
 # Returns the lowest complete block the node has.
 # Arguments:
 #   Node ordinal identifier.


### PR DESCRIPTION
This PR adds two NCTL tests that check for round exponent changes: one with even weights, and one with uneven ones.

The planned addition of another failpoint has been put on hold for now, as the failpoint didn't turn out to be useful in the tests.

Closes #4397 