### PR TITLE
Bump juliet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "strum 0.25.0",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "juliet"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4800e6c04db91d3a80a9b84da77f73ce21bdd60f064b2e1a3a55680aacd88c"
+checksum = "4336a0d5e38193caafe774bd2be027cf5aa3c3e45b3f1bda1791fcacc9e9951d"
 dependencies = [
  "array-init",
  "bimap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,7 +13,7 @@ default-run = "casper-node"
 exclude = ["proptest-regressions"]
 
 [dependencies]
-juliet = "0.3"
+juliet = { version ="0.3", features = ["tracing"] }
 ansi_term = "0.12.1"
 anyhow = "1"
 aquamarine = "0.1.12"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,7 +13,7 @@ default-run = "casper-node"
 exclude = ["proptest-regressions"]
 
 [dependencies]
-juliet = "0.2"
+juliet = "0.3"
 ansi_term = "0.12.1"
 anyhow = "1"
 aquamarine = "0.1.12"


### PR DESCRIPTION
This PR bumps the `juliet` crate version to `0.3` and enables the `tracing` feature.