### PR TITLE
Restore gossip peer selection

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `network.maximum_frame_size` to the chainspec
 * Add `tcp_connect_timeout`, `setup_timeout`, `tcp_connect_attempts`, `tcp_connect_base_backoff`, `significant_error_backoff`, `permanent_error_backoff`, `successful_reconnect_delay`, `flaky_connection_threshold`, `max_incoming_connections` and `max_outgoing_connections` to the `network.conman` section in the config.
 * `use_validator_broadcast` can now be configured to control the node's broadcast behavior.
+* `use_mixed_gossip` can now be configured to enable or disable the node's gossip peer selection.
 
 ### Changed
 * The node's connection model has changed, now only establishing a single connection per peer. The direction of the connection is chosen based on the randomly generated `NodeID`s.

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -143,7 +143,7 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
         effect_builder: EffectBuilder<REv>,
         item_id: T::Id,
         requested_count: usize,
-        peers: HashSet<NodeId>,
+        peers: Vec<NodeId>,
     ) -> Effects<Event<T>>
     where
         REv: From<GossiperAnnouncement<T>> + Send,

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashSet,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 use derive_more::From;
 use serde::Serialize;
@@ -29,7 +26,7 @@ pub(crate) enum Event<T: GossipItem> {
     GossipedTo {
         item_id: T::Id,
         requested_count: usize,
-        peers: HashSet<NodeId>,
+        peers: Vec<NodeId>,
     },
     /// The timeout for waiting for a gossip response has elapsed and we should check the response
     /// arrived.

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -279,7 +279,7 @@
 use std::{
     any::Any,
     cell::RefCell,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::{self, Display, Formatter},
     sync::{Arc, RwLock},
 };
@@ -578,7 +578,7 @@ where
                 gossip_target: _,
             } => {
                 if let Ok(guard) = self.nodes.read() {
-                    let chosen: HashSet<_> = guard
+                    let chosen: Vec<_> = guard
                         .keys()
                         .filter(|&node_id| !exclude.contains(node_id) && node_id != &self.node_id)
                         .cloned()

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -367,7 +367,7 @@ where
         exclude: HashSet<NodeId>,
     ) -> HashSet<NodeId> {
         let Some(ref conman) = self.conman else {
-            error!("should never attempt to gossip on unintialized component");
+            error!("should never attempt to gossip on uninitialized component");
             return Default::default();
         };
         let state = conman.read_state();

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -956,28 +956,13 @@ where
         + From<PeerBehaviorAnnouncement>,
     P: Payload,
 {
+    #[inline(always)]
     fn handle_validators(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
         _rng: &mut NodeRng,
     ) -> Effects<Self::Event> {
-        // If we receive an updated set of validators, recalculate validator status for every
-        // existing connection.
-
-        let _active_validators = self.validator_matrix.active_or_upcoming_validators();
-
-        // Update the validator status for every connection.
-        // for (public_key, status) in self.incoming_validator_status.iter_mut() {
-        //     // If there is only a `Weak` ref, we lost the connection to the validator, but the
-        //     // disconnection has not reached us yet.
-        //     if let Some(arc) = status.upgrade() {
-        //         arc.store(
-        //             active_validators.contains(public_key),
-        //             std::sync::atomic::Ordering::Relaxed,
-        //         )
-        //     }
-        // }
-        // TODO: Restore functionality.
+        // TODO: Not used at the moment, consider removing this in the future.
 
         Effects::default()
     }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -325,7 +325,7 @@ where
     }
 
     /// Queues a message to be sent to validator nodes in the given era.
-    fn broadcast_message_to_validators(&self, channel: Channel, payload: Bytes, _era_id: EraId) {
+    fn broadcast_message_to_validators(&self, channel: Channel, payload: Bytes, era_id: EraId) {
         let Some(ref conman) = self.conman else {
             error!(
                 "cannot broadcast message to validators on non-initialized networking component"
@@ -336,7 +336,10 @@ where
         self.net_metrics.broadcast_requests.inc();
 
         // Determine whether we should restrict broadcasts at all.
-        let validators = self.validator_matrix.active_or_upcoming_validators();
+        let validators = self
+            .validator_matrix
+            .era_validators(era_id)
+            .unwrap_or_default();
         if self.config.use_validator_broadcast && !validators.is_empty() {
             let state = conman.read_state();
             for (consensus_key, &peer_id) in state.key_index().iter() {

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -413,7 +413,13 @@ where
                         .cloned()
                         .collect()
                 } else {
-                    // TODO: warn! about failing to select
+                    rate_limited!(
+                        ERA_NOT_READY,
+                        5,
+                        Duration::from_secs(10),
+                        |dropped| warn!(%gossip_target, dropped, "failed to select mixed target for era gossip")
+                    );
+
                     // Fall through, keeping `chosen` empty.
                     Vec::new()
                 }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -428,6 +428,15 @@ where
             chosen.extend(connected_peers.choose_multiple(rng, count).cloned());
         }
 
+        if chosen.len() != count {
+            rate_limited!(
+                GOSSIP_SELECTION_FELL_SHORT,
+                5,
+                Duration::from_secs(60),
+                |dropped| warn!(%gossip_target, wanted=count, got=chosen.len(), dropped, "gossip selection fell short")
+            );
+        }
+
         for &peer_id in &chosen {
             self.send_message(&state, peer_id, channel, payload.clone(), None);
         }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -380,7 +380,7 @@ where
             .collect();
 
         let mut chosen: Vec<NodeId> = match gossip_target {
-            GossipTarget::Mixed(era_id) => {
+            GossipTarget::Mixed(era_id) if self.config.use_mixed_gossip => {
                 if let Some(known_era_validators) = self.validator_matrix.era_validators(era_id) {
                     // We have the validators for the given era by consensus key, map to node ID.
                     let connected_era_validators: HashSet<NodeId> = known_era_validators
@@ -423,6 +423,10 @@ where
                     // Fall through, keeping `chosen` empty.
                     Vec::new()
                 }
+            }
+            GossipTarget::Mixed(_) => {
+                // Mixed mode gossip is disabled.
+                Vec::new()
             }
             GossipTarget::All => {
                 // Simply fall through, since `GossipTarget::All` is also our fallback mode.

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -365,7 +365,7 @@ where
         gossip_target: GossipTarget,
         count: usize,
         exclude: HashSet<NodeId>,
-    ) -> HashSet<NodeId> {
+    ) -> Vec<NodeId> {
         let Some(ref conman) = self.conman else {
             error!("should never attempt to gossip on uninitialized component");
             return Default::default();
@@ -451,8 +451,7 @@ where
             self.send_message(&state, peer_id, channel, payload.clone(), None);
         }
 
-        // TODO: We should actually return just the Vec instead.
-        chosen.into_iter().collect()
+        chosen
     }
 
     /// Queues a message to be sent to a specific node.

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -43,6 +43,7 @@ use std::{
     fmt::Debug,
     fs::OpenOptions,
     marker::PhantomData,
+    mem,
     net::{SocketAddr, TcpListener},
     sync::Arc,
     time::{Duration, Instant},
@@ -360,71 +361,79 @@ where
         rng: &mut NodeRng,
         channel: Channel,
         payload: Bytes,
-        _gossip_target: GossipTarget,
+        gossip_target: GossipTarget,
         count: usize,
         exclude: HashSet<NodeId>,
     ) -> HashSet<NodeId> {
-        // TODO: Restore sampling functionality. We currently override with `GossipTarget::All`.
-        //       See #4247.
-        // let is_validator_in_era = |_, _: &_| true;
-        // let gossip_target = GossipTarget::All;
-
-        // let peer_ids = choose_gossip_peers(
-        //     rng,
-        //     gossip_target,
-        //     count,
-        //     exclude.clone(),
-        //     self.outgoing_manager.connected_peers(),
-        //     is_validator_in_era,
-        // );
-
-        // // todo!() - consider sampling more validators (for example: 10%, but not fewer than 5)
-
-        // if peer_ids.len() != count {
-        //     let not_excluded = self
-        //         .outgoing_manager
-        //         .connected_peers()
-        //         .filter(|peer_id| !exclude.contains(peer_id))
-        //         .count();
-        //     if not_excluded > 0 {
-        //         let connected = self.outgoing_manager.connected_peers().count();
-        //         debug!(
-        //             our_id=%self.context.our_id(),
-        //             %gossip_target,
-        //             wanted = count,
-        //             connected,
-        //             not_excluded,
-        //             selected = peer_ids.len(),
-        //             "could not select enough random nodes for gossiping"
-        //         );
-        //     }
-        // }
-
-        // for &peer_id in &peer_ids {
-        //     self.send_message(peer_id, msg.clone(), None);
-        // }
-
-        // peer_ids.into_iter().collect()
-
         let Some(ref conman) = self.conman else {
-            error!("cannot gossip on non-initialized networking component");
+            error!("should never attempt to gossip on unintialized component");
             return Default::default();
         };
-
-        let mut selected = HashSet::new();
         let state = conman.read_state();
-        for route in state
-            .routing_table()
-            .values()
-            .filter(move |route| !exclude.contains(&route.peer))
-            .choose_multiple(rng, count)
-        {
-            self.send_message(&*state, route.peer, channel, payload.clone(), None);
 
-            selected.insert(route.peer);
+        // Construct an iterator over all eligable connected peers, sans exclusion list.
+        let connected_peers = state
+            .routing_table()
+            .keys()
+            .filter(|node_id| !exclude.contains(node_id));
+
+        let mut chosen: Vec<NodeId> = match gossip_target {
+            GossipTarget::Mixed(era_id) => {
+                if let Some(known_era_validators) = self.validator_matrix.era_validators(era_id) {
+                    // We have the validators for the given era by consensus key, map to node ID.
+                    let connected_era_validators: HashSet<NodeId> = known_era_validators
+                        .iter()
+                        .filter_map(|key| state.key_index().get(key))
+                        .filter(|node_id| !exclude.contains(node_id))
+                        .cloned()
+                        .collect();
+
+                    // Create two separate batches, first all non-validators, second all validators.
+                    let mut first = connected_peers
+                        .filter(|node_id| connected_era_validators.contains(node_id))
+                        .cloned()
+                        .choose_multiple(rng, count);
+
+                    let mut second = connected_era_validators
+                        .into_iter()
+                        .choose_multiple(rng, count);
+
+                    if rng.gen() {
+                        mem::swap(&mut first, &mut second);
+                    }
+
+                    // Shuffle, then sample.
+                    first.shuffle(rng);
+                    second.shuffle(rng);
+
+                    first
+                        .into_iter()
+                        .interleave(second.into_iter())
+                        .take(count)
+                        .collect()
+                } else {
+                    // TODO: warn! about failing to select
+                    // Fall through, keeping `chosen` empty.
+                    Vec::new()
+                }
+            }
+            GossipTarget::All => {
+                // Simply fall through, since `GossipTarget::All` is also our fallback mode.
+                Vec::new()
+            }
+        };
+
+        if chosen.is_empty() {
+            chosen = connected_peers.cloned().choose_multiple(rng, count);
+            chosen.shuffle(rng);
         }
 
-        selected
+        for &peer_id in &chosen {
+            self.send_message(&state, peer_id, channel, payload.clone(), None);
+        }
+
+        // TODO: We should actually return just the Vec instead.
+        chosen.into_iter().collect()
     }
 
     /// Queues a message to be sent to a specific node.
@@ -714,43 +723,6 @@ fn resolve_addresses<'a>(addresses: impl Iterator<Item = &'a str>) -> HashSet<So
         }
     }
     resolved
-}
-
-fn choose_gossip_peers<F>(
-    rng: &mut NodeRng,
-    gossip_target: GossipTarget,
-    count: usize,
-    exclude: HashSet<NodeId>,
-    connected_peers: impl Iterator<Item = NodeId>,
-    is_validator_in_era: F,
-) -> HashSet<NodeId>
-where
-    F: Fn(EraId, &NodeId) -> bool,
-{
-    let filtered_peers = connected_peers.filter(|peer_id| !exclude.contains(peer_id));
-    match gossip_target {
-        GossipTarget::Mixed(era_id) => {
-            let (validators, non_validators): (Vec<_>, Vec<_>) =
-                filtered_peers.partition(|node_id| is_validator_in_era(era_id, node_id));
-
-            let (first, second) = if rng.gen() {
-                (validators, non_validators)
-            } else {
-                (non_validators, validators)
-            };
-
-            first
-                .choose_multiple(rng, count)
-                .interleave(second.iter().choose_multiple(rng, count))
-                .take(count)
-                .copied()
-                .collect()
-        }
-        GossipTarget::All => filtered_peers
-            .choose_multiple(rng, count)
-            .into_iter()
-            .collect(),
-    }
 }
 
 impl<REv, P> Component<REv> for Network<P>
@@ -1062,307 +1034,6 @@ fn process_request_guard(channel: Channel, guard: RequestGuard) {
         Err(guard) => {
             // No ACK received yet, forget, so we don't cancel.
             guard.forget();
-        }
-    }
-}
-
-#[cfg(test)]
-mod gossip_target_tests {
-    use std::{collections::BTreeSet, iter};
-
-    use static_assertions::const_assert;
-
-    use casper_types::testing::TestRng;
-
-    use super::*;
-
-    const VALIDATOR_COUNT: usize = 10;
-    const NON_VALIDATOR_COUNT: usize = 20;
-    // The tests assume that we have fewer validators than non-validators.
-    const_assert!(VALIDATOR_COUNT < NON_VALIDATOR_COUNT);
-
-    struct Fixture {
-        validators: BTreeSet<NodeId>,
-        non_validators: BTreeSet<NodeId>,
-        all_peers: Vec<NodeId>,
-    }
-
-    impl Fixture {
-        fn new(rng: &mut TestRng) -> Self {
-            let validators: BTreeSet<NodeId> = iter::repeat_with(|| NodeId::random(rng))
-                .take(VALIDATOR_COUNT)
-                .collect();
-            let non_validators: BTreeSet<NodeId> = iter::repeat_with(|| NodeId::random(rng))
-                .take(NON_VALIDATOR_COUNT)
-                .collect();
-
-            let mut all_peers: Vec<NodeId> = validators
-                .iter()
-                .copied()
-                .chain(non_validators.iter().copied())
-                .collect();
-            all_peers.shuffle(rng);
-
-            Fixture {
-                validators,
-                non_validators,
-                all_peers,
-            }
-        }
-
-        fn is_validator_in_era(&self) -> impl Fn(EraId, &NodeId) -> bool + '_ {
-            move |_era_id: EraId, node_id: &NodeId| self.validators.contains(node_id)
-        }
-
-        fn num_validators<'a>(&self, input: impl Iterator<Item = &'a NodeId>) -> usize {
-            input
-                .filter(move |&node_id| self.validators.contains(node_id))
-                .count()
-        }
-
-        fn num_non_validators<'a>(&self, input: impl Iterator<Item = &'a NodeId>) -> usize {
-            input
-                .filter(move |&node_id| self.non_validators.contains(node_id))
-                .count()
-        }
-    }
-
-    #[test]
-    fn should_choose_mixed() {
-        const TARGET: GossipTarget = GossipTarget::Mixed(EraId::new(1));
-
-        let mut rng = TestRng::new();
-        let fixture = Fixture::new(&mut rng);
-
-        // Choose more than total count from all peers, exclude none, should return all peers.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT + NON_VALIDATOR_COUNT + 1,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), fixture.all_peers.len());
-
-        // Choose total count from all peers, exclude none, should return all peers.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT + NON_VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), fixture.all_peers.len());
-
-        // Choose 2 * VALIDATOR_COUNT from all peers, exclude none, should return all validators and
-        // VALIDATOR_COUNT non-validators.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            2 * VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), 2 * VALIDATOR_COUNT);
-        assert_eq!(fixture.num_validators(chosen.iter()), VALIDATOR_COUNT);
-        assert_eq!(fixture.num_non_validators(chosen.iter()), VALIDATOR_COUNT);
-
-        // Choose VALIDATOR_COUNT from all peers, exclude none, should return VALIDATOR_COUNT peers,
-        // half validators and half non-validators.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), VALIDATOR_COUNT);
-        assert_eq!(fixture.num_validators(chosen.iter()), VALIDATOR_COUNT / 2);
-        assert_eq!(
-            fixture.num_non_validators(chosen.iter()),
-            VALIDATOR_COUNT / 2
-        );
-
-        // Choose two from all peers, exclude none, should return two peers, one validator and one
-        // non-validator.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            2,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), 2);
-        assert_eq!(fixture.num_validators(chosen.iter()), 1);
-        assert_eq!(fixture.num_non_validators(chosen.iter()), 1);
-
-        // Choose one from all peers, exclude none, should return one peer with 50-50 chance of
-        // being a validator.
-        let mut got_validator = false;
-        let mut got_non_validator = false;
-        let mut attempts = 0;
-        while !got_validator || !got_non_validator {
-            let chosen = choose_gossip_peers(
-                &mut rng,
-                TARGET,
-                1,
-                HashSet::new(),
-                fixture.all_peers.iter().copied(),
-                fixture.is_validator_in_era(),
-            );
-            assert_eq!(chosen.len(), 1);
-            let node_id = chosen.iter().next().unwrap();
-            got_validator |= fixture.validators.contains(node_id);
-            got_non_validator |= fixture.non_validators.contains(node_id);
-            attempts += 1;
-            assert!(attempts < 1_000_000);
-        }
-
-        // Choose VALIDATOR_COUNT from all peers, exclude all but one validator, should return the
-        // one validator and VALIDATOR_COUNT - 1 non-validators.
-        let exclude: HashSet<_> = fixture
-            .validators
-            .iter()
-            .copied()
-            .take(VALIDATOR_COUNT - 1)
-            .collect();
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT,
-            exclude.clone(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), VALIDATOR_COUNT);
-        assert_eq!(fixture.num_validators(chosen.iter()), 1);
-        assert_eq!(
-            fixture.num_non_validators(chosen.iter()),
-            VALIDATOR_COUNT - 1
-        );
-        assert!(exclude.is_disjoint(&chosen));
-
-        // Choose 3 from all peers, exclude all non-validators, should return 3 validators.
-        let exclude: HashSet<_> = fixture.non_validators.iter().copied().collect();
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            3,
-            exclude.clone(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), 3);
-        assert_eq!(fixture.num_validators(chosen.iter()), 3);
-        assert!(exclude.is_disjoint(&chosen));
-    }
-
-    #[test]
-    fn should_choose_all() {
-        const TARGET: GossipTarget = GossipTarget::All;
-
-        let mut rng = TestRng::new();
-        let fixture = Fixture::new(&mut rng);
-
-        // Choose more than total count from all peers, exclude none, should return all peers.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT + NON_VALIDATOR_COUNT + 1,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), fixture.all_peers.len());
-
-        // Choose total count from all peers, exclude none, should return all peers.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT + NON_VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), fixture.all_peers.len());
-
-        // Choose VALIDATOR_COUNT from only validators, exclude none, should return all validators.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.validators.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), VALIDATOR_COUNT);
-        assert_eq!(fixture.num_validators(chosen.iter()), VALIDATOR_COUNT);
-
-        // Choose VALIDATOR_COUNT from only non-validators, exclude none, should return
-        // VALIDATOR_COUNT non-validators.
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT,
-            HashSet::new(),
-            fixture.non_validators.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), VALIDATOR_COUNT);
-        assert_eq!(fixture.num_non_validators(chosen.iter()), VALIDATOR_COUNT);
-
-        // Choose VALIDATOR_COUNT from all peers, exclude all but VALIDATOR_COUNT from all peers,
-        // should return all the non-excluded peers.
-        let exclude: HashSet<_> = fixture
-            .all_peers
-            .iter()
-            .copied()
-            .take(NON_VALIDATOR_COUNT)
-            .collect();
-        let chosen = choose_gossip_peers(
-            &mut rng,
-            TARGET,
-            VALIDATOR_COUNT,
-            exclude.clone(),
-            fixture.all_peers.iter().copied(),
-            fixture.is_validator_in_era(),
-        );
-        assert_eq!(chosen.len(), VALIDATOR_COUNT);
-        assert!(exclude.is_disjoint(&chosen));
-
-        // Choose one from all peers, exclude enough non-validators to have an even chance of
-        // returning a validator as a non-validator, should return one peer with 50-50 chance of
-        // being a validator.
-        let exclude: HashSet<_> = fixture
-            .non_validators
-            .iter()
-            .copied()
-            .take(NON_VALIDATOR_COUNT - VALIDATOR_COUNT)
-            .collect();
-        let mut got_validator = false;
-        let mut got_non_validator = false;
-        let mut attempts = 0;
-        while !got_validator || !got_non_validator {
-            let chosen = choose_gossip_peers(
-                &mut rng,
-                TARGET,
-                1,
-                exclude.clone(),
-                fixture.all_peers.iter().copied(),
-                fixture.is_validator_in_era(),
-            );
-            assert_eq!(chosen.len(), 1);
-            assert!(exclude.is_disjoint(&chosen));
-            let node_id = chosen.iter().next().unwrap();
-            got_validator |= fixture.validators.contains(node_id);
-            got_non_validator |= fixture.non_validators.contains(node_id);
-            attempts += 1;
-            assert!(attempts < 1_000_000);
         }
     }
 }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -187,7 +187,7 @@ where
             known_addresses: Default::default(),
             public_addr: None,
             chain_info: chain_info_source.into(),
