### PR TITLE
Rename `BlockValidator` to `ProposedBlockValidator`

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## Unreleased
+
+### Changed
+* Rename `BlockValidator` component to `ProposedBlockValidator`, and corresponding config section `block_validator` to `proposed_block_validator`.
+
+
+
 ## 1.5.5
 
 ### Added
@@ -60,6 +67,8 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Removed
 * There is no more weighted rate limiting on incoming traffic, instead the nodes dynamically adjusts allowed rates from peers based on available resources. This resulted in the removal of the `estimator_weights` configuration option and the `accumulated_incoming_limiter_delay` metric.
+
+
 
 ## 1.5.3
 

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -46,7 +46,6 @@
 
 pub(crate) mod block_accumulator;
 pub(crate) mod block_synchronizer;
-pub(crate) mod block_validator;
 pub mod consensus;
 pub mod contract_runtime;
 pub(crate) mod deploy_acceptor;
@@ -55,6 +54,7 @@ pub(crate) mod diagnostics_port;
 pub(crate) mod event_stream_server;
 pub(crate) mod fetcher;
 pub(crate) mod gossiper;
+pub(crate) mod proposed_block_validator;
 // The `in_memory_network` is public for use in doctests.
 #[cfg(test)]
 pub mod in_memory_network;

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -43,9 +43,9 @@ use crate::{
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{ConsensusDemand, ConsensusMessageIncoming},
         requests::{
-            BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest,
-            ContractRuntimeRequest, DeployBufferRequest, NetworkInfoRequest, NetworkRequest,
-            StorageRequest,
+            ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest,
+            DeployBufferRequest, NetworkInfoRequest, NetworkRequest,
+            ProposedBlockValidationRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -456,7 +456,7 @@ pub(crate) trait ReactorEventT:
     + From<NetworkInfoRequest>
     + From<DeployBufferRequest>
     + From<ConsensusAnnouncement>
-    + From<BlockValidationRequest>
+    + From<ProposedBlockValidationRequest>
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
     + From<ChainspecRawBytesRequest>
@@ -475,7 +475,7 @@ impl<REv> ReactorEventT for REv where
         + From<NetworkInfoRequest>
         + From<DeployBufferRequest>
         + From<ConsensusAnnouncement>
-        + From<BlockValidationRequest>
+        + From<ProposedBlockValidationRequest>
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
         + From<ChainspecRawBytesRequest>

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -51,7 +51,7 @@ use crate::{
     consensus::ValidationError,
     effect::{
         announcements::FatalAnnouncement,
-        requests::{BlockValidationRequest, ContractRuntimeRequest, StorageRequest},
+        requests::{ContractRuntimeRequest, ProposedBlockValidationRequest, StorageRequest},
         AutoClosingResponder, EffectBuilder, EffectExt, Effects, Responder,
     },
     failpoints::Failpoint,
@@ -1396,7 +1396,7 @@ async fn check_deploys_for_replay_in_previous_eras_and_validate_block<REv>(
     proposed_block: ProposedBlock<ClContext>,
 ) -> Event
 where
-    REv: From<BlockValidationRequest> + From<StorageRequest>,
+    REv: From<ProposedBlockValidationRequest> + From<StorageRequest>,
 {
     let deploys_era_ids = effect_builder
         .get_deploys_era_ids(

--- a/node/src/components/consensus/highway_core/synchronizer.rs
+++ b/node/src/components/consensus/highway_core/synchronizer.rs
@@ -393,8 +393,8 @@ impl<C: Context + 'static> Synchronizer<C> {
                 // state after `dep` is added, rather than `transitive_dependency`.
                 self.add_missing_dependency(dep.clone(), pv);
                 // If we already have the dependency and it is a proposal that is currently being
-                // handled by the block validator, and this sender is already known as a source,
-                // do nothing.
+                // handled by the proposed block validator, and this sender is already known as a
+                // source, do nothing.
                 if pending_values
                     .values()
                     .flatten()
@@ -403,8 +403,9 @@ impl<C: Context + 'static> Synchronizer<C> {
                     continue;
                 }
                 // If we already have the dependency and it is a proposal that is currently being
-                // handled by the block validator, and this sender is not yet known as a source,
-                // we return the proposal as if this sender had sent it to us, so they get added.
+                // handled by the proposed block validator, and this sender is not yet known as a
+                // source, we return the proposal as if this sender had sent it to us, so they get
+                // added.
                 if let Some((vv, _)) = pending_values
                     .values()
                     .flatten()

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -1047,9 +1047,9 @@ where
                 .collect();
             // recursively remove vertices depending on the dropped ones
             let _faulty_senders = self.synchronizer.invalid_vertices(dropped_vertex_ids);
-            // We don't disconnect from the faulty senders here: The block validator considers the
-            // value "invalid" even if it just couldn't download the deploys, which could just be
-            // because the original sender went offline.
+            // We don't disconnect from the faulty senders here: The proposed block validator
+            // considers the value "invalid" even if it just couldn't download the deploys, which
+            // could just be because the original sender went offline.
             vec![]
         } else {
             let mut outcomes = self

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -1708,8 +1708,8 @@ impl<C: Context + 'static> Zug<C> {
         true
     }
 
-    /// Sends a proposal to the `BlockValidator` component for validation. If no validation is
-    /// needed, immediately calls `insert_proposal`.
+    /// Sends a proposal to the `ProposedBlockValidator` component for validation. If no validation
+    /// is needed, immediately calls `insert_proposal`.
     fn validate_proposal(
         &mut self,
         round_id: RoundId,
@@ -2283,9 +2283,9 @@ where
             outcomes.extend(self.update(now));
         } else {
             for (round_id, proposal, sender) in rounds_and_node_ids {
-                // We don't disconnect from the faulty sender here: The block validator considers
-                // the value "invalid" even if it just couldn't download the deploys, which could
-                // just be because the original sender went offline.
+                // We don't disconnect from the faulty sender here: The proposed block validator
+                // considers the value "invalid" even if it just couldn't download the deploys,
+                // which could just be because the original sender went offline.
                 let validator_index = self.leader(round_id).0;
                 info!(
                     our_idx = self.our_idx(),

--- a/node/src/components/proposed_block_validator/config.rs
+++ b/node/src/components/proposed_block_validator/config.rs
@@ -1,7 +1,7 @@
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
-/// Configuration options for block validation.
+/// Configuration options for proposed block validation.
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
     pub max_completed_entries: u32,

--- a/node/src/components/proposed_block_validator/event.rs
+++ b/node/src/components/proposed_block_validator/event.rs
@@ -2,14 +2,14 @@ use derive_more::{Display, From};
 
 use crate::{
     components::fetcher::FetchResult,
-    effect::requests::BlockValidationRequest,
+    effect::requests::ProposedBlockValidationRequest,
     types::{Deploy, DeployOrTransferHash},
 };
 
 #[derive(Debug, From, Display)]
 pub(crate) enum Event {
     #[from]
-    Request(BlockValidationRequest),
+    Request(ProposedBlockValidationRequest),
 
     #[display(fmt = "{} fetched", dt_hash)]
     DeployFetched {

--- a/node/src/components/proposed_block_validator/state.rs
+++ b/node/src/components/proposed_block_validator/state.rs
@@ -80,7 +80,7 @@ impl ApprovalInfo {
     }
 }
 
-/// State of the current process of block validation.
+/// State of the current process of proposed block validation.
 ///
 /// Tracks whether or not there are deploys still missing and who is interested in the final result.
 #[derive(DataSize, Debug)]
@@ -227,7 +227,7 @@ impl BlockValidationState {
                     debug!(
                         block_timestamp = %appendable_block.timestamp(),
                         peer = %entry.key(),
-                        "already registered peer as holder for block validation"
+                        "already registered peer as holder for proposed block validation"
                     );
                 }
                 Entry::Vacant(entry) => {
@@ -353,13 +353,13 @@ impl BlockValidationState {
                             debug!(
                                 block_timestamp = %appendable_block.timestamp(),
                                 missing_deploys_len = missing_deploys.len(),
-                                "still missing deploys - block validation incomplete"
+                                "still missing deploys - proposed block validation incomplete"
                             );
                             return vec![];
                         }
                         debug!(
                             block_timestamp = %appendable_block.timestamp(),
-                            "no further missing deploys - block validation complete"
+                            "no further missing deploys - proposed block validation complete"
                         );
                         let new_state = BlockValidationState::Valid(appendable_block.timestamp());
                         (new_state, mem::take(responders))

--- a/node/src/components/proposed_block_validator/tests.rs
+++ b/node/src/components/proposed_block_validator/tests.rs
@@ -27,16 +27,16 @@ use super::*;
 #[derive(Debug, From)]
 enum ReactorEvent {
     #[from]
-    BlockValidator(Event),
+    ProposedBlockValidator(Event),
     #[from]
     Fetcher(FetcherRequest<Deploy>),
     #[from]
     Storage(StorageRequest),
 }
 
-impl From<BlockValidationRequest> for ReactorEvent {
-    fn from(req: BlockValidationRequest) -> ReactorEvent {
-        ReactorEvent::BlockValidator(req.into())
+impl From<ProposedBlockValidationRequest> for ReactorEvent {
+    fn from(req: ProposedBlockValidationRequest) -> ReactorEvent {
+        ReactorEvent::ProposedBlockValidator(req.into())
     }
 }
 
@@ -51,9 +51,9 @@ impl MockReactor {
         }
     }
 
-    async fn expect_block_validator_event(&self) -> Event {
+    async fn expect_proposed_block_validator_event(&self) -> Event {
         let ((_ancestor, reactor_event), _) = self.scheduler.pop().await;
-        if let ReactorEvent::BlockValidator(event) = reactor_event {
+        if let ReactorEvent::ProposedBlockValidator(event) = reactor_event {
             event
         } else {
             panic!("unexpected event: {:?}", reactor_event);
@@ -107,7 +107,7 @@ pub(super) fn new_proposed_block(
     transfers: Vec<DeployHashWithApprovals>,
 ) -> ProposedBlock<ClContext> {
     // Accusations and ancestors are empty, and the random bit is always true:
-    // These values are not checked by the block validator.
+    // These values are not checked by the proposed block validator.
     let block_context = BlockContext::new(timestamp, vec![]);
     let block_payload = BlockPayload::new(deploys, transfers, vec![], true);
     ProposedBlock::new(Arc::new(block_payload), block_context)
@@ -166,7 +166,7 @@ pub(super) fn new_transfer(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDif
     )
 }
 
-/// Validates a block using a `BlockValidator` component, and returns the result.
+/// Validates a block using a `ProposedBlockValidator` component, and returns the result.
 async fn validate_block(
     rng: &mut TestRng,
     timestamp: Timestamp,
@@ -188,18 +188,19 @@ async fn validate_block(
     let reactor = MockReactor::new();
     let effect_builder = EffectBuilder::new(EventQueueHandle::without_shutdown(reactor.scheduler));
     let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
-    let mut block_validator = BlockValidator::new(Arc::new(chainspec), Config::default());
+    let mut proposed_block_validator =
+        ProposedBlockValidator::new(Arc::new(chainspec), Config::default());
 
     // Pass the block to the component. This future will eventually resolve to the result, i.e.
     // whether the block is valid or not.
     let bob_node_id = NodeId::random(rng);
     let validation_result =
         tokio::spawn(effect_builder.validate_block(bob_node_id, proposed_block.clone()));
-    let event = reactor.expect_block_validator_event().await;
-    let effects = block_validator.handle_event(effect_builder, rng, event);
+    let event = reactor.expect_proposed_block_validator_event().await;
+    let effects = proposed_block_validator.handle_event(effect_builder, rng, event);
 
     // If validity could already be determined, the effect will be the validation response.
-    if block_validator
+    if proposed_block_validator
         .validation_states
         .values()
         .all(BlockValidationState::completed)
@@ -229,7 +230,7 @@ async fn validate_block(
         let events = fetch_result.await.unwrap();
         assert_eq!(1, events.len());
         effects.extend(events.into_iter().flat_map(|found_deploy| {
-            block_validator.handle_event(effect_builder, rng, found_deploy)
+            proposed_block_validator.handle_event(effect_builder, rng, found_deploy)
         }));
     }
 
@@ -247,7 +248,7 @@ async fn empty_block() {
     assert!(validate_block(&mut TestRng::new(), 1000.into(), vec![], vec![]).await);
 }
 
-/// Verifies that the block validator checks deploy and transfer timestamps and ttl.
+/// Verifies that the proposed block validator checks deploy and transfer timestamps and ttl.
 #[tokio::test]
 async fn ttl() {
     // The ttl is 200 ms, and our deploys and transfers have timestamps 900 and 1000. So the block
@@ -316,7 +317,7 @@ async fn transfer_deploy_mixup_and_replay() {
     assert!(!validate_block(&mut rng, timestamp, deploys, transfers).await);
 }
 
-/// Verifies that the block validator fetches from multiple peers.
+/// Verifies that the proposed block validator fetches from multiple peers.
 #[tokio::test]
 async fn should_fetch_from_multiple_peers() {
     let _ = crate::logging::init();
@@ -348,7 +349,8 @@ async fn should_fetch_from_multiple_peers() {
         let effect_builder =
             EffectBuilder::new(EventQueueHandle::without_shutdown(reactor.scheduler));
         let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
-        let mut block_validator = BlockValidator::new(Arc::new(chainspec), Config::default());
+        let mut proposed_block_validator =
+            ProposedBlockValidator::new(Arc::new(chainspec), Config::default());
 
         // Have a validation request for each one of the peers. These futures will eventually all
         // resolve to the same result, i.e. whether the block is valid or not.
@@ -361,8 +363,8 @@ async fn should_fetch_from_multiple_peers() {
 
         let mut fetch_effects = VecDeque::new();
         for index in 0..peer_count {
-            let event = reactor.expect_block_validator_event().await;
-            let effects = block_validator.handle_event(effect_builder, &mut rng, event);
+            let event = reactor.expect_proposed_block_validator_event().await;
+            let effects = proposed_block_validator.handle_event(effect_builder, &mut rng, event);
             if index == 0 {
                 assert_eq!(effects.len(), 6);
                 fetch_effects.extend(effects);
@@ -397,10 +399,10 @@ async fn should_fetch_from_multiple_peers() {
             let event = events.pop().unwrap();
             // New fetch requests will be made using a different peer for all deploys not already
             // registered as fetched.
-            let effects = block_validator.handle_event(effect_builder, &mut rng, event);
+            let effects = proposed_block_validator.handle_event(effect_builder, &mut rng, event);
             if !effects.is_empty() {
                 assert!(missing.is_empty());
-                missing = block_validator
+                missing = proposed_block_validator
                     .validation_states
                     .values()
                     .next()
@@ -436,10 +438,10 @@ async fn should_fetch_from_multiple_peers() {
             let event = events.pop().unwrap();
             // New fetch requests will be made using a different peer for all deploys not already
             // registered as fetched.
-            let effects = block_validator.handle_event(effect_builder, &mut rng, event);
+            let effects = proposed_block_validator.handle_event(effect_builder, &mut rng, event);
             if !effects.is_empty() {
                 assert!(missing.is_empty());
-                missing = block_validator
+                missing = proposed_block_validator
                     .validation_states
                     .values()
                     .next()
@@ -471,7 +473,7 @@ async fn should_fetch_from_multiple_peers() {
             let event = events.pop().unwrap();
             // Once the block is deemed valid (i.e. when the final missing deploy is successfully
             // fetched) the effects will be three validation responses.
-            effects.extend(block_validator.handle_event(effect_builder, &mut rng, event));
+            effects.extend(proposed_block_validator.handle_event(effect_builder, &mut rng, event));
             assert!(effects.is_empty() || effects.len() == peer_count as usize);
         }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -168,10 +168,11 @@ use announcements::{
 use diagnostics_port::DumpConsensusStateRequest;
 use requests::{
     AcceptDeployRequest, BeginGossipRequest, BlockAccumulatorRequest, BlockSynchronizerRequest,
-    BlockValidationRequest, ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest,
-    DeployBufferRequest, FetcherRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest,
-    MetricsRequest, NetworkInfoRequest, NetworkRequest, ReactorStatusRequest, SetNodeStopRequest,
-    StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest, UpgradeWatcherRequest,
+    ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest, DeployBufferRequest,
+    FetcherRequest, MakeBlockExecutableRequest, MarkBlockCompletedRequest, MetricsRequest,
+    NetworkInfoRequest, NetworkRequest, ProposedBlockValidationRequest, ReactorStatusRequest,
+    SetNodeStopRequest, StorageRequest, SyncGlobalStateRequest, TrieAccumulatorRequest,
+    UpgradeWatcherRequest,
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
@@ -1795,14 +1796,14 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn validate_block(
         self,
         sender: NodeId,
-        block: ProposedBlock<ClContext>,
+        proposed_block: ProposedBlock<ClContext>,
     ) -> Result<(), ValidationError>
     where
-        REv: From<BlockValidationRequest>,
+        REv: From<ProposedBlockValidationRequest>,
     {
         self.make_request(
-            |responder| BlockValidationRequest {
-                block,
+            |responder| ProposedBlockValidationRequest {
+                proposed_block,
                 sender,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1037,12 +1037,12 @@ impl Display for SyncGlobalStateRequest {
     }
 }
 
-/// A block validator request.
+/// A proposed block validator request.
 #[derive(Debug)]
 #[must_use]
-pub(crate) struct BlockValidationRequest {
-    /// The block to be validated.
-    pub(crate) block: ProposedBlock<ClContext>,
+pub(crate) struct ProposedBlockValidationRequest {
+    /// The proposed block to be validated.
+    pub(crate) proposed_block: ProposedBlock<ClContext>,
     /// The sender of the block, which will be asked to provide all missing deploys.
     pub(crate) sender: NodeId,
     /// Responder to call with the result.
@@ -1051,10 +1051,14 @@ pub(crate) struct BlockValidationRequest {
     pub(crate) responder: Responder<Result<(), ValidationError>>,
 }
 
-impl Display for BlockValidationRequest {
+impl Display for ProposedBlockValidationRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let BlockValidationRequest { block, sender, .. } = self;
-        write!(f, "validate block {} from {}", block, sender)
+        let ProposedBlockValidationRequest {
+            proposed_block,
+            sender,
+            ..
+        } = self;
+        write!(f, "validate {} from {}", proposed_block, sender)
     }
 }
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -55,7 +55,6 @@ use tracing::warn;
 pub(crate) use components::{
     block_accumulator::Config as BlockAccumulatorConfig,
     block_synchronizer::Config as BlockSynchronizerConfig,
-    block_validator::Config as BlockValidatorConfig,
     consensus::Config as ConsensusConfig,
     contract_runtime::Config as ContractRuntimeConfig,
     deploy_acceptor::Config as DeployAcceptorConfig,
@@ -65,6 +64,7 @@ pub(crate) use components::{
     fetcher::Config as FetcherConfig,
     gossiper::Config as GossipConfig,
     network::Config as NetworkConfig,
+    proposed_block_validator::Config as ProposedBlockValidatorConfig,
     rest_server::Config as RestServerConfig,
     rpc_server::{Config as RpcServerConfig, SpeculativeExecConfig},
     upgrade_watcher::Config as UpgradeWatcherConfig,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -31,7 +31,6 @@ use crate::{
     components::{
         block_accumulator::{self, BlockAccumulator},
         block_synchronizer::{self, BlockSynchronizer},
-        block_validator::{self, BlockValidator},
         consensus::{self, EraSupervisor},
         contract_runtime::ContractRuntime,
         deploy_acceptor::{self, DeployAcceptor},
@@ -41,6 +40,7 @@ use crate::{
         gossiper::{self, GossipItem, Gossiper},
         metrics::Metrics,
         network::{self, GossipedAddress, Identity as NetworkIdentity, Network},
+        proposed_block_validator::{self, ProposedBlockValidator},
         rest_server::RestServer,
         rpc_server::RpcServer,
         shutdown_trigger::{self, ShutdownTrigger},
@@ -149,7 +149,7 @@ pub(crate) struct MainReactor {
     consensus: EraSupervisor,
 
     // block handling
-    block_validator: BlockValidator,
+    proposed_block_validator: ProposedBlockValidator,
     block_accumulator: BlockAccumulator,
     block_synchronizer: BlockSynchronizer,
 
@@ -462,15 +462,15 @@ impl reactor::Reactor for MainReactor {
             }
 
             // BLOCKS
-            MainEvent::BlockValidator(event) => reactor::wrap_effects(
-                MainEvent::BlockValidator,
-                self.block_validator
+            MainEvent::ProposedBlockValidator(event) => reactor::wrap_effects(
+                MainEvent::ProposedBlockValidator,
+                self.proposed_block_validator
                     .handle_event(effect_builder, rng, event),
             ),
-            MainEvent::BlockValidatorRequest(req) => self.dispatch_event(
+            MainEvent::ProposedBlockValidatorRequest(req) => self.dispatch_event(
                 effect_builder,
                 rng,
-                MainEvent::BlockValidator(block_validator::Event::from(req)),
+                MainEvent::ProposedBlockValidator(proposed_block_validator::Event::from(req)),
             ),
             MainEvent::BlockAccumulator(event) => reactor::wrap_effects(
                 MainEvent::BlockAccumulator,
@@ -1160,7 +1160,8 @@ impl reactor::Reactor for MainReactor {
             validator_matrix.clone(),
             registry,
         )?;
-        let block_validator = BlockValidator::new(Arc::clone(&chainspec), config.block_validator);
+        let proposed_block_validator =
+            ProposedBlockValidator::new(Arc::clone(&chainspec), config.proposed_block_validator);
         let upgrade_watcher =
             UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;
         let deploy_acceptor =
@@ -1189,7 +1190,7 @@ impl reactor::Reactor for MainReactor {
             sync_leaper,
             deploy_buffer,
             consensus,
-            block_validator,
+            proposed_block_validator,
             block_accumulator,
             block_synchronizer,
             diagnostics_port,

--- a/node/src/reactor/main_reactor/config.rs
+++ b/node/src/reactor/main_reactor/config.rs
@@ -5,9 +5,9 @@ use tracing::error;
 use crate::{
     logging::LoggingConfig,
     types::{Chainspec, NodeConfig},
-    BlockAccumulatorConfig, BlockSynchronizerConfig, BlockValidatorConfig, ConsensusConfig,
-    ContractRuntimeConfig, DeployAcceptorConfig, DeployBufferConfig, DiagnosticsPortConfig,
-    EventStreamServerConfig, FetcherConfig, GossipConfig, NetworkConfig, RestServerConfig,
+    BlockAccumulatorConfig, BlockSynchronizerConfig, ConsensusConfig, ContractRuntimeConfig,
+    DeployAcceptorConfig, DeployBufferConfig, DiagnosticsPortConfig, EventStreamServerConfig,
+    FetcherConfig, GossipConfig, NetworkConfig, ProposedBlockValidatorConfig, RestServerConfig,
     RpcServerConfig, SpeculativeExecConfig, StorageConfig, UpgradeWatcherConfig,
 };
 
@@ -50,8 +50,8 @@ pub struct Config {
     pub block_accumulator: BlockAccumulatorConfig,
     /// Config values for the block synchronizer.
     pub block_synchronizer: BlockSynchronizerConfig,
-    /// Config values for the block validator.
-    pub block_validator: BlockValidatorConfig,
+    /// Config values for the proposed block validator.
+    pub proposed_block_validator: ProposedBlockValidatorConfig,
     /// Config values for the upgrade watcher.
     pub upgrade_watcher: UpgradeWatcherConfig,
 }

--- a/node/src/reactor/main_reactor/memory_metrics.rs
+++ b/node/src/reactor/main_reactor/memory_metrics.rs
@@ -22,7 +22,7 @@ pub(super) struct MemoryMetrics {
     mem_finality_signature_gossiper: RegisteredMetric<IntGauge>,
     mem_block_gossiper: RegisteredMetric<IntGauge>,
     mem_deploy_buffer: RegisteredMetric<IntGauge>,
-    mem_block_validator: RegisteredMetric<IntGauge>,
+    mem_proposed_block_validator: RegisteredMetric<IntGauge>,
     mem_sync_leaper: RegisteredMetric<IntGauge>,
     mem_deploy_acceptor: RegisteredMetric<IntGauge>,
     mem_block_synchronizer: RegisteredMetric<IntGauge>,
@@ -73,9 +73,9 @@ impl MemoryMetrics {
             registry.new_int_gauge("mem_block_gossiper", "block gossiper memory usage in bytes")?;
         let mem_deploy_buffer =
             registry.new_int_gauge("mem_deploy_buffer", "deploy buffer memory usage in bytes")?;
-        let mem_block_validator = registry.new_int_gauge(
+        let mem_proposed_block_validator = registry.new_int_gauge(
             "mem_block_validator",
-            "block validator memory usage in bytes",
+            "proposed block validator memory usage in bytes",
         )?;
         let mem_sync_leaper =
             registry.new_int_gauge("mem_sync_leaper", "sync leaper memory usage in bytes")?;
@@ -121,7 +121,7 @@ impl MemoryMetrics {
             mem_finality_signature_gossiper,
             mem_block_gossiper,
             mem_deploy_buffer,
-            mem_block_validator,
+            mem_proposed_block_validator,
             mem_sync_leaper,
             mem_deploy_acceptor,
             mem_block_synchronizer,
@@ -151,7 +151,7 @@ impl MemoryMetrics {
             reactor.finality_signature_gossiper.estimate_heap_size() as i64;
         let block_gossiper = reactor.block_gossiper.estimate_heap_size() as i64;
         let deploy_buffer = reactor.deploy_buffer.estimate_heap_size() as i64;
-        let block_validator = reactor.block_validator.estimate_heap_size() as i64;
+        let proposed_block_validator = reactor.proposed_block_validator.estimate_heap_size() as i64;
         let sync_leaper = reactor.sync_leaper.estimate_heap_size() as i64;
         let deploy_acceptor = reactor.deploy_acceptor.estimate_heap_size() as i64;
         let block_synchronizer = reactor.block_synchronizer.estimate_heap_size() as i64;
@@ -173,7 +173,7 @@ impl MemoryMetrics {
             + finality_signature_gossiper
             + block_gossiper
             + deploy_buffer
-            + block_validator
+            + proposed_block_validator
             + sync_leaper
             + deploy_acceptor
             + block_synchronizer
@@ -195,7 +195,8 @@ impl MemoryMetrics {
             .set(finality_signature_gossiper);
         self.mem_block_gossiper.set(block_gossiper);
         self.mem_deploy_buffer.set(deploy_buffer);
-        self.mem_block_validator.set(block_validator);
+        self.mem_proposed_block_validator
+            .set(proposed_block_validator);
         self.mem_sync_leaper.set(sync_leaper);
         self.mem_deploy_acceptor.set(deploy_acceptor);
         self.mem_block_synchronizer.set(block_synchronizer);
@@ -225,7 +226,7 @@ impl MemoryMetrics {
                %finality_signature_gossiper,
                %block_gossiper,
                %deploy_buffer,
-               %block_validator,
+               %proposed_block_validator,
                %sync_leaper,
                %deploy_acceptor,
                %block_synchronizer,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -507,10 +507,10 @@ disconnect_dishonest_peers_interval = '10 seconds'
 latch_reset_interval = '5 seconds'
 
 
-# =============================================
-# Configuration options for the block validator
-# =============================================
-[block_validator]
+# ======================================================
+# Configuration options for the proposed block validator
+# ======================================================
+[proposed_block_validator]
 
 # Maximum number of completed entries to retain.
 #

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -506,10 +506,10 @@ disconnect_dishonest_peers_interval = '10 seconds'
 latch_reset_interval = '5 seconds'
 
 
-# =============================================
-# Configuration options for the block validator
-# =============================================
-[block_validator]
+# ======================================================
+# Configuration options for the proposed block validator
+# ======================================================
+[proposed_block_validator]
 
 # Maximum number of completed entries to retain.
 #


### PR DESCRIPTION
This PR is a simple rename of the given component and related variables/config options.

Note that the name of memory metrics for the component was left unchanged as `"mem_block_validator"` in order to avoid breaking the generated metrics API.  This can be updated in 2.0.

Closes #4309.