### PR TITLE
Fix several JsonSchema impls and update the schema

### DIFF
--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -198,7 +198,11 @@
     },
     "BlockHash": {
       "description": "Hex-encoded cryptographic hash of a block.",
-      "type": "string"
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
     },
     "Timestamp": {
       "description": "Timestamp formatted as per RFC 3339",

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -202,9 +202,7 @@
     },
     "Timestamp": {
       "description": "Timestamp formatted as per RFC 3339",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+      "type": "string"
     },
     "EraId": {
       "description": "Era ID newtype.",
@@ -235,9 +233,7 @@
     },
     "TimeDiff": {
       "description": "Human-readable duration.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+      "type": "string"
     },
     "NextUpgrade": {
       "description": "Information about the next protocol upgrade.",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -2150,15 +2150,11 @@
       },
       "Timestamp": {
         "description": "Timestamp formatted as per RFC 3339",
-        "type": "integer",
-        "format": "uint64",
-        "minimum": 0.0
+        "type": "string"
       },
       "TimeDiff": {
         "description": "Human-readable duration.",
-        "type": "integer",
-        "format": "uint64",
-        "minimum": 0.0
+        "type": "string"
       },
       "Digest": {
         "description": "Hex-encoded hash digest.",
@@ -2773,11 +2769,7 @@
       },
       "TransactionV1Hash": {
         "description": "Hex-encoded TransactionV1 hash.",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Digest"
-          }
-        ]
+        "type": "string"
       },
       "TransactionV1Header": {
         "description": "The header portion of a TransactionV1.",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -2161,7 +2161,7 @@
         "type": "string"
       },
       "TimeDiff": {
-        "description": "Human-readable duratio.n",
+        "description": "Human-readable duration.",
         "type": "string"
       },
       "ExecutableDeployItem": {

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -2083,6 +2083,14 @@
       },
       "DeployHash": {
         "description": "Hex-encoded deploy hash.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Digest"
+          }
+        ]
+      },
+      "Digest": {
+        "description": "Hex-encoded hash digest.",
         "type": "string"
       },
       "DeployHeader": {
@@ -2153,11 +2161,7 @@
         "type": "string"
       },
       "TimeDiff": {
-        "description": "Human-readable duration.",
-        "type": "string"
-      },
-      "Digest": {
-        "description": "Hex-encoded hash digest.",
+        "description": "Human-readable duratio.n",
         "type": "string"
       },
       "ExecutableDeployItem": {
@@ -2769,7 +2773,11 @@
       },
       "TransactionV1Hash": {
         "description": "Hex-encoded TransactionV1 hash.",
-        "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Digest"
+          }
+        ]
       },
       "TransactionV1Header": {
         "description": "The header portion of a TransactionV1.",
@@ -3310,7 +3318,11 @@
       },
       "BlockHash": {
         "description": "Hex-encoded cryptographic hash of a block.",
-        "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Digest"
+          }
+        ]
       },
       "ExecutionResult": {
         "description": "The versioned result of executing a single deploy.",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -2183,7 +2183,11 @@
                 "properties": {
                   "module_bytes": {
                     "description": "Hex-encoded raw Wasm bytes.",
-                    "type": "string"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Bytes"
+                      }
+                    ]
                   },
                   "args": {
                     "description": "Runtime arguments.",
@@ -2216,7 +2220,11 @@
                 "properties": {
                   "hash": {
                     "description": "Hex-encoded contract hash.",
-                    "type": "string"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AddressableEntityHash"
+                      }
+                    ]
                   },
                   "entry_point": {
                     "description": "Name of an entry point.",
@@ -2290,7 +2298,11 @@
                 "properties": {
                   "hash": {
                     "description": "Hex-encoded contract package hash.",
-                    "type": "string"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/PackageHash"
+                      }
+                    ]
                   },
                   "version": {
                     "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -2393,6 +2405,10 @@
             "additionalProperties": false
           }
         ]
