### PR TITLE
Update Doc disable/enable_contract_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/smart_contracts/contract/src/contract_api/storage.rs
+++ b/smart_contracts/contract/src/contract_api/storage.rs
@@ -366,10 +366,20 @@ pub fn add_contract_version(
     (entity_hash, entity_version)
 }
 
-/// Disable a version of a contract from the contract stored at the given
-/// `Key`. That version of the contract will no longer be callable by
-/// `call_versioned_contract`. Note that this contract must have been created by
-/// `create_contract` or `create_contract_package_at_hash` first.
+/// Disables a specific version of a contract within the contract package identified by
+/// `contract_package_hash`. Once disabled, the specified version will no longer be
+/// callable by `call_versioned_contract`. Please note that the contract must have been
+/// previously created using `create_contract` or `create_contract_package_at_hash`.
+///
+/// # Arguments
+///
+/// * `contract_package_hash` - The hash of the contract package containing the version to be
+/// disabled.
+/// * `contract_hash` - The hash of the specific contract version to be disabled.
+///
+/// # Errors
+///
+/// Returns a `Result` indicating success or an `ApiError` if the operation fails.
 pub fn disable_contract_version(
     contract_package_hash: PackageHash,
     contract_hash: AddressableEntityHash,
@@ -390,10 +400,17 @@ pub fn disable_contract_version(
     api_error::result_from(result)
 }
 
-/// Enable a version of a contract from the contract stored at the given hash.
-/// That version of the contract will no longer be callable by
-/// `call_versioned_contract`. Note that this contract must have been created by
-/// [`new_contract`] or [`create_contract_package_at_hash`] first.
+/// Enables a specific version of a contract from the contract package stored at the given hash.
+/// Once enabled, that version of the contract becomes callable again by `call_versioned_contract`.
+///
+/// # Arguments
+///
+/// * `contract_package_hash` - The hash of the contract package containing the desired version.
+/// * `contract_hash` - The hash of the specific contract version to be enabled.
+///
+/// # Errors
+///
+/// Returns a `Result` indicating success or an `ApiError` if the operation fails.
 pub fn enable_contract_version(
     contract_package_hash: PackageHash,
     contract_hash: AddressableEntityHash,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -76,7 +76,7 @@ untrusted = "0.7.1"
 json-schema = ["once_cell", "schemars", "serde-map-to-array/json-schema"]
 testing = ["proptest", "proptest-derive", "rand/default", "rand_pcg", "strum", "bincode"]
 # Includes a restricted set of std lib functionality suitable for usage e.g. in a JS environment when compiled to Wasm.
-std = ["base16/std", "derp", "getrandom/std", "humantime", "libc", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
+std = ["base16/std", "derp", "getrandom/std", "humantime","itertools/use_std", "libc", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
 # Includes a complete set of std lib functionality, including filesystem I/O operations.
 std-fs-io = ["std"]
 # DEPRECATED - use "testing" instead of "gens".

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -76,7 +76,7 @@ untrusted = "0.7.1"
 json-schema = ["once_cell", "schemars", "serde-map-to-array/json-schema"]
 testing = ["proptest", "proptest-derive", "rand/default", "rand_pcg", "strum", "bincode"]
 # Includes a restricted set of std lib functionality suitable for usage e.g. in a JS environment when compiled to Wasm.
-std = ["base16/std", "derp", "getrandom/std", "humantime","itertools/use_std", "libc", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
+std = ["base16/std", "derp", "getrandom/std", "humantime", "itertools/use_std", "libc", "once_cell", "pem", "serde_json/preserve_order", "thiserror", "untrusted"]
 # Includes a complete set of std lib functionality, including filesystem I/O operations.
 std-fs-io = ["std"]
 # DEPRECATED - use "testing" instead of "gens".


### PR DESCRIPTION
Change rust doc to two functions  enable_contract_version disable_contract_version

In Cargo lock toml file :

- Update "h2" to version = "0.3.26" because of audit warning on `make check-rs`

- Add "itertools/use_std" in std feature of casper types to remove error

```
error[E0599]: no method named `unique` found for struct `std::vec::IntoIter` in the current scope
   --> /root/.cargo/git/checkouts/casper-node-dd1233ff78032163/abe4631/types/src/transaction/deploy.rs:211:53
    |
211 |         let dependencies = dependencies.into_iter().unique().collect();
    |                                                     ^^^^^^ method not found in `IntoIter<DeployHash>`
```


