### PR TITLE
Amortized gas holds chainspec option

### DIFF
--- a/execution_engine_testing/test_support/src/transfer_request_builder.rs
+++ b/execution_engine_testing/test_support/src/transfer_request_builder.rs
@@ -19,7 +19,7 @@ use casper_types::{
     system::mint::{ARG_AMOUNT, ARG_ID, ARG_SOURCE, ARG_TARGET},
     BlockTime, CLValue, Digest, FeeHandling, Gas, HoldsEpoch, InitiatorAddr, ProtocolVersion,
     RefundHandling, RuntimeArgs, TransactionHash, TransactionV1Hash, TransferTarget, URef,
-    DEFAULT_BALANCE_HOLD_INTERVAL, U512,
+    DEFAULT_GAS_HOLD_INTERVAL, U512,
 };
 
 use crate::{
@@ -53,7 +53,7 @@ impl TransferRequestBuilder {
         true,
         0,
         500_000_000_000,
-        DEFAULT_BALANCE_HOLD_INTERVAL.millis(),
+        DEFAULT_GAS_HOLD_INTERVAL.millis(),
     );
     /// The default value used for `TransferRequest::state_hash`.
     pub const DEFAULT_STATE_HASH: Digest = Digest::from_raw([1; 32]);

--- a/execution_engine_testing/test_support/src/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/upgrade_request_builder.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use num_rational::Ratio;
 
 use casper_types::{
-    ChainspecRegistry, Digest, EraId, FeeHandling, Key, ProtocolUpgradeConfig, ProtocolVersion,
-    StoredValue,
+    ChainspecRegistry, Digest, EraId, FeeHandling, HoldBalanceHandling, Key, ProtocolUpgradeConfig,
+    ProtocolVersion, StoredValue,
 };
 
 /// Builds an `UpgradeConfig`.
@@ -13,6 +13,7 @@ pub struct UpgradeRequestBuilder {
     current_protocol_version: ProtocolVersion,
     new_protocol_version: ProtocolVersion,
     activation_point: Option<EraId>,
+    new_gas_hold_handling: Option<HoldBalanceHandling>,
     new_gas_hold_interval: Option<u64>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
@@ -48,7 +49,13 @@ impl UpgradeRequestBuilder {
         self
     }
 
-    /// Sets `new_validator_slots`.
+    /// Sets `with_new_gas_hold_handling`.
+    pub fn with_new_gas_hold_handling(mut self, gas_hold_handling: HoldBalanceHandling) -> Self {
+        self.new_gas_hold_handling = Some(gas_hold_handling);
+        self
+    }
+
+    /// Sets `with_new_gas_hold_interval`.
     pub fn with_new_gas_hold_interval(mut self, gas_hold_interval: u64) -> Self {
         self.new_gas_hold_interval = Some(gas_hold_interval);
         self
@@ -121,6 +128,7 @@ impl UpgradeRequestBuilder {
             self.current_protocol_version,
             self.new_protocol_version,
             self.activation_point,
+            self.new_gas_hold_handling,
             self.new_gas_hold_interval,
             self.new_validator_slots,
             self.new_auction_delay,
@@ -141,6 +149,7 @@ impl Default for UpgradeRequestBuilder {
             current_protocol_version: Default::default(),
             new_protocol_version: Default::default(),
             activation_point: None,
+            new_gas_hold_handling: None,
             new_gas_hold_interval: None,
             new_validator_slots: None,
             new_auction_delay: None,

--- a/execution_engine_testing/test_support/src/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/upgrade_request_builder.rs
@@ -13,6 +13,7 @@ pub struct UpgradeRequestBuilder {
     current_protocol_version: ProtocolVersion,
     new_protocol_version: ProtocolVersion,
     activation_point: Option<EraId>,
+    new_gas_hold_interval: Option<u64>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
     new_locked_funds_period_millis: Option<u64>,
@@ -44,6 +45,12 @@ impl UpgradeRequestBuilder {
     /// Sets `new_protocol_version` to the given [`ProtocolVersion`].
     pub fn with_new_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
         self.new_protocol_version = protocol_version;
+        self
+    }
+
+    /// Sets `new_validator_slots`.
+    pub fn with_new_gas_hold_interval(mut self, gas_hold_interval: u64) -> Self {
+        self.new_gas_hold_interval = Some(gas_hold_interval);
         self
     }
 
@@ -114,6 +121,7 @@ impl UpgradeRequestBuilder {
             self.current_protocol_version,
             self.new_protocol_version,
             self.activation_point,
+            self.new_gas_hold_interval,
             self.new_validator_slots,
             self.new_auction_delay,
             self.new_locked_funds_period_millis,
@@ -133,6 +141,7 @@ impl Default for UpgradeRequestBuilder {
             current_protocol_version: Default::default(),
             new_protocol_version: Default::default(),
             activation_point: None,
+            new_gas_hold_interval: None,
             new_validator_slots: None,
             new_auction_delay: None,
             new_locked_funds_period_millis: None,

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -24,12 +24,12 @@ use casper_storage::{
         balance::BalanceHandling, AuctionMethod, BalanceIdentifier, BalanceRequest, BalanceResult,
         BiddingRequest, BiddingResult, BidsRequest, BlockRewardsRequest, BlockRewardsResult,
         BlockStore, DataAccessLayer, EraValidatorsRequest, EraValidatorsResult, FeeRequest,
-        FeeResult, FlushRequest, FlushResult, GasHoldBalanceHandling, GenesisRequest,
-        GenesisResult, ProofHandling, ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest,
-        PruneResult, QueryRequest, QueryResult, RoundSeigniorageRateRequest,
-        RoundSeigniorageRateResult, StepRequest, StepResult, SystemEntityRegistryPayload,
-        SystemEntityRegistryRequest, SystemEntityRegistryResult, SystemEntityRegistrySelector,
-        TotalSupplyRequest, TotalSupplyResult, TransferRequest, TrieRequest,
+        FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult, ProofHandling,
+        ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest, PruneResult, QueryRequest,
+        QueryResult, RoundSeigniorageRateRequest, RoundSeigniorageRateResult, StepRequest,
+        StepResult, SystemEntityRegistryPayload, SystemEntityRegistryRequest,
+        SystemEntityRegistryResult, SystemEntityRegistrySelector, TotalSupplyRequest,
+        TotalSupplyResult, TransferRequest, TrieRequest,
     },
     global_state::{
         state::{
@@ -61,8 +61,8 @@ use casper_types::{
     },
     AddressableEntity, AddressableEntityHash, AuctionCosts, BlockTime, ByteCode, ByteCodeAddr,
     ByteCodeHash, CLTyped, CLValue, Contract, Digest, EntityAddr, EraId, Gas, HandlePaymentCosts,
-    HoldBalanceHandling, HoldsEpoch, InitiatorAddr, Key, KeyTag, MintCosts, Motes, Package,
-    PackageHash, ProtocolUpgradeConfig, ProtocolVersion, PublicKey, RefundHandling, StoredValue,
+    HoldsEpoch, InitiatorAddr, Key, KeyTag, MintCosts, Motes, Package, PackageHash,
+    ProtocolUpgradeConfig, ProtocolVersion, PublicKey, RefundHandling, StoredValue,
     SystemEntityRegistry, TransactionHash, TransactionV1Hash, URef, OS_PAGE_SIZE, U512,
 };
 
@@ -1230,8 +1230,6 @@ where
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
         let balance_handling = BalanceHandling::Available { holds_epoch };
         let proof_handling = ProofHandling::Proofs;
-        let gas_hold_balance_handling = GasHoldBalanceHandling::new(HoldBalanceHandling::default());
-
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
         let request = BalanceRequest::new(
             state_root_hash,
@@ -1240,7 +1238,6 @@ where
             balance_identifier,
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         );
         self.data_access_layer.balance(request)
     }
@@ -1257,7 +1254,6 @@ where
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
         let balance_handling = BalanceHandling::Available { holds_epoch };
         let proof_handling = ProofHandling::Proofs;
-        let gas_hold_balance_handling = GasHoldBalanceHandling::new(HoldBalanceHandling::default());
         let request = BalanceRequest::from_public_key(
             state_root_hash,
             block_time.into(),
@@ -1265,7 +1261,6 @@ where
             public_key,
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         );
         self.data_access_layer.balance(request)
     }

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1230,8 +1230,7 @@ where
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
         let balance_handling = BalanceHandling::Available { holds_epoch };
         let proof_handling = ProofHandling::Proofs;
-        let gas_hold_balance_handling =
-            GasHoldBalanceHandling::new(HoldBalanceHandling::default(), hold_interval);
+        let gas_hold_balance_handling = GasHoldBalanceHandling::new(HoldBalanceHandling::default());
 
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
         let request = BalanceRequest::new(
@@ -1258,8 +1257,7 @@ where
         let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
         let balance_handling = BalanceHandling::Available { holds_epoch };
         let proof_handling = ProofHandling::Proofs;
-        let gas_hold_balance_handling =
-            GasHoldBalanceHandling::new(HoldBalanceHandling::default(), hold_interval);
+        let gas_hold_balance_handling = GasHoldBalanceHandling::new(HoldBalanceHandling::default());
         let request = BalanceRequest::from_public_key(
             state_root_hash,
             block_time.into(),

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -548,8 +548,7 @@ where
     let balance_handling = BalanceHandling::Available {
         holds_epoch: HoldsEpoch::from_timestamp(timestamp, gas_hold_interval),
     };
-    let gas_hold_balance_handling =
-        GasHoldBalanceHandling::new(gas_hold_handling, gas_hold_interval);
+    let gas_hold_balance_handling = GasHoldBalanceHandling::new(gas_hold_handling);
 
     let balance_req = BalanceRequest::new(
         state_root_hash,

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -20,17 +20,16 @@ use casper_storage::{
     data_access_layer::{
         balance::BalanceHandling,
         tagged_values::{TaggedValuesRequest, TaggedValuesResult, TaggedValuesSelection},
-        BalanceIdentifier, BalanceRequest, BalanceResult, GasHoldBalanceHandling, ProofHandling,
-        ProofsResult, QueryRequest, QueryResult, TrieRequest,
+        BalanceIdentifier, BalanceRequest, BalanceResult, ProofHandling, ProofsResult,
+        QueryRequest, QueryResult, TrieRequest,
     },
     global_state::trie::TrieRaw,
 };
 use casper_types::{
     addressable_entity::NamedKeyAddr,
     bytesrepr::{self, FromBytes, ToBytes},
-    BlockHeader, BlockIdentifier, Chainspec, Digest, EntityAddr, GlobalStateIdentifier,
-    HoldBalanceHandling, HoldsEpoch, Key, Peers, ProtocolVersion, SignedBlock, StoredValue,
-    TimeDiff, Timestamp, Transaction,
+    BlockHeader, BlockIdentifier, Chainspec, Digest, EntityAddr, GlobalStateIdentifier, HoldsEpoch,
+    Key, Peers, ProtocolVersion, SignedBlock, StoredValue, TimeDiff, Timestamp, Transaction,
 };
 
 use datasize::DataSize;
@@ -419,7 +418,6 @@ where
                 header.timestamp(),
                 purse_identifier,
                 protocol_version,
-                chainspec.core_config.gas_hold_balance_handling,
                 chainspec.core_config.gas_hold_interval,
             )
             .await
@@ -438,7 +436,6 @@ where
                 timestamp,
                 purse_identifier,
                 protocol_version,
-                chainspec.core_config.gas_hold_balance_handling,
                 chainspec.core_config.gas_hold_interval,
             )
             .await
@@ -528,7 +525,6 @@ async fn get_balance<REv>(
     timestamp: Timestamp,
     purse_identifier: PurseIdentifier,
     protocol_version: ProtocolVersion,
-    gas_hold_handling: HoldBalanceHandling,
     gas_hold_interval: TimeDiff,
 ) -> BinaryResponse
 where
@@ -548,7 +544,6 @@ where
     let balance_handling = BalanceHandling::Available {
         holds_epoch: HoldsEpoch::from_timestamp(timestamp, gas_hold_interval),
     };
-    let gas_hold_balance_handling = GasHoldBalanceHandling::new(gas_hold_handling);
 
     let balance_req = BalanceRequest::new(
         state_root_hash,
@@ -557,7 +552,6 @@ where
         balance_id,
         balance_handling,
         ProofHandling::Proofs,
-        gas_hold_balance_handling,
     );
     match effect_builder.get_balance(balance_req).await {
         BalanceResult::RootNotFound => {

--- a/node/src/components/binary_port/config.rs
+++ b/node/src/components/binary_port/config.rs
@@ -1,3 +1,4 @@
+use casper_types::{HoldBalanceHandling, DEFAULT_GAS_HOLD_BALANCE_HANDLING};
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
@@ -39,10 +40,12 @@ pub struct Config {
     pub client_request_buffer_size: usize,
     /// Maximum number of connections to the server.
     pub max_connections: usize,
+    /// Gas hold handling
+    pub gas_hold_handling: HoldBalanceHandling,
 }
 
 impl Config {
-    /// Creates a default instance for `RpcServer`.
+    /// Creates a default instance for `BinaryPort`.
     pub fn new() -> Self {
         Config {
             enable_server: true,
@@ -55,6 +58,7 @@ impl Config {
             max_response_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             client_request_buffer_size: DEFAULT_CHANNEL_BUFFER_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
+            gas_hold_handling: DEFAULT_GAS_HOLD_BALANCE_HANDLING,
         }
     }
 }

--- a/node/src/components/binary_port/tests.rs
+++ b/node/src/components/binary_port/tests.rs
@@ -223,14 +223,14 @@ impl Reactor for MockReactor {
 
     fn new(
         config: Self::Config,
-        _chainspec: Arc<Chainspec>,
+        chainspec: Arc<Chainspec>,
         _chainspec_raw_bytes: Arc<ChainspecRawBytes>,
         _network_identity: NetworkIdentity,
         registry: &Registry,
         _event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
-        let mut binary_port = BinaryPort::new(config, registry).unwrap();
+        let mut binary_port = BinaryPort::new(config, chainspec, registry).unwrap();
         <BinaryPort as InitializedComponent<Event>>::start_initialization(&mut binary_port);
 
         let reactor = MockReactor { binary_port };

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -289,7 +289,6 @@ pub fn execute_finalized_block(
             balance_identifier.clone(),
             balance_handling,
             ProofHandling::NoProofs,
-            gas_hold_balance_handling,
         ));
 
         let allow_execution = {

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -10,9 +10,9 @@ use casper_storage::{
         balance::BalanceHandling, AuctionMethod, BalanceHoldKind, BalanceHoldRequest,
         BalanceIdentifier, BalanceRequest, BiddingRequest, BlockRewardsRequest, BlockRewardsResult,
         DataAccessLayer, EraValidatorsRequest, EraValidatorsResult, EvictItem, FeeRequest,
-        FeeResult, FlushRequest, HandleFeeMode, HandleFeeRequest, HandleRefundMode,
-        HandleRefundRequest, InsufficientBalanceHandling, ProofHandling, PruneRequest, PruneResult,
-        StepRequest, StepResult, TransferRequest,
+        FeeResult, FlushRequest, GasHoldBalanceHandling, HandleFeeMode, HandleFeeRequest,
+        HandleRefundMode, HandleRefundRequest, InsufficientBalanceHandling, ProofHandling,
+        PruneRequest, PruneResult, StepRequest, StepResult, TransferRequest,
     },
     global_state::state::{
         lmdb::LmdbGlobalState, scratch::ScratchGlobalState, CommitProvider, ScratchProvider,
@@ -89,12 +89,17 @@ pub fn execute_finalized_block(
     let mut artifacts = Vec::with_capacity(executable_block.transactions.len());
 
     // set up accounting variables / settings
-    let holds_epoch =
-        HoldsEpoch::from_block_time(block_time, chainspec.core_config.balance_hold_interval);
-    let balance_handling = BalanceHandling::Available { holds_epoch };
     let insufficient_balance_handling = InsufficientBalanceHandling::HoldRemaining;
     let refund_handling = chainspec.core_config.refund_handling;
     let fee_handling = chainspec.core_config.fee_handling;
+    let gas_hold_interval = chainspec.core_config.gas_hold_interval;
+    let gas_hold_balance_handling: GasHoldBalanceHandling = (
+        chainspec.core_config.gas_hold_balance_handling,
+        gas_hold_interval,
+    )
+        .into();
+    let holds_epoch = HoldsEpoch::from_block_time(block_time, gas_hold_interval);
+    let balance_handling = BalanceHandling::Available { holds_epoch };
 
     // get scratch state, which must be used for all processing and post processing data
     // requirements.
@@ -279,10 +284,12 @@ pub fn execute_finalized_block(
 
         let initial_balance_result = scratch_state.balance(BalanceRequest::new(
             state_root_hash,
+            block_time,
             protocol_version,
             balance_identifier.clone(),
             balance_handling,
             ProofHandling::NoProofs,
+            gas_hold_balance_handling,
         ));
 
         let allow_execution = {
@@ -304,6 +311,7 @@ pub fn execute_finalized_block(
                     block_time,
                     holds_epoch,
                     insufficient_balance_handling,
+                    gas_hold_balance_handling,
                 );
                 let hold_result = scratch_state.balance_hold(hold_request);
                 state_root_hash =
@@ -416,6 +424,7 @@ pub fn execute_finalized_block(
                 BalanceHoldKind::All,
                 balance_identifier.clone(),
                 holds_epoch,
+                gas_hold_balance_handling,
             );
             let hold_result = scratch_state.balance_hold(hold_request);
             state_root_hash =
@@ -500,6 +509,7 @@ pub fn execute_finalized_block(
                     block_time,
                     holds_epoch,
                     insufficient_balance_handling,
+                    gas_hold_balance_handling,
                 );
                 let hold_result = scratch_state.balance_hold(hold_request);
                 state_root_hash =

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -410,7 +410,7 @@ mod trie_chunking_tests {
         global_state::Pointer,
         testing::TestRng,
         ActivationPoint, CLValue, Chainspec, ChunkWithProof, CoreConfig, Digest, EraId, Key,
-        ProtocolConfig, StoredValue, TimeDiff, DEFAULT_BALANCE_HOLD_INTERVAL, DEFAULT_FEE_HANDLING,
+        ProtocolConfig, StoredValue, TimeDiff, DEFAULT_FEE_HANDLING, DEFAULT_GAS_HOLD_INTERVAL,
         DEFAULT_REFUND_HANDLING,
     };
 
@@ -487,7 +487,7 @@ mod trie_chunking_tests {
                 allow_unrestricted_transfers: true,
                 fee_handling: DEFAULT_FEE_HANDLING,
                 refund_handling: DEFAULT_REFUND_HANDLING,
-                balance_hold_interval: DEFAULT_BALANCE_HOLD_INTERVAL,
+                gas_hold_interval: DEFAULT_GAS_HOLD_INTERVAL,
                 ..CoreConfig::random(rng)
             },
             wasm_config: Default::default(),

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -11,15 +11,13 @@ use prometheus::Registry;
 use tracing::{debug, error, trace};
 
 use casper_execution_engine::engine_state::MAX_PAYMENT;
-use casper_storage::data_access_layer::{
-    balance::BalanceHandling, BalanceRequest, GasHoldBalanceHandling, ProofHandling,
-};
+use casper_storage::data_access_layer::{balance::BalanceHandling, BalanceRequest, ProofHandling};
 use casper_types::{
     account::AccountHash, addressable_entity::AddressableEntity, contracts::ContractHash,
     system::auction::ARG_AMOUNT, AddressableEntityHash, AddressableEntityIdentifier, BlockHeader,
     Chainspec, EntityAddr, EntityVersion, EntityVersionKey, ExecutableDeployItem,
-    ExecutableDeployItemIdentifier, HoldBalanceHandling, HoldsEpoch, InitiatorAddr, Key, Package,
-    PackageAddr, PackageHash, PackageIdentifier, TimeDiff, Transaction, TransactionEntryPoint,
+    ExecutableDeployItemIdentifier, HoldsEpoch, InitiatorAddr, Key, Package, PackageAddr,
+    PackageHash, PackageIdentifier, Transaction, TransactionEntryPoint,
     TransactionInvocationTarget, TransactionTarget, U512,
 };
 
@@ -224,11 +222,6 @@ impl TransactionAcceptor {
                 let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
                 let balance_handling = BalanceHandling::Available { holds_epoch };
                 let proof_handling = ProofHandling::NoProofs;
-                let gas_hold_balance_handling: GasHoldBalanceHandling = (
-                    HoldBalanceHandling::default(),
-                    TimeDiff::from_millis(hold_interval),
-                )
-                    .into();
                 let balance_request = BalanceRequest::from_purse(
                     *block_header.state_root_hash(),
                     block_header.timestamp().into(),
@@ -236,7 +229,6 @@ impl TransactionAcceptor {
                     entity.main_purse(),
                     balance_handling,
                     proof_handling,
-                    gas_hold_balance_handling,
                 );
                 effect_builder
                     .get_balance(balance_request)

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -766,7 +766,8 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Refund => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("refund".to_string()),
+                                    TrackingCopyError::NamedKeyNotFound("refund".to_string())
+                                        .into(),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -774,7 +775,8 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Payment => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("payment".to_string()),
+                                    TrackingCopyError::NamedKeyNotFound("payment".to_string())
+                                        .into(),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -782,7 +784,8 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Accumulate => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("accumulate".to_string()),
+                                    TrackingCopyError::NamedKeyNotFound("accumulate".to_string())
+                                        .into(),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -793,7 +796,7 @@ impl reactor::Reactor for Reactor {
                         None => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::UnexpectedKeyVariant(key),
+                                    TrackingCopyError::UnexpectedKeyVariant(key).into(),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1530,6 +1530,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    #[allow(unused)]
     pub(crate) async fn get_balance_holds_interval(self) -> TimeDiff
     where
         REv: From<ReactorInfoRequest>,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -264,7 +264,7 @@ impl reactor::Reactor for MainReactor {
                     .respond(self.chainspec.protocol_version())
                     .ignore(),
                 ReactorInfoRequest::BalanceHoldsInterval { responder } => responder
-                    .respond(self.chainspec.core_config.balance_hold_interval)
+                    .respond(self.chainspec.core_config.gas_hold_interval)
                     .ignore(),
             },
             MainEvent::MetaBlockAnnouncement(MetaBlockAnnouncement(meta_block)) => self
@@ -1144,7 +1144,12 @@ impl reactor::Reactor for MainReactor {
             protocol_version,
             chainspec.network_config.name.clone(),
         );
-        let binary_port = BinaryPort::new(config.binary_port_server.clone(), registry)?;
+
+        let binary_port = BinaryPort::new(
+            config.binary_port_server.clone(),
+            chainspec.clone(),
+            registry,
+        )?;
         let event_stream_server = EventStreamServer::new(
             config.event_stream_server.clone(),
             storage.root_path().to_path_buf(),

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -918,10 +918,7 @@ impl TestFixture {
 
 impl From<&TestFixture> for GasHoldBalanceHandling {
     fn from(value: &TestFixture) -> Self {
-        GasHoldBalanceHandling::new(
-            value.chainspec.core_config.gas_hold_balance_handling,
-            value.chainspec.core_config.gas_hold_interval,
-        )
+        GasHoldBalanceHandling::new(value.chainspec.core_config.gas_hold_balance_handling)
     }
 }
 

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -24,7 +24,7 @@ use casper_storage::{
     data_access_layer::{
         balance::{BalanceHandling, BalanceResult},
         AddressableEntityRequest, AddressableEntityResult, BalanceRequest, BidsRequest, BidsResult,
-        GasHoldBalanceHandling, ProofHandling, TotalSupplyRequest, TotalSupplyResult,
+        ProofHandling, TotalSupplyRequest, TotalSupplyResult,
     },
     global_state::state::{StateProvider, StateReader},
 };
@@ -818,8 +818,6 @@ impl TestFixture {
         let holds_epoch =
             HoldsEpoch::from_timestamp(block_time, self.chainspec.core_config.gas_hold_interval);
 
-        let gas_balance_hold_handling: GasHoldBalanceHandling = self.into();
-
         let balance_request = BalanceRequest::from_public_key(
             *highest_block.state_root_hash(),
             block_time.into(),
@@ -827,7 +825,6 @@ impl TestFixture {
             account_public_key,
             BalanceHandling::Available { holds_epoch },
             ProofHandling::NoProofs,
-            gas_balance_hold_handling,
         );
 
         let balance_result = runner
@@ -913,12 +910,6 @@ impl TestFixture {
         rng: TestRng,
     ) -> impl futures::Future<Output = (TestingNetwork<FilterReactor<MainReactor>>, TestRng)> {
         self.network.crank_until_stopped(rng)
-    }
-}
-
-impl From<&TestFixture> for GasHoldBalanceHandling {
-    fn from(value: &TestFixture) -> Self {
-        GasHoldBalanceHandling::new(value.chainspec.core_config.gas_hold_balance_handling)
     }
 }
 

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -128,11 +128,6 @@ fn get_balance(
             ),
         }
     };
-    let gas_hold_balance_handling: GasHoldBalanceHandling = (
-        fixture.chainspec.core_config.gas_hold_balance_handling,
-        fixture.chainspec.core_config.gas_hold_interval,
-    )
-        .into();
     runner
         .main_reactor()
         .contract_runtime()
@@ -144,7 +139,6 @@ fn get_balance(
             account_key.clone(),
             balance_handling,
             ProofHandling::NoProofs,
-            gas_hold_balance_handling,
         ))
 }
 

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -117,27 +117,34 @@ fn get_balance(
         .expect("failure to read block header")
         .unwrap();
     let state_hash = *block_header.state_root_hash();
+    let block_time = block_header.timestamp().into();
     let balance_handling = if get_total {
         BalanceHandling::Total
     } else {
-        let block_time = block_header.timestamp().into();
         BalanceHandling::Available {
             holds_epoch: HoldsEpoch::from_block_time(
                 block_time,
-                fixture.chainspec.core_config.balance_hold_interval,
+                fixture.chainspec.core_config.gas_hold_interval,
             ),
         }
     };
+    let gas_hold_balance_handling: GasHoldBalanceHandling = (
+        fixture.chainspec.core_config.gas_hold_balance_handling,
+        fixture.chainspec.core_config.gas_hold_interval,
+    )
+        .into();
     runner
         .main_reactor()
         .contract_runtime()
         .data_access_layer()
         .balance(BalanceRequest::from_public_key(
             state_hash,
+            block_time,
             protocol_version,
             account_key.clone(),
             balance_handling,
             ProofHandling::NoProofs,
+            gas_hold_balance_handling,
         ))
 }
 

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -106,7 +106,7 @@ refund_handling = { type = 'no_refund' }
 #                 administrator accounts
 #   'burn': fees are burned
 fee_handling = { type = 'no_fee' }
-# Defines how fees are handled.
+# Defines how pricing is handled.
 #
 # Valid options are:
 #   'classic': senders of transaction self-specify how much they pay.
@@ -117,9 +117,20 @@ pricing_handling = { type = 'fixed' }
 # execution? Currently not supported.
 #
 allow_reservations = false
+# Defines how gas holds affect available balance calculations.
 #
-# How long does it take for a balance hold to fade away?
-balance_hold_interval = '24 hours'
+# Valid options are:
+#   'accrued': sum of full value of all non-expired holds.
+#   'amortized': sum of each hold is amortized over the time remaining until expiry.
+#
+# For instance, if 12 hours remained on a gas hold with a 24-hour `gas_hold_interval`,
+#   with accrued, the full hold amount would be applied
+#   with amortized, half the hold amount would be applied
+gas_hold_balance_handling = { type = 'accrued' }
+# Defines how long gas holds last.
+#
+# How long does it take for a gas hold to fade away?
+gas_hold_interval = '24 hours'
 # List of public keys of administrator accounts. Setting this option makes only on private chains which require
 # administrator accounts for regulatory reasons.
 administrators = []

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -129,7 +129,15 @@ allow_reservations = false
 gas_hold_balance_handling = { type = 'accrued' }
 # Defines how long gas holds last.
 #
-# How long does it take for a gas hold to fade away?
+# If fee_handling is set to 'no_fee', the system places a balance hold on the payer
+# equal to the value the fee would have been. Such balance holds expire after a time
+# interval has elapsed. This setting controls how long that interval is. The available
+# balance of a purse equals its total balance minus the held amount(s) of non-expired
+# holds (see gas_hold_balance_handling setting for details of how that is calculated).
+#
+# For instance, if gas_hold_interval is 24 hours and 100 gas is used from a purse,
+# a hold for 100 is placed on that purse and is considered when calculating total balance
+# for 24 hours starting from the block_time when the hold was placed.
 gas_hold_interval = '24 hours'
 # List of public keys of administrator accounts. Setting this option makes only on private chains which require
 # administrator accounts for regulatory reasons.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -116,7 +116,7 @@ refund_handling = { type = 'no_refund' }
 #                 administrator accounts
 #   'burn': fees are burned
 fee_handling = { type = 'no_fee' }
-# Defines how fees are handled.
+# Defines how pricing is handled.
 #
 # Valid options are:
 #   'classic': senders of transaction self-specify how much they pay.
@@ -127,8 +127,20 @@ pricing_handling = { type = 'fixed' }
 # execution? Currently not supported.
 #
 allow_reservations = false
-# How long does it take for a balance hold to fade away?
-balance_hold_interval = '24 hours'
+# Defines how gas holds affect available balance calculations.
+#
+# Valid options are:
+#   'accrued': sum of full value of all non-expired holds.
+#   'amortized': sum of each hold is amortized over the time remaining until expiry.
+#
+# For instance, if 12 hours remained on a gas hold with a 24-hour `gas_hold_interval`,
+#   with accrued, the full hold amount would be applied
+#   with amortized, half the hold amount would be applied
+gas_hold_balance_handling = { type = 'accrued' }
+# Defines how long gas holds last.
+#
+# How long does it take for a gas hold to fade away?
+gas_hold_interval = '24 hours'
 # List of public keys of administrator accounts. Setting this option makes only on private chains which require
 # administrator accounts for regulatory reasons.
 administrators = []

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -139,7 +139,15 @@ allow_reservations = false
 gas_hold_balance_handling = { type = 'accrued' }
 # Defines how long gas holds last.
 #
-# How long does it take for a gas hold to fade away?
+# If fee_handling is set to 'no_fee', the system places a balance hold on the payer
+# equal to the value the fee would have been. Such balance holds expire after a time
+# interval has elapsed. This setting controls how long that interval is. The available
+# balance of a purse equals its total balance minus the held amount(s) of non-expired
+# holds (see gas_hold_balance_handling setting for details of how that is calculated).
+#
+# For instance, if gas_hold_interval is 24 hours and 100 gas is used from a purse,
+# a hold for 100 is placed on that purse and is considered when calculating total balance
+# for 24 hours starting from the block_time when the hold was placed.
 gas_hold_interval = '24 hours'
 # List of public keys of administrator accounts. Setting this option makes only on private chains which require
 # administrator accounts for regulatory reasons.

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -34,7 +34,7 @@ pub use addressable_entity::{AddressableEntityRequest, AddressableEntityResult};
 pub use auction::{AuctionMethod, BiddingRequest, BiddingResult};
 pub use balance::{
     BalanceHolds, BalanceHoldsWithProof, BalanceIdentifier, BalanceRequest, BalanceResult,
-    ProofHandling, ProofsResult,
+    GasHoldBalanceHandling, ProofHandling, ProofsResult,
 };
 pub use balance_hold::{
     BalanceHoldError, BalanceHoldKind, BalanceHoldMode, BalanceHoldRequest, BalanceHoldResult,

--- a/storage/src/data_access_layer/balance.rs
+++ b/storage/src/data_access_layer/balance.rs
@@ -4,8 +4,8 @@ use casper_types::{
     global_state::TrieMerkleProof,
     system::{
         handle_payment::{ACCUMULATION_PURSE_KEY, PAYMENT_PURSE_KEY, REFUND_PURSE_KEY},
-        mint::{BalanceHoldAddrTag, MINT_GAS_HOLD_INTERVAL_KEY},
-        HANDLE_PAYMENT, MINT,
+        mint::BalanceHoldAddrTag,
+        HANDLE_PAYMENT,
     },
     AccessRights, BlockTime, Digest, EntityAddr, HoldBalanceHandling, HoldsEpoch, InitiatorAddr,
     Key, ProtocolVersion, PublicKey, StoredValue, TimeDiff, URef, URefAddr, U512,
@@ -174,14 +174,46 @@ impl From<InitiatorAddr> for BalanceIdentifier {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub struct ProcessingHoldBalanceHandling {}
+
+impl ProcessingHoldBalanceHandling {
+    /// Returns new instance.
+    pub fn new() -> Self {
+        ProcessingHoldBalanceHandling::default()
+    }
+
+    /// Returns handling.
+    pub fn handling(&self) -> HoldBalanceHandling {
+        HoldBalanceHandling::Accrued
+    }
+
+    /// Returns true if handling is amortized.
+    pub fn is_amortized(&self) -> bool {
+        false
+    }
+
+    /// Returns hold interval.
+    pub fn interval(&self) -> TimeDiff {
+        TimeDiff::default()
+    }
+}
+
+impl From<(HoldBalanceHandling, u64)> for ProcessingHoldBalanceHandling {
+    fn from(_value: (HoldBalanceHandling, u64)) -> Self {
+        ProcessingHoldBalanceHandling::default()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct GasHoldBalanceHandling {
     handling: HoldBalanceHandling,
+    interval: TimeDiff,
 }
 
 impl GasHoldBalanceHandling {
     /// Returns new instance.
-    pub fn new(handling: HoldBalanceHandling) -> Self {
-        GasHoldBalanceHandling { handling }
+    pub fn new(handling: HoldBalanceHandling, interval: TimeDiff) -> Self {
+        GasHoldBalanceHandling { handling, interval }
     }
 
     /// Returns handling.
@@ -190,42 +222,31 @@ impl GasHoldBalanceHandling {
     }
 
     /// Returns interval.
-    pub fn gas_hold_interval<S>(
-        &self,
-        tc: &mut TrackingCopy<S>,
-    ) -> Result<TimeDiff, TrackingCopyError>
-    where
-        S: StateReader<Key, StoredValue, Error = crate::global_state::error::Error>,
-    {
-        let system_contract_registry = tc.get_system_entity_registry()?;
+    pub fn interval(&self) -> TimeDiff {
+        self.interval
+    }
 
-        let entity_hash = system_contract_registry.get(MINT).ok_or_else(|| {
-            error!("Missing system mint contract hash");
-            TrackingCopyError::MissingSystemContractHash(MINT.to_string())
-        })?;
-
-        let named_keys = tc.get_named_keys(EntityAddr::System(entity_hash.value()))?;
-        let named_key = named_keys.get(MINT_GAS_HOLD_INTERVAL_KEY).ok_or(
-            TrackingCopyError::NamedKeyNotFound(MINT_GAS_HOLD_INTERVAL_KEY.to_string()),
-        )?;
-        let _uref = named_key
-            .as_uref()
-            .ok_or(TrackingCopyError::UnexpectedKeyVariant(*named_key))?;
-
-        match tc.read(named_key) {
-            Ok(Some(StoredValue::CLValue(cl_value))) => {
-                let interval = cl_value.into_t().map_err(TrackingCopyError::CLValue)?;
-                Ok(TimeDiff::from_millis(interval))
-            }
-            Ok(_) => Err(TrackingCopyError::UnexpectedStoredValueVariant),
-            Err(tce) => Err(tce),
-        }
+    /// Returns true if handling is amortized.
+    pub fn is_amortized(&self) -> bool {
+        matches!(self.handling, HoldBalanceHandling::Amortized)
     }
 }
 
 impl From<(HoldBalanceHandling, TimeDiff)> for GasHoldBalanceHandling {
     fn from(value: (HoldBalanceHandling, TimeDiff)) -> Self {
-        GasHoldBalanceHandling { handling: value.0 }
+        GasHoldBalanceHandling {
+            handling: value.0,
+            interval: value.1,
+        }
+    }
+}
+
+impl From<(HoldBalanceHandling, u64)> for GasHoldBalanceHandling {
+    fn from(value: (HoldBalanceHandling, u64)) -> Self {
+        GasHoldBalanceHandling {
+            handling: value.0,
+            interval: TimeDiff::from_millis(value.1),
+        }
     }
 }
 
@@ -238,7 +259,6 @@ pub struct BalanceRequest {
     identifier: BalanceIdentifier,
     balance_handling: BalanceHandling,
     proof_handling: ProofHandling,
-    gas_hold_balance_handling: GasHoldBalanceHandling,
 }
 
 impl BalanceRequest {
@@ -250,9 +270,7 @@ impl BalanceRequest {
         identifier: BalanceIdentifier,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -260,7 +278,6 @@ impl BalanceRequest {
             identifier,
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -272,9 +289,7 @@ impl BalanceRequest {
         purse_uref: URef,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -282,7 +297,6 @@ impl BalanceRequest {
             identifier: BalanceIdentifier::Purse(purse_uref),
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -294,9 +308,7 @@ impl BalanceRequest {
         public_key: PublicKey,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -304,7 +316,6 @@ impl BalanceRequest {
             identifier: BalanceIdentifier::Public(public_key),
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -316,9 +327,7 @@ impl BalanceRequest {
         account_hash: AccountHash,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -326,7 +335,6 @@ impl BalanceRequest {
             identifier: BalanceIdentifier::Account(account_hash),
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -338,9 +346,7 @@ impl BalanceRequest {
         entity_addr: EntityAddr,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -348,7 +354,6 @@ impl BalanceRequest {
             identifier: BalanceIdentifier::Entity(entity_addr),
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -360,9 +365,7 @@ impl BalanceRequest {
         balance_addr: URefAddr,
         balance_handling: BalanceHandling,
         proof_handling: ProofHandling,
-        gas_hold_balance_handling: impl Into<GasHoldBalanceHandling>,
     ) -> Self {
-        let gas_hold_balance_handling = gas_hold_balance_handling.into();
         BalanceRequest {
             state_hash,
             block_time,
@@ -370,7 +373,6 @@ impl BalanceRequest {
             identifier: BalanceIdentifier::Internal(balance_addr),
             balance_handling,
             proof_handling,
-            gas_hold_balance_handling,
         }
     }
 
@@ -403,11 +405,6 @@ impl BalanceRequest {
     pub fn proof_handling(&self) -> ProofHandling {
         self.proof_handling
     }
-
-    /// Returns gas hold balance handling.
-    pub fn gas_hold_balance_handling(&self) -> GasHoldBalanceHandling {
-        self.gas_hold_balance_handling
-    }
 }
 
 pub trait AvailableBalanceChecker {
@@ -417,55 +414,31 @@ pub trait AvailableBalanceChecker {
         &self,
         block_time: BlockTime,
         total_balance: U512,
-        handling: HoldBalanceHandling,
-        interval: TimeDiff,
+        gas_hold_balance_handling: GasHoldBalanceHandling,
+        processing_hold_balance_handling: ProcessingHoldBalanceHandling,
     ) -> Result<U512, BalanceError> {
         if self.is_empty() {
             return Ok(total_balance);
         }
-        let held = match handling {
-            HoldBalanceHandling::Accrued => self.accrued(),
-            HoldBalanceHandling::Amortized => {
-                let mut held = U512::zero();
-                let block_time = block_time.value();
-                let interval = interval.millis();
 
-                for (hold_created_time, holds) in self.holds() {
-                    let hold_created_time = hold_created_time.value();
-                    if hold_created_time > block_time {
-                        continue;
-                    }
-                    let expiry = hold_created_time.saturating_add(interval);
-                    if block_time > expiry {
-                        continue;
-                    }
-                    // total held amount
-                    let held_ratio = Ratio::new_raw(
-                        holds.values().copied().collect_vec().into_iter().sum(),
-                        U512::one(),
-                    );
-                    // remaining time
-                    let remaining_time = U512::from(expiry.saturating_sub(block_time));
-                    // remaining time over total time
-                    let ratio = Ratio::new_raw(remaining_time, U512::from(interval));
-                    /*
-                        EXAMPLE: 1000 held for 24 hours
-                        if 1 hours has elapsed, held amount = 1000 * (23/24) == 958
-                        if 2 hours has elapsed, held amount = 1000 * (22/24) == 916
-                        ...
-                        if 23 hours has elapsed, held amount    = 1000 * (1/24) == 41
-                        if 23.50 hours has elapsed, held amount = 1000 * (1/48) == 20
-                        if 23.75 hours has elapsed, held amount = 1000 * (1/96) == 10
-                                                        (54000 ms / 5184000 ms)
-                    */
-                    match held_ratio.checked_mul(&ratio) {
-                        Some(amortized) => held += amortized.to_integer(),
-                        None => return Err(BalanceError::AmortizationFailure),
-                    }
-                }
-                held
+        let gas_held = match gas_hold_balance_handling.handling() {
+            HoldBalanceHandling::Accrued => self.accrued(BalanceHoldAddrTag::Gas),
+            HoldBalanceHandling::Amortized => {
+                let interval = gas_hold_balance_handling.interval();
+                self.amortization(BalanceHoldAddrTag::Gas, block_time, interval)?
             }
         };
+
+        let processing_held = match processing_hold_balance_handling.handling() {
+            HoldBalanceHandling::Accrued => self.accrued(BalanceHoldAddrTag::Processing),
+            HoldBalanceHandling::Amortized => {
+                let interval = processing_hold_balance_handling.interval();
+                self.amortization(BalanceHoldAddrTag::Processing, block_time, interval)?
+            }
+        };
+
+        let held = gas_held.saturating_add(processing_held);
+
         debug_assert!(
             total_balance >= held,
             "it should not be possible to hold more than the total available"
@@ -479,11 +452,57 @@ pub trait AvailableBalanceChecker {
         }
     }
 
+    fn amortization(
+        &self,
+        hold_kind: BalanceHoldAddrTag,
+        block_time: BlockTime,
+        interval: TimeDiff,
+    ) -> Result<U512, BalanceError> {
+        let mut held = U512::zero();
+        let block_time = block_time.value();
+        let interval = interval.millis();
+
+        for (hold_created_time, holds) in self.holds(hold_kind) {
+            let hold_created_time = hold_created_time.value();
+            if hold_created_time > block_time {
+                continue;
+            }
+            let expiry = hold_created_time.saturating_add(interval);
+            if block_time > expiry {
+                continue;
+            }
+            // total held amount
+            let held_ratio = Ratio::new_raw(
+                holds.values().copied().collect_vec().into_iter().sum(),
+                U512::one(),
+            );
+            // remaining time
+            let remaining_time = U512::from(expiry.saturating_sub(block_time));
+            // remaining time over total time
+            let ratio = Ratio::new_raw(remaining_time, U512::from(interval));
+            /*
+                EXAMPLE: 1000 held for 24 hours
+                if 1 hours has elapsed, held amount = 1000 * (23/24) == 958
+                if 2 hours has elapsed, held amount = 1000 * (22/24) == 916
+                ...
+                if 23 hours has elapsed, held amount    = 1000 * (1/24) == 41
+                if 23.50 hours has elapsed, held amount = 1000 * (1/48) == 20
+                if 23.75 hours has elapsed, held amount = 1000 * (1/96) == 10
+                                                (54000 ms / 5184000 ms)
+            */
+            match held_ratio.checked_mul(&ratio) {
+                Some(amortized) => held += amortized.to_integer(),
+                None => return Err(BalanceError::AmortizationFailure),
+            }
+        }
+        Ok(held)
+    }
+
     /// Return accrued amount.
-    fn accrued(&self) -> U512;
+    fn accrued(&self, hold_kind: BalanceHoldAddrTag) -> U512;
 
     /// Return holds.
-    fn holds(&self) -> BTreeMap<BlockTime, BalanceHolds>;
+    fn holds(&self, hold_kind: BalanceHoldAddrTag) -> BTreeMap<BlockTime, BalanceHolds>;
 
     /// Return true if empty.
     fn is_empty(&self) -> bool;
@@ -493,16 +512,24 @@ pub trait AvailableBalanceChecker {
 pub type BalanceHolds = BTreeMap<BalanceHoldAddrTag, U512>;
 
 impl AvailableBalanceChecker for BTreeMap<BlockTime, BalanceHolds> {
-    fn accrued(&self) -> U512 {
+    fn accrued(&self, hold_kind: BalanceHoldAddrTag) -> U512 {
         self.values()
-            .flat_map(|holds| holds.values().copied())
+            .filter_map(|holds| holds.get(&hold_kind).copied())
             .collect_vec()
             .into_iter()
             .sum()
     }
 
-    fn holds(&self) -> BTreeMap<BlockTime, BalanceHolds> {
-        self.clone()
+    fn holds(&self, hold_kind: BalanceHoldAddrTag) -> BTreeMap<BlockTime, BalanceHolds> {
+        let mut ret = BTreeMap::new();
+        for (k, v) in self {
+            if let Some(hold) = v.get(&hold_kind) {
+                let mut inner = BTreeMap::new();
+                inner.insert(hold_kind, *hold);
+                ret.insert(*k, inner);
+            }
+        }
+        ret
     }
 
     fn is_empty(&self) -> bool {
@@ -515,28 +542,33 @@ pub type BalanceHoldsWithProof =
     BTreeMap<BalanceHoldAddrTag, (U512, TrieMerkleProof<Key, StoredValue>)>;
 
 impl AvailableBalanceChecker for BTreeMap<BlockTime, BalanceHoldsWithProof> {
-    fn accrued(&self) -> U512 {
+    fn accrued(&self, hold_kind: BalanceHoldAddrTag) -> U512 {
         self.values()
-            .flat_map(|holds| holds.values().map(|(v, _)| *v))
+            .filter_map(|holds| holds.get(&hold_kind))
+            .map(|(amount, _)| *amount)
             .collect_vec()
             .into_iter()
             .sum()
     }
 
-    fn holds(&self) -> BTreeMap<BlockTime, BalanceHolds> {
+    fn holds(&self, hold_kind: BalanceHoldAddrTag) -> BTreeMap<BlockTime, BalanceHolds> {
         let mut ret: BTreeMap<BlockTime, BalanceHolds> = BTreeMap::new();
         for (block_time, holds_with_proof) in self {
             let mut holds: BTreeMap<BalanceHoldAddrTag, U512> = BTreeMap::new();
             for (addr, (held, _)) in holds_with_proof {
-                match holds.entry(*addr) {
-                    Entry::Vacant(v) => v.insert(*held),
-                    Entry::Occupied(mut o) => &mut o.insert(*held),
+                if addr == &hold_kind {
+                    match holds.entry(*addr) {
+                        Entry::Vacant(v) => v.insert(*held),
+                        Entry::Occupied(mut o) => &mut o.insert(*held),
+                    };
+                }
+            }
+            if !holds.is_empty() {
+                match ret.entry(*block_time) {
+                    Entry::Vacant(v) => v.insert(holds),
+                    Entry::Occupied(mut o) => &mut o.insert(holds),
                 };
             }
-            match ret.entry(*block_time) {
-                Entry::Vacant(v) => v.insert(holds),
-                Entry::Occupied(mut o) => &mut o.insert(holds),
-            };
         }
         ret
     }
@@ -612,16 +644,22 @@ impl ProofsResult {
         &self,
         block_time: BlockTime,
         total_balance: U512,
-        handling: HoldBalanceHandling,
-        interval: TimeDiff,
+        gas_hold_balance_handling: GasHoldBalanceHandling,
+        processing_hold_balance_handling: ProcessingHoldBalanceHandling,
     ) -> Result<U512, BalanceError> {
         match self {
-            ProofsResult::NotRequested { balance_holds } => {
-                balance_holds.available_balance(block_time, total_balance, handling, interval)
-            }
-            ProofsResult::Proofs { balance_holds, .. } => {
-                balance_holds.available_balance(block_time, total_balance, handling, interval)
-            }
+            ProofsResult::NotRequested { balance_holds } => balance_holds.available_balance(
+                block_time,
+                total_balance,
+                gas_hold_balance_handling,
+                processing_hold_balance_handling,
+            ),
+            ProofsResult::Proofs { balance_holds, .. } => balance_holds.available_balance(
+                block_time,
+                total_balance,
+                gas_hold_balance_handling,
+                processing_hold_balance_handling,
+            ),
         }
     }
 }

--- a/storage/src/data_access_layer/balance.rs
+++ b/storage/src/data_access_layer/balance.rs
@@ -456,10 +456,10 @@ impl ProofsResult {
 pub enum BalanceError {
     /// Tracking copy error.
     TrackingCopy(TrackingCopyError),
-    /// Hold created time should never be greater than its own expiry (programmer error)."
-    HoldCreatedExceedsExpiry,
     /// Failed to calculate amortization (checked multiplication).
     AmortizationFailure,
+    /// Held amount exceeds total balance, which should never occur.
+    HeldExceedsTotal,
 }
 
 impl Display for BalanceError {
@@ -468,13 +468,16 @@ impl Display for BalanceError {
             BalanceError::TrackingCopy(err) => {
                 write!(f, "TrackingCopy: {:?}", err)
             }
-            BalanceError::HoldCreatedExceedsExpiry => {
-                write!(f, "HoldCreatedExceedsExpiry: hold created time should never be greater than its own expiry (programmer error).",)
-            }
             BalanceError::AmortizationFailure => {
                 write!(
                     f,
                     "AmortizationFailure: failed to calculate amortization (checked multiplication)."
+                )
+            }
+            BalanceError::HeldExceedsTotal => {
+                write!(
+                    f,
+                    "HeldExceedsTotal: held amount exceeds total balance, which should never occur."
                 )
             }
         }

--- a/storage/src/system/genesis.rs
+++ b/storage/src/system/genesis.rs
@@ -34,8 +34,8 @@ use casper_types::{
         },
         handle_payment::{self, ACCUMULATION_PURSE_KEY},
         mint::{
-            self, ARG_ROUND_SEIGNIORAGE_RATE, MINT_GAS_HOLD_INTERVAL_KEY,
-            ROUND_SEIGNIORAGE_RATE_KEY, TOTAL_SUPPLY_KEY,
+            self, ARG_ROUND_SEIGNIORAGE_RATE, MINT_GAS_HOLD_HANDLING_KEY,
+            MINT_GAS_HOLD_INTERVAL_KEY, ROUND_SEIGNIORAGE_RATE_KEY, TOTAL_SUPPLY_KEY,
         },
         SystemEntityType, AUCTION, HANDLE_PAYMENT, MINT,
     },
@@ -228,6 +228,23 @@ where
             total_supply_uref
         };
 
+        let gas_hold_handling_uref =
+            {
+                let gas_hold_handling = self.config.gas_hold_balance_handling().tag();
+                let gas_hold_handling_uref = self
+                    .address_generator
+                    .borrow_mut()
+                    .new_uref(AccessRights::READ_ADD_WRITE);
+
+                self.tracking_copy.borrow_mut().write(
+                    gas_hold_handling_uref.into(),
+                    StoredValue::CLValue(CLValue::from_t(gas_hold_handling).map_err(|_| {
+                        GenesisError::CLValue(MINT_GAS_HOLD_HANDLING_KEY.to_string())
+                    })?),
+                );
+                gas_hold_handling_uref
+            };
+
         let gas_hold_interval_uref =
             {
                 let gas_hold_interval = self.config.gas_hold_interval_millis();
@@ -252,6 +269,10 @@ where
                 round_seigniorage_rate_uref.into(),
             );
             named_keys.insert(TOTAL_SUPPLY_KEY.to_string(), total_supply_uref.into());
+            named_keys.insert(
+                MINT_GAS_HOLD_HANDLING_KEY.to_string(),
+                gas_hold_handling_uref.into(),
+            );
             named_keys.insert(
                 MINT_GAS_HOLD_INTERVAL_KEY.to_string(),
                 gas_hold_interval_uref.into(),

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -17,7 +17,9 @@ use casper_types::{
             UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
         },
         handle_payment::ACCUMULATION_PURSE_KEY,
-        mint::{MINT_GAS_HOLD_INTERVAL_KEY, ROUND_SEIGNIORAGE_RATE_KEY},
+        mint::{
+            MINT_GAS_HOLD_HANDLING_KEY, MINT_GAS_HOLD_INTERVAL_KEY, ROUND_SEIGNIORAGE_RATE_KEY,
+        },
         SystemEntityType, AUCTION, HANDLE_PAYMENT, MINT,
     },
     AccessRights, AddressableEntity, AddressableEntityHash, ByteCode, ByteCodeAddr, ByteCodeHash,
@@ -175,7 +177,7 @@ where
             self.config.fee_handling(),
         )?;
         self.refresh_system_contracts(&system_entity_addresses)?;
-        self.handle_new_gas_hold_interval(system_entity_addresses.mint())?;
+        self.handle_new_gas_hold_config(system_entity_addresses.mint())?;
         self.handle_new_validator_slots(system_entity_addresses.auction())?;
         self.handle_new_auction_delay(system_entity_addresses.auction())?;
         self.handle_new_locked_funds_period_millis(system_entity_addresses.auction())?;
@@ -665,67 +667,100 @@ where
     }
 
     /// Upsert gas hold interval to mint named keys.
-    pub fn handle_new_gas_hold_interval(
+    pub fn handle_new_gas_hold_config(
         &self,
         mint: AddressableEntityHash,
     ) -> Result<(), ProtocolUpgradeError> {
+        if self.config.new_gas_hold_handling().is_none()
+            && self.config.new_gas_hold_interval().is_none()
+        {
+            return Ok(());
+        }
+
+        let mint_addr = EntityAddr::new_system(mint.value());
+        let named_keys = self.tracking_copy.borrow_mut().get_named_keys(mint_addr)?;
+
+        if let Some(new_gas_hold_handling) = self.config.new_gas_hold_handling() {
+            debug!(%new_gas_hold_handling, "handle new gas hold handling");
+            let stored_value =
+                StoredValue::CLValue(CLValue::from_t(new_gas_hold_handling.tag()).map_err(
+                    |_| ProtocolUpgradeError::Bytesrepr("new_gas_hold_handling".to_string()),
+                )?);
+
+            self.system_uref(
+                mint_addr,
+                MINT_GAS_HOLD_HANDLING_KEY,
+                &named_keys,
+                stored_value,
+            )?;
+        }
+
         if let Some(new_gas_hold_interval) = self.config.new_gas_hold_interval() {
             debug!(%new_gas_hold_interval, "handle new gas hold interval");
-            // no reason to keep going if we can't produce a stored value from the interval
             let stored_value =
                 StoredValue::CLValue(CLValue::from_t(new_gas_hold_interval).map_err(|_| {
                     ProtocolUpgradeError::Bytesrepr("new_gas_hold_interval".to_string())
                 })?);
 
-            let mint_addr = EntityAddr::new_system(mint.value());
-            let named_keys = self.tracking_copy.borrow_mut().get_named_keys(mint_addr)?;
-
-            match named_keys.get(MINT_GAS_HOLD_INTERVAL_KEY) {
-                Some(key) => {
-                    if let Key::URef(_) = key {
-                        // write current interval to URef
-                        self.tracking_copy.borrow_mut().write(*key, stored_value);
-                    } else {
-                        return Err(ProtocolUpgradeError::UnexpectedKeyVariant);
-                    }
-                }
-                None => {
-                    // first put value into global state under a uref
-                    let uref = self
-                        .address_generator
-                        .borrow_mut()
-                        .new_uref(AccessRights::READ_ADD_WRITE);
-
-                    let uref_key = Key::URef(uref).normalize();
-                    self.tracking_copy
-                        .borrow_mut()
-                        .write(uref_key, stored_value);
-                    // next, add the Key::URef to the mint's named keys
-                    let entry_key = {
-                        let named_key_entry = NamedKeyAddr::new_from_string(
-                            mint_addr,
-                            MINT_GAS_HOLD_INTERVAL_KEY.to_string(),
-                        )
-                        .map_err(|_| {
-                            ProtocolUpgradeError::Bytesrepr("new_gas_hold_interval".to_string())
-                        })?;
-                        Key::NamedKey(named_key_entry)
-                    };
-                    let entry_value = {
-                        let named_key_value = NamedKeyValue::from_concrete_values(
-                            entry_key,
-                            MINT_GAS_HOLD_INTERVAL_KEY.to_string(),
-                        )
-                        .map_err(|error| ProtocolUpgradeError::CLValue(error.to_string()))?;
-                        StoredValue::NamedKey(named_key_value)
-                    };
-
-                    self.tracking_copy
-                        .borrow_mut()
-                        .write(entry_key, entry_value);
-                }
-            };
+            self.system_uref(
+                mint_addr,
+                MINT_GAS_HOLD_INTERVAL_KEY,
+                &named_keys,
+                stored_value,
+            )?;
         }
+        Ok(())
+    }
+
+    fn system_uref(
+        &self,
+        entity_addr: EntityAddr,
+        name: &str,
+        named_keys: &NamedKeys,
+        stored_value: StoredValue,
+    ) -> Result<(), ProtocolUpgradeError> {
+        match named_keys.get(name) {
+            Some(key) => {
+                if let Key::URef(_) = key {
+                    // write current interval to URef
+                    self.tracking_copy.borrow_mut().write(*key, stored_value);
+                } else {
+                    return Err(ProtocolUpgradeError::UnexpectedKeyVariant);
+                }
+            }
+            None => {
+                // first put value into global state under a uref
+                let uref = self
+                    .address_generator
+                    .borrow_mut()
+                    .new_uref(AccessRights::READ_ADD_WRITE);
+
+                let uref_key = Key::URef(uref).normalize();
+                self.tracking_copy
+                    .borrow_mut()
+                    .write(uref_key, stored_value);
+                // next, add the Key::URef to the mint's named keys
+                let entry_key = {
+                    let named_key_entry =
+                        NamedKeyAddr::new_from_string(entity_addr, name.to_string()).map_err(
+                            |_| {
+                                ProtocolUpgradeError::Bytesrepr("new_gas_hold_interval".to_string())
+                            },
+                        )?;
+                    Key::NamedKey(named_key_entry)
+                };
+                let entry_value = {
+                    let named_key_value =
+                        NamedKeyValue::from_concrete_values(entry_key, name.to_string())
+                            .map_err(|error| ProtocolUpgradeError::CLValue(error.to_string()))?;
+                    StoredValue::NamedKey(named_key_value)
+                };
+
+                self.tracking_copy
+                    .borrow_mut()
+                    .write(entry_key, entry_value);
+            }
+        };
         Ok(())
     }
 

--- a/storage/src/system/runtime_native.rs
+++ b/storage/src/system/runtime_native.rs
@@ -58,7 +58,7 @@ impl Config {
         let compute_rewards = chainspec.core_config.compute_rewards;
         let max_delegators_per_validator = chainspec.core_config.max_delegators_per_validator;
         let minimum_delegation_amount = chainspec.core_config.minimum_delegation_amount;
-        let balance_hold_interval = chainspec.core_config.balance_hold_interval.millis();
+        let balance_hold_interval = chainspec.core_config.gas_hold_interval.millis();
         Config::new(
             transfer_config,
             fee_handling,

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -192,6 +192,7 @@ impl Chainspec {
             current_protocol_version,
             self.protocol_config.version,
             Some(era_id),
+            Some(self.core_config.gas_hold_interval.millis()),
             Some(self.core_config.validator_slots),
             Some(self.core_config.auction_delay),
             Some(self.core_config.locked_funds_period.millis()),

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -192,6 +192,7 @@ impl Chainspec {
             current_protocol_version,
             self.protocol_config.version,
             Some(era_id),
+            Some(self.core_config.gas_hold_balance_handling),
             Some(self.core_config.gas_hold_interval.millis()),
             Some(self.core_config.validator_slots),
             Some(self.core_config.auction_delay),

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -9,6 +9,7 @@ mod fee_handling;
 pub mod genesis_config;
 mod global_state_update;
 mod highway_config;
+mod hold_balance_handling;
 mod network_config;
 mod next_upgrade;
 mod pricing_handling;
@@ -46,7 +47,8 @@ pub use core_config::DEFAULT_FEE_HANDLING;
 #[cfg(any(feature = "std", test))]
 pub use core_config::DEFAULT_REFUND_HANDLING;
 pub use core_config::{
-    ConsensusProtocolName, CoreConfig, LegacyRequiredFinality, DEFAULT_BALANCE_HOLD_INTERVAL,
+    ConsensusProtocolName, CoreConfig, LegacyRequiredFinality, DEFAULT_GAS_HOLD_BALANCE_HANDLING,
+    DEFAULT_GAS_HOLD_INTERVAL,
 };
 pub use fee_handling::FeeHandling;
 #[cfg(any(feature = "testing", test))]
@@ -55,6 +57,7 @@ pub use genesis_config::DEFAULT_AUCTION_DELAY;
 pub use genesis_config::{GenesisConfig, GenesisConfigBuilder};
 pub use global_state_update::{GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError};
 pub use highway_config::HighwayConfig;
+pub use hold_balance_handling::HoldBalanceHandling;
 pub use network_config::NetworkConfig;
 pub use next_upgrade::NextUpgrade;
 pub use pricing_handling::PricingHandling;
@@ -205,7 +208,7 @@ impl Chainspec {
     pub fn balance_holds_epoch(&self, timestamp: Timestamp) -> u64 {
         timestamp
             .millis()
-            .saturating_sub(self.core_config.balance_hold_interval.millis())
+            .saturating_sub(self.core_config.gas_hold_interval.millis())
     }
 }
 

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -33,6 +33,8 @@ pub const DEFAULT_UNBONDING_DELAY: u64 = 7;
 pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(7, 175070816);
 /// Default genesis timestamp in milliseconds.
 pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
+/// Default gas hold interval in milliseconds.
+pub const DEFAULT_GAS_HOLD_INTERVAL_MILLIS: u64 = 24 * 60 * 60 * 60;
 
 /// Represents the details of a genesis process.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +48,7 @@ pub struct GenesisConfig {
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: u64,
     genesis_timestamp_millis: u64,
+    gas_hold_interval_millis: u64,
 }
 
 impl GenesisConfig {
@@ -68,6 +71,7 @@ impl GenesisConfig {
         round_seigniorage_rate: Ratio<u64>,
         unbonding_delay: u64,
         genesis_timestamp_millis: u64,
+        gas_hold_interval_millis: u64,
     ) -> GenesisConfig {
         GenesisConfig {
             accounts,
@@ -79,6 +83,7 @@ impl GenesisConfig {
             round_seigniorage_rate,
             unbonding_delay,
             genesis_timestamp_millis,
+            gas_hold_interval_millis,
         }
     }
 
@@ -158,6 +163,11 @@ impl GenesisConfig {
     pub fn genesis_timestamp_millis(&self) -> u64 {
         self.genesis_timestamp_millis
     }
+
+    /// Returns gas hold interval expressed in milliseconds.
+    pub fn gas_hold_interval_millis(&self) -> u64 {
+        self.gas_hold_interval_millis
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -185,6 +195,7 @@ impl Distribution<GenesisConfig> for Standard {
         let unbonding_delay = rng.gen();
 
         let genesis_timestamp_millis = rng.gen();
+        let gas_hold_interval_millis = rng.gen();
 
         GenesisConfig {
             accounts,
@@ -196,6 +207,7 @@ impl Distribution<GenesisConfig> for Standard {
             round_seigniorage_rate,
             unbonding_delay,
             genesis_timestamp_millis,
+            gas_hold_interval_millis,
         }
     }
 }
@@ -215,6 +227,7 @@ pub struct GenesisConfigBuilder {
     round_seigniorage_rate: Option<Ratio<u64>>,
     unbonding_delay: Option<u64>,
     genesis_timestamp_millis: Option<u64>,
+    gas_hold_interval_millis: Option<u64>,
 }
 
 impl GenesisConfigBuilder {
@@ -277,6 +290,12 @@ impl GenesisConfigBuilder {
         self
     }
 
+    /// Sets the gas hold interval config option expressed as milliseconds.
+    pub fn with_gas_hold_interval_millis(mut self, gas_hold_interval_millis: u64) -> Self {
+        self.gas_hold_interval_millis = Some(gas_hold_interval_millis);
+        self
+    }
+
     /// Builds a new [`GenesisConfig`] object.
     pub fn build(self) -> GenesisConfig {
         GenesisConfig {
@@ -295,6 +314,9 @@ impl GenesisConfigBuilder {
             genesis_timestamp_millis: self
                 .genesis_timestamp_millis
                 .unwrap_or(DEFAULT_GENESIS_TIMESTAMP_MILLIS),
+            gas_hold_interval_millis: self
+                .gas_hold_interval_millis
+                .unwrap_or(DEFAULT_GAS_HOLD_INTERVAL_MILLIS),
         }
     }
 }
@@ -306,6 +328,7 @@ impl From<&Chainspec> for GenesisConfig {
             .activation_point
             .genesis_timestamp()
             .map_or(0, |timestamp| timestamp.millis());
+        let gas_hold_interval_millis = chainspec.core_config.gas_hold_interval.millis();
 
         GenesisConfigBuilder::default()
             .with_accounts(chainspec.network_config.accounts_config.clone().into())
@@ -317,6 +340,7 @@ impl From<&Chainspec> for GenesisConfig {
             .with_round_seigniorage_rate(chainspec.core_config.round_seigniorage_rate)
             .with_unbonding_delay(chainspec.core_config.unbonding_delay)
             .with_genesis_timestamp_millis(genesis_timestamp_millis)
+            .with_gas_hold_interval_millis(gas_hold_interval_millis)
             .build()
     }
 }

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -12,7 +12,8 @@ use rand::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AdministratorAccount, Chainspec, GenesisAccount, Motes, PublicKey, SystemConfig, WasmConfig,
+    AdministratorAccount, Chainspec, GenesisAccount, HoldBalanceHandling, Motes, PublicKey,
+    SystemConfig, WasmConfig,
 };
 
 /// Default number of validator slots.
@@ -36,6 +37,9 @@ pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 /// Default gas hold interval in milliseconds.
 pub const DEFAULT_GAS_HOLD_INTERVAL_MILLIS: u64 = 24 * 60 * 60 * 60;
 
+/// Default gas hold balance handling.
+pub const DEFAULT_GAS_HOLD_BALANCE_HANDLING: HoldBalanceHandling = HoldBalanceHandling::Accrued;
+
 /// Represents the details of a genesis process.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenesisConfig {
@@ -48,6 +52,7 @@ pub struct GenesisConfig {
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: u64,
     genesis_timestamp_millis: u64,
+    gas_hold_balance_handling: HoldBalanceHandling,
     gas_hold_interval_millis: u64,
 }
 
@@ -71,6 +76,7 @@ impl GenesisConfig {
         round_seigniorage_rate: Ratio<u64>,
         unbonding_delay: u64,
         genesis_timestamp_millis: u64,
+        gas_hold_balance_handling: HoldBalanceHandling,
         gas_hold_interval_millis: u64,
     ) -> GenesisConfig {
         GenesisConfig {
@@ -83,6 +89,7 @@ impl GenesisConfig {
             round_seigniorage_rate,
             unbonding_delay,
             genesis_timestamp_millis,
+            gas_hold_balance_handling,
             gas_hold_interval_millis,
         }
     }
@@ -164,6 +171,11 @@ impl GenesisConfig {
         self.genesis_timestamp_millis
     }
 
+    /// Returns gas hold balance handling.
+    pub fn gas_hold_balance_handling(&self) -> HoldBalanceHandling {
+        self.gas_hold_balance_handling
+    }
+
     /// Returns gas hold interval expressed in milliseconds.
     pub fn gas_hold_interval_millis(&self) -> u64 {
         self.gas_hold_interval_millis
@@ -195,6 +207,7 @@ impl Distribution<GenesisConfig> for Standard {
         let unbonding_delay = rng.gen();
 
         let genesis_timestamp_millis = rng.gen();
+        let gas_hold_balance_handling = rng.gen();
         let gas_hold_interval_millis = rng.gen();
 
         GenesisConfig {
@@ -207,6 +220,7 @@ impl Distribution<GenesisConfig> for Standard {
             round_seigniorage_rate,
             unbonding_delay,
             genesis_timestamp_millis,
+            gas_hold_balance_handling,
             gas_hold_interval_millis,
         }
     }
@@ -227,6 +241,7 @@ pub struct GenesisConfigBuilder {
     round_seigniorage_rate: Option<Ratio<u64>>,
     unbonding_delay: Option<u64>,
     genesis_timestamp_millis: Option<u64>,
+    gas_hold_balance_handling: Option<HoldBalanceHandling>,
     gas_hold_interval_millis: Option<u64>,
 }
 
@@ -314,6 +329,9 @@ impl GenesisConfigBuilder {
             genesis_timestamp_millis: self
                 .genesis_timestamp_millis
                 .unwrap_or(DEFAULT_GENESIS_TIMESTAMP_MILLIS),
+            gas_hold_balance_handling: self
+                .gas_hold_balance_handling
+                .unwrap_or(DEFAULT_GAS_HOLD_BALANCE_HANDLING),
             gas_hold_interval_millis: self
                 .gas_hold_interval_millis
                 .unwrap_or(DEFAULT_GAS_HOLD_INTERVAL_MILLIS),

--- a/types/src/chainspec/hold_balance_handling.rs
+++ b/types/src/chainspec/hold_balance_handling.rs
@@ -1,0 +1,98 @@
+use crate::{
+    bytesrepr,
+    bytesrepr::{FromBytes, ToBytes},
+};
+use core::fmt::{Display, Formatter};
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+const HOLD_BALANCE_ACCRUED_TAG: u8 = 0;
+const HOLD_BALANCE_AMORTIZED_TAG: u8 = 1;
+const HOLD_BALANCE_HANDLING_TAG_LENGTH: u8 = 1;
+
+/// Defines how a given network handles holds when calculating available balances. There may be
+/// multiple types of holds (such as Processing and Gas currently, and potentially other kinds in
+/// the future), and each type of hold can differ on how it applies to available
+/// balance calculation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+pub enum HoldBalanceHandling {
+    /// The sum of full value of all non-expired holds is used.
+    Accrued,
+    /// The sum of each hold is amortized over the time remaining until expiry.
+    /// For instance, if 12 hours remain on a 24 hour hold, half the hold amount is applied.
+    Amortized,
+}
+
+impl Display for HoldBalanceHandling {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            HoldBalanceHandling::Accrued => {
+                write!(f, "HoldBalanceHandling::Accrued")
+            }
+            HoldBalanceHandling::Amortized => {
+                write!(f, "HoldBalanceHandling::Amortized")
+            }
+        }
+    }
+}
+
+impl ToBytes for HoldBalanceHandling {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+
+        match self {
+            HoldBalanceHandling::Accrued => {
+                buffer.push(HOLD_BALANCE_ACCRUED_TAG);
+            }
+            HoldBalanceHandling::Amortized => {
+                buffer.push(HOLD_BALANCE_AMORTIZED_TAG);
+            }
+        }
+
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        HOLD_BALANCE_HANDLING_TAG_LENGTH as usize
+    }
+}
+
+impl FromBytes for HoldBalanceHandling {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem) = u8::from_bytes(bytes)?;
+        match tag {
+            HOLD_BALANCE_ACCRUED_TAG => Ok((HoldBalanceHandling::Accrued, rem)),
+            HOLD_BALANCE_AMORTIZED_TAG => Ok((HoldBalanceHandling::Amortized, rem)),
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+impl Default for HoldBalanceHandling {
+    fn default() -> Self {
+        // in 2.0 the default hold balance handling is Accrued,
+        // which means a non-expired hold is applied in full to
+        // available balance calculations
+        HoldBalanceHandling::Accrued
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytesrepr_roundtrip_for_accrued() {
+        let handling = HoldBalanceHandling::Accrued;
+        bytesrepr::test_serialization_roundtrip(&handling);
+    }
+
+    #[test]
+    fn bytesrepr_roundtrip_for_amortized() {
+        let handling = HoldBalanceHandling::Amortized;
+        bytesrepr::test_serialization_roundtrip(&handling);
+    }
+}

--- a/types/src/chainspec/upgrade_config.rs
+++ b/types/src/chainspec/upgrade_config.rs
@@ -10,6 +10,7 @@ pub struct ProtocolUpgradeConfig {
     current_protocol_version: ProtocolVersion,
     new_protocol_version: ProtocolVersion,
     activation_point: Option<EraId>,
+    new_gas_hold_interval: Option<u64>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
     new_locked_funds_period_millis: Option<u64>,
@@ -28,6 +29,7 @@ impl ProtocolUpgradeConfig {
         current_protocol_version: ProtocolVersion,
         new_protocol_version: ProtocolVersion,
         activation_point: Option<EraId>,
+        new_gas_hold_interval: Option<u64>,
         new_validator_slots: Option<u32>,
         new_auction_delay: Option<u64>,
         new_locked_funds_period_millis: Option<u64>,
@@ -42,6 +44,7 @@ impl ProtocolUpgradeConfig {
             current_protocol_version,
             new_protocol_version,
             activation_point,
+            new_gas_hold_interval,
             new_validator_slots,
             new_auction_delay,
             new_locked_funds_period_millis,
@@ -71,6 +74,11 @@ impl ProtocolUpgradeConfig {
     /// Returns activation point in eras.
     pub fn activation_point(&self) -> Option<EraId> {
         self.activation_point
+    }
+
+    /// Returns new auction delay if specified.
+    pub fn new_gas_hold_interval(&self) -> Option<u64> {
+        self.new_gas_hold_interval
     }
 
     /// Returns new validator slots if specified.

--- a/types/src/chainspec/upgrade_config.rs
+++ b/types/src/chainspec/upgrade_config.rs
@@ -1,7 +1,10 @@
 use num_rational::Ratio;
 use std::collections::BTreeMap;
 
-use crate::{ChainspecRegistry, Digest, EraId, FeeHandling, Key, ProtocolVersion, StoredValue};
+use crate::{
+    ChainspecRegistry, Digest, EraId, FeeHandling, HoldBalanceHandling, Key, ProtocolVersion,
+    StoredValue,
+};
 
 /// Represents the configuration of a protocol upgrade.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,6 +13,7 @@ pub struct ProtocolUpgradeConfig {
     current_protocol_version: ProtocolVersion,
     new_protocol_version: ProtocolVersion,
     activation_point: Option<EraId>,
+    new_gas_hold_handling: Option<HoldBalanceHandling>,
     new_gas_hold_interval: Option<u64>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
@@ -29,6 +33,7 @@ impl ProtocolUpgradeConfig {
         current_protocol_version: ProtocolVersion,
         new_protocol_version: ProtocolVersion,
         activation_point: Option<EraId>,
+        new_gas_hold_handling: Option<HoldBalanceHandling>,
         new_gas_hold_interval: Option<u64>,
         new_validator_slots: Option<u32>,
         new_auction_delay: Option<u64>,
@@ -44,6 +49,7 @@ impl ProtocolUpgradeConfig {
             current_protocol_version,
             new_protocol_version,
             activation_point,
+            new_gas_hold_handling,
             new_gas_hold_interval,
             new_validator_slots,
             new_auction_delay,
@@ -74,6 +80,11 @@ impl ProtocolUpgradeConfig {
     /// Returns activation point in eras.
     pub fn activation_point(&self) -> Option<EraId> {
         self.activation_point
+    }
+
+    /// Returns new gas hold handling if specified.
+    pub fn new_gas_hold_handling(&self) -> Option<HoldBalanceHandling> {
+        self.new_gas_hold_handling
     }
 
     /// Returns new auction delay if specified.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -22,6 +22,7 @@
 extern crate alloc;
 
 extern crate core;
+
 mod access_rights;
 pub mod account;
 pub mod addressable_entity;
@@ -116,11 +117,12 @@ pub use chainspec::{
     ControlFlowCosts, CoreConfig, DelegatorConfig, DeployConfig, FeeHandling, GenesisAccount,
     GenesisConfig, GenesisConfigBuilder, GenesisValidator, GlobalStateUpdate,
     GlobalStateUpdateConfig, GlobalStateUpdateError, HandlePaymentCosts, HighwayConfig,
-    HostFunction, HostFunctionCost, HostFunctionCosts, LegacyRequiredFinality, MessageLimits,
-    MintCosts, NetworkConfig, NextUpgrade, OpcodeCosts, PricingHandling, ProtocolConfig,
-    ProtocolUpgradeConfig, RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig,
-    TransactionConfig, TransactionV1Config, VacancyConfig, ValidatorConfig, WasmConfig,
-    DEFAULT_BALANCE_HOLD_INTERVAL, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_REFUND_HANDLING,
+    HoldBalanceHandling, HostFunction, HostFunctionCost, HostFunctionCosts, LegacyRequiredFinality,
+    MessageLimits, MintCosts, NetworkConfig, NextUpgrade, OpcodeCosts, PricingHandling,
+    ProtocolConfig, ProtocolUpgradeConfig, RefundHandling, StandardPaymentCosts, StorageCosts,
+    SystemConfig, TransactionConfig, TransactionV1Config, VacancyConfig, ValidatorConfig,
+    WasmConfig, DEFAULT_GAS_HOLD_INTERVAL, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
+    DEFAULT_REFUND_HANDLING,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use chainspec::{
@@ -133,9 +135,9 @@ pub use chainspec::{
     DEFAULT_CONTROL_FLOW_IF_OPCODE, DEFAULT_CONTROL_FLOW_LOOP_OPCODE,
     DEFAULT_CONTROL_FLOW_RETURN_OPCODE, DEFAULT_CONTROL_FLOW_SELECT_OPCODE,
     DEFAULT_CONVERSION_COST, DEFAULT_CURRENT_MEMORY_COST, DEFAULT_DELEGATE_COST, DEFAULT_DIV_COST,
-    DEFAULT_FEE_HANDLING, DEFAULT_GLOBAL_COST, DEFAULT_GROW_MEMORY_COST,
-    DEFAULT_INSTALL_UPGRADE_GAS_LIMIT, DEFAULT_INTEGER_COMPARISON_COST, DEFAULT_LOAD_COST,
-    DEFAULT_LOCAL_COST, DEFAULT_MAX_PAYMENT_MOTES, DEFAULT_MAX_STACK_HEIGHT,
+    DEFAULT_FEE_HANDLING, DEFAULT_GAS_HOLD_BALANCE_HANDLING, DEFAULT_GLOBAL_COST,
+    DEFAULT_GROW_MEMORY_COST, DEFAULT_INSTALL_UPGRADE_GAS_LIMIT, DEFAULT_INTEGER_COMPARISON_COST,
+    DEFAULT_LOAD_COST, DEFAULT_LOCAL_COST, DEFAULT_MAX_PAYMENT_MOTES, DEFAULT_MAX_STACK_HEIGHT,
     DEFAULT_MIN_TRANSFER_MOTES, DEFAULT_MUL_COST, DEFAULT_NEW_DICTIONARY_COST, DEFAULT_NOP_COST,
     DEFAULT_STANDARD_TRANSACTION_GAS_LIMIT, DEFAULT_STORE_COST, DEFAULT_TRANSFER_COST,
     DEFAULT_UNREACHABLE_COST, DEFAULT_WASM_MAX_MEMORY,

--- a/types/src/system/mint/constants.rs
+++ b/types/src/system/mint/constants.rs
@@ -38,5 +38,7 @@ pub const BASE_ROUND_REWARD_KEY: &str = "mint_base_round_reward";
 pub const TOTAL_SUPPLY_KEY: &str = "total_supply";
 /// Storage for mint round seigniorage rate.
 pub const ROUND_SEIGNIORAGE_RATE_KEY: &str = "round_seigniorage_rate";
+/// Storage for gas hold handling.
+pub const MINT_GAS_HOLD_HANDLING_KEY: &str = "gas_hold_handling";
 /// Storage for gas hold interval.
 pub const MINT_GAS_HOLD_INTERVAL_KEY: &str = "gas_hold_interval";

--- a/types/src/system/mint/constants.rs
+++ b/types/src/system/mint/constants.rs
@@ -38,3 +38,5 @@ pub const BASE_ROUND_REWARD_KEY: &str = "mint_base_round_reward";
 pub const TOTAL_SUPPLY_KEY: &str = "total_supply";
 /// Storage for mint round seigniorage rate.
 pub const ROUND_SEIGNIORAGE_RATE_KEY: &str = "round_seigniorage_rate";
+/// Storage for gas hold interval.
+pub const MINT_GAS_HOLD_INTERVAL_KEY: &str = "gas_hold_interval";

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -6,7 +6,7 @@ mod transaction_v1_category;
 mod transaction_v1_hash;
 mod transaction_v1_header;
 
-#[cfg(any(feature = "std", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use alloc::string::ToString;
 use alloc::{collections::BTreeSet, vec::Vec};
 use core::{
@@ -31,13 +31,15 @@ use super::{
 };
 #[cfg(any(feature = "std", test))]
 use super::{GasLimited, InitiatorAddrAndSecretKey};
+#[cfg(any(feature = "std", test))]
+use crate::chainspec::Chainspec;
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
+use crate::chainspec::PricingHandling;
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
     crypto, Digest, DisplayIter, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionRuntime,
     TransactionSessionKind,
 };
-#[cfg(any(feature = "std", test))]
-use crate::{chainspec::Chainspec, chainspec::PricingHandling};
 
 #[cfg(any(feature = "std", test))]
 use crate::{Gas, Motes, TransactionConfig, U512};


### PR DESCRIPTION
This PR adds a new chainspec toggled behavior using a field called `gas_hold_balance_handling`, with two options `accrued` and `amortized`. Accrued is the previously implemented behavior to apply the full amount of gas holds until they expire when calculating available balance. Amortized is a new behavior to apply a percentage of each gas hold based upon the time elapsed / time remaining until expiry for that hold...in simple terms if 50% of a hold period has elapsed apply half the held amount, if 90% of a hold period has elapsed apply 10% of the held amount. 

This is an either / or choice...a given network can have one or the other strategy for gas holds turned on. A given network could switch between the settings across an upgrade boundary. Given that this affects a runtime calculation at time of balance check, this would not require a migration of hold records.

Other strategies could be added in future if desired, by extending the option set and wiring up the applicable logic. Other types of holds might also be introduced into the system in future, in which case a separate but basically identical set of chainspec fields for interval and handling would be added to the chainspec. Such a hypothetical future case could have the same or different settings for these fields...in other words could have a different interval and or a different handling.
