### PR TITLE
Update rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -1881,6 +1881,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3006df2e7bf21592b4983931164020b02f54eefdc1e35b2f70147858cc1e20ad"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2252,17 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5136,6 +5153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "state-initializer"
 version = "0.1.0"
 dependencies = [
@@ -6049,15 +6072,17 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+checksum = "0a7b95ecf5892b48104914fa021721699bb8149ae754cff50a22daeb7df0928f"
 dependencies = [
  "anyhow",
+ "gimli 0.26.2",
  "id-arena",
  "leb128",
  "log",
  "walrus-macro",
+ "wasm-encoder 0.29.0",
  "wasmparser",
 ]
 
@@ -6197,6 +6222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6211,9 +6245,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.77.0"
+version = "0.80.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
+checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "wast"
@@ -6224,7 +6258,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.26.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ default-members = [
 
 exclude = ["utils/nctl/remotes/casper-client-rs"]
 
+resolver = "2"
+
 # Include debug symbols in the release build of `casper-engine-tests` so that `simple-transfer` will yield useful
 # perf data.
 [profile.release.package.casper-engine-tests]

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -261,7 +261,7 @@ pub mod chainspec_protocol_version {
             ),
             DependentFile::new(
                 "node/src/components/rpc_server/rpcs/docs.rs",
-                Regex::new(r#"(?m)(DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =\s*ProtocolVersion::from_parts)\((\d+,\s*\d+,\s*\d+)\)"#).unwrap(),
+                Regex::new(r"(?m)(DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =\s*ProtocolVersion::from_parts)\((\d+,\s*\d+,\s*\d+)\)").unwrap(),
                 rpcs_docs_rs_replacement,
             ),
             DependentFile::new(

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -55,7 +55,7 @@ casper-types = { path = "../types", features = ["datasize", "json-schema", "test
 criterion = "0.3.5"
 proptest = "1.0.0"
 tempfile = "3.4.0"
-walrus = "0.19.0"
+walrus = "0.20.2"
 
 [features]
 default = ["gens"]

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -508,7 +508,7 @@ impl ExecutionResultBuilder {
             }
             Some(ExecutionResult::Success {
                 execution_journal, ..
-            }) => journal.extend(execution_journal.into_iter()),
+            }) => journal.extend(execution_journal),
             None => return Err(ExecutionResultBuilderError::MissingSessionExecutionResult),
         };
 
@@ -521,7 +521,7 @@ impl ExecutionResultBuilder {
             }
             Some(ExecutionResult::Success {
                 execution_journal, ..
-            }) => journal.extend(execution_journal.into_iter()),
+            }) => journal.extend(execution_journal),
             None => return Err(ExecutionResultBuilderError::MissingFinalizeExecutionResult),
         }
 

