### PR TITLE
Fix rewards distribution

### DIFF
--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -107,7 +107,7 @@ administrators = []
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
-maximum_round_length = '525 seconds'
+maximum_round_length = '17 seconds'
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 # Expressed as a fraction (1/5 by default).
 reduced_reward_multiplier = [1, 5]

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -609,6 +609,12 @@ pub trait Auction:
             let total_reward = Ratio::from(reward_amount);
             let recipient = seigniorage_recipients
                 .get(&proposer)
+                .cloned()
+                .or_else(|| {
+                    let bid_key = BidAddr::from(proposer.clone()).into();
+                    let validator_bid = detail::read_validator_bid(self, &bid_key).ok()?;
+                    detail::seigniorage_recipient(self, &validator_bid).ok()
+                })
                 .ok_or(Error::ValidatorNotFound)?;
 
             let total_stake = recipient.total_stake().ok_or(Error::ArithmeticOverflow)?;

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -94,6 +94,9 @@ pub trait Auction:
         let (target, validator_bid) = if let Some(BidKind::Validator(mut validator_bid)) =
             self.read_bid(&validator_bid_key)?
         {
+            if validator_bid.inactive() {
+                validator_bid.activate();
+            }
             validator_bid.increase_stake(amount)?;
             validator_bid.with_delegation_rate(delegation_rate);
             (*validator_bid.bonding_purse(), validator_bid)


### PR DESCRIPTION
This fixes a bug in which a validator from previous era that stopped being a validator couldn't receive a reward for a finality signature created in the previous era.

Closes #4611 
