### PR TITLE
Filter out non-IPv4 addresses when resolving DNS names

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.  The format
     - `ttl` - node will attempt to acquire all block data to comply with time to live enforcement
     - `nosync` - node will only acquire blocks moving forward
 * Make the `network.estimator_weights` section of the node config more fine-grained to provide more precise throttling of non-validator traffic.
+* Any IPv6 address resolved for the node's own public IP will now be ignored, resulting in fewer connectivity issues on nodes misconfigured due to using an older installation script.
 
 ### Removed
 * The section `consensus.highway.round_success_meter` has been removed from the config file as no longer relevant with the introduction of a new method of determining the round exponent in Highway.

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -117,8 +117,7 @@ pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddres
             address: address.to_string(),
             kind: ResolveAddressErrorKind::ErrorResolving(err),
         })?
-        .filter(SocketAddr::is_ipv4)
-        .next()
+        .find(SocketAddr::is_ipv4)
         .ok_or_else(|| ResolveAddressError {
             address: address.to_string(),
             kind: ResolveAddressErrorKind::NoAddressFound,

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -108,6 +108,8 @@ impl<T, E> FlattenResult for Result<Result<T, E>, E> {
 }
 
 /// Parses a network address from a string, with DNS resolution.
+///
+/// Only resolves to IPv4 addresses, IPv6 addresses are filtered out.
 pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddressError> {
     address
         .to_socket_addrs()
@@ -115,6 +117,7 @@ pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddres
             address: address.to_string(),
             kind: ResolveAddressErrorKind::ErrorResolving(err),
         })?
+        .filter(SocketAddr::is_ipv4)
         .next()
         .ok_or_else(|| ResolveAddressError {
             address: address.to_string(),


### PR DESCRIPTION
As suggested in #4486, although rewritten since the original submission was missing some docs and failed linting. ~~Targeted at 1.5.5 for now.~~ Aimed at 1.6.