+      },
+      "Bytes": {
+        "description": "Hex-encoded bytes.",
+        "type": "string"
       },
       "RuntimeArgs": {
         "description": "Represents a collection of arguments passed to a smart contract.",
@@ -2689,6 +2705,14 @@
             ]
           }
         ]
+      },
+      "AddressableEntityHash": {
+        "description": "The hex-encoded address of the addressable entity.",
+        "type": "string"
+      },
+      "PackageHash": {
+        "description": "The hex-encoded address of the Package.",
+        "type": "string"
       },
       "DeployApproval": {
         "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
@@ -3159,10 +3183,6 @@
             ]
           }
         ]
-      },
-      "Bytes": {
-        "description": "Hex-encoded bytes.",
-        "type": "string"
       },
       "TransactionEntryPoint": {
         "description": "Entry point of a Transaction.",
@@ -5470,10 +5490,6 @@
           }
         }
       },
-      "PackageHash": {
-        "description": "The hex-encoded address of the Package.",
-        "type": "string"
-      },
       "ByteCodeHash": {
         "description": "The hash address of the contract wasm",
         "type": "string"
@@ -5619,10 +5635,6 @@
             "minimum": 0.0
           }
         }
-      },
-      "AddressableEntityHash": {
-        "description": "The hex-encoded address of the addressable entity.",
-        "type": "string"
       },
       "PackageStatus": {
         "description": "A enum to determine the lock status of the package.",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -532,9 +532,7 @@
     },
     "Timestamp": {
       "description": "Timestamp formatted as per RFC 3339",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+      "type": "string"
     },
     "EraId": {
       "description": "Era ID newtype.",
@@ -840,11 +838,7 @@
     },
     "TransactionV1Hash": {
       "description": "Hex-encoded TransactionV1 hash.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Digest"
-        }
-      ]
+      "type": "string"
     },
     "RewardedSignatures": {
       "description": "Describes finality signatures that will be rewarded in a block. Consists of a vector of `SingleBlockRewardedSignatures`, each of which describes signatures for a single ancestor block. The first entry represents the signatures for the parent block, the second for the parent of the parent, and so on.",
@@ -970,9 +964,7 @@
     },
     "TimeDiff": {
       "description": "Human-readable duration.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+      "type": "string"
     },
     "ExecutableDeployItem": {
       "description": "The executable component of a [`Deploy`].",

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -218,6 +218,14 @@
     },
     "BlockHash": {
       "description": "Hex-encoded cryptographic hash of a block.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
+    },
+    "Digest": {
+      "description": "Hex-encoded hash digest.",
       "type": "string"
     },
     "Block": {
@@ -379,10 +387,6 @@
           ]
         }
       }
-    },
-    "Digest": {
-      "description": "Hex-encoded hash digest.",
-      "type": "string"
     },
     "EraEndV1": {
       "description": "Information related to the end of an era, and validator weights for the following era.",
@@ -575,7 +579,11 @@
     },
     "DeployHash": {
       "description": "Hex-encoded deploy hash.",
-      "type": "string"
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
     },
     "BlockV2": {
       "description": "A block after execution, with the resulting global state root hash. This is the core component of the Casper linear blockchain. Version 2.",
@@ -838,7 +846,11 @@
     },
     "TransactionV1Hash": {
       "description": "Hex-encoded TransactionV1 hash.",
-      "type": "string"
+      "allOf": [
+        {
+          "$ref": "#/definitions/Digest"
+        }
+      ]
     },
     "RewardedSignatures": {
       "description": "Describes finality signatures that will be rewarded in a block. Consists of a vector of `SingleBlockRewardedSignatures`, each of which describes signatures for a single ancestor block. The first entry represents the signatures for the parent block, the second for the parent of the parent, and so on.",
@@ -985,7 +997,11 @@
               "properties": {
                 "module_bytes": {
                   "description": "Hex-encoded raw Wasm bytes.",
-                  "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Bytes"
+                    }
+                  ]
                 },
                 "args": {
                   "description": "Runtime arguments.",
@@ -1018,7 +1034,11 @@
               "properties": {
                 "hash": {
                   "description": "Hex-encoded contract hash.",
-                  "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/AddressableEntityHash"
+                    }
+                  ]
                 },
                 "entry_point": {
                   "description": "Name of an entry point.",
@@ -1092,7 +1112,11 @@
               "properties": {
                 "hash": {
                   "description": "Hex-encoded contract package hash.",
-                  "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PackageHash"
+                    }
+                  ]
                 },
                 "version": {
                   "description": "An optional version of the contract to call. It will default to the highest enabled version if no value is specified.",
@@ -1195,6 +1219,10 @@
           "additionalProperties": false
         }
       ]
