### PR TITLE
Use consistent administrator account in both 'accounts' and 'chainspe…

### DIFF
--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -272,6 +272,11 @@ function setup_asset_chainspec()
     SCRIPT+=("toml.dump(cfg, open('$PATH_TO_CHAINSPEC', 'w'));")
 
     python3 -c "${SCRIPT[*]}"
+
+    # Set administrator for private chains.
+    PBK_KEY="PBK_FAUCET"
+    ACCOUNT_KEY="$(get_account_key "$NCTL_ACCOUNT_TYPE_FAUCET")"
+    sed -i "s/""$PBK_KEY""/""$ACCOUNT_KEY""/" "$PATH_TO_CHAINSPEC"
 }
 
 #######################################

--- a/utils/nctl/sh/scenarios/chainspecs/itst07_private_chain.chainspec.toml.override
+++ b/utils/nctl/sh/scenarios/chainspecs/itst07_private_chain.chainspec.toml.override
@@ -10,5 +10,5 @@ refund_handling = { type = "refund", refund_ratio = [1, 1] }
 # How fees are paid
 fee_handling = { type = "accumulate" }
 # System account is an administrator
-administrators = ["01f137c5b0c252a028cdb3eccf62946c5340837c66a892fc5079a7c1854f0f962f"]
+administrators = ["PBK_FAUCET"]
 compute_rewards = false


### PR DESCRIPTION
This PR makes correction to the toml override files related to private chain NCTL tests.

Blocked by: https://github.com/casper-network/casper-node/pull/4618