-            node_key_pair: node_key_pair,
+            node_key_pair,
             identity,
             our_id,
             validator_matrix,
@@ -341,7 +341,7 @@ where
             let state = conman.read_state();
             for (consensus_key, &peer_id) in state.key_index().iter() {
                 if validators.contains(consensus_key) {
-                    self.send_message(&*state, peer_id, channel, payload.clone(), None)
+                    self.send_message(&state, peer_id, channel, payload.clone(), None)
                 }
             }
         } else {
@@ -349,7 +349,7 @@ where
             // available. Broadcast to everyone instead.
             let state = conman.read_state();
             for &peer_id in state.routing_table().keys() {
-                self.send_message(&*state, peer_id, channel, payload.clone(), None)
+                self.send_message(&state, peer_id, channel, payload.clone(), None)
             }
         }
     }
@@ -408,7 +408,7 @@ where
 
                     first
                         .into_iter()
-                        .interleave(second.into_iter())
+                        .interleave(second)
                         .take(count)
                         .cloned()
                         .collect()
@@ -577,7 +577,7 @@ where
                 // We're given a message to send. Pass on the responder so that confirmation
                 // can later be given once the message has actually been buffered.
                 self.send_message(
-                    &*conman.read_state(),
+                    &conman.read_state(),
                     *dest,
                     channel,
                     payload,

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -425,7 +425,7 @@ where
                 }
             }
             GossipTarget::Mixed(_) => {
-                // Mixed mode gossip is disabled.
+                // Mixed mode gossip is disabled through config.
                 Vec::new()
             }
             GossipTarget::All => {

--- a/node/src/components/network/config.rs
+++ b/node/src/components/network/config.rs
@@ -38,6 +38,9 @@ const DEFAULT_ERROR_TIMEOUT: TimeDiff = TimeDiff::from_seconds(10);
 /// Default value for validator broadcast.
 const DEFAULT_USE_VALIDATOR_BROADCAST: bool = true;
 
+/// Default value for use of mixed gossip.
+const DEFAULT_USE_MIXED_GOSSIP: bool = true;
+
 impl Default for Config {
     fn default() -> Self {
         Config {
@@ -57,6 +60,7 @@ impl Default for Config {
             bubble_timeouts: DEFAULT_BUBBLE_TIMEOUTS,
             error_timeout: DEFAULT_ERROR_TIMEOUT,
             use_validator_broadcast: DEFAULT_USE_VALIDATOR_BROADCAST,
+            use_mixed_gossip: DEFAULT_USE_MIXED_GOSSIP,
         }
     }
 }
@@ -121,6 +125,8 @@ pub struct Config {
     pub error_timeout: TimeDiff,
     /// Whether to restrict broadcasts of certain values to validators.
     pub use_validator_broadcast: bool,
+    /// Whether to enable the use of mixed mode gossiping.
+    pub use_mixed_gossip: bool,
 }
 
 #[cfg(test)]

--- a/node/src/components/network/conman.rs
+++ b/node/src/components/network/conman.rs
@@ -691,7 +691,7 @@ async fn handle_incoming(
         }
 
         ActiveRoute::new(
-            &mut *guard,
+            &mut guard,
             ctx.clone(),
             peer_id,
             rpc_client,
@@ -794,7 +794,7 @@ impl OutgoingHandler {
             }
             guard.prune_should_not_call(&peer_addr);
 
-            Self::new(&mut *guard, ctx.clone(), peer_addr)
+            Self::new(&mut guard, ctx.clone(), peer_addr)
         };
 
         // We now enter a connection loop. After attempting to connect and serve, we either sleep
@@ -951,7 +951,7 @@ impl OutgoingHandler {
             }
 
             ActiveRoute::new(
-                &mut *guard,
+                &mut guard,
                 self.ctx.clone(),
                 peer_id,
                 rpc_client,

--- a/node/src/components/network/connection_id.rs
+++ b/node/src/components/network/connection_id.rs
@@ -49,7 +49,7 @@ impl TlsRandomData {
         ssl.client_random(&mut combined_random[RLEN..]);
 
         Self {
-            digest: Digest::hash(&combined_random),
+            digest: Digest::hash(combined_random),
         }
     }
 
@@ -61,7 +61,7 @@ impl TlsRandomData {
         rng.fill_bytes(&mut buffer);
 
         Self {
-            digest: Digest::hash(&buffer),
+            digest: Digest::hash(buffer),
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -772,7 +772,7 @@ impl<REv> EffectBuilder<REv> {
         gossip_target: GossipTarget,
         count: usize,
         exclude: HashSet<NodeId>,
-    ) -> HashSet<NodeId>
+    ) -> Vec<NodeId>
     where
         REv: From<NetworkRequest<P>>,
         P: Send,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -194,11 +194,18 @@ pub(crate) type Effects<Ev> = Multiple<Effect<Ev>>;
 pub(crate) type Multiple<T> = SmallVec<[T; 2]>;
 
 /// The type of peers that should receive the gossip message.
+///
+/// The selection process is as follows:
+///
+/// 1. From all peers
+/// 2. exclude those explicitly specified to be excluded
+/// 3. construct subsequences according to [`GossipTarget`]
+/// 4. then select desired number of peers.
 #[derive(Debug, Serialize, PartialEq, Eq, Hash, Copy, Clone, DataSize)]
 pub(crate) enum GossipTarget {
-    /// Both validators and non validators.
+    /// Alternate between validators and non-validators.
     Mixed(EraId),
-    /// All peers.
+    /// A random subset of all connected peers.
     All,
 }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -126,7 +126,7 @@ pub(crate) enum NetworkRequest<P> {
         exclude: HashSet<NodeId>,
         /// Responder to be called when all messages are queued.
         #[serde(skip_serializing)]
-        auto_closing_responder: AutoClosingResponder<HashSet<NodeId>>,
+        auto_closing_responder: AutoClosingResponder<Vec<NodeId>>,
     },
 }
 

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -236,6 +236,26 @@ impl ValidatorMatrix {
         }
     }
 
+    /// Returns the public keys of all validators in a given era.
+    ///
+    /// Will return `None` if the era is not known.
+    pub(crate) fn era_validators<'a>(&'a self, era_id: EraId) -> Option<Vec<PublicKey>> {
+        if let Some(ref chainspec_validators) = self.chainspec_validators {
+            if era_id == self.chainspec_activation_era {
+                return Some(chainspec_validators.keys().cloned().collect());
+            }
+        }
+
+        Some(
+            self.read_inner()
+                .get(&era_id)?
+                .validator_weights
+                .keys()
+                .cloned()
+                .collect(),
+        )
+    }
+
     pub(crate) fn public_signing_key(&self) -> &PublicKey {
         &self.public_signing_key
     }

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -266,21 +266,6 @@ impl ValidatorMatrix {
         self.is_validator_in_era(era_id, &self.public_signing_key)
     }
 
-    /// Return the set of active or upcoming validators.
-    ///
-    /// The set is not guaranteed to be minimal, as it will include validators up to `auction_delay
-    /// + 1` back eras from the highest era known.
-    #[inline]
-    pub(crate) fn active_or_upcoming_validators(&self) -> HashSet<PublicKey> {
-        self.read_inner()
-            .values()
-            .rev()
-            .take(self.auction_delay as usize + 1)
-            .flat_map(|validator_weights| validator_weights.validator_public_keys())
-            .cloned()
-            .collect()
-    }
-
     pub(crate) fn create_finality_signature(
         &self,
         block_header: &BlockHeader,

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -239,7 +239,7 @@ impl ValidatorMatrix {
     /// Returns the public keys of all validators in a given era.
     ///
     /// Will return `None` if the era is not known.
-    pub(crate) fn era_validators<'a>(&'a self, era_id: EraId) -> Option<Vec<PublicKey>> {
+    pub(crate) fn era_validators(&self, era_id: EraId) -> Option<Vec<PublicKey>> {
         if let Some(ref chainspec_validators) = self.chainspec_validators {
             if era_id == self.chainspec_activation_era {
                 return Some(chainspec_validators.keys().cloned().collect());

--- a/node/src/utils/rate_limited.rs
+++ b/node/src/utils/rate_limited.rs
@@ -73,6 +73,7 @@ macro_rules! rate_limited {
         static $key: $crate::utils::rate_limited::RateLimited =
             $crate::utils::rate_limited::RateLimited::new();
 
+        #[allow(clippy::redundant_closure_call)]
         if let Some(skipped) = $key.acquire($count, $per) {
             $action(skipped);
         }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -230,6 +230,9 @@ error_timeout = '10 seconds'
 # Whether to restrict broadcasts of values most likely only relevant for validators to only those.
 use_validator_broadcast = true
 
+# Whether to enable the use of optimized gossip peer selection for a subset of items.
+use_mixed_gossip = true
+
 # Identity of a node
 #
 # When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -230,6 +230,9 @@ error_timeout = '10 seconds'
 # Whether to restrict broadcasts of values most likely only relevant for validators to only those.
 use_validator_broadcast = true
 
+# Whether to enable the use of optimized gossip peer selection for a subset of items.
+use_mixed_gossip = true
+
 # Identity of a node
 #
 # When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.


### PR DESCRIPTION
This restore the gossiping peer selection. Note that the original method of sampling the outgoing limiter was not portable, since we do not keep a pre-built mapping of which `NodeId`s are validators ready. The use of the validator matrix changes, requiring only one lock instead of `O(# connected peers)`.

Furthermore, the setting is now configurable, should it cause issues.


