### PR TITLE
2.0 ScratchDb fix

### DIFF
--- a/execution_engine/src/runtime/mint_internal.rs
+++ b/execution_engine/src/runtime/mint_internal.rs
@@ -141,6 +141,11 @@ where
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
     }
 
+    fn total_balance(&mut self, purse: URef) -> Result<U512, Error> {
+        Runtime::total_balance(self, purse)
+            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
+    }
+
     fn available_balance(
         &mut self,
         purse: URef,

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -2691,6 +2691,13 @@ where
         }
     }
 
+    fn total_balance(&mut self, purse: URef) -> Result<U512, ExecError> {
+        match self.context.total_balance(&purse) {
+            Ok(motes) => Ok(motes.value()),
+            Err(err) => Err(err),
+        }
+    }
+
     fn available_balance(
         &mut self,
         purse: URef,

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -422,7 +422,20 @@ where
         self.entity.clone()
     }
 
-    /// Reads the balance of a purse [`URef`].
+    /// Reads the total balance of a purse [`URef`].
+    ///
+    /// Currently address of a purse [`URef`] is also a hash in the [`Key::Hash`] space.
+    pub(crate) fn total_balance(&mut self, purse_uref: &URef) -> Result<Motes, ExecError> {
+        let key = Key::URef(*purse_uref);
+        let (total, _) = self
+            .tracking_copy
+            .borrow_mut()
+            .get_total_balance_with_proof(key)
+            .map_err(ExecError::TrackingCopy)?;
+        Ok(Motes::new(total))
+    }
+
+    /// Reads the available balance of a purse [`URef`].
     ///
     /// Currently address of a purse [`URef`] is also a hash in the [`Key::Hash`] space.
     pub(crate) fn available_balance(

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -427,12 +427,12 @@ where
     /// Currently address of a purse [`URef`] is also a hash in the [`Key::Hash`] space.
     pub(crate) fn total_balance(&mut self, purse_uref: &URef) -> Result<Motes, ExecError> {
         let key = Key::URef(*purse_uref);
-        let (total, _) = self
+        let total = self
             .tracking_copy
             .borrow_mut()
-            .get_total_balance_with_proof(key)
+            .get_total_balance(key)
             .map_err(ExecError::TrackingCopy)?;
-        Ok(Motes::new(total))
+        Ok(total)
     }
 
     /// Reads the available balance of a purse [`URef`].

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -24,7 +24,7 @@ use casper_storage::{
         balance::BalanceHandling, AuctionMethod, BalanceIdentifier, BalanceRequest, BalanceResult,
         BiddingRequest, BiddingResult, BidsRequest, BlockRewardsRequest, BlockRewardsResult,
         BlockStore, DataAccessLayer, EraValidatorsRequest, EraValidatorsResult, FeeRequest,
-        FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult,
+        FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult, ProofHandling,
         ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest, PruneResult, QueryRequest,
         QueryResult, RoundSeigniorageRateRequest, RoundSeigniorageRateResult, StepRequest,
         StepResult, SystemEntityRegistryPayload, SystemEntityRegistryRequest,
@@ -1229,6 +1229,7 @@ where
         let hold_interval = self.chainspec.core_config.balance_hold_interval.millis();
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
         let balance_handling = BalanceHandling::Available { holds_epoch };
+        let proof_handling = ProofHandling::NoProofs;
 
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
         let request = BalanceRequest::new(
@@ -1236,6 +1237,7 @@ where
             protocol_version,
             balance_identifier,
             balance_handling,
+            proof_handling,
         );
         self.data_access_layer.balance(request)
     }
@@ -1251,11 +1253,13 @@ where
         let hold_interval = self.chainspec.core_config.balance_hold_interval.millis();
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
         let balance_handling = BalanceHandling::Available { holds_epoch };
+        let proof_handling = ProofHandling::NoProofs;
         let request = BalanceRequest::from_public_key(
             state_root_hash,
             protocol_version,
             public_key,
             balance_handling,
+            proof_handling,
         );
         self.data_access_layer.balance(request)
     }

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1220,7 +1220,7 @@ where
     }
 
     /// Returns a `BalanceResult` for a purse, panics if the balance can't be found.
