### PR TITLE
Expose latest switch block information in the binary port

### DIFF
--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -595,6 +595,12 @@ where
             (*effect_builder.get_chainspec_raw_bytes().await).clone(),
             protocol_version,
         ),
+        InformationRequest::LatestSwitchBlockHeader => BinaryResponse::from_option(
+            effect_builder
+                .get_latest_switch_block_header_from_storage()
+                .await,
+            protocol_version,
+        ),
         InformationRequest::NodeStatus => {
             let (
                 node_uptime,
@@ -607,6 +613,7 @@ where
                 last_progress,
                 available_block_range,
                 block_sync,
+                latest_switch_block_header,
             ) = join!(
                 effect_builder.get_uptime(),
                 effect_builder.get_network_name(),
@@ -618,6 +625,7 @@ where
                 effect_builder.get_last_progress(),
                 effect_builder.get_available_block_range_from_storage(),
                 effect_builder.get_block_synchronizer_status(),
+                effect_builder.get_latest_switch_block_header_from_storage(),
             );
             let starting_state_root_hash = effect_builder
                 .get_block_header_at_height_from_storage(available_block_range.low(), true)
@@ -654,6 +662,8 @@ where
                 last_progress: last_progress.into(),
                 available_block_range,
                 block_sync,
+                latest_switch_block_hash: latest_switch_block_header
+                    .map(|header| header.block_hash()),
             };
             BinaryResponse::from_value(status, protocol_version)
         }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -911,6 +911,11 @@ impl Storage {
                     .read_block_header_by_height(block_height, only_from_available_block_range)?;
                 responder.respond(maybe_header).ignore()
             }
+            StorageRequest::GetLatestSwitchBlockHeader { responder } => {
+                let txn = self.block_store.checkout_ro()?;
+                let maybe_header = txn.read(LatestSwitchBlock)?;
+                responder.respond(maybe_header).ignore()
+            }
             StorageRequest::GetSwitchBlockHeaderByEra { era_id, responder } => {
                 let txn = self.block_store.checkout_ro()?;
                 let maybe_header = txn.read(era_id)?;

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1226,6 +1226,17 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    pub(crate) async fn get_latest_switch_block_header_from_storage(self) -> Option<BlockHeader>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetLatestSwitchBlockHeader { responder },
+            QueueKind::FromStorage,
+        )
+        .await
+    }
+
     pub(crate) async fn get_switch_block_header_by_era_id_from_storage(
         self,
         era_id: EraId,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -352,6 +352,9 @@ pub(crate) enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
+    GetLatestSwitchBlockHeader {
+        responder: Responder<Option<BlockHeader>>,
+    },
     GetSwitchBlockHeaderByEra {
         /// Era ID for which to get the block header.
         era_id: EraId,
@@ -531,6 +534,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetBlockHeaderByHeight { block_height, .. } => {
                 write!(formatter, "get header for height {}", block_height)
+            }
+            StorageRequest::GetLatestSwitchBlockHeader { .. } => {
+                write!(formatter, "get latest switch block header")
             }
             StorageRequest::GetSwitchBlockHeaderByEra { era_id, .. } => {
                 write!(formatter, "get header for era {}", era_id)

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -505,7 +505,7 @@ fn latest_switch_block_header() -> TestCase {
         }),
         asserter: Box::new(move |response| {
             assert_response::<BlockHeader, _>(response, Some(PayloadType::BlockHeader), |header| {
-                header.next_era_validator_weights().is_some()
+                header.is_switch_block()
             })
         }),
     }

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -227,6 +227,7 @@ async fn binary_port_component() {
         next_upgrade(),
         consensus_status(),
         chainspec_raw_bytes(network_chainspec_raw_bytes),
+        latest_switch_block_header(),
         node_status(),
         get_block_header(highest_block.clone_header()),
         get_block_transfers(highest_block.clone_header()),
@@ -495,6 +496,21 @@ fn chainspec_raw_bytes(network_chainspec_raw_bytes: ChainspecRawBytes) -> TestCa
     }
 }
 
+fn latest_switch_block_header() -> TestCase {
+    TestCase {
+        name: "latest_switch_block_header",
+        request: BinaryRequest::Get(GetRequest::Information {
+            info_type_tag: InformationRequestTag::LatestSwitchBlockHeader.into(),
+            key: vec![],
+        }),
+        asserter: Box::new(move |response| {
+            assert_response::<BlockHeader, _>(response, Some(PayloadType::BlockHeader), |header| {
+                header.next_era_validator_weights().is_some()
+            })
+        }),
+    }
+}
+
 fn node_status() -> TestCase {
     TestCase {
         name: "node_status",
@@ -514,6 +530,7 @@ fn node_status() -> TestCase {
                         && node_status.block_sync.historical().is_none()
                         && node_status.block_sync.forward().is_none()
                         && matches!(node_status.reactor_state.into_inner().as_str(), "Validate")
+                        && node_status.latest_switch_block_hash.is_some()
                 },
             )
         }),

