### PR TITLE
Update config-example.toml and chainspec.toml for 16s blocks.

### DIFF
--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -112,7 +112,7 @@ administrators = []
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
-maximum_round_length = '132 seconds'
+maximum_round_length = '66 seconds'
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
@@ -125,13 +125,13 @@ max_ttl = '18 hours'
 # The maximum number of other deploys a deploy can depend on (require to have been executed before it can execute).
 max_dependencies = 10
 # Maximum block size in bytes including deploys contained by the block.  0 means unlimited.
-max_block_size = 10_485_760
+max_block_size = 5_242_880
 # Maximum deploy size in bytes.  Size is of the deploy when serialized via ToBytes.
 max_deploy_size = 1_048_576
 # The maximum number of non-transfer deploys permitted in a single block.
-block_max_deploy_count = 50
+block_max_deploy_count = 25
 # The maximum number of wasm-less transfer deploys permitted in a single block.
-block_max_transfer_count = 1250
+block_max_transfer_count = 650
 # The maximum number of approvals permitted in a single block.
 block_max_approval_count = 2600
 # The upper limit of total gas of all deploys in a block.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -281,7 +281,7 @@ address = '0.0.0.0:7777'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 100
+qps_limit = 50
 
 # Maximum number of bytes to accept in a single request body.
 max_body_bytes = 2_621_440


### PR DESCRIPTION
Final changes for configurations to match testing values for 16s blocks.
