### PR TITLE
Remove outdated network settings

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -13,12 +13,14 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 
-### Changed
-* Rename `BlockValidator` component to `ProposedBlockValidator`, and corresponding config section `block_validator` to `proposed_block_validator`.
+### Added
 * Add `network.maximum_frame_size` to the chainspec
 * Add `tcp_connect_timeout`, `setup_timeout`, `tcp_connect_attempts`, `tcp_connect_base_backoff`, `significant_error_backoff`, `permanent_error_backoff`, `successful_reconnect_delay`, `flaky_connection_threshold`, `max_incoming_connections` and `max_outgoing_connections` to the `network.conman` section in the config.
 
-### Remove
+### Changed
+* Rename `BlockValidator` component to `ProposedBlockValidator`, and corresponding config section `block_validator` to `proposed_block_validator`.
+
+### Removed
 * The `max_in_flight_demands` and `max_incoming_message_rate_non_validators` settings has been removed from the network section of the configuration file due to the changes in the underlying networking protocol.
 
 ## 1.5.6

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Removed
 * The `max_in_flight_demands` and `max_incoming_message_rate_non_validators` settings has been removed from the network section of the configuration file due to the changes in the underlying networking protocol.
+* The `max_addr_pending_time` setting has been removed due to new connection management.
 
 ## 1.5.6
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.  The format
 ### Removed
 * The `max_in_flight_demands` and `max_incoming_message_rate_non_validators` settings has been removed from the network section of the configuration file due to the changes in the underlying networking protocol.
 * The `max_addr_pending_time` setting has been removed due to new connection management.
+* The `max_incoming_peer_connections` setting has been removed, we only allow a single connection per peer now.
+* The `max_outgoing_byte_rate_non_validators` setting has been removed.
 
 ## 1.5.6
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.  The format
 * The `max_addr_pending_time` setting has been removed due to new connection management.
 * The `max_incoming_peer_connections` setting has been removed, we only allow a single connection per peer now.
 * The `max_outgoing_byte_rate_non_validators` setting has been removed.
