### PR TITLE
Chainspec cost update

### DIFF
--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -253,7 +253,7 @@ print = { cost = 20_000, arguments = [0, 4_600] }
 provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
 put_key = { cost = 100_000_000, arguments = [0, 120_000, 0, 120_000] }
 read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
-read_value = { cost = 6_000, arguments = [0, 0, 0] }
+read_value = { cost = 60_000, arguments = [0, 120_000, 0] }
 dictionary_get = { cost = 5_500, arguments = [0, 590, 0] }
 remove_associated_key = { cost = 4_200, arguments = [0, 0] }
 remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }


### PR DESCRIPTION
There is a mismatch causing a test failure with the current cost tables (defaults in the Rust sources don't match the production `chainspec.toml`). This is an attempt to fix this.

May or may not be cherry-picked onto `dev` instead.
