### PR TITLE
block_synchronizer: sync transactions

### DIFF
--- a/node/src/components/block_synchronizer/deploy_acquisition.rs
+++ b/node/src/components/block_synchronizer/deploy_acquisition.rs
@@ -9,7 +9,7 @@ use std::{
 use datasize::DataSize;
 use tracing::debug;
 
-use casper_types::{DeployHash, DeployId, TransactionApprovalsHash};
+use casper_types::{TransactionApprovalsHash, TransactionHash, TransactionId};
 
 use crate::types::ApprovalsHashes;
 
@@ -18,43 +18,55 @@ use super::block_acquisition::Acceptance;
 #[derive(Clone, Copy, PartialEq, Eq, DataSize, Debug)]
 pub(crate) enum Error {
     AcquisitionByIdNotPossible,
-    EncounteredNonVacantDeployState,
+    EncounteredNonVacantTransactionState,
+    TransactionTypeMismatch,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::AcquisitionByIdNotPossible => write!(f, "acquisition by id is not possible"),
-            Error::EncounteredNonVacantDeployState => {
-                write!(f, "encountered non vacant deploy state")
+            Error::EncounteredNonVacantTransactionState => {
+                write!(f, "encountered non vacant transaction state")
+            }
+            Error::TransactionTypeMismatch => {
+                write!(f, "transaction type mismatch")
             }
         }
     }
 }
 