+    },
+    "Bytes": {
+      "description": "Hex-encoded bytes.",
+      "type": "string"
     },
     "RuntimeArgs": {
       "description": "Represents a collection of arguments passed to a smart contract.",
@@ -1491,6 +1519,14 @@
           ]
         }
       ]
+    },
+    "AddressableEntityHash": {
+      "description": "The hex-encoded address of the addressable entity.",
+      "type": "string"
+    },
+    "PackageHash": {
+      "description": "The hex-encoded address of the Package.",
+      "type": "string"
     },
     "DeployApproval": {
       "description": "A struct containing a signature of a deploy hash and the public key of the signer.",
@@ -1922,10 +1958,6 @@
           ]
         }
       ]
-    },
-    "Bytes": {
-      "description": "Hex-encoded bytes.",
-      "type": "string"
     },
     "TransactionEntryPoint": {
       "description": "Entry point of a Transaction.",
@@ -3332,7 +3364,11 @@
       "properties": {
         "entity_addr": {
           "description": "The identity of the entity that produced the message.",
-          "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/definitions/AddressableEntityHash"
+            }
+          ]
         },
         "message": {
           "description": "The payload of the message.",

--- a/types/src/block/block_hash.rs
+++ b/types/src/block/block_hash.rs
@@ -37,11 +37,7 @@ static BLOCK_HASH: Lazy<BlockHash> =
     schemars(description = "Hex-encoded cryptographic hash of a block.")
 )]
 #[serde(deny_unknown_fields)]
-#[rustfmt::skip]
-pub struct BlockHash(
-    #[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))]
-    Digest
-);
+pub struct BlockHash(Digest);
 
 impl BlockHash {
     /// The number of bytes in a `BlockHash` digest.

--- a/types/src/contract_messages/messages.rs
+++ b/types/src/contract_messages/messages.rs
@@ -172,7 +172,6 @@ impl FromBytes for MessagePayload {
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct Message {
     /// The identity of the entity that produced the message.
-    #[cfg_attr(feature = "json-schema", schemars(with = "String"))]
     entity_addr: AddressableEntityHash,
     /// The payload of the message.
     message: MessagePayload,

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -240,7 +240,7 @@ impl From<u64> for Timestamp {
 #[cfg_attr(
     feature = "json-schema",
     derive(JsonSchema),
-    schemars(description = "Human-readable duratio.n")
+    schemars(description = "Human-readable duration.")
 )]
 pub struct TimeDiff(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] u64);
 

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -30,7 +30,12 @@ const TIMESTAMP: Timestamp = Timestamp(1_605_573_564_072);
 /// A timestamp type, representing a concrete moment in time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-pub struct Timestamp(u64);
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Timestamp formatted as per RFC 3339")
+)]
+pub struct Timestamp(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] u64);
 
 impl Timestamp {
     /// The maximum value a timestamp can have.
@@ -229,25 +234,15 @@ impl From<u64> for Timestamp {
     }
 }
 
