### PR TITLE
Re-generate chainspec.toml for EE test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ resources/production/*.wasm
 resources/node-storage/*
 resources/local/chainspec.toml
 
+execution_engine_testing/test_support/resources/chainspec.toml
+
 # CLion
 .idea/
 cmake-build-debug/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "serde",
  "tempfile",
  "toml 0.5.11",
+ "toml_edit 0.21.0",
  "version-sync",
 ]
 
@@ -5834,7 +5835,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -5855,6 +5856,17 @@ dependencies = [
  "indexmap 2.0.0",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -32,6 +32,10 @@ toml = "0.5.6"
 casper-types = { version = "5.0.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
+[build-dependencies]
+toml_edit = "=0.21.0"
+humantime = "2"
+
 [features]
 use-as-wasm = []
 

--- a/execution_engine_testing/test_support/build.rs
+++ b/execution_engine_testing/test_support/build.rs
@@ -1,17 +1,17 @@
 use humantime::format_rfc3339;
 use std::{
-    fs,
+    env, fs,
     path::Path,
     time::{Duration, SystemTime},
 };
 use toml_edit::{value, Document};
 
 fn main() {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let input_chainspec = Path::new(manifest_dir)
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let input_chainspec = Path::new(&manifest_dir)
         .join("resources")
         .join("chainspec.toml.in");
-    let output_chainspec = Path::new(manifest_dir)
+    let output_chainspec = Path::new(&manifest_dir)
         .join("resources")
         .join("chainspec.toml");
 

--- a/execution_engine_testing/test_support/build.rs
+++ b/execution_engine_testing/test_support/build.rs
@@ -1,0 +1,28 @@
+use humantime::format_rfc3339;
+use std::{
+    fs,
+    path::Path,
+    time::{Duration, SystemTime},
+};
+use toml_edit::{value, Document};
+
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let input_chainspec = Path::new(manifest_dir)
+        .join("resources")
+        .join("chainspec.toml.in");
+    let output_chainspec = Path::new(manifest_dir)
+        .join("resources")
+        .join("chainspec.toml");
+
+    println!("cargo:rerun-if-changed={}", input_chainspec.display());
+
+    let toml = fs::read_to_string(input_chainspec).expect("could not read chainspec.toml.in");
+    let mut doc = toml
+        .parse::<Document>()
+        .expect("invalid document in chainspec.toml.in");
+    let activation_point = SystemTime::now() + Duration::from_secs(40);
+    doc["protocol"]["activation_point"] = value(format_rfc3339(activation_point).to_string());
+
+    fs::write(output_chainspec, doc.to_string()).expect("could not write chainspec.toml");
+}

--- a/execution_engine_testing/test_support/resources/chainspec.toml
+++ b/execution_engine_testing/test_support/resources/chainspec.toml
@@ -1,1 +1,0 @@
-../../../resources/local/chainspec.toml

--- a/execution_engine_testing/test_support/resources/chainspec.toml.in
+++ b/execution_engine_testing/test_support/resources/chainspec.toml.in
@@ -1,0 +1,1 @@
+../../../resources/local/chainspec.toml.in


### PR DESCRIPTION
chainspec.toml.in is now packaged with the test support crate (instead of a symlink to to chainspec.toml) and a small build script was added to generate a local chainspec automatically during a cargo build.

Closes https://github.com/casper-network/casper-sidecar/issues/285.