-#[derive(Clone, PartialEq, Eq, DataSize, Debug)]
-pub(super) enum DeployIdentifier {
-    ByHash(DeployHash),
-    ById(DeployId),
+#[derive(Clone, Copy, PartialEq, Eq, DataSize, Debug)]
+pub(super) enum TransactionIdentifier {
+    ByHash(TransactionHash),
+    ById(TransactionId),
 }
 
 #[derive(Clone, PartialEq, Eq, DataSize, Debug)]
-pub(super) enum DeployAcquisition {
-    ByHash(Acquisition<DeployHash>),
-    ById(Acquisition<DeployId>),
+pub(super) enum TransactionAcquisition {
+    ByHash(Acquisition<TransactionHash>),
+    ById(Acquisition<TransactionId>),
 }
 
-impl DeployAcquisition {
-    pub(super) fn new_by_hash(deploy_hashes: Vec<DeployHash>, need_execution_result: bool) -> Self {
-        DeployAcquisition::ByHash(Acquisition::new(deploy_hashes, need_execution_result))
+impl TransactionAcquisition {
+    pub(super) fn new_by_hash(
+        transaction_hashes: Vec<TransactionHash>,
+        need_execution_result: bool,
+    ) -> Self {
+        TransactionAcquisition::ByHash(Acquisition::new(transaction_hashes, need_execution_result))
     }
 
-    pub(super) fn apply_deploy(&mut self, deploy_id: DeployId) -> Option<Acceptance> {
+    pub(super) fn apply_transaction(
+        &mut self,
+        transaction_id: TransactionId,
+    ) -> Option<Acceptance> {
         match self {
-            DeployAcquisition::ByHash(acquisition) => {
-                acquisition.apply_deploy(*deploy_id.deploy_hash())
+            TransactionAcquisition::ByHash(acquisition) => {
+                acquisition.apply_transaction(transaction_id.transaction_hash())
             }
-            DeployAcquisition::ById(acquisition) => acquisition.apply_deploy(deploy_id),
+            TransactionAcquisition::ById(acquisition) => {
+                acquisition.apply_transaction(transaction_id)
+            }
         }
     }
 
@@ -63,36 +75,37 @@ impl DeployAcquisition {
         approvals_hashes: &ApprovalsHashes,
     ) -> Result<(), Error> {
         let new_acquisition = match self {
-            DeployAcquisition::ByHash(acquisition) => {
-                let mut new_deploy_ids = vec![];
-                for ((deploy_hash, deploy_state), approvals_hash) in acquisition
+            TransactionAcquisition::ByHash(acquisition) => {
+                let mut new_txn_ids = vec![];
+                for ((transaction_hash, txn_state), approvals_hash) in acquisition
                     .inner
                     .drain(..)
-                    .zip(approvals_hashes.approvals_hashes().iter().filter_map(
-                        |txn_approvals_hash| match txn_approvals_hash {
-                            TransactionApprovalsHash::Deploy(deploy_approvals_hash) => {
-                                Some(deploy_approvals_hash)
-                            }
-                            TransactionApprovalsHash::V1(_) => None,
-                        },
-                    ))
+                    .zip(approvals_hashes.approvals_hashes())
                 {
-                    if !matches!(deploy_state, DeployState::Vacant) {
-                        return Err(Error::EncounteredNonVacantDeployState);
+                    if !matches!(txn_state, TransactionState::Vacant) {
+                        return Err(Error::EncounteredNonVacantTransactionState);
                     };
-                    new_deploy_ids.push((
-                        DeployId::new(deploy_hash, *approvals_hash),
-                        DeployState::Vacant,
-                    ));
+                    let txn_id = match (transaction_hash, approvals_hash) {
+                        (
+                            TransactionHash::Deploy(deploy_hash),
+                            TransactionApprovalsHash::Deploy(deploy_approvals_hash),
+                        ) => TransactionId::new_deploy(deploy_hash, deploy_approvals_hash),
+                        (
+                            TransactionHash::V1(transaction_v1_hash),
+                            TransactionApprovalsHash::V1(txn_v1_approvals_hash),
+                        ) => TransactionId::new_v1(transaction_v1_hash, txn_v1_approvals_hash),
+                        _ => return Err(Error::TransactionTypeMismatch),
+                    };
+                    new_txn_ids.push((txn_id, TransactionState::Vacant));
                 }
 
-                DeployAcquisition::ById(Acquisition {
-                    inner: new_deploy_ids,
+                TransactionAcquisition::ById(Acquisition {
+                    inner: new_txn_ids,
                     need_execution_result: acquisition.need_execution_result,
                 })
             }
-            DeployAcquisition::ById(_) => {
-                debug!("DeployAcquisition: attempt to apply approvals hashes on a deploy acquired by ID");
+            TransactionAcquisition::ById(_) => {
+                debug!("TransactionAcquisition: attempt to apply approvals hashes on a transaction acquired by ID");
                 return Err(Error::AcquisitionByIdNotPossible);
             }
         };
@@ -101,32 +114,43 @@ impl DeployAcquisition {
         Ok(())
     }
 
-    pub(super) fn needs_deploy(&self) -> Option<DeployIdentifier> {
+    pub(super) fn needs_transaction(&self) -> bool {
         match self {
-            DeployAcquisition::ByHash(acq) => acq.needs_deploy().map(DeployIdentifier::ByHash),
-            DeployAcquisition::ById(acq) => acq.needs_deploy().map(DeployIdentifier::ById),
+            TransactionAcquisition::ByHash(acq) => acq.needs_transaction().is_some(),
+            TransactionAcquisition::ById(acq) => acq.needs_transaction().is_some(),
+        }
+    }
+
+    pub(super) fn next_needed_transaction(&self) -> Option<TransactionIdentifier> {
+        match self {
+            TransactionAcquisition::ByHash(acq) => {
+                acq.needs_transaction().map(TransactionIdentifier::ByHash)
+            }
+            TransactionAcquisition::ById(acq) => {
+                acq.needs_transaction().map(TransactionIdentifier::ById)
+            }
         }
     }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, DataSize, Debug, Default)]
-pub(super) enum DeployState {
+pub(super) enum TransactionState {
     #[default]
     Vacant,
-    HaveDeployBody,
+    HaveTransactionBody,
 }
 
 #[derive(Clone, PartialEq, Eq, DataSize, Debug)]
 pub(super) struct Acquisition<T> {
-    inner: Vec<(T, DeployState)>,
+    inner: Vec<(T, TransactionState)>,
     need_execution_result: bool,
 }
 
 impl<T: Copy + Ord> Acquisition<T> {
-    fn new(deploy_identifiers: Vec<T>, need_execution_result: bool) -> Self {
-        let inner = deploy_identifiers
+    fn new(txn_identifiers: Vec<T>, need_execution_result: bool) -> Self {
+        let inner = txn_identifiers
             .into_iter()
-            .map(|deploy_identifier| (deploy_identifier, DeployState::Vacant))
+            .map(|txn_identifier| (txn_identifier, TransactionState::Vacant))
             .collect();
         Acquisition {
             inner,
@@ -134,27 +158,27 @@ impl<T: Copy + Ord> Acquisition<T> {
         }
     }
 
-    fn apply_deploy(&mut self, deploy_identifier: T) -> Option<Acceptance> {
+    fn apply_transaction(&mut self, transaction_identifier: T) -> Option<Acceptance> {
         for item in self.inner.iter_mut() {
-            if item.0 == deploy_identifier {
+            if item.0 == transaction_identifier {
                 match item.1 {
-                    DeployState::Vacant => {
-                        item.1 = DeployState::HaveDeployBody;
+                    TransactionState::Vacant => {
+                        item.1 = TransactionState::HaveTransactionBody;
                         return Some(Acceptance::NeededIt);
                     }
-                    DeployState::HaveDeployBody => return Some(Acceptance::HadIt),
+                    TransactionState::HaveTransactionBody => return Some(Acceptance::HadIt),
                 }
             }
         }
         None
     }
 
-    fn needs_deploy(&self) -> Option<T> {
+    fn needs_transaction(&self) -> Option<T> {
         self.inner
             .iter()
-            .find_map(|(deploy_identifier, state)| match state {
-                DeployState::Vacant => Some(*deploy_identifier),
-                DeployState::HaveDeployBody => None,
+            .find_map(|(txn_identifier, state)| match state {
+                TransactionState::Vacant => Some(*txn_identifier),
+                TransactionState::HaveTransactionBody => None,
             })
     }
 }

--- a/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/deploy_acquisition/tests.rs
@@ -66,10 +66,7 @@ fn dont_apply_approvals_hashes_when_acquiring_by_id() {
     let approvals_hashes = gen_approvals_hashes(&mut rng, test_transactions.values());
 
     let mut txn_acquisition = TransactionAcquisition::ById(Acquisition::new(
-        test_transactions
-            .values()
-            .map(|txn| get_transaction_id(txn))
-            .collect(),
+        test_transactions.values().map(get_transaction_id).collect(),
         false,
     ));
 

--- a/node/src/components/block_synchronizer/error.rs
+++ b/node/src/components/block_synchronizer/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use datasize::DataSize;
 use derive_more::From;
 
-use casper_types::{DeployId, Digest};
+use casper_types::{Digest, TransactionHash, TransactionId};
 
 use super::deploy_acquisition;
 
@@ -23,12 +23,14 @@ pub(crate) enum BlockAcquisitionError {
     InvalidAttemptToAcquireExecutionResults,
     #[from]
     InvalidAttemptToApplyApprovalsHashes(deploy_acquisition::Error),
-    InvalidAttemptToApplyDeploy {
-        deploy_id: DeployId,
+    InvalidAttemptToApplyTransaction {
+        txn_id: TransactionId,
     },
+    MissingApprovalsHashes(TransactionHash),
     InvalidAttemptToMarkComplete,
     InvalidAttemptToEnqueueBlockForExecution,
     ExecutionResults(super::execution_results_acquisition::Error),
+    InvalidTransactionType,
 }
 
 impl Display for BlockAcquisitionError {
@@ -67,8 +69,18 @@ impl Display for BlockAcquisitionError {
             BlockAcquisitionError::InvalidAttemptToEnqueueBlockForExecution => {
                 write!(f, "invalid attempt to enqueue block for execution")
             }
-            BlockAcquisitionError::InvalidAttemptToApplyDeploy { deploy_id } => {
-                write!(f, "invalid attempt to apply deploy: {}", deploy_id)
+            BlockAcquisitionError::InvalidAttemptToApplyTransaction { txn_id } => {
+                write!(f, "invalid attempt to apply transaction: {}", txn_id)
+            }
+            BlockAcquisitionError::MissingApprovalsHashes(missing_txn_hash) => {
+                write!(
+                    f,
+                    "missing approvals hashes for transaction {}",
+                    missing_txn_hash
+                )
+            }
+            BlockAcquisitionError::InvalidTransactionType => {
+                write!(f, "invalid transaction identifier",)
             }
         }
     }

--- a/node/src/components/block_synchronizer/execution_results_acquisition.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 
 use casper_types::{
-    bytesrepr, execution::ExecutionResult, BlockHash, ChunkWithProof, DeployHash, Digest,
+    bytesrepr, execution::ExecutionResult, BlockHash, ChunkWithProof, Digest, TransactionHash,
 };
 
 use super::block_acquisition::Acceptance;
@@ -201,7 +201,7 @@ pub(super) enum ExecutionResultsAcquisition {
     Complete {
         block_hash: BlockHash,
         checksum: ExecutionResultsChecksum,
-        results: HashMap<DeployHash, ExecutionResult>,
+        results: HashMap<TransactionHash, ExecutionResult>,
     },
 }
 
@@ -279,7 +279,7 @@ impl ExecutionResultsAcquisition {
     pub(super) fn apply_block_execution_results_or_chunk(
         self,
         block_execution_results_or_chunk: BlockExecutionResultsOrChunk,
-        deploy_hashes: Vec<DeployHash>,
+        transaction_hashes: Vec<TransactionHash>,
     ) -> Result<(Self, Acceptance), Error> {
         let block_hash = *block_execution_results_or_chunk.block_hash();
         let value = block_execution_results_or_chunk.into_value();
@@ -401,18 +401,21 @@ impl ExecutionResultsAcquisition {
             }
         };
 
-        if deploy_hashes.len() != execution_results.len() {
+        if transaction_hashes.len() != execution_results.len() {
             debug!(
                 %block_hash,
                 "apply_block_execution_results_or_chunk: Error::ExecutionResultToDeployHashLengthDiscrepancy"
             );
             return Err(Error::ExecutionResultToDeployHashLengthDiscrepancy {
                 block_hash,
-                expected: deploy_hashes.len(),
+                expected: transaction_hashes.len(),
                 actual: execution_results.len(),
             });
         }
-        let results = deploy_hashes.into_iter().zip(execution_results).collect();
+        let results = transaction_hashes
+            .into_iter()
+            .zip(execution_results)
+            .collect();
         debug!(
             %block_hash,
             "apply_block_execution_results_or_chunk: returning ExecutionResultsAcquisition::Complete"

--- a/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition/tests.rs
@@ -1,7 +1,8 @@
 use assert_matches::assert_matches;
 
 use casper_types::{
-    bytesrepr::ToBytes, execution::ExecutionResultV2, testing::TestRng, TestBlockBuilder,
+    bytesrepr::ToBytes, execution::ExecutionResultV2, testing::TestRng, DeployHash,
+    TestBlockBuilder,
 };
 
 use super::*;
@@ -272,7 +273,7 @@ impl ExecutionResultsAcquisition {
     fn new_complete(
         block_hash: BlockHash,
         checksum: ExecutionResultsChecksum,
-        results: HashMap<DeployHash, ExecutionResult>,
+        results: HashMap<TransactionHash, ExecutionResult>,
     ) -> Self {
         let acq = Self::Complete {
             block_hash,
@@ -349,7 +350,7 @@ fn acquisition_pending_state_has_correct_transitions() {
     assert_matches!(
         acquisition.clone().apply_block_execution_results_or_chunk(
             exec_result,
-            vec![DeployHash::new(Digest::hash([0; 32]))]
+            vec![DeployHash::new(Digest::hash([0; 32])).into()]
         ),
         Ok((
             ExecutionResultsAcquisition::Complete { .. },
@@ -370,9 +371,9 @@ fn acquisition_pending_state_has_correct_transitions() {
         *block.hash(),
         ValueOrChunk::ChunkWithProof(first_chunk.clone()),
     );
-    let deploy_hashes: Vec<DeployHash> = (0..NUM_TEST_EXECUTION_RESULTS)
+    let deploy_hashes: Vec<TransactionHash> = (0..NUM_TEST_EXECUTION_RESULTS)
         .into_iter()
-        .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())))
+        .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())).into())
         .collect();
     assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, deploy_hashes),
@@ -429,9 +430,9 @@ fn acquisition_acquiring_state_has_correct_transitions() {
         *block.hash(),
         ValueOrChunk::ChunkWithProof(last_chunk.clone()),
     );
-    let deploy_hashes: Vec<DeployHash> = (0..NUM_TEST_EXECUTION_RESULTS)
+    let deploy_hashes: Vec<TransactionHash> = (0..NUM_TEST_EXECUTION_RESULTS)
         .into_iter()
-        .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())))
+        .map(|index| DeployHash::new(Digest::hash(index.to_bytes().unwrap())).into())
         .collect();
     acquisition = assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(exec_result, deploy_hashes),
@@ -483,7 +484,7 @@ fn acquisition_acquiring_state_gets_overridden_by_value() {
     assert_matches!(
         acquisition.apply_block_execution_results_or_chunk(
             exec_result,
-            vec![DeployHash::new(Digest::hash([0; 32]))]
+            vec![DeployHash::new(Digest::hash([0; 32])).into()]
         ),
         Ok((
             ExecutionResultsAcquisition::Complete { .. },

--- a/node/src/components/block_synchronizer/need_next.rs
+++ b/node/src/components/block_synchronizer/need_next.rs
@@ -1,7 +1,7 @@
 use datasize::DataSize;
 use derive_more::Display;
 
-use casper_types::{Block, BlockHash, DeployHash, DeployId, Digest, EraId, PublicKey};
+use casper_types::{Block, BlockHash, DeployHash, Digest, EraId, PublicKey, TransactionId};
 
 use crate::types::{BlockExecutionResultsOrChunkId, ExecutableBlock};
 
@@ -32,8 +32,8 @@ pub(crate) enum NeedNext {
     GlobalState(BlockHash, Digest),
     #[display(fmt = "need next for {}: deploy {}", _0, _1)]
     DeployByHash(BlockHash, DeployHash),
-    #[display(fmt = "need next for {}: deploy {}", _0, _1)]
-    DeployById(BlockHash, DeployId),
+    #[display(fmt = "need next for {}: transaction {}", _0, _1)]
+    TransactionById(BlockHash, TransactionId),
     #[display(fmt = "need next for {}: make block executable (height {})", _0, _1)]
     MakeExecutableBlock(BlockHash, u64),
     #[display(

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -1029,7 +1029,7 @@ async fn registering_header_successfully_triggers_signatures_fetch_for_weak_fina
         mock_reactor.effect_builder(),
         &mut rng,
         Event::BlockHeaderFetched(Ok(FetchedData::FromPeer {
-            item: Box::new(block.clone().take_header().into()),
+            item: Box::new(block.clone_header()),
             peer: peers_asked[0],
         })),
     );
@@ -1088,7 +1088,7 @@ async fn fwd_more_signatures_are_requested_if_weak_finality_is_not_reached() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1214,7 +1214,7 @@ async fn fwd_sync_is_not_blocked_by_failed_signatures_fetch_within_latch_interva
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1343,7 +1343,7 @@ async fn next_action_for_have_weak_finality_is_fetching_block_body() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1409,7 +1409,7 @@ async fn registering_block_body_transitions_builder_to_have_block_state() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1489,7 +1489,7 @@ async fn fwd_having_block_body_for_block_without_deploys_requires_only_signature
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1553,7 +1553,7 @@ async fn fwd_having_block_body_for_block_with_deploys_requires_approvals_hashes(
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1637,7 +1637,7 @@ async fn fwd_registering_approvals_hashes_triggers_fetch_for_deploys() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1714,7 +1714,7 @@ async fn fwd_have_block_body_without_deploys_and_strict_finality_transitions_sta
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1775,7 +1775,7 @@ async fn fwd_have_block_with_strict_finality_requires_creation_of_finalized_bloc
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1846,7 +1846,7 @@ async fn fwd_have_strict_finality_requests_enqueue_when_finalized_block_is_creat
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -1940,7 +1940,7 @@ async fn fwd_builder_status_is_executing_when_block_is_enqueued_for_execution() 
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -2015,7 +2015,7 @@ async fn fwd_sync_is_finished_when_block_is_marked_as_executed() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -2086,7 +2086,7 @@ async fn historical_sync_announces_meta_block() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     assert!(historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
 
@@ -2231,7 +2231,7 @@ async fn synchronizer_halts_if_block_cannot_be_made_executable() {
         .as_mut()
         .expect("Forward builder should have been initialized");
     assert!(fwd_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .is_ok());
     fwd_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     // Register finality signatures to reach weak finality
@@ -2331,7 +2331,7 @@ async fn historical_sync_skips_exec_results_and_deploys_if_block_empty() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -2436,7 +2436,7 @@ async fn historical_sync_no_legacy_block() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -2660,7 +2660,7 @@ async fn historical_sync_legacy_block_strict_finality() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -2860,7 +2860,7 @@ async fn historical_sync_legacy_block_weak_finality() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -3073,7 +3073,7 @@ async fn historical_sync_legacy_block_any_finality() {
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -3341,7 +3341,7 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
             mock_reactor.effect_builder(),
             &mut rng,
             Event::BlockHeaderFetched(Ok(FetchedData::FromPeer {
-                item: Box::new(block.clone().take_header().into()),
+                item: Box::new(block.clone_header()),
                 peer: peers_asked[0],
             })),
         );
@@ -3381,7 +3381,7 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
             mock_reactor.effect_builder(),
             &mut rng,
             Event::BlockHeaderFetched(Ok(FetchedData::FromPeer {
-                item: Box::new(block.clone().take_header().into()),
+                item: Box::new(block.clone_header()),
                 peer: peers_asked[1],
             })),
         );
@@ -3496,7 +3496,7 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
             mock_reactor.effect_builder(),
             &mut rng,
             Event::BlockFetched(Ok(FetchedData::FromPeer {
-                item: Box::new(block.clone().into()),
+                item: Box::new(block.clone()),
                 peer: peers[0],
             })),
         );
@@ -3529,7 +3529,7 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
             mock_reactor.effect_builder(),
             &mut rng,
             Event::BlockFetched(Ok(FetchedData::FromPeer {
-                item: Box::new(block.clone().into()),
+                item: Box::new(block.clone()),
                 peer: peers[1],
             })),
         );
@@ -3734,7 +3734,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_deploy_fetch_respons
     let block = test_env.block();
     let block_v2: BlockV2 = block.clone().try_into().unwrap();
     let first_txn = transactions
-        .get(block_v2.all_transactions().nth(0).unwrap())
+        .get(block_v2.all_transactions().next().unwrap())
         .unwrap();
     let second_txn = transactions
         .get(block_v2.all_transactions().nth(1).unwrap())
@@ -3760,7 +3760,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_deploy_fetch_respons
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(
@@ -4027,7 +4027,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_execution_results() 
         .as_mut()
         .expect("Historical builder should have been initialized");
     historical_builder
-        .register_block_header(block.clone().take_header().into(), None)
+        .register_block_header(block.clone_header(), None)
         .expect("header registration works");
     historical_builder.register_era_validator_weights(&block_synchronizer.validator_matrix);
     register_multiple_signatures(

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -987,7 +987,7 @@ impl ContractRuntime {
         let execution_results_map: HashMap<_, _> = execution_results
             .iter()
             .cloned()
-            .map(|artifact| (artifact.deploy_hash, artifact.execution_result))
+            .map(|artifact| (artifact.deploy_hash.into(), artifact.execution_result))
             .collect();
         if meta_block_state.register_as_stored().was_updated() {
             effect_builder

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -76,9 +76,9 @@ use casper_types::{
         execution_result_v1, ExecutionResult, ExecutionResultV1, ExecutionResultV2, TransformKind,
     },
     Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, BlockV2, DeployApprovalsHash,
-    DeployHash, DeployHeader, Digest, EraId, FinalitySignature, ProtocolVersion, PublicKey,
-    SignedBlockHeader, StoredValue, Timestamp, Transaction, TransactionApprovalsHash,
-    TransactionHash, TransactionId, TransactionV1ApprovalsHash, Transfer,
+    DeployHash, Digest, EraId, FinalitySignature, ProtocolVersion, PublicKey, SignedBlockHeader,
+    StoredValue, Timestamp, Transaction, TransactionApprovalsHash, TransactionHash,
+    TransactionHeader, TransactionId, TransactionV1ApprovalsHash, Transfer,
 };
 
 use crate::{
@@ -1252,7 +1252,7 @@ impl Storage {
         &mut self,
         block: &Block,
         approvals_hashes: &ApprovalsHashes,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
     ) -> Result<bool, FatalStorageError> {
         let env = Rc::clone(&self.env);
         let mut txn = env.begin_rw_txn()?;
@@ -1500,12 +1500,9 @@ impl Storage {
         block_hash: &BlockHash,
         block_height: u64,
         era_id: EraId,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
     ) -> Result<bool, FatalStorageError> {
-        let transaction_hashes = execution_results
-            .keys()
-            .map(|deploy_hash| TransactionHash::Deploy(*deploy_hash))
-            .collect();
+        let transaction_hashes = execution_results.keys().copied().collect();
         Self::insert_to_transaction_index(
             &mut self.transaction_hash_index,
             *block_hash,
@@ -1514,20 +1511,17 @@ impl Storage {
             transaction_hashes,
         )?;
         let mut transfers: Vec<Transfer> = vec![];
-        for (deploy_hash, execution_result) in execution_results.into_iter() {
+        for (transaction_hash, execution_result) in execution_results.into_iter() {
             transfers.extend(successful_transfers(&execution_result));
 
-            let was_written = self.execution_result_dbs.put(
-                txn,
-                &TransactionHash::Deploy(deploy_hash),
-                &execution_result,
-                true,
-            )?;
+            let was_written =
+                self.execution_result_dbs
+                    .put(txn, &transaction_hash, &execution_result, true)?;
 
             if !was_written {
                 error!(
                     ?block_hash,
-                    ?deploy_hash,
+                    ?transaction_hash,
                     "failed to write execution results"
                 );
                 debug_assert!(was_written);
@@ -2561,7 +2555,7 @@ impl Storage {
         &self,
         txn: &mut Tx,
         block_hash: &BlockHash,
-    ) -> Result<Option<Vec<(DeployHash, ExecutionResult)>>, FatalStorageError> {
+    ) -> Result<Option<Vec<(TransactionHash, ExecutionResult)>>, FatalStorageError> {
         let block_header = match self.get_single_block_header(txn, block_hash)? {
             Some(block_header) => block_header,
             None => return Ok(None),
@@ -2576,19 +2570,15 @@ impl Storage {
             return Ok(None);
         };
 
-        let deploy_hashes: Vec<DeployHash> = match block_body {
-            BlockBody::V1(v1) => v1.deploy_and_transfer_hashes().copied().collect(),
-            BlockBody::V2(v2) => v2
-                .all_transactions()
-                .filter_map(|transaction_hash| match transaction_hash {
-                    TransactionHash::Deploy(deploy_hash) => Some(*deploy_hash),
-                    TransactionHash::V1(_) => None,
-                })
+        let transaction_hashes: Vec<TransactionHash> = match block_body {
+            BlockBody::V1(v1) => v1
+                .deploy_and_transfer_hashes()
+                .map(TransactionHash::from)
                 .collect(),
+            BlockBody::V2(v2) => v2.all_transactions().copied().collect(),
         };
         let mut execution_results = vec![];
-        for deploy_hash in deploy_hashes {
-            let transaction_hash = TransactionHash::Deploy(deploy_hash);
+        for transaction_hash in transaction_hashes {
             match self.execution_result_dbs.get(txn, &transaction_hash)? {
                 None => {
                     debug!(
@@ -2599,7 +2589,7 @@ impl Storage {
                     return Ok(None);
                 }
                 Some(execution_result) => {
-                    execution_results.push((deploy_hash, execution_result));
+                    execution_results.push((transaction_hash, execution_result));
                 }
             }
         }
@@ -2610,7 +2600,8 @@ impl Storage {
     fn read_execution_results(
         &self,
         block_hash: &BlockHash,
-    ) -> Result<Option<Vec<(DeployHash, DeployHeader, ExecutionResult)>>, FatalStorageError> {
+    ) -> Result<Option<Vec<(TransactionHash, TransactionHeader, ExecutionResult)>>, FatalStorageError>
+    {
         let mut txn = self.env.begin_ro_txn()?;
         let execution_results = match self.get_execution_results(&mut txn, block_hash)? {
             Some(execution_results) => execution_results,
@@ -2618,23 +2609,26 @@ impl Storage {
         };
 
         let mut ret = Vec::with_capacity(execution_results.len());
-        for (deploy_hash, execution_result) in execution_results {
-            let transaction_hash = TransactionHash::from(deploy_hash);
+        for (transaction_hash, execution_result) in execution_results {
             match self.transaction_dbs.get(&mut txn, &transaction_hash)? {
                 None => {
-                    warn!(
+                    error!(
                         %block_hash,
                         %transaction_hash,
                         "missing transaction"
                     );
                     return Ok(None);
                 }
-                Some(Transaction::Deploy(deploy)) => {
-                    ret.push((deploy_hash, deploy.take_header(), execution_result))
-                }
-                // Note: the `unreachable!` below will be removed when execution results are updated
-                // to handle Transactions.
-                Some(Transaction::V1(_)) => unreachable!(),
+                Some(Transaction::Deploy(deploy)) => ret.push((
+                    transaction_hash,
+                    deploy.take_header().into(),
+                    execution_result,
+                )),
+                Some(Transaction::V1(transaction_v1)) => ret.push((
+                    transaction_hash,
+                    transaction_v1.take_header().into(),
+                    execution_result,
+                )),
             };
         }
         Ok(Some(ret))

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1258,7 +1258,7 @@ fn store_execution_results_twice_for_same_block_deploy_pair() {
     let transaction = Transaction::random(&mut harness.rng);
     let transaction_hash = transaction.hash();
 
-    put_transaction(&mut harness, &mut storage, &transaction.clone());
+    put_transaction(&mut harness, &mut storage, &transaction);
 
     let mut exec_result_1 = HashMap::new();
     exec_result_1.insert(
@@ -1537,12 +1537,12 @@ fn persist_blocks_txns_and_execution_info_across_instantiations() {
     // Create some sample data.
     let transaction = Transaction::random(&mut harness.rng);
     let block: Block = TestBlockBuilder::new()
-        .transactions(Some(&transaction.clone()))
+        .transactions(Some(&transaction))
         .build_versioned(&mut harness.rng);
 
     let block_height = block.height();
     let execution_result = ExecutionResult::from(ExecutionResultV2::random(&mut harness.rng));
-    put_transaction(&mut harness, &mut storage, &transaction.clone());
+    put_transaction(&mut harness, &mut storage, &transaction);
     put_complete_block(&mut harness, &mut storage, block.clone());
     let mut execution_results = HashMap::new();
     execution_results.insert(transaction.hash(), execution_result.clone());

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -127,8 +127,8 @@ use casper_types::{
     package::Package,
     system::auction::EraValidators,
     AddressableEntity, Block, BlockHash, BlockHeader, BlockSignatures, BlockV2, ChainspecRawBytes,
-    DeployHash, DeployHeader, Digest, EraId, FinalitySignature, FinalitySignatureId, Key,
-    PublicKey, TimeDiff, Timestamp, Transaction, TransactionHash, TransactionId, Transfer, U512,
+    DeployHash, Digest, EraId, FinalitySignature, FinalitySignatureId, Key, PublicKey, TimeDiff,
+    Timestamp, Transaction, TransactionHash, TransactionHeader, TransactionId, Transfer, U512,
 };
 
 use crate::{
@@ -1100,7 +1100,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         block: Arc<BlockV2>,
         approvals_hashes: Box<ApprovalsHashes>,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
     ) -> bool
     where
         REv: From<StorageRequest>,
@@ -1240,7 +1240,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn get_execution_results_from_storage(
         self,
         block_hash: BlockHash,
-    ) -> Option<Vec<(DeployHash, DeployHeader, ExecutionResult)>>
+    ) -> Option<Vec<(TransactionHash, TransactionHeader, ExecutionResult)>>
     where
         REv: From<StorageRequest>,
     {
@@ -1528,7 +1528,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the requested transaction from storage by DeployId.
+    /// Gets the requested transaction from storage by TransactionId.
     ///
     /// Returns the "original" transaction, which is the first received by the node, along with a
     /// potentially different set of approvals used during execution of the recorded block.
@@ -1570,7 +1570,7 @@ impl<REv> EffectBuilder<REv> {
         block_hash: BlockHash,
         block_height: u64,
         era_id: EraId,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
     ) where
         REv: From<StorageRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -30,10 +30,10 @@ use casper_types::{
     contract_messages::Messages,
     execution::{ExecutionResult, ExecutionResultV2},
     system::auction::EraValidators,
-    Block, BlockHash, BlockHeader, BlockSignatures, BlockV2, ChainspecRawBytes, DeployHash,
-    DeployHeader, Digest, DisplayIter, EraId, FinalitySignature, FinalitySignatureId, Key,
-    ProtocolVersion, PublicKey, TimeDiff, Timestamp, Transaction, TransactionHash, TransactionId,
-    Transfer, URef, U512,
+    Block, BlockHash, BlockHeader, BlockSignatures, BlockV2, ChainspecRawBytes, DeployHash, Digest,
+    DisplayIter, EraId, FinalitySignature, FinalitySignatureId, Key, ProtocolVersion, PublicKey,
+    TimeDiff, Timestamp, Transaction, TransactionHash, TransactionHeader, TransactionId, Transfer,
+    URef, U512,
 };
 
 use super::{AutoClosingResponder, GossipTarget, Responder};
@@ -289,7 +289,7 @@ pub(crate) enum StorageRequest {
         block: Arc<BlockV2>,
         /// Approvals hashes to store.
         approvals_hashes: Box<ApprovalsHashes>,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
         responder: Responder<bool>,
     },
     /// Retrieve block with given hash.
@@ -398,14 +398,14 @@ pub(crate) enum StorageRequest {
         block_hash: Box<BlockHash>,
         block_height: u64,
         era_id: EraId,
-        /// Mapping of deploys to execution results of the block.
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        /// Mapping of transactions to execution results of the block.
+        execution_results: HashMap<TransactionHash, ExecutionResult>,
         /// Responder to call when done storing.
         responder: Responder<()>,
     },
     GetExecutionResults {
         block_hash: BlockHash,
-        responder: Responder<Option<Vec<(DeployHash, DeployHeader, ExecutionResult)>>>,
+        responder: Responder<Option<Vec<(TransactionHash, TransactionHeader, ExecutionResult)>>>,
     },
     GetBlockExecutionResultsOrChunk {
         /// Request ID.

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1612,14 +1612,12 @@ impl MainReactor {
                 }
             }
             MetaBlock::Historical(historical_meta_block) => {
-                for (deploy_hash, deploy_header, execution_result) in
+                for (transaction_hash, transaction_header, execution_result) in
                     historical_meta_block.execution_results.iter()
                 {
                     let event = event_stream_server::Event::TransactionProcessed {
-                        transaction_hash: TransactionHash::Deploy(*deploy_hash),
-                        transaction_header: Box::new(TransactionHeader::Deploy(
-                            deploy_header.clone(),
-                        )),
+                        transaction_hash: *transaction_hash,
+                        transaction_header: Box::new(transaction_header.clone()),
                         block_hash: *historical_meta_block.block.hash(),
                         execution_result: Box::new(execution_result.clone()),
                         messages: Vec::new(),

--- a/node/src/types/block/meta_block.rs
+++ b/node/src/types/block/meta_block.rs
@@ -7,8 +7,8 @@ use datasize::DataSize;
 use serde::Serialize;
 
 use casper_types::{
-    execution::ExecutionResult, ActivationPoint, Block, BlockHash, BlockV2, DeployHash,
-    DeployHeader, EraId,
+    execution::ExecutionResult, ActivationPoint, Block, BlockHash, BlockV2, EraId, TransactionHash,
+    TransactionHeader,
 };
 
 pub(crate) use merge_mismatch_error::MergeMismatchError;
@@ -44,7 +44,7 @@ impl MetaBlock {
 
     pub(crate) fn new_historical(
         block: Arc<Block>,
-        execution_results: Vec<(DeployHash, DeployHeader, ExecutionResult)>,
+        execution_results: Vec<(TransactionHash, TransactionHeader, ExecutionResult)>,
         state: State,
     ) -> Self {
         Self::Historical(HistoricalMetaBlock {
@@ -107,7 +107,7 @@ pub(crate) struct ForwardMetaBlock {
 #[derive(Clone, Eq, PartialEq, Serialize, Debug, DataSize)]
 pub(crate) struct HistoricalMetaBlock {
     pub(crate) block: Arc<Block>,
-    pub(crate) execution_results: Vec<(DeployHash, DeployHeader, ExecutionResult)>,
+    pub(crate) execution_results: Vec<(TransactionHash, TransactionHeader, ExecutionResult)>,
     pub(crate) state: State,
 }
 

--- a/node/src/types/transaction/deploy/legacy_deploy.rs
+++ b/node/src/types/transaction/deploy/legacy_deploy.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    Deploy, DeployConfigFailure, DeployHash,
+    Deploy, DeployConfigFailure, DeployHash, Transaction,
 };
 
 use crate::components::fetcher::{EmptyValidationMetadata, FetchItem, Tag};
@@ -52,6 +52,12 @@ impl FromBytes for LegacyDeploy {
 impl From<LegacyDeploy> for Deploy {
     fn from(legacy_deploy: LegacyDeploy) -> Self {
         legacy_deploy.0
+    }
+}
+
+impl From<LegacyDeploy> for Transaction {
+    fn from(legacy_deploy: LegacyDeploy) -> Self {
+        Self::Deploy(legacy_deploy.0)
     }
 }
 

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::{error, warn};
 
-use casper_types::{BlockHeader, Deploy, DeployApprovalsHash, DeployId, Digest};
+use casper_types::BlockHeader;
 
 use crate::types::NodeId;
 pub(crate) use block_signatures::{check_sufficient_block_signatures, BlockSignatureError};
@@ -418,17 +418,6 @@ impl TimeAnchor {
             self.wall_clock_now - self.now.duration_since(then)
         }
     }
-}
-
-// TODO: remove once https://github.com/casper-network/roadmap/issues/190 and
-//       https://github.com/casper-network/casper-node/issues/4340 are complete.
-pub(crate) fn fetch_id(deploy: &Deploy) -> DeployId {
-    let deploy_hash = *deploy.hash();
-    let approvals_hash = deploy.compute_approvals_hash().unwrap_or_else(|error| {
-        tracing::error!(%error, "failed to serialize approvals");
-        DeployApprovalsHash::from(Digest::default())
-    });
-    DeployId::new(deploy_hash, approvals_hash)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add synching for transactions.

- Storage: changed `put_executed_block`, `get_execution_results` and `read_execution_results` to store/get execution results by `TransactionHash` instead of `DeployHash`
- MetaBlock: store transaction hashes and headers in historical meta blocks instead of deploy hashes and headers
- Refactor the `deploy_acquisition` component to work with transaction hashes and ids.
- BlockSychronizer: added stricter checks for fetching legacy deploys and introduced some new Error variants.
- Adjusted the tests for the block synchronizer to generate random transactions instead of deploys for testing.