### PR TITLE
Remove `add_session_version`

### DIFF
--- a/execution_engine/src/resolvers/v1_function_index.rs
+++ b/execution_engine/src/resolvers/v1_function_index.rs
@@ -60,7 +60,6 @@ pub(crate) enum FunctionIndex {
     RandomBytes,
     DictionaryReadFuncIndex,
     EnableContractVersion,
-    AddSessionVersion,
     ManageMessageTopic,
     EmitMessage,
 }

--- a/execution_engine/src/resolvers/v1_resolver.rs
+++ b/execution_engine/src/resolvers/v1_resolver.rs
@@ -245,10 +245,6 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::EnableContractVersion.into(),
             ),
-            "casper_add_session_logic" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
-                FunctionIndex::AddSessionVersion.into(),
-            ),
             "casper_manage_message_topic" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::ManageMessageTopic.into(),

--- a/execution_engine/src/runtime/externals.rs
+++ b/execution_engine/src/runtime/externals.rs
@@ -605,20 +605,6 @@ where
                 )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
-            FunctionIndex::AddSessionVersion => {
-                // args(0) = pointer to entrypoints in wasm memory
-                // args(1) = size of entrypoints in wasm memory
-                let (entry_points_ptr, entry_points_size) = Args::parse(args)?;
-                self.charge_host_function_call(
-                    &host_function_costs.add_session_version,
-                    [entry_points_ptr, entry_points_size],
-                )?;
-
-                let entry_points: EntryPoints =
-                    self.t_from_mem(entry_points_ptr, entry_points_size)?;
-                let ret = self.add_session_version(entry_points)?;
-                Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
-            }
             FunctionIndex::AddPackageVersion => {
                 // args(0)  = pointer to package hash in wasm memory
                 // args(1)  = size of package hash in wasm memory

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -1746,61 +1746,6 @@ where
         Ok(Ok(()))
     }
 