--- a/types/src/binary_port/information_request.rs
+++ b/types/src/binary_port/information_request.rs
@@ -51,6 +51,8 @@ pub enum InformationRequest {
     ChainspecRawBytes,
     /// Returns the status information of the node.
     NodeStatus,
+    /// Returns the latest switch block header.
+    LatestSwitchBlockHeader,
 }
 
 impl InformationRequest {
@@ -76,6 +78,9 @@ impl InformationRequest {
             InformationRequest::ConsensusStatus => InformationRequestTag::ConsensusStatus,
             InformationRequest::ChainspecRawBytes => InformationRequestTag::ChainspecRawBytes,
             InformationRequest::NodeStatus => InformationRequestTag::NodeStatus,
+            InformationRequest::LatestSwitchBlockHeader => {
+                InformationRequestTag::LatestSwitchBlockHeader
+            }
         }
     }
 
@@ -116,6 +121,9 @@ impl InformationRequest {
             InformationRequestTag::ConsensusStatus => InformationRequest::ConsensusStatus,
             InformationRequestTag::ChainspecRawBytes => InformationRequest::ChainspecRawBytes,
             InformationRequestTag::NodeStatus => InformationRequest::NodeStatus,
+            InformationRequestTag::LatestSwitchBlockHeader => {
+                InformationRequest::LatestSwitchBlockHeader
+            }
         }
     }
 }
@@ -153,7 +161,8 @@ impl ToBytes for InformationRequest {
             | InformationRequest::NextUpgrade
             | InformationRequest::ConsensusStatus
             | InformationRequest::ChainspecRawBytes
-            | InformationRequest::NodeStatus => Ok(()),
+            | InformationRequest::NodeStatus
+            | InformationRequest::LatestSwitchBlockHeader => Ok(()),
         }
     }
 
@@ -180,7 +189,8 @@ impl ToBytes for InformationRequest {
             | InformationRequest::NextUpgrade
             | InformationRequest::ConsensusStatus
             | InformationRequest::ChainspecRawBytes
-            | InformationRequest::NodeStatus => 0,
+            | InformationRequest::NodeStatus
+            | InformationRequest::LatestSwitchBlockHeader => 0,
         }
     }
 }
@@ -231,6 +241,9 @@ impl TryFrom<(InformationRequestTag, &[u8])> for InformationRequest {
                 (InformationRequest::ChainspecRawBytes, key_bytes)
             }
             InformationRequestTag::NodeStatus => (InformationRequest::NodeStatus, key_bytes),
+            InformationRequestTag::LatestSwitchBlockHeader => {
+                (InformationRequest::LatestSwitchBlockHeader, key_bytes)
+            }
         };
         if !remainder.is_empty() {
             return Err(bytesrepr::Error::LeftOverBytes);
@@ -284,12 +297,14 @@ pub enum InformationRequestTag {
     ChainspecRawBytes = 13,
     /// Node status request.
     NodeStatus = 14,
+    /// Latest switch block header request.
+    LatestSwitchBlockHeader = 15,
 }
 
 impl InformationRequestTag {
     #[cfg(test)]
     pub(crate) fn random(rng: &mut TestRng) -> Self {
-        match rng.gen_range(0..15) {
+        match rng.gen_range(0..16) {
             0 => InformationRequestTag::BlockHeader,
             1 => InformationRequestTag::SignedBlock,
             2 => InformationRequestTag::Transaction,
@@ -305,6 +320,7 @@ impl InformationRequestTag {
             12 => InformationRequestTag::ConsensusStatus,
             13 => InformationRequestTag::ChainspecRawBytes,
             14 => InformationRequestTag::NodeStatus,
+            15 => InformationRequestTag::LatestSwitchBlockHeader,
             _ => unreachable!(),
         }
     }
@@ -330,6 +346,7 @@ impl TryFrom<u16> for InformationRequestTag {
             12 => Ok(InformationRequestTag::ConsensusStatus),
             13 => Ok(InformationRequestTag::ChainspecRawBytes),
             14 => Ok(InformationRequestTag::NodeStatus),
+            15 => Ok(InformationRequestTag::LatestSwitchBlockHeader),
             _ => Err(UnknownInformationRequestTag(value)),
         }
     }


### PR DESCRIPTION
Added two things:
- new field, `latest_switch_block_hash` in the status
- new request type, `InformationRequest::LatestSwitchBlockHeader`, so that we can look up the latest switch block in the sidecar

Ticket: https://app.zenhub.com/workspaces/core-protocol-60953fafb1945f0011a3592d/issues/gh/casper-network/casper-node/4504