### PR TITLE
Leverage validator matrix to restore incoming request prioritization

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -199,7 +199,11 @@ pub(crate) trait PortBoundComponent<REv>: InitializedComponent<REv> {
     ) -> Result<Effects<Self::ComponentEvent>, Self::Error>;
 }
 
+/// A component that is subscribing to changes in the validator set.
 pub(crate) trait ValidatorBoundComponent<REv>: Component<REv> {
+    /// Notifies the component that the validator set has changed.
+    ///
+    /// This function is guaranteed to be called whenever a new era begins.
     fn handle_validators(
         &mut self,
         effect_builder: EffectBuilder<REv>,

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -294,6 +294,7 @@ where
             handshake_configuration,
             keylog,
             self.net_metrics.clone(),
+            self.validator_matrix.clone(),
         );
 
         let conman = ConMan::new(

--- a/node/src/components/network/conman.rs
+++ b/node/src/components/network/conman.rs
@@ -246,6 +246,7 @@ pub(crate) trait ProtocolHandler: Send + Sync {
     async fn handle_incoming_request(
         &self,
         peer: NodeId,
+        consensus_key: Option<&PublicKey>,
         request: IncomingRequest,
     ) -> Result<(), String>;
 }
@@ -1032,7 +1033,7 @@ impl ActiveRoute {
             if let Err(err) = self
                 .ctx
                 .protocol_handler
-                .handle_incoming_request(self.peer_id, request)
+                .handle_incoming_request(self.peer_id, self.consensus_key.as_deref(), request)
                 .await
             {
                 // The handler return an error, exit and close connection.

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -238,8 +238,8 @@ impl ValidatorMatrix {
 
     /// Determine if the active validator is in a current or upcoming set of active validators.
     ///
-    /// This function may produce false positives, as it works backwards from the highest known era.
-    /// Depending on the current network state, this may be an upcoming or active era, at least the
+    /// This function may produce false positives, as it works backwards from the highest known
+    /// era. Depending on the current network state, this may be an upcoming or active era, the
     /// previous era validators may be positively identified by this function.
     #[inline]
     pub(crate) fn is_active_or_upcoming_validator(&self, public_key: &PublicKey) -> bool {

--- a/node/src/types/validator_matrix.rs
+++ b/node/src/types/validator_matrix.rs
@@ -236,6 +236,20 @@ impl ValidatorMatrix {
         }
     }
 
+    /// Determine if the active validator is in a current or upcoming set of active validators.
+    ///
+    /// This function may produce false positives, as it works backwards from the highest known era.
+    /// Depending on the current network state, this may be an upcoming or active era, at least the
+    /// previous era validators may be positively identified by this function.
+    #[inline]
+    pub(crate) fn is_active_or_upcoming_validator(&self, public_key: &PublicKey) -> bool {
+        self.read_inner()
+            .values()
+            .rev()
+            .take(self.auction_delay as usize + 1)
+            .any(|validator_weights| validator_weights.is_validator(public_key))
+    }
+
     /// Returns the public keys of all validators in a given era.
     ///
     /// Will return `None` if the era is not known.


### PR DESCRIPTION
This re-adds a feature that missing in the interim in the 1.6 branch, specifically prioritization of incoming messages based on the validator status of a peer.