### PR TITLE
Expose dictionary item key in lookup response

### DIFF
--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -739,7 +739,7 @@ fn get_dictionary_item_by_addr(state_root_hash: Digest, addr: DictionaryAddr) ->
         name: "get_dictionary_item_by_addr",
         request: BinaryRequest::Get(GetRequest::State(GlobalStateRequest::DictionaryItem {
             state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
-            identifier: DictionaryItemIdentifier::DictionaryItem(addr.clone()),
+            identifier: DictionaryItemIdentifier::DictionaryItem(addr),
         })),
         asserter: Box::new(move |response| {
             assert_response::<DictionaryQueryResult, _>(
@@ -766,7 +766,7 @@ fn get_dictionary_item_by_seed_uref(
         request: BinaryRequest::Get(GetRequest::State(GlobalStateRequest::DictionaryItem {
             state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
             identifier: DictionaryItemIdentifier::URef {
-                seed_uref: seed_uref.clone(),
+                seed_uref,
                 dictionary_item_key: dictionary_item_key.clone(),
             },
         })),

--- a/types/src/binary_port.rs
+++ b/types/src/binary_port.rs
@@ -33,8 +33,9 @@ pub use payload_type::{PayloadEntity, PayloadType};
 pub use record_id::RecordId;
 pub use state_request::GlobalStateRequest;
 pub use type_wrappers::{
-    ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
-    ReactorStateName, SpeculativeExecutionResult, TransactionWithExecutionInfo, Uptime,
+    ConsensusStatus, ConsensusValidatorChanges, DictionaryQueryResult, GetTrieFullResult,
+    LastProgress, NetworkName, ReactorStateName, SpeculativeExecutionResult,
+    TransactionWithExecutionInfo, Uptime,
 };
 
 use alloc::vec::Vec;

--- a/types/src/binary_port/global_state_query_result.rs
+++ b/types/src/binary_port/global_state_query_result.rs
@@ -31,6 +31,11 @@ impl GlobalStateQueryResult {
         }
     }
 
+    /// Returns the stored value.
+    pub fn value(&self) -> &StoredValue {
+        &self.value
+    }
+
     /// Returns the stored value and the merkle proof.
     pub fn into_inner(self) -> (StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>) {
         (self.value, self.merkle_proof)

--- a/types/src/binary_port/payload_type.rs
+++ b/types/src/binary_port/payload_type.rs
@@ -31,7 +31,7 @@ use super::{
         ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
         ReactorStateName, SpeculativeExecutionResult,
     },
-    TransactionWithExecutionInfo, Uptime,
+    DictionaryQueryResult, TransactionWithExecutionInfo, Uptime,
 };
 
 /// A type of the payload being returned in a binary response.
@@ -107,6 +107,8 @@ pub enum PayloadType {
     GetTrieFullResult,
     /// Node status.
     NodeStatus,
+    /// Result of querying for a dictionary item.
+    DictionaryQueryResult,
 }
 
 impl PayloadType {
@@ -192,6 +194,9 @@ impl TryFrom<u8> for PayloadType {
             x if x == PayloadType::StoredValues as u8 => Ok(PayloadType::StoredValues),
             x if x == PayloadType::GetTrieFullResult as u8 => Ok(PayloadType::GetTrieFullResult),
             x if x == PayloadType::NodeStatus as u8 => Ok(PayloadType::NodeStatus),
+            x if x == PayloadType::DictionaryQueryResult as u8 => {
+                Ok(PayloadType::DictionaryQueryResult)
+            }
             _ => Err(()),
         }
     }
@@ -242,6 +247,7 @@ impl fmt::Display for PayloadType {
             PayloadType::StoredValues => write!(f, "StoredValues"),
             PayloadType::GetTrieFullResult => write!(f, "GetTrieFullResult"),
             PayloadType::NodeStatus => write!(f, "NodeStatus"),
+            PayloadType::DictionaryQueryResult => write!(f, "DictionaryQueryResult"),
         }
     }
 }
@@ -280,6 +286,7 @@ const GLOBAL_STATE_QUERY_RESULT_TAG: u8 = 30;
 const STORED_VALUES_TAG: u8 = 31;
 const GET_TRIE_FULL_RESULT_TAG: u8 = 32;
 const NODE_STATUS_TAG: u8 = 33;
+const DICTIONARY_QUERY_RESULT_TAG: u8 = 34;
 
 impl ToBytes for PayloadType {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
@@ -324,6 +331,7 @@ impl ToBytes for PayloadType {
             PayloadType::StoredValues => STORED_VALUES_TAG,
             PayloadType::GetTrieFullResult => GET_TRIE_FULL_RESULT_TAG,
             PayloadType::NodeStatus => NODE_STATUS_TAG,
+            PayloadType::DictionaryQueryResult => DICTIONARY_QUERY_RESULT_TAG,
         }
         .write_bytes(writer)
     }
@@ -371,6 +379,7 @@ impl FromBytes for PayloadType {
             STORED_VALUES_TAG => PayloadType::StoredValues,
             GET_TRIE_FULL_RESULT_TAG => PayloadType::GetTrieFullResult,
             NODE_STATUS_TAG => PayloadType::NodeStatus,
+            DICTIONARY_QUERY_RESULT_TAG => PayloadType::DictionaryQueryResult,
             _ => return Err(bytesrepr::Error::Formatting),
         };
         Ok((record_id, remainder))
@@ -454,6 +463,10 @@ impl PayloadEntity for ConsensusValidatorChanges {
 
 impl PayloadEntity for GlobalStateQueryResult {
     const PAYLOAD_TYPE: PayloadType = PayloadType::GlobalStateQueryResult;
+}
+
+impl PayloadEntity for DictionaryQueryResult {
+    const PAYLOAD_TYPE: PayloadType = PayloadType::DictionaryQueryResult;
 }
 
 impl PayloadEntity for Vec<StoredValue> {

--- a/types/src/binary_port/type_wrappers.rs
+++ b/types/src/binary_port/type_wrappers.rs
@@ -302,7 +302,7 @@ impl FromBytes for TransactionWithExecutionInfo {
 
 /// A query result for a dictionary item, contains the dictionary item key and a global state query
 /// result.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DictionaryQueryResult {
     key: Key,
     query_result: GlobalStateQueryResult,
@@ -359,7 +359,7 @@ mod tests {
     use rand::Rng;
 
     use super::*;
-    use crate::testing::TestRng;
+    use crate::{execution::ExecutionResult, testing::TestRng, BlockHash, CLValue, StoredValue};
 
     #[test]
     fn uptime_roundtrip() {
@@ -420,6 +420,31 @@ mod tests {
         bytesrepr::test_serialization_roundtrip(&ConsensusStatus::new(
             PublicKey::random(rng),
             Some(TimeDiff::from_millis(rng.gen())),
+        ));
+    }
+
+    #[test]
+    fn transaction_with_execution_info_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&TransactionWithExecutionInfo::new(
+            Transaction::random(rng),
+            rng.gen::<bool>().then(|| ExecutionInfo {
+                block_hash: BlockHash::random(rng),
+                block_height: rng.gen(),
+                execution_result: rng.gen::<bool>().then(|| ExecutionResult::random(rng)),
+            }),
+        ));
+    }
+
+    #[test]
+    fn dictionary_query_result_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&DictionaryQueryResult::new(
+            Key::Account(rng.gen()),
+            GlobalStateQueryResult::new(
+                StoredValue::CLValue(CLValue::from_t(rng.gen::<i32>()).unwrap()),
+                vec![],
+            ),
         ));
     }
 }

--- a/types/src/binary_port/type_wrappers.rs
+++ b/types/src/binary_port/type_wrappers.rs
@@ -302,7 +302,7 @@ impl FromBytes for TransactionWithExecutionInfo {
 
 /// A query result for a dictionary item, contains the dictionary item key and a global state query
 /// result.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DictionaryQueryResult {
     key: Key,
     query_result: GlobalStateQueryResult,

--- a/types/src/binary_port/type_wrappers.rs
+++ b/types/src/binary_port/type_wrappers.rs
@@ -300,7 +300,8 @@ impl FromBytes for TransactionWithExecutionInfo {
     }
 }
 
-/// A query result for a dictionary item, contains the dictionary item key and a global state query result.
+/// A query result for a dictionary item, contains the dictionary item key and a global state query
+/// result.
 #[derive(Debug)]
 pub struct DictionaryQueryResult {
     key: Key,


### PR DESCRIPTION
The current RPC response contains the dictionary item key as well as the value, so this addition is needed to maintain compatibility.