### PR TITLE
Create a proper validation error for the block validation process

### DIFF
--- a/node/src/components/block_validator/state.rs
+++ b/node/src/components/block_validator/state.rs
@@ -253,6 +253,8 @@ impl BlockValidationState {
                 if missing_deploys.is_empty() {
                     error!("should always have missing deploys while in state `InProgress`");
                     debug_assert!(false, "invalid state");
+                    // Note: This branch should never happen and is a bug in the software. We are
+                    //       "repurposing" a different error variant, avoiding `unreachable!`.
                     return MaybeStartFetching::ValidationFailed;
                 }
                 let mut unasked = None;

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -208,7 +208,7 @@ async fn validate_block(
         for effect in effects {
             tokio::spawn(effect).await.unwrap(); // Response.
         }
-        return validation_result.await.unwrap();
+        return validation_result.await.unwrap().is_ok();
     }
 
     // Otherwise the effects must be requests to fetch the block's deploys.
@@ -238,7 +238,7 @@ async fn validate_block(
     for effect in effects {
         tokio::spawn(effect).await.unwrap(); // Response.
     }
-    validation_result.await.unwrap()
+    validation_result.await.unwrap().is_ok()
 }
 
 /// Verifies that a block without any deploys or transfers is valid.
@@ -480,7 +480,7 @@ async fn should_fetch_from_multiple_peers() {
         }
 
         for validation_result in validation_results {
-            assert!(validation_result.await.unwrap());
+            assert!(validation_result.await.unwrap().is_ok());
         }
     })
     .await

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -153,6 +153,37 @@ pub enum ValidationError {
         /// The deploys still missing.
         missing_deploys: Vec<DeployOrTransferHash>,
     },
+    /// An already invalid block was submitted for validation.
+    ///
+    /// This is likely a bug in the node itself.
+    #[error("validation of failed block, likely a bug")]
+    ValidationOfFailedBlock,
+    /// The submitted block is already in process of being validated.
+    ///
+    /// This is likely a bug, since no block should be submitted for validation twice.
+    #[error("duplicate validation attempt, likely a bug")]
+    DuplicateValidationAttempt,
+    /// Found deploy in storage, but did not match the hash requested.
+    ///
+    /// This indicates a corrupted storage.
+    // Note: It seems rather mean to ban peers for our own corrupted storage.
+    #[error("local storage appears corrupted, deploy mismatch when asked for deploy {0}")]
+    InternalDataCorruption(DeployOrTransferHash),
+    /// The deploy we received
+    ///
+    /// This is likely a bug, since the deploy fetcher should ensure that this does not happen.
+    #[error("received wrong or invalid deploy from peer when asked for deploy {0}")]
+    WrongDeploySent(DeployOrTransferHash),
+    /// A contained deploy has no valid deploy footprint.
+    #[error("no valid deploy footprint for deploy {deploy_hash}: {error}")]
+    DeployHasInvalidFootprint {
+        /// Hash of deploy that failed.
+        deploy_hash: DeployOrTransferHash,
+        /// The error reported when trying to footprint it.
+        // Note: The respective error is hard to serialize and make `Sync`-able, so it is inlined
+        //       in string form here.
+        error: String,
+    },
     /// TODO: Placeholder variant, all instances of this should be removed.
     #[error("unspecified error")]
     TodoUnknown,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -51,7 +51,7 @@ use crate::{
     },
     protocol::Message,
     reactor::ReactorEvent,
-    types::{BlockHash, BlockHeader, BlockPayload, DeployHash, NodeId},
+    types::{BlockHash, BlockHeader, BlockPayload, DeployHash, DeployOrTransferHash, NodeId},
     NodeRng,
 };
 use protocols::{highway::HighwayProtocol, zug::Zug};
@@ -141,12 +141,18 @@ pub struct ValidationResult {
     error: Option<ValidationError>,
 }
 
