### PR TITLE
Filter for IPv4 addresses

### DIFF
--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -111,6 +111,8 @@ pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddres
             address: address.to_string(),
             kind: ResolveAddressErrorKind::ErrorResolving(err),
         })?
+        /// Filter for IPv4 addresses
+        .filter(|addr| addr.is_ipv4())
         .next()
         .ok_or_else(|| ResolveAddressError {
             address: address.to_string(),


### PR DESCRIPTION
Since IPv6 isn't officially supported but caused trouble during multiple upgrades in the past already -> filter it out.

I have NOT tested this PR because I lack the required test network and time and experience.

Reason is that right now there are quite some validators/nodes running on IPv6 because the initial upgrade instructions and scripts didn't filter out IPv6 and the node operators didn't understand that.

So I think it's the best to stop IPv6 on the node level and to force node operators to check and fix their config.