### PR TITLE
Fixes for bond its test

### DIFF
--- a/utils/nctl/sh/contracts-auction/do_bid_withdraw.sh
+++ b/utils/nctl/sh/contracts-auction/do_bid_withdraw.sh
@@ -55,7 +55,7 @@ function main()
     fi
 
     log "... sending deploy"
-    DEPLOY_RESULT =$($PATH_TO_CLIENT put-deploy \
+    DEPLOY_RESULT=$($PATH_TO_CLIENT put-deploy \
                                  --chain-name "$CHAIN_NAME" \
                                  --node-address "$NODE_ADDRESS" \
                                  --payment-amount "$GAS_PAYMENT" \
@@ -65,7 +65,7 @@ function main()
                                  --session-arg "$(get_cl_arg_u512 'amount' "$AMOUNT")" \
                                  --session-arg "$(get_cl_arg_opt_uref 'unbond_purse' "$BIDDER_MAIN_PURSE_UREF")" \
                                  --session-path "$PATH_TO_CONTRACT")
-    if [ ! -z "DEPLOY_RESULT" ]; then
+    if [ -z "$DEPLOY_RESULT" ]; then
         log "failed to get deploy result"
         log "... node address: $NODE_ADDRESS"
         exit 1
@@ -74,10 +74,7 @@ function main()
     fi
 
     log "... getting deploy hash"
-    DEPLOY_HASH=$("$DEPLOY_RESULT"
-            | jq '.result.deploy_hash' \
-            | sed -e 's/^"//' -e 's/"$//'
-        )
+    DEPLOY_HASH=$(echo $DEPLOY_RESULT | jq -r '.result.deploy_hash')
 
     if [ "$QUIET" != "TRUE" ]; then
         log "deploy dispatched:"

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml.override
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml.override
@@ -1,0 +1,2 @@
+[binary_port_server]
+allow_request_get_all_values = true

--- a/utils/nctl/sh/utils/accounts.sh
+++ b/utils/nctl/sh/utils/accounts.sh
@@ -105,9 +105,9 @@ function get_main_purse_uref()
     local ACCOUNT_KEY=${1}
     local STATE_ROOT_HASH=${2:-$(get_state_root_hash)}
 
-   source "$NCTL"/sh/views/view_chain_account.sh \
-       account-key="$ACCOUNT_KEY" \
-       root-hash="$STATE_ROOT_HASH" \
-       | jq '.stored_value.AddressableEntity.main_purse' \
-       | sed -e 's/^"//' -e 's/"$//'
+    source "$NCTL"/sh/views/view_chain_account.sh \
+        account-key="$ACCOUNT_KEY" \
+        root-hash="$STATE_ROOT_HASH" \
+        | jq '.stored_value.AddressableEntity.main_purse' \
+        | sed -e 's/^"//' -e 's/"$//'
 }

--- a/utils/nctl/sh/utils/accounts.sh
+++ b/utils/nctl/sh/utils/accounts.sh
@@ -105,9 +105,9 @@ function get_main_purse_uref()
     local ACCOUNT_KEY=${1}
     local STATE_ROOT_HASH=${2:-$(get_state_root_hash)}
 
-    source "$NCTL"/sh/views/view_chain_account.sh \
-        account-key="$ACCOUNT_KEY" \
-        root-hash="$STATE_ROOT_HASH" \
-        | jq '.stored_value.Account.main_purse' \
-        | sed -e 's/^"//' -e 's/"$//'
+   source "$NCTL"/sh/views/view_chain_account.sh \
+       account-key="$ACCOUNT_KEY" \
+       root-hash="$STATE_ROOT_HASH" \
+       | jq '.stored_value.AddressableEntity.main_purse' \
+       | sed -e 's/^"//' -e 's/"$//'
 }

--- a/utils/nctl/sh/views/view_chain_account.sh
+++ b/utils/nctl/sh/views/view_chain_account.sh
@@ -23,8 +23,14 @@ source "$NCTL"/sh/utils/main.sh
 NODE_ADDRESS=$(get_node_address_rpc)
 STATE_ROOT_HASH=${STATE_ROOT_HASH:-$(get_state_root_hash)}
 
-$(get_path_to_client) query-global-state \
+ADDRESSABLE_ENTITY=$($(get_path_to_client) query-global-state \
     --node-address "$NODE_ADDRESS" \
     --state-root-hash "$STATE_ROOT_HASH" \
     --key "$ACCOUNT_KEY" \
-    | jq '.result'
+     | jq -r '.result.stored_value.CLValue.parsed')
+
+$(get_path_to_client) query-global-state \
+    --node-address "$NODE_ADDRESS" \
+    --state-root-hash "$STATE_ROOT_HASH" \
+    --key "$ADDRESSABLE_ENTITY" \
+    | jq -r '.result'


### PR DESCRIPTION
This PR fixes the NCTL functions needed to execute the `bond_its.sh` nightly test.

**Note:**
The test is still failing due to rewards bug (tracked in a separate issue) which causes the network to stall at STEP 8 with:

```
{"timestamp":"2024-03-14T07:50:20.110497Z","level":"ERROR","fields":{"message":"distribute block rewards failed due to auction error ValidatorNotFound"},"target":"casper_storage::global_state::state"}
{"timestamp":"2024-03-14T07:50:20.110558Z","level":"ERROR","fields":{"message":"failed to execute block","error":"Auction error: Validator not found"},"target":"casper_node::components::contract_runtime::utils"}
```
