### PR TITLE
Host function `generic_hash()` with blake2b/blake3 support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +372,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +533,7 @@ dependencies = [
  "assert_matches",
  "base16",
  "bincode",
+ "blake3",
  "casper-hashing",
  "casper-types",
  "casper-wasm",
@@ -950,6 +976,12 @@ name = "const-oid"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "contract-context"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
+blake3 = { version = "1.5.0", default-features = false }
 casper-hashing = { version = "2.0.0", path = "../hashing" }
 casper-types = { version = "3.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 casper-wasm = { version = "0.46.0", default-features = false }

--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -60,6 +60,7 @@ pub(crate) enum FunctionIndex {
     RandomBytes,
     DictionaryReadFuncIndex,
     EnableContractVersion,
+    GenericHash,
 }
 
 impl From<FunctionIndex> for usize {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -245,6 +245,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::EnableContractVersion.into(),
             ),
+            "casper_generic_hash" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
+                FunctionIndex::GenericHash.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution_engine/src/core/runtime/crypto.rs
+++ b/execution_engine/src/core/runtime/crypto.rs
@@ -1,0 +1,15 @@
+/// The number of bytes in a Blake3 hash.
+/// NOTE: It does not make sense to use different lengths.
+const BLAKE3_DIGEST_LENGTH: usize = 32;
+
+#[doc(hidden)]
+pub fn blake3<T: AsRef<[u8]>>(data: T) -> [u8; BLAKE3_DIGEST_LENGTH] {
+    let mut result = [0; BLAKE3_DIGEST_LENGTH];
+    let mut hasher = blake3::Hasher::new();
+
+    hasher.update(data.as_ref());
+    let hash = hasher.finalize();
+    let hash_bytes: &[u8; BLAKE3_DIGEST_LENGTH] = hash.as_bytes();
+    result.copy_from_slice(hash_bytes);
+    result
+}

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -1106,8 +1106,19 @@ where
                 // args(3) = size of hash type in Wasm memory
                 // args(4) = pointer to output pointer in Wasm memory
                 // args(5) = size of output
-                let (in_ptr, in_size, hash_algo_type_ptr, hash_algo_type_size, out_ptr, out_size): (u32, u32, u32, u32, u32, u32) =
+                let (in_ptr, in_size, hash_algo_type_ptr, hash_algo_type_size, out_ptr, out_size) =
                     Args::parse(args)?;
+                self.charge_host_function_call(
+                    &host_function_costs.generic_hash,
+                    [
+                        in_ptr,
+                        in_size,
+                        hash_algo_type_ptr,
+                        hash_algo_type_size,
+                        out_ptr,
+                        out_size,
+                    ],
+                )?;
                 let hash_algo_type = self.t_from_mem(hash_algo_type_ptr, hash_algo_type_size)?;
                 let digest =
                     self.checked_memory_slice(in_ptr as usize, in_size as usize, |input| {

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains executor state of the WASM code.
 mod args;
 mod auction_internal;
+mod crypto;
 mod externals;
 mod handle_payment_internal;
 mod host_function_flag;

--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -290,6 +290,8 @@ pub struct HostFunctionCosts {
     pub random_bytes: HostFunction<[Cost; 2]>,
     /// Cost of calling the `enable_contract_version` host function.
     pub enable_contract_version: HostFunction<[Cost; 4]>,
+    /// Cost of calling the `generic_hash` host function.
+    pub generic_hash: HostFunction<[Cost; 6]>,
 }
 
 impl Default for HostFunctionCosts {
@@ -422,6 +424,7 @@ impl Default for HostFunctionCosts {
             blake2b: HostFunction::default(),
             random_bytes: HostFunction::default(),
             enable_contract_version: HostFunction::default(),
+            generic_hash: HostFunction::default(),
         }
     }
 }
@@ -473,6 +476,7 @@ impl ToBytes for HostFunctionCosts {
         ret.append(&mut self.blake2b.to_bytes()?);
         ret.append(&mut self.random_bytes.to_bytes()?);
         ret.append(&mut self.enable_contract_version.to_bytes()?);
+        ret.append(&mut self.generic_hash.to_bytes()?);
         Ok(ret)
     }
 
@@ -521,6 +525,7 @@ impl ToBytes for HostFunctionCosts {
             + self.blake2b.serialized_length()
             + self.random_bytes.serialized_length()
             + self.enable_contract_version.serialized_length()
+            + self.generic_hash.serialized_length()
     }
 }
 
@@ -570,6 +575,7 @@ impl FromBytes for HostFunctionCosts {
         let (blake2b, rem) = FromBytes::from_bytes(rem)?;
         let (random_bytes, rem) = FromBytes::from_bytes(rem)?;
         let (enable_contract_version, rem) = FromBytes::from_bytes(rem)?;
+        let (generic_hash, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             HostFunctionCosts {
                 read_value,
@@ -616,6 +622,7 @@ impl FromBytes for HostFunctionCosts {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
+                generic_hash,
             },
             rem,
         ))
@@ -669,6 +676,7 @@ impl Distribution<HostFunctionCosts> for Standard {
             blake2b: rng.gen(),
             random_bytes: rng.gen(),
             enable_contract_version: rng.gen(),
+            generic_hash: rng.gen(),
         }
     }
 }
@@ -730,6 +738,7 @@ pub mod gens {
             blake2b in host_function_cost_arb(),
             random_bytes in host_function_cost_arb(),
             enable_contract_version in host_function_cost_arb(),
+            generic_hash in host_function_cost_arb(),
         ) -> HostFunctionCosts {
             HostFunctionCosts {
                 read_value,
@@ -776,6 +785,7 @@ pub mod gens {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
+                generic_hash,
             }
         }
     }

--- a/execution_engine_testing/tests/src/test/storage_costs.rs
+++ b/execution_engine_testing/tests/src/test/storage_costs.rs
@@ -139,6 +139,7 @@ static NEW_HOST_FUNCTION_COSTS: Lazy<HostFunctionCosts> = Lazy::new(|| HostFunct
     blake2b: HostFunction::fixed(0),
     random_bytes: HostFunction::fixed(0),
     enable_contract_version: HostFunction::fixed(0),
+    generic_hash: HostFunction::fixed(0),
 });
 static STORAGE_COSTS_ONLY: Lazy<WasmConfig> = Lazy::new(|| {
     WasmConfig::new(

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -979,6 +979,7 @@ fn should_verify_wasm_add_bid_wasm_cost_is_not_recursive() {
         blake2b: HostFunction::fixed(0),
         random_bytes: HostFunction::fixed(0),
         enable_contract_version: HostFunction::fixed(0),
+        generic_hash: HostFunction::fixed(0),
     };
 
     let new_wasm_config = WasmConfig::new(

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -363,6 +363,7 @@ mod tests {
             blake2b: HostFunction::new(133, [0, 1, 2, 3]),
             random_bytes: HostFunction::new(123, [0, 1]),
             enable_contract_version: HostFunction::new(142, [0, 1, 2, 3]),
+            generic_hash: HostFunction::new(152, [0, 1, 2, 3, 4, 5]),
         });
     static EXPECTED_GENESIS_WASM_COSTS: Lazy<WasmConfig> = Lazy::new(|| {
         WasmConfig::new(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -243,6 +243,7 @@ transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] 
 update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
+generic_hash = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -254,6 +254,7 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
+generic_hash = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -141,6 +141,7 @@ update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 enable_contract_version = { cost = 142, arguments = [0, 1, 2, 3] }
+generic_hash = { cost = 152, arguments = [0, 1, 2, 3, 4, 5] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -139,6 +139,7 @@ update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 enable_contract_version = { cost = 142, arguments = [0, 1, 2, 3] }
+generic_hash = { cost = 152, arguments = [0, 1, 2, 3, 4, 5] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -142,6 +142,7 @@ update_associated_key = { cost = 139, arguments = [0, 1, 2] }
 write = { cost = 140,  arguments = [0, 1, 0, 2] }
 write_local = { cost = 141, arguments = [0, 1, 2, 3] }
 enable_contract_version = { cost = 142, arguments = [0, 1, 2, 3] }
+generic_hash = { cost = 152, arguments = [0, 1, 2, 3, 4, 5] }
 
 [system_costs]
 wasmless_transfer_cost = 100_000_000

--- a/smart_contracts/contract/CHANGELOG.md
+++ b/smart_contracts/contract/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Add `storage::enable_contract_version` for enabling a specific version of a contract.
+* Add `crypto::generic_hash` with blake2b and blake3 support.
 
 
 

--- a/smart_contracts/contract/src/contract_api/crypto.rs
+++ b/smart_contracts/contract/src/contract_api/crypto.rs
@@ -1,0 +1,25 @@
+//! Functions with cryptographic utils.
+
+use casper_types::{api_error, HashAlgoType, BLAKE2B_DIGEST_LENGTH};
+
+use crate::{ext_ffi, unwrap_or_revert::UnwrapOrRevert};
+
+/// Computes digest hash, using provided algorithm type.
+pub fn generic_hash<T: AsRef<[u8]>>(input: T, algo: HashAlgoType) -> [u8; 32] {
+    let mut ret = [0; 32];
+
+    let algo_ptr = &algo as *const _ as *const u8;
+
+    let result = unsafe {
+        ext_ffi::casper_generic_hash(
+            input.as_ref().as_ptr(),
+            input.as_ref().len(),
+            algo_ptr,
+            1, // HashAlgoType is just one byte (u8).
+            ret.as_mut_ptr(),
+            BLAKE2B_DIGEST_LENGTH,
+        )
+    };
+    api_error::result_from(result).unwrap_or_revert();
+    ret
+}

--- a/smart_contracts/contract/src/contract_api/mod.rs
+++ b/smart_contracts/contract/src/contract_api/mod.rs
@@ -1,6 +1,7 @@
 //! Contains support for writing smart contracts.
 
 pub mod account;
+pub mod crypto;
 pub mod runtime;
 pub mod storage;
 pub mod system;

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -805,4 +805,22 @@ extern "C" {
         contract_hash_ptr: *const u8,
         contract_hash_size: usize,
     ) -> i32;
+    /// Computes digest hash, using provided algorithm type.
+    ///
+    /// # Arguments
+    ///
+    /// * `in_ptr` - pointer to the location where argument bytes will be copied from the host side
+    /// * `in_size` - size of output pointer
+    /// * `hash_algo_type_ptr` - pointer to serialized hash type
+    /// * `hash_algo_type_size` - size of hash type in serialized form
+    /// * `out_ptr` - pointer to the location where argument bytes will be copied to the host side
+    /// * `out_size` - size of output pointer
+    pub fn casper_generic_hash(
+        in_ptr: *const u8,
+        in_size: usize,
+        hash_algo_type_ptr: *const u8,
+        hash_algo_type_size: usize,
+        out_ptr: *const u8,
+        out_size: usize,
+    ) -> i32;
 }

--- a/types/src/crypto.rs
+++ b/types/src/crypto.rs
@@ -3,10 +3,20 @@
 mod asymmetric_key;
 mod error;
 
+use alloc::vec::Vec;
+
 use blake2::{
     digest::{Update, VariableOutput},
     VarBlake2b,
 };
+
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::bytesrepr::{self, FromBytes, ToBytes};
 
 use crate::key::BLAKE2B_DIGEST_LENGTH;
 #[cfg(any(feature = "std", test))]
@@ -32,4 +42,54 @@ pub fn blake2b<T: AsRef<[u8]>>(data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
         result.copy_from_slice(slice);
     });
     result
+}
+
+/// HashAlgoType
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub enum HashAlgoType {
+    /// Blake2b
+    Blake2b = 0,
+    /// Blake3
+    Blake3 = 1,
+}
+
+impl ToBytes for HashAlgoType {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        (*self as u8).to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        1
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(*self as u8);
+        Ok(())
+    }
+}
+
+impl FromBytes for HashAlgoType {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (value, bytes) = u8::from_bytes(bytes)?;
+        match value {
+            0 => Ok((HashAlgoType::Blake2b, bytes)),
+            1 => Ok((HashAlgoType::Blake3, bytes)),
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+// Statics representing the discriminant values of the enum
+static VARIANT_BLAKE_2B: u8 = HashAlgoType::Blake2b as u8;
+static VARIANT_BLAKE_3: u8 = HashAlgoType::Blake3 as u8;
+impl AsRef<u8> for HashAlgoType {
+    fn as_ref(&self) -> &u8 {
+        match self {
+            HashAlgoType::Blake2b => &VARIANT_BLAKE_2B,
+            HashAlgoType::Blake3 => &VARIANT_BLAKE_3,
+        }
+    }
 }


### PR DESCRIPTION
_In order to support **Zero Knowledge** software, cryptography related utils should be implemented as a host functions, otherwise execution cost would be too unacceptable. For example running Risc0 VM proof verification for simple **sum of squares** takes more than 6000 CSPR. The underlying hash used: sha256._

This PR adds host function called `generic_hash(input, type)` with support for the following types:
- `HashAlgoType::Blake2b` - used existing blake2b implementation,
- `HashAlgoType::Blake3b` - blake3 library was introduced.

We expect to add more algorithms, i.e. _sha256_, _keccak_, _poseidon_.

### Example usage

Smart contract:

```rust
#![no_std]
#![no_main]

extern crate alloc;

use alloc::format;
use casper_contract::contract_api::{crypto, runtime};
use casper_types::HashAlgoType;

#[no_mangle]
pub extern "C" fn call() {
    let input = "casper".as_bytes();
    runtime::print(&format!("Input: {:?}", input));

    let blake2b = crypto::generic_hash(input, HashAlgoType::Blake2b);
    runtime::print(&format!("Blake2b hash: {:?}", blake2b));

    let blake3 = crypto::generic_hash(input, HashAlgoType::Blake3);
    runtime::print(&format!("Blake3 hash: {:?}", blake3));
}
```

Node output:

```
Input: [99, 97, 115, 112, 101, 114]
Blake2b hash: [163, 40, 63, 203, 149, 170, 125, 252, 231, 127, 90, 198, 44, 250, 234, 42, 1, 199, 20, 158, 150, 188, 25, 205, 21, 106, 255, 40, 204, 65, 45, 196]
Blake3 hash: [122, 158, 116, 51, 175, 213, 20, 50, 237, 63, 251, 230, 53, 2, 233, 86, 36, 159, 195, 109, 254, 108, 189, 210, 233, 1, 93, 219, 226, 1, 50, 217]
```

---

### Considerations

**1. AssemblyScript support**

Is AssemblyScript binding required? I am pretty sure no one uses it.

**2. Gas cost**

For now, I used the same cost for `generic_hash()` as defined for `blake2()` - default fixed value 200. I can do benchmarks for WASM bytecode execution, but is there any conversion ratio between CPU time and execution cost?

**3. Place for core hashes implementation**

Blake2b is implemented in `types` package, which does not seem to be reasonable. I added blake3 to new module `crypto` in execution engine, but I am not fully sure if this is the correct place.

**4. Single vs multiple host function**

Do we want to introduce separate host functions for each hash algorithm?

**5. Place for `generic_hash()` in contract API**

I was thinking of using `runtime`, but finally decided to create new `crypto` module.