### PR TITLE
Update Logo & Discord URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![LOGO](https://raw.githubusercontent.com/casper-network/casper-node/master/images/casper-association-logo-new.svg)](https://casper.network/)
+[![LOGO](https://raw.githubusercontent.com/casper-network/casper-node/dev/images/Casper-association-logo-new.svg)](https://casper.network/)
 
 # casper-node
 
@@ -32,7 +32,7 @@ The Casper MainNet is live.
 
 ### Community
 
-- [Discord Server](https://discord.gg/mpZ9AYD)
+- [Discord Server](https://discord.com/invite/casperblockchain)
 - [Telegram Channel](https://t.me/casperofficialann)
 
 


### PR DESCRIPTION
Someone will also need to update the discord URL in the footer of https://casper.network/en-us/

Also here; https://casper.network/en-us/community

The discord URL is now; https://discord.com/invite/casperblockchain