-#[cfg(feature = "json-schema")]
-impl JsonSchema for Timestamp {
-    fn schema_name() -> String {
-        String::from("Timestamp")
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema = gen.subschema_for::<String>();
-        let mut schema_object = schema.into_object();
-        schema_object.metadata().description =
-            Some("Timestamp formatted as per RFC 3339".to_string());
-        schema_object.into()
-    }
-}
-
 /// A time difference between two timestamps.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-pub struct TimeDiff(u64);
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Human-readable duratio.n")
+)]
+pub struct TimeDiff(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] u64);
 
 impl Display for TimeDiff {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -266,20 +261,6 @@ impl FromStr for TimeDiff {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let inner = humantime::parse_duration(value)?.as_millis() as u64;
         Ok(TimeDiff(inner))
-    }
-}
-
-#[cfg(feature = "json-schema")]
-impl JsonSchema for TimeDiff {
-    fn schema_name() -> String {
-        String::from("TimeDiff")
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema = gen.subschema_for::<String>();
-        let mut schema_object = schema.into_object();
-        schema_object.metadata().description = Some("Human-readable duration.".to_string());
-        schema_object.into()
     }
 }
 

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -30,11 +30,6 @@ const TIMESTAMP: Timestamp = Timestamp(1_605_573_564_072);
 /// A timestamp type, representing a concrete moment in time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(
-    feature = "json-schema",
-    derive(JsonSchema),
-    schemars(with = "String", description = "Timestamp formatted as per RFC 3339")
-)]
 pub struct Timestamp(u64);
 
 impl Timestamp {
@@ -234,14 +229,24 @@ impl From<u64> for Timestamp {
     }
 }
 
+#[cfg(feature = "json-schema")]
+impl JsonSchema for Timestamp {
+    fn schema_name() -> String {
+        String::from("Timestamp")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = gen.subschema_for::<String>();
+        let mut schema_object = schema.into_object();
+        schema_object.metadata().description =
+            Some("Timestamp formatted as per RFC 3339".to_string());
+        schema_object.into()
+    }
+}
+
 /// A time difference between two timestamps.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(
-    feature = "json-schema",
-    derive(JsonSchema),
-    schemars(with = "String", description = "Human-readable duration.")
-)]
 pub struct TimeDiff(u64);
 
 impl Display for TimeDiff {
@@ -261,6 +266,20 @@ impl FromStr for TimeDiff {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let inner = humantime::parse_duration(value)?.as_millis() as u64;
         Ok(TimeDiff(inner))
+    }
+}
+
+#[cfg(feature = "json-schema")]
+impl JsonSchema for TimeDiff {
+    fn schema_name() -> String {
+        String::from("TimeDiff")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = gen.subschema_for::<String>();
+        let mut schema_object = schema.into_object();
+        schema_object.metadata().description = Some("Human-readable duration.".to_string());
+        schema_object.into()
     }
 }
 

--- a/types/src/transaction/deploy/deploy_hash.rs
+++ b/types/src/transaction/deploy/deploy_hash.rs
@@ -29,7 +29,7 @@ use crate::{
     schemars(description = "Hex-encoded deploy hash.")
 )]
 #[serde(deny_unknown_fields)]
