### PR TITLE
Make the number of blocks to consider configurable in the chainspec

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.5.5
+
+### Added
+* New chainspec setting `highway.performance_meter.blocks_to_consider` with a value of 10, meaning that nodes will take 10 most recent blocks into account when determining their performance in Highway for the purpose of choosing their round lengths.
+
+
+
 ## 1.5.4
 
 ### Added

--- a/node/src/components/consensus/protocols/highway/performance_meter.rs
+++ b/node/src/components/consensus/protocols/highway/performance_meter.rs
@@ -21,10 +21,10 @@ use crate::{
 };
 
 /// The average max quorum that triggers us to slow down: with this big or smaller average max
-/// quorum per `BLOCKS_TO_CONSIDER`, we increase our round length.
+/// quorum among some number of past blocks, we increase our round length.
 const SLOW_DOWN_THRESHOLD: f64 = 0.8;
 /// The average max quorum that triggers us to speed up: with this big or larger average max quorum
-/// per `BLOCKS_TO_CONSIDER`, we decrease our round length.
+/// among some number of past blocks, we decrease our round length.
 const ACCELERATION_THRESHOLD: f64 = 0.9;
 /// We will try to accelerate (decrease our round length) at least every
 /// `MAX_ACCELERATION_PARAMETER` rounds if we have a big enough average max quorum.
