### PR TITLE
Makefile: fix rust smart contracts build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,12 @@ CONTRACT_TARGET_DIR_AS    = target_as
 
 build-contract-rs/%:
 	cd smart_contracts/contracts && RUSTFLAGS=$(RUSTC_FLAGS) $(CARGO) build --verbose --release $(filter-out --release, $(CARGO_FLAGS)) --package $*
-	wasm-strip $(CONTRACT_TARGET_DIR)/$(subst -,_,$*).wasm 2>/dev/null | true
 
 .PHONY: build-all-contracts-rs
-build-all-contracts-rs:
-	cd smart_contracts/contracts && \
-	RUSTFLAGS=$(RUSTC_FLAGS) $(CARGO) build --verbose --release $(filter-out --release, $(CARGO_FLAGS)) $(patsubst %, -p %, $(ALL_CONTRACTS))
+build-all-contracts-rs: $(patsubst %, build-contract-rs/%, $(ALL_CONTRACTS))
 
 .PHONY: build-client-contracts-rs
-build-client-contracts-rs:
-	cd smart_contracts/contracts && \
-	$(CARGO) build --release $(filter-out --release, $(CARGO_FLAGS)) $(patsubst %, -p %, $(CLIENT_CONTRACTS))
+build-client-contracts-rs: $(patsubst %, build-contract-rs/%, $(CLIENT_CONTRACTS))
 
 strip-contract/%:
 	wasm-strip $(CONTRACT_TARGET_DIR)/$(subst -,_,$*).wasm 2>/dev/null | true

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -926,7 +926,7 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 92_116_501_090;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 88_784_431_090;
     const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_243_280;
     const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_813_900;
     const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_679_000;


### PR DESCRIPTION
The contracts built using `make build-contracts-rs` were not working on
a production network because they included the `casper_print` FFI. This
happened because of the way `cargo` optimizes builds of dependencies.
Because one of the contracts had a requirement for the `test-support`
feature, all contracts were built with the `casper-contract` that had
that feature enabled (and which enabled the `casper_print` FFI).
Now we build each smart contract idependently to make sure that never
happens.