### PR TITLE
Add a failpoint for delaying proposals

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -514,5 +514,6 @@ where
 
     fn activate_failpoint(&mut self, activation: &FailpointActivation) {
         self.message_delay_failpoint.update_from(activation);
+        self.proposal_delay_failpoint.update_from(activation);
     }
 }


### PR DESCRIPTION
This adds a failpoint simulating a delay in generating an appendable block when a node is about to propose, for better testing of consensus.
