### PR TITLE
Rewards calculation fixes

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -86,7 +86,7 @@ function dev_branch_settings() {
     pushd "$(get_path_to_remotes)"
     RC_VERSION="$(ls --group-directories-first -d */ | sort -r | head -n 1 | tr -d '/')"
 
-    [[ "$RC_VERSION" =~ (.*[^0-9])([0-9])(.)([0-9]+) ]] && INCREMENT="${BASH_REMATCH[1]}$((${BASH_REMATCH[2]} + 1))${BASH_REMATCH[3]}${BASH_REMATCH[4]}"
+    [[ "$RC_VERSION" =~ (.*[^0-9])([0-9])(.)([0-9]+) ]] && INCREMENT="2.0${BASH_REMATCH[3]}${BASH_REMATCH[4]}"
 
     RC_VERSION=$(echo "$RC_VERSION" | sed 's/\./\_/g')
     INCREMENT=$(echo "$INCREMENT" | sed 's/\./\_/g')

--- a/node/src/components/contract_runtime/rewards.rs
+++ b/node/src/components/contract_runtime/rewards.rs
@@ -342,9 +342,11 @@ pub(crate) async fn fetch_data_and_calculate_rewards_for_era<REv: ReactorEventT>
         "starting the rewards calculation"
     );
 
