### PR TITLE
Ensure there is at least one txn when calling `random_with_specifics()`

### DIFF
--- a/node/src/components/deploy_buffer/tests.rs
+++ b/node/src/components/deploy_buffer/tests.rs
@@ -452,7 +452,7 @@ fn register_deploys_and_blocks() {
 
     // test if deploys held for proposed blocks which did not get finalized in time
     // are eligible again
-    let count = rng.gen_range(0..11);
+    let count = rng.gen_range(1..11);
     let txns: Vec<_> = std::iter::repeat_with(|| Transaction::Deploy(Deploy::random(&mut rng)))
         .take(count)
         .collect();


### PR DESCRIPTION
This PR fixes the flakiness in `register_deploys_and_blocks()` test.

When using the `CL_TEST_SEED=66ee5988281c41b543ce58bf618b9c65` it produced 0 additional transactions, which is interpreted by `random_with_specifics()` as "[create an arbitrary number of test transactions for me](https://github.com/casper-network/casper-node/blob/feat-2.0/node/src/types/block/finalized_block.rs#L130-L136)". This was causing a mismatch in the expected number of transactions.