### PR TITLE
Correct CI json file path

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -53,7 +53,7 @@ function get_remotes() {
     local CI_JSON_CONFIG_FILE
     local PROTO_1
 
-    CI_JSON_CONFIG_FILE="$NCTL/ci/ci.json"
+    CI_JSON_CONFIG_FILE="$NCTL_CASPER_HOME/ci/ci.json"
     PROTO_1=$(jq -r '.nctl_upgrade_tests."protocol_1"' "$CI_JSON_CONFIG_FILE")
     nctl-stage-set-remotes "$PROTO_1"
 }


### PR DESCRIPTION
I noticed that the file got duplicated, it exists in casper-nctl as well (https://github.com/casper-network/casper-nctl/blob/dev/ci/ci.json), and this path points at the duplicate, which I intend to remove, so I'm updating the path here first.