### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -3010,7 +3010,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util 0.7.8",
@@ -5214,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -66,7 +66,7 @@ serde-map-to-array = "1.1.0"
 serde_bytes = "0.11.5"
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_repr = "0.1.6"
-shlex = "1.0.0"
+shlex = "1.3.0"
 signal-hook = "0.3.4"
 signature = "1"
 smallvec = { version = "1", features = ["serde"] }


### PR DESCRIPTION
This updates `h2` and `shlex` as advised by [`RUSTSEC-2024-0003`](https://rustsec.org/advisories/RUSTSEC-2024-0003) and [`RUSTSEC-2024-0006`](https://rustsec.org/advisories/RUSTSEC-2024-0006) respectively.