--- a/execution_engine/src/core/engine_state/op.rs
+++ b/execution_engine/src/core/engine_state/op.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 /// Representation of a single operation during execution.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Default)]
 pub enum Op {
     /// Read value from a `Key`.
     Read,
@@ -15,6 +15,7 @@ pub enum Op {
     /// Add a value into a `Key`.
     Add,
     /// No operation.
+    #[default]
     NoOp,
 }
 
@@ -41,12 +42,6 @@ impl AddAssign for Op {
 impl Display for Op {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl Default for Op {
-    fn default() -> Self {
-        Op::NoOp
     }
 }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -3007,8 +3007,7 @@ where
         }
 
         // A set of keys is converted into a vector so it can be written to a host buffer
-        let authorization_keys =
-            Vec::from_iter(self.context.authorization_keys().clone().into_iter());
+        let authorization_keys = Vec::from_iter(self.context.authorization_keys().clone());
 
         let total_keys: u32 = match authorization_keys.len().try_into() {
             Ok(value) => value,
@@ -3046,8 +3045,7 @@ where
 #[cfg(feature = "test-support")]
 fn dump_runtime_stack_info(instance: casper_wasmi::ModuleRef, max_stack_height: u32) {
     let globals = instance.globals();
-    let Some(current_runtime_call_stack_height) = globals.last()
-    else {
+    let Some(current_runtime_call_stack_height) = globals.last() else {
         return;
     };
 

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -3,7 +3,7 @@
 //! were applied on it.
 mod byte_size;
 mod ext;
-pub(self) mod meter;
+mod meter;
 #[cfg(test)]
 mod tests;
 
@@ -193,10 +193,7 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
     pub fn insert_write(&mut self, key: Key, value: StoredValue) {
         self.muts_cached.insert(key, value);
 
-        let key_set = self
-            .key_tag_muts_cached
-            .entry(key.tag())
-            .or_insert_with(BTreeSet::new);
+        let key_set = self.key_tag_muts_cached.entry(key.tag()).or_default();
 
         key_set.insert(key);
     }

--- a/execution_engine/src/shared/logging/structured_message.rs
+++ b/execution_engine/src/shared/logging/structured_message.rs
@@ -239,9 +239,9 @@ impl<'kvs> Visitor<'kvs> for MessageProperties {
         let value = value
             .to_string()
             .trim_matches('"')
-            .replace(r#"\'"#, r#"'"#)
+            .replace(r"\'", "'")
             .replace(r#"\""#, r#"""#)
-            .replace(r#"\\"#, r#"\"#);
+            .replace(r"\\", r"\");
         self.0.insert(key.to_string(), value);
         Ok(())
     }

--- a/execution_engine/src/shared/newtypes/macros.rs
+++ b/execution_engine/src/shared/newtypes/macros.rs
@@ -16,8 +16,7 @@ macro_rules! make_array_newtype {
 
         impl Clone for $name {
             fn clone(&self) -> $name {
-                let &$name(ref dat) = self;
-                $name(dat.clone())
+                *self
             }
         }
 

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -59,11 +59,12 @@ impl From<CLValueError> for Error {
 /// Note that all arithmetic variants of [`Transform`] are commutative which means that a given
 /// collection of them can be executed in any order to produce the same end result.
 #[allow(clippy::large_enum_variant)]
-#[derive(PartialEq, Eq, Debug, Clone, DataSize)]
+#[derive(PartialEq, Eq, Debug, Clone, DataSize, Default)]
 pub enum Transform {
     /// An identity transformation that does not modify a value in the global state.
     ///
     /// Created as part of a read from the global state.
+    #[default]
     Identity,
     /// Writes a new value in the global state.
     Write(StoredValue),
@@ -330,12 +331,6 @@ impl AddAssign for Transform {
 impl Display for Transform {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl Default for Transform {
-    fn default() -> Self {
-        Transform::Identity
     }
 }
 

--- a/execution_engine/src/storage/trie_store/in_memory.rs
+++ b/execution_engine/src/storage/trie_store/in_memory.rs
@@ -97,7 +97,7 @@ mod tests {
             let txn = env.create_read_txn().unwrap();
 
             // Observe that nothing has been persisted to the store
-            for hash in vec![&leaf_1_hash, &leaf_2_hash, &node_hash].iter() {
+            for hash in [&leaf_1_hash, &leaf_2_hash, &node_hash].iter() {
                 // We need to use a type annotation here to help the compiler choose
                 // a suitable FromBytes instance
                 let maybe_trie: Option<Trie<Bytes, Bytes>> = store.get(&txn, hash).unwrap();

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -698,7 +698,7 @@ where
     Ok(ret)
 }
 
-fn check_keys<K, V, T, S, E>(
+fn check_keys<K, V, T, S>(
     correlation_id: CorrelationId,
     txn: &T,
     store: &S,
@@ -711,7 +711,6 @@ where
     T: Readable<Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,
-    E: From<S::Error> + From<bytesrepr::Error>,
 {
     let expected = {
         let mut tmp = leaves
@@ -774,7 +773,7 @@ where
             .all(bool::not)
     );
 
-    assert!(check_keys::<_, _, _, _, E>(
+    assert!(check_keys::<_, _, _, _>(
         correlation_id,
         &txn,
         store,

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -32,7 +32,7 @@ num-rational = "0.4.0"
 num-traits = "0.2.10"
 once_cell = "1.5.2"
 regex = "1.5.4"
-walrus = "0.19.0"
+walrus = "0.20.2"
 wat = "1.0.47"
 
 [features]

--- a/execution_engine_testing/tests/src/test/regression/gh_3710.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3710.rs
@@ -301,11 +301,11 @@ mod fixture {
             let rewards: Vec<&U512> = era_infos
                 .iter()
                 .flat_map(|era_info| era_info.seigniorage_allocations())
-                .filter_map(|seigniorage| match seigniorage {
+                .map(|seigniorage| match seigniorage {
                     SeigniorageAllocation::Validator {
                         validator_public_key,
                         amount,
-                    } if validator_public_key == &*DEFAULT_ACCOUNT_PUBLIC_KEY => Some(amount),
+                    } if validator_public_key == &*DEFAULT_ACCOUNT_PUBLIC_KEY => amount,
                     SeigniorageAllocation::Validator { .. } => panic!("Unexpected validator"),
                     SeigniorageAllocation::Delegator { .. } => panic!("No delegators"),
                 })

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -147,14 +147,12 @@ fn should_pass_elem_section() {
     );
 
     // wasmi assumes table size and function pointers are equal
-    assert!(matches!(
-        test_element_section(
-            DEFAULT_MAX_TABLE_SIZE,
-            Some(DEFAULT_MAX_TABLE_SIZE),
-            DEFAULT_MAX_TABLE_SIZE
-        ),
-        None
-    ));
+    assert!(test_element_section(
+        DEFAULT_MAX_TABLE_SIZE,
+        Some(DEFAULT_MAX_TABLE_SIZE),
+        DEFAULT_MAX_TABLE_SIZE
+    )
+    .is_none());
 }
 
 fn test_element_section(

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -1911,8 +1911,7 @@ fn should_handle_evictions() {
         let era_validators: EraValidators = builder.get_era_validators();
         let validators = era_validators
             .iter()
-            .rev()
-            .next()
+            .next_back()
             .map(|(_era_id, validators)| validators)
             .expect("should have validators");
         validators.keys().cloned().collect::<BTreeSet<PublicKey>>()
@@ -2557,7 +2556,7 @@ fn should_not_undelegate_vfta_holder_stake() {
             .vesting_schedule()
             .expect("should have vesting schedule");
         assert!(
-            matches!(vesting_schedule.locked_amounts(), Some(_)),
+            vesting_schedule.locked_amounts().is_some(),
             "{:?}",
             vesting_schedule
         );

--- a/hashing/src/chunk_with_proof.rs
+++ b/hashing/src/chunk_with_proof.rs
@@ -138,7 +138,7 @@ mod tests {
     fn prepare_bytes(length: usize) -> Vec<u8> {
         let mut rng = rand::thread_rng();
 
-        (0..length).into_iter().map(|_| rng.gen()).collect()
+        (0..length).map(|_| rng.gen()).collect()
     }
 
     fn random_chunk_with_proof() -> ChunkWithProof {
@@ -204,7 +204,6 @@ mod tests {
                 .unwrap();
 
             assert!((0..number_of_chunks)
-                .into_iter()
                 .map(|chunk_index| { ChunkWithProof::new(data.as_slice(), chunk_index).unwrap() })
                 .all(|chunk_with_proof| chunk_with_proof.verify().is_ok()));
         }

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_hash_rfold() {
-        let hashes = vec![
+        let hashes = [
             Digest([1u8; 32]),
             Digest([2u8; 32]),
             Digest([3u8; 32]),

--- a/node/src/components/block_accumulator/local_tip_identifier.rs
+++ b/node/src/components/block_accumulator/local_tip_identifier.rs
@@ -17,7 +17,7 @@ impl LocalTipIdentifier {
 
 impl PartialOrd for LocalTipIdentifier {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.height.partial_cmp(&other.height)
+        Some(self.cmp(other))
     }
 }
 

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -618,10 +618,7 @@ fn acceptor_should_store_block() {
     let mut acceptor = BlockAcceptor::new(*block.hash(), vec![]);
 
     // Create 4 pairs of keys so we can later create 4 signatures.
-    let keys: Vec<(SecretKey, PublicKey)> = (0..4)
-        .into_iter()
-        .map(|_| generate_ed25519_keypair())
-        .collect();
+    let keys: Vec<(SecretKey, PublicKey)> = (0..4).map(|_| generate_ed25519_keypair()).collect();
     // Register the keys into the era validator weights, front loaded on the
     // first 2 with 80% weight.
     let era_validator_weights = EraValidatorWeights::new(

--- a/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
@@ -11,7 +11,6 @@ use super::*;
 fn gen_test_deploys(rng: &mut TestRng) -> BTreeMap<DeployHash, Deploy> {
     let num_deploys = rng.gen_range(2..15);
     (0..num_deploys)
-        .into_iter()
         .map(|_| {
             let deploy = Deploy::random(rng);
             (*deploy.hash(), deploy)

--- a/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
@@ -15,10 +15,8 @@ fn execution_results_chunks_apply_correctly() {
     let block = Block::random(&mut rng);
 
     // Create chunkable execution results
-    let exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
-        .map(|_| rng.gen())
-        .collect();
+    let exec_results: Vec<ExecutionResult> =
+        (0..NUM_TEST_EXECUTION_RESULTS).map(|_| rng.gen()).collect();
     let test_chunks = chunks_with_proof_from_data(&exec_results.to_bytes().unwrap());
     assert!(test_chunks.len() >= 3);
 
@@ -166,10 +164,8 @@ fn cant_apply_chunk_from_different_exec_results_or_invalid_checksum() {
     let block = Block::random(&mut rng);
 
     // Create valid execution results
-    let valid_exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
-        .map(|_| rng.gen())
-        .collect();
+    let valid_exec_results: Vec<ExecutionResult> =
+        (0..NUM_TEST_EXECUTION_RESULTS).map(|_| rng.gen()).collect();
     let valid_test_chunks = chunks_with_proof_from_data(&valid_exec_results.to_bytes().unwrap());
     assert!(valid_test_chunks.len() >= 3);
 
@@ -351,10 +347,8 @@ fn acquisition_pending_state_has_correct_transitions() {
     );
 
     // Acquisition can transition from `Pending` to `Acquiring` if a single chunk is applied
-    let exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
-        .map(|_| rng.gen())
-        .collect();
+    let exec_results: Vec<ExecutionResult> =
+        (0..NUM_TEST_EXECUTION_RESULTS).map(|_| rng.gen()).collect();
     let test_chunks = chunks_with_proof_from_data(&exec_results.to_bytes().unwrap());
     assert!(test_chunks.len() >= 3);
 
@@ -362,7 +356,6 @@ fn acquisition_pending_state_has_correct_transitions() {
     let exec_result = BlockExecutionResultsOrChunkId::new(*block.hash())
         .response(ValueOrChunk::ChunkWithProof(first_chunk.clone()));
     let deploy_hashes: Vec<DeployHash> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
         .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())))
         .collect();
     assert_matches!(
@@ -380,10 +373,8 @@ fn acquisition_acquiring_state_has_correct_transitions() {
     let block = Block::random(&mut rng);
 
     // Generate valid execution results that are chunkable
-    let exec_results: Vec<ExecutionResult> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
-        .map(|_| rng.gen())
-        .collect();
+    let exec_results: Vec<ExecutionResult> =
+        (0..NUM_TEST_EXECUTION_RESULTS).map(|_| rng.gen()).collect();
     let test_chunks = chunks_with_proof_from_data(&exec_results.to_bytes().unwrap());
     assert!(test_chunks.len() >= 3);
 
@@ -417,7 +408,6 @@ fn acquisition_acquiring_state_has_correct_transitions() {
     let exec_result = BlockExecutionResultsOrChunkId::new(*block.hash())
         .response(ValueOrChunk::ChunkWithProof(last_chunk.clone()));
     let deploy_hashes: Vec<DeployHash> = (0..NUM_TEST_EXECUTION_RESULTS)
-        .into_iter()
         .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())))
         .collect();
     acquisition = assert_matches!(

--- a/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer/tests.rs
@@ -78,7 +78,7 @@ impl MockReactor {
 }
 
 fn random_test_trie(rng: &mut TestRng) -> TrieRaw {
-    let data: Vec<u8> = (0..64).into_iter().map(|_| rng.gen()).collect();
+    let data: Vec<u8> = (0..64).map(|_| rng.gen()).collect();
     TrieRaw::new(Bytes::from(data))
 }
 
@@ -210,7 +210,6 @@ async fn sync_global_state_request_starts_maximum_trie_fetches() {
         // root node would have some children that we haven't yet downloaded
         Err(engine_state::Error::MissingTrieNodeChildren(
             (0u8..255)
-                .into_iter()
                 // TODO: generate random hashes when `rng.gen` works
                 .map(|i| Digest::hash([i; 32]))
                 .collect(),
@@ -497,7 +496,6 @@ async fn missing_trie_node_children_triggers_fetch() {
     // We generate more than the parallel_fetch_limit.
     let num_missing_trie_nodes = rng.gen_range(12..20);
     let missing_tries: Vec<TrieRaw> = (0..num_missing_trie_nodes)
-        .into_iter()
         .map(|_| random_test_trie(&mut rng))
         .collect();
     let missing_trie_nodes_hashes: Vec<Digest> = missing_tries

--- a/node/src/components/block_synchronizer/peer_list/tests.rs
+++ b/node/src/components/block_synchronizer/peer_list/tests.rs
@@ -19,10 +19,7 @@ impl PeerList {
 
 // Create multiple random peers
 fn random_peers(rng: &mut TestRng, num_random_peers: usize) -> HashSet<NodeId> {
-    (0..num_random_peers)
-        .into_iter()
-        .map(|_| NodeId::random(rng))
-        .collect()
+    (0..num_random_peers).map(|_| NodeId::random(rng)).collect()
 }
 
 #[test]

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -95,7 +95,7 @@ impl MockReactor {
     ) -> Vec<MockReactorEvent> {
         let mut events = Vec::new();
         for effect in effects {
-            tokio::spawn(async move { effect.await });
+            tokio::spawn(effect);
             let event = self.crank().await;
             events.push(event);
         }
@@ -661,7 +661,7 @@ async fn should_not_stall_after_registering_new_era_validator_weights() {
 
     // bleed off the event q, checking the expected event kind
     for effect in effects {
-        tokio::spawn(async move { effect.await });
+        tokio::spawn(effect);
         let event = mock_reactor.crank().await;
         match event {
             MockReactorEvent::SyncLeapFetcherRequest(_) => (),

--- a/node/src/components/block_synchronizer/tests/test_utils.rs
+++ b/node/src/components/block_synchronizer/tests/test_utils.rs
@@ -7,7 +7,6 @@ use rand::Rng;
 
 pub(crate) fn chunks_with_proof_from_data(data: &[u8]) -> BTreeMap<u64, ChunkWithProof> {
     (0..data.chunks(ChunkWithProof::CHUNK_SIZE_BYTES).count())
-        .into_iter()
         .map(|index| {
             (
                 index as u64,
@@ -22,7 +21,6 @@ pub(crate) fn test_chunks_with_proof(
 ) -> (Vec<ChunkWithProof>, Vec<TrieOrChunkId>, Vec<u8>) {
     let mut rng = rand::thread_rng();
     let data: Vec<u8> = (0..ChunkWithProof::CHUNK_SIZE_BYTES * num_chunks as usize)
-        .into_iter()
         .map(|_| rng.gen())
         .collect();
 

--- a/node/src/components/block_synchronizer/trie_accumulator/tests.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator/tests.rs
@@ -131,10 +131,7 @@ async fn failed_fetch_retriggers_download_with_different_peer() {
     let (_, chunk_ids, _) = test_chunks_with_proof(1);
 
     // Create multiple peers
-    let peers: Vec<NodeId> = (0..2)
-        .into_iter()
-        .map(|_| NodeId::random(&mut rng))
-        .collect();
+    let peers: Vec<NodeId> = (0..2).map(|_| NodeId::random(&mut rng)).collect();
 
     let chunks = PartialChunks {
         peers: peers.clone(),

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -1,6 +1,6 @@
 //! The consensus component. Provides distributed consensus among the nodes in the network.
 
-#![warn(clippy::integer_arithmetic)]
+#![warn(clippy::arithmetic_side_effects)]
 
 mod cl_context;
 mod config;
@@ -71,10 +71,10 @@ pub(crate) use validator_change::ValidatorChange;
 
 const COMPONENT_NAME: &str = "consensus";
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use casper_types::{EraId, PublicKey};
     use datasize::DataSize;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -466,7 +466,7 @@ impl EraSupervisor {
         let seed = Self::era_seed(booking_block_hash, key_block.accumulated_seed());
 
         // The beginning of the new era is marked by the key block.
-        #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
+        #[allow(clippy::arithmetic_side_effects)] // Block height should never reach u64::MAX.
         let start_height = key_block.height() + 1;
         let start_time = key_block.timestamp();
 
@@ -947,7 +947,7 @@ impl EraSupervisor {
         self.open_eras.get_mut(&era_id).unwrap()
     }
 
-    #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
+    #[allow(clippy::arithmetic_side_effects)] // Block height should never reach u64::MAX.
     fn handle_consensus_outcome<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -194,7 +194,7 @@ impl<C: Context> ActiveValidator<C> {
             if timestamp == r_id && state.leader(r_id) == self.vidx {
                 effects.extend(self.request_new_block(state, instance_id, timestamp));
                 return effects;
-            } else if timestamp == r_id + self.witness_offset(r_len) {
+            } else if timestamp == r_id.saturating_add(self.witness_offset(r_len)) {
                 let panorama = self.panorama_at(state, timestamp);
                 if let Some(witness_unit) =
                     self.new_unit(panorama, timestamp, None, state, instance_id)
@@ -213,7 +213,10 @@ impl<C: Context> ActiveValidator<C> {
         // We are not creating a new unit. Send a ping once per maximum-length round, to show that
         // we're online.
         let one_max_round_ago = timestamp.saturating_sub(state.params().max_round_length());
-        if !state.has_ping(self.vidx, one_max_round_ago + TimeDiff::from_millis(1)) {
+        if !state.has_ping(
+            self.vidx,
+            one_max_round_ago.saturating_add(TimeDiff::from_millis(1)),
+        ) {
             warn!(%timestamp, "too many validators offline, sending ping");
             effects.push(self.send_ping(timestamp, instance_id));
         }
@@ -230,6 +233,7 @@ impl<C: Context> ActiveValidator<C> {
     /// tolerance threshold, always counting this validator as online.
     fn enough_validators_online(&self, state: &State<C>, now: Timestamp) -> bool {
         // We divide before adding, because  total_weight + target_fft  could overflow u64.
+        #[allow(clippy::arithmetic_side_effects)]
         let target_quorum = state.total_weight() / 2 + self.target_ftt / 2;
         let online_weight: Weight = state
             .weights()
@@ -446,6 +450,7 @@ impl<C: Context> ActiveValidator<C> {
         }
         let seq_number = panorama.next_seq_num(state, self.vidx);
         let endorsed = state.seen_endorsed(&panorama);
+        #[allow(clippy::arithmetic_side_effects)] // min_round_length is guaranteed to be > 0.
         let round_exp = (self.round_len(state, timestamp) / state.params().min_round_length())
             .trailing_zeros() as u8;
         let hwunit = WireUnit {
@@ -480,15 +485,15 @@ impl<C: Context> ActiveValidator<C> {
         }
         let r_len = self.round_len(state, timestamp);
         let r_id = state::round_id(timestamp, r_len);
-        self.next_timer = if timestamp < r_id + self.witness_offset(r_len) {
-            r_id + self.witness_offset(r_len)
+        self.next_timer = if timestamp < r_id.saturating_add(self.witness_offset(r_len)) {
+            r_id.saturating_add(self.witness_offset(r_len))
         } else {
-            let next_r_id = r_id + r_len;
+            let next_r_id = r_id.saturating_add(r_len);
             if state.leader(next_r_id) == self.vidx {
                 next_r_id
             } else {
                 let next_r_len = self.round_len(state, next_r_id);
-                next_r_id + self.witness_offset(next_r_len)
+                next_r_id.saturating_add(self.witness_offset(next_r_len))
             }
         };
         vec![Effect::ScheduleTimer(self.next_timer)]
@@ -501,7 +506,8 @@ impl<C: Context> ActiveValidator<C> {
             .map_or(state.params().start_timestamp(), |unit| {
                 unit.previous().map_or(unit.timestamp, |vh2| {
                     let unit2 = state.unit(vh2);
-                    unit.timestamp.max(unit2.round_id() + unit2.round_len())
+                    unit.timestamp
+                        .max(unit2.round_id().saturating_add(unit2.round_len()))
                 })
             })
     }
@@ -524,6 +530,7 @@ impl<C: Context> ActiveValidator<C> {
     }
 
     /// Returns the duration after the beginning of a round when the witness units are sent.
+    #[allow(clippy::arithmetic_side_effects)] // Round length will never be large enough to overflow.
     fn witness_offset(&self, round_len: TimeDiff) -> TimeDiff {
         round_len * 2 / 3
     }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -653,7 +653,7 @@ pub(crate) fn write_last_unit<C: Context>(
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_arithmetic)] // Overflows in tests panic anyway.
+#[allow(clippy::arithmetic_side_effects)] // Overflows in tests panic anyway.
 mod tests {
     use std::{collections::BTreeSet, fmt::Debug};
     use tempfile::tempdir;

--- a/node/src/components/consensus/highway_core/evidence.rs
+++ b/node/src/components/consensus/highway_core/evidence.rs
@@ -34,10 +34,10 @@ pub enum EvidenceError {
     Signature,
 }
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use datasize::DataSize;
     use serde::{Deserialize, Serialize};

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -130,7 +130,7 @@ impl<C: Context> FinalityDetector<C> {
     }
 
     /// Returns the quorum required by a summit with the specified level and the required FTT.
-    #[allow(clippy::integer_arithmetic)] // See comments.
+    #[allow(clippy::arithmetic_side_effects)] // See comments.
     fn quorum_for_lvl(&self, lvl: usize, total_w: Weight) -> Weight {
         // A level-lvl summit with quorum  total_w/2 + t  has relative FTT  2t(1 − 1/2^lvl). So:
         // quorum = total_w / 2 + ftt / 2 / (1 - 1/2^lvl)
@@ -158,7 +158,7 @@ impl<C: Context> FinalityDetector<C> {
     /// Returns the height of the next block that will be finalized.
     fn next_height(&self, state: &State<C>) -> u64 {
         // In a trillion years, we need to make block height u128.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let height_plus_1 = |bhash| state.block(bhash).height + 1;
         self.last_finalized.as_ref().map_or(0, height_plus_1)
     }
@@ -208,7 +208,7 @@ impl<C: Context> FinalityDetector<C> {
     }
 }
 
-#[allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.
+#[allow(unused_qualifications, clippy::arithmetic_side_effects)] // This is to suppress warnings originating in the test macros.
 #[cfg(test)]
 mod tests {
     use super::{

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -55,7 +55,7 @@ pub fn assigned_weight_and_latest_unit<'a, 'b: 'a, 'c: 'a, C: Context>(
             RoundParticipation::No => (),
             RoundParticipation::Yes(latest_vh) => latest[idx] = Some(latest_vh),
         }
-        assigned_weight += state.weight(idx);
+        assigned_weight = assigned_weight.saturating_add(state.weight(idx));
     }
     (assigned_weight, latest)
 }
@@ -72,7 +72,8 @@ pub fn find_max_quora<C: Context>(
     let mut max_quorum = ValidatorMap::from(vec![Weight(0); latest.len()]);
     while let Some(quorum) = horizon.committee_quorum(&committee) {
         // The current committee is a level-1 summit with `quorum`. Try to go higher:
-        let (new_committee, pruned) = horizon.prune_committee(quorum + Weight(1), committee);
+        let (new_committee, pruned) =
+            horizon.prune_committee(quorum.saturating_add(Weight(1)), committee);
         committee = new_committee;
         // Pruned validators are not part of any summit with a higher quorum than this.
         for vidx in pruned {

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -103,7 +103,7 @@ pub fn compute_rewards_for<C: Context>(
     let faulty_w: Weight = panorama.iter_faulty().map(|vidx| state.weight(vidx)).sum();
 
     // Collect the block rewards for each validator who is a member of at least one summit.
-    #[allow(clippy::integer_arithmetic)] // See inline comments.
+    #[allow(clippy::arithmetic_side_effects)] // See inline comments.
     max_quorum
         .enumerate()
         .zip(state.weights())
@@ -161,7 +161,7 @@ pub fn round_participation<'a, C: Context>(
     maybe_unit.map_or(RoundParticipation::No, |(vh, unit)| {
         // Round length is not 0:
         // It is computed as 2^round_exp * min_round_length from a valid WireUnit.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         if r_id.millis() % unit.round_len.millis() != 0 {
             // Round length doesn't divide `r_id`, so the validator was not assigned to that round.
             RoundParticipation::Unassigned
@@ -175,7 +175,7 @@ pub fn round_participation<'a, C: Context>(
 }
 
 #[allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.
-#[allow(clippy::integer_arithmetic)] // Overflows in tests would panic anyway.
+#[allow(clippy::arithmetic_side_effects)] // Overflows in tests would panic anyway.
 #[cfg(test)]
 mod tests {
     use casper_types::TimeDiff;

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -72,8 +72,11 @@ pub fn find_max_quora<C: Context>(
     let mut max_quorum = ValidatorMap::from(vec![Weight(0); latest.len()]);
     while let Some(quorum) = horizon.committee_quorum(&committee) {
         // The current committee is a level-1 summit with `quorum`. Try to go higher:
-        let (new_committee, pruned) =
-            horizon.prune_committee(quorum.saturating_add(Weight(1)), committee);
+        let new_quorum = match quorum.checked_add(Weight(1)) {
+            Some(weight) => weight,
+            None => break, // we reached the maximum, it's valid, so just return it.
+        };
+        let (new_committee, pruned) = horizon.prune_committee(new_quorum, committee);
         committee = new_committee;
         // Pruned validators are not part of any summit with a higher quorum than this.
         for vidx in pruned {

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -732,7 +732,7 @@ impl<C: Context> Highway<C> {
             state.params().start_timestamp()
         };
         for skipped_r_id in (1..=MAX_SKIPPED_PROPOSAL_LOGS)
-            .map(|i| r_id.saturating_sub(state.params().min_round_length().saturating_mul(i)))
+            .filter_map(|i| r_id.checked_sub(state.params().min_round_length().checked_mul(i)?))
             .take_while(|skipped_r_id| *skipped_r_id > parent_timestamp)
         {
             let leader_index = state.leader(skipped_r_id);

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -223,7 +223,7 @@ impl<C: Context> Highway<C> {
 
     /// Gets the round exponent for the next message this instance will create.
     #[cfg(test)]
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     pub(crate) fn get_round_exp(&self) -> Option<u8> {
         self.active_validator.as_ref().map(|av| {
             (av.next_round_length().millis() / self.state.params().min_round_length().millis())
@@ -770,6 +770,7 @@ impl<C: Context> Highway<C> {
 }
 
 #[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)]
 pub(crate) mod tests {
     use std::{collections::BTreeSet, iter::FromIterator};
 

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -732,7 +732,7 @@ impl<C: Context> Highway<C> {
             state.params().start_timestamp()
         };
         for skipped_r_id in (1..=MAX_SKIPPED_PROPOSAL_LOGS)
-            .map(|i| r_id.saturating_sub(state.params().min_round_length() * i))
+            .map(|i| r_id.saturating_sub(state.params().min_round_length().saturating_mul(i)))
             .take_while(|skipped_r_id| *skipped_r_id > parent_timestamp)
         {
             let leader_index = state.leader(skipped_r_id);

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -15,10 +15,10 @@ use crate::components::consensus::{
     utils::{ValidatorIndex, Validators},
 };
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use casper_types::Timestamp;
     use datasize::DataSize;

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)] // In tests, overflows panic anyway.
+#![allow(clippy::arithmetic_side_effects)] // In tests, overflows panic anyway.
 
 use std::{
     collections::{hash_map::DefaultHasher, HashMap, VecDeque},

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -688,12 +688,12 @@ impl<C: Context> State<C> {
         if block.height == height {
             return Some(hash);
         }
-        #[allow(clippy::integer_arithmetic)] // block.height > height, otherwise we returned.
+        #[allow(clippy::arithmetic_side_effects)] // block.height > height, otherwise we returned.
         let diff = block.height - height;
         // We want to make the greatest step 2^i such that 2^i <= diff.
         let max_i = log2(diff) as usize;
         // A block at height > 0 always has at least its parent entry in skip_idx.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let i = max_i.min(block.skip_idx.len() - 1);
         self.find_ancestor_proposal(&block.skip_idx[i], height)
     }
@@ -711,7 +711,7 @@ impl<C: Context> State<C> {
             return Err(UnitError::Banned);
         }
         let rl_millis = self.params.min_round_length().millis();
-        #[allow(clippy::integer_arithmetic)] // We check for overflow before the left shift.
+        #[allow(clippy::arithmetic_side_effects)] // We check for overflow before the left shift.
         if wunit.round_exp as u32 > rl_millis.leading_zeros()
             || rl_millis << wunit.round_exp > self.params.max_round_length().millis()
         {
@@ -745,7 +745,7 @@ impl<C: Context> State<C> {
         if wunit.seq_number != panorama.next_seq_num(self, creator) {
             return Err(UnitError::SequenceNumber);
         }
-        #[allow(clippy::integer_arithmetic)] // We checked for overflow in pre_validate_unit.
+        #[allow(clippy::arithmetic_side_effects)] // We checked for overflow in pre_validate_unit.
         let round_len =
             TimeDiff::from_millis(self.params.min_round_length().millis() << wunit.round_exp);
         let r_id = round_id(timestamp, round_len);
@@ -755,7 +755,7 @@ impl<C: Context> State<C> {
                 // The round length must not change within a round: Even with respect to the
                 // greater of the two lengths, a round boundary must be between the units.
                 let max_rl = prev_unit.round_len().max(round_len);
-                #[allow(clippy::integer_arithmetic)] // max_rl is always greater than 0.
+                #[allow(clippy::arithmetic_side_effects)] // max_rl is always greater than 0.
                 if prev_unit.timestamp.millis() / max_rl.millis()
                     == timestamp.millis() / max_rl.millis()
                 {
@@ -842,7 +842,7 @@ impl<C: Context> State<C> {
                 let max_i = log2(diff) as usize; // Log is safe because diff is not zero.
 
                 // Diff is not zero, so the unit has a predecessor and skip_idx is not empty.
-                #[allow(clippy::integer_arithmetic)]
+                #[allow(clippy::arithmetic_side_effects)]
                 let i = max_i.min(unit.skip_idx.len() - 1);
                 self.find_in_swimlane(&unit.skip_idx[i], seq_number)
             }
@@ -1124,7 +1124,7 @@ pub(crate) fn round_id(timestamp: Timestamp, round_len: TimeDiff) -> Timestamp {
         error!("called round_id with round_len 0.");
         return timestamp;
     }
-    #[allow(clippy::integer_arithmetic)] // Checked for division by 0 above.
+    #[allow(clippy::arithmetic_side_effects)] // Checked for division by 0 above.
     Timestamp::from((timestamp.millis() / round_len.millis()) * round_len.millis())
 }
 

--- a/node/src/components/consensus/highway_core/state/block.rs
+++ b/node/src/components/consensus/highway_core/state/block.rs
@@ -33,7 +33,7 @@ impl<C: Context> Block<C> {
             Some(hash) => (state.block(&hash), vec![hash]),
         };
         // In a trillion years, we need to make block height u128.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let height = parent.height + 1;
         for i in 0..height.trailing_zeros() as usize {
             let ancestor = state.block(&skip_idx[i]);

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -13,10 +13,10 @@ use crate::components::consensus::{
     utils::{ValidatorIndex, ValidatorMap},
 };
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use datasize::DataSize;
     use serde::{Deserialize, Serialize};
@@ -154,7 +154,7 @@ impl<C: Context> Panorama<C> {
     /// Returns the correct sequence number for a new unit by `vidx` with this panorama.
     pub(crate) fn next_seq_num(&self, state: &State<C>, vidx: ValidatorIndex) -> u64 {
         // In a trillion years, we need to make seq number u128.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let add1 = |vh: &C::Hash| state.unit(vh).seq_number + 1;
         self[vidx].correct().map_or(0, add1)
     }

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -151,7 +151,8 @@ impl<'a, C: Context> Tallies<'a, C> {
             // If any block received more than 50%, a decision can be made: Either that block is
             // the fork choice, or we can pick its highest scoring child from `prev_tally`.
             if h_tally.max_w() > total_weight / 2 {
-                #[allow(clippy::integer_arithmetic)] // height < max_height, so height < u64::MAX
+                #[allow(clippy::arithmetic_side_effects)]
+                // height < max_height, so height < u64::MAX
                 return Some(
                     match prev_tally.filter_descendants(height, h_tally.max_bhash(), state) {
                         Some(filtered) => (height + 1, filtered.max_bhash()),
@@ -196,6 +197,7 @@ impl<'a, C: Context> Tallies<'a, C> {
 }
 
 #[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)]
 mod tests {
     use super::{
         super::{tests::*, State},

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -65,7 +65,7 @@ impl<'a, C: Context> Tally<'a, C> {
     /// Adds a vote for a block to the tally, possibly updating the current maximum.
     fn add(&mut self, bhash: &'a C::Hash, weight: Weight) {
         let w = self.votes.entry(bhash).or_default();
-        *w += weight;
+        *w = (*w).saturating_add(weight);
         self.max = (*w, bhash).max(self.max);
     }
 
@@ -150,8 +150,8 @@ impl<'a, C: Context> Tallies<'a, C> {
             }
             // If any block received more than 50%, a decision can be made: Either that block is
             // the fork choice, or we can pick its highest scoring child from `prev_tally`.
+            #[allow(clippy::arithmetic_side_effects)]
             if h_tally.max_w() > total_weight / 2 {
-                #[allow(clippy::arithmetic_side_effects)]
                 // height < max_height, so height < u64::MAX
                 return Some(
                     match prev_tally.filter_descendants(height, h_tally.max_bhash(), state) {

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -1,5 +1,5 @@
 #![allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.
-#![allow(clippy::integer_arithmetic)] // Overflows in tests would panic anyway.
+#![allow(clippy::arithmetic_side_effects)] // Overflows in tests would panic anyway.
 
 use std::{
     collections::{hash_map::DefaultHasher, BTreeSet},

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -83,7 +83,7 @@ impl<C: Context> Unit<C> {
                 skip_idx.push(old_unit.skip_idx[i]);
             }
         }
-        #[allow(clippy::integer_arithmetic)] // Only called with valid units.
+        #[allow(clippy::arithmetic_side_effects)] // Only called with valid units.
         let round_len =
             TimeDiff::from_millis(state.params().min_round_length().millis() << wunit.round_exp);
         let unit = Unit {

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -49,7 +49,7 @@ impl<C: Context> PendingVertices<C> {
         }
         self.0.retain(|pvv, time_by_peer| {
             if time_by_peer.is_empty() {
-                removed.extend(pvv.inner().unit_hash().into_iter());
+                removed.extend(pvv.inner().unit_hash());
                 false
             } else {
                 true

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use std::collections::BTreeSet;
 
 use itertools::Itertools;
@@ -103,7 +105,7 @@ fn purge_vertices() {
     // * b0: in the main queue
     // * c2: waiting for dependency c1 to be added
     let purge_vertex_timeout = 0x20;
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     sync.purge_vertices((0x41 - purge_vertex_timeout).into());
 
     // The main queue should now contain only c1. If we remove it, the synchronizer is empty.

--- a/node/src/components/consensus/protocols/common.rs
+++ b/node/src/components/consensus/protocols/common.rs
@@ -21,7 +21,7 @@ pub fn validators<C: Context>(
 ) -> Validators<C::ValidatorId> {
     let sum_stakes = safe_sum(validator_stakes.values().copied()).expect("should not overflow");
     // We use u64 weights. Scale down by floor(sum / u64::MAX) + 1.
-    // This guarantees that the resulting sum is greater than 0 less than u64::MAX.
+    // This guarantees that the resulting sum is greater than 0 and less than u64::MAX.
     #[allow(clippy::arithmetic_side_effects)] // Divisor isn't 0 and addition can't overflow.
     let scaling_factor: U512 = sum_stakes / U512::from(u64::MAX) + 1;
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -14,6 +14,8 @@ use std::{
 
 use datasize::DataSize;
 use itertools::Itertools;
+use num_rational::Ratio;
+use num_traits::CheckedMul;
 use rand::RngCore;
 use tracing::{debug, error, info, trace, warn};
 
@@ -114,6 +116,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         // The maximum round exponent x is such that 2^x * m is at most M, where m and M are min
         // and max round length. So x is the floor of log_2(M / m). Thus the ceiling of
         // log_2(M / m + 1) is always x + 1.
+        #[allow(clippy::arithmetic_side_effects)] // minimum_round_length is guaranteed to be > 0.
         let maximum_round_exponent = (highway_config.maximum_round_length / minimum_round_length)
             .saturating_add(1)
             .next_power_of_two()
@@ -159,16 +162,23 @@ impl<C: Context + 'static> HighwayProtocol<C> {
             0
         };
 
+        let reduced_block_reward = match highway_config
+            .reduced_reward_multiplier
+            .checked_mul(&Ratio::from(block_reward))
+        {
+            None => u64::MAX,
+            Some(ratio) => ratio.to_integer(),
+        };
         let params = Params::new(
             seed,
             block_reward,
-            (highway_config.reduced_reward_multiplier * block_reward).to_integer(),
+            reduced_block_reward,
             minimum_round_length,
             maximum_round_length,
             init_round_len,
             chainspec.core_config.minimum_era_height,
             era_start_time,
-            era_start_time + chainspec.core_config.era_duration,
+            era_start_time.saturating_add(chainspec.core_config.era_duration),
             endorsement_evidence_limit,
         );
 
@@ -195,18 +205,18 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         config: &config::Config,
     ) -> ProtocolOutcomes<C> {
         let mut outcomes = vec![ProtocolOutcome::ScheduleTimer(
-            now + config.pending_vertex_timeout,
+            now.saturating_add(config.pending_vertex_timeout),
             TIMER_ID_PURGE_VERTICES,
         )];
         if let Some(interval) = config.log_participation_interval {
             outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now.max(era_start_time) + interval,
+                now.max(era_start_time).saturating_add(interval),
                 TIMER_ID_LOG_PARTICIPATION,
             ));
         }
         if let Some(interval) = config.log_synchronizer_interval {
             outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now + interval,
+                now.saturating_add(interval),
                 TIMER_ID_SYNCHRONIZER_LOG,
             ));
         }
@@ -466,7 +476,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         let mut outcomes = self.latest_state_request();
         if let Some(interval) = self.config.request_state_interval {
             outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now + interval,
+                now.saturating_add(interval),
                 TIMER_ID_REQUEST_STATE,
             ));
         }
@@ -785,7 +795,9 @@ where
                 }
 
                 match pvv.timestamp() {
-                    Some(timestamp) if timestamp > now + self.config.pending_vertex_timeout => {
+                    Some(timestamp)
+                        if timestamp > now.saturating_add(self.config.pending_vertex_timeout) =>
+                    {
                         trace!("received a vertex with a timestamp far in the future; dropping");
                         vec![]
                     }
@@ -933,14 +945,14 @@ where
                 let oldest = timestamp.saturating_sub(self.config.pending_vertex_timeout);
                 self.synchronizer.purge_vertices(oldest);
                 self.pvv_cache.clear();
-                let next_time = timestamp + self.config.pending_vertex_timeout;
+                let next_time = timestamp.saturating_add(self.config.pending_vertex_timeout);
                 vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
             }
             TIMER_ID_LOG_PARTICIPATION => match self.config.log_participation_interval {
                 Some(interval) if !self.evidence_only && !self.finalized_switch_block() => {
                     self.log_participation();
                     vec![ProtocolOutcome::ScheduleTimer(
-                        timestamp + interval,
+                        timestamp.saturating_add(interval),
                         timer_id,
                     )]
                 }
@@ -952,7 +964,7 @@ where
                 match self.config.log_synchronizer_interval {
                     Some(interval) if !self.finalized_switch_block() => {
                         vec![ProtocolOutcome::ScheduleTimer(
-                            timestamp + interval,
+                            timestamp.saturating_add(interval),
                             timer_id,
                         )]
                     }
@@ -969,7 +981,7 @@ where
         // If configured, schedule periodic latest state requests.
         if let Some(interval) = self.config.request_state_interval {
             outcomes.push(ProtocolOutcome::ScheduleTimer(
-                now + interval,
+                now.saturating_add(interval),
                 TIMER_ID_REQUEST_STATE,
             ));
         }
@@ -1150,5 +1162,6 @@ pub fn max_rounds_per_era(
     era_duration: TimeDiff,
     minimum_round_length: TimeDiff,
 ) -> u64 {
-    minimum_era_height.max((TimeDiff::from_millis(1) + era_duration) / minimum_round_length)
+    #[allow(clippy::arithmetic_side_effects)] // minimum_round_length is guaranteed to be > 0.
+    minimum_era_height.max((era_duration.saturating_add(1)) / minimum_round_length)
 }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -120,7 +120,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
             .trailing_zeros()
             .saturating_sub(1) as u8;
         // Doesn't overflow since it's at most highway_config.maximum_round_length.
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let maximum_round_length =
             TimeDiff::from_millis(minimum_round_length.millis() << maximum_round_exponent);
 
@@ -361,7 +361,9 @@ impl<C: Context + 'static> HighwayProtocol<C> {
     }
 
     fn calculate_round_length(&mut self) {
-        let Some(performance_meter) = self.performance_meter.as_mut() else { return; };
+        let Some(performance_meter) = self.performance_meter.as_mut() else {
+            return;
+        };
 
         let new_round_len = performance_meter.calculate_new_length(self.highway.state());
         self.highway.set_round_len(new_round_len);
@@ -591,7 +593,6 @@ impl<C: Context + 'static> HighwayProtocol<C> {
                         unit_seq_number,
                     }
                 })
-                .into_iter()
                 .collect()
         } else {
             // We're ahead.
@@ -631,7 +632,6 @@ impl<C: Context + 'static> HighwayProtocol<C> {
                                 .wire_unit(unit, *self.highway.instance_id())
                                 .map(|swu| HighwayMessage::NewVertex(Vertex::Unit(swu)))
                         })
-                        .into_iter()
                         .collect(),
                 },
             }
@@ -645,10 +645,10 @@ impl<C: Context + 'static> HighwayProtocol<C> {
     }
 }
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use datasize::DataSize;
     use serde::{Deserialize, Serialize};

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -39,7 +39,11 @@ impl Status {
         if state.panorama()[idx].is_none() {
             return Some(Status::Inactive);
         }
-        if state.last_seen(idx) + state.params().max_round_length() < now {
+        if state
+            .last_seen(idx)
+            .saturating_add(state.params().max_round_length())
+            < now
+        {
             let seconds = now.saturating_diff(state.last_seen(idx)).millis() / 1000;
             return Some(Status::LastSeenSecondsAgo(seconds));
         }

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -65,7 +65,7 @@ where
 impl<C: Context> Participation<C> {
     /// Creates a new `Participation` map, showing validators seen as faulty or inactive by the
     /// Highway instance.
-    #[allow(clippy::integer_arithmetic)] // We use u128 to prevent overflows in weight calculation.
+    #[allow(clippy::arithmetic_side_effects)] // We use u128 to prevent overflows in weight calculation.
     pub(crate) fn new(highway: &Highway<C>) -> Self {
         let now = Timestamp::now();
         let state = highway.state();

--- a/node/src/components/consensus/protocols/highway/performance_meter.rs
+++ b/node/src/components/consensus/protocols/highway/performance_meter.rs
@@ -114,7 +114,7 @@ impl PerformanceMeter {
         let current_round_id = state.unit(latest_block).round_id();
         let current_round_index = round_index(current_round_id, self.current_round_len);
 
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         if avg_max_quorum < SLOW_DOWN_THRESHOLD {
             let new_round_len = min(self.current_round_len * 2, self.max_round_len);
             if new_round_len != self.current_round_len {
@@ -136,7 +136,7 @@ impl PerformanceMeter {
 }
 
 /// Returns the round index `i`, if `r_id` is the ID of the `i`-th round after the epoch.
-#[allow(clippy::integer_arithmetic)] // Checking for division by 0.
+#[allow(clippy::arithmetic_side_effects)] // Checking for division by 0.
 fn round_index(r_id: Timestamp, round_len: TimeDiff) -> u64 {
     if round_len.millis() == 0 {
         error!("called round_index with round_len 0.");

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -42,7 +42,7 @@ where
     I: IntoIterator<Item = T>,
     T: Into<Weight>,
 {
-    #[allow(clippy::integer_arithmetic)] // Left shift with small enough constants.
+    #[allow(clippy::arithmetic_side_effects)] // Left shift with small enough constants.
     let params = state::Params::new(
         seed,
         highway_testing::TEST_BLOCK_REWARD,

--- a/node/src/components/consensus/protocols/highway/tests/consensus_environment.rs
+++ b/node/src/components/consensus/protocols/highway/tests/consensus_environment.rs
@@ -1,5 +1,5 @@
 // This is a test module, so we're not worried about integer arithmetic here.
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -1243,9 +1243,9 @@ impl<C: Context + 'static> Zug<C> {
                 );
                 self.proposals_waiting_for_parent
                     .entry(parent_round_id)
-                    .or_insert_with(HashMap::new)
+                    .or_default()
                     .entry(hashed_prop)
-                    .or_insert_with(HashSet::new)
+                    .or_default()
                     .insert((round_id, sender));
                 return vec![];
             }

--- a/node/src/components/consensus/protocols/zug/des_testing.rs
+++ b/node/src/components/consensus/protocols/zug/des_testing.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)] // In tests, overflows panic anyway.
+#![allow(clippy::arithmetic_side_effects)] // In tests, overflows panic anyway.
 
 use std::{
     collections::{hash_map::DefaultHasher, HashMap, VecDeque},

--- a/node/src/components/consensus/protocols/zug/message.rs
+++ b/node/src/components/consensus/protocols/zug/message.rs
@@ -14,10 +14,10 @@ use crate::{
     utils::ds,
 };
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod relaxed {
     // This module exists solely to exempt the `EnumDiscriminants` macro generated code from the
-    // module-wide `clippy::integer_arithmetic` lint.
+    // module-wide `clippy::arithmetic_side_effects` lint.
 
     use datasize::DataSize;
     use serde::{Deserialize, Serialize};

--- a/node/src/components/consensus/protocols/zug/round.rs
+++ b/node/src/components/consensus/protocols/zug/round.rs
@@ -98,7 +98,7 @@ impl<C: Context> Round<C> {
     ) -> bool {
         self.echoes
             .entry(hash)
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(validator_idx, signature)
             .is_none()
     }

--- a/node/src/components/consensus/utils/validators.rs
+++ b/node/src/components/consensus/utils/validators.rs
@@ -346,6 +346,7 @@ impl<'a, T> IntoIterator for &'a ValidatorMap<T> {
 impl<Rhs, T: Copy + Add<Rhs, Output = T>> Add<ValidatorMap<Rhs>> for ValidatorMap<T> {
     type Output = ValidatorMap<T>;
     fn add(mut self, rhs: ValidatorMap<Rhs>) -> Self::Output {
+        #[allow(clippy::arithmetic_side_effects)]
         self.0
             .iter_mut()
             .zip(rhs)

--- a/node/src/components/consensus/utils/weight.rs
+++ b/node/src/components/consensus/utils/weight.rs
@@ -40,6 +40,11 @@ impl Weight {
         Weight(self.0.saturating_add(rhs.0))
     }
 
+    /// Saturating subtraction. Returns `Weight(0)` if underflow would occur.
+    pub fn saturating_sub(self, rhs: Weight) -> Weight {
+        Weight(self.0.saturating_sub(rhs.0))
+    }
+
     /// Returns `true` if this weight is zero.
     pub fn is_zero(self) -> bool {
         self.0 == 0

--- a/node/src/components/consensus/utils/weight.rs
+++ b/node/src/components/consensus/utils/weight.rs
@@ -55,7 +55,7 @@ impl<'a> Sum<&'a Weight> for Weight {
 impl Mul<u64> for Weight {
     type Output = Self;
 
-    #[allow(clippy::integer_arithmetic)] // The caller needs to prevent overflows.
+    #[allow(clippy::arithmetic_side_effects)] // The caller needs to prevent overflows.
     fn mul(self, rhs: u64) -> Self {
         Weight(self.0 * rhs)
     }
@@ -64,7 +64,7 @@ impl Mul<u64> for Weight {
 impl Div<u64> for Weight {
     type Output = Self;
 
-    #[allow(clippy::integer_arithmetic)] // The caller needs to avoid dividing by zero.
+    #[allow(clippy::arithmetic_side_effects)] // The caller needs to avoid dividing by zero.
     fn div(self, rhs: u64) -> Self {
         Weight(self.0 / rhs)
     }

--- a/node/src/components/diagnostics_port/command.rs
+++ b/node/src/components/diagnostics_port/command.rs
@@ -23,22 +23,17 @@ pub(super) enum Error {
 }
 
 /// Output format information is sent back to the client it.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Default)]
 pub(super) enum OutputFormat {
     /// Human-readable interactive format.
     ///
     /// No string form, utilizes the `Display` implementation of types passed in.
+    #[default]
     Interactive,
     /// JSON, pretty-printed.
     Json,
     /// Binary using bincode.
     Bincode,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        OutputFormat::Interactive
-    }
 }
 
 impl Display for OutputFormat {

--- a/node/src/components/diagnostics_port/stop_at.rs
+++ b/node/src/components/diagnostics_port/stop_at.rs
@@ -8,10 +8,11 @@ use datasize::DataSize;
 use serde::Serialize;
 
 /// A specification for a stopping point.
-#[derive(Copy, Clone, DataSize, Debug, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, DataSize, Debug, Eq, PartialEq, Serialize, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub(crate) enum StopAtSpec {
     /// Stop after completion of the current block.
+    #[default]
     NextBlock,
     /// Stop after the completion of the next switch block.
     EndOfCurrentEra,
@@ -21,12 +22,6 @@ pub(crate) enum StopAtSpec {
     BlockHeight(u64),
     /// Stop at a given era id.
     EraId(EraId),
-}
-
-impl Default for StopAtSpec {
-    fn default() -> Self {
-        StopAtSpec::NextBlock
-    }
 }
 
 impl Display for StopAtSpec {

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -242,7 +242,7 @@ impl ReactorTrait for Reactor {
             Event::NetResponseIncoming(announcement) => {
                 let mut announcement_effects = Effects::new();
                 let effects = self.handle_net_response(effect_builder, rng, announcement);
-                announcement_effects.extend(effects.into_iter());
+                announcement_effects.extend(effects);
                 announcement_effects
             }
             Event::MarkBlockCompletedRequest(request) => reactor::wrap_effects(

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -722,11 +722,11 @@ where
                 let mut requests = Vec::new();
 
                 if let Some(justification) = self.is_blockable_offense_for_outgoing(&error) {
-                    requests.extend(
-                        self.outgoing_manager
-                            .block_addr(peer_addr, now, justification)
-                            .into_iter(),
-                    );
+                    requests.extend(self.outgoing_manager.block_addr(
+                        peer_addr,
+                        now,
+                        justification,
+                    ));
                 }
 
                 // Now we can proceed with the regular updates.
@@ -736,8 +736,7 @@ where
                             addr: peer_addr,
                             error,
                             when: now,
-                        })
-                        .into_iter(),
+                        }),
                 );
 
                 self.process_dial_requests(requests)
@@ -1012,9 +1011,8 @@ where
     ) -> Vec<NodeId> {
         self.connection_symmetries
             .iter()
-            .filter_map(|(node_id, sym)| {
-                matches!(sym, ConnectionSymmetry::Symmetric { .. }).then(|| *node_id)
-            })
+            .filter(|(_, sym)| matches!(sym, ConnectionSymmetry::Symmetric { .. }))
+            .map(|(node_id, _)| *node_id)
             .choose_multiple(rng, count)
     }
 
@@ -1207,19 +1205,17 @@ where
                 Event::NetworkRequest { req: request } => {
                     self.handle_network_request(*request, rng)
                 }
-                Event::NetworkInfoRequest { req } => {
-                    return match *req {
-                        NetworkInfoRequest::Peers { responder } => {
-                            responder.respond(self.peers()).ignore()
-                        }
-                        NetworkInfoRequest::FullyConnectedPeers { count, responder } => responder
-                            .respond(self.fully_connected_peers_random(rng, count))
-                            .ignore(),
-                        NetworkInfoRequest::Insight { responder } => responder
-                            .respond(NetworkInsights::collect_from_component(self))
-                            .ignore(),
+                Event::NetworkInfoRequest { req } => match *req {
+                    NetworkInfoRequest::Peers { responder } => {
+                        responder.respond(self.peers()).ignore()
                     }
-                }
+                    NetworkInfoRequest::FullyConnectedPeers { count, responder } => responder
+                        .respond(self.fully_connected_peers_random(rng, count))
+                        .ignore(),
+                    NetworkInfoRequest::Insight { responder } => responder
+                        .respond(NetworkInsights::collect_from_component(self))
+                        .ignore(),
+                },
                 Event::GossipOurAddress => {
                     let our_address = GossipedAddress::new(
                         self.context

--- a/node/src/components/network/symmetry.rs
+++ b/node/src/components/network/symmetry.rs
@@ -9,7 +9,7 @@ use datasize::DataSize;
 use tracing::{debug, warn};
 
 /// Describes whether a connection is uni- or bi-directional.
-#[derive(DataSize, Debug)]
+#[derive(DataSize, Debug, Default)]
 pub(super) enum ConnectionSymmetry {
     /// We have only seen an incoming connection.
     IncomingOnly {
@@ -29,13 +29,8 @@ pub(super) enum ConnectionSymmetry {
         peer_addrs: BTreeSet<SocketAddr>,
     },
     /// The connection is invalid/missing and should be removed.
+    #[default]
     Gone,
-}
-
-impl Default for ConnectionSymmetry {
-    fn default() -> Self {
-        ConnectionSymmetry::Gone
-    }
 }
 
 impl ConnectionSymmetry {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -310,7 +310,7 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         let result = match event {
-            Event::StorageRequest(req) => self.handle_storage_request::<REv>(*req),
+            Event::StorageRequest(req) => self.handle_storage_request(*req),
             Event::NetRequestIncoming(ref incoming) => {
                 match self.handle_net_request_incoming::<REv>(effect_builder, incoming) {
                     Ok(effects) => Ok(effects),
@@ -784,7 +784,7 @@ impl Storage {
     }
 
     /// Handles a storage request.
-    fn handle_storage_request<REv>(
+    fn handle_storage_request(
         &mut self,
         req: StorageRequest,
     ) -> Result<Effects<Event>, FatalStorageError> {
@@ -1636,7 +1636,6 @@ impl Storage {
             .copied()
             .unwrap_or(EraId::new(0));
         for era_id in (0..=last_era.value())
-            .into_iter()
             .rev()
             .take(count as usize)
             .map(EraId::new)

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -531,9 +531,7 @@ pub(crate) struct EffectBuilder<REv: 'static> {
 // Implement `Clone` and `Copy` manually, as `derive` will make it depend on `REv` otherwise.
 impl<REv> Clone for EffectBuilder<REv> {
     fn clone(&self) -> Self {
-        EffectBuilder {
-            event_queue: self.event_queue,
-        }
+        *self
     }
 }
 

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -72,19 +72,14 @@ impl LoggingConfig {
 /// Logging output format.
 ///
 /// Defaults to "text"".
-#[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
+#[derive(Clone, DataSize, Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LoggingFormat {
     /// Text format.
+    #[default]
     Text,
     /// JSON format.
     Json,
-}
-
-impl Default for LoggingFormat {
-    fn default() -> Self {
-        LoggingFormat::Text
-    }
 }
 
 /// This is used to implement tracing's `FormatEvent` so that we can customize the way tracing

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -452,7 +452,10 @@ where
         Self: Sized + Send,
     {
         match payload {
-            Message::GetRequest { tag, serialized_id } if tag == Tag::TrieOrChunk => {
+            Message::GetRequest {
+                tag: Tag::TrieOrChunk,
+                serialized_id,
+            } => {
                 let (ev, fut) = effect_builder.create_request_parts(move |responder| TrieDemand {
                     sender,
                     request_msg: Box::new(TrieRequest(serialized_id)),

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -190,10 +190,7 @@ where
 // Implement `Clone` and `Copy` manually, as `derive` will make it depend on `R` and `Ev` otherwise.
 impl<REv> Clone for EventQueueHandle<REv> {
     fn clone(&self) -> Self {
-        EventQueueHandle {
-            scheduler: self.scheduler,
-            is_shutting_down: self.is_shutting_down,
-        }
+        *self
     }
 }
 impl<REv> Copy for EventQueueHandle<REv> {}

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -130,12 +130,10 @@ impl MainReactor {
                         // no trusted hash, no local block, might be genesis
                         self.catch_up_check_genesis()
                     }
-                    Err(storage_err) => {
-                        return Either::Right(CatchUpInstruction::Fatal(format!(
-                            "CatchUp: Could not read storage to find highest switch block header: {}",
-                            storage_err
-                        )));
-                    }
+                    Err(storage_err) => Either::Right(CatchUpInstruction::Fatal(format!(
+                        "CatchUp: Could not read storage to find highest switch block header: {}",
+                        storage_err
+                    ))),
                 }
             }
             Err(err) => Either::Right(CatchUpInstruction::Fatal(format!(

--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -12,7 +12,9 @@ use serde::Serialize;
 /// Scheduling priority.
 ///
 /// Priorities are ordered from lowest to highest.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, IntoEnumIterator, PartialOrd, Ord, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Hash, IntoEnumIterator, PartialOrd, Ord, Serialize, Default,
+)]
 pub enum QueueKind {
     /// Control messages for the runtime itself.
     Control,
@@ -37,6 +39,7 @@ pub enum QueueKind {
     /// Events of unspecified priority.
     ///
     /// This is the default queue.
+    #[default]
     Regular,
     /// Gossiper events.
     Gossip,
@@ -79,12 +82,6 @@ impl Display for QueueKind {
             QueueKind::Api => "Api",
         };
         write!(f, "{}", str_value)
-    }
-}
-
-impl Default for QueueKind {
-    fn default() -> Self {
-        QueueKind::Regular
     }
 }
 

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -171,7 +171,7 @@ impl<REv: 'static + Debug> ComponentHarnessBuilder<REv> {
             }
         };
 
-        let rng = self.rng.unwrap_or_else(TestRng::new);
+        let rng = self.rng.unwrap_or_default();
 
         let scheduler = Box::leak(Box::new(Scheduler::new(QueueKind::weights(), None)));
         let event_queue_handle = EventQueueHandle::without_shutdown(scheduler);

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1918,7 +1918,7 @@ impl BlockExecutionResultsOrChunk {
         num_results: usize,
     ) -> Self {
         let execution_results: Vec<casper_types::ExecutionResult> =
-            (0..num_results).into_iter().map(|_| rng.gen()).collect();
+            (0..num_results).map(|_| rng.gen()).collect();
 
         Self {
             block_hash,

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -543,7 +543,6 @@ mod tests {
         let mut era_validator_weights = vec![validator_matrix.validator_weights(0.into()).unwrap()];
         era_validator_weights.extend(
             (1..MAX_VALIDATOR_MATRIX_ENTRIES as u64)
-                .into_iter()
                 .map(EraId::from)
                 .map(empty_era_validator_weights),
         );
@@ -636,7 +635,6 @@ mod tests {
         let mut era_validator_weights = vec![validator_matrix.validator_weights(0.into()).unwrap()];
         era_validator_weights.extend(
             (1..=MAX_VALIDATOR_MATRIX_ENTRIES as u64)
-                .into_iter()
                 .map(EraId::from)
                 .map(empty_era_validator_weights),
         );
@@ -653,12 +651,7 @@ mod tests {
         }
 
         // Register eras [7, 8, 9].
-        era_validator_weights.extend(
-            (7..=9)
-                .into_iter()
-                .map(EraId::from)
-                .map(empty_era_validator_weights),
-        );
+        era_validator_weights.extend((7..=9).map(EraId::from).map(empty_era_validator_weights));
         for evw in era_validator_weights.iter().rev().take(3).cloned() {
             assert!(
                 validator_matrix.register_era_validator_weights(evw),

--- a/node/src/utils/external.rs
+++ b/node/src/utils/external.rs
@@ -43,13 +43,14 @@ pub static RESOURCES_PATH: Lazy<PathBuf> =
 /// An `External` also always provides a default, which will always result in an error when `load`
 /// is called. Should the underlying type `T` implement `Default`, the `with_default` can be
 /// used instead.
-#[derive(Clone, DataSize, Eq, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, DataSize, Eq, Debug, Deserialize, PartialEq, Serialize, Default)]
 #[serde(untagged)]
 pub enum External {
     /// Value that should be loaded from an external path.
     Path(PathBuf),
     /// The value has not been specified, but a default has been requested.
     #[serde(skip)]
+    #[default]
     Missing,
 }
 
@@ -100,12 +101,6 @@ pub trait Loadable: Sized {
                 error
             )
         })
-    }
-}
-
-impl Default for External {
-    fn default() -> Self {
-        External::Missing
     }
 }
 

--- a/node/src/utils/fmt_limit.rs
+++ b/node/src/utils/fmt_limit.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn limit_debug_works() {
-        let collection: Vec<_> = (0..5).into_iter().collect();
+        let collection: Vec<_> = (0..5).collect();
 
         // Sanity check.
         assert_eq!(format!("{:?}", collection), "[0, 1, 2, 3, 4]");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.73.0"

--- a/smart_contracts/contracts/nctl/nctl-dictionary/Cargo.toml
+++ b/smart_contracts/contracts/nctl/nctl-dictionary/Cargo.toml
@@ -3,8 +3,6 @@ name = "nctl-dictionary"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 casper-contract = { path = "../../../contract" }
 casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/dictionary-read/Cargo.toml
+++ b/smart_contracts/contracts/test/dictionary-read/Cargo.toml
@@ -3,8 +3,6 @@ name = "dictionary-read"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [[bin]]
 name = "dictionary_read"
 path = "src/main.rs"

--- a/smart_contracts/contracts/test/read-from-key/Cargo.toml
+++ b/smart_contracts/contracts/test/read-from-key/Cargo.toml
@@ -3,8 +3,6 @@ name = "read-from-key"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [[bin]]
 name = "read_from_key"
 path = "src/main.rs"

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -655,22 +655,22 @@ impl Debug for ApiError {
             ApiError::AuctionError(value) => write!(
                 f,
                 "ApiError::AuctionError({:?})",
-                auction::Error::try_from(*value).map_err(|_err| fmt::Error::default())?
+                auction::Error::try_from(*value).map_err(|_err| fmt::Error)?
             )?,
             ApiError::ContractHeader(value) => write!(
                 f,
                 "ApiError::ContractHeader({:?})",
-                contracts::Error::try_from(*value).map_err(|_err| fmt::Error::default())?
+                contracts::Error::try_from(*value).map_err(|_err| fmt::Error)?
             )?,
             ApiError::Mint(value) => write!(
                 f,
                 "ApiError::Mint({:?})",
-                mint::Error::try_from(*value).map_err(|_err| fmt::Error::default())?
+                mint::Error::try_from(*value).map_err(|_err| fmt::Error)?
             )?,
             ApiError::HandlePayment(value) => write!(
                 f,
                 "ApiError::HandlePayment({:?})",
-                handle_payment::Error::try_from(*value).map_err(|_err| fmt::Error::default())?
+                handle_payment::Error::try_from(*value).map_err(|_err| fmt::Error)?
             )?,
             ApiError::User(value) => write!(f, "ApiError::User({})", value)?,
         }

--- a/types/src/checksummed_hex.rs
+++ b/types/src/checksummed_hex.rs
@@ -218,10 +218,7 @@ mod tests {
 
     #[proptest]
     fn hex_roundtrip_sanity(input: Vec<u8>) {
-        prop_assert!(matches!(
-            decode(encode_iter(&input).collect::<String>()),
-            Ok(_)
-        ))
+        prop_assert!(decode(encode_iter(&input).collect::<String>()).is_ok())
     }
 
     #[proptest]

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -762,7 +762,7 @@ impl ContractPackage {
 
     /// Adds new group to this contract.
     pub fn add_group(&mut self, group: Group, urefs: BTreeSet<URef>) {
-        let v = self.groups.entry(group).or_insert_with(Default::default);
+        let v = self.groups.entry(group).or_default();
         v.extend(urefs)
     }
 

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -759,7 +759,7 @@ impl Ord for PublicKey {
 
 // This implementation of `Hash` agrees with the derived `PartialEq`.  It's required since
 // `ed25519_dalek::PublicKey` doesn't implement `Hash`.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.tag().hash(state);

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -128,7 +128,7 @@ impl FromStr for EraId {
 impl Add<u64> for EraId {
     type Output = EraId;
 
-    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
+    #[allow(clippy::arithmetic_side_effects)] // The caller must make sure this doesn't overflow.
     fn add(self, x: u64) -> EraId {
         EraId::from(self.0 + x)
     }
@@ -143,7 +143,7 @@ impl AddAssign<u64> for EraId {
 impl Sub<u64> for EraId {
     type Output = EraId;
 
-    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
+    #[allow(clippy::arithmetic_side_effects)] // The caller must make sure this doesn't overflow.
     fn sub(self, x: u64) -> EraId {
         EraId::from(self.0 - x)
     }
@@ -220,7 +220,7 @@ mod tests {
         assert_eq!(window.len(), auction_delay as usize + 1);
         assert_eq!(window.get(0), Some(&current_era));
         assert_eq!(
-            window.iter().rev().next(),
+            window.iter().next_back(),
             Some(&(current_era + auction_delay))
         );
     }

--- a/types/src/system/auction/bid.rs
+++ b/types/src/system/auction/bid.rs
@@ -300,9 +300,7 @@ impl Bid {
     pub fn total_staked_amount(&self) -> Result<U512, Error> {
         self.delegators
             .iter()
-            .fold(Some(U512::zero()), |maybe_a, (_, b)| {
-                maybe_a.and_then(|a| a.checked_add(*b.staked_amount()))
-            })
+            .try_fold(U512::zero(), |a, (_, b)| a.checked_add(*b.staked_amount()))
             .and_then(|delegators_sum| delegators_sum.checked_add(*self.staked_amount()))
             .ok_or(Error::InvalidAmount)
     }

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -281,6 +281,12 @@ impl TimeDiff {
     pub fn saturating_mul(self, rhs: u64) -> Self {
         TimeDiff(self.0.saturating_mul(rhs))
     }
+
+    /// Returns the product, or `None` if it would overflow.
+    #[must_use]
+    pub fn checked_mul(self, rhs: u64) -> Option<Self> {
+        Some(TimeDiff(self.0.checked_mul(rhs)?))
+    }
 }
 
 impl Add<TimeDiff> for TimeDiff {

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -270,6 +270,12 @@ impl TimeDiff {
         TimeDiff(millis)
     }
 
+    /// Returns the sum, or `TimeDiff(u64::MAX)` if it would overflow.
+    #[must_use]
+    pub fn saturating_add(self, rhs: u64) -> Self {
+        TimeDiff(self.0.saturating_add(rhs))
+    }
+
     /// Returns the product, or `TimeDiff(u64::MAX)` if it would overflow.
     #[must_use]
     pub fn saturating_mul(self, rhs: u64) -> Self {

--- a/utils/global-state-update-gen/src/generic.rs
+++ b/utils/global-state-update-gen/src/generic.rs
@@ -277,7 +277,7 @@ pub fn add_and_remove_bids<T: StateReader>(
         validators_diff.removed.clone()
     };
 
-    for (pub_key, seigniorage_recipient) in new_snapshot.values().rev().next().unwrap() {
+    for (pub_key, seigniorage_recipient) in new_snapshot.values().next_back().unwrap() {
         create_or_update_bid(state, pub_key, seigniorage_recipient, slash);
     }
 

--- a/utils/highway-rewards-analysis/Cargo.toml
+++ b/utils/highway-rewards-analysis/Cargo.toml
@@ -3,8 +3,6 @@ name = "highway-rewards-analysis"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bincode = "1"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
This PR updates the pinned rust version to 1.73.0.

All fixes for new `clippy::arithmetic_side_effects` warnings were grouped into a single commit ([888c2f0](https://github.com/casper-network/casper-node/commit/888c2f02b5818f081e52a44018c54695e0903dec)), and are worth special attention for correctness.

Closes #4416.