+* The tarpit feature has been removed along with the respective `tarpit_version_threshold`, `tarpit_duration` and `tarpit_chance` configuration settings.
 
 ## 1.5.6
 

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -46,7 +46,6 @@ impl Default for Config {
             gossip_interval: DEFAULT_GOSSIP_INTERVAL,
             initial_gossip_delay: DEFAULT_INITIAL_GOSSIP_DELAY,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
-            max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
@@ -98,8 +97,6 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
-    /// Maximum number of incoming connections per unique peer. Unlimited if `0`.
-    pub max_incoming_peer_connections: u16,
     /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
     pub max_outgoing_byte_rate_non_validators: u32,
     /// The protocol version at which (or under) tarpitting is enabled.

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -26,9 +26,6 @@ const DEFAULT_GOSSIP_INTERVAL: TimeDiff = TimeDiff::from_seconds(30);
 /// Default delay until initial round of address gossiping starts.
 const DEFAULT_INITIAL_GOSSIP_DELAY: TimeDiff = TimeDiff::from_seconds(5);
 
-/// Default time limit for an address to be in the pending set.
-const DEFAULT_MAX_ADDR_PENDING_TIME: TimeDiff = TimeDiff::from_seconds(60);
-
 /// Default timeout during which the handshake needs to be completed.
 const DEFAULT_HANDSHAKE_TIMEOUT: TimeDiff = TimeDiff::from_seconds(20);
 
@@ -48,7 +45,6 @@ impl Default for Config {
             min_peers_for_initialization: DEFAULT_MIN_PEERS_FOR_INITIALIZATION,
             gossip_interval: DEFAULT_GOSSIP_INTERVAL,
             initial_gossip_delay: DEFAULT_INITIAL_GOSSIP_DELAY,
-            max_addr_pending_time: DEFAULT_MAX_ADDR_PENDING_TIME,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             max_incoming_peer_connections: 0,
             max_outgoing_byte_rate_non_validators: 0,
@@ -100,8 +96,6 @@ pub struct Config {
     pub gossip_interval: TimeDiff,
     /// Initial delay before the first round of gossip.
     pub initial_gossip_delay: TimeDiff,
-    /// Maximum allowed time for an address to be kept in the pending set.
-    pub max_addr_pending_time: TimeDiff,
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
     /// Maximum number of incoming connections per unique peer. Unlimited if `0`.

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -46,9 +46,6 @@ impl Default for Config {
             gossip_interval: DEFAULT_GOSSIP_INTERVAL,
             initial_gossip_delay: DEFAULT_INITIAL_GOSSIP_DELAY,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
-            tarpit_version_threshold: None,
-            tarpit_duration: TimeDiff::from_seconds(600),
-            tarpit_chance: 0.2,
             send_buffer_size: PerChannel::init_with(|_| None),
             ack_timeout: TimeDiff::from_seconds(30),
             blocklist_retain_duration: TimeDiff::from_seconds(600),
@@ -96,12 +93,6 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
-    /// The protocol version at which (or under) tarpitting is enabled.
-    pub tarpit_version_threshold: Option<ProtocolVersion>,
-    /// If tarpitting is enabled, duration for which connections should be kept open.
-    pub tarpit_duration: TimeDiff,
-    /// The chance, expressed as a number between 0.0 and 1.0, of triggering the tarpit.
-    pub tarpit_chance: f32,
     /// An optional buffer size for each Juliet channel, allowing to setup how many messages
     /// we can keep in a memory buffer before blocking at call site.
     ///

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -46,7 +46,6 @@ impl Default for Config {
             gossip_interval: DEFAULT_GOSSIP_INTERVAL,
             initial_gossip_delay: DEFAULT_INITIAL_GOSSIP_DELAY,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
-            max_outgoing_byte_rate_non_validators: 0,
             tarpit_version_threshold: None,
             tarpit_duration: TimeDiff::from_seconds(600),
             tarpit_chance: 0.2,
@@ -97,8 +96,6 @@ pub struct Config {
     pub initial_gossip_delay: TimeDiff,
     /// Maximum allowed time for handshake completion.
     pub handshake_timeout: TimeDiff,
-    /// Maximum number of bytes per second allowed for non-validating peers. Unlimited if 0.
-    pub max_outgoing_byte_rate_non_validators: u32,
     /// The protocol version at which (or under) tarpitting is enabled.
     pub tarpit_version_threshold: Option<ProtocolVersion>,
     /// If tarpitting is enabled, duration for which connections should be kept open.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -213,10 +213,6 @@ initial_gossip_delay = '5 seconds'
 # terminated.
 handshake_timeout = '20 seconds'
 
-# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
-# connections will be rejected. A value of `0` means unlimited.
-max_incoming_peer_connections = 3
-
 # The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 0

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -217,28 +217,6 @@ handshake_timeout = '20 seconds'
 # responding to a received message, it is considered unresponsive and the connection severed.
 ack_timeout = '30sec'
 
-# Version threshold to enable tarpit for.
-#
-# When set to a version (the value may be `null` to disable the feature), any peer that reports a
-# protocol version equal or below the threshold will be rejected only after holding open the
-# connection for a specific (`tarpit_duration`) amount of time.
-#
-# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
-# still in operation are connecting to, as these older versions will only attempt to reconnect to
-# other nodes once they have exhausted their set of known nodes.
-tarpit_version_threshold = '1.2.1'
-
-# How long to hold connections to trapped legacy nodes.
-tarpit_duration = '10 minutes'
-
-# The probability [0.0, 1.0] of this node trapping a legacy node.
-#
-# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
-# single known node to hold open a connection to prevent the node from reconnecting. This should be
-# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
-# legacy nodes running this software.
-tarpit_chance = 0.2
-
 # How long peers remain blocked after they get blocklisted.
 blocklist_retain_duration = '1 minute'
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -213,10 +213,6 @@ initial_gossip_delay = '5 seconds'
 # terminated.
 handshake_timeout = '20 seconds'
 
-# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
-# A value of `0` means unlimited.
-max_outgoing_byte_rate_non_validators = 0
-
 # Timeout before giving up on a peer. If a peer exceeds this time limit for acknowledging or
 # responding to a received message, it is considered unresponsive and the connection severed.
 ack_timeout = '30sec'

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -208,9 +208,6 @@ gossip_interval = '30 seconds'
 # more than the expected time required for initial connections to complete.
 initial_gossip_delay = '5 seconds'
 
-# How long a connection is allowed to be stuck as pending before it is abandoned.
-max_addr_pending_time = '1 minute'
-
 # Maximum time allowed for a connection handshake between two nodes to be completed. Connections
 # exceeding this threshold are considered unlikely to be healthy or even malicious and thus
 # terminated.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -213,10 +213,6 @@ initial_gossip_delay = '5 seconds'
 # terminated.
 handshake_timeout = '20 seconds'
 
-# Maximum number of incoming connections per unique peer allowed. If the limit is hit, additional
-# connections will be rejected. A value of `0` means unlimited.
-max_incoming_peer_connections = 3
-
 # The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
 # A value of `0` means unlimited.
 max_outgoing_byte_rate_non_validators = 6553600

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -217,28 +217,6 @@ handshake_timeout = '20 seconds'
 # responding to a received message, it is considered unresponsive and the connection severed.
 ack_timeout = '30sec'
 
-# Version threshold to enable tarpit for.
-#
-# When set to a version (the value may be `null` to disable the feature), any peer that reports a
-# protocol version equal or below the threshold will be rejected only after holding open the
-# connection for a specific (`tarpit_duration`) amount of time.
-#
-# This option makes most sense to enable on known nodes with addresses where legacy nodes that are
-# still in operation are connecting to, as these older versions will only attempt to reconnect to
-# other nodes once they have exhausted their set of known nodes.
-tarpit_version_threshold = '1.2.1'
-
-# How long to hold connections to trapped legacy nodes.
-tarpit_duration = '10 minutes'
-
-# The probability [0.0, 1.0] of this node trapping a legacy node.
-#
-# Since older nodes will only reconnect if all their options are exhausted, it is sufficient for a
-# single known node to hold open a connection to prevent the node from reconnecting. This should be
-# set to `1/n` or higher, with `n` being the number of known nodes expected in the configuration of
-# legacy nodes running this software.
-tarpit_chance = 0.2
-
 # How long peers remain blocked after they get blocklisted.
 blocklist_retain_duration = '10 minutes'
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -208,9 +208,6 @@ gossip_interval = '120 seconds'
 # more than the expected time required for initial connections to complete.
 initial_gossip_delay = '5 seconds'
 
-# How long a connection is allowed to be stuck as pending before it is abandoned.
-max_addr_pending_time = '1 minute'
-
 # Maximum time allowed for a connection handshake between two nodes to be completed. Connections
 # exceeding this threshold are considered unlikely to be healthy or even malicious and thus
 # terminated.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -213,10 +213,6 @@ initial_gossip_delay = '5 seconds'
 # terminated.
 handshake_timeout = '20 seconds'
 
-# The maximum total of upstream bandwidth in bytes per second allocated to non-validating peers.
-# A value of `0` means unlimited.
-max_outgoing_byte_rate_non_validators = 6553600
-
 # Timeout before giving up on a peer. If a peer exceeds this time limit for acknowledging or
 # responding to a received message, it is considered unresponsive and the connection severed.
 ack_timeout = '30sec'


### PR DESCRIPTION
Removes some network settings that are no longer in use, and marks their removal in the `CHANGELOG.md`.