### PR TITLE
Changed the format used to deserialize StoredValue::ContractPackage variant because it broke backwards compatibility.

### DIFF
--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -4236,11 +4236,10 @@
         },
         "versions": {
           "description": "All versions (enabled & disabled)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Array_of_ContractVersionAndHash"
-            }
-          ]
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContractVersion"
+          }
         },
         "disabled_versions": {
           "description": "Disabled versions",
@@ -4268,34 +4267,32 @@
         }
       }
     },
-    "Array_of_ContractVersionAndHash": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ContractVersionAndHash"
-      }
-    },
-    "ContractVersionAndHash": {
+    "ContractVersion": {
       "type": "object",
       "required": [
-        "contract_entity_hash",
-        "contract_version_key"
+        "contract_hash",
+        "contract_version",
+        "protocol_version_major"
       ],
       "properties": {
-        "contract_version_key": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/ContractVersionKey"
-            }
-          ]
+        "protocol_version_major": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
         },
-        "contract_entity_hash": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/ContractHash"
-            }
-          ]
+        "contract_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "contract_hash": {
+          "$ref": "#/definitions/ContractHash"
         }
       }
+    },
+    "ContractHash": {
+      "description": "The hash address of the contract",
+      "type": "string"
     },
     "ContractVersionKey": {
       "description": "Major element of `ProtocolVersion` combined with `ContractVersion`.",
@@ -4314,10 +4311,6 @@
       ],
       "maxItems": 2,
       "minItems": 2