-#[derive(Clone, Copy, DataSize, Debug, Error)]
+#[derive(Clone, DataSize, Debug, Error, Serialize)]
 /// A proposed block validation error.
 pub enum ValidationError {
     /// A deploy hash in the proposed block has been found in an ancestor block.
     #[error("deploy hash {0} has been replayed")]
     ContainsReplayedDeploy(DeployHash),
+    /// A deploy could not be fetched from any of the identified holders.
+    #[error("exhausted potential holders of proposed block, missing {} deploys", missing_deploys.len())]
+    ExhaustedBlockHolders {
+        /// The deploys still missing.
+        missing_deploys: Vec<DeployOrTransferHash>,
+    },
     /// TODO: Placeholder variant, all instances of this should be removed.
     #[error("unspecified error")]
     TodoUnknown,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -143,6 +143,7 @@ pub struct ValidationResult {
 
 #[derive(Clone, DataSize, Debug, Error, Serialize)]
 /// A proposed block validation error.
+// TODO: This error probably needs to move to a different component.
 pub enum ValidationError {
     /// A deploy hash in the proposed block has been found in an ancestor block.
     #[error("deploy hash {0} has been replayed")]
@@ -184,6 +185,19 @@ pub enum ValidationError {
         //       in string form here.
         error: String,
     },
+    /// Too many non-transfer deploys in block.
+    #[error("block exceeds limit of non-transfer deploys of {0}")]
+    ExceedsNonTransferDeployLimit(usize),
+    /// Too many non-transfer deploys in block.
+    #[error("block exceeds limit of transfers of {0}")]
+    ExceedsTransferLimit(usize),
+    /// The approvals hash could not be serialized.
+    // Note: `bytesrepr::Error` does not implement `std::error::Error`.
+    #[error("failed to serialize approvals hash: {0}")]
+    CannotSerializeApprovalsHash(String),
+    /// A duplicated deploy was found within the block.
+    #[error("duplicate deploy {0} in block")]
+    DuplicateDeploy(DeployOrTransferHash),
     /// TODO: Placeholder variant, all instances of this should be removed.
     #[error("unspecified error")]
     TodoUnknown,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -876,12 +876,15 @@ impl EraSupervisor {
     ) -> Effects<Event> {
         self.metrics.proposed_block();
         let mut effects = Effects::new();
-        if !result.is_valid() {
+        if let Some(ref error) = result.error {
             effects.extend({
                 effect_builder
                     .announce_block_peer_with_justification(
                         result.sender,
-                        BlocklistJustification::SentInvalidConsensusValue { era: result.era_id },
+                        BlocklistJustification::SentInvalidConsensusValue {
+                            era: result.era_id,
+                            cause: error.clone(),
+                        },
                     )
                     .ignore()
             });

--- a/node/src/components/network/blocklist.rs
+++ b/node/src/components/network/blocklist.rs
@@ -9,7 +9,10 @@ use casper_types::EraId;
 use datasize::DataSize;
 use serde::Serialize;
 
-use crate::components::{block_accumulator, fetcher::Tag};
+use crate::{
+    components::{block_accumulator, fetcher::Tag},
+    consensus::ValidationError,
+};
 
 /// Reasons why a peer was blocked.
 #[derive(DataSize, Debug, Serialize)]
@@ -36,6 +39,8 @@ pub(crate) enum BlocklistJustification {
     SentInvalidConsensusValue {
         /// The era for which the invalid value was destined.
         era: EraId,
+        //// Cause of value invalidity.
+        cause: ValidationError,
     },
     /// Peer misbehaved during consensus and is blocked for it.
     BadConsensusBehavior,
@@ -71,8 +76,8 @@ impl Display for BlocklistJustification {
                 "sent a finality signature that is invalid or unexpected ({})",
                 error
             ),
-            BlocklistJustification::SentInvalidConsensusValue { era } => {
-                write!(f, "sent an invalid consensus value in {}", era)
+            BlocklistJustification::SentInvalidConsensusValue { era, cause } => {
+                write!(f, "sent an invalid consensus value in {}: {}", era, cause)
             }
             BlocklistJustification::BadConsensusBehavior => {
                 f.write_str("sent invalid data in consensus")

--- a/node/src/components/network/blocklist.rs
+++ b/node/src/components/network/blocklist.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use crate::{
     components::{block_accumulator, fetcher::Tag},
     consensus::ValidationError,
+    utils::display_error,
 };
 
 /// Reasons why a peer was blocked.
@@ -77,7 +78,12 @@ impl Display for BlocklistJustification {
                 error
             ),
             BlocklistJustification::SentInvalidConsensusValue { era, cause } => {
-                write!(f, "sent an invalid consensus value in {}: {}", era, cause)
+                write!(
+                    f,
+                    "sent an invalid consensus value in {}: {}",
+                    era,
+                    display_error(cause)
+                )
             }
             BlocklistJustification::BadConsensusBehavior => {
                 f.write_str("sent invalid data in consensus")

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -144,6 +144,7 @@ use crate::{
         network::{blocklist::BlocklistJustification, FromIncoming, NetworkInsights, Ticket},
         upgrade_watcher::NextUpgrade,
     },
+    consensus::ValidationError,
     contract_runtime::SpeculativeExecutionState,
     reactor::{main_reactor::ReactorState, EventQueueHandle, QueueKind},
     types::{
@@ -1796,7 +1797,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         sender: NodeId,
         block: ProposedBlock<ClContext>,
-    ) -> bool
+    ) -> Result<(), ValidationError>
     where
         REv: From<BlockValidationRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -46,6 +46,7 @@ use crate::{
         network::NetworkInsights,
         upgrade_watcher::NextUpgrade,
     },
+    consensus::ValidationError,
     contract_runtime::{ContractRuntimeError, SpeculativeExecutionState},
     effect::{AutoClosingResponder, Responder},
     reactor::main_reactor::ReactorState,
@@ -1047,7 +1048,7 @@ pub(crate) struct BlockValidationRequest {
     /// Responder to call with the result.
     ///
     /// Indicates whether or not validation was successful.
-    pub(crate) responder: Responder<bool>,
+    pub(crate) responder: Responder<Result<(), ValidationError>>,
 }
 
 impl Display for BlockValidationRequest {

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -75,7 +75,7 @@ where
     R::Config: Default,
     <R as Reactor>::Error: Debug,
     R::Event: Serialize,
-    R::Error: From<prometheus::Error>,
+    R::Error: From<prometheus::Error> + Send,
 {
     /// Creates a new networking node on the network using the default root node port.
     ///
@@ -105,7 +105,7 @@ impl<R> TestingNetwork<R>
 where
     R: Reactor + NetworkedReactor,
     R::Event: Serialize,
-    R::Error: From<prometheus::Error> + From<R::Error>,
+    R::Error: From<prometheus::Error> + From<R::Error> + Send,
 {
     /// Creates a new network.
     pub(crate) fn new() -> Self {
@@ -557,7 +557,7 @@ impl<R> Finalize for TestingNetwork<R>
 where
     R: Finalize + NetworkedReactor + Reactor + Send + 'static,
     R::Event: Serialize + Send + Sync,
-    R::Error: From<prometheus::Error>,
+    R::Error: From<prometheus::Error> + Send,
 {
     fn finalize(self) -> BoxFuture<'static, ()> {
         // We support finalizing networks where the reactor itself can be finalized.

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -6,6 +6,7 @@ use std::{
 use casper_types::{Gas, PublicKey, TimeDiff, Timestamp};
 use datasize::DataSize;
 use num_traits::Zero;
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::types::{
@@ -15,8 +16,8 @@ use crate::types::{
 
 const NO_LEEWAY: TimeDiff = TimeDiff::from_millis(0);
 
-#[derive(Debug, Error)]
-pub(crate) enum AddError {
+#[derive(Copy, Clone, DataSize, Debug, Error, Serialize)]
+pub enum AddError {
     #[error("would exceed maximum transfer count per block")]
     TransferCount,
     #[error("would exceed maximum deploy count per block")]

--- a/node/src/types/deploy/error.rs
+++ b/node/src/types/deploy/error.rs
@@ -156,7 +156,7 @@ pub enum Error {
 
     /// Error while decoding from JSON.
     #[error("decoding from JSON: {0}")]
-    DecodeFromJson(Box<dyn StdError>),
+    DecodeFromJson(Box<dyn StdError + Send>),
 
     /// Failed to get "amount" from `payment()`'s runtime args.
     #[error("invalid payment: missing \"amount\" arg")]


### PR DESCRIPTION
Replaces the single `bool` that indicated validity with a proper error, giving cause. This causes the block notification in the log to contain the correct message.