### PR TITLE
Always start a new era with an inactive PerformanceMeter

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -370,11 +370,12 @@ impl<C: Context + 'static> HighwayProtocol<C> {
     }
 
     fn calculate_round_length(&mut self) {
-        let Some(new_round_len) =
-            self.performance_meter.calculate_new_length(self.highway.state())
-            else {
-                return;
-            };
+        let Some(new_round_len) = self
+            .performance_meter
+            .calculate_new_length(self.highway.state())
+        else {
+            return;
+        };
         self.highway.set_round_len(new_round_len);
     }
 
@@ -418,7 +419,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
     /// Returns an instance of `RoundSuccessMeter` for the new era: resetting the counters where
     /// appropriate.
     fn next_era_perf_meter(&self) -> PerformanceMeter {
-        self.performance_meter.clone()
+        self.performance_meter.next_era_perf_meter()
     }
 
     /// Returns an iterator over all the values that are in parents of the given block.

--- a/node/src/components/consensus/protocols/highway/performance_meter.rs
+++ b/node/src/components/consensus/protocols/highway/performance_meter.rs
@@ -93,8 +93,8 @@ impl PerformanceMeter {
     /// Returns an instance of the `PerformanceMeter` for the next era.
     pub fn next_era_perf_meter(&self) -> Self {
         let config = match self {
-            Self::Inactive { config } => config.clone(),
-            Self::Active(apm) => apm.config.clone(),
+            Self::Inactive { config } => *config,
+            Self::Active(apm) => apm.config,
         };
         // Deliberately start the next era with an inactive meter: even if we were a validator in
         // the current era, we may cease to be one in the next one, or our validator index might

--- a/node/src/components/consensus/protocols/highway/performance_meter.rs
+++ b/node/src/components/consensus/protocols/highway/performance_meter.rs
@@ -90,6 +90,18 @@ impl PerformanceMeter {
         }
     }
 
+    /// Returns an instance of the `PerformanceMeter` for the next era.
+    pub fn next_era_perf_meter(&self) -> Self {
+        let config = match self {
+            Self::Inactive { config } => config.clone(),
+            Self::Active(apm) => apm.config.clone(),
+        };
+        // Deliberately start the next era with an inactive meter: even if we were a validator in
+        // the current era, we may cease to be one in the next one, or our validator index might
+        // change - if we are still a validator in the next era, `activate` will be called, anyway.
+        Self::Inactive { config }
+    }
+
     /// Returns the current round length, if active, and `None` otherwise.
     pub fn current_round_len(&self) -> Option<TimeDiff> {
         match self {


### PR DESCRIPTION
This should fix the "out of bounds" panic observed in nightly tests.

The reason there was that one of the nodes was being ejected in the test scenario, bringing the network size down from 5 to 4. However, the validator indices of the nodes weren't being updated in `PerformanceMeter`, so the node that was at index 4 in the 5-node network still believed it was at index 4 in the 4-node network - which led to an out-of-bounds panic.

This PR makes it so the `PerformanceMeter` starts out as inactive in every era. If the validator is supposed to be active, it has to call `activate_validator`, anyway, and that will activate the `PerformanceMeter` and initialize it with the correct index, too.

A local run of the test that panicked confirmed that it passes after applying the fix.