-    },
-    "ContractHash": {
-      "description": "The hash address of the contract",
-      "type": "string"
     },
     "Array_of_NamedUserGroup": {
       "type": "array",

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -19,9 +19,6 @@ use datasize::DataSize;
 #[cfg(feature = "json-schema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "json-schema")]
-use serde_map_to_array::KeyValueJsonSchema;
-use serde_map_to_array::{BTreeMapToArray, KeyValueLabels};
 
 use crate::{
     account,
@@ -662,7 +659,6 @@ pub struct ContractPackage {
     /// Key used to add or disable versions
     access_key: URef,
     /// All versions (enabled & disabled)
-    #[serde(with = "BTreeMapToArray::<ContractVersionKey, ContractHash, ContractVersionLabels>")]
     versions: ContractVersions,
     /// Disabled versions
     disabled_versions: DisabledVersions,
@@ -732,6 +728,11 @@ impl ContractPackage {
     /// Returns mut reference to all of this contract's disabled versions.
     pub fn disabled_versions_mut(&mut self) -> &mut DisabledVersions {
         &mut self.disabled_versions
+    }
+
+    /// Returns lock_status of the contract package.
+    pub fn lock_status(&self) -> ContractPackageStatus {
+        self.lock_status.clone()
     }
 
     #[cfg(test)]
@@ -856,18 +857,6 @@ impl From<ContractPackage> for Package {
             lock_status,
         )
     }
-}
-
-struct ContractVersionLabels;
-
-impl KeyValueLabels for ContractVersionLabels {
-    const KEY: &'static str = "contract_version_key";
-    const VALUE: &'static str = "contract_entity_hash";
-}
-
-#[cfg(feature = "json-schema")]
-impl KeyValueJsonSchema for ContractVersionLabels {
-    const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("ContractVersionAndHash");
 }
 
 /// Methods and type signatures supported by a contract.

--- a/types/src/serde_helpers.rs
+++ b/types/src/serde_helpers.rs
@@ -126,6 +126,7 @@ pub mod contract_package {
 
     #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
     #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+    #[cfg_attr(feature = "json-schema", schemars(rename = "ContractVersion"))]
     pub struct HumanReadableContractVersion {
         protocol_version_major: ProtocolVersionMajor,
         contract_version: ContractVersion,
@@ -135,6 +136,7 @@ pub mod contract_package {
     /// Helper struct for deserializing/serializing `ContractPackage` from and to JSON.
     #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
     #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+    #[cfg_attr(feature = "json-schema", schemars(rename = "ContractPackage"))]
     pub struct HumanReadableContractPackage {
         access_key: URef,
         versions: Vec<HumanReadableContractVersion>,

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -63,7 +63,7 @@ enum Tag {
 #[cfg_attr(
     feature = "json-schema",
     derive(JsonSchema),
-    schemars(with = "serde_helpers::BinarySerHelper")
+    schemars(with = "serde_helpers::HumanReadableSerHelper")
 )]
 pub enum StoredValue {
     /// A CLValue.

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -947,8 +947,44 @@ mod tests {
     use crate::{bytesrepr, gens, StoredValue};
     use proptest::proptest;
     use serde_json::Value;
-    const STORED_VALUE_CONTRACT_PACKAGE_RAW: &str = "{\"ContractPackage\":{\"access_key\":\"uref-024d69e50a458f337817d3d11ba95bdbdd6258ba8f2dc980644c9efdbd64945d-007\",\"versions\":[{\"protocol_version_major\":1,\"contract_version\":1,\"contract_hash\":\"contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfd\"}],\"disabled_versions\":[],\"groups\":[],\"lock_status\":\"Unlocked\"}}";
-    const INCORRECT_STORED_VALUE_CONTRACT_PACKAGE_RAW: &str = "{\"ContractPackage\":{\"access_key\":\"uref-024d69e50a458f337817d3d11ba95bdbdd6258ba8f2dc980644c9efdbd64945d-007\",\"versions\":[{\"protocol_version_major\":1,\"contract_version\":1,\"contract_hash\":\"contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfd\"}, {\"protocol_version_major\":1,\"contract_version\":1,\"contract_hash\":\"contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfe\"}],\"disabled_versions\":[],\"groups\":[],\"lock_status\":\"Unlocked\"}}";
+    const STORED_VALUE_CONTRACT_PACKAGE_RAW: &str = r#"
+    {
+        "ContractPackage": {
+          "access_key": "uref-024d69e50a458f337817d3d11ba95bdbdd6258ba8f2dc980644c9efdbd64945d-007",
+          "versions": [
+            {
+              "protocol_version_major": 1,
+              "contract_version": 1,
+              "contract_hash": "contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfd"
+            }
+          ],
+          "disabled_versions": [],
+          "groups": [],
+          "lock_status": "Unlocked"
+        }
+    }"#;
+    const INCORRECT_STORED_VALUE_CONTRACT_PACKAGE_RAW: &str = r#"
+    {
+        "ContractPackage": {
+          "access_key": "uref-024d69e50a458f337817d3d11ba95bdbdd6258ba8f2dc980644c9efdbd64945d-007",
+          "versions": [
+            {
+              "protocol_version_major": 1,
+              "contract_version": 1,
+              "contract_hash": "contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfd"
+            },
+            {
+              "protocol_version_major": 1,
+              "contract_version": 1,
+              "contract_hash": "contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfe"
+            }
+          ],
+          "disabled_versions": [],
+          "groups": [],
+          "lock_status": "Unlocked"
+        }
+    }
+    "#;
 
     #[test]
     fn contract_package_stored_value_serializes_versions_to_flat_array() {

--- a/types/src/transaction/transaction_hash.rs
+++ b/types/src/transaction/transaction_hash.rs
@@ -160,7 +160,6 @@ impl FromBytes for TransactionHash {
 mod tests {
     use super::*;
     use crate::testing::TestRng;
-
     #[test]
     fn bytesrepr_roundtrip() {
         let rng = &mut TestRng::new();


### PR DESCRIPTION
StoredValue::ContractPackage deserialization fix presented some time ago changed the way json is structured which made it backwards incompatible:
In 1.x a ContractPackage will be json-formatted as:
```
"ContractPackage": {
        "access_key": "uref-024d69e50a458f337817d3d11ba95bdbdd6258ba8f2dc980644c9efdbd64945d-007",
        "versions": [
          {
            "protocol_version_major": 1,
            "contract_version": 1,
            "contract_hash": "contract-1b301b49505ec5eaec1787686c54818bd60836b9301cce3f5c0237560e5a4bfd"
          }
        ],
        "disabled_versions": [],
        "groups": [],
        "lock_status": "Unlocked"
      }
```
and this flat representation of `versions` collection is what needed to be reinstantiated in this PR.