-    pub fn get_purse_balance_result(
+    pub fn get_purse_balance_result_with_proofs(
         &self,
         protocol_version: ProtocolVersion,
         balance_identifier: BalanceIdentifier,
@@ -1229,7 +1229,7 @@ where
         let hold_interval = self.chainspec.core_config.balance_hold_interval.millis();
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
         let balance_handling = BalanceHandling::Available { holds_epoch };
-        let proof_handling = ProofHandling::NoProofs;
+        let proof_handling = ProofHandling::Proofs;
 
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
         let request = BalanceRequest::new(
@@ -1243,7 +1243,7 @@ where
     }
 
     /// Returns a `BalanceResult` for a purse using a `PublicKey`.
-    pub fn get_public_key_balance_result(
+    pub fn get_public_key_balance_result_with_proofs(
         &self,
         protocol_version: ProtocolVersion,
         public_key: PublicKey,
@@ -1253,7 +1253,7 @@ where
         let hold_interval = self.chainspec.core_config.balance_hold_interval.millis();
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
         let balance_handling = BalanceHandling::Available { holds_epoch };
-        let proof_handling = ProofHandling::NoProofs;
+        let proof_handling = ProofHandling::Proofs;
         let request = BalanceRequest::from_public_key(
             state_root_hash,
             protocol_version,

--- a/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
@@ -114,7 +114,7 @@ fn should_charge_non_main_purse() {
     );
 
     let paid_amount = *payment_purse_balance
-        .motes()
+        .available_balance()
         .expect("should have payment amount");
 
     assert_eq!(

--- a/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
@@ -102,7 +102,7 @@ fn should_charge_non_main_purse() {
         .expect_success()
         .commit();
 
-    let payment_purse_balance = builder.get_purse_balance_result(
+    let payment_purse_balance = builder.get_purse_balance_result_with_proofs(
         DEFAULT_PROTOCOL_VERSION,
         BalanceIdentifier::Payment,
         block_time,

--- a/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/stored_contracts.rs
@@ -408,11 +408,9 @@ fn should_fail_payment_stored_at_hash_with_incompatible_major_version() {
         .get(STORED_PAYMENT_CONTRACT_HASH_NAME)
         .expect("should have stored payment key");
 
-    let stored_payment = builder
+    let _stored_payment = builder
         .query(None, stored_payment_key, &[])
         .expect("should have stored payement");
-
-    println!("{:?}", stored_payment);
 
     let stored_payment_contract_hash = stored_payment_key
         .into_entity_hash_addr()

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -926,10 +926,10 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 91_914_271_090;
-    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_340_630;
-    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_911_250;
-    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_882_230;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 92_116_501_090;
+    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_243_280;
+    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_813_900;
+    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_679_000;
 
     let installer_account = AccountHash::new([1u8; 32]);
     let user_account: AccountHash = AccountHash::new([2u8; 32]);

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -49,7 +49,7 @@ fn get_balance_should_work() {
     );
 
     let alice_balance = alice_balance_result
-        .motes()
+        .available_balance()
         .cloned()
         .expect("should have motes");
 
@@ -57,7 +57,13 @@ fn get_balance_should_work() {
 
     let state_root_hash = builder.get_post_state_hash();
 
-    let balance_proof = alice_balance_result.proof().expect("should have proofs");
+    let proofs_result = alice_balance_result
+        .proofs_result()
+        .expect("should have proofs result");
+    let balance_proof = proofs_result
+        .total_balance_proof()
+        .expect("should have proofs")
+        .clone();
 
     assert!(tracking_copy::validate_balance_proof(
         &state_root_hash,
@@ -138,7 +144,7 @@ fn get_balance_using_public_key_should_work() {
         builder.get_public_key_balance_result(protocol_version, ALICE_KEY.clone(), block_time);
 
     let alice_balance = alice_balance_result
-        .motes()
+        .available_balance()
         .cloned()
         .expect("should have motes");
 
@@ -146,7 +152,13 @@ fn get_balance_using_public_key_should_work() {
 
     let state_root_hash = builder.get_post_state_hash();
 
-    let balance_proof = alice_balance_result.proof().expect("should have proofs");
+    let proofs_result = alice_balance_result
+        .proofs_result()
+        .expect("should have proofs result");
+    let balance_proof = proofs_result
+        .total_balance_proof()
+        .expect("should have proofs")
+        .clone();
 
     assert!(tracking_copy::validate_balance_proof(
         &state_root_hash,

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -42,7 +42,7 @@ fn get_balance_should_work() {
 
     let alice_main_purse = alice_account.main_purse();
 
-    let alice_balance_result = builder.get_purse_balance_result(
+    let alice_balance_result = builder.get_purse_balance_result_with_proofs(
         protocol_version,
         BalanceIdentifier::Purse(alice_main_purse),
         block_time,
@@ -140,8 +140,11 @@ fn get_balance_using_public_key_should_work() {
 
     let alice_main_purse = alice_account.main_purse();
 
-    let alice_balance_result =
-        builder.get_public_key_balance_result(protocol_version, ALICE_KEY.clone(), block_time);
+    let alice_balance_result = builder.get_public_key_balance_result_with_proofs(
+        protocol_version,
+        ALICE_KEY.clone(),
+        block_time,
+    );
 
     let alice_balance = alice_balance_result
         .available_balance()

--- a/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
@@ -99,8 +99,7 @@ fn should_not_create_any_purse() {
     );
 
     let effects_1 = match builder.step(step_request_1) {
-        StepResult::Failure(step_error) => {
-            println!("step_request_1: {}", step_error);
+        StepResult::Failure(_) => {
             panic!("step_request_1: Failure")
         }
         StepResult::RootNotFound => {

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -7,12 +7,12 @@ use casper_execution_engine::engine_state::{ExecutionEngineV1, WasmV1Request, Wa
 use casper_storage::{
     block_store::types::ApprovalsHashes,
     data_access_layer::{
-        balance::BalanceHandling, AuctionMethod, BalanceHoldRequest, BalanceIdentifier,
-        BalanceRequest, BiddingRequest, BlockRewardsRequest, BlockRewardsResult, DataAccessLayer,
-        EraValidatorsRequest, EraValidatorsResult, EvictItem, FeeRequest, FeeResult, FlushRequest,
-        HandleFeeMode, HandleFeeRequest, HandleRefundMode, HandleRefundRequest,
-        InsufficientBalanceHandling, PruneRequest, PruneResult, StepRequest, StepResult,
-        TransferRequest,
+        balance::BalanceHandling, AuctionMethod, BalanceHoldKind, BalanceHoldRequest,
+        BalanceIdentifier, BalanceRequest, BiddingRequest, BlockRewardsRequest, BlockRewardsResult,
+        DataAccessLayer, EraValidatorsRequest, EraValidatorsResult, EvictItem, FeeRequest,
+        FeeResult, FlushRequest, HandleFeeMode, HandleFeeRequest, HandleRefundMode,
+        HandleRefundRequest, InsufficientBalanceHandling, ProofHandling, PruneRequest, PruneResult,
+        StepRequest, StepResult, TransferRequest,
     },
     global_state::state::{
         lmdb::LmdbGlobalState, scratch::ScratchGlobalState, CommitProvider, ScratchProvider,
@@ -24,7 +24,6 @@ use casper_storage::{
 use casper_types::{
     bytesrepr::{self, ToBytes, U32_SERIALIZED_LENGTH},
     execution::{Effects, ExecutionResult, TransformKindV2, TransformV2},
-    system::mint::BalanceHoldAddrTag,
     BlockHeader, BlockTime, BlockV2, CLValue, CategorizedTransaction, Chainspec, ChecksumRegistry,
     Digest, EraEndV2, EraId, FeeHandling, Gas, GasLimited, HoldsEpoch, Key, ProtocolVersion,
     PublicKey, RefundHandling, Transaction, TransactionCategory, U512,
@@ -66,42 +65,56 @@ pub fn execute_finalized_block(
             execution_pre_state: Box::new(execution_pre_state),
         });
     }
-
     if executable_block.era_report.is_some() && next_era_gas_price.is_none() {
         return Err(BlockExecutionError::FailedToGetNewEraGasPrice {
             era_id: executable_block.era_id.successor(),
         });
     }
-
+    let start = Instant::now();
     let protocol_version = chainspec.protocol_version();
     let activation_point_era_id = chainspec.protocol_config.activation_point.era_id();
     let prune_batch_size = chainspec.core_config.prune_batch_size;
     let native_runtime_config = NativeRuntimeConfig::from_chainspec(chainspec);
 
-    let pre_state_root_hash = execution_pre_state.pre_state_root_hash();
+    // scrape variables from execution pre state
     let parent_hash = execution_pre_state.parent_hash();
     let parent_seed = execution_pre_state.parent_seed();
+    let pre_state_root_hash = execution_pre_state.pre_state_root_hash();
+    let mut state_root_hash = pre_state_root_hash; // initial state root is parent's state root
 
-    let mut state_root_hash = pre_state_root_hash;
-    let mut artifacts = Vec::with_capacity(executable_block.transactions.len());
+    // scrape variables from executable block
     let block_time = BlockTime::new(executable_block.timestamp.millis());
+    let proposer = executable_block.proposer.clone();
+    let mut artifacts = Vec::with_capacity(executable_block.transactions.len());
+
+    // set up accounting variables / settings
     let holds_epoch =
         HoldsEpoch::from_block_time(block_time, chainspec.core_config.balance_hold_interval);
     let balance_handling = BalanceHandling::Available { holds_epoch };
-    let proposer = executable_block.proposer.clone();
+    let insufficient_balance_handling = InsufficientBalanceHandling::HoldRemaining;
+    let refund_handling = chainspec.core_config.refund_handling;
+    let fee_handling = chainspec.core_config.fee_handling;
 
-    let start = Instant::now();
-
+    // get scratch state, which must be used for all processing and post processing data
+    // requirements.
     let scratch_state = data_access_layer.get_scratch_global_state();
 
+    // pre processing is finished
+    if let Some(metrics) = metrics.as_ref() {
+        metrics
+            .exec_block_pre_processing
+            .observe(start.elapsed().as_secs_f64());
+    }
+
+    // grabbing transaction id's now to avoid cloning transactions
     let transaction_ids = executable_block
         .transactions
         .iter()
         .map(Transaction::fetch_id)
         .collect_vec();
 
-    let refund_handling = chainspec.core_config.refund_handling;
-    let insufficient_balance_handling = InsufficientBalanceHandling::HoldRemaining;
+    // transaction processing starts now
+    let txn_processing_start = Instant::now();
 
     for transaction in executable_block.transactions {
         let mut artifact_builder = ExecutionArtifactBuilder::new(&transaction);
@@ -111,33 +124,6 @@ pub fn execute_finalized_block(
         let runtime_args = transaction.session_args().clone();
         let entry_point = transaction.entry_point();
         let authorization_keys = transaction.authorization_keys();
-
-        // set up the refund purse for this transaction, if refunds are on
-        if !refund_handling.skip_refund() {
-            // if refunds are turned on we initialize the refund purse to the initiator's main
-            // purse before doing any processing. NOTE: when executed, custom payment logic
-            // has the option to call set_refund_purse on the handle payment contract to set
-            // up a different refund purse, if desired.
-            let handle_refund_request = HandleRefundRequest::new(
-                native_runtime_config.clone(),
-                state_root_hash,
-                protocol_version,
-                transaction_hash,
-                HandleRefundMode::SetRefundPurse {
-                    target: Box::new(initiator_addr.clone().into()),
-                },
-            );
-            let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
-            if let Err(rnf) = artifact_builder.with_set_refund_purse_result(&handle_refund_result) {
-                if rnf {
-                    return Err(BlockExecutionError::RootNotFound(state_root_hash));
-                }
-                artifacts.push(artifact_builder.build());
-                continue; // no reason to commit the effects, move on
-            }
-            state_root_hash =
-                scratch_state.commit(state_root_hash, handle_refund_result.effects().clone())?;
-        }
 
         /*
         we solve for halting state using a `gas limit` which is the maximum amount of
@@ -183,9 +169,39 @@ pub fn execute_finalized_block(
         };
         artifact_builder.with_added_cost(cost);
 
+        let is_standard_payment = transaction.is_standard_payment();
+        let refund_purse_active = !is_standard_payment && !refund_handling.skip_refund();
+        // set up the refund purse for this transaction, if custom payment && refunds are on
+        if refund_purse_active {
+            // if refunds are turned on we initialize the refund purse to the initiator's main
+            // purse before doing any processing. NOTE: when executed, custom payment logic
+            // has the option to call set_refund_purse on the handle payment contract to set
+            // up a different refund purse, if desired.
+            let handle_refund_request = HandleRefundRequest::new(
+                native_runtime_config.clone(),
+                state_root_hash,
+                protocol_version,
+                transaction_hash,
+                HandleRefundMode::SetRefundPurse {
+                    target: Box::new(initiator_addr.clone().into()),
+                },
+            );
+            let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
+            if let Err(root_not_found) =
+                artifact_builder.with_set_refund_purse_result(&handle_refund_result)
+            {
+                if root_not_found {
+                    return Err(BlockExecutionError::RootNotFound(state_root_hash));
+                }
+                artifacts.push(artifact_builder.build());
+                continue; // no reason to commit the effects, move on
+            }
+            state_root_hash =
+                scratch_state.commit(state_root_hash, handle_refund_result.effects().clone())?;
+        }
+
         let balance_identifier = {
             let is_account_session = transaction.is_account_session();
-            let is_standard_payment = transaction.is_standard_payment();
             //  if standard payment & is session based...use account main purse
             //  if standard payment & is targeting a contract
             //      load contract & check entry point, if it pays use contract main purse
@@ -257,6 +273,7 @@ pub fn execute_finalized_block(
             protocol_version,
             balance_identifier.clone(),
             balance_handling,
+            ProofHandling::NoProofs,
         ));
 
         let allow_execution = {
@@ -267,6 +284,26 @@ pub fn execute_finalized_block(
         };
 
         if allow_execution {
+            if is_standard_payment {
+                // place a processing hold on the paying account to prevent double spend.
+                let hold_amount = cost;
+                let hold_request = BalanceHoldRequest::new_processing_hold(
+                    state_root_hash,
+                    protocol_version,
+                    balance_identifier.clone(),
+                    hold_amount,
+                    block_time,
+                    holds_epoch,
+                    insufficient_balance_handling,
+                );
+                let hold_result = scratch_state.balance_hold(hold_request);
+                state_root_hash =
+                    scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
+                artifact_builder
+                    .with_balance_hold_result(&hold_result)
+                    .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
+            }
+
             let category = transaction.category();
             trace!(%transaction_hash, ?category, "eligible for execution");
             match category {
@@ -326,6 +363,7 @@ pub fn execute_finalized_block(
                     };
                 }
                 TransactionCategory::Standard | TransactionCategory::InstallUpgrade => {
+                    let wasm_v1_start = Instant::now();
                     match WasmV1Request::new_session(
                         state_root_hash,
                         block_time,
@@ -349,40 +387,82 @@ pub fn execute_finalized_block(
                             artifact_builder.with_invalid_wasm_v1_request(&ire);
                         }
                     };
+                    if let Some(metrics) = metrics.as_ref() {
+                        metrics
+                            .exec_wasm_v1
+                            .observe(wasm_v1_start.elapsed().as_secs_f64());
+                    }
                 }
             }
         } else {
             debug!(%transaction_hash, "not eligible for execution");
         }
 
+        // clear all holds on the balance_identifier purse before payment processing
+        {
+            let hold_request = BalanceHoldRequest::new_clear(
+                state_root_hash,
+                protocol_version,
+                block_time,
+                BalanceHoldKind::All,
+                balance_identifier.clone(),
+                holds_epoch,
+            );
+            let hold_result = scratch_state.balance_hold(hold_request);
+            state_root_hash =
+                scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
+            artifact_builder
+                .with_balance_hold_result(&hold_result)
+                .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
+        }
+
         // handle refunds per the chainspec determined setting.
-        let refund_amount = match refund_handling {
-            RefundHandling::NoRefund => U512::zero(),
-            RefundHandling::Refund { refund_ratio } => {
-                // if it is standard payment we will instead just reduce the amount taken,
-                // rather than take all and then refund some back later
-                // however, we take custom payment up front and thus need to refund
-                if transaction.is_standard_payment() {
-                    U512::zero()
-                } else {
-                    let consumed = Gas::new(artifact_builder.consumed());
+        let refund_amount = {
+            let consumed = artifact_builder.consumed();
+            let refund_mode = match refund_handling {
+                RefundHandling::NoRefund => None,
+                RefundHandling::Burn { refund_ratio } => Some(HandleRefundMode::Burn {
+                    limit: gas_limit.value(),
+                    gas_price: current_gas_price,
+                    cost,
+                    consumed,
+                    source: Box::new(balance_identifier.clone()),
+                    ratio: refund_ratio,
+                }),
+                RefundHandling::Refund { refund_ratio } => {
+                    if transaction.is_standard_payment() {
+                        Some(HandleRefundMode::RefundAmount {
+                            limit: gas_limit.value(),
+                            gas_price: current_gas_price,
+                            consumed,
+                            cost,
+                            ratio: refund_ratio,
+                            source: Box::new(balance_identifier.clone()),
+                        })
+                    } else {
+                        Some(HandleRefundMode::Refund {
+                            initiator_addr: Box::new(initiator_addr.clone()),
+                            limit: gas_limit.value(),
+                            gas_price: current_gas_price,
+                            consumed,
+                            cost,
+                            ratio: refund_ratio,
+                            // as this is currently behind a custom payment check,
+                            // the source is always BalanceIdentifier::Payment
+                            source: Box::new(balance_identifier.clone()),
+                            target: Box::new(BalanceIdentifier::Refund),
+                        })
+                    }
+                }
+            };
+            match refund_mode {
+                Some(refund_mode) => {
                     let handle_refund_request = HandleRefundRequest::new(
                         native_runtime_config.clone(),
                         state_root_hash,
                         protocol_version,
                         transaction_hash,
-                        HandleRefundMode::Refund {
-                            limit: gas_limit.value(),
-                            gas_price: current_gas_price,
-                            consumed: consumed.value(),
-                            cost,
-                            // as this is currently behind a custom payment check,
-                            // the source is always BalanceIdentifier::Payment
-                            source: Box::new(balance_identifier.clone()),
-                            target: Box::new(BalanceIdentifier::Refund),
-                            ratio: refund_ratio,
-                            initiator_addr: Box::new(initiator_addr.clone()),
-                        },
+                        refund_mode,
                     );
                     let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
                     let refunded_amount = handle_refund_result.refund_amount();
@@ -393,62 +473,20 @@ pub fn execute_finalized_block(
                         .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
                     refunded_amount
                 }
-            }
-            RefundHandling::Burn { refund_ratio } => {
-                // regardless of custom or standard payment, burn the appropriate amount from source
-                let consumed = Gas::new(artifact_builder.consumed());
-                let handle_refund_request = HandleRefundRequest::new(
-                    native_runtime_config.clone(),
-                    state_root_hash,
-                    protocol_version,
-                    transaction_hash,
-                    HandleRefundMode::Burn {
-                        limit: gas_limit.value(),
-                        gas_price: current_gas_price,
-                        cost,
-                        consumed: consumed.value(),
-                        source: Box::new(balance_identifier.clone()),
-                        ratio: refund_ratio,
-                    },
-                );
-                let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
-                let burned_amount = handle_refund_result.refund_amount();
-                state_root_hash = scratch_state
-                    .commit(state_root_hash, handle_refund_result.effects().clone())?;
-                artifact_builder
-                    .with_handle_refund_result(&handle_refund_result)
-                    .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
-                burned_amount
+                None => U512::zero(),
             }
         };
 
         // handle fees per the chainspec determined setting.
-        let fee_handling = chainspec.core_config.fee_handling;
         match fee_handling {
             FeeHandling::NoFee => {
-                // this is an opportunity to prune away any expired holds on source.
-                // it has no effect on the outcome, but it reduces width of gs at the tip of the
-                // chain
-                let handle_fee_request = HandleFeeRequest::new(
-                    native_runtime_config.clone(),
-                    state_root_hash,
-                    protocol_version,
-                    transaction_hash,
-                    HandleFeeMode::clear_holds(balance_identifier.clone(), holds_epoch),
-                );
-                let handle_fee_result = scratch_state.handle_fee(handle_fee_request);
-                state_root_hash =
-                    scratch_state.commit(state_root_hash, handle_fee_result.effects().clone())?;
-                artifact_builder
-                    .with_handle_fee_result(&handle_fee_result)
-                    .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
-                // in this mode, a hold for cost - refund (if any) is placed on the payer's purse.
+                // in this mode, a gas hold for cost - refund (if any) is placed
+                // on the payer's purse.
                 let amount = cost.saturating_sub(refund_amount);
-                let hold_request = BalanceHoldRequest::new(
+                let hold_request = BalanceHoldRequest::new_gas_hold(
                     state_root_hash,
                     protocol_version,
                     balance_identifier,
-                    BalanceHoldAddrTag::Gas,
                     amount,
                     block_time,
                     holds_epoch,
@@ -459,6 +497,23 @@ pub fn execute_finalized_block(
                     scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
                 artifact_builder
                     .with_balance_hold_result(&hold_result)
+                    .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
+            }
+            FeeHandling::Burn => {
+                // in this mode, the fee portion is burned.
+                let amount = cost.saturating_sub(refund_amount);
+                let handle_fee_request = HandleFeeRequest::new(
+                    native_runtime_config.clone(),
+                    state_root_hash,
+                    protocol_version,
+                    transaction_hash,
+                    HandleFeeMode::burn(balance_identifier, Some(amount)),
+                );
+                let handle_fee_result = scratch_state.handle_fee(handle_fee_request);
+                state_root_hash =
+                    scratch_state.commit(state_root_hash, handle_fee_result.effects().clone())?;
+                artifact_builder
+                    .with_handle_fee_result(&handle_fee_result)
                     .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
             }
             FeeHandling::PayToProposer => {
@@ -508,32 +563,52 @@ pub fn execute_finalized_block(
                     .with_handle_fee_result(&handle_fee_result)
                     .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
             }
-            FeeHandling::Burn => {
-                // in this mode, the fee portion is burned.
-                let amount = cost.saturating_sub(refund_amount);
-                let handle_fee_request = HandleFeeRequest::new(
-                    native_runtime_config.clone(),
-                    state_root_hash,
-                    protocol_version,
-                    transaction_hash,
-                    HandleFeeMode::burn(balance_identifier, Some(amount)),
-                );
-                let handle_fee_result = scratch_state.handle_fee(handle_fee_request);
-                state_root_hash =
-                    scratch_state.commit(state_root_hash, handle_fee_result.effects().clone())?;
-                artifact_builder
-                    .with_handle_fee_result(&handle_fee_result)
-                    .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
-            }
         }
 
-        if let Some(metrics) = metrics.as_ref() {
-            metrics
-                .commit_effects
-                .observe(start.elapsed().as_secs_f64());
+        // clear refund purse if it was set
+        if refund_purse_active {
+            // if refunds are turned on we initialize the refund purse to the initiator's main
+            // purse before doing any processing. NOTE: when executed, custom payment logic
+            // has the option to call set_refund_purse on the handle payment contract to set
+            // up a different refund purse, if desired.
+            let handle_refund_request = HandleRefundRequest::new(
+                native_runtime_config.clone(),
+                state_root_hash,
+                protocol_version,
+                transaction_hash,
+                HandleRefundMode::ClearRefundPurse,
+            );
+            let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
+            if let Err(root_not_found) =
+                artifact_builder.with_clear_refund_purse_result(&handle_refund_result)
+            {
+                if root_not_found {
+                    return Err(BlockExecutionError::RootNotFound(state_root_hash));
+                }
+                warn!(
+                    "{}",
+                    artifact_builder.error_message().unwrap_or(
+                        "unknown error encountered when attempting to clear refund purse"
+                            .to_string()
+                    )
+                );
+            }
+            state_root_hash =
+                scratch_state.commit(state_root_hash, handle_refund_result.effects().clone())?;
         }
+
         artifacts.push(artifact_builder.build());
     }
+
+    // transaction processing is finished
+    if let Some(metrics) = metrics.as_ref() {
+        metrics
+            .exec_block_tnx_processing
+            .observe(txn_processing_start.elapsed().as_secs_f64());
+    }
+
+    // post processing starts now
+    let post_processing_start = Instant::now();
 
     // calculate and store checksums for approvals and execution effects across the transactions in
     // the block we do this so that the full set of approvals and the full set of effect meta
@@ -564,12 +639,6 @@ pub fn execute_finalized_block(
             .map(|id| id.approvals_hash())
             .collect()
     };
-
-    // Update exec_block metric BEFORE determining per era things such as era rewards and step.
-    // the commit_step function handles the metrics for step
-    if let Some(metrics) = metrics.as_ref() {
-        metrics.exec_block.observe(start.elapsed().as_secs_f64());
-    }
 
     // Pay out  ̶b̶l̶o̶c̶k̶ e͇r͇a͇ rewards
     // NOTE: despite the name, these rewards are currently paid out per ERA not per BLOCK
@@ -625,10 +694,12 @@ pub fn execute_finalized_block(
     // if era report is some, this is a switch block. a series of end-of-era extra processing must
     // transpire before this block is entirely finished.
     let step_outcome = if let Some(era_report) = &executable_block.era_report {
+        // step processing starts now
+        let step_processing_start = Instant::now();
         let step_effects = match commit_step(
             native_runtime_config,
             &scratch_state,
-            metrics,
+            metrics.clone(),
             protocol_version,
             state_root_hash,
             era_report.clone(),
@@ -649,8 +720,6 @@ pub fn execute_finalized_block(
             }
         };
 
-        state_root_hash = data_access_layer.write_scratch_to_db(state_root_hash, scratch_state)?;
-
         let era_validators_req = EraValidatorsRequest::new(state_root_hash, protocol_version);
         let era_validators_result = data_access_layer.era_validators(era_validators_req);
 
@@ -670,14 +739,17 @@ pub fn execute_finalized_block(
             EraValidatorsResult::Success { era_validators } => era_validators,
         };
 
+        // step processing is finished
+        if let Some(metrics) = metrics.as_ref() {
+            metrics
+                .exec_block_step_processing
+                .observe(step_processing_start.elapsed().as_secs_f64());
+        }
         Some(StepOutcome {
             step_effects,
             upcoming_era_validators,
         })
     } else {
-        // Finally, the new state-root-hash from the cumulative changes to global state is
-        // returned when they are written to LMDB.
-        state_root_hash = data_access_layer.write_scratch_to_db(state_root_hash, scratch_state)?;
         None
     };
 
@@ -701,7 +773,7 @@ pub fn execute_finalized_block(
                 "commit prune: preparing prune config"
             );
             let request = PruneRequest::new(state_root_hash, keys_to_prune);
-            match data_access_layer.prune(request) {
+            match scratch_state.prune(request) {
                 PruneResult::RootNotFound => {
                     error!(
                         previous_block_height,
@@ -742,12 +814,17 @@ pub fn execute_finalized_block(
         }
     }
 
-    // Flush once, after all data mutation.
-    let flush_req = FlushRequest::new();
-    let flush_result = data_access_layer.flush(flush_req);
-    if let Err(gse) = flush_result.as_error() {
-        error!("failed to flush lmdb");
-        return Err(BlockExecutionError::Lmdb(gse));
+    {
+        // Finally, the new state-root-hash from the cumulative changes to global state is
+        // returned when they are written to LMDB.
+        state_root_hash = data_access_layer.write_scratch_to_db(state_root_hash, scratch_state)?;
+        // Flush once, after all data mutation.
+        let flush_req = FlushRequest::new();
+        let flush_result = data_access_layer.flush(flush_req);
+        if let Err(gse) = flush_result.as_error() {
+            error!("failed to flush lmdb");
+            return Err(BlockExecutionError::Lmdb(gse));
+        }
     }
 
     // the rest of this is post process, picking out data bits to return to caller
@@ -839,6 +916,16 @@ pub fn execute_finalized_block(
         txns_approvals_hashes,
         proof_of_checksum_registry,
     ));
+
+    // processing is finished now
+    if let Some(metrics) = metrics.as_ref() {
+        metrics
+            .exec_block_post_processing
+            .observe(post_processing_start.elapsed().as_secs_f64());
+        metrics
+            .exec_block_total
+            .observe(start.elapsed().as_secs_f64());
+    }
 
     Ok(BlockAndExecutionArtifacts {
         block,

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -94,6 +94,10 @@ impl ExecutionArtifactBuilder {
         }
     }
 
+    pub fn error_message(&self) -> Option<String> {
+        self.error_message.clone()
+    }
+
     pub fn consumed(&self) -> U512 {
         self.consumed.value()
     }
@@ -135,10 +139,25 @@ impl ExecutionArtifactBuilder {
             return Err(true);
         }
         self.with_appended_effects(handle_refund_result.effects());
-        if let (None, HandleRefundResult::Failure(err)) =
-            (&self.error_message, handle_refund_result)
+        if let (None, HandleRefundResult::Failure(_)) = (&self.error_message, handle_refund_result)
         {
-            self.error_message = Some(format!("{}", err));
+            self.error_message = handle_refund_result.error_message();
+            return Err(false);
+        }
+        Ok(self)
+    }
+
+    pub fn with_clear_refund_purse_result(
+        &mut self,
+        handle_refund_result: &HandleRefundResult,
+    ) -> Result<&mut Self, bool> {
+        if let HandleRefundResult::RootNotFound = handle_refund_result {
+            return Err(true);
+        }
+        self.with_appended_effects(handle_refund_result.effects());
+        if let (None, HandleRefundResult::Failure(_)) = (&self.error_message, handle_refund_result)
+        {
+            self.error_message = handle_refund_result.error_message();
             return Err(false);
         }
         Ok(self)
@@ -151,13 +170,9 @@ impl ExecutionArtifactBuilder {
         if let HandleRefundResult::RootNotFound = handle_refund_result {
             return Err(());
         }
-        if let (None, HandleRefundResult::Failure(err)) =
-            (&self.error_message, handle_refund_result)
+        if let (None, HandleRefundResult::Failure(_)) = (&self.error_message, handle_refund_result)
         {
-            self.error_message = Some(format!("{}", err));
-            // NOTE: if handle refund fails, we revert any prior effects.
-            // and only commit effects produced by refund payment (if any).
-            self.effects = handle_refund_result.effects();
+            self.error_message = handle_refund_result.error_message();
             return Ok(self);
         }
         self.with_appended_effects(handle_refund_result.effects());
@@ -173,9 +188,6 @@ impl ExecutionArtifactBuilder {
         }
         if let (None, HandleFeeResult::Failure(err)) = (&self.error_message, handle_fee_result) {
             self.error_message = Some(format!("{}", err));
-            // NOTE: if handle fee fails, we revert any prior effects.
-            // and only commit effects produced by handle fee (if any).
-            self.effects = handle_fee_result.effects();
             return Ok(self);
         }
         self.with_appended_effects(handle_fee_result.effects());
@@ -191,9 +203,6 @@ impl ExecutionArtifactBuilder {
         }
         if let (None, BalanceHoldResult::Failure(err)) = (&self.error_message, hold_result) {
             self.error_message = Some(format!("{}", err));
-            // NOTE: if holding balance fails, we revert any prior effects.
-            // and only commit effects produced by balance hold (if any).
-            self.effects = hold_result.effects();
             return Ok(self);
         }
         self.with_appended_effects(hold_result.effects());

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -22,7 +22,9 @@ use tokio::time;
 
 use casper_execution_engine::engine_state::MAX_PAYMENT_AMOUNT;
 use casper_storage::{
-    data_access_layer::{AddressableEntityResult, BalanceIdentifier, BalanceResult, QueryResult},
+    data_access_layer::{
+        AddressableEntityResult, BalanceIdentifier, BalanceResult, ProofsResult, QueryResult,
+    },
     tracking_copy::TrackingCopyError,
 };
 use casper_types::{
@@ -815,12 +817,15 @@ impl reactor::Reactor for Reactor {
                         if self.test_scenario == TestScenario::AccountWithUnknownBalance {
                             BalanceResult::RootNotFound
                         } else {
+                            let proofs_result = ProofsResult::Proofs {
+                                total_balance_proof: Box::new(proof),
+                                balance_holds: Default::default(),
+                            };
                             BalanceResult::Success {
                                 purse_addr,
                                 total_balance: Default::default(),
                                 available_balance: U512::from(motes),
-                                total_balance_proof: Box::new(proof),
-                                balance_holds: Default::default(),
+                                proofs_result,
                             }
                         };
                     responder.respond(balance_result).ignore()

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -2,7 +2,7 @@ use super::*;
 use casper_storage::data_access_layer::{ProofHandling, ProofsResult};
 use casper_types::BlockTime;
 
-use casper_types::execution::ExecutionResultV1;
+use casper_types::{bytesrepr::Bytes, execution::ExecutionResultV1, TransactionSessionKind};
 
 async fn transfer_to_account<A: Into<U512>>(
     fixture: &mut TestFixture,
@@ -35,6 +35,50 @@ async fn transfer_to_account<A: Into<U512>>(
         .await;
 
     info!("transfer_to_account finished run_until_executed_transaction");
+    let (_node_id, runner) = fixture.network.nodes().iter().next().unwrap();
+    let exec_info = runner
+        .main_reactor()
+        .storage()
+        .read_execution_info(txn_hash)
+        .expect("Expected transaction to be included in a block.");
+
+    (
+        txn_hash,
+        exec_info.block_height,
+        exec_info
+            .execution_result
+            .expect("Exec result should have been stored."),
+    )
+}
+
+async fn send_wasm_transaction(
+    fixture: &mut TestFixture,
+    from: &SecretKey,
+    pricing: PricingMode,
+) -> (TransactionHash, u64, ExecutionResult) {
+    let chain_name = fixture.chainspec.network_config.name.clone();
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_session(
+            TransactionSessionKind::Standard,
+            Bytes::from(vec![1]),
+            "call",
+        )
+        .with_chain_name(chain_name)
+        .with_pricing_mode(pricing)
+        .with_initiator_addr(PublicKey::from(from))
+        .build()
+        .unwrap(),
+    );
+
+    txn.sign(from);
+    let txn_hash = txn.hash();
+
+    fixture.inject_transaction(txn).await;
+    fixture
+        .run_until_executed_transaction(&txn_hash, TEN_SECS)
+        .await;
+
     let (_node_id, runner) = fixture.network.nodes().iter().next().unwrap();
     let exec_info = runner
         .main_reactor()
@@ -1005,4 +1049,336 @@ async fn fee_is_payed_to_proposer_no_refund() {
             .clone(),
         alice_expected_total_balance
     );
+}
+
+#[tokio::test]
+async fn native_operations_fees_are_not_refunded() {
+    const MIN_GAS_PRICE: u8 = 5;
+    const MAX_GAS_PRICE: u8 = MIN_GAS_PRICE;
+
+    let initial_stakes = InitialStakes::FromVec(vec![u128::MAX, 1]); // Node 0 is effectively guaranteed to be the proposer.
+
+    let config = ConfigsOverride::default()
+        .with_minimum_era_height(5) // make the era longer so that the transaction doesn't land in the switch block.
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::Refund {
+            refund_ratio: Ratio::new(1, 2),
+        })
+        .with_fee_handling(FeeHandling::PayToProposer)
+        .with_balance_hold_interval(TimeDiff::from_seconds(5))
+        .with_min_gas_price(MIN_GAS_PRICE)
+        .with_max_gas_price(MAX_GAS_PRICE);
+
+    let mut fixture = TestFixture::new(initial_stakes, Some(config)).await;
+
+    let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
+    let alice_public_key = PublicKey::from(&*alice_secret_key);
+    let bob_secret_key = Arc::clone(&fixture.node_contexts[1].secret_key);
+    let bob_public_key = PublicKey::from(&*bob_secret_key);
+    let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
+    let charlie_public_key = PublicKey::from(&*charlie_secret_key);
+
+    // Wait for all nodes to complete era 0.
+    fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
+
+    let bob_initial_balance = *get_balance(&mut fixture, &bob_public_key, None, true)
+        .total_balance()
+        .expect("Expected Bob to have a balance.");
+    let alice_initial_balance = *get_balance(&mut fixture, &alice_public_key, None, true)
+        .total_balance()
+        .expect("Expected Alice to have a balance.");
+
+    let transfer_amount = fixture
+        .chainspec
+        .transaction_config
+        .native_transfer_minimum_motes
+        + 100;
+
+    let (_txn_hash, block_height, exec_result) = transfer_to_account(
+        &mut fixture,
+        transfer_amount,
+        &bob_secret_key,
+        PublicKey::from(&*charlie_secret_key),
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+        None,
+    )
+    .await;
+
+    assert!(exec_result_is_success(&exec_result)); // transaction should have succeeded.
+
+    let expected_transfer_gas: u64 = fixture
+        .chainspec
+        .system_costs_config
+        .mint_costs()
+        .transfer
+        .into();
+    let expected_transfer_cost = expected_transfer_gas * MIN_GAS_PRICE as u64;
+    assert_exec_result_cost(
+        exec_result,
+        expected_transfer_cost.into(),
+        expected_transfer_gas.into(),
+    );
+
+    let bob_available_balance =
+        *get_balance(&mut fixture, &bob_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Bob to have a balance");
+    let bob_total_balance = *get_balance(&mut fixture, &bob_public_key, Some(block_height), true)
+        .total_balance()
+        .expect("Expected Bob to have a balance");
+
+    let alice_available_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Alice to have a balance");
+    let alice_total_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), true)
+            .total_balance()
+            .expect("Expected Alice to have a balance");
+
+    // Bob shouldn't get a refund since there is no refund for native transfers.
+    let bob_expected_total_balance = bob_initial_balance - transfer_amount - expected_transfer_cost;
+    let bob_expected_available_balance = bob_expected_total_balance;
+
+    // Alice should get the full fee since there is no refund for native transfers.
+    let alice_expected_total_balance = alice_initial_balance + expected_transfer_cost;
+    let alice_expected_available_balance = alice_expected_total_balance;
+
+    let charlie_balance =
+        *get_balance(&mut fixture, &charlie_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Charlie to have a balance");
+    assert_eq!(charlie_balance.clone(), transfer_amount.into());
+
+    assert_eq!(
+        bob_available_balance.clone(),
+        bob_expected_available_balance
+    );
+
+    assert_eq!(bob_total_balance.clone(), bob_expected_total_balance);
+
+    assert_eq!(
+        alice_available_balance.clone(),
+        alice_expected_available_balance
+    );
+
+    assert_eq!(alice_total_balance.clone(), alice_expected_total_balance);
+}
+
+#[tokio::test]
+async fn wasm_transaction_fees_are_refunded() {
+    const MIN_GAS_PRICE: u8 = 5;
+    const MAX_GAS_PRICE: u8 = MIN_GAS_PRICE;
+
+    let initial_stakes = InitialStakes::FromVec(vec![u128::MAX, 1]); // Node 0 is effectively guaranteed to be the proposer.
+
+    let refund_ratio = Ratio::new(1, 2);
+    let config = ConfigsOverride::default()
+        .with_minimum_era_height(5) // make the era longer so that the transaction doesn't land in the switch block.
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::Refund { refund_ratio })
+        .with_fee_handling(FeeHandling::PayToProposer)
+        .with_balance_hold_interval(TimeDiff::from_seconds(5))
+        .with_min_gas_price(MIN_GAS_PRICE)
+        .with_max_gas_price(MAX_GAS_PRICE);
+
+    let mut fixture = TestFixture::new(initial_stakes, Some(config)).await;
+
+    let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
+    let alice_public_key = PublicKey::from(&*alice_secret_key);
+    let bob_secret_key = Arc::clone(&fixture.node_contexts[1].secret_key);
+    let bob_public_key = PublicKey::from(&*bob_secret_key);
+
+    // Wait for all nodes to complete era 0.
+    fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
+
+    let bob_initial_balance = *get_balance(&mut fixture, &bob_public_key, None, true)
+        .total_balance()
+        .expect("Expected Bob to have a balance.");
+    let alice_initial_balance = *get_balance(&mut fixture, &alice_public_key, None, true)
+        .total_balance()
+        .expect("Expected Alice to have a balance.");
+
+    let (_txn_hash, block_height, exec_result) = send_wasm_transaction(
+        &mut fixture,
+        &bob_secret_key,
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+    )
+    .await;
+
+    assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
+
+    let expected_transaction_gas: u64 = fixture
+        .chainspec
+        .system_costs_config
+        .standard_transaction_limit();
+    let expected_transaction_cost = expected_transaction_gas * MIN_GAS_PRICE as u64;
+    assert_exec_result_cost(
+        exec_result,
+        expected_transaction_cost.into(),
+        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
+                      * invalid wasm. */
+    );
+
+    let bob_available_balance =
+        *get_balance(&mut fixture, &bob_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Bob to have a balance");
+    let bob_total_balance = *get_balance(&mut fixture, &bob_public_key, Some(block_height), true)
+        .total_balance()
+        .expect("Expected Bob to have a balance");
+
+    let alice_available_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Alice to have a balance");
+    let alice_total_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), true)
+            .total_balance()
+            .expect("Expected Alice to have a balance");
+
+    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed 0
+    // gas, the unspent gas is equal to the limit.
+    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
+        .to_integer()
+        .into();
+
+    let bob_expected_total_balance =
+        bob_initial_balance - expected_transaction_cost + refund_amount;
+    let bob_expected_available_balance = bob_expected_total_balance;
+
+    // Alice should get the non-refunded part of the fee since it's set to pay to proposer
+    let alice_expected_total_balance =
+        alice_initial_balance + expected_transaction_cost - refund_amount;
+    let alice_expected_available_balance = alice_expected_total_balance;
+
+    assert_eq!(
+        bob_available_balance.clone(),
+        bob_expected_available_balance
+    );
+
+    assert_eq!(bob_total_balance.clone(), bob_expected_total_balance);
+
+    assert_eq!(
+        alice_available_balance.clone(),
+        alice_expected_available_balance
+    );
+
+    assert_eq!(alice_total_balance.clone(), alice_expected_total_balance);
+}
+
+#[tokio::test]
+async fn wasm_transaction_refunds_are_burnt() {
+    const MIN_GAS_PRICE: u8 = 5;
+    const MAX_GAS_PRICE: u8 = MIN_GAS_PRICE;
+
+    let initial_stakes = InitialStakes::FromVec(vec![u128::MAX, 1]); // Node 0 is effectively guaranteed to be the proposer.
+
+    let refund_ratio = Ratio::new(1, 2);
+    let config = ConfigsOverride::default()
+        .with_minimum_era_height(5) // make the era longer so that the transaction doesn't land in the switch block.
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::Burn { refund_ratio })
+        .with_fee_handling(FeeHandling::PayToProposer)
+        .with_balance_hold_interval(TimeDiff::from_seconds(5))
+        .with_min_gas_price(MIN_GAS_PRICE)
+        .with_max_gas_price(MAX_GAS_PRICE);
+
+    let mut fixture = TestFixture::new(initial_stakes, Some(config)).await;
+
+    let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
+    let alice_public_key = PublicKey::from(&*alice_secret_key);
+    let bob_secret_key = Arc::clone(&fixture.node_contexts[1].secret_key);
+    let bob_public_key = PublicKey::from(&*bob_secret_key);
+
+    // Wait for all nodes to complete era 0.
+    fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
+
+    let bob_initial_balance = *get_balance(&mut fixture, &bob_public_key, None, true)
+        .total_balance()
+        .expect("Expected Bob to have a balance.");
+    let alice_initial_balance = *get_balance(&mut fixture, &alice_public_key, None, true)
+        .total_balance()
+        .expect("Expected Alice to have a balance.");
+    let initial_total_supply = get_total_supply(&mut fixture, None);
+
+    let (_txn_hash, block_height, exec_result) = send_wasm_transaction(
+        &mut fixture,
+        &bob_secret_key,
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+    )
+    .await;
+
+    assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
+    let expected_transaction_gas: u64 = fixture
+        .chainspec
+        .system_costs_config
+        .standard_transaction_limit();
+    let expected_transaction_cost = expected_transaction_gas * MIN_GAS_PRICE as u64;
+    assert_exec_result_cost(
+        exec_result,
+        expected_transaction_cost.into(),
+        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
+                      * invalid wasm. */
+    );
+
+    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed 0
+    // gas, the unspent gas is equal to the limit.
+    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
+        .to_integer()
+        .into();
+
+    // The refund should have been burnt. So expect the total supply should have been reduced by the
+    // refund amount that was burnt.
+    let total_supply_after_transaction = get_total_supply(&mut fixture, Some(block_height));
+    assert_eq!(
+        total_supply_after_transaction,
+        initial_total_supply - refund_amount
+    );
+
+    let bob_available_balance =
+        *get_balance(&mut fixture, &bob_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Bob to have a balance");
+    let bob_total_balance = *get_balance(&mut fixture, &bob_public_key, Some(block_height), true)
+        .total_balance()
+        .expect("Expected Bob to have a balance");
+
+    let alice_available_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), false)
+            .available_balance()
+            .expect("Expected Alice to have a balance");
+    let alice_total_balance =
+        *get_balance(&mut fixture, &alice_public_key, Some(block_height), true)
+            .total_balance()
+            .expect("Expected Alice to have a balance");
+
+    // Bob doesn't get a refund. The refund is burnt.
+    let bob_expected_total_balance = bob_initial_balance - expected_transaction_cost;
+    let bob_expected_available_balance = bob_expected_total_balance;
+
+    // Alice should get the non-refunded part of the fee since it's set to pay to proposer
+    let alice_expected_total_balance =
+        alice_initial_balance + expected_transaction_cost - refund_amount;
+    let alice_expected_available_balance = alice_expected_total_balance;
+
+    assert_eq!(
+        bob_available_balance.clone(),
+        bob_expected_available_balance
+    );
+
+    assert_eq!(bob_total_balance.clone(), bob_expected_total_balance);
+
+    assert_eq!(
+        alice_available_balance.clone(),
+        alice_expected_available_balance
+    );
+
+    assert_eq!(alice_total_balance.clone(), alice_expected_total_balance);
 }

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -32,9 +32,13 @@ mod trie;
 
 pub use addressable_entity::{AddressableEntityRequest, AddressableEntityResult};
 pub use auction::{AuctionMethod, BiddingRequest, BiddingResult};
-pub use balance::{BalanceIdentifier, BalanceRequest, BalanceResult};
+pub use balance::{
+    BalanceHolds, BalanceHoldsWithProof, BalanceIdentifier, BalanceRequest, BalanceResult,
+    ProofHandling, ProofsResult,
+};
 pub use balance_hold::{
-    BalanceHoldError, BalanceHoldRequest, BalanceHoldResult, InsufficientBalanceHandling,
+    BalanceHoldError, BalanceHoldKind, BalanceHoldMode, BalanceHoldRequest, BalanceHoldResult,
+    InsufficientBalanceHandling,
 };
 pub use bids::{BidsRequest, BidsResult};
 pub use block_rewards::{BlockRewardsError, BlockRewardsRequest, BlockRewardsResult};

--- a/storage/src/data_access_layer/balance.rs
+++ b/storage/src/data_access_layer/balance.rs
@@ -1,5 +1,4 @@
 //! Types for balance queries.
-use crate::data_access_layer::BalanceHoldRequest;
 use casper_types::{
     account::AccountHash,
     global_state::TrieMerkleProof,
@@ -11,6 +10,7 @@ use casper_types::{
     AccessRights, BlockTime, Digest, EntityAddr, HoldsEpoch, InitiatorAddr, Key, ProtocolVersion,
     PublicKey, StoredValue, URef, URefAddr, U512,
 };
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use tracing::error;
 
@@ -28,6 +28,16 @@ pub enum BalanceHandling {
     Total,
     /// Adjust for balance holds (if any).
     Available { holds_epoch: HoldsEpoch },
+}
+
+/// Merkle proof handling options.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum ProofHandling {
+    /// Do not attempt to provide proofs.
+    #[default]
+    NoProofs,
+    /// Provide proofs.
+    Proofs,
 }
 
 /// Represents a way to make a balance inquiry.
@@ -165,6 +175,7 @@ pub struct BalanceRequest {
     protocol_version: ProtocolVersion,
     identifier: BalanceIdentifier,
     balance_handling: BalanceHandling,
+    proof_handling: ProofHandling,
 }
 
 impl BalanceRequest {
@@ -174,12 +185,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         identifier: BalanceIdentifier,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier,
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -189,12 +202,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         purse_uref: URef,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier: BalanceIdentifier::Purse(purse_uref),
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -204,12 +219,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         public_key: PublicKey,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier: BalanceIdentifier::Public(public_key),
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -219,12 +236,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         account_hash: AccountHash,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier: BalanceIdentifier::Account(account_hash),
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -234,12 +253,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         entity_addr: EntityAddr,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier: BalanceIdentifier::Entity(entity_addr),
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -249,12 +270,14 @@ impl BalanceRequest {
         protocol_version: ProtocolVersion,
         balance_addr: URefAddr,
         balance_handling: BalanceHandling,
+        proof_handling: ProofHandling,
     ) -> Self {
         BalanceRequest {
             state_hash,
             protocol_version,
             identifier: BalanceIdentifier::Internal(balance_addr),
             balance_handling,
+            proof_handling,
         }
     }
 
@@ -277,28 +300,83 @@ impl BalanceRequest {
     pub fn balance_handling(&self) -> BalanceHandling {
         self.balance_handling
     }
-}
 
-impl From<BalanceHoldRequest> for BalanceRequest {
-    fn from(request: BalanceHoldRequest) -> Self {
-        let balance_handling = BalanceHandling::Available {
-            holds_epoch: request.holds_epoch(),
-        };
-        BalanceRequest::new(
-            request.state_hash(),
-            request.protocol_version(),
-            request.identifier().clone(),
-            balance_handling,
-        )
+    /// Returns proof handling.
+    pub fn proof_handling(&self) -> ProofHandling {
+        self.proof_handling
     }
 }
+
+/// Balance holds with Merkle proofs.
+pub type BalanceHolds = BTreeMap<BalanceHoldAddrTag, U512>;
 
 /// Balance holds with Merkle proofs.
 pub type BalanceHoldsWithProof =
     BTreeMap<BalanceHoldAddrTag, (U512, TrieMerkleProof<Key, StoredValue>)>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProofsResult {
+    NotRequested {
+        /// Any time-relevant active holds on the balance, without proofs.
+        balance_holds: BTreeMap<BlockTime, BalanceHolds>,
+    },
+    Proofs {
+        /// A proof that the given value is present in the Merkle trie.
+        total_balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+        /// Any time-relevant active holds on the balance, with proofs..
+        balance_holds: BTreeMap<BlockTime, BalanceHoldsWithProof>,
+    },
+}
+
+impl ProofsResult {
+    /// Returns total balance proof, if any.
+    pub fn total_balance_proof(&self) -> Option<&TrieMerkleProof<Key, StoredValue>> {
+        match self {
+            ProofsResult::NotRequested { .. } => None,
+            ProofsResult::Proofs {
+                total_balance_proof,
+                ..
+            } => Some(total_balance_proof),
+        }
+    }
+
+    /// Returns balance holds, if any.
+    pub fn balance_holds_with_proof(&self) -> Option<&BTreeMap<BlockTime, BalanceHoldsWithProof>> {
+        match self {
+            ProofsResult::NotRequested { .. } => None,
+            ProofsResult::Proofs { balance_holds, .. } => Some(balance_holds),
+        }
+    }
+
+    /// Returns balance holds, if any.
+    pub fn balance_holds(&self) -> Option<&BTreeMap<BlockTime, BalanceHolds>> {
+        match self {
+            ProofsResult::NotRequested { balance_holds } => Some(balance_holds),
+            ProofsResult::Proofs { .. } => None,
+        }
+    }
+
+    /// Returns the total held amount.
+    pub fn total_held_amount(&self) -> U512 {
+        match self {
+            ProofsResult::NotRequested { balance_holds } => balance_holds
+                .values()
+                .flat_map(|holds| holds.values().copied())
+                .collect_vec()
+                .into_iter()
+                .sum(),
+            ProofsResult::Proofs { balance_holds, .. } => balance_holds
+                .values()
+                .flat_map(|holds| holds.values().map(|(v, _)| *v))
+                .collect_vec()
+                .into_iter()
+                .sum(),
+        }
+    }
+}
+
 /// Result enum that represents all possible outcomes of a balance request.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BalanceResult {
     /// Returned if a passed state root hash is not found.
     RootNotFound,
@@ -310,33 +388,43 @@ pub enum BalanceResult {
         total_balance: U512,
         /// The available balance (total balance - sum of all active holds).
         available_balance: U512,
-        /// A proof that the given value is present in the Merkle trie.
-        total_balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
-        /// Any time-relevant active holds on the balance.
-        balance_holds: BTreeMap<BlockTime, BalanceHoldsWithProof>,
+        /// Proofs result.
+        proofs_result: ProofsResult,
     },
     Failure(TrackingCopyError),
 }
 
 impl BalanceResult {
-    /// Returns the amount of motes for a [`BalanceResult::Success`] variant.
-    pub fn motes(&self) -> Option<&U512> {
+    /// Returns the purse address for a [`BalanceResult::Success`] variant.
+    pub fn purse_addr(&self) -> Option<URefAddr> {
         match self {
-            BalanceResult::Success {
-                available_balance: motes,
-                ..
-            } => Some(motes),
+            BalanceResult::Success { purse_addr, .. } => Some(*purse_addr),
             _ => None,
         }
     }
 
-    /// Returns the Merkle proof for a given [`BalanceResult::Success`] variant.
-    pub fn proof(self) -> Option<TrieMerkleProof<Key, StoredValue>> {
+    /// Returns the total balance for a [`BalanceResult::Success`] variant.
+    pub fn total_balance(&self) -> Option<&U512> {
+        match self {
+            BalanceResult::Success { total_balance, .. } => Some(total_balance),
+            _ => None,
+        }
+    }
+
+    /// Returns the available balance for a [`BalanceResult::Success`] variant.
+    pub fn available_balance(&self) -> Option<&U512> {
         match self {
             BalanceResult::Success {
-                total_balance_proof: proof,
-                ..
-            } => Some(*proof),
+                available_balance, ..
+            } => Some(available_balance),
+            _ => None,
+        }
+    }
+
+    /// Returns the Merkle proofs, if any.
+    pub fn proofs_result(self) -> Option<ProofsResult> {
+        match self {
+            BalanceResult::Success { proofs_result, .. } => Some(proofs_result),
             _ => None,
         }
     }

--- a/storage/src/data_access_layer/balance_hold.rs
+++ b/storage/src/data_access_layer/balance_hold.rs
@@ -1,10 +1,54 @@
 use crate::{data_access_layer::BalanceIdentifier, tracking_copy::TrackingCopyError};
 use casper_types::{
-    execution::Effects, system::mint::BalanceHoldAddrTag, BlockTime, Digest, HoldsEpoch,
-    ProtocolVersion, U512,
+    account::AccountHash,
+    execution::Effects,
+    system::mint::{BalanceHoldAddr, BalanceHoldAddrTag},
+    BlockTime, Digest, HoldsEpoch, ProtocolVersion, U512,
 };
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum BalanceHoldKind {
+    #[default]
+    All,
+    Tag(BalanceHoldAddrTag),
+}
+
+impl BalanceHoldKind {
+    /// Returns true of imputed tag applies to instance.
+    pub fn matches(&self, balance_hold_addr_tag: BalanceHoldAddrTag) -> bool {
+        match self {
+            BalanceHoldKind::All => true,
+            BalanceHoldKind::Tag(tag) => tag == &balance_hold_addr_tag,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BalanceHoldMode {
+    Hold {
+        identifier: BalanceIdentifier,
+        hold_amount: U512,
+        holds_epoch: HoldsEpoch,
+        insufficient_handling: InsufficientBalanceHandling,
+    },
+    Clear {
+        identifier: BalanceIdentifier,
+        holds_epoch: HoldsEpoch,
+    },
+}
+
+impl Default for BalanceHoldMode {
+    fn default() -> Self {
+        BalanceHoldMode::Hold {
+            insufficient_handling: InsufficientBalanceHandling::HoldRemaining,
+            hold_amount: U512::zero(),
+            identifier: BalanceIdentifier::Account(AccountHash::default()),
+            holds_epoch: HoldsEpoch::default(),
+        }
+    }
+}
 
 /// How to handle available balance is less than hold amount?
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
@@ -20,36 +64,85 @@ pub enum InsufficientBalanceHandling {
 pub struct BalanceHoldRequest {
     state_hash: Digest,
     protocol_version: ProtocolVersion,
-    identifier: BalanceIdentifier,
-    hold_kind: BalanceHoldAddrTag,
-    hold_amount: U512,
     block_time: BlockTime,
-    holds_epoch: HoldsEpoch,
-    insufficient_handling: InsufficientBalanceHandling,
+    hold_kind: BalanceHoldKind,
+    hold_mode: BalanceHoldMode,
 }
 
 impl BalanceHoldRequest {
-    /// Creates a new [`BalanceHoldRequest`].
+    /// Creates a new [`BalanceHoldRequest`] for adding a gas balance hold.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_gas_hold(
         state_hash: Digest,
         protocol_version: ProtocolVersion,
         identifier: BalanceIdentifier,
-        hold_kind: BalanceHoldAddrTag,
         hold_amount: U512,
         block_time: BlockTime,
         holds_epoch: HoldsEpoch,
         insufficient_handling: InsufficientBalanceHandling,
     ) -> Self {
+        let hold_kind = BalanceHoldKind::Tag(BalanceHoldAddrTag::Gas);
+        let hold_mode = BalanceHoldMode::Hold {
+            identifier,
+            hold_amount,
+            holds_epoch,
+            insufficient_handling,
+        };
         BalanceHoldRequest {
             state_hash,
             protocol_version,
-            identifier,
-            hold_kind,
-            hold_amount,
             block_time,
+            hold_kind,
+            hold_mode,
+        }
+    }
+
+    /// Creates a new [`BalanceHoldRequest`] for adding a processing balance hold.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_processing_hold(
+        state_hash: Digest,
+        protocol_version: ProtocolVersion,
+        identifier: BalanceIdentifier,
+        hold_amount: U512,
+        block_time: BlockTime,
+        holds_epoch: HoldsEpoch,
+        insufficient_handling: InsufficientBalanceHandling,
+    ) -> Self {
+        let hold_kind = BalanceHoldKind::Tag(BalanceHoldAddrTag::Processing);
+        let hold_mode = BalanceHoldMode::Hold {
+            identifier,
+            hold_amount,
             holds_epoch,
             insufficient_handling,
+        };
+        BalanceHoldRequest {
+            state_hash,
+            protocol_version,
+            block_time,
+            hold_kind,
+            hold_mode,
+        }
+    }
+
+    /// Creates a new [`BalanceHoldRequest`] for clearing holds.
+    pub fn new_clear(
+        state_hash: Digest,
+        protocol_version: ProtocolVersion,
+        block_time: BlockTime,
+        hold_kind: BalanceHoldKind,
+        identifier: BalanceIdentifier,
+        holds_epoch: HoldsEpoch,
+    ) -> Self {
+        let hold_mode = BalanceHoldMode::Clear {
+            identifier,
+            holds_epoch,
+        };
+        BalanceHoldRequest {
+            state_hash,
+            protocol_version,
+            block_time,
+            hold_kind,
+            hold_mode,
         }
     }
 
@@ -63,34 +156,19 @@ impl BalanceHoldRequest {
         self.protocol_version
     }
 
-    /// Returns the identifier [`BalanceIdentifier`].
-    pub fn identifier(&self) -> &BalanceIdentifier {
-        &self.identifier
-    }
-
-    /// Returns the hold kind.
-    pub fn hold_kind(&self) -> BalanceHoldAddrTag {
-        self.hold_kind
-    }
-
-    /// Returns the hold amount.
-    pub fn hold_amount(&self) -> U512 {
-        self.hold_amount
-    }
-
-    /// Returns the block time.
+    /// Block time.
     pub fn block_time(&self) -> BlockTime {
         self.block_time
     }
 
-    /// Returns the holds epoch.
-    pub fn holds_epoch(&self) -> HoldsEpoch {
-        self.holds_epoch
+    /// Balance hold kind.
+    pub fn balance_hold_kind(&self) -> BalanceHoldKind {
+        self.hold_kind
     }
 
-    /// Returns insufficient balance handling option.
-    pub fn insufficient_handling(&self) -> InsufficientBalanceHandling {
-        self.insufficient_handling
+    /// Balance hold mode.
+    pub fn balance_hold_mode(&self) -> BalanceHoldMode {
+        self.hold_mode.clone()
     }
 }
 
@@ -100,6 +178,7 @@ impl BalanceHoldRequest {
 pub enum BalanceHoldError {
     TrackingCopy(TrackingCopyError),
     InsufficientBalance { remaining_balance: U512 },
+    UnexpectedWildcardVariant, // programmer error
 }
 
 impl Display for BalanceHoldError {
@@ -110,6 +189,12 @@ impl Display for BalanceHoldError {
             }
             BalanceHoldError::InsufficientBalance { remaining_balance } => {
                 write!(f, "InsufficientBalance: {}", remaining_balance)
+            }
+            BalanceHoldError::UnexpectedWildcardVariant => {
+                write!(
+                    f,
+                    "UnexpectedWildcardVariant: unsupported use of BalanceHoldKind::All"
+                )
             }
         }
     }
@@ -122,6 +207,8 @@ pub enum BalanceHoldResult {
     RootNotFound,
     /// Balance hold successfully placed.
     Success {
+        /// Hold addresses, if any.
+        holds: Option<Vec<BalanceHoldAddr>>,
         /// Purse total balance.
         total_balance: Box<U512>,
         /// Purse available balance after hold placed.
@@ -139,6 +226,7 @@ pub enum BalanceHoldResult {
 
 impl BalanceHoldResult {
     pub fn success(
+        holds: Option<Vec<BalanceHoldAddr>>,
         total_balance: U512,
         available_balance: U512,
         hold: U512,
@@ -146,11 +234,54 @@ impl BalanceHoldResult {
         effects: Effects,
     ) -> Self {
         BalanceHoldResult::Success {
+            holds,
             total_balance: Box::new(total_balance),
             available_balance: Box::new(available_balance),
             hold: Box::new(hold),
             held: Box::new(held),
             effects: Box::new(effects),
+        }
+    }
+
+    /// Returns the total balance for a [`BalanceHoldResult::Success`] variant.
+    pub fn total_balance(&self) -> Option<&U512> {
+        match self {
+            BalanceHoldResult::Success { total_balance, .. } => Some(total_balance),
+            _ => None,
+        }
+    }
+
+    /// Returns the available balance for a [`BalanceHoldResult::Success`] variant.
+    pub fn available_balance(&self) -> Option<&U512> {
+        match self {
+            BalanceHoldResult::Success {
+                available_balance, ..
+            } => Some(available_balance),
+            _ => None,
+        }
+    }
+
+    /// Returns the held amount for a [`BalanceHoldResult::Success`] variant.
+    pub fn held(&self) -> Option<&U512> {
+        match self {
+            BalanceHoldResult::Success { held, .. } => Some(held),
+            _ => None,
+        }
+    }
+
+    /// Hold address, if any.
+    pub fn holds(&self) -> Option<Vec<BalanceHoldAddr>> {
+        match self {
+            BalanceHoldResult::RootNotFound | BalanceHoldResult::Failure(_) => None,
+            BalanceHoldResult::Success { holds, .. } => holds.clone(),
+        }
+    }
+
+    /// Does this result contain any hold addresses?
+    pub fn has_holds(&self) -> bool {
+        match self.holds() {
+            None => false,
+            Some(holds) => !holds.is_empty(),
         }
     }
 

--- a/storage/src/data_access_layer/handle_fee.rs
+++ b/storage/src/data_access_layer/handle_fee.rs
@@ -19,10 +19,6 @@ pub enum HandleFeeMode {
         source: BalanceIdentifier,
         amount: Option<U512>,
     },
-    ClearHolds {
-        source: BalanceIdentifier,
-        holds_epoch: HoldsEpoch,
-    },
 }
 
 impl HandleFeeMode {
@@ -48,14 +44,6 @@ impl HandleFeeMode {
     /// burned leaving a remaining balance.
     pub fn burn(source: BalanceIdentifier, amount: Option<U512>) -> Self {
         HandleFeeMode::Burn { source, amount }
-    }
-
-    /// Clear expired holds against source's balance per epoch.
-    pub fn clear_holds(source: BalanceIdentifier, holds_epoch: HoldsEpoch) -> Self {
-        HandleFeeMode::ClearHolds {
-            source,
-            holds_epoch,
-        }
     }
 }
 

--- a/storage/src/global_state/error.rs
+++ b/storage/src/global_state/error.rs
@@ -37,6 +37,10 @@ pub enum Error {
     /// Failed to prune listed keys.
     #[error("Pruning attempt failed.")]
     FailedToPrune(Vec<Key>),
+
+    /// Cannot provide proofs over working state in a cache (programmer error).
+    #[error("Attempt to generate proofs using non-empty cache.")]
+    CannotProvideProofsOverCachedData,
 }
 
 impl<T> From<sync::PoisonError<T>> for Error {

--- a/storage/src/global_state/state/lmdb.rs
+++ b/storage/src/global_state/state/lmdb.rs
@@ -402,6 +402,7 @@ impl ScratchProvider for DataAccessLayer<LmdbGlobalState> {
                 Ok(TriePruneResult::Pruned(new_root)) => {
                     state_root_hash = new_root;
                 }
+                Ok(TriePruneResult::MissingKey) => continue, // idempotent outcome
                 Ok(other) => return other,
                 Err(gse) => return TriePruneResult::Failure(gse),
             }

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -33,11 +33,12 @@ use casper_types::{
         AUCTION, MINT,
     },
     Account, AddressableEntity, CLValue, Digest, EntityAddr, HoldsEpoch, Key, KeyTag, Phase,
-    PublicKey, RuntimeArgs, StoredValue, U512,
+    PublicKey, RuntimeArgs, StoredValue, TimeDiff, U512,
 };
 
 #[cfg(test)]
 pub use self::lmdb::make_temporary_global_state;
+
 use crate::{
     data_access_layer::{
         auction::{AuctionMethodRet, BiddingRequest, BiddingResult},
@@ -47,13 +48,14 @@ use crate::{
         mint::{TransferRequest, TransferRequestArgs, TransferResult},
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityRequest, AddressableEntityResult, AuctionMethod, BalanceHoldError,
-        BalanceHoldRequest, BalanceHoldResult, BalanceIdentifier, BalanceRequest, BalanceResult,
-        BidsRequest, BidsResult, BlockRewardsError, BlockRewardsRequest, BlockRewardsResult,
-        EraValidatorsRequest, ExecutionResultsChecksumRequest, ExecutionResultsChecksumResult,
-        FeeError, FeeRequest, FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult,
-        HandleRefundMode, HandleRefundRequest, HandleRefundResult, InsufficientBalanceHandling,
-        ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest, PruneResult, PutTrieRequest,
-        PutTrieResult, QueryRequest, QueryResult, RoundSeigniorageRateRequest,
+        BalanceHoldKind, BalanceHoldMode, BalanceHoldRequest, BalanceHoldResult, BalanceIdentifier,
+        BalanceRequest, BalanceResult, BidsRequest, BidsResult, BlockRewardsError,
+        BlockRewardsRequest, BlockRewardsResult, EraValidatorsRequest,
+        ExecutionResultsChecksumRequest, ExecutionResultsChecksumResult, FeeError, FeeRequest,
+        FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult, HandleRefundMode,
+        HandleRefundRequest, HandleRefundResult, InsufficientBalanceHandling, ProofHandling,
+        ProofsResult, ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest, PruneResult,
+        PutTrieRequest, PutTrieResult, QueryRequest, QueryResult, RoundSeigniorageRateRequest,
         RoundSeigniorageRateResult, StepError, StepRequest, StepResult,
         SystemEntityRegistryPayload, SystemEntityRegistryRequest, SystemEntityRegistryResult,
         SystemEntityRegistrySelector, TotalSupplyRequest, TotalSupplyResult, TrieRequest,
@@ -556,48 +558,109 @@ pub trait StateProvider {
             Err(tce) => return BalanceResult::Failure(tce),
         };
 
-        let (total_balance, total_balance_proof) =
-            match tc.get_total_balance_with_proof(purse_balance_key) {
-                Err(tce) => return BalanceResult::Failure(tce),
-                Ok((balance, proof)) => (balance, Box::new(proof)),
-            };
+        let proof_handling = request.proof_handling();
 
-        let balance_holds = match request.balance_handling() {
-            BalanceHandling::Total => BTreeMap::new(),
-            BalanceHandling::Available { holds_epoch } => {
-                match tc.get_balance_holds_with_proof(purse_addr, holds_epoch) {
+        match proof_handling {
+            ProofHandling::NoProofs => {
+                let balance_key = Key::Balance(purse_addr);
+                let total_balance = match tc.read(&balance_key) {
+                    Ok(Some(StoredValue::CLValue(cl_value))) => match cl_value.into_t::<U512>() {
+                        Ok(val) => val,
+                        Err(cve) => return BalanceResult::Failure(TrackingCopyError::CLValue(cve)),
+                    },
+                    Ok(Some(_)) => {
+                        return BalanceResult::Failure(
+                            TrackingCopyError::UnexpectedStoredValueVariant,
+                        )
+                    }
+                    Ok(None) => {
+                        return BalanceResult::Failure(TrackingCopyError::KeyNotFound(balance_key))
+                    }
                     Err(tce) => return BalanceResult::Failure(tce),
-                    Ok(holds) => holds,
+                };
+                let balance_holds = match request.balance_handling() {
+                    BalanceHandling::Total => BTreeMap::new(),
+                    BalanceHandling::Available { holds_epoch } => {
+                        match tc.get_balance_holds(purse_addr, holds_epoch) {
+                            Err(tce) => return BalanceResult::Failure(tce),
+                            Ok(holds) => holds,
+                        }
+                    }
+                };
+
+                let available_balance = if balance_holds.is_empty() {
+                    total_balance
+                } else {
+                    let held = balance_holds
+                        .values()
+                        .flat_map(|holds| holds.values().copied())
+                        .collect_vec()
+                        .into_iter()
+                        .sum();
+                    debug_assert!(
+                        total_balance >= held,
+                        "it should not be possible to hold more than the total available"
+                    );
+                    if held > total_balance {
+                        error!(%held, %total_balance, "holds somehow exceed total balance, which should never occur.");
+                    }
+                    total_balance.checked_sub(held).unwrap_or(U512::zero())
+                };
+
+                BalanceResult::Success {
+                    purse_addr,
+                    total_balance,
+                    available_balance,
+                    proofs_result: ProofsResult::NotRequested { balance_holds },
                 }
             }
-        };
+            ProofHandling::Proofs => {
+                let (total_balance, total_balance_proof) =
+                    match tc.get_total_balance_with_proof(purse_balance_key) {
+                        Err(tce) => return BalanceResult::Failure(tce),
+                        Ok((balance, proof)) => (balance, Box::new(proof)),
+                    };
 
-        let available_balance = if balance_holds.is_empty() {
-            total_balance
-        } else {
-            let held = balance_holds
-                .values()
-                .flat_map(|holds| holds.values().map(|(v, _)| *v))
-                .collect_vec()
-                .into_iter()
-                .sum();
+                let balance_holds_with_proofs = match request.balance_handling() {
+                    BalanceHandling::Total => BTreeMap::new(),
+                    BalanceHandling::Available { holds_epoch } => {
+                        match tc.get_balance_holds_with_proof(purse_addr, holds_epoch) {
+                            Err(tce) => return BalanceResult::Failure(tce),
+                            Ok(holds) => holds,
+                        }
+                    }
+                };
 
-            debug_assert!(
-                total_balance >= held,
-                "it should not be possible to hold more than the total available"
-            );
-            if held > total_balance {
-                error!(%held, %total_balance, "holds somehow exceed total balance, which should never occur.");
+                let available_balance = if balance_holds_with_proofs.is_empty() {
+                    total_balance
+                } else {
+                    let held = balance_holds_with_proofs
+                        .values()
+                        .flat_map(|holds| holds.values().map(|(v, _)| *v))
+                        .collect_vec()
+                        .into_iter()
+                        .sum();
+
+                    debug_assert!(
+                        total_balance >= held,
+                        "it should not be possible to hold more than the total available"
+                    );
+                    if held > total_balance {
+                        error!(%held, %total_balance, "holds somehow exceed total balance, which should never occur.");
+                    }
+                    total_balance.checked_sub(held).unwrap_or(U512::zero())
+                };
+
+                BalanceResult::Success {
+                    purse_addr,
+                    total_balance,
+                    available_balance,
+                    proofs_result: ProofsResult::Proofs {
+                        total_balance_proof,
+                        balance_holds: balance_holds_with_proofs,
+                    },
+                }
             }
-            total_balance.checked_sub(held).unwrap_or(U512::zero())
-        };
-
-        BalanceResult::Success {
-            purse_addr,
-            total_balance,
-            total_balance_proof,
-            available_balance,
-            balance_holds,
         }
     }
 
@@ -612,75 +675,170 @@ pub trait StateProvider {
                 ))
             }
         };
-        let balance_request = request.clone().into();
-        let balance_result = self.balance(balance_request);
-        let (total_balance, remaining_balance, purse_addr) = match balance_result {
-            BalanceResult::RootNotFound => return BalanceHoldResult::RootNotFound,
-            BalanceResult::Failure(tce) => {
-                return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce))
+        let hold_mode = request.balance_hold_mode();
+        match hold_mode {
+            BalanceHoldMode::Hold {
+                identifier,
+                hold_amount,
+                holds_epoch,
+                insufficient_handling,
+            } => {
+                let tag = match request.balance_hold_kind() {
+                    BalanceHoldKind::All => {
+                        return BalanceHoldResult::Failure(
+                            BalanceHoldError::UnexpectedWildcardVariant,
+                        )
+                    }
+                    BalanceHoldKind::Tag(tag) => tag,
+                };
+                let balance_request = BalanceRequest::new(
+                    request.state_hash(),
+                    request.protocol_version(),
+                    identifier,
+                    BalanceHandling::Available { holds_epoch },
+                    ProofHandling::NoProofs,
+                );
+                let balance_result = self.balance(balance_request);
+                let (total_balance, remaining_balance, purse_addr) = match balance_result {
+                    BalanceResult::RootNotFound => return BalanceHoldResult::RootNotFound,
+                    BalanceResult::Failure(tce) => {
+                        return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce))
+                    }
+                    BalanceResult::Success {
+                        total_balance,
+                        available_balance,
+                        purse_addr,
+                        ..
+                    } => (total_balance, available_balance, purse_addr),
+                };
+
+                let held_amount = {
+                    if remaining_balance >= hold_amount {
+                        // the purse has sufficient balance to fully cover the hold
+                        hold_amount
+                    } else if insufficient_handling == InsufficientBalanceHandling::Noop {
+                        // the purse has insufficient balance and the insufficient
+                        // balance handling mode is noop, so get out
+                        return BalanceHoldResult::Failure(BalanceHoldError::InsufficientBalance {
+                            remaining_balance,
+                        });
+                    } else {
+                        // currently this is always the default HoldRemaining variant.
+                        // the purse holder has insufficient balance to cover the hold,
+                        // but the system will put a hold on whatever balance remains.
+                        // this is basically punitive to block an edge case resource consumption
+                        // attack whereby a malicious purse holder drains a balance to not-zero
+                        // but not-enough-to-cover-holds and then spams a bunch of transactions
+                        // knowing that they will fail due to insufficient funds, but only
+                        // after making the system do the work of processing the balance
+                        // check without penalty to themselves.
+                        remaining_balance
+                    }
+                };
+                let cl_value = match CLValue::from_t(held_amount) {
+                    Ok(cl_value) => cl_value,
+                    Err(cve) => {
+                        return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(
+                            TrackingCopyError::CLValue(cve),
+                        ))
+                    }
+                };
+
+                let block_time = request.block_time();
+                let balance_hold_addr = match tag {
+                    BalanceHoldAddrTag::Gas => BalanceHoldAddr::Gas {
+                        purse_addr,
+                        block_time,
+                    },
+                    BalanceHoldAddrTag::Processing => BalanceHoldAddr::Processing {
+                        purse_addr,
+                        block_time,
+                    },
+                };
+
+                let hold_key = Key::BalanceHold(balance_hold_addr);
+                tc.write(hold_key, StoredValue::CLValue(cl_value));
+                let holds = vec![balance_hold_addr];
+
+                let available_balance = remaining_balance.saturating_sub(held_amount);
+                let effects = tc.effects();
+                BalanceHoldResult::success(
+                    Some(holds),
+                    total_balance,
+                    available_balance,
+                    hold_amount,
+                    held_amount,
+                    effects,
+                )
             }
-            BalanceResult::Success {
-                total_balance,
-                available_balance,
-                purse_addr,
-                ..
-            } => (total_balance, available_balance, purse_addr),
-        };
+            BalanceHoldMode::Clear {
+                identifier,
+                holds_epoch,
+            } => {
+                let purse_addr = match identifier.purse_uref(&mut tc, request.protocol_version()) {
+                    Ok(source_purse) => source_purse.addr(),
+                    Err(tce) => {
+                        return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce))
+                    }
+                };
 
-        let held_amount = {
-            if remaining_balance >= request.hold_amount() {
-                // the purse has sufficient balance to fully cover the hold
-                request.hold_amount()
-            } else if request.insufficient_handling() == InsufficientBalanceHandling::Noop {
-                // the purse has insufficient balance but the holding mode is noop, so get out
-                return BalanceHoldResult::Failure(BalanceHoldError::InsufficientBalance {
-                    remaining_balance,
-                });
-            } else {
-                // currently this is always the default HoldRemaining variant.
-                // the purse holder has insufficient balance to cover the hold,
-                // but the system will put a hold on whatever balance remains.
-                // this is basically punitive to block an edge case resource consumption
-                // attack whereby a malicious purse holder drains a balance to not-zero
-                // but not-enough-to-cover-holds and then spams a bunch of transactions
-                // knowing that they will fail due to insufficient funds, but only
-                // after making the system do the work of processing the balance
-                // check without penalty to themselves.
-                remaining_balance
+                {
+                    // clear holds
+                    let bid_kind = request.balance_hold_kind();
+                    let mut filter = vec![];
+                    let tag = BalanceHoldAddrTag::Processing;
+                    if bid_kind.matches(tag) {
+                        filter.push((
+                            BalanceHoldAddrTag::Processing,
+                            HoldsEpoch::from_block_time(request.block_time(), TimeDiff::ZERO),
+                        ));
+                    }
+                    let tag = BalanceHoldAddrTag::Gas;
+                    if bid_kind.matches(tag) {
+                        filter.push((tag, holds_epoch));
+                    }
+                    if let Err(tce) = tc.clear_expired_balance_holds(purse_addr, filter) {
+                        return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce));
+                    }
+                }
+
+                // get updated balance
+                let balance_result = self.balance(BalanceRequest::new(
+                    request.state_hash(),
+                    request.protocol_version(),
+                    identifier,
+                    BalanceHandling::Available { holds_epoch },
+                    ProofHandling::NoProofs,
+                ));
+                let (total_balance, available_balance) = match balance_result {
+                    BalanceResult::RootNotFound => return BalanceHoldResult::RootNotFound,
+                    BalanceResult::Failure(tce) => {
+                        return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce))
+                    }
+                    BalanceResult::Success {
+                        total_balance,
+                        available_balance,
+                        ..
+                    } => (total_balance, available_balance),
+                };
+                // note that hold & held in this context does not refer to remaining holds,
+                // but rather to the requested hold amount and the resulting held amount for
+                // this execution. as calls to this variant clears holds and does not create
+                // new holds, hold & held are zero and no new hold address exists.
+                let new_hold_addr = None;
+                let hold = U512::zero();
+                let held = U512::zero();
+                let effects = tc.effects();
+                BalanceHoldResult::success(
+                    new_hold_addr,
+                    total_balance,
+                    available_balance,
+                    hold,
+                    held,
+                    effects,
+                )
             }
-        };
-
-        let cl_value = match CLValue::from_t(held_amount) {
-            Ok(cl_value) => cl_value,
-            Err(cve) => {
-                return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(
-                    TrackingCopyError::CLValue(cve),
-                ))
-            }
-        };
-
-        let balance_hold_addr = match request.hold_kind() {
-            BalanceHoldAddrTag::Gas => BalanceHoldAddr::Gas {
-                purse_addr,
-                block_time: request.block_time(),
-            },
-        };
-
-        tc.write(
-            Key::BalanceHold(balance_hold_addr),
-            StoredValue::CLValue(cl_value),
-        );
-
-        let available_balance = remaining_balance.saturating_sub(held_amount);
-        let effects = tc.effects();
-
-        BalanceHoldResult::success(
-            total_balance,
-            available_balance,
-            request.hold_amount(),
-            held_amount,
-            effects,
-        )
+        }
     }
 
     /// Get the requested era validators.
@@ -925,7 +1083,7 @@ pub trait StateProvider {
             protocol_version,
             Id::Transaction(transaction_hash),
             Rc::clone(&tc),
-            Phase::FinalizePayment,
+            refund_mode.phase(),
         ) {
             Ok(rt) => rt,
             Err(tce) => {
@@ -934,15 +1092,47 @@ pub trait StateProvider {
         };
 
         let result = match refund_mode {
+            HandleRefundMode::RefundAmount {
+                limit,
+                cost,
+                gas_price,
+                consumed,
+                ratio,
+                source,
+            } => {
+                let source_purse = match source.purse_uref(&mut tc.borrow_mut(), protocol_version) {
+                    Ok(value) => value,
+                    Err(tce) => return HandleRefundResult::Failure(tce),
+                };
+                let (numer, denom) = ratio.into();
+                let ratio = Ratio::new_raw(U512::from(numer), U512::from(denom));
+                let refund_amount = match runtime.calculate_overpayment_and_fee(
+                    limit,
+                    gas_price,
+                    cost,
+                    consumed,
+                    source_purse,
+                    HoldsEpoch::NOT_APPLICABLE,
+                    ratio,
+                ) {
+                    Ok((refund, _)) => Some(refund),
+                    Err(hpe) => {
+                        return HandleRefundResult::Failure(TrackingCopyError::SystemContract(
+                            system::Error::HandlePayment(hpe),
+                        ));
+                    }
+                };
+                Ok(refund_amount)
+            }
             HandleRefundMode::Refund {
                 initiator_addr,
                 limit,
                 cost,
                 gas_price,
                 consumed,
+                ratio,
                 source,
                 target,
-                ratio,
             } => {
                 let source_purse = match source.purse_uref(&mut tc.borrow_mut(), protocol_version) {
                     Ok(value) => value,
@@ -982,7 +1172,7 @@ pub trait StateProvider {
                     )
                     .map_err(|_| Error::Transfer)
                 {
-                    Ok(_) => Ok(refund_amount),
+                    Ok(_) => Ok(Some(refund_amount)),
                     Err(err) => Err(err),
                 }
             }
@@ -1009,14 +1199,14 @@ pub trait StateProvider {
                     HoldsEpoch::NOT_APPLICABLE,
                     ratio,
                 ) {
-                    Ok((refund, _)) => refund,
+                    Ok((amount, _)) => Some(amount),
                     Err(hpe) => {
                         return HandleRefundResult::Failure(TrackingCopyError::SystemContract(
                             system::Error::HandlePayment(hpe),
                         ));
                     }
                 };
-                match runtime.burn(source_purse, Some(burn_amount)) {
+                match runtime.burn(source_purse, burn_amount) {
                     Ok(_) => Ok(burn_amount),
                     Err(err) => Err(err),
                 }
@@ -1027,19 +1217,20 @@ pub trait StateProvider {
                     Err(tce) => return HandleRefundResult::Failure(tce),
                 };
                 match runtime.set_refund_purse(target_purse) {
-                    Ok(_) => Ok(U512::zero()),
+                    Ok(_) => Ok(None),
                     Err(err) => Err(err),
                 }
             }
+            HandleRefundMode::ClearRefundPurse => match runtime.clear_refund_purse() {
+                Ok(_) => Ok(None),
+                Err(err) => Err(err),
+            },
         };
 
         let effects = tc.borrow_mut().effects();
 
         match result {
-            Ok(amount) => HandleRefundResult::Success {
-                effects,
-                amount: Some(amount),
-            },
+            Ok(amount) => HandleRefundResult::Success { effects, amount },
             Err(hpe) => HandleRefundResult::Failure(TrackingCopyError::SystemContract(
                 system::Error::HandlePayment(hpe),
             )),
@@ -1110,24 +1301,6 @@ pub trait StateProvider {
                     Err(tce) => return HandleFeeResult::Failure(tce),
                 };
                 runtime.burn(source_purse, amount)
-            }
-            HandleFeeMode::ClearHolds {
-                source,
-                holds_epoch,
-            } => {
-                let tag = BalanceHoldAddrTag::Gas;
-                let source_purse = match source.purse_uref(&mut tc.borrow_mut(), protocol_version) {
-                    Ok(value) => value,
-                    Err(tce) => return HandleFeeResult::Failure(tce),
-                };
-                if let Err(tce) = tc.borrow_mut().clear_expired_balance_holds(
-                    source_purse.addr(),
-                    tag,
-                    holds_epoch,
-                ) {
-                    return HandleFeeResult::Failure(tce);
-                }
-                Ok(())
             }
         };
 
@@ -1554,7 +1727,6 @@ pub trait StateProvider {
                 }
             }
         }
-
         let transfer_args = match runtime_args_builder.build(
             &entity,
             entity_named_keys,

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -231,7 +231,10 @@ impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
         for result in keys_iter {
             match result {
                 Ok(key) => {
-                    if !cache.pruned.contains(&key) {
+                    // If the key is pruned then we won't return it. If the key is already cached,
+                    // then it would have been picked up by the code above so we don't add it again
+                    // to avoid duplicates.
+                    if !cache.pruned.contains(&key) && !cache.cached_values.contains_key(&key) {
                         ret.push(key);
                     }
                 }

--- a/storage/src/system/auction/auction_native.rs
+++ b/storage/src/system/auction/auction_native.rs
@@ -366,7 +366,6 @@ where
         match <Self as Mint>::reduce_total_supply(self, amount) {
             Ok(ret) => Ok(ret),
             Err(err) => {
-                println!("{}", err);
                 error!("{}", err);
                 Err(Error::MintReduceTotalSupply)
             }

--- a/storage/src/system/genesis.rs
+++ b/storage/src/system/genesis.rs
@@ -269,13 +269,11 @@ where
             named_keys.insert(handle_payment::PAYMENT_PURSE_KEY.to_string(), named_key);
 
             // This purse is used only in FeeHandling::Accumulate setting.
-            let rewards_purse_uref = self.create_purse(U512::zero())?;
-
+            let accumulation_purse_uref = self.create_purse(U512::zero())?;
             named_keys.insert(
                 ACCUMULATION_PURSE_KEY.to_string(),
-                rewards_purse_uref.into(),
+                accumulation_purse_uref.into(),
             );
-
             named_keys
         };
 

--- a/storage/src/system/handle_payment.rs
+++ b/storage/src/system/handle_payment.rs
@@ -4,7 +4,10 @@ pub mod mint_provider;
 pub mod runtime_provider;
 pub mod storage_provider;
 
-use casper_types::{system::handle_payment::Error, AccessRights, HoldsEpoch, URef, U512};
+use casper_types::{
+    system::handle_payment::{Error, REFUND_PURSE_KEY},
+    AccessRights, HoldsEpoch, URef, U512,
+};
 use num_rational::Ratio;
 
 use crate::system::handle_payment::{
@@ -23,6 +26,9 @@ pub trait HandlePayment: MintProvider + RuntimeProvider + StorageProvider + Size
 
     /// Set refund purse.
     fn set_refund_purse(&mut self, purse: URef) -> Result<(), Error> {
+        // make sure the passed uref is actually a purse...
+        // if it has a balance it is a purse and if not it isn't
+        let _balance = self.available_balance(purse, HoldsEpoch::NOT_APPLICABLE)?;
         internal::set_refund(self, purse)
     }
 
@@ -33,6 +39,11 @@ pub trait HandlePayment: MintProvider + RuntimeProvider + StorageProvider + Size
         // supposed to have it.
         let maybe_purse = internal::get_refund_purse(self)?;
         Ok(maybe_purse.map(|p| p.remove_access_rights()))
+    }
+
+    /// Clear refund purse.
+    fn clear_refund_purse(&mut self) -> Result<(), Error> {
+        self.remove_key(REFUND_PURSE_KEY)
     }
 
     /// Calculate overpayment and fees (if any) for payment finalization.

--- a/storage/src/system/handle_payment/handle_payment_native.rs
+++ b/storage/src/system/handle_payment/handle_payment_native.rs
@@ -166,10 +166,8 @@ where
         self.tracking_copy()
             .borrow_mut()
             .write(key, named_key_value);
-        match self.named_keys_mut().insert(name, key) {
-            Some(_) => Ok(()),
-            None => Err(Error::PutKey),
-        }
+        self.named_keys_mut().insert(name, key);
+        Ok(())
     }
 
     fn remove_key(&mut self, name: &str) -> Result<(), Error> {

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -169,15 +169,29 @@ where
         Ok(())
     }
 
+    fn total_balance(&mut self, purse: URef) -> Result<U512, Error> {
+        match self
+            .tracking_copy()
+            .borrow_mut()
+            .get_total_balance(purse.into())
+        {
+            Ok(total) => Ok(total.value()),
+            Err(err) => {
+                error!(?err, "mint native total_balance");
+                Err(Error::Storage)
+            }
+        }
+    }
+
     fn available_balance(
         &mut self,
-        uref: URef,
+        purse: URef,
         holds_epoch: HoldsEpoch,
     ) -> Result<Option<U512>, Error> {
         match self
             .tracking_copy()
             .borrow_mut()
-            .get_available_balance(Key::Balance(uref.addr()), holds_epoch)
+            .get_available_balance(Key::Balance(purse.addr()), holds_epoch)
         {
             Ok(motes) => Ok(Some(motes.value())),
             Err(_) => Err(Error::Storage),

--- a/storage/src/system/mint/storage_provider.rs
+++ b/storage/src/system/mint/storage_provider.rs
@@ -18,6 +18,9 @@ pub trait StorageProvider {
     /// Add data to a [`URef`].
     fn add<T: CLTyped + ToBytes>(&mut self, uref: URef, value: T) -> Result<(), Error>;
 
+    /// Read total balance.
+    fn total_balance(&mut self, uref: URef) -> Result<U512, Error>;
+
     /// Read balance.
     fn available_balance(
         &mut self,

--- a/types/src/chainspec/refund_handling.rs
+++ b/types/src/chainspec/refund_handling.rs
@@ -45,6 +45,16 @@ impl RefundHandling {
             RefundHandling::Burn { .. } => false,
         }
     }
+
+    /// Returns refund ratio.
+    pub fn refund_ratio(&self) -> Ratio<u64> {
+        match self {
+            RefundHandling::Refund { refund_ratio } | RefundHandling::Burn { refund_ratio } => {
+                *refund_ratio
+            }
+            RefundHandling::NoRefund => Ratio::zero(),
+        }
+    }
 }
 
 impl ToBytes for RefundHandling {

--- a/types/src/system/mint/balance_hold.rs
+++ b/types/src/system/mint/balance_hold.rs
@@ -24,11 +24,11 @@ use crate::{
     bytesrepr::{FromBytes, ToBytes},
     checksummed_hex,
     key::FromStrError,
-    system::auction::Error,
     BlockTime, Key, KeyTag, Timestamp, URefAddr, BLOCKTIME_SERIALIZED_LENGTH, UREF_ADDR_LENGTH,
 };
 
 const GAS_TAG: u8 = 0;
+const PROCESSING_TAG: u8 = 1;
 
 /// Serialization tag for BalanceHold variants.
 #[derive(
@@ -41,6 +41,8 @@ pub enum BalanceHoldAddrTag {
     #[default]
     /// Tag for gas variant.
     Gas = GAS_TAG,
+    /// Tag for processing variant.
+    Processing = PROCESSING_TAG,
 }
 
 impl BalanceHoldAddrTag {
@@ -52,6 +54,9 @@ impl BalanceHoldAddrTag {
         // TryFrom requires std, so doing this instead.
         if value == GAS_TAG {
             return Some(BalanceHoldAddrTag::Gas);
+        }
+        if value == PROCESSING_TAG {
+            return Some(BalanceHoldAddrTag::Processing);
         }
         None
     }
@@ -70,6 +75,7 @@ impl Display for BalanceHoldAddrTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let tag = match self {
             BalanceHoldAddrTag::Gas => GAS_TAG,
+            BalanceHoldAddrTag::Processing => PROCESSING_TAG,
         };
         write!(f, "{}", base16::encode_lower(&[tag]))
     }
@@ -87,7 +93,13 @@ pub enum BalanceHoldAddr {
         /// The block time this hold was placed.
         block_time: BlockTime,
     },
-    // future balance hold variants might allow punitive lockup or settlement periods, etc
+    /// Processing variant
+    Processing {
+        /// The address of the purse this hold is on.
+        purse_addr: URefAddr,
+        /// The block time this hold was placed.
+        block_time: BlockTime,
+    },
 }
 
 impl BalanceHoldAddr {
@@ -104,10 +116,29 @@ impl BalanceHoldAddr {
         }
     }
 
+    /// Creates a Processing variant instance of [`BalanceHoldAddr`].
+    pub(crate) const fn new_processing(
+        purse_addr: URefAddr,
+        block_time: BlockTime,
+    ) -> BalanceHoldAddr {
+        BalanceHoldAddr::Processing {
+            purse_addr,
+            block_time,
+        }
+    }
+
     /// How long is be the serialized value for this instance.
     pub fn serialized_length(&self) -> usize {
         match self {
             BalanceHoldAddr::Gas {
+                purse_addr,
+                block_time,
+            } => {
+                BalanceHoldAddrTag::BALANCE_HOLD_ADDR_TAG_LENGTH
+                    + ToBytes::serialized_length(purse_addr)
+                    + ToBytes::serialized_length(block_time)
+            }
+            BalanceHoldAddr::Processing {
                 purse_addr,
                 block_time,
             } => {
@@ -122,6 +153,7 @@ impl BalanceHoldAddr {
     pub fn tag(&self) -> BalanceHoldAddrTag {
         match self {
             BalanceHoldAddr::Gas { .. } => BalanceHoldAddrTag::Gas,
+            BalanceHoldAddr::Processing { .. } => BalanceHoldAddrTag::Processing,
         }
     }
 
@@ -129,6 +161,7 @@ impl BalanceHoldAddr {
     pub fn purse_addr(&self) -> URefAddr {
         match self {
             BalanceHoldAddr::Gas { purse_addr, .. } => *purse_addr,
+            BalanceHoldAddr::Processing { purse_addr, .. } => *purse_addr,
         }
     }
 
@@ -136,17 +169,8 @@ impl BalanceHoldAddr {
     pub fn block_time(&self) -> BlockTime {
         match self {
             BalanceHoldAddr::Gas { block_time, .. } => *block_time,
+            BalanceHoldAddr::Processing { block_time, .. } => *block_time,
         }
-    }
-
-    /// Returns the common prefix of all holds on the cited purse.
-    pub fn balance_hold_prefix(&self) -> Result<Vec<u8>, Error> {
-        let purse_addr_bytes = self.purse_addr().to_bytes()?;
-        let size = 1 + purse_addr_bytes.len();
-        let mut ret = Vec::with_capacity(size);
-        ret.push(KeyTag::BalanceHold as u8);
-        ret.extend(purse_addr_bytes);
-        Ok(ret)
     }
 
     /// To formatted string.
@@ -161,12 +185,18 @@ impl BalanceHoldAddr {
                     // also, put the tag in readable form
                     base16::encode_lower(&GAS_TAG.to_le_bytes()),
                     base16::encode_lower(purse_addr),
-                    // TODO: we could conceivably stringify the u64 millis instead of bytes-ing
-                    // which would allow visual / human determination of the timestamp
-                    // but on the other hand, how many humans casually do from UNIX EPOCH
-                    // time calculation with their eyeballs? Something to discuss prior to
-                    // shipping.
-                    // BlockTime.value as string instead
+                    base16::encode_lower(&block_time.value().to_le_bytes())
+                )
+            }
+            BalanceHoldAddr::Processing {
+                purse_addr,
+                block_time,
+            } => {
+                format!(
+                    "{}{}{}",
+                    // also, put the tag in readable form
+                    base16::encode_lower(&PROCESSING_TAG.to_le_bytes()),
+                    base16::encode_lower(purse_addr),
                     base16::encode_lower(&block_time.value().to_le_bytes())
                 )
             }
@@ -206,6 +236,14 @@ impl BalanceHoldAddr {
             let block_time_millis = <u64>::from_le_bytes(block_time_bytes);
             let block_time = BlockTime::new(block_time_millis);
             Ok(BalanceHoldAddr::new_gas(uref_addr, block_time))
+        } else if tag == BalanceHoldAddrTag::Processing {
+            let block_time_bytes =
+                <[u8; BLOCKTIME_SERIALIZED_LENGTH]>::try_from(bytes[33..].as_ref())
+                    .map_err(|err| FromStrError::BalanceHold(err.to_string()))?;
+
+            let block_time_millis = <u64>::from_le_bytes(block_time_bytes);
+            let block_time = BlockTime::new(block_time_millis);
+            Ok(BalanceHoldAddr::new_processing(uref_addr, block_time))
         } else {
             Err(FromStrError::BalanceHold("invalid tag".to_string()))
         }
@@ -218,6 +256,10 @@ impl ToBytes for BalanceHoldAddr {
         buffer.push(self.tag() as u8);
         match self {
             BalanceHoldAddr::Gas {
+                purse_addr,
+                block_time,
+            }
+            | BalanceHoldAddr::Processing {
                 purse_addr,
                 block_time,
             } => {
@@ -242,6 +284,17 @@ impl FromBytes for BalanceHoldAddr {
                 let (block_time, rem) = BlockTime::from_bytes(rem)?;
                 Ok((
                     BalanceHoldAddr::Gas {
+                        purse_addr,
+                        block_time,
+                    },
+                    rem,
+                ))
+            }
+            tag if tag == BalanceHoldAddrTag::Processing as u8 => {
+                let (purse_addr, rem) = URefAddr::from_bytes(remainder)?;
+                let (block_time, rem) = BlockTime::from_bytes(rem)?;
+                Ok((
+                    BalanceHoldAddr::Processing {
                         purse_addr,
                         block_time,
                     },
@@ -288,6 +341,10 @@ impl Display for BalanceHoldAddr {
             BalanceHoldAddr::Gas {
                 purse_addr,
                 block_time,
+            }
+            | BalanceHoldAddr::Processing {
+                purse_addr,
+                block_time,
             } => {
                 write!(
                     f,
@@ -313,6 +370,15 @@ impl Debug for BalanceHoldAddr {
                 base16::encode_lower(&purse_addr),
                 Timestamp::from(block_time.value())
             ),
+            BalanceHoldAddr::Processing {
+                purse_addr,
+                block_time,
+            } => write!(
+                f,
+                "BidAddr::Processing({}, {})",
+                base16::encode_lower(&purse_addr),
+                Timestamp::from(block_time.value())
+            ),
         }
     }
 }
@@ -331,6 +397,9 @@ mod tests {
     #[test]
     fn serialization_roundtrip() {
         let addr = BalanceHoldAddr::new_gas([1; 32], BlockTime::new(Timestamp::now().millis()));
+        bytesrepr::test_serialization_roundtrip(&addr);
+        let addr =
+            BalanceHoldAddr::new_processing([1; 32], BlockTime::new(Timestamp::now().millis()));
         bytesrepr::test_serialization_roundtrip(&addr);
     }
 }

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -265,6 +265,9 @@ impl FromStr for TimeDiff {
 }
 
 impl TimeDiff {
+    /// Zero diff.
+    pub const ZERO: TimeDiff = TimeDiff(0);
+
     /// Returns the time difference as the number of milliseconds since the Unix epoch
     pub const fn millis(&self) -> u64 {
         self.0

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -524,7 +524,6 @@ fn should_change_one_validator() {
     update.assert_written_balance(account3.main_purse(), validator3_new_balance.as_u64());
 
     let bids = reader.get_bids();
-    println!("should_change_one_validator {:?}", bids);
 
     let old_bid3 = bids.validator_bid(&validator3).expect("should have bid");
     let bid_purse = *old_bid3.bonding_purse();


### PR DESCRIPTION
This PR addresses issues with the read with proof and keys with prefix behaviors of the scratch db. It is not possible to generate proofs over the uncommitted cache of the scratch db, which complicated various usages but particularly balance checks. The existing implementation was instead delegating to the underlying db and producing a seemingly successful result but it was incorrect unless called before any data was added to the cache. This resulted in intermittent and subtle inconsistencies that were difficult to diagnose. The logic will now return an error if called when the cache is not empty. 

Additionally, the keys by prefix checking logic was not considering the scratch db's cache. There was also a lesser issue whereby things inserted into scratch db's cache but pruned before flushing the cache would cause a MissingKey error when writing the cache back to the underlying db. 

Additional support has been added to request and process balance related data with or without proofs depending upon the calling logics situation. Logic that is not using scratch db can ask for either with or without proofs, logic using scratch db can only ask for without proofs.

Pending holds have also been added as part of this PR to allow deferment of payment to the end of processing for standard pay without risk of double spend, which is a useful optimization. Custom payment must still pay everything up front, however. If refund's are enabled in the chainspec and custom payment is provided, the refund purse is explicitly initialized before processing the transaction and explicitly cleared at the end of processing the transaction, which is an improvement over the 1.0 equivalent.

Finally more granular metrics have been added to the execute finalized block flow.
