### PR TITLE
Disable banning based on failed pings

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -947,15 +947,15 @@ where
                 // Record the time the pong arrived and forward it to outgoing.
                 let pong = TaggedTimestamp::from_parts(Instant::now(), nonce);
                 if self.outgoing_manager.record_pong(peer_id, pong) {
-                    effect_builder
-                        .announce_block_peer_with_justification(
-                            peer_id,
-                            BlocklistJustification::PongLimitExceeded,
-                        )
-                        .ignore()
-                } else {
-                    Effects::new()
+                    // Note: We no longer block peers here with a `PongLimitExceeded` for failed
+                    //       pongs, merely warn.
+                    warn!(
+                        "peer {} exceeded failed pong limit, or allowed number of pongs",
+                        peer_id // Redundant information due to span, but better safe than sorry.
+                    );
                 }
+
+                Effects::new()
             }
             Message::Payload(payload) => {
                 effect_builder.announce_incoming(peer_id, payload).ignore()

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -949,7 +949,7 @@ where
                 if self.outgoing_manager.record_pong(peer_id, pong) {
                     // Note: We no longer block peers here with a `PongLimitExceeded` for failed
                     //       pongs, merely warn.
-                    warn!(
+                    info!(
                         "peer {} exceeded failed pong limit, or allowed number of pongs",
                         peer_id // Redundant information due to span, but better safe than sorry.
                     );

--- a/node/src/components/network/blocklist.rs
+++ b/node/src/components/network/blocklist.rs
@@ -38,6 +38,7 @@ pub(crate) enum BlocklistJustification {
         era: EraId,
     },
     /// Too many unasked or expired pongs were sent by the peer.
+    #[allow(dead_code)] // Disabled as per 1.5.5 for stability reasons.
     PongLimitExceeded,
     /// Peer misbehaved during consensus and is blocked for it.
     BadConsensusBehavior,


### PR DESCRIPTION
Disables the ban due to failed ping roundtrips in the networking component, turning this feature into a more diagnostic one instead (ping roundtrip times should be visible through the diagnostic port's network info).