@@ -101,8 +101,8 @@ impl PerformanceMeter {
     /// Whenever a block is proposed in a round and nodes cast their confirmation and witness
     /// units, a "max quorum" can be calculated for each node - the maximum quorum for which there
     /// exists a level-1 summit within the round, containing the particular node.
-    /// This function calculates the average max quorum for this node out of `BLOCKS_TO_CONSIDER`
-    /// most recent ancestor proposals of the current fork choice.
+    /// This function calculates the average max quorum for this node out of
+    /// `config.blocks_to_consider` most recent ancestor proposals of the current fork choice.
     /// If this average max quorum is below a certain threshold, a higher round length will be
     /// returned.
     /// If it is above a certain threshold, and the current round ID is divisible by a certain

--- a/node/src/components/consensus/protocols/highway/performance_meter.rs
+++ b/node/src/components/consensus/protocols/highway/performance_meter.rs
@@ -5,20 +5,21 @@ use tracing::error;
 
 use casper_types::{TimeDiff, Timestamp};
 
-use crate::components::consensus::{
-    highway_core::{
-        finality_detector::{
-            assigned_weight_and_latest_unit, find_max_quora, round_participation,
-            RoundParticipation,
+use crate::{
+    components::consensus::{
+        highway_core::{
+            finality_detector::{
+                assigned_weight_and_latest_unit, find_max_quora, round_participation,
+                RoundParticipation,
+            },
+            state, State,
         },
-        state, State,
+        traits::Context,
+        utils::ValidatorIndex,
     },
-    traits::Context,
-    utils::ValidatorIndex,
+    types::chainspec::PerformanceMeterConfig,
 };
 
-/// The number of most recent blocks for which we average the max quorum in which we participated.
-const BLOCKS_TO_CONSIDER: usize = 5;
 /// The average max quorum that triggers us to slow down: with this big or smaller average max
 /// quorum per `BLOCKS_TO_CONSIDER`, we increase our round length.
 const SLOW_DOWN_THRESHOLD: f64 = 0.8;
@@ -30,37 +31,71 @@ const ACCELERATION_THRESHOLD: f64 = 0.9;
 const MAX_ACCELERATION_PARAMETER: u64 = 20;
 
 #[derive(DataSize, Debug, Clone)]
-pub(crate) struct PerformanceMeter {
+pub(crate) enum PerformanceMeter {
+    Inactive { config: PerformanceMeterConfig },
+    Active(ActivePerformanceMeter),
+}
+
+#[derive(DataSize, Debug, Clone)]
+pub(crate) struct ActivePerformanceMeter {
     our_vid: ValidatorIndex,
     min_round_len: TimeDiff,
     max_round_len: TimeDiff,
     current_round_len: TimeDiff,
     acceleration_parameter: u64,
     last_exponent_change_round_id: Timestamp,
+    config: PerformanceMeterConfig,
 }
 
 impl PerformanceMeter {
-    pub fn new(
+    /// Creates a new inactive instance of the PerformanceMeter.
+    pub fn new_inactive(config: PerformanceMeterConfig) -> Self {
+        Self::Inactive { config }
+    }
+
+    /// Activates this PerformanceMeter.
+    pub fn activate(
+        &mut self,
         our_vid: ValidatorIndex,
         round_len: TimeDiff,
         min_round_len: TimeDiff,
         max_round_len: TimeDiff,
         min_era_height: u64,
         timestamp: Timestamp,
-    ) -> Self {
-        let current_round_id = state::round_id(timestamp, round_len);
-        Self {
-            our_vid,
-            min_round_len,
-            max_round_len,
-            current_round_len: round_len,
-            acceleration_parameter: min(MAX_ACCELERATION_PARAMETER, min_era_height / 2),
-            last_exponent_change_round_id: current_round_id,
+    ) {
+        match *self {
+            Self::Active(_) => (),
+            Self::Inactive { config } => {
+                let current_round_id = state::round_id(timestamp, round_len);
+                *self = Self::Active(ActivePerformanceMeter {
+                    our_vid,
+                    min_round_len,
+                    max_round_len,
+                    current_round_len: round_len,
+                    acceleration_parameter: min(MAX_ACCELERATION_PARAMETER, min_era_height / 2),
+                    last_exponent_change_round_id: current_round_id,
+                    config,
+                })
+            }
         }
     }
 
-    pub fn current_round_len(&self) -> TimeDiff {
-        self.current_round_len
+    /// Deactivates this PerformanceMeter.
+    pub fn deactivate(&mut self) {
+        match self {
+            Self::Inactive { .. } => (),
+            Self::Active(apm) => {
+                *self = Self::Inactive { config: apm.config };
+            }
+        }
+    }
+
+    /// Returns the current round length, if active, and `None` otherwise.
+    pub fn current_round_len(&self) -> Option<TimeDiff> {
+        match self {
+            Self::Inactive { .. } => None,
+            Self::Active(apm) => Some(apm.current_round_len),
+        }
     }
 
     /// Whenever a block is proposed in a round and nodes cast their confirmation and witness
@@ -72,66 +107,73 @@ impl PerformanceMeter {
     /// returned.
     /// If it is above a certain threshold, and the current round ID is divisible by a certain
     /// number, a lower round length is returned.
-    pub fn calculate_new_length<C: Context>(&mut self, state: &State<C>) -> TimeDiff {
+    pub fn calculate_new_length<C: Context>(&mut self, state: &State<C>) -> Option<TimeDiff> {
+        let apm = match self {
+            Self::Inactive { .. } => {
+                return None;
+            }
+            Self::Active(apm) => apm,
+        };
+
         let panorama = state.panorama();
         let latest_block = match state.fork_choice(panorama) {
             Some(block) => block,
             None => {
                 // we have no blocks to check - just return the current setting
-                return self.current_round_len;
+                return Some(apm.current_round_len);
             }
         };
 
         let blocks_to_check = state.ancestor_hashes(latest_block);
 
         let max_quora: Vec<_> = blocks_to_check
-            .take_while(|block| state.unit(block).round_id() >= self.last_exponent_change_round_id)
+            .take_while(|block| state.unit(block).round_id() >= apm.last_exponent_change_round_id)
             .filter_map(|block| {
                 let round_id = state.unit(block).round_id();
                 (!matches!(
-                    round_participation(state, &panorama[self.our_vid], round_id),
+                    round_participation(state, &panorama[apm.our_vid], round_id),
                     RoundParticipation::Unassigned
                 ))
                 .then(|| {
                     let (assigned_weight, latest_units) =
                         assigned_weight_and_latest_unit(state, panorama, round_id);
                     let max_quorum = find_max_quora(state, block, &latest_units)
-                        .get(self.our_vid)
+                        .get(apm.our_vid)
                         .copied()
                         .unwrap_or(0u64.into());
                     max_quorum.0 as f64 / assigned_weight.0 as f64
                 })
             })
-            .take(BLOCKS_TO_CONSIDER)
+            .take(apm.config.blocks_to_consider as usize)
             .collect();
 
-        if max_quora.len() < BLOCKS_TO_CONSIDER {
-            return self.current_round_len;
+        if max_quora.len() < apm.config.blocks_to_consider as usize {
+            return Some(apm.current_round_len);
         }
 
         let avg_max_quorum = max_quora.iter().sum::<f64>() / max_quora.len() as f64;
 
         let current_round_id = state.unit(latest_block).round_id();
-        let current_round_index = round_index(current_round_id, self.current_round_len);
+        let current_round_index = round_index(current_round_id, apm.current_round_len);
 
         #[allow(clippy::arithmetic_side_effects)]
         if avg_max_quorum < SLOW_DOWN_THRESHOLD {
-            let new_round_len = min(self.current_round_len * 2, self.max_round_len);
-            if new_round_len != self.current_round_len {
-                self.current_round_len = new_round_len;
-                self.last_exponent_change_round_id = current_round_id;
+            let new_round_len = min(apm.current_round_len * 2, apm.max_round_len);
+            if new_round_len != apm.current_round_len {
+                apm.current_round_len = new_round_len;
+                apm.last_exponent_change_round_id = current_round_id;
             }
         } else if avg_max_quorum > ACCELERATION_THRESHOLD
-            && current_round_index % self.acceleration_parameter == 0
+            && current_round_index % apm.acceleration_parameter == 0
         {
-            let new_round_len = max(self.current_round_len / 2, self.min_round_len);
-            if new_round_len != self.current_round_len {
-                self.current_round_len = new_round_len;
-                self.last_exponent_change_round_id = current_round_id;
+            let new_round_len = max(apm.current_round_len / 2, apm.min_round_len);
+            if new_round_len != apm.current_round_len {
+                apm.current_round_len = new_round_len;
+                apm.last_exponent_change_round_id = current_round_id;
             }
         }
 
-        self.current_round_len
+        Some(apm.current_round_len)
     }
 }
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -321,7 +321,7 @@ fn slow_node_should_switch_own_round_exponent() {
     slow_nodes.insert(ALICE_PUBLIC_KEY.clone());
 
     let mut env = ConsensusEnvironment::new(validators, slow_nodes);
-    for _ in 0..10 {
+    for _ in 0..15 {
         env.crank_round();
     }
 
@@ -360,7 +360,7 @@ fn slow_down_when_majority_slow() {
     slow_nodes.insert(ELLEN_PUBLIC_KEY.clone());
 
     let mut env = ConsensusEnvironment::new(validators, slow_nodes);
-    for _ in 0..10 {
+    for _ in 0..15 {
         env.crank_round();
     }
 

--- a/node/src/components/consensus/protocols/highway/tests/consensus_environment.rs
+++ b/node/src/components/consensus/protocols/highway/tests/consensus_environment.rs
@@ -64,7 +64,7 @@ impl ConsensusEnvironment {
                 .iter()
                 .map(|(pub_key, value)| (pub_key.clone(), value.1)),
             vec![],
-            Some(10),
+            Some(15),
         );
         // our active validator will be the first in the map
         let (pub_key, (keypair, _)) = validators.iter().next().unwrap();

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -44,7 +44,7 @@ pub use self::{
     deploy_config::DeployConfig,
     error::Error,
     global_state_update::GlobalStateUpdate,
-    highway_config::HighwayConfig,
+    highway_config::{HighwayConfig, PerformanceMeterConfig},
     network_config::NetworkConfig,
     protocol_config::ProtocolConfig,
 };

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -106,6 +106,10 @@ maximum_round_length = '525 seconds'
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
 
+[highway.performance_meter]
+# The number of recent blocks to consider when measuring performance for the purpose of deciding the round length.
+blocks_to_consider = 10
+
 [deploys]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.
 max_payment_cost = '0'

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -117,6 +117,10 @@ maximum_round_length = '66 seconds'
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]
 
+[highway.performance_meter]
+# The number of recent blocks to consider when measuring performance for the purpose of deciding the round length.
+blocks_to_consider = 10
+
 [deploys]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.
 max_payment_cost = '0'

--- a/utils/nctl/sh/scenarios/chainspecs/slow-node-01.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/slow-node-01.chainspec.toml.override
@@ -1,0 +1,3 @@
+[core]
+minimum_era_height = 15
+era_duration = "63 seconds"

--- a/utils/nctl/sh/scenarios/chainspecs/slow-node-02.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/slow-node-02.chainspec.toml.override
@@ -1,0 +1,3 @@
+[core]
+minimum_era_height = 15
+era_duration = "63 seconds"


### PR DESCRIPTION
This adds a chainspec setting for the number of recent blocks taken into account by `PerformanceMeter` when measuring performance and sets it to 10 by default.

The era lengths in slow node nightly tests are also increased in order to give the nodes a chance to slow down within an era.

Closes #4427
