### PR TITLE
Ticket handling

### DIFF
--- a/node/src/components/block_accumulator.rs
+++ b/node/src/components/block_accumulator.rs
@@ -803,8 +803,18 @@ impl<REv: ReactorEvent> Component<REv> for BlockAccumulator {
             Event::ReceivedFinalitySignature {
                 finality_signature,
                 sender,
+                ticket,
             } => {
-                self.register_finality_signature(effect_builder, *finality_signature, Some(sender))
+                let rv = self.register_finality_signature(
+                    effect_builder,
+                    *finality_signature,
+                    Some(sender),
+                );
+
+                // After registering the signature, we consider the work complete.
+                drop(ticket);
+
+                rv
             }
             Event::ExecutedBlock { meta_block } => {
                 let height = meta_block.block.header().height();

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -25,7 +25,7 @@ pub(crate) enum Event {
     ReceivedBlock {
         block: Arc<Block>,
         sender: NodeId,
-        ticket: Option<Ticket>,
+        ticket: Ticket,
     },
     CreatedFinalitySignature {
         finality_signature: Box<FinalitySignature>,

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -33,7 +33,7 @@ pub(crate) enum Event {
     ReceivedFinalitySignature {
         finality_signature: Box<FinalitySignature>,
         sender: NodeId,
-        ticket: Ticket,
+        ticket: Option<Ticket>,
     },
     ExecutedBlock {
         meta_block: MetaBlock,

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -8,6 +8,7 @@ use derive_more::From;
 use casper_types::EraId;
 
 use crate::{
+    components::network::Ticket,
     effect::requests::BlockAccumulatorRequest,
     types::{Block, BlockHash, BlockSignatures, FinalitySignature, MetaBlock, NodeId},
 };
@@ -31,6 +32,7 @@ pub(crate) enum Event {
     ReceivedFinalitySignature {
         finality_signature: Box<FinalitySignature>,
         sender: NodeId,
+        ticket: Ticket,
     },
     ExecutedBlock {
         meta_block: MetaBlock,
@@ -69,6 +71,7 @@ impl Display for Event {
             Event::ReceivedFinalitySignature {
                 finality_signature,
                 sender,
+                ticket: _,
             } => {
                 write!(f, "received {} from {}", finality_signature, sender)
             }

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -25,6 +25,7 @@ pub(crate) enum Event {
     ReceivedBlock {
         block: Arc<Block>,
         sender: NodeId,
+        ticket: Ticket,
     },
     CreatedFinalitySignature {
         finality_signature: Box<FinalitySignature>,
@@ -62,7 +63,11 @@ impl Display for Event {
                     sender, block_hash
                 )
             }
-            Event::ReceivedBlock { block, sender } => {
+            Event::ReceivedBlock {
+                block,
+                sender,
+                ticket: _,
+            } => {
                 write!(f, "received {} from {}", block, sender)
             }
             Event::CreatedFinalitySignature { finality_signature } => {

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -25,7 +25,7 @@ pub(crate) enum Event {
     ReceivedBlock {
         block: Arc<Block>,
         sender: NodeId,
-        ticket: Ticket,
+        ticket: Option<Ticket>,
     },
     CreatedFinalitySignature {
         finality_signature: Box<FinalitySignature>,

--- a/node/src/components/block_accumulator/event.rs
+++ b/node/src/components/block_accumulator/event.rs
@@ -33,7 +33,7 @@ pub(crate) enum Event {
     ReceivedFinalitySignature {
         finality_signature: Box<FinalitySignature>,
         sender: NodeId,
-        ticket: Option<Ticket>,
+        ticket: Ticket,
     },
     ExecutedBlock {
         meta_block: MetaBlock,

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -26,7 +26,7 @@ use crate::{
             ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID, BOB_PUBLIC_KEY,
             BOB_SECRET_KEY, CAROL_PUBLIC_KEY, CAROL_SECRET_KEY,
         },
-        network::Identity as NetworkIdentity,
+        network::{Identity as NetworkIdentity, Ticket},
         storage::{self, Storage},
     },
     effect::{
@@ -1572,7 +1572,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_1.clone()),
             sender: peer_1,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1855,7 +1855,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(older_block_signature),
             sender: peer_2,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1891,7 +1891,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(old_era_signature),
             sender: peer_2,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1972,7 +1972,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_bob.clone()),
             sender: peer_1,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1980,7 +1980,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_carol.clone()),
             sender: peer_1,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1585,6 +1585,7 @@ async fn block_accumulator_reactor_flow() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
+                    ticket: Ticket::create_dummy(),
                 };
                 effect_builder
                     .into_inner()
@@ -1625,6 +1626,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(block_2.clone()),
             sender: peer_2,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1827,6 +1829,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(older_block.clone()),
             sender: peer_1,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1998,6 +2001,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
+                    ticket: Ticket::create_dummy(),
                 };
                 effect_builder
                     .into_inner()

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1585,7 +1585,7 @@ async fn block_accumulator_reactor_flow() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 };
                 effect_builder
                     .into_inner()
@@ -1626,7 +1626,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(block_2.clone()),
             sender: peer_2,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1829,7 +1829,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(older_block.clone()),
             sender: peer_1,
-            ticket: None,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -2001,7 +2001,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 };
                 effect_builder
                     .into_inner()

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -26,7 +26,7 @@ use crate::{
             ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID, BOB_PUBLIC_KEY,
             BOB_SECRET_KEY, CAROL_PUBLIC_KEY, CAROL_SECRET_KEY,
         },
-        network::{Identity as NetworkIdentity, Ticket},
+        network::Identity as NetworkIdentity,
         storage::{self, Storage},
     },
     effect::{
@@ -1572,7 +1572,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_1.clone()),
             sender: peer_1,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1855,7 +1855,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(older_block_signature),
             sender: peer_2,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1891,7 +1891,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(old_era_signature),
             sender: peer_2,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1972,7 +1972,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_bob.clone()),
             sender: peer_1,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1980,7 +1980,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_carol.clone()),
             sender: peer_1,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -26,7 +26,7 @@ use crate::{
             ALICE_NODE_ID, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_NODE_ID, BOB_PUBLIC_KEY,
             BOB_SECRET_KEY, CAROL_PUBLIC_KEY, CAROL_SECRET_KEY,
         },
-        network::Identity as NetworkIdentity,
+        network::{Identity as NetworkIdentity, Ticket},
         storage::{self, Storage},
     },
     effect::{
@@ -1572,6 +1572,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_1.clone()),
             sender: peer_1,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1851,6 +1852,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(older_block_signature),
             sender: peer_2,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1886,6 +1888,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(old_era_signature),
             sender: peer_2,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1966,6 +1969,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_bob.clone()),
             sender: peer_1,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1973,6 +1977,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
         let event = super::Event::ReceivedFinalitySignature {
             finality_signature: Box::new(fin_sig_carol.clone()),
             sender: peer_1,
+            ticket: Ticket::create_dummy(),
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -1585,7 +1585,7 @@ async fn block_accumulator_reactor_flow() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 };
                 effect_builder
                     .into_inner()
@@ -1626,7 +1626,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(block_2.clone()),
             sender: peer_2,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -1829,7 +1829,7 @@ async fn block_accumulator_reactor_flow() {
         let event = super::Event::ReceivedBlock {
             block: Arc::new(older_block.clone()),
             sender: peer_1,
-            ticket: Ticket::create_dummy(),
+            ticket: None,
         };
         let effects = block_accumulator.handle_event(effect_builder, &mut rng, event);
         assert!(effects.is_empty());
@@ -2001,7 +2001,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
                 let event = super::Event::ReceivedBlock {
                     block: Arc::new(block_1.clone()),
                     sender: peer_2,
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 };
                 effect_builder
                     .into_inner()

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -521,8 +521,8 @@ where
             Event::DemandIncoming(ConsensusDemand {
                 sender,
                 request_msg: demand,
-                auto_closing_responder,
-            }) => self.handle_demand(effect_builder, rng, sender, demand, auto_closing_responder),
+                ticket,
+            }) => self.handle_demand(effect_builder, rng, sender, demand, ticket),
             Event::NewBlockPayload(new_block_payload) => {
                 self.handle_new_block_payload(effect_builder, rng, new_block_payload)
             }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -358,8 +358,12 @@ impl Display for Event {
             }) => {
                 write!(f, "delayed message from {:?}: {}", sender, message)
             }
-            Event::RequestMessageIncoming(demand) => {
-                write!(f, "demand from {:?}: {}", demand.sender, demand.message)
+            Event::RequestMessageIncoming(incoming) => {
+                write!(
+                    f,
+                    "request message from {:?}: {}",
+                    incoming.sender, incoming.message
+                )
             }
             Event::Timer {
                 era_id,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -512,16 +512,14 @@ where
                             })
                         })
                 } else {
-                    let rv = self.handle_message(effect_builder, rng, sender, *message);
-                    drop(ticket); // TODO: drop ticket in `handle_message` effect instead
-                    rv
+                    self.handle_message(effect_builder, rng, sender, *message, ticket)
                 }
             }
             Event::DelayedIncoming(ConsensusMessageIncoming {
                 sender,
                 message,
-                ticket: _, // TODO: drop ticket in `handle_message` effect instead
-            }) => self.handle_message(effect_builder, rng, sender, *message),
+                ticket,
+            }) => self.handle_message(effect_builder, rng, sender, *message, ticket),
             Event::RequestMessageIncoming(ConsensusRequestMessageIncoming {
                 sender,
                 message,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -41,7 +41,7 @@ use crate::{
             PeerBehaviorAnnouncement,
         },
         diagnostics_port::DumpConsensusStateRequest,
-        incoming::{ConsensusDemand, ConsensusMessageIncoming},
+        incoming::{ConsensusMessageIncoming, ConsensusRequestMessageIncoming},
         requests::{
             ChainspecRawBytesRequest, ConsensusRequest, ContractRuntimeRequest,
             DeployBufferRequest, NetworkInfoRequest, NetworkRequest,
@@ -257,9 +257,9 @@ pub(crate) enum Event {
     /// A variant used with failpoints - when a message arrives, we fire this event with a delay,
     /// and it also causes the message to be handled.
     DelayedIncoming(ConsensusMessageIncoming),
-    /// An incoming demand message.
+    /// An incoming request message.
     #[from]
-    DemandIncoming(ConsensusDemand),
+    RequestMessageIncoming(ConsensusRequestMessageIncoming),
     /// A scheduled event to be handled by a specified era.
     Timer {
         era_id: EraId,
@@ -358,8 +358,8 @@ impl Display for Event {
             }) => {
                 write!(f, "delayed message from {:?}: {}", sender, message)
             }
-            Event::DemandIncoming(demand) => {
-                write!(f, "demand from {:?}: {}", demand.sender, demand.request_msg)
+            Event::RequestMessageIncoming(demand) => {
+                write!(f, "demand from {:?}: {}", demand.sender, demand.message)
             }
             Event::Timer {
                 era_id,
@@ -436,7 +436,7 @@ pub(crate) trait ReactorEventT:
     + From<Event>
     + Send
     + From<NetworkRequest<Message>>
-    + From<ConsensusDemand>
+    + From<ConsensusRequestMessageIncoming>
     + From<NetworkInfoRequest>
     + From<DeployBufferRequest>
     + From<ConsensusAnnouncement>
@@ -454,7 +454,7 @@ impl<REv> ReactorEventT for REv where
     REv: ReactorEvent
         + From<Event>
         + Send
-        + From<ConsensusDemand>
+        + From<ConsensusRequestMessageIncoming>
         + From<NetworkRequest<Message>>
         + From<NetworkInfoRequest>
         + From<DeployBufferRequest>
@@ -518,11 +518,11 @@ where
                 message,
                 ticket: _, // TODO: drop ticket in `handle_message` effect instead
             }) => self.handle_message(effect_builder, rng, sender, *message),
-            Event::DemandIncoming(ConsensusDemand {
+            Event::RequestMessageIncoming(ConsensusRequestMessageIncoming {
                 sender,
-                request_msg: demand,
+                message,
                 ticket,
-            }) => self.handle_demand(effect_builder, rng, sender, demand, ticket),
+            }) => self.handle_request_message(effect_builder, rng, sender, message, ticket),
             Event::NewBlockPayload(new_block_payload) => {
                 self.handle_new_block_payload(effect_builder, rng, new_block_payload)
             }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -728,15 +728,15 @@ impl EraSupervisor {
         }
     }
 
-    pub(super) fn handle_demand<REv: ReactorEventT>(
+    pub(super) fn handle_request_message<REv: ReactorEventT>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
         sender: NodeId,
-        request: Box<ConsensusRequestMessage>,
+        message: Box<ConsensusRequestMessage>,
         ticket: Ticket,
     ) -> Effects<Event> {
-        let ConsensusRequestMessage { era_id, payload } = *request;
+        let ConsensusRequestMessage { era_id, payload } = *message;
 
         trace!(era = era_id.value(), "received a consensus request");
         match self.open_eras.get_mut(&era_id) {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -244,7 +244,7 @@ impl DeployAcceptor {
         deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
-        _: Option<Ticket>, // We currently drop the ticket implicitly, see below.
+        _: Ticket, // We currently drop the ticket implicitly, see below.
     ) -> Effects<Event> {
         debug!(%source, %deploy, "checking acceptance");
         let verification_start_timestamp = Timestamp::now();

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -244,7 +244,7 @@ impl DeployAcceptor {
         deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
-        _: Ticket, // We currently drop the ticket implicitly, see below.
+        _: Option<Ticket>, // We currently drop the ticket implicitly, see below.
     ) -> Effects<Event> {
         debug!(%source, %deploy, "checking acceptance");
         let verification_start_timestamp = Timestamp::now();

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -12,7 +12,7 @@ use casper_types::{
 
 use super::Source;
 use crate::{
-    components::deploy_acceptor::Error,
+    components::{deploy_acceptor::Error, network::Ticket},
     effect::Responder,
     types::{BlockHeader, Deploy},
 };
@@ -47,6 +47,8 @@ pub(crate) enum Event {
         deploy: Arc<Deploy>,
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
+        #[serde(skip)]
+        ticket: Ticket,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -48,7 +48,7 @@ pub(crate) enum Event {
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
         #[serde(skip)]
-        ticket: Ticket,
+        ticket: Option<Ticket>,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -48,7 +48,7 @@ pub(crate) enum Event {
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
         #[serde(skip)]
-        ticket: Option<Ticket>,
+        ticket: Ticket,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -760,6 +760,7 @@ fn schedule_accept_deploy(
                     deploy,
                     source,
                     maybe_responder: Some(responder),
+                    ticket: Ticket::create_dummy(),
                 },
                 QueueKind::Validation,
             )

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -760,7 +760,7 @@ fn schedule_accept_deploy(
                     deploy,
                     source,
                     maybe_responder: Some(responder),
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 },
                 QueueKind::Validation,
             )

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -760,7 +760,7 @@ fn schedule_accept_deploy(
                     deploy,
                     source,
                     maybe_responder: Some(responder),
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 },
                 QueueKind::Validation,
             )

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     components::{
         deploy_acceptor, fetcher,
         in_memory_network::{self, InMemoryNetwork, NetworkController},
-        network::{GossipedAddress, Identity as NetworkIdentity},
+        network::{GossipedAddress, Identity as NetworkIdentity, Ticket},
         storage::{self, Storage},
     },
     effect::{
@@ -224,7 +224,7 @@ impl ReactorTrait for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 };
                 reactor::wrap_effects(
                     Event::FakeDeployAcceptor,
@@ -353,7 +353,7 @@ impl Reactor {
                         deploy,
                         source: Source::Peer(response.sender),
                         maybe_responder: None,
-                        ticket: None,
+                        ticket: Ticket::create_dummy(),
                     }),
                 )
             }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -16,7 +16,6 @@ use casper_types::testing::TestRng;
 use super::*;
 use crate::{
     components::{
-        consensus::ConsensusRequestMessage,
         deploy_acceptor, fetcher,
         in_memory_network::{self, InMemoryNetwork, NetworkController},
         network::{GossipedAddress, Identity as NetworkIdentity},
@@ -25,9 +24,9 @@ use crate::{
     effect::{
         announcements::{ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement},
         incoming::{
-            ConsensusMessageIncoming, DemandIncoming, FinalitySignatureIncoming, GossiperIncoming,
-            NetRequestIncoming, NetResponse, NetResponseIncoming, TrieRequestIncoming,
-            TrieResponseIncoming,
+            ConsensusMessageIncoming, ConsensusRequestMessageIncoming, FinalitySignatureIncoming,
+            GossiperIncoming, NetRequestIncoming, NetResponse, NetResponseIncoming,
+            TrieRequestIncoming, TrieResponseIncoming,
         },
         requests::{AcceptDeployRequest, MarkBlockCompletedRequest},
     },
@@ -134,7 +133,7 @@ enum Event {
     #[from]
     ConsensusMessageIncoming(ConsensusMessageIncoming),
     #[from]
-    ConsensusDemandIncoming(DemandIncoming<ConsensusRequestMessage>),
+    ConsensusRequestMessageIncoming(ConsensusRequestMessageIncoming),
     #[from]
     FinalitySignatureIncoming(FinalitySignatureIncoming),
 }
@@ -258,7 +257,7 @@ impl ReactorTrait for Reactor {
             | Event::TrieRequestIncoming(_)
             | Event::TrieResponseIncoming(_)
             | Event::ConsensusMessageIncoming(_)
-            | Event::ConsensusDemandIncoming(_)
+            | Event::ConsensusRequestMessageIncoming(_)
             | Event::FinalitySignatureIncoming(_)
             | Event::FetchedNewBlockAnnouncement(_)
             | Event::FetchedNewFinalitySignatureAnnouncement(_)

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     components::{
         deploy_acceptor, fetcher,
         in_memory_network::{self, InMemoryNetwork, NetworkController},
-        network::{GossipedAddress, Identity as NetworkIdentity},
+        network::{GossipedAddress, Identity as NetworkIdentity, Ticket},
         storage::{self, Storage},
     },
     effect::{
@@ -224,6 +224,7 @@ impl ReactorTrait for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
+                    ticket: Ticket::create_dummy(),
                 };
                 reactor::wrap_effects(
                     Event::FakeDeployAcceptor,
@@ -352,6 +353,7 @@ impl Reactor {
                         deploy,
                         source: Source::Peer(response.sender),
                         maybe_responder: None,
+                        ticket: Ticket::create_dummy(),
                     }),
                 )
             }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     components::{
         deploy_acceptor, fetcher,
         in_memory_network::{self, InMemoryNetwork, NetworkController},
-        network::{GossipedAddress, Identity as NetworkIdentity, Ticket},
+        network::{GossipedAddress, Identity as NetworkIdentity},
         storage::{self, Storage},
     },
     effect::{
@@ -224,7 +224,7 @@ impl ReactorTrait for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 };
                 reactor::wrap_effects(
                     Event::FakeDeployAcceptor,
@@ -353,7 +353,7 @@ impl Reactor {
                         deploy,
                         source: Source::Peer(response.sender),
                         maybe_responder: None,
-                        ticket: Ticket::create_dummy(),
+                        ticket: None,
                     }),
                 )
             }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -26,7 +26,7 @@ use crate::{
         announcements::{ControlAnnouncement, DeployAcceptorAnnouncement, FatalAnnouncement},
         incoming::{
             ConsensusMessageIncoming, DemandIncoming, FinalitySignatureIncoming, GossiperIncoming,
-            NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
+            NetRequestIncoming, NetResponse, NetResponseIncoming, TrieRequestIncoming,
             TrieResponseIncoming,
         },
         requests::{AcceptDeployRequest, MarkBlockCompletedRequest},
@@ -117,8 +117,6 @@ enum Event {
     BlocklistAnnouncement(PeerBehaviorAnnouncement),
     #[from]
     MarkBlockCompletedRequest(MarkBlockCompletedRequest),
-    #[from]
-    TrieDemand(TrieDemand),
     #[from]
     ContractRuntimeRequest(ContractRuntimeRequest),
     #[from]
@@ -250,8 +248,7 @@ impl ReactorTrait for Reactor {
                 self.storage
                     .handle_event(effect_builder, rng, request.into()),
             ),
-            Event::TrieDemand(_)
-            | Event::ContractRuntimeRequest(_)
+            Event::ContractRuntimeRequest(_)
             | Event::BlockAccumulatorRequest(_)
             | Event::BlocklistAnnouncement(_)
             | Event::GossiperIncomingDeploy(_)

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -40,6 +40,8 @@ use item_provider::ItemProvider;
 pub(crate) use message::Message;
 use metrics::Metrics;
 
+use super::network::Ticket;
+
 /// The component which gossips to peers and handles incoming gossip messages from peers.
 #[allow(clippy::type_complexity)]
 pub(crate) struct Gossiper<const ID_IS_COMPLETE_ITEM: bool, T>
@@ -271,6 +273,7 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
         item_id: T::Id,
         sender: NodeId,
         action: GossipAction,
+        ticket: Ticket,
     ) -> Effects<Event<T>>
     where
         REv: From<NetworkRequest<Message<T>>> + From<GossiperAnnouncement<T>> + Send,
@@ -303,7 +306,11 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
                     item_id: item_id.clone(),
                     is_already_held: should_gossip.is_already_held,
                 };
-                effects.extend(effect_builder.send_message(sender, reply).ignore());
+                effects.extend(
+                    effect_builder
+                        .send_message_and_drop_ticket(sender, reply, ticket)
+                        .ignore(),
+                );
                 effects
             }
             GossipAction::GetRemainder { .. } => {
@@ -315,7 +322,9 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
                     item_id: item_id.clone(),
                     is_already_held: false,
                 };
-                let mut effects = effect_builder.send_message(sender, reply).ignore();
+                let mut effects = effect_builder
+                    .send_message_and_drop_ticket(sender, reply, ticket)
+                    .ignore();
                 let item_id_clone = item_id.clone();
                 effects.extend(
                     effect_builder
@@ -336,7 +345,9 @@ impl<const ID_IS_COMPLETE_ITEM: bool, T: GossipItem + 'static> Gossiper<ID_IS_CO
                     item_id: item_id.clone(),
                     is_already_held: true,
                 };
-                let mut effects = effect_builder.send_message(sender, reply).ignore();
+                let mut effects = effect_builder
+                    .send_message_and_drop_ticket(sender, reply, ticket)
+                    .ignore();
 
                 if action == GossipAction::AnnounceFinished {
                     effects.extend(
@@ -569,85 +580,98 @@ where
         _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
-        let effects = match event {
-            Event::BeginGossipRequest(BeginGossipRequest {
-                item_id,
-                source,
-                target,
-                responder,
-            }) => {
-                let mut effects =
-                    self.handle_item_received(effect_builder, item_id, source, target);
-                effects.extend(responder.respond(()).ignore());
-                effects
-            }
-            Event::ItemReceived {
-                item_id,
-                source,
-                target,
-            } => self.handle_item_received(effect_builder, item_id, source, target),
-            Event::GossipedTo {
-                item_id,
-                requested_count,
-                peers,
-            } => self.gossiped_to(effect_builder, item_id, requested_count, peers),
-            Event::CheckGossipTimeout { item_id, peer } => {
-                self.check_gossip_timeout(effect_builder, item_id, peer)
-            }
-            Event::CheckGetFromPeerTimeout { item_id, peer } => {
-                self.check_get_from_peer_timeout(effect_builder, item_id, peer)
-            }
-            Event::Incoming(GossiperIncoming::<T> {
-                sender,
-                message,
-                ticket: _, // TODO: Sensibly process ticket.
-            }) => match *message {
-                Message::Gossip(item_id) => {
-                    Self::is_stored(effect_builder, item_id.clone()).event(move |result| {
-                        Event::IsStoredResult {
+        let effects =
+            match event {
+                Event::BeginGossipRequest(BeginGossipRequest {
+                    item_id,
+                    source,
+                    target,
+                    responder,
+                }) => {
+                    let mut effects =
+                        self.handle_item_received(effect_builder, item_id, source, target);
+                    effects.extend(responder.respond(()).ignore());
+                    effects
+                }
+                Event::ItemReceived {
+                    item_id,
+                    source,
+                    target,
+                } => self.handle_item_received(effect_builder, item_id, source, target),
+                Event::GossipedTo {
+                    item_id,
+                    requested_count,
+                    peers,
+                } => self.gossiped_to(effect_builder, item_id, requested_count, peers),
+                Event::CheckGossipTimeout { item_id, peer } => {
+                    self.check_gossip_timeout(effect_builder, item_id, peer)
+                }
+                Event::CheckGetFromPeerTimeout { item_id, peer } => {
+                    self.check_get_from_peer_timeout(effect_builder, item_id, peer)
+                }
+                Event::Incoming(GossiperIncoming::<T> {
+                    sender,
+                    message,
+                    ticket,
+                }) => match *message {
+                    Message::Gossip(item_id) => Self::is_stored(effect_builder, item_id.clone())
+                        .event(move |result| Event::IsStoredResult {
                             item_id,
                             sender,
                             result,
-                        }
-                    })
+                            ticket,
+                        }),
+                    Message::GossipResponse {
+                        item_id,
+                        is_already_held,
+                    } => {
+                        let rv = self.handle_gossip_response(
+                            effect_builder,
+                            item_id,
+                            is_already_held,
+                            sender,
+                        );
+
+                        // Best guess that we're "done" processing the response, drop ticket here.
+                        drop(ticket);
+
+                        rv
+                    }
+                    Message::GetItem(item_id) => {
+                        self.handle_get_item_request(effect_builder, item_id, sender)
+                    }
+                    Message::Item(item) => {
+                        self.handle_item_received_from_peer(effect_builder, item, sender)
+                    }
+                },
+                Event::CheckItemReceivedTimeout { item_id } => {
+                    self.check_item_received_timeout(effect_builder, item_id)
                 }
-                Message::GossipResponse {
+                Event::IsStoredResult {
                     item_id,
-                    is_already_held,
-                } => self.handle_gossip_response(effect_builder, item_id, is_already_held, sender),
-                Message::GetItem(item_id) => {
-                    self.handle_get_item_request(effect_builder, item_id, sender)
+                    sender,
+                    result: is_stored_locally,
+                    ticket,
+                } => {
+                    let action = if self.table.has_entry(&item_id) || !is_stored_locally {
+                        // TODO: Ticket, do something?
+                        self.table.new_data_id(&item_id, sender)
+                    } else {
+                        // We're not already handling this item, and we do have the full item stored, so
+                        // don't initiate gossiping for it.
+                        GossipAction::Noop
+                    };
+                    self.handle_gossip(effect_builder, item_id, sender, action, ticket)
                 }
-                Message::Item(item) => {
-                    self.handle_item_received_from_peer(effect_builder, item, sender)
-                }
-            },
-            Event::CheckItemReceivedTimeout { item_id } => {
-                self.check_item_received_timeout(effect_builder, item_id)
-            }
-            Event::IsStoredResult {
-                item_id,
-                sender,
-                result: is_stored_locally,
-            } => {
-                let action = if self.table.has_entry(&item_id) || !is_stored_locally {
-                    self.table.new_data_id(&item_id, sender)
-                } else {
-                    // We're not already handling this item, and we do have the full item stored, so
-                    // don't initiate gossiping for it.
-                    GossipAction::Noop
-                };
-                self.handle_gossip(effect_builder, item_id, sender, action)
-            }
-            Event::GetFromStorageResult {
-                item_id,
-                requester,
-                maybe_item,
-            } => match maybe_item {
-                Some(item) => Self::got_from_storage(effect_builder, item, requester),
-                None => self.failed_to_get_from_storage(effect_builder, item_id),
-            },
-        };
+                Event::GetFromStorageResult {
+                    item_id,
+                    requester,
+                    maybe_item,
+                } => match maybe_item {
+                    Some(item) => Self::got_from_storage(effect_builder, item, requester),
+                    None => self.failed_to_get_from_storage(effect_builder, item_id),
+                },
+            };
         self.update_gossip_table_metrics();
         effects
     }
@@ -707,24 +731,39 @@ where
             Event::Incoming(GossiperIncoming::<T> {
                 sender,
                 message,
-                ticket: _, // TODO: Properly handle `ticket`.
+                ticket,
             }) => match *message {
                 Message::Gossip(item_id) => {
                     let target = <T as SmallGossipItem>::id_as_item(&item_id).gossip_target();
                     let action = self.table.new_complete_data(&item_id, Some(sender), target);
-                    self.handle_gossip(effect_builder, item_id, sender, action)
+                    self.handle_gossip(effect_builder, item_id, sender, action, ticket)
                 }
                 Message::GossipResponse {
                     item_id,
                     is_already_held,
-                } => self.handle_gossip_response(effect_builder, item_id, is_already_held, sender),
+                } => {
+                    let rv = self.handle_gossip_response(
+                        effect_builder,
+                        item_id,
+                        is_already_held,
+                        sender,
+                    );
+
+                    // There's no single response to be sent out, so we drop the ticket once the
+                    // processing is finished.
+                    drop(ticket);
+
+                    rv
+                }
                 Message::GetItem(item_id) => {
                     debug!(%item_id, %sender, "unexpected get request for small item");
+                    drop(ticket);
                     Effects::new()
                 }
                 Message::Item(item) => {
                     let item_id = item.gossip_id();
                     debug!(%item_id, %sender, "unexpected get response for small item");
+                    drop(ticket);
                     Effects::new()
                 }
             },

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -659,8 +659,8 @@ where
                         // TODO: Ticket, do something?
                         self.table.new_data_id(&item_id, sender)
                     } else {
-                        // We're not already handling this item, and we do have the full item stored, so
-                        // don't initiate gossiping for it.
+                        // We're not already handling this item, and we do have the full item
+                        // stored, so don't initiate gossiping for it.
                         GossipAction::Noop
                     };
                     self.handle_gossip(effect_builder, item_id, sender, action, ticket)

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -55,6 +55,8 @@ pub(crate) enum Event<T: GossipItem> {
         item_id: T::Id,
         requester: NodeId,
         maybe_item: Option<Box<T>>,
+        #[serde(skip)]
+        ticket: Ticket,
     },
 }
 

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 use super::GossipItem;
 use crate::{
+    components::network::Ticket,
     effect::{incoming::GossiperIncoming, requests::BeginGossipRequest, GossipTarget},
     types::NodeId,
     utils::{DisplayIter, Source},
@@ -45,6 +46,8 @@ pub(crate) enum Event<T: GossipItem> {
         item_id: T::Id,
         sender: NodeId,
         result: bool,
+        #[serde(skip)]
+        ticket: Ticket,
     },
     /// The result of the gossiper getting an item from storage. If the result is `Some`, the item
     /// should be sent to the requesting peer.
@@ -98,6 +101,7 @@ impl<T: GossipItem> Display for Event<T> {
                 item_id,
                 sender,
                 result,
+                ticket: _,
             } => {
                 write!(
                     formatter,

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -33,7 +33,7 @@ use crate::{
             GossiperAnnouncement,
         },
         incoming::{
-            ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming,
+            ConsensusMessageIncoming, ConsensusRequestMessageIncoming, FinalitySignatureIncoming,
             NetRequestIncoming, NetResponseIncoming, TrieRequestIncoming, TrieResponseIncoming,
         },
         requests::AcceptDeployRequest,
@@ -104,7 +104,7 @@ impl<T: Unhandled> From<T> for Event {
     }
 }
 
-impl Unhandled for ConsensusDemand {}
+impl Unhandled for ConsensusRequestMessageIncoming {}
 impl Unhandled for ControlAnnouncement {}
 impl Unhandled for FatalAnnouncement {}
 impl Unhandled for ConsensusMessageIncoming {}

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -34,8 +34,7 @@ use crate::{
         },
         incoming::{
             ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming,
-            NetRequestIncoming, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
-            TrieResponseIncoming,
+            NetRequestIncoming, NetResponseIncoming, TrieRequestIncoming, TrieResponseIncoming,
         },
         requests::AcceptDeployRequest,
     },
@@ -115,7 +114,6 @@ impl Unhandled for GossiperIncoming<GossipedAddress> {}
 impl Unhandled for NetRequestIncoming {}
 impl Unhandled for NetResponseIncoming {}
 impl Unhandled for TrieRequestIncoming {}
-impl Unhandled for TrieDemand {}
 impl Unhandled for TrieResponseIncoming {}
 impl Unhandled for FinalitySignatureIncoming {}
 
@@ -632,7 +630,7 @@ async fn should_not_gossip_old_stored_item_again() {
             let event = Event::DeployGossiperIncoming(GossiperIncoming {
                 sender: node_ids[1],
                 message: Box::new(Message::Gossip(deploy.gossip_id())),
-                ticket: Arc::new(Ticket::create_dummy()),
+                ticket: Ticket::create_dummy(),
             });
             effect_builder
                 .into_inner()
@@ -705,7 +703,7 @@ async fn should_ignore_unexpected_message(message_type: Unexpected) {
             let event = Event::DeployGossiperIncoming(GossiperIncoming {
                 sender: node_ids[1],
                 message: Box::new(message),
-                ticket: Arc::new(Ticket::create_dummy()),
+                ticket: Ticket::create_dummy(),
             });
             effect_builder
                 .into_inner()

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -269,6 +269,7 @@ impl reactor::Reactor for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
+                    ticket: Ticket::create_dummy(),
                 };
                 self.dispatch_event(effect_builder, rng, Event::DeployAcceptor(event))
             }
@@ -290,6 +291,7 @@ impl reactor::Reactor for Reactor {
             Event::DeployGossiperAnnouncement(GossiperAnnouncement::NewItemBody {
                 item,
                 sender,
+                ticket: _, // The fake deploy acceptor does not do any ticket handling
             }) => reactor::wrap_effects(
                 Event::DeployAcceptor,
                 self.fake_deploy_acceptor.handle_event(
@@ -299,6 +301,7 @@ impl reactor::Reactor for Reactor {
                         deploy: Arc::new(*item),
                         source: Source::Peer(sender),
                         maybe_responder: None,
+                        ticket: Ticket::create_dummy(),
                     },
                 ),
             ),

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -269,7 +269,7 @@ impl reactor::Reactor for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 };
                 self.dispatch_event(effect_builder, rng, Event::DeployAcceptor(event))
             }
@@ -301,7 +301,7 @@ impl reactor::Reactor for Reactor {
                         deploy: Arc::new(*item),
                         source: Source::Peer(sender),
                         maybe_responder: None,
-                        ticket: Ticket::create_dummy(),
+                        ticket: None,
                     },
                 ),
             ),

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -269,7 +269,7 @@ impl reactor::Reactor for Reactor {
                     deploy,
                     source: Source::Client,
                     maybe_responder: Some(responder),
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 };
                 self.dispatch_event(effect_builder, rng, Event::DeployAcceptor(event))
             }
@@ -301,7 +301,7 @@ impl reactor::Reactor for Reactor {
                         deploy: Arc::new(*item),
                         source: Source::Peer(sender),
                         maybe_responder: None,
-                        ticket: None,
+                        ticket: Ticket::create_dummy(),
                     },
                 ),
             ),

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -386,21 +386,6 @@ pub(crate) trait Payload:
 pub(crate) trait FromIncoming<P> {
     /// Creates a new value from a received payload.
     fn from_incoming(sender: NodeId, payload: P, ticket: Ticket) -> Self;
-
-    /// Tries to convert a payload into a demand.
-    ///
-    /// This function can optionally be called before `from_incoming` to attempt to convert an
-    /// incoming payload into a potential demand.
-    fn try_demand_from_incoming(
-        _sender: NodeId,
-        payload: P,
-        ticket: Ticket,
-    ) -> Result<Self, (P, Ticket)>
-    where
-        Self: Sized + Send,
-    {
-        Err((payload, ticket))
-    }
 }
 
 #[cfg(test)]

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use datasize::DataSize;
-use futures::future::BoxFuture;
 use juliet::ChannelId;
 use serde::{
     de::{DeserializeOwned, Error as SerdeError},
@@ -19,7 +18,7 @@ use casper_types::testing::TestRng;
 use casper_types::{crypto, AsymmetricType, ProtocolVersion, PublicKey, SecretKey, Signature};
 
 use super::{connection_id::ConnectionId, Ticket};
-use crate::{effect::EffectBuilder, types::NodeId, utils::opt_display::OptDisplay};
+use crate::{types::NodeId, utils::opt_display::OptDisplay};
 
 /// The default protocol version to use in absence of one in the protocol version field.
 #[inline]
@@ -392,15 +391,11 @@ pub(crate) trait FromIncoming<P> {
     ///
     /// This function can optionally be called before `from_incoming` to attempt to convert an
     /// incoming payload into a potential demand.
-
-    // TODO: Replace both this and `from_incoming` with a single function that returns an
-    //       appropriate `Either`.
     fn try_demand_from_incoming(
-        _effect_builder: EffectBuilder<Self>,
         _sender: NodeId,
         payload: P,
         ticket: Ticket,
-    ) -> Result<(Self, BoxFuture<'static, Option<P>>), (P, Ticket)>
+    ) -> Result<Self, (P, Ticket)>
     where
         Self: Sized + Send,
     {

--- a/node/src/components/network/message.rs
+++ b/node/src/components/network/message.rs
@@ -399,11 +399,12 @@ pub(crate) trait FromIncoming<P> {
         _effect_builder: EffectBuilder<Self>,
         _sender: NodeId,
         payload: P,
-    ) -> Result<(Self, BoxFuture<'static, Option<P>>), P>
+        ticket: Ticket,
+    ) -> Result<(Self, BoxFuture<'static, Option<P>>), (P, Ticket)>
     where
         Self: Sized + Send,
     {
-        Err(payload)
+        Err((payload, ticket))
     }
 }
 

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -128,7 +128,7 @@ impl FromIncoming<Message> for Event {
             Message::AddressGossiper(message) => Event::AddressGossiperIncoming(GossiperIncoming {
                 sender,
                 message: Box::new(message),
-                ticket: Arc::new(ticket),
+                ticket,
             }),
         }
     }

--- a/node/src/components/network/transport.rs
+++ b/node/src/components/network/transport.rs
@@ -104,9 +104,20 @@ impl Ticket {
     }
 
     /// Creates a new dummy ticket for testing.
+    ///
+    /// Unlike [`standin`], it is perfectly fine to use in testing.
     #[cfg(test)]
     #[inline(always)]
     pub(crate) fn create_dummy() -> Self {
+        Self::stub()
+    }
+
+    /// Creates a new ticket that does nothing.
+    ///
+    /// This method indicates a "hole" in the pass-through chain of `Ticket`s and its usage should
+    /// ultimately be removed.
+    #[inline(always)]
+    pub(crate) fn stub() -> Self {
         Ticket {
             opt_request: None,
             net_metrics: Weak::new(),

--- a/node/src/components/network/transport.rs
+++ b/node/src/components/network/transport.rs
@@ -9,6 +9,7 @@ use std::{
     sync::{Arc, Weak},
 };
 
+use datasize::DataSize;
 use juliet::rpc::IncomingRequest;
 use openssl::ssl::Ssl;
 use strum::EnumCount;
@@ -79,11 +80,13 @@ pub(super) fn create_rpc_builder(
 ///
 /// Dropping it will cause an "ACK", which in the Juliet transport's case is an empty response, to
 /// be sent. Cancellations or responses with actual payloads are not used at this time.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct Ticket {
     /// The underlying request.
+    #[data_size(skip)]
     opt_request: Option<Box<IncomingRequest>>,
     /// A weak reference to the networking metrics.
+    #[data_size(skip)]
     net_metrics: Weak<Metrics>,
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -314,7 +314,7 @@ where
             Event::StorageRequest(req) => self.handle_storage_request(*req),
             Event::NetRequestIncoming(incoming) => {
                 let sender = incoming.sender;
-                match self.handle_net_request_incoming::<REv>(effect_builder, incoming) {
+                match self.handle_net_request_incoming::<REv>(effect_builder, *incoming) {
                     Ok(effects) => Ok(effects),
                     Err(GetRequestError::Fatal(fatal_error)) => Err(fatal_error),
                     Err(ref other_err) => {
@@ -646,7 +646,7 @@ impl Storage {
     fn handle_net_request_incoming<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        incoming: Box<NetRequestIncoming>,
+        incoming: NetRequestIncoming,
     ) -> Result<Effects<Event>, GetRequestError>
     where
         REv: From<NetworkRequest<Message>> + Send,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -885,16 +885,23 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces that a gossiper has received a full item, where the item's ID is NOT the complete
     /// item.
+    ///
+    /// The associated [`Ticket`] is the ticket from the message received containing the item.
     pub(crate) async fn announce_item_body_received_via_gossip<T: GossipItem>(
         self,
         item: Box<T>,
         sender: NodeId,
+        ticket: Ticket,
     ) where
         REv: From<GossiperAnnouncement<T>>,
     {
         self.event_queue
             .schedule(
-                GossiperAnnouncement::NewItemBody { item, sender },
+                GossiperAnnouncement::NewItemBody {
+                    item,
+                    sender,
+                    ticket,
+                },
                 QueueKind::Gossip,
             )
             .await;

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -257,11 +257,6 @@ impl<T: Debug> AutoClosingResponder<T> {
     pub(crate) async fn respond(self, data: T) {
         self.into_inner().respond(Some(data)).await
     }
-
-    /// Send `None` to the origin of the request.
-    pub(crate) async fn respond_none(self) {
-        self.into_inner().respond(None).await
-    }
 }
 
 impl<T> Drop for AutoClosingResponder<T> {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -858,14 +858,7 @@ impl<REv> EffectBuilder<REv> {
         REv: FromIncoming<P> + From<NetworkRequest<P>> + Send,
         P: 'static + Send,
     {
-        // TODO: Remove demands entirely as they are no longer needed with tickets.
-        let reactor_event =
-            match <REv as FromIncoming<P>>::try_demand_from_incoming(sender, payload, ticket) {
-                Ok(rev) => rev,
-                Err((payload, ticket)) => {
-                    <REv as FromIncoming<P>>::from_incoming(sender, payload, ticket)
-                }
-            };
+        let reactor_event = <REv as FromIncoming<P>>::from_incoming(sender, payload, ticket);
 
         self.event_queue
             .schedule::<REv>(reactor_event, QueueKind::MessageIncoming)

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -711,6 +711,23 @@ impl<REv> EffectBuilder<REv> {
         //       delivery.
     }
 
+    /// Sends a network message, drops a ticket upon successful sending.
+    ///
+    /// Similar to `send_message`, except a [`Ticket`] is passed as well, which will be dropped as
+    /// soon as `send_message` returns (but no earlier).
+    pub(crate) async fn send_message_and_drop_ticket<P>(
+        self,
+        dest: NodeId,
+        payload: P,
+        ticket: Ticket,
+    ) where
+        REv: From<NetworkRequest<P>>,
+    {
+        self.send_message(dest, payload).await;
+
+        drop(ticket);
+    }
+
     /// Sends a network message with best effort.
     ///
     /// The message is queued in "fire-and-forget" fashion, there is no guarantee that the peer will

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -860,16 +860,8 @@ impl<REv> EffectBuilder<REv> {
     {
         // TODO: Remove demands entirely as they are no longer needed with tickets.
         let reactor_event =
-            match <REv as FromIncoming<P>>::try_demand_from_incoming(self, sender, payload, ticket)
-            {
-                Ok((rev, demand_has_been_satisfied)) => {
-                    tokio::spawn(async move {
-                        if let Some(answer) = demand_has_been_satisfied.await {
-                            self.send_message(sender, answer).await;
-                        }
-                    });
-                    rev
-                }
+            match <REv as FromIncoming<P>>::try_demand_from_incoming(sender, payload, ticket) {
+                Ok(rev) => rev,
                 Err((payload, ticket)) => {
                     <REv as FromIncoming<P>>::from_incoming(sender, payload, ticket)
                 }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -22,7 +22,7 @@ use crate::{
         diagnostics_port::FileSerializer,
         fetcher::FetchItem,
         gossiper::GossipItem,
-        network::blocklist::BlocklistJustification,
+        network::{blocklist::BlocklistJustification, Ticket},
         upgrade_watcher::NextUpgrade,
     },
     effect::Responder,
@@ -310,7 +310,11 @@ pub(crate) enum GossiperAnnouncement<T: GossipItem> {
     NewCompleteItem(T::Id),
 
     /// A new item has been received where the item's ID is NOT the complete item.
-    NewItemBody { item: Box<T>, sender: NodeId },
+    NewItemBody {
+        item: Box<T>,
+        sender: NodeId,
+        ticket: Ticket,
+    },
 
     /// Finished gossiping about the indicated item.
     FinishedGossiping(T::Id),
@@ -323,7 +327,11 @@ impl<T: GossipItem> Display for GossiperAnnouncement<T> {
                 write!(f, "new gossiped item {} from sender {}", item_id, sender)
             }
             GossiperAnnouncement::NewCompleteItem(item) => write!(f, "new complete item {}", item),
-            GossiperAnnouncement::NewItemBody { item, sender } => {
+            GossiperAnnouncement::NewItemBody {
+                item,
+                sender,
+                ticket: _,
+            } => {
                 write!(f, "new item body {} from {}", item.gossip_id(), sender)
             }
             GossiperAnnouncement::FinishedGossiping(item_id) => {

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -21,7 +21,7 @@ pub struct MessageIncoming<M> {
     pub(crate) sender: NodeId,
     pub(crate) message: Box<M>,
     #[serde(skip)]
-    pub(crate) ticket: Arc<Ticket>,
+    pub(crate) ticket: Ticket,
 }
 
 impl<M> Display for MessageIncoming<M>
@@ -68,9 +68,6 @@ pub(crate) type NetResponseIncoming = MessageIncoming<NetResponse>;
 
 /// A new message requesting a trie arrived.
 pub(crate) type TrieRequestIncoming = MessageIncoming<TrieRequest>;
-
-/// A demand for a trie that should be answered.
-pub(crate) type TrieDemand = DemandIncoming<TrieRequest>;
 
 /// A demand for consensus protocol data that should be answered.
 pub(crate) type ConsensusDemand = DemandIncoming<consensus::ConsensusRequestMessage>;

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -18,8 +18,15 @@ use crate::{
 /// An envelope for an incoming message, attaching a sender address and a backpressure ticket.
 #[derive(DataSize, Debug, Serialize)]
 pub struct MessageIncoming<M> {
+    /// Sender of the incoming message.
     pub(crate) sender: NodeId,
+    /// Actual message, deserialized.
     pub(crate) message: Box<M>,
+    /// A ticket representing the "work" for processing the incoming message.
+    ///
+    /// Only drop this once no more resources are consumed, as doing so will signal the peer that it
+    /// is okay to send another message. If a response is generated, consider using
+    /// [`crate::effect::EffectBuilder::send_message_and_drop_ticket`].
     #[serde(skip)]
     pub(crate) ticket: Ticket,
 }
@@ -30,27 +37,6 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "incoming from {}: {}", self.sender, self.message)
-    }
-}
-
-/// An envelope for an incoming demand, attaching a sender address and responder.
-#[derive(DataSize, Debug, Serialize)]
-pub struct DemandIncoming<M> {
-    /// The sender from which the demand originated.
-    pub(crate) sender: NodeId,
-    /// The wrapped demand.
-    pub(crate) request_msg: Box<M>,
-    /// Ticket associated with the demand.
-    #[serde(skip)]
-    pub(crate) ticket: Ticket,
-}
-
-impl<M> Display for DemandIncoming<M>
-where
-    M: Display,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "demand from {}: {}", self.sender, self.request_msg)
     }
 }
 

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -57,6 +57,10 @@ where
 /// A new consensus message arrived.
 pub(crate) type ConsensusMessageIncoming = MessageIncoming<consensus::ConsensusMessage>;
 
+/// A request for consensus protocol data that should be answered.
+pub(crate) type ConsensusRequestMessageIncoming =
+    MessageIncoming<consensus::ConsensusRequestMessage>;
+
 /// A new message from a gossiper arrived.
 pub(crate) type GossiperIncoming<T> = MessageIncoming<gossiper::Message<T>>;
 
@@ -68,9 +72,6 @@ pub(crate) type NetResponseIncoming = MessageIncoming<NetResponse>;
 
 /// A new message requesting a trie arrived.
 pub(crate) type TrieRequestIncoming = MessageIncoming<TrieRequest>;
-
-/// A demand for consensus protocol data that should be answered.
-pub(crate) type ConsensusDemand = DemandIncoming<consensus::ConsensusRequestMessage>;
 
 /// A new message responding to a trie request arrived.
 pub(crate) type TrieResponseIncoming = MessageIncoming<TrieResponse>;

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -24,8 +24,8 @@ pub struct MessageIncoming<M> {
     pub(crate) message: Box<M>,
     /// A ticket representing the "work" for processing the incoming message.
     ///
-    /// Only drop this once no more resources are consumed, as doing so will signal the peer that it
-    /// is okay to send another message. If a response is generated, consider using
+    /// Only drop this once no more resources are consumed, as doing so will signal the peer to
+    /// start sending another message. If a response is generated, consider using
     /// [`crate::effect::EffectBuilder::send_message_and_drop_ticket`].
     #[serde(skip)]
     pub(crate) ticket: Ticket,

--- a/node/src/effect/incoming.rs
+++ b/node/src/effect/incoming.rs
@@ -12,11 +12,8 @@ use serde::Serialize;
 
 use crate::{
     components::{consensus, fetcher::Tag, gossiper, network::Ticket},
-    protocol::Message,
     types::{FinalitySignature, NodeId, TrieOrChunkIdDisplay},
 };
-
-use super::AutoClosingResponder;
 
 /// An envelope for an incoming message, attaching a sender address and a backpressure ticket.
 #[derive(DataSize, Debug, Serialize)]
@@ -43,8 +40,9 @@ pub struct DemandIncoming<M> {
     pub(crate) sender: NodeId,
     /// The wrapped demand.
     pub(crate) request_msg: Box<M>,
-    /// Responder to send the answer down through.
-    pub(crate) auto_closing_responder: AutoClosingResponder<Message>,
+    /// Ticket associated with the demand.
+    #[serde(skip)]
+    pub(crate) ticket: Ticket,
 }
 
 impl<M> Display for DemandIncoming<M>

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     effect::incoming::{
         ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming,
-        NetRequest, NetRequestIncoming, NetResponse, NetResponseIncoming, TrieDemand, TrieRequest,
+        NetRequest, NetRequestIncoming, NetResponse, NetResponseIncoming, TrieRequest,
         TrieRequestIncoming, TrieResponse, TrieResponseIncoming,
     },
     types::{Block, Deploy, FinalitySignature, NodeId},
@@ -247,12 +247,10 @@ where
         + From<NetRequestIncoming>
         + From<NetResponseIncoming>
         + From<TrieRequestIncoming>
-        + From<TrieDemand>
         + From<TrieResponseIncoming>
         + From<FinalitySignatureIncoming>,
 {
     fn from_incoming(sender: NodeId, payload: Message, ticket: Ticket) -> Self {
-        let ticket = Arc::new(ticket);
         match payload {
             Message::Consensus(message) => ConsensusMessageIncoming {
                 sender,
@@ -431,15 +429,6 @@ where
         Self: Sized + Send,
     {
         match payload {
-            Message::GetRequest {
-                tag: Tag::TrieOrChunk,
-                serialized_id,
-            } => Ok(TrieDemand {
-                sender,
-                request_msg: Box::new(TrieRequest(serialized_id)),
-                ticket,
-            }
-            .into()),
             Message::ConsensusRequest(request_msg) => Ok(ConsensusDemand {
                 sender,
                 request_msg: Box::new(request_msg),

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -31,7 +31,7 @@ pub(crate) enum Message {
     /// Consensus component message.
     #[from]
     Consensus(consensus::ConsensusMessage),
-    /// Consensus component demand.
+    /// Consensus component request.
     #[from]
     ConsensusRequest(consensus::ConsensusRequestMessage),
     /// Block gossiper component message.
@@ -419,19 +419,6 @@ where
                 ticket,
             }
             .into(),
-        }
-    }
-
-    fn try_demand_from_incoming(
-        sender: NodeId,
-        payload: Message,
-        ticket: Ticket,
-    ) -> Result<Self, (Message, Ticket)>
-    where
-        Self: Sized + Send,
-    {
-        match payload {
-            _ => Err((payload, ticket)),
         }
     }
 }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -956,6 +956,7 @@ fn handle_fetch_response<R, I>(
     rng: &mut NodeRng,
     sender: NodeId,
     serialized_item: &[u8],
+    ticket: Ticket,
 ) -> Effects<<R as Reactor>::Event>
 where
     I: FetchItem,
@@ -964,14 +965,20 @@ where
 {
     match fetcher::Event::<I>::from_get_response_serialized_item(sender, serialized_item) {
         Some(fetcher_event) => {
-            Reactor::dispatch_event(reactor, effect_builder, rng, fetcher_event.into())
+            let effects =
+                Reactor::dispatch_event(reactor, effect_builder, rng, fetcher_event.into());
+
+            // We have processed the response, drop the ticket before evaluating effects.
+            drop(ticket);
+
+            effects
         }
         None => effect_builder
             .announce_block_peer_with_justification(
                 sender,
                 BlocklistJustification::SentBadItem { tag: I::TAG },
             )
-            .ignore(),
+            .ignore(), // Implicitly drops `ticket`.
     }
 }
 
@@ -981,6 +988,7 @@ fn handle_get_response<R>(
     rng: &mut NodeRng,
     sender: NodeId,
     message: Box<NetResponse>,
+    ticket: Ticket,
 ) -> Effects<<R as Reactor>::Event>
 where
     R: Reactor,
@@ -1004,6 +1012,7 @@ where
             rng,
             sender,
             serialized_item,
+            ticket,
         ),
         NetResponse::LegacyDeploy(ref serialized_item) => handle_fetch_response::<R, LegacyDeploy>(
             reactor,
@@ -1011,16 +1020,23 @@ where
             rng,
             sender,
             serialized_item,
+            ticket,
         ),
-        NetResponse::Block(ref serialized_item) => {
-            handle_fetch_response::<R, Block>(reactor, effect_builder, rng, sender, serialized_item)
-        }
+        NetResponse::Block(ref serialized_item) => handle_fetch_response::<R, Block>(
+            reactor,
+            effect_builder,
+            rng,
+            sender,
+            serialized_item,
+            ticket,
+        ),
         NetResponse::BlockHeader(ref serialized_item) => handle_fetch_response::<R, BlockHeader>(
             reactor,
             effect_builder,
             rng,
             sender,
             serialized_item,
+            ticket,
         ),
         NetResponse::FinalitySignature(ref serialized_item) => {
             handle_fetch_response::<R, FinalitySignature>(
@@ -1029,6 +1045,7 @@ where
                 rng,
                 sender,
                 serialized_item,
+                ticket,
             )
         }
         NetResponse::SyncLeap(ref serialized_item) => handle_fetch_response::<R, SyncLeap>(
@@ -1037,6 +1054,7 @@ where
             rng,
             sender,
             serialized_item,
+            ticket,
         ),
         NetResponse::ApprovalsHashes(ref serialized_item) => {
             handle_fetch_response::<R, ApprovalsHashes>(
@@ -1045,6 +1063,7 @@ where
                 rng,
                 sender,
                 serialized_item,
+                ticket,
             )
         }
         NetResponse::BlockExecutionResults(ref serialized_item) => {
@@ -1054,6 +1073,7 @@ where
                 rng,
                 sender,
                 serialized_item,
+                ticket,
             )
         }
     }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -72,7 +72,7 @@ use crate::{
     components::{
         block_accumulator, deploy_acceptor,
         fetcher::{self, FetchItem},
-        network::{blocklist::BlocklistJustification, Identity as NetworkIdentity},
+        network::{blocklist::BlocklistJustification, Identity as NetworkIdentity, Ticket},
     },
     effect::{
         announcements::{ControlAnnouncement, PeerBehaviorAnnouncement, QueueDumpFormat},

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -432,10 +432,10 @@ impl reactor::Reactor for MainReactor {
                 self.consensus
                     .handle_event(effect_builder, rng, incoming.into()),
             ),
-            MainEvent::ConsensusDemand(demand) => reactor::wrap_effects(
+            MainEvent::ConsensusRequestMessageIncoming(request_message) => reactor::wrap_effects(
                 MainEvent::Consensus,
                 self.consensus
-                    .handle_event(effect_builder, rng, demand.into()),
+                    .handle_event(effect_builder, rng, request_message.into()),
             ),
             MainEvent::ConsensusAnnouncement(consensus_announcement) => {
                 match consensus_announcement {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -569,7 +569,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedBlock {
                         block: Arc::new(*item),
                         sender,
-                        ticket,
+                        ticket: Some(ticket),
                     },
                 ),
             ),
@@ -585,7 +585,7 @@ impl reactor::Reactor for MainReactor {
                         block_accumulator::Event::ReceivedBlock {
                             block,
                             sender: peer,
-                            ticket: Ticket::create_dummy(),
+                            ticket: None,
                         },
                     ),
                 )

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -864,11 +864,6 @@ impl reactor::Reactor for MainReactor {
                 self.contract_runtime
                     .handle_event(effect_builder, rng, req.into()),
             ),
-            MainEvent::TrieDemand(demand) => reactor::wrap_effects(
-                MainEvent::ContractRuntime,
-                self.contract_runtime
-                    .handle_event(effect_builder, rng, demand.into()),
-            ),
             MainEvent::TrieResponseIncoming(TrieResponseIncoming {
                 sender,
                 message,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -392,8 +392,8 @@ impl reactor::Reactor for MainReactor {
             MainEvent::NetworkPeerProvidingData(NetResponseIncoming {
                 sender,
                 message,
-                ticket: _, // TODO: Properly handle ticket.
-            }) => reactor::handle_get_response(self, effect_builder, rng, sender, message),
+                ticket,
+            }) => reactor::handle_get_response(self, effect_builder, rng, sender, message, ticket),
             MainEvent::AddressGossiper(event) => reactor::wrap_effects(
                 MainEvent::AddressGossiper,
                 self.address_gossiper
@@ -867,13 +867,14 @@ impl reactor::Reactor for MainReactor {
             MainEvent::TrieResponseIncoming(TrieResponseIncoming {
                 sender,
                 message,
-                ticket: _, // TODO: Sensibly process ticket.
+                ticket,
             }) => reactor::handle_fetch_response::<Self, TrieOrChunk>(
                 self,
                 effect_builder,
                 rng,
                 sender,
                 &message.0,
+                ticket,
             ),
 
             // STORAGE

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -602,6 +602,7 @@ impl reactor::Reactor for MainReactor {
                 let block_accumulator_event = block_accumulator::Event::ReceivedFinalitySignature {
                     finality_signature,
                     sender,
+                    ticket: incoming.ticket,
                 };
                 reactor::wrap_effects(
                     MainEvent::BlockAccumulator,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -39,7 +39,7 @@ use crate::{
         event_stream_server::{self, EventStreamServer},
         gossiper::{self, GossipItem, Gossiper},
         metrics::Metrics,
-        network::{self, GossipedAddress, Identity as NetworkIdentity, Network},
+        network::{self, GossipedAddress, Identity as NetworkIdentity, Network, Ticket},
         proposed_block_validator::{self, ProposedBlockValidator},
         rest_server::RestServer,
         rpc_server::RpcServer,
@@ -605,7 +605,7 @@ impl reactor::Reactor for MainReactor {
                 let block_accumulator_event = block_accumulator::Event::ReceivedFinalitySignature {
                     finality_signature,
                     sender,
-                    ticket: Some(incoming.ticket),
+                    ticket: incoming.ticket,
                 };
                 reactor::wrap_effects(
                     MainEvent::BlockAccumulator,
@@ -663,7 +663,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedFinalitySignature {
                         finality_signature: item,
                         sender,
-                        ticket: Some(ticket),
+                        ticket,
                     },
                 ),
             ),
@@ -687,7 +687,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedFinalitySignature {
                         finality_signature,
                         sender: peer,
-                        ticket: None,
+                        ticket: Ticket::create_dummy(),
                     },
                 ),
             ),
@@ -712,7 +712,7 @@ impl reactor::Reactor for MainReactor {
                     deploy,
                     source,
                     maybe_responder: Some(responder),
-                    ticket: None,
+                    ticket: Ticket::create_dummy(),
                 };
                 reactor::wrap_effects(
                     MainEvent::DeployAcceptor,
@@ -806,7 +806,7 @@ impl reactor::Reactor for MainReactor {
                         deploy: Arc::new(*item),
                         source: Source::PeerGossiped(sender),
                         maybe_responder: None,
-                        ticket: Some(ticket),
+                        ticket,
                     },
                 ),
             ),

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -585,7 +585,7 @@ impl reactor::Reactor for MainReactor {
                         block_accumulator::Event::ReceivedBlock {
                             block,
                             sender: peer,
-                            ticket: Ticket::create_dummy(),
+                            ticket: Ticket::stub(),
                         },
                     ),
                 )
@@ -687,7 +687,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedFinalitySignature {
                         finality_signature,
                         sender: peer,
-                        ticket: Ticket::create_dummy(),
+                        ticket: Ticket::stub(),
                     },
                 ),
             ),
@@ -712,7 +712,7 @@ impl reactor::Reactor for MainReactor {
                     deploy,
                     source,
                     maybe_responder: Some(responder),
-                    ticket: Ticket::create_dummy(),
+                    ticket: Ticket::stub(),
                 };
                 reactor::wrap_effects(
                     MainEvent::DeployAcceptor,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -569,7 +569,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedBlock {
                         block: Arc::new(*item),
                         sender,
-                        ticket: Some(ticket),
+                        ticket,
                     },
                 ),
             ),
@@ -585,7 +585,7 @@ impl reactor::Reactor for MainReactor {
                         block_accumulator::Event::ReceivedBlock {
                             block,
                             sender: peer,
-                            ticket: None,
+                            ticket: Ticket::create_dummy(),
                         },
                     ),
                 )

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -39,7 +39,7 @@ use crate::{
         event_stream_server::{self, EventStreamServer},
         gossiper::{self, GossipItem, Gossiper},
         metrics::Metrics,
-        network::{self, GossipedAddress, Identity as NetworkIdentity, Network, Ticket},
+        network::{self, GossipedAddress, Identity as NetworkIdentity, Network},
         proposed_block_validator::{self, ProposedBlockValidator},
         rest_server::RestServer,
         rpc_server::RpcServer,
@@ -605,7 +605,7 @@ impl reactor::Reactor for MainReactor {
                 let block_accumulator_event = block_accumulator::Event::ReceivedFinalitySignature {
                     finality_signature,
                     sender,
-                    ticket: incoming.ticket,
+                    ticket: Some(incoming.ticket),
                 };
                 reactor::wrap_effects(
                     MainEvent::BlockAccumulator,
@@ -663,7 +663,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedFinalitySignature {
                         finality_signature: item,
                         sender,
-                        ticket,
+                        ticket: Some(ticket),
                     },
                 ),
             ),
@@ -687,7 +687,7 @@ impl reactor::Reactor for MainReactor {
                     block_accumulator::Event::ReceivedFinalitySignature {
                         finality_signature,
                         sender: peer,
-                        ticket: Ticket::create_dummy(),
+                        ticket: None,
                     },
                 ),
             ),
@@ -712,7 +712,7 @@ impl reactor::Reactor for MainReactor {
                     deploy,
                     source,
                     maybe_responder: Some(responder),
-                    ticket: Ticket::create_dummy(),
+                    ticket: None,
                 };
                 reactor::wrap_effects(
                     MainEvent::DeployAcceptor,
@@ -806,7 +806,7 @@ impl reactor::Reactor for MainReactor {
                         deploy: Arc::new(*item),
                         source: Source::PeerGossiped(sender),
                         maybe_responder: None,
-                        ticket,
+                        ticket: Some(ticket),
                     },
                 ),
             ),

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -30,8 +30,7 @@ use crate::{
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
             ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming,
-            NetRequestIncoming, NetResponseIncoming, TrieDemand, TrieRequestIncoming,
-            TrieResponseIncoming,
+            NetRequestIncoming, NetResponseIncoming, TrieRequestIncoming, TrieResponseIncoming,
         },
         requests::{
             AcceptDeployRequest, BeginGossipRequest, BlockAccumulatorRequest,
@@ -230,8 +229,6 @@ pub(crate) enum MainEvent {
     #[from]
     TrieRequestIncoming(TrieRequestIncoming),
     #[from]
-    TrieDemand(TrieDemand),
-    #[from]
     TrieResponseIncoming(TrieResponseIncoming),
     #[from]
     Storage(storage::Event),
@@ -337,7 +334,6 @@ impl ReactorEvent for MainEvent {
             MainEvent::NetworkPeerRequestingData(_) => "NetRequestIncoming",
             MainEvent::NetworkPeerProvidingData(_) => "NetResponseIncoming",
             MainEvent::TrieRequestIncoming(_) => "TrieRequestIncoming",
-            MainEvent::TrieDemand(_) => "TrieDemand",
             MainEvent::TrieResponseIncoming(_) => "TrieResponseIncoming",
             MainEvent::FinalitySignatureIncoming(_) => "FinalitySignatureIncoming",
             MainEvent::ContractRuntime(_) => "ContractRuntime",
@@ -527,7 +523,6 @@ impl Display for MainEvent {
             MainEvent::NetworkPeerRequestingData(inner) => Display::fmt(inner, f),
             MainEvent::NetworkPeerProvidingData(inner) => Display::fmt(inner, f),
             MainEvent::TrieRequestIncoming(inner) => Display::fmt(inner, f),
-            MainEvent::TrieDemand(inner) => Display::fmt(inner, f),
             MainEvent::TrieResponseIncoming(inner) => Display::fmt(inner, f),
             MainEvent::FinalitySignatureIncoming(inner) => Display::fmt(inner, f),
             MainEvent::ContractRuntime(inner) => Display::fmt(inner, f),

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -29,8 +29,9 @@ use crate::{
         },
         diagnostics_port::DumpConsensusStateRequest,
         incoming::{
-            ConsensusDemand, ConsensusMessageIncoming, FinalitySignatureIncoming, GossiperIncoming,
-            NetRequestIncoming, NetResponseIncoming, TrieRequestIncoming, TrieResponseIncoming,
+            ConsensusMessageIncoming, ConsensusRequestMessageIncoming, FinalitySignatureIncoming,
+            GossiperIncoming, NetRequestIncoming, NetResponseIncoming, TrieRequestIncoming,
+            TrieResponseIncoming,
         },
         requests::{
             AcceptDeployRequest, BeginGossipRequest, BlockAccumulatorRequest,
@@ -121,7 +122,7 @@ pub(crate) enum MainEvent {
     #[from]
     ConsensusMessageIncoming(ConsensusMessageIncoming),
     #[from]
-    ConsensusDemand(ConsensusDemand),
+    ConsensusDemand(ConsensusRequestMessageIncoming),
     #[from]
     ConsensusAnnouncement(#[serde(skip_serializing)] ConsensusAnnouncement),
     #[from]

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -122,7 +122,7 @@ pub(crate) enum MainEvent {
     #[from]
     ConsensusMessageIncoming(ConsensusMessageIncoming),
     #[from]
-    ConsensusDemand(ConsensusRequestMessageIncoming),
+    ConsensusRequestMessageIncoming(ConsensusRequestMessageIncoming),
     #[from]
     ConsensusAnnouncement(#[serde(skip_serializing)] ConsensusAnnouncement),
     #[from]
@@ -328,7 +328,7 @@ impl ReactorEvent for MainEvent {
             }
             MainEvent::AddressGossiperCrank(_) => "BeginAddressGossipRequest",
             MainEvent::ConsensusMessageIncoming(_) => "ConsensusMessageIncoming",
-            MainEvent::ConsensusDemand(_) => "ConsensusDemand",
+            MainEvent::ConsensusRequestMessageIncoming(_) => "ConsensusRequestMessageIncoming",
             MainEvent::DeployGossiperIncoming(_) => "DeployGossiperIncoming",
             MainEvent::FinalitySignatureGossiperIncoming(_) => "FinalitySignatureGossiperIncoming",
             MainEvent::AddressGossiperIncoming(_) => "AddressGossiperIncoming",
@@ -517,7 +517,7 @@ impl Display for MainEvent {
                 write!(f, "finality signature fetcher announcement: {}", ann)
             }
             MainEvent::ConsensusMessageIncoming(inner) => Display::fmt(inner, f),
-            MainEvent::ConsensusDemand(inner) => Display::fmt(inner, f),
+            MainEvent::ConsensusRequestMessageIncoming(inner) => Display::fmt(inner, f),
             MainEvent::DeployGossiperIncoming(inner) => Display::fmt(inner, f),
             MainEvent::FinalitySignatureGossiperIncoming(inner) => Display::fmt(inner, f),
             MainEvent::AddressGossiperIncoming(inner) => Display::fmt(inner, f),

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -752,7 +752,8 @@ async fn run_equivocator_network() {
         // Filter out all incoming and outgoing consensus message traffic.
         let now = Timestamp::now();
         match &event {
-            MainEvent::ConsensusMessageIncoming(_) | MainEvent::ConsensusDemand(_) => {
+            MainEvent::ConsensusMessageIncoming(_)
+            | MainEvent::ConsensusRequestMessageIncoming(_) => {
                 // delayed.
             }
             MainEvent::NetworkRequest(req) if matches!(req.payload(), Message::Consensus(_)) => {

--- a/node/src/testing/fake_deploy_acceptor.rs
+++ b/node/src/testing/fake_deploy_acceptor.rs
@@ -119,6 +119,7 @@ impl<REv: ReactorEventT> Component<REv> for FakeDeployAcceptor {
                 deploy,
                 source,
                 maybe_responder,
+                ticket: _, // not handled in tests.
             } => self.accept(effect_builder, deploy, source, maybe_responder),
             Event::PutToStorageResult {
                 event_metadata,


### PR DESCRIPTION
Improves the threading of `Ticket`s through the node.

A follow-up ticket for further on handling `Tickets` in consensus will be coming forth later. ~~This is a draft PR, as the underlying PRs are not merged yet.~~

Closes #3939, #4564.