### PR TITLE
Version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.5.4" # when updating, also update 'html_root_url' in lib.rs
+version = "1.5.5" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2021"
 description = "The Casper blockchain node"

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -30,7 +30,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 5, 4);
+    ProtocolVersion::from_parts(1, 5, 5);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.5.4")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.5.5")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon_48.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon.png",

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.5.4'
+version = '1.5.5'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "1.5.4",
+    "version": "1.5.5",
     "title": "Client API of Casper Node",
     "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
     "contact": {
@@ -116,7 +116,7 @@
           "result": {
             "name": "account_put_deploy_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
             }
           }
@@ -201,7 +201,7 @@
           "result": {
             "name": "info_get_deploy_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "deploy": {
                 "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                 "header": {
@@ -368,7 +368,7 @@
           "result": {
             "name": "state_get_account_info_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "account": {
                 "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                 "named_keys": [],
@@ -464,7 +464,7 @@
           "result": {
             "name": "state_get_dictionary_item_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
               "stored_value": {
                 "CLValue": {
@@ -579,7 +579,7 @@
           "result": {
             "name": "query_global_state_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "block_header": {
                 "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
                 "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
@@ -713,7 +713,7 @@
           "result": {
             "name": "query_balance_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "balance": "123456"
             }
           }
@@ -753,7 +753,7 @@
           "result": {
             "name": "info_get_peers_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "peers": [
                 {
                   "node_id": "tls:0101..0101",
@@ -888,7 +888,7 @@
                   "address": "127.0.0.1:54321"
                 }
               ],
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "build_version": "1.0.0-xxxxxxxxx@DEBUG",
               "chainspec_name": "casper-example",
               "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -966,7 +966,7 @@
           "result": {
             "name": "info_get_validator_changes_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "changes": [
                 {
                   "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -1015,7 +1015,7 @@
           "result": {
             "name": "info_get_chainspec_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "chainspec_bytes": {
                 "chainspec_bytes": "2a2a",
                 "maybe_genesis_accounts_bytes": null,
@@ -1081,7 +1081,7 @@
           "result": {
             "name": "chain_get_block_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "block": {
                 "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                 "header": {
@@ -1209,7 +1209,7 @@
           "result": {
             "name": "chain_get_block_transfers_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
               "transfers": [
                 {
@@ -1283,7 +1283,7 @@
           "result": {
             "name": "chain_get_state_root_hash_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
             }
           }
@@ -1372,7 +1372,7 @@
           "result": {
             "name": "state_get_item_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "stored_value": {
                 "CLValue": {
                   "cl_type": "U64",
@@ -1450,7 +1450,7 @@
           "result": {
             "name": "state_get_balance_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "balance_value": "123456",
               "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
             }
@@ -1513,7 +1513,7 @@
           "result": {
             "name": "chain_get_era_info_by_switch_block_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "era_summary": {
                 "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                 "era_id": 42,
@@ -1593,7 +1593,7 @@
           "result": {
             "name": "state_get_auction_info_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "auction_state": {
                 "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                 "block_height": 10,
@@ -1675,7 +1675,7 @@
           "result": {
             "name": "chain_get_era_summary_example_result",
             "value": {
-              "api_version": "1.5.4",
+              "api_version": "1.5.5",
               "era_summary": {
                 "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                 "era_id": 42,

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {


### PR DESCRIPTION
This PR bumps `casper-node`'s version to 1.5.5.