-    if current_era_id.is_genesis() {
-        // Special case: genesis block does not yield any reward, because there is no block
-        // producer, and no previous blocks whose signatures are to be rewarded:
+    if current_era_id.is_genesis()
+        || current_era_id == chainspec.protocol_config.activation_point.era_id()
+    {
+        // Special case: genesis block and immediate switch blocks do not yield any reward, because
+        // there is no block producer, and no signatures from previous blocks to be rewarded:
         Ok(chainspec
             .network_config
             .accounts_config

--- a/node/src/components/contract_runtime/rewards.rs
+++ b/node/src/components/contract_runtime/rewards.rs
@@ -4,7 +4,8 @@ mod tests;
 use std::{collections::BTreeMap, ops::Range, sync::Arc};
 
 use casper_storage::data_access_layer::{
-    EraValidatorsRequest, RoundSeigniorageRateResult, TotalSupplyResult,
+    EraValidatorsRequest, RoundSeigniorageRateRequest, RoundSeigniorageRateResult,
+    TotalSupplyRequest, TotalSupplyResult,
 };
 use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 
@@ -32,6 +33,7 @@ impl<T> ReactorEventT for T where T: Send + From<StorageRequest> + From<Contract
 
 #[derive(Debug)]
 pub(crate) struct CitedBlock {
+    protocol_version: ProtocolVersion,
     height: u64,
     era_id: EraId,
     proposer: PublicKey,
@@ -39,6 +41,21 @@ pub(crate) struct CitedBlock {
     state_root_hash: Digest,
     is_switch_block: bool,
     is_genesis: bool,
+}
+
+impl CitedBlock {
+    fn from_executable_block(block: ExecutableBlock, protocol_version: ProtocolVersion) -> Self {
+        Self {
+            protocol_version,
+            era_id: block.era_id,
+            height: block.height,
+            proposer: *block.proposer,
+            rewarded_signatures: block.rewarded_signatures,
+            state_root_hash: Digest::default(),
+            is_switch_block: block.era_report.is_some(),
+            is_genesis: block.era_id.is_genesis(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -78,7 +95,7 @@ pub enum RewardsError {
 }
 
 impl RewardsInfo {
-    pub async fn new_from_storage<REv: ReactorEventT>(
+    pub async fn new<REv: ReactorEventT>(
         effect_builder: EffectBuilder<REv>,
         protocol_version: ProtocolVersion,
         signature_rewards_max_delay: u64,
@@ -114,15 +131,13 @@ impl RewardsInfo {
             "blocks fetched",
         );
 
-        let eras_info = Self::create_eras_info(
-            effect_builder,
-            current_era_id,
-            protocol_version,
-            cited_blocks.iter(),
-        )
-        .await?;
+        let eras_info =
+            Self::create_eras_info(effect_builder, current_era_id, cited_blocks.iter()).await?;
 
-        cited_blocks.push(executable_block.into());
+        cited_blocks.push(CitedBlock::from_executable_block(
+            executable_block,
+            protocol_version,
+        ));
 
         Ok(RewardsInfo {
             eras_info,
@@ -143,7 +158,6 @@ impl RewardsInfo {
     async fn create_eras_info<REv: ReactorEventT>(
         effect_builder: EffectBuilder<REv>,
         current_era_id: EraId,
-        protocol_version: ProtocolVersion,
         mut cited_blocks: impl Iterator<Item = &CitedBlock>,
     ) -> Result<BTreeMap<EraId, EraInfo>, RewardsError> {
         let oldest_block = cited_blocks.next();
@@ -165,13 +179,14 @@ impl RewardsInfo {
             .chain(cited_blocks.filter(|&block| block.is_switch_block))
             .map(|block| {
                 let state_root_hash = block.state_root_hash;
+                let protocol_version = block.protocol_version;
                 let era = if block.is_switch_block {
                     block.era_id.successor()
                 } else {
                     block.era_id
                 };
 
-                (era, state_root_hash)
+                (era, protocol_version, state_root_hash)
             })
             .collect();
 
@@ -179,7 +194,7 @@ impl RewardsInfo {
             eras_and_state_root_hashes.len() + usize::from(oldest_block_is_genesis);
 
         let mut eras_info: BTreeMap<_, _> = stream::iter(eras_and_state_root_hashes)
-            .then(|(era_id, state_root_hash)| async move {
+            .then(|(era_id, protocol_version, state_root_hash)| async move {
                 let era_validators_result = effect_builder
                     .get_era_validators_from_contract_runtime(EraValidatorsRequest::new(
                         state_root_hash,
@@ -197,7 +212,10 @@ impl RewardsInfo {
                     .ok_or_else(|| RewardsError::FailedToFetchEraValidators(state_root_hash))?
                     .1;
 
-                let total_supply = match effect_builder.get_total_supply(state_root_hash).await {
+                let total_supply_request =
+                    TotalSupplyRequest::new(state_root_hash, protocol_version);
+                let total_supply = match effect_builder.get_total_supply(total_supply_request).await
+                {
                     TotalSupplyResult::RootNotFound
                     | TotalSupplyResult::MintNotFound
                     | TotalSupplyResult::ValueNotFound(_)
@@ -207,8 +225,10 @@ impl RewardsInfo {
                     TotalSupplyResult::Success { total_supply } => total_supply,
                 };
 
+                let seignorate_rate_request =
+                    RoundSeigniorageRateRequest::new(state_root_hash, protocol_version);
                 let seignorate_rate = match effect_builder
-                    .get_round_seigniorage_rate(state_root_hash)
+                    .get_round_seigniorage_rate(seignorate_rate_request)
                     .await
                 {
                     RoundSeigniorageRateResult::RootNotFound
@@ -354,7 +374,7 @@ pub(crate) async fn fetch_data_and_calculate_rewards_for_era<REv: ReactorEventT>
             .map(|account| (account.public_key.clone(), U512::zero()))
             .collect())
     } else {
-        let rewards_info = RewardsInfo::new_from_storage(
+        let rewards_info = RewardsInfo::new(
             effect_builder,
             chainspec.protocol_version(),
             chainspec.core_config.signature_rewards_max_delay,
@@ -501,6 +521,7 @@ async fn collect_past_blocks_batched<REv: From<StorageRequest>>(
 impl From<Block> for CitedBlock {
     fn from(block: Block) -> Self {
         Self {
+            protocol_version: block.protocol_version(),
             era_id: block.era_id(),
             height: block.height(),
             proposer: block.proposer().clone(),
@@ -508,20 +529,6 @@ impl From<Block> for CitedBlock {
             state_root_hash: *block.state_root_hash(),
             is_switch_block: block.is_switch_block(),
             is_genesis: block.is_genesis(),
-        }
-    }
-}
-
-impl From<ExecutableBlock> for CitedBlock {
-    fn from(block: ExecutableBlock) -> Self {
-        Self {
-            era_id: block.era_id,
-            height: block.height,
-            proposer: *block.proposer,
-            rewarded_signatures: block.rewarded_signatures,
-            state_root_hash: Digest::default(),
-            is_switch_block: block.era_report.is_some(),
-            is_genesis: block.era_id.is_genesis(),
         }
     }
 }

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 5, 3);
+    ProtocolVersion::from_parts(2, 0, 0);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1992,11 +1992,10 @@ impl<REv> EffectBuilder<REv> {
     /// Returns the total supply from the given `root_hash`.
     ///
     /// This operation is read only.
-    pub(crate) async fn get_total_supply(self, state_hash: Digest) -> TotalSupplyResult
+    pub(crate) async fn get_total_supply(self, request: TotalSupplyRequest) -> TotalSupplyResult
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let request = TotalSupplyRequest::new(state_hash);
         self.make_request(
             move |responder| ContractRuntimeRequest::GetTotalSupply { request, responder },
             QueueKind::ContractRuntime,
@@ -2009,12 +2008,11 @@ impl<REv> EffectBuilder<REv> {
     /// This operation is read only.
     pub(crate) async fn get_round_seigniorage_rate(
         self,
-        state_hash: Digest,
+        request: RoundSeigniorageRateRequest,
     ) -> RoundSeigniorageRateResult
     where
         REv: From<ContractRuntimeRequest>,
     {
-        let request = RoundSeigniorageRateRequest::new(state_hash);
         self.make_request(
             move |responder| ContractRuntimeRequest::GetRoundSeigniorageRate { request, responder },
             QueueKind::ContractRuntime,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.0.0'
+version = '2.0.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = false
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.5.3'
+version = '2.0.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "1.5.3",
+    "version": "2.0.0",
     "title": "Client API of Casper Node",
     "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
     "contact": {
@@ -116,7 +116,7 @@
           "result": {
             "name": "account_put_deploy_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
             }
           }
@@ -246,7 +246,7 @@
           "result": {
             "name": "account_put_transaction_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "transaction_hash": {
                 "Version1": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2"
               }
@@ -333,7 +333,7 @@
           "result": {
             "name": "info_get_deploy_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "deploy": {
                 "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
                 "header": {
@@ -494,7 +494,7 @@
           "result": {
             "name": "info_get_transaction_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "transaction": {
                 "Version1": {
                   "hash": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2",
@@ -675,7 +675,7 @@
           "result": {
             "name": "state_get_account_info_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "account": {
                 "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
                 "named_keys": [
@@ -776,7 +776,7 @@
           "result": {
             "name": "state_get_dictionary_item_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
               "stored_value": {
                 "CLValue": {
@@ -891,7 +891,7 @@
           "result": {
             "name": "query_global_state_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "block_header": {
                 "Version2": {
                   "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
@@ -1025,7 +1025,7 @@
           "result": {
             "name": "query_balance_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "balance": "123456"
             }
           }
@@ -1065,7 +1065,7 @@
           "result": {
             "name": "info_get_peers_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "peers": [
                 {
                   "node_id": "tls:0101..0101",
@@ -1200,7 +1200,7 @@
                   "address": "127.0.0.1:54321"
                 }
               ],
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "build_version": "1.0.0-xxxxxxxxx@DEBUG",
               "chainspec_name": "casper-example",
               "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -1278,7 +1278,7 @@
           "result": {
             "name": "info_get_validator_changes_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "changes": [
                 {
                   "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -1327,7 +1327,7 @@
           "result": {
             "name": "info_get_chainspec_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "chainspec_bytes": {
                 "chainspec_bytes": "2a2a",
                 "maybe_genesis_accounts_bytes": null,
@@ -1393,7 +1393,7 @@
           "result": {
             "name": "chain_get_block_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "block_with_signatures": {
                 "block": {
                   "Version2": {
@@ -1535,7 +1535,7 @@
           "result": {
             "name": "chain_get_block_transfers_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "block_hash": "0707070707070707070707070707070707070707070707070707070707070707",
               "transfers": [
                 {
@@ -1609,7 +1609,7 @@
           "result": {
             "name": "chain_get_state_root_hash_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
             }
           }
@@ -1698,7 +1698,7 @@
           "result": {
             "name": "state_get_item_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "stored_value": {
                 "CLValue": {
                   "cl_type": "U64",
@@ -1776,7 +1776,7 @@
           "result": {
             "name": "state_get_balance_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "balance_value": "123456",
               "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
             }
@@ -1839,7 +1839,7 @@
           "result": {
             "name": "chain_get_era_info_by_switch_block_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "era_summary": {
                 "block_hash": "9ccc716f5f3c7ac238bf7aaad113c2add3586921a7966faffb3a5a253aa1d75e",
                 "era_id": 42,
@@ -1919,7 +1919,7 @@
           "result": {
             "name": "state_get_auction_info_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "auction_state": {
                 "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                 "block_height": 10,
@@ -2014,7 +2014,7 @@
           "result": {
             "name": "chain_get_era_summary_example_result",
             "value": {
-              "api_version": "1.5.3",
+              "api_version": "2.0.0",
               "era_summary": {
                 "block_hash": "9ccc716f5f3c7ac238bf7aaad113c2add3586921a7966faffb3a5a253aa1d75e",
                 "era_id": 42,

--- a/storage/src/data_access_layer/round_seigniorage.rs
+++ b/storage/src/data_access_layer/round_seigniorage.rs
@@ -1,22 +1,31 @@
 use crate::tracking_copy::TrackingCopyError;
-use casper_types::{Digest, U512};
+use casper_types::{Digest, ProtocolVersion, U512};
 use num_rational::Ratio;
 
 /// Request to get the current round seigniorage rate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RoundSeigniorageRateRequest {
     state_hash: Digest,
+    protocol_version: ProtocolVersion,
 }
 
 impl RoundSeigniorageRateRequest {
     /// Create instance of RoundSeigniorageRateRequest.
-    pub fn new(state_hash: Digest) -> Self {
-        RoundSeigniorageRateRequest { state_hash }
+    pub fn new(state_hash: Digest, protocol_version: ProtocolVersion) -> Self {
+        RoundSeigniorageRateRequest {
+            state_hash,
+            protocol_version,
+        }
     }
 
     /// Returns state root hash.
     pub fn state_hash(&self) -> Digest {
         self.state_hash
+    }
+
+    /// Returns the protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 }
 

--- a/storage/src/data_access_layer/total_supply.rs
+++ b/storage/src/data_access_layer/total_supply.rs
@@ -1,21 +1,30 @@
 use crate::tracking_copy::TrackingCopyError;
-use casper_types::{Digest, U512};
+use casper_types::{Digest, ProtocolVersion, U512};
 
 /// Request for total supply.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TotalSupplyRequest {
     state_hash: Digest,
+    protocol_version: ProtocolVersion,
 }
 
 impl TotalSupplyRequest {
     /// Creates an instance of TotalSupplyRequest.
-    pub fn new(state_hash: Digest) -> Self {
-        TotalSupplyRequest { state_hash }
+    pub fn new(state_hash: Digest, protocol_version: ProtocolVersion) -> Self {
+        TotalSupplyRequest {
+            state_hash,
+            protocol_version,
+        }
     }
 
     /// Returns state root hash.
     pub fn state_hash(&self) -> Digest {
         self.state_hash
+    }
+
+    /// Returns the protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 }
 

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -435,11 +435,18 @@ pub trait StateProvider {
 
         let query_request = match tc.get_system_entity_registry() {
             Ok(scr) => match scr.get(AUCTION).copied() {
-                Some(auction_hash) => QueryRequest::new(
-                    state_hash,
-                    Key::addressable_entity_key(EntityKindTag::System, auction_hash),
-                    vec![SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY.to_string()],
-                ),
+                Some(auction_hash) => {
+                    let key = if request.protocol_version().value().major < 2 {
+                        Key::Hash(auction_hash.value())
+                    } else {
+                        Key::addressable_entity_key(EntityKindTag::System, auction_hash)
+                    };
+                    QueryRequest::new(
+                        state_hash,
+                        key,
+                        vec![SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY.to_string()],
+                    )
+                }
                 None => return EraValidatorsResult::AuctionNotFound,
             },
             Err(err) => return EraValidatorsResult::Failure(err),
@@ -645,11 +652,14 @@ pub trait StateProvider {
 
         let query_request = match tc.get_system_entity_registry() {
             Ok(scr) => match scr.get(MINT).copied() {
-                Some(mint_hash) => QueryRequest::new(
-                    state_hash,
-                    Key::addressable_entity_key(EntityKindTag::System, mint_hash),
-                    vec![TOTAL_SUPPLY_KEY.to_string()],
-                ),
+                Some(mint_hash) => {
+                    let key = if request.protocol_version().value().major < 2 {
+                        Key::Hash(mint_hash.value())
+                    } else {
+                        Key::addressable_entity_key(EntityKindTag::System, mint_hash)
+                    };
+                    QueryRequest::new(state_hash, key, vec![TOTAL_SUPPLY_KEY.to_string()])
+                }
                 None => {
                     error!("unexpected query failure; mint not found");
                     return TotalSupplyResult::MintNotFound;
@@ -697,11 +707,18 @@ pub trait StateProvider {
 
         let query_request = match tc.get_system_entity_registry() {
             Ok(scr) => match scr.get(MINT).copied() {
-                Some(mint_hash) => QueryRequest::new(
-                    state_hash,
-                    Key::addressable_entity_key(EntityKindTag::System, mint_hash),
-                    vec![ROUND_SEIGNIORAGE_RATE_KEY.to_string()],
-                ),
+                Some(mint_hash) => {
+                    let key = if request.protocol_version().value().major < 2 {
+                        Key::Hash(mint_hash.value())
+                    } else {
+                        Key::addressable_entity_key(EntityKindTag::System, mint_hash)
+                    };
+                    QueryRequest::new(
+                        state_hash,
+                        key,
+                        vec![ROUND_SEIGNIORAGE_RATE_KEY.to_string()],
+                    )
+                }
                 None => {
                     error!("unexpected query failure; mint not found");
                     return RoundSeigniorageRateResult::MintNotFound;


### PR DESCRIPTION
This PR fixes the issues with calculating rewards after an upgrade from 1.x to 2.0:

- The immediate switch blocks are no longer rewarded.
- Rewards calculation code passes the correct protocol versions to the data storage layer.
- Data storage layer takes the protocol version into account in requests for era validators, total supply and seigniorage rate.
- Upgrade tests set 2.0.x as the upgraded version.
