### PR TITLE
Split 'std' feature into 'std' and 'std-fs-io' in casper-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,8 +2193,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ test-contracts-as: build-contracts-rs build-contracts-as
 .PHONY: test-contracts
 test-contracts: test-contracts-rs
 
+.PHONY: check-no-default-features
+check-no-default-features:
+	cd types && $(CARGO) check --all-targets --no-default-features
+
 .PHONY: check-std-features
 check-std-features:
 	cd types && $(CARGO) check --all-targets --no-default-features --features=std
@@ -157,6 +161,7 @@ check-rs: \
 	doc \
 	lint \
 	audit \
+	check-no-default-features \
 	check-std-features \
 	test-rs \
 	test-rs-no-default-features \

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.0.1"
 casper-execution-engine = { version = "7.0.0", path = "../execution_engine" }
 casper-hashing = { version = "3.0.0", path = "../hashing" }
 casper-json-rpc = { version = "1.1.0", path = "../json_rpc" }
-casper-types = { version = "4.0.1", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-types = { version = "4.0.1", path = "../types", features = ["datasize", "json-schema", "std-fs-io"] }
 datasize = { version = "0.2.11", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"
 either = { version = "1", features = ["serde"] }
@@ -97,7 +97,7 @@ vergen = { version = "8.2.1", default-features = false, features = ["git", "gito
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 assert_matches = "1.5.0"
-casper-types = { path = "../types", features = ["datasize", "json-schema", "std", "testing"] }
+casper-types = { path = "../types", features = ["datasize", "json-schema", "std-fs-io", "testing"] }
 fake_instant = "0.4.0"
 pnet = "0.28.0"
 pretty_assertions = "0.7.2"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## Unreleased
+
+### Changed
+* Remove filesystem I/O functionality from the `std` feature, and gated this behind a new feature `std-fs-io` which depends upon `std`.
+
+
+
 ## 4.0.1
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,7 @@ blake2 = { version = "0.9.0", default-features = false }
 datasize = { version = "0.2.4", optional = true }
 derp = { version = "0.0.14", optional = true }
 ed25519-dalek = { version = "2.0.0", default-features = false, features = ["alloc", "zeroize"] }
-getrandom = { version = "0.2.0", features = ["rdrand"], optional = true }
+getrandom = { version = "0.2.0", features = ["rdrand", "js"], optional = true }
 hex = { version = "0.4.2", default-features = false, features = ["alloc"] }
 hex_fmt = "0.3.0"
 humantime = { version = "2", optional = true }
@@ -67,7 +67,10 @@ untrusted = "0.7.1"
 
 [features]
 json-schema = ["once_cell", "schemars"]
-std = ["derp", "getrandom/std", "humantime", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
+# Includes a restricted set of std lib functionality suitable for usage e.g. in a JS environment when compiled to Wasm.
+std = ["base16/std", "derp", "getrandom/std", "humantime", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
+# Includes a complete set of std lib functionality, including filesystem I/O operations.
+std-fs-io = ["std"]
 testing = ["proptest", "proptest-derive", "rand_pcg", "strum"]
 # DEPRECATED - use "testing" instead of "gens".
 gens = ["testing"]

--- a/types/src/cl_value.rs
+++ b/types/src/cl_value.rs
@@ -15,7 +15,7 @@ use crate::{
     bytesrepr::{self, Bytes, FromBytes, ToBytes, U32_SERIALIZED_LENGTH},
     checksummed_hex, CLType, CLTyped,
 };
-
+pub use jsonrepr::cl_value_to_json;
 mod jsonrepr;
 
 /// Error while converting a [`CLValue`] into a given type.

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -45,6 +45,10 @@ use serde_json::json;
 #[cfg(any(feature = "std", test))]
 use untrusted::Input;
 
+#[cfg(any(feature = "std", test))]
+use crate::crypto::ErrorExt;
+#[cfg(any(feature = "std-fs-io", test))]
+use crate::file_utils::{read_file, write_file, write_private_file};
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::testing::TestRng;
 use crate::{
@@ -54,11 +58,6 @@ use crate::{
     checksummed_hex,
     crypto::Error,
     CLType, CLTyped, Tagged,
-};
-#[cfg(any(feature = "std", test))]
-use crate::{
-    crypto::ErrorExt,
-    file_utils::{read_file, write_file, write_private_file},
 };
 
 #[cfg(any(feature = "testing", test))]
@@ -247,11 +246,13 @@ impl SecretKey {
     }
 
     /// Attempts to write the key bytes to the configured file path.
+    #[cfg(any(feature = "std-fs-io", test))]
     pub fn to_file<P: AsRef<Path>>(&self, file: P) -> Result<(), ErrorExt> {
         write_private_file(file, self.to_pem()?).map_err(ErrorExt::SecretKeySave)
     }
 
     /// Attempts to read the key bytes from configured file path.
+    #[cfg(any(feature = "std-fs-io", test))]
     pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self, ErrorExt> {
         let data = read_file(file).map_err(ErrorExt::SecretKeyLoad)?;
         Self::from_pem(data)
@@ -528,11 +529,13 @@ impl PublicKey {
     }
 
     /// Attempts to write the key bytes to the configured file path.
+    #[cfg(any(feature = "std-fs-io", test))]
     pub fn to_file<P: AsRef<Path>>(&self, file: P) -> Result<(), ErrorExt> {
         write_file(file, self.to_pem()?).map_err(ErrorExt::PublicKeySave)
     }
 
     /// Attempts to read the key bytes from configured file path.
+    #[cfg(any(feature = "std-fs-io", test))]
     pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self, ErrorExt> {
         let data = read_file(file).map_err(ErrorExt::PublicKeyLoad)?;
         Self::from_pem(data)

--- a/types/src/crypto/error.rs
+++ b/types/src/crypto/error.rs
@@ -11,7 +11,7 @@ use pem::PemError;
 #[cfg(any(feature = "std", test))]
 use thiserror::Error;
 
-#[cfg(any(feature = "std", test))]
+#[cfg(any(feature = "std-fs-io", test))]
 use crate::file_utils::{ReadFileError, WriteFileError};
 
 /// Cryptographic errors.
@@ -75,18 +75,22 @@ pub enum ErrorExt {
     CryptoError(#[from] Error),
 
     /// Error trying to read a secret key.
+    #[cfg(any(feature = "std-fs-io", test))]
     #[error("secret key load failed: {0}")]
     SecretKeyLoad(ReadFileError),
 
     /// Error trying to read a public key.
+    #[cfg(any(feature = "std-fs-io", test))]
     #[error("public key load failed: {0}")]
     PublicKeyLoad(ReadFileError),
 
     /// Error trying to write a secret key.
+    #[cfg(any(feature = "std-fs-io", test))]
     #[error("secret key save failed: {0}")]
     SecretKeySave(WriteFileError),
 
     /// Error trying to write a public key.
+    #[cfg(any(feature = "std-fs-io", test))]
     #[error("public key save failed: {0}")]
     PublicKeySave(WriteFileError),
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -35,7 +35,7 @@ pub mod crypto;
 mod deploy_info;
 mod era_id;
 mod execution_result;
-#[cfg(any(feature = "std", test))]
+#[cfg(any(feature = "std-fs-io", test))]
 pub mod file_utils;
 mod gas;
 #[cfg(any(feature = "testing", feature = "gens", test))]
@@ -66,7 +66,7 @@ pub use access_rights::{
 pub use api_error::ApiError;
 pub use block_time::{BlockTime, BLOCKTIME_SERIALIZED_LENGTH};
 pub use cl_type::{named_key_type, CLType, CLTyped};
-pub use cl_value::{CLTypeMismatch, CLValue, CLValueError};
+pub use cl_value::{cl_value_to_json, CLTypeMismatch, CLValue, CLValueError};
 pub use contract_wasm::{ContractWasm, ContractWasmHash};
 #[doc(inline)]
 pub use contracts::{

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -53,6 +53,12 @@ impl DeployHash {
     }
 }
 
+impl AsRef<[u8]> for DeployHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 #[cfg(feature = "json-schema")]
 impl JsonSchema for DeployHash {
     fn schema_name() -> String {


### PR DESCRIPTION
This PR restricts the functionality of the `std` feature of `casper-types` to exclude methods unsuitable when compiling the crate to Wasm.  It also adds a `std-fs-io` feature to include this functionality.

It borrows the concept and supersedes #4348 by @gRoussac.

https://github.com/casper-ecosystem/rustSDK/issues/8
https://github.com/casper-ecosystem/rustSDK/issues/10