### PR TITLE
Fix a bug in the BlockValidator

### DIFF
--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -464,7 +464,7 @@ impl BlockValidator {
                     response_to_send,
                 } => {
                     debug!(%response_to_send, "proposed block validation already completed");
-                    return MaybeHandled::Handled(responder.respond(response_to_send).ignore());
+                    return responder.respond(response_to_send).ignore();
                 }
             }
             old_state.add_holder(sender);

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -451,6 +451,26 @@ impl BlockValidator {
             + From<FatalAnnouncement>
             + Send,
     {
+        if let Some(old_state) = self.validation_states.get_mut(&block) {
+            // if we got two requests for the same block in quick succession, it is possible that
+            // a state has been created and inserted for one of them while the other one was
+            // awaiting the past blocks from storage; in such a case just save the holder and
+            // responders, and return no effects, as all the fetching will have already been
+            // started
+            match old_state.add_responder(responder) {
+                AddResponderResult::Added => {}
+                AddResponderResult::ValidationCompleted {
+                    responder,
+                    response_to_send,
+                } => {
+                    debug!(%response_to_send, "proposed block validation already completed");
+                    return MaybeHandled::Handled(responder.respond(response_to_send).ignore());
+                }
+            }
+            old_state.add_holder(sender);
+            return Effects::new();
+        }
+
         let (mut state, maybe_responder) = BlockValidationState::new(
             &block,
             missing_signatures,


### PR DESCRIPTION
Closes #4619 

This is a simple, slightly hacky approach to solving the issue - but a less hacky one involving adding more variants to `BlockValidationState` and storing the state immediately after receiving a request turned out to become quite complex, which is why I chose this way eventually.
