### PR TITLE
Fix the build for casper-types with single features enabled.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,8 @@ steps:
   environment:
     SCCACHE_S3_PUBLIC: true
   commands:
+  - make check-std-features
+  - make check-testing-features
   - make test CARGO_FLAGS=--release
   - make test-contracts CARGO_FLAGS=--release
   - cachepot --show-stats
@@ -48,6 +50,8 @@ steps:
 - name: cargo-test-push
   <<: *buildenv
   commands:
+  - make check-std-features
+  - make check-testing-features
   - make test CARGO_FLAGS=--release
   - make test-contracts CARGO_FLAGS=--release
   - cachepot --show-stats

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,11 @@ check-std-features:
 	cd smart_contracts/contract && $(CARGO) check --all-targets --no-default-features --features=std
 	cd smart_contracts/contract && $(CARGO) check --all-targets --features=std
 
+.PHONY: check-testing-features
+check-testing-features:
+	cd types && $(CARGO) check --all-targets --no-default-features --features=testing
+	cd types && $(CARGO) check --all-targets --features=testing
+
 .PHONY: check-format
 check-format:
 	$(CARGO_PINNED_NIGHTLY) fmt --all -- --check
@@ -158,18 +163,15 @@ check-rs: \
 	lint \
 	audit \
 	check-std-features \
+	check-testing-features \
 	test-rs \
 	test-rs-no-default-features \
 	test-contracts-rs
 
 .PHONY: check
 check: \
-	check-format \
-	doc \
-	lint \
-	audit \
-	test \
-	test-contracts
+	check-rs \
+	test-as
 
 .PHONY: clean
 clean:

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -253,8 +253,6 @@ where
     /// contracts, sets up the genesis accounts, and sets up the auction state based on that. At
     /// the end of the process, [`SystemEntityRegistry`] is persisted under the special global
     /// state space [`Key::SystemEntityRegistry`].
-    ///
-    /// Returns a [`GenesisResult`].
     pub fn commit_genesis(&self, request: GenesisRequest) -> GenesisResult {
         self.state.genesis(request)
     }
@@ -262,8 +260,6 @@ where
     /// Commits upgrade.
     ///
     /// This process applies changes to the global state.
-    ///
-    /// Returns [`UpgradeSuccess`].
     pub fn commit_upgrade(&self, request: ProtocolUpgradeRequest) -> ProtocolUpgradeResult {
         self.state.protocol_upgrade(request)
     }

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1045,7 +1045,7 @@ where
         self.exec_results.len()
     }
 
