### PR TITLE
Fix chainspec modules cfg statement.

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -30,7 +30,7 @@ mod block;
 mod block_time;
 mod byte_code;
 pub mod bytesrepr;
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
+#[cfg(any(feature = "std", test))]
 mod chainspec;
 pub mod checksummed_hex;
 mod cl_type;


### PR DESCRIPTION
This PR updates the cfg statement on the chainspec module in casper-types lib.rs to allow it to compile with either the std or test feature flags enabled.

Currently it only compiles with either the testing feature, or *BOTH* std and testing.
