### PR TITLE
Add 'latest_switch_block_hash' field to rest status endpoint

### DIFF
--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -196,6 +196,7 @@ where
                             node_uptime,
                             available_block_range,
                             block_sync,
+                            latest_switch_block_header,
                         ) = join!(
                             effect_builder.get_highest_complete_block_from_storage(),
                             effect_builder.network_peers(),
@@ -206,6 +207,7 @@ where
                             effect_builder.get_uptime(),
                             effect_builder.get_available_block_range_from_storage(),
                             effect_builder.get_block_synchronizer_status(),
+                            effect_builder.get_latest_switch_block_header_from_storage()
                         );
                         let starting_state_root_hash = effect_builder
                             .get_block_header_at_height_from_storage(
@@ -226,6 +228,7 @@ where
                             available_block_range,
                             block_sync,
                             starting_state_root_hash,
+                            latest_switch_block_header.map(|header| header.block_hash()),
                         );
                         responder.respond(status_feed).await;
                     }

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -49,6 +49,7 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         available_block_range: AvailableBlockRange::RANGE_0_0,
         block_sync: BlockSynchronizerStatus::example().clone(),
         starting_state_root_hash: Digest::default(),
+        latest_switch_block_hash: Some(BlockHash::default()),
     };
     GetStatusResult::new(status_feed, DOCS_EXAMPLE_PROTOCOL_VERSION)
 });
@@ -103,6 +104,8 @@ pub struct StatusFeed {
     pub block_sync: BlockSynchronizerStatus,
     /// The state root hash of the lowest block in the available block range.
     pub starting_state_root_hash: Digest,
+    /// The hash of the latest switch block.
+    pub latest_switch_block_hash: Option<BlockHash>,
 }
 
 impl StatusFeed {
@@ -118,6 +121,7 @@ impl StatusFeed {
         available_block_range: AvailableBlockRange,
         block_sync: BlockSynchronizerStatus,
         starting_state_root_hash: Digest,
+        latest_switch_block_hash: Option<BlockHash>,
     ) -> Self {
         let (our_public_signing_key, round_length) =
             consensus_status.map_or((None, None), |consensus_status| {
@@ -139,6 +143,7 @@ impl StatusFeed {
             available_block_range,
             block_sync,
             starting_state_root_hash,
+            latest_switch_block_hash,
         }
     }
 }
@@ -206,6 +211,8 @@ pub struct GetStatusResult {
     pub available_block_range: AvailableBlockRange,
     /// The status of the block synchronizer builders.
     pub block_sync: BlockSynchronizerStatus,
+    /// The hash of the latest switch block.
+    pub latest_switch_block_hash: Option<BlockHash>,
 }
 
 impl GetStatusResult {
@@ -225,6 +232,7 @@ impl GetStatusResult {
             last_progress: status_feed.last_progress,
             available_block_range: status_feed.available_block_range,
             block_sync: status_feed.block_sync,
+            latest_switch_block_hash: status_feed.latest_switch_block_hash,
             #[cfg(not(test))]
             build_version: crate::VERSION_STRING.clone(),
 

--- a/resources/test/rest_schema_status.json
+++ b/resources/test/rest_schema_status.json
@@ -127,6 +127,17 @@
           "$ref": "#/definitions/BlockSynchronizerStatus"
         }
       ]
+    },
+    "latest_switch_block_hash": {
+      "description": "The hash of the latest switch block.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BlockHash"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This PR adds the `latest_switch_block_hash` to the REST `/status` endpoint to make it consistent with the recent change to binary port ([here](https://github.com/casper-network/casper-node/pull/4599)).