### PR TITLE
Return None in case of an error in get_addressable_entity

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1248,7 +1248,7 @@ where
                     Key::addressable_entity_key(EntityKindTag::System, entity_hash),
                     &[],
                 )
-                .expect("must have value"),
+                .ok()?,
         };
 
         if let StoredValue::AddressableEntity(entity) = value {


### PR DESCRIPTION
The current behaviour causes a problem in NCTL upgrade scenario 11, where we use `get_total_supply_key` from the state upgrade script. The `get_addressable_entity` function fails instead of returning None, while `get_total_supply_key` expects it to return None in order to handle the legacy format. The error type here has already been converted to a String, so we can't match precisely on the NotFound error.