### PR TITLE
Update default versions in nctl to 2.0.0

### DIFF
--- a/types/src/transaction/initiator_addr.rs
+++ b/types/src/transaction/initiator_addr.rs
@@ -16,7 +16,7 @@ use crate::testing::TestRng;
 use crate::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    PublicKey,
+    AsymmetricType, PublicKey,
 };
 
 const PUBLIC_KEY_TAG: u8 = 0;
@@ -61,9 +61,11 @@ impl InitiatorAddr {
 impl Display for InitiatorAddr {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            InitiatorAddr::PublicKey(public_key) => write!(formatter, "{}", public_key),
+            InitiatorAddr::PublicKey(public_key) => {
+                write!(formatter, "public key {}", public_key.to_hex())
+            }
             InitiatorAddr::AccountHash(account_hash) => {
-                write!(formatter, "account-hash({})", account_hash)
+                write!(formatter, "account hash {}", account_hash)
             }
         }
     }

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -67,7 +67,7 @@ function _set_nodes()
 
     for IDX in $(seq 1 "$(get_count_of_nodes)")
     do
-        PATH_TO_CFG=$(get_path_to_node "$IDX")/config/1_0_0
+        PATH_TO_CFG=$(get_path_to_node "$IDX")/config/2_0_0
         PATH_TO_FILE="$PATH_TO_CFG"/config.toml
 
         cp "$PATH_TO_CONFIG_TOML" "$PATH_TO_CFG"
@@ -133,17 +133,17 @@ function _main()
     log "asset setup begins ... please wait"
 
     # Setup new.
-    setup_asset_directories "$COUNT_NODES" "$COUNT_USERS" "1_0_0"
+    setup_asset_directories "$COUNT_NODES" "$COUNT_USERS" "2_0_0"
 
     if [ "$NCTL_COMPILE_TARGET" = "debug" ]; then
-        setup_asset_binaries "1_0_0" \
+        setup_asset_binaries "2_0_0" \
                              "$(get_count_of_nodes)" \
                              "$NCTL_CASPER_CLIENT_HOME/target/debug/casper-client" \
                              "$NCTL_CASPER_HOME/target/debug/casper-node" \
                              "$NCTL_CASPER_NODE_LAUNCHER_HOME/target/debug/casper-node-launcher" \
                              "$NCTL_CASPER_HOME/target/wasm32-unknown-unknown/release"
     else
-        setup_asset_binaries "1_0_0" \
+        setup_asset_binaries "2_0_0" \
                              "$(get_count_of_nodes)" \
                              "$NCTL_CASPER_CLIENT_HOME/target/release/casper-client" \
                              "$NCTL_CASPER_HOME/target/release/casper-node" \
@@ -156,7 +156,7 @@ function _main()
     setup_asset_daemon
 
     setup_asset_chainspec "$COUNT_NODES" \
-                          "1.0.0" \
+                          "2.0.0" \
                           $(get_genesis_timestamp "$GENESIS_DELAY") \
                           "$PATH_TO_CHAINSPEC" \
                           true
@@ -168,7 +168,7 @@ function _main()
     fi
 
     setup_asset_node_configs "$COUNT_NODES" \
-                             "1_0_0" \
+                             "2_0_0" \
                              "$PATH_TO_CONFIG_TOML" \
                              true
 

--- a/utils/nctl/sh/node/dport.sh
+++ b/utils/nctl/sh/node/dport.sh
@@ -13,7 +13,7 @@ function main()
 {
     local NODE_ID=${1}
     local NODE_CONFIG_PATH=$(get_path_to_node_config $NODE_ID)
-    local DPORT_SOCKET_PATH="${NODE_CONFIG_PATH}/1_0_0/debug.socket"
+    local DPORT_SOCKET_PATH="${NODE_CONFIG_PATH}/2_0_0/debug.socket"
 
     socat readline "unix:${DPORT_SOCKET_PATH}"
 }

--- a/utils/nctl/sh/scenarios/client.sh
+++ b/utils/nctl/sh/scenarios/client.sh
@@ -912,8 +912,8 @@ function test_get_chainspec() {
     get_chainspec_from_rpc > "$OUTPUT_PATH/rpc_chainspec.toml"
     get_accounts_from_rpc > "$OUTPUT_PATH/rpc_accounts.toml"
     # Test File From RPC matches whats running on a node
-    compare_md5sum "$OUTPUT_PATH/rpc_chainspec.toml" "$(get_path_to_node 1)/config/1_0_0/chainspec.toml"
-    compare_md5sum "$OUTPUT_PATH/rpc_accounts.toml" "$(get_path_to_node 1)/config/1_0_0/accounts.toml"
+    compare_md5sum "$OUTPUT_PATH/rpc_chainspec.toml" "$(get_path_to_node 1)/config/2_0_0/chainspec.toml"
+    compare_md5sum "$OUTPUT_PATH/rpc_accounts.toml" "$(get_path_to_node 1)/config/2_0_0/accounts.toml"
     # Test JSON OUTPUT is Valid, jq will balk if invalid json
     get_chainspec_json_from_rpc | jq '.'
 }

--- a/utils/nctl/sh/staging/build.sh
+++ b/utils/nctl/sh/staging/build.sh
@@ -158,4 +158,4 @@ done
 
 _main "${STAGE_ID:-1}" \
       "${STAGE_SOURCE:-"local"}" \
-      "${PROTOCOL_VERSION:-"1_0_0"}"
+      "${PROTOCOL_VERSION:-"2_0_0"}"


### PR DESCRIPTION
This PR fixes the nctl setup to use version 2.0.0 by default (in line with the recent change to the local testing chainspec).

It also updates the display impl of `InitiatorAddr` to make errors received by the client more consistently styled.