### PR TITLE
Fix upgrade scenario 09 in 2.0

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -48,6 +48,8 @@ function _main()
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
     ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
+    # This explicitly queries expecting the previous major version of the node, which might not be backwards compatible
+    # TODO: The version here should be updated in the next major release.
     PRE_UPGRADE_BLOCK_HASH="$(get_block_v1 "2" | jq -r '.hash')"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -48,7 +48,7 @@ function _main()
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
     ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
-    PRE_UPGRADE_BLOCK_HASH="$($(get_path_to_client) get-block --node-address "$(get_node_address_rpc '2')" | jq -r '.result.block.hash')"
+    PRE_UPGRADE_BLOCK_HASH="$(get_block_v1 "2" | jq -r '.hash')"
 
     _step_03 "$STAGE_ID" "$ACTIVATION_POINT"
     _step_04 "$INITIAL_PROTOCOL_VERSION"

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_09.sh
@@ -48,7 +48,7 @@ function _main()
     INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     # Establish consistent activation point for use later.
     ACTIVATION_POINT="$(($(get_chain_era) + NCTL_DEFAULT_ERA_ACTIVATION_OFFSET))"
-    # This explicitly queries expecting the previous major version of the node, which might not be backwards compatible
+    # This explicitly expects the previous major version of the node, which might not be backwards compatible
     # TODO: The version here should be updated in the next major release.
     PRE_UPGRADE_BLOCK_HASH="$(get_block_v1 "2" | jq -r '.hash')"
 

--- a/utils/nctl/sh/scenarios/common/itst.sh
+++ b/utils/nctl/sh/scenarios/common/itst.sh
@@ -316,7 +316,7 @@ function get_switch_block() {
     fi
 }
 
-# Gets the header of the switch block of the given era from a V1 node without using casper-client.
+# Gets the switch block of the given era from a V1 node without using casper-client.
 function get_switch_block_v1() {
     local NODE_ID=${1}
     # Number of blocks to walkback before erroring out
@@ -324,16 +324,9 @@ function get_switch_block_v1() {
     local BLOCK_HASH=${3}
     local ERA=${4}
 
-    if [ -z "$BLOCK_HASH" ]; then
-        JSON_OUT=$(curl $(get_node_address_rpc_for_curl "$NODE_ID") -s -H "Content-Type: application/json" -d \
-            '{"jsonrpc":"2.0","method":"chain_get_block","id":0,"params":{}}')
-    else
-        JSON_OUT=$(curl $(get_node_address_rpc_for_curl "$NODE_ID") -s -H "Content-Type: application/json" -d \
-            '{"jsonrpc":"2.0","method":"chain_get_block","id":0,"params":{"block_identifier":{"Hash":"'$BLOCK_HASH'"}}}')
-    fi
+    local BLOCK=$(get_block_v1 "$NODE_ID" "$BLOCK_HASH")
 
     if [ "$WALKBACK" -gt 0 ]; then
-        local BLOCK=$(echo "$JSON_OUT" | jq '.result.block')
         local ERA_END="$(echo "$BLOCK" | jq '.header.era_end')"
         local ERA_ID="$(echo "$BLOCK" | jq '.header.era_id')"
         if [ "$ERA_END" = "null" ] || { [ -n "$ERA" ] && [ "$ERA_ID" != "$ERA" ]; }; then
@@ -346,6 +339,23 @@ function get_switch_block_v1() {
     else
         echo "null"
     fi
+}
+
+# Gets either the latest block or one with the provided hash from a V1 node without using casper-client.
+function get_block_v1() {
+    local NODE_ID=${1}
+    local BLOCK_HASH=${2}
+
+    if [ -z "$BLOCK_HASH" ]; then
+        JSON_OUT=$(curl $(get_node_address_rpc_for_curl "$NODE_ID") -s -H "Content-Type: application/json" -d \
+            '{"jsonrpc":"2.0","method":"chain_get_block","id":0,"params":{}}')
+    else
+        JSON_OUT=$(curl $(get_node_address_rpc_for_curl "$NODE_ID") -s -H "Content-Type: application/json" -d \
+            '{"jsonrpc":"2.0","method":"chain_get_block","id":0,"params":{"block_identifier":{"Hash":"'$BLOCK_HASH'"}}}')
+    fi
+
+    local BLOCK=$(echo "$JSON_OUT" | jq '.result.block')
+    echo "$BLOCK"
 }
 
 function get_switch_block_equivocators() {

--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -180,7 +180,7 @@ function get_node_is_up()
     local NODE_ID=${1}
     local NODE_PORT
 
-    NODE_PORT=$(get_node_port_rpc "$NODE_ID")
+    NODE_PORT=$(get_node_port "$NCTL_BASE_PORT_NETWORK" "$NODE_ID")
 
     if grep -q "$NODE_PORT (LISTEN)" <<< "$(lsof -i -P -n)"; then
         echo true


### PR DESCRIPTION
- had to update one request to use curl, because it runs against V1 node
- `get_node_is_up` was checking the rpc port being bound, which caused problems with detecting nodes going down, because the rpc port is now in the sidecar, I changed it to the listen port of the node