-pub struct DeployHash(#[cfg_attr(feature = "json-schema", schemars(skip, with = "String"))] Digest);
+pub struct DeployHash(Digest);
 
 impl DeployHash {
     /// The number of bytes in a `DeployHash` digest.

--- a/types/src/transaction/deploy/executable_deploy_item.rs
+++ b/types/src/transaction/deploy/executable_deploy_item.rs
@@ -79,6 +79,7 @@ pub enum ExecutableDeployItem {
         #[cfg_attr(
             feature = "json-schema",
             schemars(
+                // this attribute is necessary due to a bug: https://github.com/GREsau/schemars/issues/89
                 with = "AddressableEntityHash",
                 description = "Hex-encoded contract hash."
             )
@@ -107,6 +108,7 @@ pub enum ExecutableDeployItem {
         #[cfg_attr(
             feature = "json-schema",
             schemars(
+                // this attribute is necessary due to a bug: https://github.com/GREsau/schemars/issues/89
                 with = "PackageHash",
                 description = "Hex-encoded contract package hash."
             )

--- a/types/src/transaction/deploy/executable_deploy_item.rs
+++ b/types/src/transaction/deploy/executable_deploy_item.rs
@@ -65,7 +65,7 @@ pub enum ExecutableDeployItem {
         /// Raw Wasm module bytes with 'call' exported as an entrypoint.
         #[cfg_attr(
             feature = "json-schema",
-            schemars(with = "String", description = "Hex-encoded raw Wasm bytes.")
+            schemars(description = "Hex-encoded raw Wasm bytes.")
         )]
         module_bytes: Bytes,
         /// Runtime arguments.
@@ -78,7 +78,10 @@ pub enum ExecutableDeployItem {
         #[serde(with = "serde_helpers::contract_hash_as_digest")]
         #[cfg_attr(
             feature = "json-schema",
-            schemars(with = "String", description = "Hex-encoded contract hash.")
+            schemars(
+                with = "AddressableEntityHash",
+                description = "Hex-encoded contract hash."
+            )
         )]
         hash: AddressableEntityHash,
         /// Name of an entry point.
@@ -103,7 +106,10 @@ pub enum ExecutableDeployItem {
         #[serde(with = "serde_helpers::contract_package_hash_as_digest")]
         #[cfg_attr(
             feature = "json-schema",
-            schemars(with = "String", description = "Hex-encoded contract package hash.")
+            schemars(
+                with = "PackageHash",
+                description = "Hex-encoded contract package hash."
+            )
         )]
         hash: PackageHash,
         /// An optional version of the contract to call. It will default to the highest enabled

--- a/types/src/transaction/transaction_v1/transaction_v1_hash.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_hash.rs
@@ -23,6 +23,11 @@ use crate::{
     Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Default,
 )]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Hex-encoded TransactionV1 hash.")
+)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionV1Hash(Digest);
 
@@ -96,20 +101,6 @@ impl ToBytes for TransactionV1Hash {
 impl FromBytes for TransactionV1Hash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         Digest::from_bytes(bytes).map(|(inner, remainder)| (TransactionV1Hash(inner), remainder))
-    }
-}
-
-#[cfg(feature = "json-schema")]
-impl JsonSchema for TransactionV1Hash {
-    fn schema_name() -> String {
-        String::from("TransactionV1Hash")
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema = gen.subschema_for::<String>();
-        let mut schema_object = schema.into_object();
-        schema_object.metadata().description = Some("Hex-encoded TransactionV1 hash.".to_string());
-        schema_object.into()
     }
 }
 

--- a/types/src/transaction/transaction_v1/transaction_v1_hash.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_hash.rs
@@ -23,13 +23,8 @@ use crate::{
     Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Default,
 )]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
-#[cfg_attr(
-    feature = "json-schema",
-    derive(JsonSchema),
-    schemars(with = "String", description = "Hex-encoded TransactionV1 hash.")
-)]
 #[serde(deny_unknown_fields)]
-pub struct TransactionV1Hash(#[cfg_attr(feature = "json-schema", schemars(skip))] Digest);
+pub struct TransactionV1Hash(Digest);
 
 impl TransactionV1Hash {
     /// The number of bytes in a `TransactionV1Hash` digest.
@@ -101,6 +96,20 @@ impl ToBytes for TransactionV1Hash {
 impl FromBytes for TransactionV1Hash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         Digest::from_bytes(bytes).map(|(inner, remainder)| (TransactionV1Hash(inner), remainder))
+    }
+}
+
+#[cfg(feature = "json-schema")]
+impl JsonSchema for TransactionV1Hash {
+    fn schema_name() -> String {
+        String::from("TransactionV1Hash")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = gen.subschema_for::<String>();
+        let mut schema_object = schema.into_object();
+        schema_object.metadata().description = Some("Hex-encoded TransactionV1 hash.".to_string());
+        schema_object.into()
     }
 }
 


### PR DESCRIPTION
Several types generate incorrect schema due to invalid use of the schemars macro attributes, the code was using the `with` attribute, but it doesn't support container types (structs/enums) ([it's documented here](https://github.com/GREsau/schemars/blob/master/docs/1.1-attributes.md#serdewith--type--schemarswith--type)). I've written the impls by hand, there seems to be no way to do it with attributes out of the box.