-    /// Returns a `Result` containing an [`UpgradeSuccess`].
+    /// Returns the result of upgrading.
     pub fn get_upgrade_result(&self, index: usize) -> Option<&ProtocolUpgradeResult> {
         self.upgrade_results.get(index)
     }

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -7,6 +7,7 @@ use core::fmt::{self, Display, Formatter};
 use bitflags::bitflags;
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -124,6 +125,7 @@ impl<'de> Deserialize<'de> for AccessRights {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<AccessRights> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccessRights {
         let mut result = AccessRights::NONE;

--- a/types/src/account/account_hash.rs
+++ b/types/src/account/account_hash.rs
@@ -5,6 +5,7 @@ use core::{
 };
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -205,6 +206,7 @@ impl AsRef<[u8]> for AccountHash {
 #[derive(Debug)]
 pub struct TryFromSliceForAccountHashError(());
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<AccountHash> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccountHash {
         AccountHash::new(rng.gen())

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -47,10 +47,7 @@ pub use rewarded_signatures::{RewardedSignatures, SingleBlockRewardedSignatures}
 pub use rewards::Rewards;
 pub use signed_block_header::{SignedBlockHeader, SignedBlockHeaderValidationError};
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
-pub use test_block_builder::{
-    TestBlockV1Builder,
-    TestBlockBuilder,
-};
+pub use test_block_builder::{TestBlockBuilder, TestBlockV1Builder};
 
 #[cfg(feature = "json-schema")]
 static BLOCK: Lazy<Block> = Lazy::new(|| BlockV2::example().into());

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -11,12 +11,8 @@ mod json_compatibility;
 mod rewarded_signatures;
 mod rewards;
 mod signed_block_header;
-
-#[cfg(any(feature = "testing", test))]
-mod test_block_builder {
-    pub mod test_block_v1_builder;
-    pub mod test_block_v2_builder;
-}
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
+mod test_block_builder;
 
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt::{self, Display, Formatter};
@@ -50,10 +46,10 @@ pub use json_compatibility::JsonBlockWithSignatures;
 pub use rewarded_signatures::{RewardedSignatures, SingleBlockRewardedSignatures};
 pub use rewards::Rewards;
 pub use signed_block_header::{SignedBlockHeader, SignedBlockHeaderValidationError};
-#[cfg(any(feature = "testing", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use test_block_builder::{
-    test_block_v1_builder::TestBlockV1Builder,
-    test_block_v2_builder::TestBlockV2Builder as TestBlockBuilder,
+    TestBlockV1Builder,
+    TestBlockBuilder,
 };
 
 #[cfg(feature = "json-schema")]

--- a/types/src/block/test_block_builder.rs
+++ b/types/src/block/test_block_builder.rs
@@ -1,0 +1,5 @@
+mod test_block_v1_builder;
+mod test_block_v2_builder;
+
+pub use test_block_v1_builder::TestBlockV1Builder;
+pub use test_block_v2_builder::TestBlockV2Builder as TestBlockBuilder;

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -43,7 +43,6 @@ pub use fee_handling::FeeHandling;
 pub use genesis_config::{GenesisConfig, GenesisConfigBuilder};
 #[cfg(any(feature = "testing", test))]
 pub use genesis_config::{DEFAULT_AUCTION_DELAY, DEFAULT_FEE_HANDLING, DEFAULT_REFUND_HANDLING};
-
 pub use global_state_update::{GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError};
 pub use highway_config::HighwayConfig;
 pub use network_config::NetworkConfig;

--- a/types/src/chainspec/accounts_config/genesis.rs
+++ b/types/src/chainspec/accounts_config/genesis.rs
@@ -1,18 +1,21 @@
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 use num_traits::Zero;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(any(feature = "testing", test))]
+use crate::SecretKey;
 use crate::{
     account::AccountHash,
     bytesrepr,
     bytesrepr::{FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     system::auction::DelegationRate,
-    Motes, PublicKey, SecretKey,
+    Motes, PublicKey,
 };
 
 const TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
@@ -80,6 +83,7 @@ impl GenesisValidator {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<GenesisValidator> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisValidator {
         let bonded_amount = Motes::new(rng.gen());
@@ -375,6 +379,7 @@ impl GenesisAccount {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<GenesisAccount> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisAccount {
         let mut bytes = [0u8; 32];

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -1,6 +1,8 @@
+#[cfg(any(feature = "testing", test))]
 use std::iter;
 
 use num_rational::Ratio;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -167,6 +169,7 @@ impl GenesisConfig {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<GenesisConfig> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisConfig {
         let count = rng.gen_range(1..10);

--- a/types/src/chainspec/vm_config/auction_costs.rs
+++ b/types/src/chainspec/vm_config/auction_costs.rs
@@ -1,7 +1,11 @@
 //! Costs of the auction system contract.
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -203,6 +207,7 @@ impl FromBytes for AuctionCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<AuctionCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AuctionCosts {
         AuctionCosts {

--- a/types/src/chainspec/vm_config/chainspec_registry.rs
+++ b/types/src/chainspec/vm_config/chainspec_registry.rs
@@ -1,10 +1,12 @@
 //! The registry of chainspec hash digests.
 
+use std::{collections::BTreeMap, convert::TryFrom};
+
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-use std::{collections::BTreeMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
@@ -130,6 +132,7 @@ impl CLTyped for ChainspecRegistry {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<ChainspecRegistry> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ChainspecRegistry {
         ChainspecRegistry {

--- a/types/src/chainspec/vm_config/handle_payment_costs.rs
+++ b/types/src/chainspec/vm_config/handle_payment_costs.rs
@@ -1,7 +1,11 @@
 //! Costs of the `handle_payment` system contract.
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -80,6 +84,7 @@ impl FromBytes for HandlePaymentCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<HandlePaymentCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> HandlePaymentCosts {
         HandlePaymentCosts {

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -842,6 +842,7 @@ impl FromBytes for HostFunctionCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<HostFunctionCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> HostFunctionCosts {
         HostFunctionCosts {

--- a/types/src/chainspec/vm_config/message_limits.rs
+++ b/types/src/chainspec/vm_config/message_limits.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -80,6 +84,7 @@ impl FromBytes for MessageLimits {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<MessageLimits> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MessageLimits {
         MessageLimits {

--- a/types/src/chainspec/vm_config/mint_costs.rs
+++ b/types/src/chainspec/vm_config/mint_costs.rs
@@ -1,7 +1,11 @@
 //! Costs of the mint system contract.
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -127,6 +131,7 @@ impl FromBytes for MintCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<MintCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MintCosts {
         MintCosts {

--- a/types/src/chainspec/vm_config/opcode_costs.rs
+++ b/types/src/chainspec/vm_config/opcode_costs.rs
@@ -4,7 +4,11 @@
 use datasize::DataSize;
 use derive_more::Add;
 use num_traits::Zero;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -96,6 +100,7 @@ impl Default for BrTableCost {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<BrTableCost> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BrTableCost {
         BrTableCost {
@@ -321,6 +326,7 @@ impl FromBytes for ControlFlowCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<ControlFlowCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ControlFlowCosts {
         ControlFlowCosts {
@@ -457,6 +463,7 @@ impl Default for OpcodeCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<OpcodeCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> OpcodeCosts {
         OpcodeCosts {

--- a/types/src/chainspec/vm_config/standard_payment_costs.rs
+++ b/types/src/chainspec/vm_config/standard_payment_costs.rs
@@ -1,7 +1,11 @@
 //! Costs of the standard payment system contract.
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::bytesrepr::{self, FromBytes, ToBytes};
@@ -45,6 +49,7 @@ impl FromBytes for StandardPaymentCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<StandardPaymentCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> StandardPaymentCosts {
         StandardPaymentCosts { pay: rng.gen() }

--- a/types/src/chainspec/vm_config/storage_costs.rs
+++ b/types/src/chainspec/vm_config/storage_costs.rs
@@ -3,7 +3,11 @@
 use datasize::DataSize;
 use derive_more::Add;
 use num_traits::Zero;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -49,6 +53,7 @@ impl Default for StorageCosts {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<StorageCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> StorageCosts {
         StorageCosts {

--- a/types/src/chainspec/vm_config/system_config.rs
+++ b/types/src/chainspec/vm_config/system_config.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -91,6 +95,7 @@ impl Default for SystemConfig {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<SystemConfig> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SystemConfig {
         SystemConfig {

--- a/types/src/chainspec/vm_config/wasm_config.rs
+++ b/types/src/chainspec/vm_config/wasm_config.rs
@@ -1,7 +1,11 @@
 //! Configuration of the Wasm execution engine.
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use rand::{distributions::Standard, prelude::*, Rng};
+#[cfg(any(feature = "testing", test))]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -137,6 +141,7 @@ impl FromBytes for WasmConfig {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<WasmConfig> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> WasmConfig {
         WasmConfig {

--- a/types/src/contract_messages/topics.rs
+++ b/types/src/contract_messages/topics.rs
@@ -10,6 +10,7 @@ use core::fmt::{Debug, Display, Formatter};
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -121,6 +122,7 @@ impl Debug for TopicNameHash {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<TopicNameHash> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TopicNameHash {
         TopicNameHash(rng.gen())

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -95,7 +95,7 @@ pub use block::{
     FinalitySignatureId, RewardedSignatures, Rewards, SignedBlockHeader,
     SignedBlockHeaderValidationError, SingleBlockRewardedSignatures,
 };
-#[cfg(any(feature = "testing", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use block::{TestBlockBuilder, TestBlockV1Builder};
 
 pub use block_time::{BlockTime, BLOCKTIME_SERIALIZED_LENGTH};

--- a/types/src/system/auction/bid_addr.rs
+++ b/types/src/system/auction/bid_addr.rs
@@ -9,6 +9,7 @@ use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -285,6 +286,7 @@ impl Debug for BidAddr {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<BidAddr> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BidAddr {
         BidAddr::Validator(AccountHash::new(rng.gen()))

--- a/types/src/transaction/transaction_v1/transaction_v1_body.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body.rs
@@ -6,7 +6,7 @@ use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-#[cfg(any(feature = "testing", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use rand::{Rng, RngCore};
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
@@ -21,7 +21,7 @@ use super::TransactionV1;
 #[cfg(any(feature = "std", test))]
 use super::{TransactionConfig, TransactionV1ConfigFailure};
 use crate::bytesrepr::{self, FromBytes, ToBytes};
-#[cfg(any(feature = "testing", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::{
     bytesrepr::Bytes, testing::TestRng, PublicKey, TransactionInvocationTarget, TransactionRuntime,
     TransactionSessionKind,
@@ -174,7 +174,7 @@ impl TransactionV1Body {
     }
 
     /// Returns a random `TransactionV1Body`.
-    #[cfg(any(feature = "testing", test))]
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn random(rng: &mut TestRng) -> Self {
         match rng.gen_range(0..8) {
             0 => {

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -7,6 +7,7 @@ use core::{
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -310,6 +311,7 @@ impl AsRef<[u8]> for TransferAddr {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<TransferAddr> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TransferAddr {
         TransferAddr::new(rng.gen())

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -8,6 +8,7 @@ use core::{
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -304,6 +305,7 @@ impl TryFrom<Key> for URef {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<URef> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> URef {
         URef::new(rng.gen(), rng.gen())


### PR DESCRIPTION
This fixes the build for `casper-types` with only the `std` feature enabled, or only the `testing` feature enabled.

These features are also now checked as part of CI for PRs.