-    fn add_session_version(
-        &mut self,
-        entry_points: EntryPoints,
-    ) -> Result<Result<(), ApiError>, ExecError> {
-        if !self.context.entity().is_account_kind() {
-            return Err(ExecError::InvalidContext);
-        }
-
-        let package_hash = self.context.entity().package_hash();
-
-        let package = self.context.get_package(package_hash)?;
-
-        let byte_code_hash = self.context.new_hash_address()?;
-
-        let byte_code = {
-            let module_bytes = self.get_module_from_entry_points(&entry_points)?;
-            ByteCode::new(ByteCodeKind::V1CasperWasm, module_bytes)
-        };
-
-        let entity_hash =
-            if let Some(entity_hash) = self.context.get_entity_key().into_entity_hash() {
-                entity_hash
-            } else {
-                return Err(ExecError::UnexpectedKeyVariant(
-                    self.context.get_entity_key(),
-                ));
-            };
-
-        let entity = self.context.entity().clone();
-
-        let updated_session_entity =
-            entity.update_session_entity(ByteCodeHash::new(byte_code_hash), entry_points);
-
-        self.context.metered_write_gs_unsafe(
-            Key::ByteCode(ByteCodeAddr::new_wasm_addr(byte_code_hash)),
-            byte_code,
-        )?;
-
-        let entity_kind = updated_session_entity.entity_kind();
-
-        if entity_kind != EntityKind::SmartContract {
-            return Err(ExecError::InvalidContext);
-        }
-
-        let entity_addr = EntityAddr::new_contract_entity_addr(entity_hash.value());
-
-        self.context
-            .metered_write_gs_unsafe(Key::AddressableEntity(entity_addr), updated_session_entity)?;
-
-        self.context
-            .metered_write_gs_unsafe(package_hash, package)?;
-
-        Ok(Ok(()))
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn add_contract_version(
         &mut self,

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -243,8 +243,6 @@ mod tests {
             blake2b: HostFunction::new(133, [0, 1, 2, 3]),
             random_bytes: HostFunction::new(123, [0, 1]),
             enable_contract_version: HostFunction::new(142, [0, 1, 2, 3]),
-            // TODO: Update this cost.
-            add_session_version: HostFunction::default(),
             manage_message_topic: HostFunction::new(100, [0, 1, 2, 4]),
             emit_message: HostFunction::new(100, [0, 1, 2, 3]),
             cost_increase_per_message: 50,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -261,7 +261,6 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
-add_session_version = { cost = 200, arguments = [0, 0] }
 manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
 emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
 cost_increase_per_message = 50

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -272,7 +272,6 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
-add_session_version = { cost = 200, arguments = [0, 0] }
 manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
 emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
 cost_increase_per_message = 50

--- a/smart_contracts/contract/src/contract_api/account.rs
+++ b/smart_contracts/contract/src/contract_api/account.rs
@@ -8,13 +8,11 @@ use casper_types::{
     addressable_entity::{
         ActionType, AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
     },
-    api_error, bytesrepr, EntryPoints, URef, UREF_SERIALIZED_LENGTH,
+    bytesrepr, URef, UREF_SERIALIZED_LENGTH,
 };
 
 use super::to_ptr;
-use crate::{
-    contract_api, contract_api::runtime::revert, ext_ffi, unwrap_or_revert::UnwrapOrRevert,
-};
+use crate::{contract_api, ext_ffi, unwrap_or_revert::UnwrapOrRevert};
 
 /// Retrieves the ID of the account's main purse.
 pub fn get_main_purse() -> URef {
@@ -93,17 +91,5 @@ pub fn update_associated_key(
         Ok(())
     } else {
         Err(UpdateKeyFailure::try_from(result).unwrap_or_revert())
-    }
-}
-
-/// Add session code to an entity associated with an Account.
-pub fn add_session_version(entry_points: EntryPoints) {
-    let (entry_points_ptr, entry_points_size, _entry_point_bytes) = to_ptr(entry_points);
-
-    let result = unsafe { ext_ffi::casper_add_session_logic(entry_points_ptr, entry_points_size) };
-
-    match api_error::result_from(result) {
-        Ok(_) => {}
-        Err(e) => revert(e),
     }
 }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -506,12 +506,6 @@ extern "C" {
         existing_urefs_size: usize,
         output_size_ptr: *mut usize,
     ) -> i32;
-    /// Adds new session logic to an addressable entity of kind Account.
-    ///
-    /// # Arguments
-    /// * `entry_points_ptr` - pointer to serialized [`casper_types::EntryPoints`]
-    /// * `entry_points_size` - size of serialized [`casper_types::EntryPoints`]
-    pub fn casper_add_session_logic(entry_points_ptr: *const u8, entry_points_size: usize) -> i32;
     /// Adds a new version to a package.
     ///
     /// # Arguments

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -328,8 +328,6 @@ pub struct HostFunctionCosts {
     pub random_bytes: HostFunction<[Cost; 2]>,
     /// Cost of calling the `enable_contract_version` host function.
     pub enable_contract_version: HostFunction<[Cost; 4]>,
-    /// Cost of calling the `add_session_version` host function.
-    pub add_session_version: HostFunction<[Cost; 2]>,
     /// Cost of calling the `casper_manage_message_topic` host function.
     pub manage_message_topic: HostFunction<[Cost; 4]>,
     /// Cost of calling the `casper_emit_message` host function.
@@ -383,7 +381,6 @@ impl Zero for HostFunctionCosts {
             blake2b: HostFunction::zero(),
             random_bytes: HostFunction::zero(),
             enable_contract_version: HostFunction::zero(),
-            add_session_version: HostFunction::zero(),
             manage_message_topic: HostFunction::zero(),
             emit_message: HostFunction::zero(),
             cost_increase_per_message: Zero::zero(),
@@ -437,7 +434,6 @@ impl Zero for HostFunctionCosts {
             blake2b,
             random_bytes,
             enable_contract_version,
-            add_session_version,
             manage_message_topic,
             emit_message,
         } = self;
@@ -485,7 +481,6 @@ impl Zero for HostFunctionCosts {
             && blake2b.is_zero()
             && random_bytes.is_zero()
             && enable_contract_version.is_zero()
-            && add_session_version.is_zero()
             && manage_message_topic.is_zero()
             && emit_message.is_zero()
             && cost_increase_per_message.is_zero()
@@ -622,7 +617,6 @@ impl Default for HostFunctionCosts {
             blake2b: HostFunction::default(),
             random_bytes: HostFunction::default(),
             enable_contract_version: HostFunction::default(),
-            add_session_version: HostFunction::default(),
             manage_message_topic: HostFunction::default(),
             emit_message: HostFunction::default(),
             cost_increase_per_message: DEFAULT_COST_INCREASE_PER_MESSAGE_EMITTED,
@@ -677,7 +671,6 @@ impl ToBytes for HostFunctionCosts {
         ret.append(&mut self.blake2b.to_bytes()?);
         ret.append(&mut self.random_bytes.to_bytes()?);
         ret.append(&mut self.enable_contract_version.to_bytes()?);
-        ret.append(&mut self.add_session_version.to_bytes()?);
         ret.append(&mut self.manage_message_topic.to_bytes()?);
         ret.append(&mut self.emit_message.to_bytes()?);
         ret.append(&mut self.cost_increase_per_message.to_bytes()?);
@@ -729,7 +722,6 @@ impl ToBytes for HostFunctionCosts {
             + self.blake2b.serialized_length()
             + self.random_bytes.serialized_length()
             + self.enable_contract_version.serialized_length()
-            + self.add_session_version.serialized_length()
             + self.manage_message_topic.serialized_length()
             + self.emit_message.serialized_length()
             + self.cost_increase_per_message.serialized_length()
@@ -782,7 +774,6 @@ impl FromBytes for HostFunctionCosts {
         let (blake2b, rem) = FromBytes::from_bytes(rem)?;
         let (random_bytes, rem) = FromBytes::from_bytes(rem)?;
         let (enable_contract_version, rem) = FromBytes::from_bytes(rem)?;
-        let (add_session_version, rem) = FromBytes::from_bytes(rem)?;
         let (manage_message_topic, rem) = FromBytes::from_bytes(rem)?;
         let (emit_message, rem) = FromBytes::from_bytes(rem)?;
         let (cost_increase_per_message, rem) = FromBytes::from_bytes(rem)?;
@@ -832,7 +823,6 @@ impl FromBytes for HostFunctionCosts {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
-                add_session_version,
                 manage_message_topic,
                 emit_message,
                 cost_increase_per_message,
@@ -890,7 +880,6 @@ impl Distribution<HostFunctionCosts> for Standard {
             blake2b: rng.gen(),
             random_bytes: rng.gen(),
             enable_contract_version: rng.gen(),
-            add_session_version: rng.gen(),
             manage_message_topic: rng.gen(),
             emit_message: rng.gen(),
             cost_increase_per_message: rng.gen(),
@@ -957,7 +946,6 @@ pub mod gens {
             blake2b in host_function_cost_arb(),
             random_bytes in host_function_cost_arb(),
             enable_contract_version in host_function_cost_arb(),
-            add_session_version in host_function_cost_arb(),
             manage_message_topic in host_function_cost_arb(),
             emit_message in host_function_cost_arb(),
             cost_increase_per_message in num::u32::ANY,
@@ -1007,7 +995,6 @@ pub mod gens {
                 blake2b,
                 random_bytes,
                 enable_contract_version,
-                add_session_version,
                 manage_message_topic,
                 emit_message,
                 cost_increase_per_message,


### PR DESCRIPTION
CHANGELOG:

- Removed `add_session_version` function, the associated cost table entry and FFI method

The `add_session_version` work was never completed and was incorrectly merged as part of the Named keys rework. As such the incomplete implementation is being removed.

