### PR TITLE
Add configurability to the network layer

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -252,7 +252,7 @@ where
 
         let rpc_builder = transport::create_rpc_builder(
             chain_info.networking_config,
-            cfg.buffer_size,
+            cfg.send_buffer_size,
             cfg.ack_timeout,
         );
 

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -36,6 +36,7 @@ mod insights;
 mod message;
 mod metrics;
 mod outgoing;
+mod per_channel;
 mod symmetry;
 pub(crate) mod tasks;
 #[cfg(test)]
@@ -100,6 +101,7 @@ pub(crate) use self::{
     message::{
         generate_largest_serialized_message, Channel, FromIncoming, Message, MessageKind, Payload,
     },
+    per_channel::PerChannel,
     transport::Ticket,
 };
 use crate::{
@@ -222,6 +224,8 @@ where
     ) -> Result<Network<REv, P>, Error> {
         let net_metrics = Arc::new(Metrics::new(registry)?);
 
+        let chain_info = chain_info_source.into();
+
         let outgoing_manager = OutgoingManager::with_metrics(
             OutgoingConfig {
                 retry_attempts: RECONNECTION_ATTEMPTS,
@@ -246,10 +250,9 @@ where
             None => None,
         };
 
-        let chain_info = chain_info_source.into();
         let rpc_builder = transport::create_rpc_builder(
-            chain_info.maximum_net_message_size,
-            cfg.max_in_flight_demands,
+            chain_info.networking_config,
+            cfg.buffer_size,
             cfg.ack_timeout,
         );
 

--- a/node/src/components/network/chain_info.rs
+++ b/node/src/components/network/chain_info.rs
@@ -12,9 +12,9 @@ use datasize::DataSize;
 use super::{
     connection_id::ConnectionId,
     message::{ConsensusCertificate, NodeKeyPair},
-    Message,
+    Message, PerChannel,
 };
-use crate::types::Chainspec;
+use crate::types::{chainspec::JulietConfig, Chainspec};
 
 /// Data retained from the chainspec by the networking component.
 ///
@@ -25,11 +25,13 @@ pub(crate) struct ChainInfo {
     /// network name as us.
     pub(super) network_name: String,
     /// The maximum message size for a network message, as supplied from the chainspec.
-    pub(super) maximum_net_message_size: u32,
+    pub(super) maximum_handshake_message_size: u32,
     /// The protocol version.
     pub(super) protocol_version: ProtocolVersion,
     /// The hash of the chainspec.
     pub(super) chainspec_hash: Digest,
+    /// The Juliet low-level data.
+    pub(super) networking_config: PerChannel<JulietConfig>,
 }
 
 impl ChainInfo {
@@ -39,9 +41,10 @@ impl ChainInfo {
         let network_name = "rust-tests-network";
         ChainInfo {
             network_name: network_name.to_string(),
-            maximum_net_message_size: 24 * 1024 * 1024, // Hardcoded at 24M.
+            maximum_handshake_message_size: 1024 * 1024, // Hardcoded at 1MiB.
             protocol_version: ProtocolVersion::V1_0_0,
             chainspec_hash: Digest::hash(format!("{}-chainspec", network_name)),
+            networking_config: Default::default(),
         }
     }
 
@@ -67,9 +70,10 @@ impl From<&Chainspec> for ChainInfo {
     fn from(chainspec: &Chainspec) -> Self {
         ChainInfo {
             network_name: chainspec.network_config.name.clone(),
-            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
+            maximum_handshake_message_size: chainspec.network_config.maximum_handshake_message_size,
             protocol_version: chainspec.protocol_version(),
             chainspec_hash: chainspec.hash(),
+            networking_config: chainspec.network_config.networking_config,
         }
     }
 }

--- a/node/src/components/network/chain_info.rs
+++ b/node/src/components/network/chain_info.rs
@@ -24,7 +24,7 @@ pub(crate) struct ChainInfo {
     /// Name of the network we participate in. We only remain connected to peers with the same
     /// network name as us.
     pub(super) network_name: String,
-    /// The maximum message size for a network message, as supplied from the chainspec.
+    /// The maximum handshake message size, as supplied from the chainspec.
     pub(super) maximum_handshake_message_size: u32,
     /// The protocol version.
     pub(super) protocol_version: ProtocolVersion,

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -49,7 +49,7 @@ impl Default for Config {
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
-            buffer_size: PerChannel::all(None), // TODO: Adjust after testing.
+            send_buffer_size: PerChannel::init_with(|_| None), // TODO: Adjust after testing.
             ack_timeout: TimeDiff::from_seconds(30),
             blocklist_retain_duration: TimeDiff::from_seconds(600),
             identity: None,
@@ -96,7 +96,7 @@ pub struct Config {
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
     /// Maximum number of incoming connections per unique peer. Unlimited if `0`.
-    pub max_incoming_peer_connections: u16, //remove?
+    pub max_incoming_peer_connections: u16,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_outgoing_byte_rate_non_validators: u32,
     /// The protocol version at which (or under) tarpitting is enabled.
@@ -105,8 +105,11 @@ pub struct Config {
     pub tarpit_duration: TimeDiff,
     /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
     pub tarpit_chance: f32,
-    /// An optional buffer size for each Juliet channel, allowing to replace the default value.
-    pub buffer_size: PerChannel<Option<u16>>,
+    /// An optional buffer size for each Juliet channel, allowing to setup how many messages
+    /// we can keep in a memory buffer before blocking at call site.
+    ///
+    /// If it is not specified, `in_flight_limit * 2` is used as a default.
+    pub send_buffer_size: PerChannel<Option<usize>>,
     /// Timeout for completing handling of a message before closing a connection to a peer.
     pub ack_timeout: TimeDiff,
     /// Duration peers are kept on the block list, before being redeemed.

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -6,6 +6,8 @@ use casper_types::{ProtocolVersion, TimeDiff};
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
+use super::PerChannel;
+
 /// Default binding address.
 ///
 /// Uses a fixed port per node, but binds on any interface.
@@ -44,11 +46,10 @@ impl Default for Config {
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
-            max_incoming_message_rate_non_validators: 0,
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
-            max_in_flight_demands: 5000, // TODO: Adjust after testing.
+            buffer_size: PerChannel::all(None), // TODO: Adjust after testing.
             ack_timeout: TimeDiff::from_seconds(30),
             blocklist_retain_duration: TimeDiff::from_seconds(600),
             identity: None,
@@ -95,19 +96,17 @@ pub struct Config {
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
     /// Maximum number of incoming connections per unique peer. Unlimited if `0`.
-    pub max_incoming_peer_connections: u16,
+    pub max_incoming_peer_connections: u16, //remove?
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_outgoing_byte_rate_non_validators: u32,
-    /// Maximum of requests answered from non-validating peers. Unlimited if 0.
-    pub max_incoming_message_rate_non_validators: u32,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.
     pub tarpit_duration: TimeDiff,
     /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
     pub tarpit_chance: f32,
-    /// Maximum number of demands for objects that can be in-flight.
-    pub max_in_flight_demands: u16,
+    /// An optional buffer size for each Juliet channel, allowing to replace the default value.
+    pub buffer_size: PerChannel<Option<u16>>,
     /// Timeout for completing handling of a message before closing a connection to a peer.
     pub ack_timeout: TimeDiff,
     /// Duration peers are kept on the block list, before being redeemed.

--- a/node/src/components/network/handshake.rs
+++ b/node/src/components/network/handshake.rs
@@ -156,7 +156,7 @@ where
     // The remote's message should be a handshake, but can technically be any message. We receive,
     // deserialize and check it.
     let remote_message_raw = read_length_prefixed_frame(
-        context.chain_info().maximum_net_message_size,
+        context.chain_info().maximum_handshake_message_size,
         &mut read_half,
     )
     .await

--- a/node/src/components/network/per_channel.rs
+++ b/node/src/components/network/per_channel.rs
@@ -1,0 +1,168 @@
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use super::Channel;
+
+/// Allows to hold some data for every channel used in the node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DataSize, Serialize, Deserialize)]
+pub struct PerChannel<T> {
+    network: T,
+    sync_data_request: T,
+    sync_data_responses: T,
+    data_requests: T,
+    data_responses: T,
+    consensus: T,
+    bulk_gossip: T,
+}
+
+impl<T> PerChannel<T> {
+    #[inline(always)]
+    pub const fn get(&self, channel: Channel) -> &T {
+        match channel {
+            Channel::Network => &self.network,
+            Channel::SyncDataRequests => &self.sync_data_request,
+            Channel::SyncDataResponses => &self.sync_data_responses,
+            Channel::DataRequests => &self.data_requests,
+            Channel::DataResponses => &self.data_responses,
+            Channel::Consensus => &self.consensus,
+            Channel::BulkGossip => &self.bulk_gossip,
+        }
+    }
+
+    pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> PerChannel<U> {
+        PerChannel {
+            network: f(self.network),
+            sync_data_request: f(self.sync_data_request),
+            sync_data_responses: f(self.sync_data_responses),
+            data_requests: f(self.data_requests),
+            data_responses: f(self.data_responses),
+            consensus: f(self.consensus),
+            bulk_gossip: f(self.bulk_gossip),
+        }
+    }
+
+    /// Fill the fields for all the channels with a value generated from the given closure.
+    pub fn all_with(mut getter: impl FnMut() -> T) -> Self {
+        PerChannel {
+            network: getter(),
+            sync_data_request: getter(),
+            sync_data_responses: getter(),
+            data_requests: getter(),
+            data_responses: getter(),
+            consensus: getter(),
+            bulk_gossip: getter(),
+        }
+    }
+}
+
+impl<T: Clone> PerChannel<T> {
+    /// Fill the fields for all the channels with the given value.
+    pub fn all(value: T) -> Self {
+        PerChannel {
+            network: value.clone(),
+            sync_data_request: value.clone(),
+            sync_data_responses: value.clone(),
+            data_requests: value.clone(),
+            data_responses: value.clone(),
+            consensus: value.clone(),
+            bulk_gossip: value,
+        }
+    }
+}
+
+impl<T> IntoIterator for PerChannel<T> {
+    type Item = (Channel, T);
+
+    type IntoIter = std::array::IntoIter<(Channel, T), 7>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let Self {
+            network,
+            sync_data_request,
+            sync_data_responses,
+            data_requests,
+            data_responses,
+            consensus,
+            bulk_gossip,
+        } = self;
+
+        [
+            (Channel::Network, network),
+            (Channel::SyncDataRequests, sync_data_request),
+            (Channel::SyncDataResponses, sync_data_responses),
+            (Channel::DataRequests, data_requests),
+            (Channel::DataResponses, data_responses),
+            (Channel::Consensus, consensus),
+            (Channel::BulkGossip, bulk_gossip),
+        ]
+        .into_iter()
+    }
+}
+
+impl<T: ToBytes> ToBytes for PerChannel<T> {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        let Self {
+            network,
+            sync_data_request,
+            sync_data_responses,
+            data_requests,
+            data_responses,
+            consensus,
+            bulk_gossip,
+        } = self;
+
+        buffer.extend(network.to_bytes()?);
+        buffer.extend(sync_data_request.to_bytes()?);
+        buffer.extend(sync_data_responses.to_bytes()?);
+        buffer.extend(data_requests.to_bytes()?);
+        buffer.extend(data_responses.to_bytes()?);
+        buffer.extend(consensus.to_bytes()?);
+        buffer.extend(bulk_gossip.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        let Self {
+            network,
+            sync_data_request,
+            sync_data_responses,
+            data_requests,
+            data_responses,
+            consensus,
+            bulk_gossip,
+        } = self;
+
+        network.serialized_length()
+            + sync_data_request.serialized_length()
+            + sync_data_responses.serialized_length()
+            + data_requests.serialized_length()
+            + data_responses.serialized_length()
+            + consensus.serialized_length()
+            + bulk_gossip.serialized_length()
+    }
+}
+
+impl<T: FromBytes> FromBytes for PerChannel<T> {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (network, bytes) = FromBytes::from_bytes(bytes)?;
+        let (sync_data_request, bytes) = FromBytes::from_bytes(bytes)?;
+        let (sync_data_responses, bytes) = FromBytes::from_bytes(bytes)?;
+        let (data_requests, bytes) = FromBytes::from_bytes(bytes)?;
+        let (data_responses, bytes) = FromBytes::from_bytes(bytes)?;
+        let (consensus, bytes) = FromBytes::from_bytes(bytes)?;
+        let (bulk_gossip, bytes) = FromBytes::from_bytes(bytes)?;
+
+        let config = Self {
+            network,
+            sync_data_request,
+            sync_data_responses,
+            data_requests,
+            data_responses,
+            consensus,
+            bulk_gossip,
+        };
+        Ok((config, bytes))
+    }
+}

--- a/node/src/components/network/tasks.rs
+++ b/node/src/components/network/tasks.rs
@@ -37,8 +37,7 @@ use super::{
     error::{ConnectionError, MessageReceiverError, MessageSenderError},
     event::{IncomingConnection, OutgoingConnection},
     message::NodeKeyPair,
-    Channel, Event, FromIncoming, Identity, Message, Metrics, Payload, PerChannel, RpcServer,
-    Transport,
+    Channel, Event, FromIncoming, Identity, Message, Metrics, Payload, RpcServer, Transport,
 };
 
 use crate::{
@@ -196,9 +195,6 @@ where
     tarpit_duration: TimeDiff,
     /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
     tarpit_chance: f32,
-    /// Maximum number of demands allowed to be running at once. If 0, no limit is enforced.
-    #[allow(dead_code)] // TODO: Read if necessary for backpressure.
-    max_in_flight_demands: PerChannel<usize>,
 }
 
 impl<REv> NetworkContext<REv> {
@@ -210,15 +206,6 @@ impl<REv> NetworkContext<REv> {
         chain_info: ChainInfo,
         net_metrics: &Arc<Metrics>,
     ) -> Self {
-        // Set the demand max from configuration, regarding `0` as "unlimited".
-        let max_in_flight_demands = chain_info.networking_config.map(|cfg| {
-            if cfg.in_flight_limit == 0 {
-                usize::MAX
-            } else {
-                cfg.in_flight_limit as usize
-            }
-        });
-
         let Identity {
             secret_key,
             tls_certificate,
@@ -240,7 +227,6 @@ impl<REv> NetworkContext<REv> {
             tarpit_version_threshold: cfg.tarpit_version_threshold,
             tarpit_duration: cfg.tarpit_duration,
             tarpit_chance: cfg.tarpit_chance,
-            max_in_flight_demands,
             keylog,
         }
     }

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -45,7 +45,7 @@ pub use self::{
     error::Error,
     global_state_update::GlobalStateUpdate,
     highway_config::{HighwayConfig, PerformanceMeterConfig},
-    network_config::NetworkConfig,
+    network_config::{JulietConfig, NetworkConfig},
     protocol_config::ProtocolConfig,
 };
 use crate::{components::network::generate_largest_serialized_message, utils::Loadable};
@@ -96,16 +96,20 @@ impl Chainspec {
         info!("begin chainspec validation");
         // Ensure the size of the largest message generated under these chainspec settings does not
         // exceed the configured message size limit.
-        let serialized = generate_largest_serialized_message(self);
+        let _serialized = generate_largest_serialized_message(self);
+        let _ = CHAINSPEC_NETWORK_MESSAGE_SAFETY_MARGIN;
 
-        if serialized.len() + CHAINSPEC_NETWORK_MESSAGE_SAFETY_MARGIN
-            > self.network_config.maximum_net_message_size as usize
-        {
-            warn!(calculated_length=serialized.len(), configured_maximum=self.network_config.maximum_net_message_size,
-                "config value [network][maximum_net_message_size] is too small to accomodate the maximum message size",
-            );
-            return false;
-        }
+        //TODO: in a next ticket, generate a maximum message size for each channel:
+        //if serialized.len() + CHAINSPEC_NETWORK_MESSAGE_SAFETY_MARGIN
+        //    > self.network_config.maximum_net_message_size as usize
+        //{
+        //    warn!(calculated_length=serialized.len(),
+        //        configured_maximum=self.network_config.maximum_net_message_size,
+        //        "config value [network][maximum_net_message_size] is too small to"
+        //        "accomodate the maximum message size",
+        //    );
+        //    return false;
+        //}
 
         if self.core_config.unbonding_delay <= self.core_config.auction_delay {
             warn!(

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -1,11 +1,14 @@
 use datasize::DataSize;
+use juliet::ChannelConfiguration;
 #[cfg(test)]
 use rand::Rng;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 #[cfg(test)]
 use casper_types::testing::TestRng;
+
+use crate::components::network::PerChannel;
 
 use super::AccountsConfig;
 
@@ -14,26 +17,52 @@ use super::AccountsConfig;
 pub struct NetworkConfig {
     /// The network name.
     pub name: String,
-    /// The maximum size of an accepted network message, in bytes.
-    pub maximum_net_message_size: u32,
+    /// The maximum size of an accepted handshake network message, in bytes.
+    pub maximum_handshake_message_size: u32,
     /// Validator accounts specified in the chainspec.
     // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
     // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
     pub accounts_config: AccountsConfig,
+    /// Low level configuration.
+    pub networking_config: PerChannel<JulietConfig>,
+}
+
+/// Low-level configuration for the Juliet crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DataSize, Serialize, Deserialize)]
+pub struct JulietConfig {
+    /// Sets a limit for channels.
+    pub in_flight_limit: u16, // 10-50
+    /// The maximum size of an accepted network message, in bytes.
+    pub maximum_request_payload_size: u32, //
+    /// The maximum size of an accepted network message, in bytes.
+    pub maximum_response_payload_size: u32,
+}
+
+impl Default for PerChannel<JulietConfig> {
+    fn default() -> Self {
+        //TODO figure out the right values:
+        PerChannel::all(JulietConfig {
+            in_flight_limit: 25,
+            maximum_request_payload_size: 24 * 1024 * 1024,
+            maximum_response_payload_size: 0,
+        })
+    }
 }
 
 #[cfg(test)]
 impl NetworkConfig {
-    /// Generates a random instance using a `TestRng`.
+    /// Generates a random instance for fuzzy testing using a `TestRng`.
     pub fn random(rng: &mut TestRng) -> Self {
         let name = rng.gen::<char>().to_string();
-        let maximum_net_message_size = 4 + rng.gen_range(0..4);
+        let maximum_handshake_message_size = 4 + rng.gen_range(0..4);
         let accounts_config = AccountsConfig::random(rng);
+        let networking_config = PerChannel::all_with(|| JulietConfig::random(rng));
 
         NetworkConfig {
             name,
-            maximum_net_message_size,
+            maximum_handshake_message_size,
             accounts_config,
+            networking_config,
         }
     }
 }
@@ -41,30 +70,118 @@ impl NetworkConfig {
 impl ToBytes for NetworkConfig {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.extend(self.name.to_bytes()?);
-        buffer.extend(self.accounts_config.to_bytes()?);
-        buffer.extend(self.maximum_net_message_size.to_bytes()?);
+        let Self {
+            name,
+            maximum_handshake_message_size,
+            accounts_config,
+
+            networking_config,
+        } = self;
+
+        buffer.extend(name.to_bytes()?);
+        buffer.extend(maximum_handshake_message_size.to_bytes()?);
+        buffer.extend(accounts_config.to_bytes()?);
+        buffer.extend(networking_config.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.name.serialized_length()
-            + self.accounts_config.serialized_length()
-            + self.maximum_net_message_size.serialized_length()
+        let Self {
+            name,
+            maximum_handshake_message_size,
+            accounts_config,
+            networking_config,
+        } = self;
+
+        name.serialized_length()
+            + maximum_handshake_message_size.serialized_length()
+            + accounts_config.serialized_length()
+            + networking_config.serialized_length()
     }
 }
 
 impl FromBytes for NetworkConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (name, remainder) = String::from_bytes(bytes)?;
+        let (maximum_handshake_message_size, remainder) = FromBytes::from_bytes(remainder)?;
         let (accounts_config, remainder) = FromBytes::from_bytes(remainder)?;
-        let (maximum_net_message_size, remainder) = FromBytes::from_bytes(remainder)?;
+        let (networking_config, remainder) = FromBytes::from_bytes(remainder)?;
+
         let config = NetworkConfig {
             name,
-            maximum_net_message_size,
+            maximum_handshake_message_size,
             accounts_config,
+            networking_config,
         };
         Ok((config, remainder))
+    }
+}
+
+#[cfg(test)]
+impl JulietConfig {
+    /// Generates a random instance using a `TestRng`.
+    pub fn random(rng: &mut TestRng) -> Self {
+        let in_flight_limit = rng.gen_range(2..50);
+        let maximum_request_payload_size = rng.gen_range(1024 * 1024..24 * 1024 * 1024);
+        let maximum_response_payload_size = rng.gen_range(0..32);
+
+        Self {
+            in_flight_limit,
+            maximum_request_payload_size,
+            maximum_response_payload_size,
+        }
+    }
+}
+
+impl ToBytes for JulietConfig {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        let Self {
+            in_flight_limit,
+            maximum_request_payload_size,
+            maximum_response_payload_size,
+        } = self;
+
+        buffer.extend(in_flight_limit.to_bytes()?);
+        buffer.extend(maximum_request_payload_size.to_bytes()?);
+        buffer.extend(maximum_response_payload_size.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        let Self {
+            in_flight_limit,
+            maximum_request_payload_size,
+            maximum_response_payload_size,
+        } = self;
+
+        in_flight_limit.serialized_length()
+            + maximum_request_payload_size.serialized_length()
+            + maximum_response_payload_size.serialized_length()
+    }
+}
+
+impl FromBytes for JulietConfig {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (in_flight_limit, remainder) = FromBytes::from_bytes(bytes)?;
+        let (maximum_request_payload_size, remainder) = FromBytes::from_bytes(remainder)?;
+        let (maximum_response_payload_size, remainder) = FromBytes::from_bytes(remainder)?;
+
+        let config = Self {
+            in_flight_limit,
+            maximum_request_payload_size,
+            maximum_response_payload_size,
+        };
+        Ok((config, remainder))
+    }
+}
+
+impl From<JulietConfig> for ChannelConfiguration {
+    fn from(juliet_config: JulietConfig) -> Self {
+        ChannelConfiguration::new()
+            .with_request_limit(juliet_config.in_flight_limit)
+            .with_max_request_payload_size(juliet_config.maximum_request_payload_size)
+            .with_max_response_payload_size(juliet_config.maximum_response_payload_size)
     }
 }
 

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -31,17 +31,17 @@ pub struct NetworkConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, DataSize, Serialize, Deserialize)]
 pub struct JulietConfig {
     /// Sets a limit for channels.
-    pub in_flight_limit: u16, // 10-50
-    /// The maximum size of an accepted network message, in bytes.
-    pub maximum_request_payload_size: u32, //
-    /// The maximum size of an accepted network message, in bytes.
+    pub in_flight_limit: u16, // order of magnitude: 10-50
+    /// The maximum size of a request payload on this channel.
+    pub maximum_request_payload_size: u32,
+    /// The maximum size of a response payload on this channel.
     pub maximum_response_payload_size: u32,
 }
 
 impl Default for PerChannel<JulietConfig> {
     fn default() -> Self {
         //TODO figure out the right values:
-        PerChannel::all(JulietConfig {
+        PerChannel::init_with(|_| JulietConfig {
             in_flight_limit: 25,
             maximum_request_payload_size: 24 * 1024 * 1024,
             maximum_response_payload_size: 0,
@@ -56,7 +56,7 @@ impl NetworkConfig {
         let name = rng.gen::<char>().to_string();
         let maximum_handshake_message_size = 4 + rng.gen_range(0..4);
         let accounts_config = AccountsConfig::random(rng);
-        let networking_config = PerChannel::all_with(|| JulietConfig::random(rng));
+        let networking_config = PerChannel::init_with(|_| JulietConfig::random(rng));
 
         NetworkConfig {
             name,

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -13,10 +13,12 @@ use serde::{Deserialize, Serialize};
 use casper_execution_engine::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
 use casper_types::{bytesrepr::Bytes, file_utils, ProtocolVersion};
 
+use crate::components::network::PerChannel;
+
 use super::{
     accounts_config::AccountsConfig, global_state_update::GlobalStateUpdateConfig, ActivationPoint,
     Chainspec, ChainspecRawBytes, CoreConfig, DeployConfig, Error, GlobalStateUpdate,
-    HighwayConfig, NetworkConfig, ProtocolConfig,
+    HighwayConfig, JulietConfig, NetworkConfig, ProtocolConfig,
 };
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -24,7 +26,8 @@ use super::{
 #[serde(deny_unknown_fields)]
 struct TomlNetwork {
     name: String,
-    maximum_net_message_size: u32,
+    maximum_handshake_message_size: u32,
+    networking_config: PerChannel<JulietConfig>,
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -59,7 +62,8 @@ impl From<&Chainspec> for TomlChainspec {
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
-            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
+            maximum_handshake_message_size: chainspec.network_config.maximum_handshake_message_size,
+            networking_config: chainspec.network_config.networking_config,
         };
 
         let core = chainspec.core_config.clone();
@@ -98,7 +102,8 @@ pub(super) fn parse_toml<P: AsRef<Path>>(
     let network_config = NetworkConfig {
         name: toml_chainspec.network.name,
         accounts_config,
-        maximum_net_message_size: toml_chainspec.network.maximum_net_message_size,
+        maximum_handshake_message_size: toml_chainspec.network.maximum_handshake_message_size,
+        networking_config: toml_chainspec.network.networking_config,
     };
 
     // global_state_update.toml must live in the same directory as chainspec.toml.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -20,7 +20,16 @@ activation_point = '${TIMESTAMP}'
 name = 'casper-example'
 # The maximum size of an acceptable networking message in bytes.  Any message larger than this will
 # be rejected at the networking level.
-maximum_net_message_size = 25_165_824
+maximum_handshake_message_size = 1_048_576
+
+[network.networking_config]
+network = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+sync_data_request = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+sync_data_responses = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+data_requests = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+data_responses = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+consensus = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+bulk_gossip = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
 
 [core]
 # Era duration.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -18,7 +18,7 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
-# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# The maximum size of an acceptable handshake message in bytes. Any handshake larger than this will
 # be rejected at the networking level.
 maximum_handshake_message_size = 1_048_576
 

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -18,9 +18,18 @@ activation_point = 11000
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper'
-# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# The maximum size of an acceptable handshake message in bytes. Any handshake larger than this will
 # be rejected at the networking level.
-maximum_net_message_size = 25_165_824
+maximum_handshake_message_size = 1_048_576
+
+[network.networking_config]
+network = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+sync_data_request = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+sync_data_responses = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+data_requests = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+data_responses = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+consensus = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
+bulk_gossip = { in_flight_limit = 25, maximum_request_payload_size = 25_165_824, maximum_response_payload_size = 0 }
 
 [core]
 # Era duration.


### PR DESCRIPTION
Fix #4457 
The network is configured on a per-channel basis:
- The in-flight limits and payload sizes are setup in the chainspec;
- The buffer size is in the networking component config.